### PR TITLE
UI/Qt: Preserve hidden omnibox edits on new tabs

### DIFF
--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -251,6 +251,9 @@ LocationEdit::LocationEdit(QWidget* parent)
         if (m_is_applying_inline_autocomplete)
             return;
 
+        if (m_url_is_hidden)
+            m_has_user_edited_hidden_url = true;
+
         auto query = current_query();
 
         if (m_should_suppress_inline_autocomplete_on_next_change) {
@@ -293,6 +296,18 @@ QAction* LocationEdit::trailing_action() const
     return m_trailing_action_button->defaultAction();
 }
 
+void LocationEdit::set_url_is_hidden(bool url_is_hidden)
+{
+    if (m_url_is_hidden == url_is_hidden)
+        return;
+
+    m_url_is_hidden = url_is_hidden;
+    m_has_user_edited_hidden_url = false;
+
+    if (m_url_is_hidden)
+        clear();
+}
+
 void LocationEdit::changeEvent(QEvent* event)
 {
     QLineEdit::changeEvent(event);
@@ -322,6 +337,7 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
 
     if (m_url_is_hidden) {
         m_url_is_hidden = false;
+        m_has_user_edited_hidden_url = false;
         if (text().isEmpty() && m_url.has_value())
             setText(qstring_from_ak_string(m_url->serialize()));
     }
@@ -517,7 +533,8 @@ void LocationEdit::set_url(Optional<URL::URL> url)
     m_url = AK::move(url);
 
     if (m_url_is_hidden) {
-        clear();
+        if (!m_has_user_edited_hidden_url)
+            clear();
     } else if (m_url.has_value()) {
         setText(qstring_from_ak_string(m_url->serialize()));
         setCursorPosition(0);

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -45,7 +45,7 @@ public:
     void set_favicon(QIcon const&);
 
     bool url_is_hidden() const { return m_url_is_hidden; }
-    void set_url_is_hidden(bool url_is_hidden) { m_url_is_hidden = url_is_hidden; }
+    void set_url_is_hidden(bool);
 
 private:
     virtual void changeEvent(QEvent* event) override;
@@ -83,6 +83,7 @@ private:
     Optional<URL::URL> m_url;
     QIcon m_favicon;
     bool m_url_is_hidden { false };
+    bool m_has_user_edited_hidden_url { false };
     bool m_is_loading { false };
     bool m_is_updating_chrome_style { false };
     bool m_has_pending_chrome_style_update { false };

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -206,7 +206,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_location_edit->set_favicon({});
         m_location_edit->set_loading(true);
         m_location_edit->set_url(url);
-        m_location_edit->setCursorPosition(0);
     };
 
     view().on_load_finish = [this](auto const&) {


### PR DESCRIPTION
Keep late about:newtab load notifications from clearing hidden location text after the user has started typing. Let LocationEdit own cursor placement for normal URL display so load-start updates do not disturb inline autocomplete selection.