### PR TITLE
UI/Qt: Detach dragged tabs dropped outside any tab bar to a new window

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -622,6 +622,7 @@ void BrowserWindow::detach_tab_to_new_window(int index, QPoint global_position)
         .y = Web::DevicePixels { global_position.y() - 18 },
         .width = Web::DevicePixels { width() },
         .height = Web::DevicePixels { height() },
+        .maximized = isMaximized(),
     };
 
     auto& window = Application::the().new_window({}, configuration);

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -452,8 +452,12 @@ void TabBar::start_tab_drag(int index)
             if (action == Qt::MoveAction && s_pending_tab_drop_target) {
                 if (auto* target_window = qobject_cast<BrowserWindow*>(s_pending_tab_drop_target->window()))
                     source_window->move_tab_to_window(current_index, *target_window, s_pending_tab_drop_index);
-            } else if (action == Qt::IgnoreAction && !source_window->geometry().contains(QCursor::pos())) {
-                source_window->detach_tab_to_new_window(current_index, QCursor::pos());
+            } else if (action == Qt::IgnoreAction) {
+                auto tab_bar_row_global = QRect(
+                    m_tab_widget->tab_bar_row()->mapToGlobal(QPoint(0, 0)),
+                    m_tab_widget->tab_bar_row()->size());
+                if (!tab_bar_row_global.contains(QCursor::pos()) && m_tab_widget->count() > 1)
+                    source_window->detach_tab_to_new_window(current_index, QCursor::pos());
             }
         }
     }
@@ -712,6 +716,12 @@ bool TabWidget::eventFilter(QObject* watched, QEvent* event)
 void TabWidget::accept_tab_drag(QDragMoveEvent* event)
 {
     if (!s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+        event->ignore();
+        return;
+    }
+
+    auto position_in_tab_bar_row = m_tab_bar_row->mapFrom(this, event->position().toPoint());
+    if (!m_tab_bar_row->rect().contains(position_in_tab_bar_row)) {
         event->ignore();
         return;
     }

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -85,6 +85,7 @@ public:
     explicit TabWidget(QWidget* parent = nullptr);
 
     TabBar* tab_bar() const { return m_tab_bar; }
+    QWidget* tab_bar_row() const { return m_tab_bar_row; }
 
     void add_tab(Tab* widget, QString const& label);
     void insert_tab(int index, Tab* widget, QString const& label);


### PR DESCRIPTION
Previously, a tab would only detach into a new window when dropped outside the source window entirely. Dropping a tab onto the content area of any browser window would instead silently move it to the end of that window's tab bar.

TabWidget now rejects tab drag events outside its tab bar row, and the detach condition checks the tab bar row bounds rather than the full window geometry. This means dropping a tab anywhere that is not a tab bar row opens a new window at the cursor position.