### PR TITLE
LibWebView: A couple of `about:settings` tweaks

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -8,13 +8,6 @@
             @media (prefers-color-scheme: light) {
                 :root {
                     --input-background-color: white;
-                    --border-color: #dcdde1;
-                }
-            }
-
-            @media (prefers-color-scheme: dark) {
-                :root {
-                    --border-color: #3d3d3d;
                 }
             }
 
@@ -100,8 +93,7 @@
             }
 
             .description {
-                margin-bottom: 10px;
-
+                margin-top: 8px;
                 font-size: 14px;
                 opacity: 0.7;
             }
@@ -428,24 +420,27 @@
             <h3 class="card-title">Browsing Behavior</h3>
             <div class="card">
                 <div class="card-body">
-                    <div class="card-group">
+                    <div class="card-group card-separator">
                         <div class="inline-container">
-                            <label for="enable-autoscroll">Enable autoscrolling</label>
+                            <label for="enable-autoscroll">
+                                Enable autoscrolling
+                                <p class="description">
+                                    Scroll pages by pressing the middle mouse button and moving the mouse.
+                                </p>
+                            </label>
                             <input id="enable-autoscroll" type="checkbox" switch />
                         </div>
-                        <p class="description">
-                            Scroll pages by pressing the middle mouse button and moving the mouse.
-                        </p>
                     </div>
-                    <hr />
-                    <div class="card-group">
+                    <div class="card-group card-separator">
                         <div class="inline-container">
-                            <label for="enable-primary-paste">Enable primary pasting</label>
+                            <label for="enable-primary-paste">
+                                Enable primary pasting
+                                <p class="description">
+                                    Paste text from the clipboard when the middle mouse button is clicked.
+                                </p>
+                            </label>
                             <input id="enable-primary-paste" type="checkbox" switch />
                         </div>
-                        <p class="description">
-                            Paste text from the clipboard when the middle mouse button is clicked.
-                        </p>
                     </div>
                 </div>
             </div>
@@ -454,10 +449,11 @@
         <div class="tab-panel" id="tab-search">
             <div class="card">
                 <div class="card-body">
-                    <p class="card-group">Default Search Engine</p>
                     <div class="card-group">
-                        <p class="description">Select the search engine to use in the address bar.</p>
-
+                        <label>
+                            Default Search Engine
+                            <p class="description">Select the search engine to use in the address bar.</p>
+                        </label>
                         <div class="inline-container">
                             <select id="search-engine" style="width: 100%">
                                 <option value="">Disable search</option>
@@ -471,9 +467,11 @@
 
             <div class="card">
                 <div class="card-body">
-                    <p class="card-group">Search Suggestions</p>
                     <div class="card-group">
-                        <p class="description">Select the engine that will provide search suggestions.</p>
+                        <label>
+                            Search Suggestions
+                            <p class="description">Select the engine that will provide search suggestions.</p>
+                        </label>
                         <select id="autocomplete-engine">
                             <option value="">Disable search suggestions</option>
                             <hr />
@@ -508,8 +506,8 @@
                             <div>
                                 <label for="browsing-data-settings-max-disk-cache-size">
                                     Maximum disk cache size
+                                    <p class="description">Limit the space used for the HTTP disk cache.</p>
                                 </label>
-                                <p class="description">Limit the space used for the HTTP disk cache.</p>
                             </div>
                             <div class="input-field-container">
                                 <input
@@ -542,10 +540,12 @@
                 <div class="card-body">
                     <div class="card-group">
                         <div class="inline-container">
-                            <label for="global-privacy-control-toggle">Global Privacy Control</label>
+                            <label for="global-privacy-control-toggle">
+                                Global Privacy Control
+                                <p class="description">Tell websites not to sell or share your data.</p>
+                            </label>
                             <input id="global-privacy-control-toggle" type="checkbox" switch />
                         </div>
-                        <p class="description">Tell websites not to sell or share your data.</p>
                     </div>
                 </div>
             </div>
@@ -635,8 +635,10 @@
                     <input id="search-custom-name" type="text" placeholder="Example" />
                 </div>
                 <div class="form-group">
-                    <label for="search-custom-url">Search URL</label>
-                    <p class="description">Use %s as a placeholder for the search query</p>
+                    <label for="search-custom-url">
+                        Search URL
+                        <p class="description">Use %s as a placeholder for the search query</p>
+                    </label>
                     <input id="search-custom-url" type="url" placeholder="https://example.com/search?q=%s" />
                 </div>
                 <div class="dialog-controls">

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -59,7 +59,8 @@
             .inline-container input[type="number"],
             .inline-container input[type="text"],
             .inline-container input[type="url"],
-            .inline-container select {
+            .inline-container select,
+            .inline-container textarea {
                 width: 50%;
             }
 
@@ -115,6 +116,10 @@
 
                 width: 100%;
                 border: 1px solid var(--border-color);
+            }
+
+            textarea {
+                resize: vertical;
             }
 
             input[type="number"].success,
@@ -281,19 +286,6 @@
                 width: 100%;
             }
 
-            .config-row {
-                display: grid;
-                grid-template-columns: minmax(0, 1fr) auto;
-                gap: 20px;
-                align-items: center;
-            }
-
-            .config-row + .config-row {
-                border-top: 1px solid var(--border-color);
-                padding-top: 16px;
-                margin-top: 16px;
-            }
-
             .config-name {
                 font-family: monospace;
                 font-size: 13px;
@@ -305,32 +297,6 @@
                 margin-top: 6px;
 
                 font-size: 14px;
-            }
-
-            .config-control {
-                min-width: 180px;
-            }
-
-            .config-control input[type="text"],
-            .config-control input[type="number"],
-            .config-control textarea {
-                width: 100%;
-            }
-
-            .config-control textarea {
-                min-width: 280px;
-                resize: vertical;
-            }
-
-            @media (max-width: 600px) {
-                .config-row {
-                    grid-template-columns: minmax(0, 1fr);
-                    align-items: stretch;
-                }
-
-                .config-control {
-                    min-width: 0;
-                }
             }
 
             .tab-bar {
@@ -598,7 +564,7 @@
                     <div class="card-group">
                         <input id="config-filter" type="search" placeholder="Filter configuration keys" />
                     </div>
-                    <div id="config-list"></div>
+                    <div class="card-group" id="config-list"></div>
                 </div>
             </div>
         </div>

--- a/Base/res/ladybird/about-pages/settings/advanced.js
+++ b/Base/res/ladybird/about-pages/settings/advanced.js
@@ -9,23 +9,22 @@ function sendConfigVariableValue(variable, value) {
 }
 
 function createControl(variable) {
-    const control = document.createElement("div");
-    control.classList.add("config-control");
+    const type = variable.type === "array" && variable.elementType === "string" ? "textarea" : "input";
+    const input = document.createElement(type);
+    input.id = variable.name;
 
     if (variable.type === "boolean") {
-        const input = document.createElement("input");
         input.type = "checkbox";
-        input.toggleAttribute("switch", true);
+        input.switch = true;
         input.checked = !!variable.value;
         input.addEventListener("change", () => {
             sendConfigVariableValue(variable, input.checked);
         });
-        control.append(input);
-        return control;
+
+        return input;
     }
 
-    if (variable.type === "array" && variable.elementType === "string") {
-        const input = document.createElement("textarea");
+    if (type === "textarea") {
         input.rows = 3;
         input.value = Array.isArray(variable.value) ? variable.value.join("\n") : "";
         input.addEventListener("change", () => {
@@ -36,11 +35,10 @@ function createControl(variable) {
 
             sendConfigVariableValue(variable, value);
         });
-        control.append(input);
-        return control;
+
+        return input;
     }
 
-    const input = document.createElement("input");
     input.value = variable.value ?? "";
 
     if (variable.type === "number") {
@@ -59,31 +57,34 @@ function createControl(variable) {
         });
     }
 
-    control.append(input);
-    return control;
+    return input;
 }
 
 function createRow(variable) {
     const row = document.createElement("div");
+    row.classList.add("card-group");
+    row.classList.add("card-separator");
     row.classList.add("config-row");
+    row.classList.add("inline-container");
     row.dataset.filterText = `${variable.name} ${variable.title} ${variable.description}`.toLowerCase();
 
-    const details = document.createElement("div");
-
-    const name = document.createElement("div");
+    const name = document.createElement("p");
     name.classList.add("config-name");
     name.textContent = variable.name;
 
-    const title = document.createElement("div");
+    const title = document.createElement("p");
     title.classList.add("config-title");
     title.textContent = variable.title;
 
     const description = document.createElement("p");
-    description.classList.add("config-description", "description");
+    description.classList.add("description");
     description.textContent = variable.description;
 
-    details.append(name, title, description);
-    row.append(details, createControl(variable));
+    const label = document.createElement("label");
+    label.htmlFor = variable.name;
+    label.append(name, title, description);
+
+    row.append(label, createControl(variable));
     return row;
 }
 

--- a/Base/res/ladybird/about-pages/webui.css
+++ b/Base/res/ladybird/about-pages/webui.css
@@ -1,5 +1,6 @@
 @media (prefers-color-scheme: light) {
     :root {
+        --border-color: #dcdde1;
         --card-background-color: #f5f5f5;
         --card-header-background-color: #f0f2f5;
     }
@@ -7,6 +8,7 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
+        --border-color: #3d3d3d;
         --card-background-color: #242424;
         --card-header-background-color: #252525;
     }
@@ -65,10 +67,11 @@ header img {
     margin: 0 8px 16px 8px;
 }
 
-.card-group {
-    margin-bottom: 20px;
+.card-group + .card-group {
+    margin-top: 16px;
 }
 
-.card-group:last-child {
-    margin-bottom: 0;
+.card-separator + .card-separator {
+    border-top: 1px solid var(--border-color);
+    padding-top: 16px;
 }


### PR DESCRIPTION
* Embed setting descriptions inside `<label>` elements so we may click on them to activate the control.
* Re-use existing infra for the advanced settings.

The main visual difference is the toggles on the advanced page are right-aligned now, which matches all other settings.

Before:
<img width="1250" height="808" alt="Screenshot 2026-05-26 at 3 28 40 PM" src="https://github.com/user-attachments/assets/70d6d1f9-7698-4ee5-bb59-78777b396761" />

After:
<img width="1250" height="808" alt="Screenshot 2026-05-26 at 3 28 52 PM" src="https://github.com/user-attachments/assets/b72e1f57-dd12-4db4-a719-e77dd8780c69" />
