### PR TITLE
Compositor: Flush display lists after overlay painting

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -120,6 +120,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
             auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
             Painting::DisplayListPlayerSkia display_list_player;
             display_list_player.execute(*display_list, resource_storage, {}, painting_surface);
+            display_list_player.flush(*painting_surface);
             break;
         }
         }

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -117,8 +117,6 @@ void DisplayListPlayer::execute(
     m_active_display_list = &display_list;
     m_resource_storage = &resource_storage;
     execute_impl(display_list, scroll_state_snapshot);
-    if (surface)
-        flush();
     m_resource_storage = nullptr;
     m_active_display_list = nullptr;
     m_surface = nullptr;

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -69,6 +69,7 @@ public:
     virtual ~DisplayListPlayer() = default;
 
     void execute(DisplayList const&, DisplayListResourceStorage const&, ScrollStateSnapshot const&, RefPtr<Gfx::PaintingSurface>);
+    virtual void flush(Gfx::PaintingSurface&) = 0;
 
 protected:
     Gfx::PaintingSurface& surface() const { return *m_surface; }
@@ -93,7 +94,6 @@ protected:
     void execute_nested_display_list(DisplayList const&, ScrollStateSnapshot const&, ReadonlyBytes command_bytes);
 
 private:
-    virtual void flush() = 0;
     virtual void draw_glyph_run(DrawGlyphRun const&) = 0;
     virtual void fill_rect(FillRect const&) = 0;
     virtual void draw_scaled_decoded_image_frame(DrawScaledDecodedImageFrame const&) = 0;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -104,11 +104,11 @@ static SkM44 to_skia_matrix4x4(Gfx::FloatMatrix4x4 const& matrix)
         matrix[3, 3]);
 }
 
-void DisplayListPlayerSkia::flush()
+void DisplayListPlayerSkia::flush(Gfx::PaintingSurface& surface)
 {
-    if (auto context = surface().skia_backend_context())
-        context->flush_and_submit(&surface().sk_surface());
-    surface().flush();
+    if (auto context = surface.skia_backend_context())
+        context->flush_and_submit(&surface.sk_surface());
+    surface.flush();
     m_image_cache.prune();
 }
 

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -22,8 +22,9 @@ public:
     explicit DisplayListPlayerSkia(RefPtr<Gfx::SkiaBackendContext>);
     ~DisplayListPlayerSkia();
 
+    void flush(Gfx::PaintingSurface&) override;
+
 private:
-    void flush() override;
     void draw_glyph_run(DrawGlyphRun const&) override;
     void fill_rect(FillRect const&) override;
     void draw_scaled_decoded_image_frame(DrawScaledDecodedImageFrame const&) override;

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -184,6 +184,7 @@ RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize
     case DisplayListPlayerType::SkiaCPU: {
         Painting::DisplayListPlayerSkia display_list_player;
         display_list_player.execute(*display_list, resource_storage, {}, surface);
+        display_list_player.flush(*surface);
         break;
     }
     default:

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -561,13 +561,8 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
             painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
         });
     m_display_list_player->execute(*context.display_list, context.display_list_resource_storage, context.scroll_state_snapshot, back_store);
+    paint_viewport_scrollbar_overlay(context, back_store);
     m_display_list_player->flush(back_store);
-    auto painted_viewport_scrollbar_overlay = paint_viewport_scrollbar_overlay(context, back_store);
-    if (painted_viewport_scrollbar_overlay) {
-        if (auto skia_backend_context = back_store.skia_backend_context())
-            skia_backend_context->flush_and_submit(&back_store.sk_surface());
-    }
-    back_store.flush();
     auto rendered_bitmap_id = context.backing_store_manager.back_bitmap_id();
     context.backing_store_manager.swap();
 
@@ -593,9 +588,8 @@ bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId co
 
     auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
     m_display_list_player->execute(*context->display_list, context->display_list_resource_storage, context->scroll_state_snapshot, *target_surface);
-    m_display_list_player->flush(*target_surface);
     paint_viewport_scrollbar_overlay(*context, *target_surface);
-    target_surface->flush();
+    m_display_list_player->flush(*target_surface);
     return true;
 }
 

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -561,6 +561,7 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
             painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
         });
     m_display_list_player->execute(*context.display_list, context.display_list_resource_storage, context.scroll_state_snapshot, back_store);
+    m_display_list_player->flush(back_store);
     auto painted_viewport_scrollbar_overlay = paint_viewport_scrollbar_overlay(context, back_store);
     if (painted_viewport_scrollbar_overlay) {
         if (auto skia_backend_context = back_store.skia_backend_context())
@@ -592,6 +593,7 @@ bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId co
 
     auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
     m_display_list_player->execute(*context->display_list, context->display_list_resource_storage, context->scroll_state_snapshot, *target_surface);
+    m_display_list_player->flush(*target_surface);
     paint_viewport_scrollbar_overlay(*context, *target_surface);
     target_surface->flush();
     return true;


### PR DESCRIPTION
Compositor presentation still preserved the old implicit replay flush
and then submitted again after viewport scrollbar overlay painting. That
left a redundant flush on every frame and an extra GPU submit when
overlay scrollbars were painted.

Flush the display list player once after compositor overlay painting in
both presentation and screenshot paths. The explicit flush now covers
all compositor painting for the target surface, so direct surface
flushes are no longer needed.