### PR TITLE
LibWeb: Fix shared-library build with multiple Rust staticlibs

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1258,8 +1258,14 @@ get_target_property(_libweb_content_blocker_rust_lib libweb_content_blocker_rust
 set_property(SOURCE HTML/Parser/HTMLTokenizer.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
 set_property(SOURCE HTML/Parser/HTMLParser.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
 set_property(SOURCE HTML/Parser/SpeculativeHTMLParser.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
-if ((LINUX OR BSD) AND NOT BUILD_SHARED_LIBS)
-    target_link_options(LibWeb INTERFACE LINKER:--allow-multiple-definition)
+if (LINUX OR BSD)
+    if (BUILD_SHARED_LIBS)
+        # Shared build: the flag must apply when LibWeb itself is linked (PRIVATE) — not just when downstream consumers
+        # link against it.
+        target_link_options(LibWeb PRIVATE LINKER:--allow-multiple-definition)
+    else()
+        target_link_options(LibWeb INTERFACE LINKER:--allow-multiple-definition)
+    endif()
 endif()
 
 if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
**Problem:** Linux builds with `BUILD_SHARED_LIBS=ON` set fail to link `liblagom-web.so`, with a _“multiple definition of rust_eh_personality”_ failure message (and `EMPTY_PANIC`, `ARGV_INIT_ARRAY`, etc.).

**Cause:** bcdbdbb added `libweb_content_blocker_rust` as a second Rust staticlib that `LibWeb` links against — and added an `--allow-multiple-definition` workaround. But it gated that on `NOT BUILD_SHARED_LIBS` — so shared builds got no workaround at all. CI never noticed, because every preset sets `BUILD_SHARED_LIBS=OFF`.

**Fix:** Extend the workaround to shared builds. The shared case uses `PRIVATE` (the flag applies when `LibWeb` itself is linked) — rather than `INTERFACE` (which only affects downstream consumers; useless for a shared library that is itself the link target). Fixes https://github.com/LadybirdBrowser/ladybird/issues/9643.
