### PR TITLE
LibWebView: Make tab closing fast and clean up child processes

### DIFF
--- a/Libraries/LibCore/Process.cpp
+++ b/Libraries/LibCore/Process.cpp
@@ -16,8 +16,10 @@
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <spawn.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #if defined(AK_OS_SERENITY)
@@ -30,6 +32,9 @@
 extern "C" {
 #    include <hurd.h>
 }
+#endif
+#if defined(AK_OS_LINUX)
+#    include <sys/prctl.h>
 #endif
 #if defined(AK_OS_FREEBSD)
 #    include <sys/user.h>
@@ -82,8 +87,109 @@ Process Process::current()
     return p;
 }
 
+#if defined(AK_OS_LINUX)
+static Optional<int> run_file_actions_in_child(Vector<ProcessSpawnOptions::FileActionType> const& file_actions)
+{
+    for (auto const& file_action : file_actions) {
+        auto error = file_action.visit(
+            [&](FileAction::OpenFile const& action) {
+                auto fd = open(
+                    action.path.characters(),
+                    File::open_mode_to_options(action.mode | Core::File::OpenMode::KeepOnExec),
+                    action.permissions);
+                if (fd < 0)
+                    return Optional<int> { errno };
+
+                if (fd != action.fd) {
+                    if (dup2(fd, action.fd) < 0) {
+                        auto saved_errno = errno;
+                        close(fd);
+                        return Optional<int> { saved_errno };
+                    }
+                    close(fd);
+                }
+                return Optional<int> {};
+            },
+            [&](FileAction::CloseFile const& action) {
+                close(action.fd);
+                return Optional<int> {};
+            },
+            [&](FileAction::DupFd const& action) {
+                if (dup2(action.write_fd, action.fd) < 0)
+                    return Optional<int> { errno };
+                return Optional<int> {};
+            });
+        if (error.has_value())
+            return error;
+    }
+    return {};
+}
+
+static ErrorOr<pid_t> fork_and_exec_with_parent_death_signal(ProcessSpawnOptions const& options, Span<char const*> arguments)
+{
+    auto error_pipe = TRY(System::pipe2(O_CLOEXEC));
+
+    auto parent_pid = getpid();
+    auto pid = fork();
+    if (pid < 0) {
+        auto saved_errno = errno;
+        MUST(System::close(error_pipe[0]));
+        MUST(System::close(error_pipe[1]));
+        return Error::from_syscall("fork"sv, saved_errno);
+    }
+
+    if (pid == 0) {
+        close(error_pipe[0]);
+
+        auto report_errno_and_exit = [&](int error) {
+            auto bytes_written = write(error_pipe[1], &error, sizeof(error));
+            (void)bytes_written;
+            _exit(127);
+        };
+
+        if (prctl(PR_SET_PDEATHSIG, SIGKILL) < 0)
+            report_errno_and_exit(errno);
+        if (getppid() != parent_pid)
+            _exit(127);
+
+        if (auto error = run_file_actions_in_child(options.file_actions); error.has_value())
+            report_errno_and_exit(error.value());
+
+        if (options.search_for_executable_in_path)
+            execvp(options.executable.characters(), const_cast<char* const*>(arguments.data()));
+        else
+            execve(options.executable.characters(), const_cast<char* const*>(arguments.data()), Environment::raw_environ());
+
+        report_errno_and_exit(errno);
+    }
+
+    MUST(System::close(error_pipe[1]));
+
+    int child_errno = 0;
+    auto bytes_read = TRY(System::read(error_pipe[0], { &child_errno, sizeof(child_errno) }));
+    MUST(System::close(error_pipe[0]));
+
+    if (bytes_read > 0) {
+        int status = 0;
+        (void)waitpid(pid, &status, 0);
+        return Error::from_errno(child_errno);
+    }
+
+    return pid;
+}
+#endif
+
 ErrorOr<Process> Process::spawn(ProcessSpawnOptions const& options)
 {
+    ArgvList argv_list(options.executable, options.arguments.size());
+    for (auto const& argument : options.arguments)
+        argv_list.append(argument.characters());
+
+#if defined(AK_OS_LINUX)
+    if (options.die_with_parent)
+        return Process { TRY(fork_and_exec_with_parent_death_signal(options, argv_list.get())) };
+#endif
+
 #define CHECK(invocation)                  \
     if (int returned_errno = (invocation)) \
         return Error::from_errno(returned_errno);
@@ -116,10 +222,6 @@ ErrorOr<Process> Process::spawn(ProcessSpawnOptions const& options)
     }
 
 #undef CHECK
-
-    ArgvList argv_list(options.executable, options.arguments.size());
-    for (auto const& argument : options.arguments)
-        argv_list.append(argument.characters());
 
     pid_t pid;
     if (options.search_for_executable_in_path) {

--- a/Libraries/LibCore/Process.h
+++ b/Libraries/LibCore/Process.h
@@ -41,6 +41,8 @@ struct ProcessSpawnOptions {
     StringView name {};
     ByteString executable {};
     bool search_for_executable_in_path { false };
+    // On supported platforms, ask the kernel to terminate this process when its parent dies.
+    bool die_with_parent { false };
     Vector<ByteString> const& arguments {};
 
     using FileActionType = Variant<FileAction::OpenFile, FileAction::CloseFile, FileAction::DupFd>;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8190,8 +8190,18 @@ void Document::set_navigable(GC::Ptr<HTML::Navigable> navigable)
 {
     if (m_navigable == navigable)
         return;
+
+    auto previous_traversable = m_navigable ? m_navigable->traversable_navigable() : nullptr;
     m_navigable = navigable.ptr();
     HTML::main_thread_event_loop().document_navigable_did_change({});
+
+    if (previous_traversable)
+        previous_traversable->page().update_needs_beforeunload_check();
+    if (navigable) {
+        auto new_traversable = navigable->traversable_navigable();
+        if (new_traversable && new_traversable != previous_traversable)
+            new_traversable->page().update_needs_beforeunload_check();
+    }
 }
 
 void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -37,6 +37,8 @@
 #include <LibWeb/HTML/HTMLBodyElement.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/HTML/HTMLFrameSetElement.h>
+#include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
 #include <LibWeb/Page/Page.h>
@@ -210,6 +212,23 @@ static void invalidate_compositor_wheel_event_listener_state(EventTarget& event_
     }
 }
 
+static void update_needs_beforeunload_check(EventTarget& event_target, DOMEventListener const& listener)
+{
+    if (listener.type != HTML::EventNames::beforeunload)
+        return;
+
+    auto* window = as_if<HTML::Window>(event_target);
+    if (!window)
+        return;
+
+    auto navigable = window->associated_document().navigable();
+    if (!navigable)
+        return;
+
+    if (auto traversable = navigable->traversable_navigable())
+        traversable->page().update_needs_beforeunload_check();
+}
+
 // https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener
 void EventTarget::add_event_listener(FlyString const& type, IDLEventListener* callback, Variant<Bindings::AddEventListenerOptions, bool> const& options)
 {
@@ -266,6 +285,7 @@ void EventTarget::add_an_event_listener(DOMEventListener& listener)
     if (it == event_listener_list.end()) {
         event_listener_list.append(listener);
         invalidate_compositor_wheel_event_listener_state(*this, listener);
+        update_needs_beforeunload_check(*this, listener);
     }
 
     // 6. If listener’s signal is not null, then add the following abort steps to it:
@@ -319,8 +339,10 @@ void EventTarget::remove_an_event_listener(DOMEventListener& listener)
     listener.removed = true;
     VERIFY(m_data);
     auto did_remove = m_data->event_listener_list.remove_first_matching([&](auto& entry) { return entry.ptr() == &listener; });
-    if (did_remove)
+    if (did_remove) {
         invalidate_compositor_wheel_event_listener_state(*this, listener);
+        update_needs_beforeunload_check(*this, listener);
+    }
 }
 
 // https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
@@ -363,11 +364,41 @@ void Page::invalidate_compositor_wheel_event_listener_state()
     top_level_traversable()->compositor_context().invalidate_wheel_event_listener_state(m_wheel_event_listener_state_generation);
 }
 
+void Page::update_needs_beforeunload_check()
+{
+    auto needs_beforeunload_check = [&] {
+        if (!top_level_traversable_is_initialized())
+            return true;
+
+        auto top_level_traversable = this->top_level_traversable();
+        auto active_document = top_level_traversable->active_document();
+        if (!active_document)
+            return true;
+        if (active_document->navigable() != top_level_traversable.ptr())
+            return true;
+
+        for (auto const& navigable : active_document->inclusive_descendant_navigables()) {
+            auto window = navigable->active_window();
+            if (window && window->has_event_listener(HTML::EventNames::beforeunload))
+                return true;
+        }
+
+        return false;
+    }();
+
+    if (m_needs_beforeunload_check == needs_beforeunload_check)
+        return;
+
+    m_needs_beforeunload_check = needs_beforeunload_check;
+    client().page_did_change_needs_beforeunload_check(m_needs_beforeunload_check);
+}
+
 void Page::set_top_level_traversable(GC::Ref<HTML::TraversableNavigable> navigable)
 {
     VERIFY(!m_top_level_traversable); // Replacement is not allowed!
     VERIFY(&navigable->page() == this);
     m_top_level_traversable = navigable;
+    update_needs_beforeunload_check();
 }
 
 bool Page::top_level_traversable_is_initialized() const

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -150,6 +150,8 @@ public:
     void set_async_scrolling_enabled(bool b) { m_async_scrolling_enabled = b; }
     u64 wheel_event_listener_state_generation() const { return m_wheel_event_listener_state_generation; }
     void invalidate_compositor_wheel_event_listener_state();
+    bool needs_beforeunload_check() const { return m_needs_beforeunload_check; }
+    void update_needs_beforeunload_check();
 
     bool is_webdriver_active() const { return m_is_webdriver_active; }
     void set_is_webdriver_active(bool b) { m_is_webdriver_active = b; }
@@ -320,6 +322,7 @@ private:
     bool m_enable_primary_paste { true };
     bool m_async_scrolling_enabled { false };
     u64 m_wheel_event_listener_state_generation { 0 };
+    bool m_needs_beforeunload_check { true };
 
     // https://w3c.github.io/webdriver/#dfn-webdriver-active-flag
     // The webdriver-active flag is set to true when the user agent is under remote control. It is initially false.
@@ -487,6 +490,7 @@ public:
     virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_top_level_traversable() { }
     virtual void page_did_update_navigation_buttons_state([[maybe_unused]] bool back_enabled, [[maybe_unused]] bool forward_enabled) { }
+    virtual void page_did_change_needs_beforeunload_check([[maybe_unused]] bool needs_beforeunload_check) { }
 
     virtual void request_file(FileRequest) = 0;
 

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -47,6 +47,7 @@ ErrorOr<Process::ProcessAndIPCTransport> Process::spawn_and_connect_to_process(C
     Array<int, 2> stderr_pipe {};
 
     Core::ProcessSpawnOptions spawn_options = options;
+    spawn_options.die_with_parent = true;
 
     if (capture_output) {
         stdout_pipe = TRY(Core::System::pipe2(O_CLOEXEC));

--- a/Libraries/LibWebView/ProcessManager.cpp
+++ b/Libraries/LibWebView/ProcessManager.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
 #include <LibWebView/ProcessManager.h>
+#include <signal.h>
 
 namespace WebView {
 
@@ -109,10 +110,46 @@ void ProcessManager::set_process_mach_port(pid_t pid, Core::MachPort&& port)
 Optional<Process> ProcessManager::remove_process(pid_t pid)
 {
     verify_event_loop();
+    cancel_forced_exit(pid);
     m_statistics.processes.remove_first_matching([&](auto const& info) {
         return (info->pid == pid);
     });
     return m_processes.take(pid);
+}
+
+void ProcessManager::cancel_forced_exit(pid_t pid)
+{
+    verify_event_loop();
+    if (auto timer = m_forced_exit_timers.take(pid); timer.has_value())
+        (*timer)->stop();
+}
+
+void ProcessManager::force_exit_after_timeout(pid_t pid, int timeout_ms)
+{
+    verify_event_loop();
+    if (!m_processes.contains(pid))
+        return;
+    if (m_forced_exit_timers.contains(pid))
+        return;
+
+    auto timer = Core::Timer::create_single_shot(timeout_ms, [this, pid] {
+        m_forced_exit_timers.remove(pid);
+        auto process = m_processes.get(pid);
+        if (!process.has_value())
+            return;
+
+#if defined(AK_OS_WINDOWS)
+        constexpr auto signal = SIGTERM;
+#else
+        constexpr auto signal = SIGKILL;
+#endif
+        dbgln("Force-killing unresponsive {} process {}", process_name_from_type(process->type()), pid);
+        auto result = Core::System::kill(pid, signal);
+        if (result.is_error())
+            dbgln("Failed to force-kill process {}: {}", pid, result.error());
+    });
+    timer->start();
+    m_forced_exit_timers.set(pid, move(timer));
 }
 
 void ProcessManager::update_all_process_statistics()

--- a/Libraries/LibWebView/ProcessManager.h
+++ b/Libraries/LibWebView/ProcessManager.h
@@ -7,10 +7,13 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/HashMap.h>
 #include <AK/JsonValue.h>
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Platform/ProcessStatistics.h>
+#include <LibCore/Timer.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Process.h>
 #include <LibWebView/ProcessMonitor.h>
@@ -31,6 +34,8 @@ public:
     void for_each_process(Function<void(Process&)>);
     Optional<Process> remove_process(pid_t);
     Optional<Process&> find_process(pid_t);
+    void cancel_forced_exit(pid_t);
+    void force_exit_after_timeout(pid_t, int timeout_ms);
 
 #if defined(AK_OS_MACH)
     void set_process_mach_port(pid_t, Core::MachPort&&);
@@ -47,6 +52,7 @@ private:
 
     Core::Platform::ProcessStatistics m_statistics;
     HashMap<pid_t, Process> m_processes;
+    HashMap<pid_t, RefPtr<Core::Timer>> m_forced_exit_timers;
     ProcessMonitor m_process_monitor;
     Core::EventLoop* m_creation_event_loop { &Core::EventLoop::current() };
 };

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -672,6 +672,11 @@ void ViewImplementation::did_update_navigation_buttons_state(Badge<WebContentCli
     m_navigate_forward_action->set_enabled(forward_enabled);
 }
 
+void ViewImplementation::did_change_needs_beforeunload_check(Badge<WebContentClient>, bool needs_beforeunload_check)
+{
+    m_needs_beforeunload_check = needs_beforeunload_check;
+}
+
 void ViewImplementation::did_change_background_color(Badge<WebContentClient>, Gfx::Color color)
 {
     m_page_background_color = color;
@@ -732,6 +737,8 @@ void ViewImplementation::handle_resize()
 
 void ViewImplementation::initialize_client(CreateNewClient create_new_client)
 {
+    m_needs_beforeunload_check = true;
+
     if (create_new_client == CreateNewClient::Yes) {
         m_client_state = {};
 
@@ -1293,7 +1300,24 @@ void ViewImplementation::remove_navigation_listener(u64 listener_id)
 
 void ViewImplementation::request_close()
 {
-    client().async_request_close(page_id());
+    if (needs_beforeunload_check()) {
+        client().async_request_close(page_id());
+        return;
+    }
+
+    client().request_close(page_id());
+}
+
+Function<void()> ViewImplementation::prepare_for_immediate_close()
+{
+    VERIFY(!needs_beforeunload_check());
+
+    auto client = m_client_state.client;
+    auto page_id = m_client_state.page_index;
+    client->prepare_for_detached_close(page_id);
+    return [client = move(client), page_id] {
+        client->async_request_close(page_id);
+    };
 }
 
 }

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -171,6 +171,7 @@ public:
     Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
 
     void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const;
+    void did_change_needs_beforeunload_check(Badge<WebContentClient>, bool needs_beforeunload_check);
     void did_change_background_color(Badge<WebContentClient>, Gfx::Color);
     Gfx::Color page_background_color() const { return m_page_background_color; }
 
@@ -195,6 +196,8 @@ public:
     void use_native_user_style_sheet();
 
     void request_close();
+    Function<void()> prepare_for_immediate_close();
+    bool needs_beforeunload_check() const { return m_needs_beforeunload_check; }
 
     Function<void()> on_ready_to_paint;
     Function<String(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Optional<u64>)> on_new_web_view;
@@ -429,6 +432,7 @@ protected:
     u64 m_next_navigation_listener_id { 1 };
 
     bool m_devtools_connected { false };
+    bool m_needs_beforeunload_check { true };
 };
 
 }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <LibCore/ElapsedTimer.h>
+#include <LibCore/Timer.h>
 #include <LibHTTP/Cookie/ParsedCookie.h>
 #include <LibIPC/Transport.h>
 #include <LibIPC/TransportHandle.h>
@@ -22,6 +23,10 @@
 namespace WebView {
 
 HashTable<WebContentClient*> WebContentClient::s_clients;
+
+static constexpr auto detached_page_close_timeout_ms = 1000;
+static constexpr auto close_server_exit_timeout_ms = 5000;
+static constexpr auto detached_page_forced_exit_timeout_ms = detached_page_close_timeout_ms + close_server_exit_timeout_ms;
 
 static Optional<String> history_title(Utf16String const& title, URL::URL const& url)
 {
@@ -142,6 +147,9 @@ void WebContentClient::set_compositor_connection_id(Badge<Application>, i32 comp
 void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 {
     VERIFY(page_id > 0);
+    if (m_detached_page_close_timer)
+        m_detached_page_close_timer->stop();
+    Application::process_manager().cancel_forced_exit(pid());
     m_views.set(page_id, view);
     m_history_recorded_urls_for_current_load.remove(page_id);
 }
@@ -150,10 +158,57 @@ void WebContentClient::unregister_view(u64 page_id)
 {
     if (auto context_id = m_page_compositor_context_ids.get(page_id); context_id.has_value())
         forget_compositor_context(*context_id);
+
+    // A page that still needs a beforeunload check is not a detached
+    // background close. It is being closed without waiting for WebContent,
+    // e.g. because the user requested a forced close.
+    if (auto view = m_views.get(page_id); view.has_value() && (*view)->needs_beforeunload_check())
+        m_detached_pages_pending_close.remove(page_id);
+
     m_views.remove(page_id);
     m_history_recorded_urls_for_current_load.remove(page_id);
-    if (m_views.is_empty())
+    close_server_if_unused();
+}
+
+void WebContentClient::prepare_for_detached_close(u64 page_id)
+{
+    m_detached_pages_pending_close.set(page_id);
+}
+
+void WebContentClient::request_close(u64 page_id)
+{
+    // The frontend may destroy the view immediately after this for pages that
+    // cannot prompt during beforeunload. Keep owning the WebContent close until
+    // the page reports that its top-level traversable has been closed.
+    prepare_for_detached_close(page_id);
+    async_request_close(page_id);
+}
+
+void WebContentClient::close_server_if_unused()
+{
+    if (!m_views.is_empty())
+        return;
+
+    if (m_detached_pages_pending_close.is_empty()) {
+        if (m_detached_page_close_timer)
+            m_detached_page_close_timer->stop();
         async_close_server();
+        Application::process_manager().force_exit_after_timeout(pid(), close_server_exit_timeout_ms);
+        return;
+    }
+
+    Application::process_manager().force_exit_after_timeout(pid(), detached_page_forced_exit_timeout_ms);
+
+    if (!m_detached_page_close_timer) {
+        m_detached_page_close_timer = Core::Timer::create_single_shot(detached_page_close_timeout_ms, [this] {
+            dbgln("Timed out waiting for detached WebContent page close acknowledgement");
+            m_detached_pages_pending_close.clear();
+            close_server_if_unused();
+        });
+    }
+
+    if (!m_detached_page_close_timer->is_active())
+        m_detached_page_close_timer->start();
 }
 
 void WebContentClient::web_ui_disconnected(Badge<WebUI>)
@@ -897,10 +952,20 @@ void WebContentClient::did_request_activate_tab(u64 page_id)
 
 void WebContentClient::did_close_browsing_context(u64 page_id)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_close)
-            view->on_close();
+    m_detached_pages_pending_close.remove(page_id);
+
+    if (auto view = m_views.get(page_id); view.has_value()) {
+        if ((*view)->on_close)
+            (*view)->on_close();
     }
+
+    close_server_if_unused();
+}
+
+void WebContentClient::did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_change_needs_beforeunload_check({}, needs_beforeunload_check);
 }
 
 void WebContentClient::did_update_resource_count(u64 page_id, i32 count_waiting)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -9,9 +9,11 @@
 #include <AK/HashMap.h>
 #include <AK/NonnullRawPtr.h>
 #include <AK/Optional.h>
+#include <AK/RefPtr.h>
 #include <AK/SourceLocation.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <LibCore/Forward.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/SharedImage.h>
 #include <LibHTTP/Header.h>
@@ -60,6 +62,8 @@ public:
     Optional<i32> compositor_connection_id(Badge<Application>) const { return m_compositor_connection_id; }
     void register_view(u64 page_id, ViewImplementation&);
     void unregister_view(u64 page_id);
+    void prepare_for_detached_close(u64 page_id);
+    void request_close(u64 page_id);
 
     void web_ui_disconnected(Badge<WebUI>);
 
@@ -84,6 +88,7 @@ public:
 
 private:
     void maybe_record_history_visit_for_current_load(u64 page_id, URL::URL const&, Optional<String> title, StringView reason);
+    void close_server_if_unused();
     bool forget_compositor_context(Web::Compositor::CompositorContextId);
     void destroy_all_compositor_contexts();
 
@@ -152,6 +157,7 @@ private:
     virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints, Optional<u64> page_index) override;
     virtual void did_request_activate_tab(u64 page_id) override;
     virtual void did_close_browsing_context(u64 page_id) override;
+    virtual void did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) override;
     virtual void did_update_resource_count(u64 page_id, i32 count_waiting) override;
     virtual void did_request_restore_window(u64 page_id) override;
     virtual void did_request_reposition_window(u64 page_id, Gfx::IntPoint) override;
@@ -190,6 +196,7 @@ private:
     void remember_compositor_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
 
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
+    HashTable<u64> m_detached_pages_pending_close;
     HashMap<Web::Compositor::CompositorContextId, CompositorContextRegistration> m_compositor_contexts;
     HashMap<u64, Web::Compositor::CompositorContextId> m_page_compositor_context_ids;
     HashMap<Web::Compositor::CompositorContextId, u64> m_page_ids_for_compositor_context_ids;
@@ -197,6 +204,7 @@ private:
     Optional<i32> m_compositor_connection_id;
 
     ProcessHandle m_process_handle;
+    RefPtr<Core::Timer> m_detached_page_close_timer;
 
     RefPtr<WebUI> m_web_ui;
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -136,8 +136,10 @@ Messages::WebContentServer::GetWindowHandleResponse ConnectionFromClient::get_wi
 
 void ConnectionFromClient::set_window_handle(u64 page_id, String handle)
 {
-    if (auto page = this->page(page_id); page.has_value())
+    if (auto page = this->page(page_id); page.has_value()) {
         page->page().top_level_traversable()->set_window_handle(move(handle));
+        page->send_current_needs_beforeunload_check();
+    }
 }
 
 void ConnectionFromClient::connect_to_webdriver(u64 page_id, ByteString webdriver_endpoint)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -710,6 +710,16 @@ void PageClient::page_did_close_top_level_traversable()
     m_owner.remove_page({}, m_id);
 }
 
+void PageClient::page_did_change_needs_beforeunload_check(bool needs_beforeunload_check)
+{
+    client().async_did_change_needs_beforeunload_check(m_id, needs_beforeunload_check);
+}
+
+void PageClient::send_current_needs_beforeunload_check()
+{
+    client().async_did_change_needs_beforeunload_check(m_id, page().needs_beforeunload_check());
+}
+
 void PageClient::page_did_update_navigation_buttons_state(bool back_enabled, bool forward_enabled)
 {
     client().async_did_update_navigation_buttons_state(m_id, back_enabled, forward_enabled);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -107,6 +107,7 @@ public:
     virtual Web::Compositor::CompositorHost const* compositor_host() const override;
 
     void queue_screenshot_task(Optional<Web::UniqueNodeID> node_id);
+    void send_current_needs_beforeunload_check();
 
 private:
     PageClient(PageHost&, u64 id);
@@ -178,6 +179,7 @@ private:
     virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Web::HTML::TokenizedFeature::NoOpener) override;
     virtual void page_did_request_activate_tab() override;
     virtual void page_did_close_top_level_traversable() override;
+    virtual void page_did_change_needs_beforeunload_check(bool needs_beforeunload_check) override;
     virtual void page_did_update_navigation_buttons_state(bool back_enabled, bool forward_enabled) override;
     virtual void request_file(Web::FileRequest) override;
     virtual void page_did_request_color_picker(Color current_color) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -101,6 +101,7 @@ endpoint WebContentClient
     did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) => (String handle)
     did_request_activate_tab(u64 page_id) =|
     did_close_browsing_context(u64 page_id) =|
+    did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) =|
     did_request_restore_window(u64 page_id) =|
     did_request_reposition_window(u64 page_id, Gfx::IntPoint position) =|
     did_request_resize_window(u64 page_id, Gfx::IntSize size) =|

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Function.h>
 #include <AK/StringUtils.h>
 #include <LibGfx/Forward.h>
 #include <LibURL/Forward.h>
@@ -70,5 +71,7 @@
 - (void)findInPagePreviousMatch;
 
 - (void)requestClose;
+- (Function<void()>)prepareForImmediateClose;
+- (BOOL)needsBeforeUnloadCheck;
 
 @end

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -249,6 +249,16 @@ struct HideCursor {
     m_web_view_bridge->request_close();
 }
 
+- (Function<void()>)prepareForImmediateClose
+{
+    return m_web_view_bridge->prepare_for_immediate_close();
+}
+
+- (BOOL)needsBeforeUnloadCheck
+{
+    return m_web_view_bridge->needs_beforeunload_check();
+}
+
 #pragma mark - Private methods
 
 - (void)updateViewportRect

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/EventLoop.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/Autocomplete.h>
 #include <LibWebView/BookmarkStore.h>
@@ -294,6 +295,7 @@ static NSImage* location_field_globe_icon()
     bool m_fullscreen_requested_for_web_content;
     bool m_fullscreen_exit_was_ui_initiated;
     bool m_fullscreen_should_restore_tab_bar;
+    Function<void()> m_pending_immediate_close;
 }
 
 @property (nonatomic, assign) BOOL already_requested_close;
@@ -923,6 +925,11 @@ static NSImage* location_field_globe_icon()
 
 - (BOOL)windowShouldClose:(NSWindow*)sender
 {
+    if (![[[self tab] web_view] needsBeforeUnloadCheck]) {
+        m_pending_immediate_close = [[[self tab] web_view] prepareForImmediateClose];
+        return true;
+    }
+
     // Prevent closing on first request so WebContent can cleanly shutdown (e.g. asking if the user is sure they want
     // to leave, closing WebSocket connections, etc.)
     if (!self.already_requested_close) {
@@ -940,6 +947,10 @@ static NSImage* location_field_globe_icon()
 {
     auto* delegate = (ApplicationDelegate*)[NSApp delegate];
     [delegate removeTab:self];
+
+    auto request_close = AK::move(m_pending_immediate_close);
+    if (request_close)
+        Core::deferred_invoke(AK::move(request_close));
 }
 
 - (void)windowDidMove:(NSNotification*)notification

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/EventLoop.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
@@ -701,6 +702,13 @@ void Tab::find_next()
 
 void Tab::request_close()
 {
+    if (!view().needs_beforeunload_check()) {
+        auto request_close = view().prepare_for_immediate_close();
+        m_window->definitely_close_tab(tab_index());
+        Core::deferred_invoke(AK::move(request_close));
+        return;
+    }
+
     // Prevent closing on first request so WebContent can cleanly shutdown (e.g. asking if the user is sure they want
     // to leave, closing WebSocket connections, etc.)
     if (!m_already_requested_close) {

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -34,6 +34,7 @@
 #include <QCursor>
 #include <QGuiApplication>
 #include <QIcon>
+#include <QKeySequence>
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPaintEvent>
@@ -805,6 +806,12 @@ bool WebContentView::event(QEvent* event)
     }
 
     if (event->type() == QEvent::ShortcutOverride) {
+        auto* key_event = static_cast<QKeyEvent*>(event);
+        if (key_event->matches(QKeySequence::StandardKey::Close)) {
+            event->ignore();
+            return false;
+        }
+
         event->accept();
         return true;
     }


### PR DESCRIPTION
This makes tabs and windows close immediately when WebContent does not need to run a `beforeunload` prompt, while still letting WebContent receive the close request so `pagehide`, `unload`, and cleanup can run.

The branch also centralizes forced child-process termination in `ProcessManager` and opts browser helper processes into parent-lifetime tracking where supported. On Linux, helper processes now ask the kernel to terminate them if the UI process exits, so WebContent, WebWorker, and other children do not survive a crashed or closed browser process.

The visible changes are:

- Tabs and windows without `beforeunload` prompts can be removed immediately.
- Detached WebContent pages stay alive until close acknowledgement or timeout.
- Unresponsive child processes are force-exited after graceful shutdown fails.
- Helper processes are tied to the browser lifetime on supported platforms (only Linux so far).