### PR TITLE
UI/Qt: Apply a stylesheet to the devtools status bar

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -16,6 +16,7 @@
 #include <LibWebView/HistoryStore.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/BrowserWindow.h>
+#include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/Settings.h>
@@ -460,6 +461,9 @@ void BrowserWindow::update_bookmarks_bar_display(bool show_bookmarks_bar)
 
 void BrowserWindow::on_devtools_enabled()
 {
+    statusBar()->setObjectName("LadybirdStatusBar");
+    statusBar()->setStyleSheet(ChromeStyle::status_bar_style_sheet(current_tab()->palette()));
+
     auto* disable_button = new QPushButton("Disable", this);
 
     connect(disable_button, &QPushButton::clicked, this, []() {

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -454,6 +454,39 @@ QWidget#LadybirdFindInPageBar QLabel {
         .replace(QStringLiteral("CONTROL_BORDER"), control_border);
 }
 
+QString status_bar_style_sheet(QPalette const& palette)
+{
+    auto background = style_sheet_color(chrome_background(palette));
+    auto border = style_sheet_color(chrome_border(palette));
+    auto control_border = style_sheet_color(chrome_control_border(palette));
+    auto hover = style_sheet_color(chrome_surface_hover(palette));
+    auto pressed = style_sheet_color(chrome_surface_pressed(palette));
+    auto text = style_sheet_color(chrome_text(palette));
+
+    return QStringLiteral(R"(
+QWidget#LadybirdStatusBar {
+    background: %1;
+    border-top: 1px solid %2;
+}
+
+QWidget#LadybirdStatusBar QPushButton {
+    background: transparent;
+    color: %6;
+}
+
+QWidget#LadybirdStatusBar QPushButton:hover {
+    background: %4;
+    border-color: %3;
+}
+
+QWidget#LadybirdStatusBar QPushButton:pressed {
+    background: %5;
+    border-color: %3;
+}
+)")
+        .arg(background, border, control_border, hover, pressed, text);
+}
+
 QString tab_widget_style_sheet(QPalette const& palette)
 {
     auto background = style_sheet_color(chrome_tab_strip_background(palette));

--- a/UI/Qt/ChromeStyle.h
+++ b/UI/Qt/ChromeStyle.h
@@ -32,6 +32,7 @@ QString navigation_toolbar_style_sheet(QPalette const&);
 QString location_edit_style_sheet(QPalette const&);
 QString bookmarks_bar_style_sheet(QPalette const&);
 QString find_in_page_style_sheet(QPalette const&);
+QString status_bar_style_sheet(QPalette const&);
 QString tab_widget_style_sheet(QPalette const&);
 QString autocomplete_popup_style_sheet(QPalette const&);
 


### PR DESCRIPTION
Got blasted by a white status bar before this change:
<img width="1300" height="1011" alt="before" src="https://github.com/user-attachments/assets/87a706d0-db9d-4fa0-9e00-6be55c495dbd" />

After:
<img width="1304" height="1012" alt="after" src="https://github.com/user-attachments/assets/5dae83d0-95e0-4666-a199-4d4686c3e456" />
