### PR TITLE
UI/Qt: Paint styled background for find in page widget

### DIFF
--- a/UI/Qt/FindInPageWidget.cpp
+++ b/UI/Qt/FindInPageWidget.cpp
@@ -21,6 +21,7 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     , m_content_view(content_view)
 {
     setObjectName("LadybirdFindInPageBar");
+    setAttribute(Qt::WA_StyledBackground);
     setFocusPolicy(Qt::FocusPolicy::StrongFocus);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     update_chrome_style();


### PR DESCRIPTION
The `WA_OpaquePaintEvent` attribute on `BrowserWindow` means Qt no longer fills widget backgrounds automatically. Plain `QWidget` subclasses do not paint their stylesheet backgrounds by default, so the find in page bar lost its background color and did not clear its state correctly between repeats . Setting `WA_StyledBackground` tells Qt to honor the stylesheet background property in the widget's paint cycle.

My screen capture software isn't actually able to capture how the broken version looked, but here's how it looks now.

<img width="723" height="483" alt="image" src="https://github.com/user-attachments/assets/555cb512-351b-4595-81e0-5ab80e790f60" />

