### PR TITLE
LibWeb: Fix link drag cancellation state

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -350,6 +350,11 @@ void Internals::mouse_move(double x, double y, WebIDL::UnsignedShort modifiers)
     page.handle_mousemove(position, position, 0, modifiers);
 }
 
+void Internals::mouse_leave()
+{
+    this->page().handle_mouseleave();
+}
+
 void Internals::click(double x, double y, WebIDL::UnsignedShort click_count, WebIDL::UnsignedShort button, WebIDL::UnsignedShort modifiers)
 {
     click_and_hold(x, y, click_count, button, modifiers);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -60,6 +60,7 @@ public:
     void mouse_down(double x, double y, WebIDL::UnsignedShort click_count, WebIDL::UnsignedShort button, WebIDL::UnsignedShort modifiers);
     void mouse_up(double x, double y, WebIDL::UnsignedShort button, WebIDL::UnsignedShort modifiers);
     void mouse_move(double x, double y, WebIDL::UnsignedShort modifiers);
+    void mouse_leave();
 
     // High-level mouse conveniences
     void click(double x, double y, WebIDL::UnsignedShort click_count, WebIDL::UnsignedShort button, WebIDL::UnsignedShort modifiers);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -35,6 +35,7 @@ interface Internals {
     undefined mouseDown(double x, double y, optional unsigned short clickCount = 1, optional unsigned short button = 0, optional unsigned short modifiers = 0);
     undefined mouseUp(double x, double y, optional unsigned short button = 0, optional unsigned short modifiers = 0);
     undefined mouseMove(double x, double y, optional unsigned short modifiers = 0);
+    undefined mouseLeave();
 
     // High-level mouse conveniences
     undefined click(double x, double y, optional unsigned short clickCount = 1, optional unsigned short button = 0, optional unsigned short modifiers = 0);

--- a/Libraries/LibWeb/Page/DragAndDropEventHandler.cpp
+++ b/Libraries/LibWeb/Page/DragAndDropEventHandler.cpp
@@ -368,6 +368,19 @@ EventResult DragAndDropEventHandler::handle_drag_leave(
     return handle_drag_end(realm, Cancelled::Yes, screen_position, page_offset, client_offset, offset, button, buttons, modifiers);
 }
 
+EventResult DragAndDropEventHandler::handle_drag_cancel(
+    JS::Realm& realm,
+    CSSPixelPoint screen_position,
+    CSSPixelPoint page_offset,
+    CSSPixelPoint client_offset,
+    CSSPixelPoint offset,
+    unsigned button,
+    unsigned buttons,
+    unsigned modifiers)
+{
+    return handle_drag_end(realm, Cancelled::Yes, screen_position, page_offset, client_offset, offset, button, buttons, modifiers);
+}
+
 EventResult DragAndDropEventHandler::handle_drop(
     JS::Realm& realm,
     CSSPixelPoint screen_position,

--- a/Libraries/LibWeb/Page/DragAndDropEventHandler.h
+++ b/Libraries/LibWeb/Page/DragAndDropEventHandler.h
@@ -25,6 +25,7 @@ public:
     EventResult handle_drag_start(JS::Realm&, GC::Ptr<DOM::Node> drag_target, CSSPixelPoint screen_position, CSSPixelPoint page_offset, CSSPixelPoint client_offset, CSSPixelPoint offset, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files);
     EventResult handle_drag_move(JS::Realm&, GC::Ref<DOM::Node>, CSSPixelPoint screen_position, CSSPixelPoint page_offset, CSSPixelPoint client_offset, CSSPixelPoint offset, unsigned button, unsigned buttons, unsigned modifiers);
     EventResult handle_drag_leave(JS::Realm&, CSSPixelPoint screen_position, CSSPixelPoint page_offset, CSSPixelPoint client_offset, CSSPixelPoint offset, unsigned button, unsigned buttons, unsigned modifiers);
+    EventResult handle_drag_cancel(JS::Realm&, CSSPixelPoint screen_position, CSSPixelPoint page_offset, CSSPixelPoint client_offset, CSSPixelPoint offset, unsigned button, unsigned buttons, unsigned modifiers);
     EventResult handle_drop(JS::Realm&, CSSPixelPoint screen_position, CSSPixelPoint page_offset, CSSPixelPoint client_offset, CSSPixelPoint offset, unsigned button, unsigned buttons, unsigned modifiers);
 
     void reset();

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -189,6 +189,9 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     if (!node)
         return EventResult::Dropped;
 
+    if (button == UIEvents::MouseButton::Primary)
+        clear_mousedown_tracking();
+
     m_mousedown_click_count = click_count;
 
     auto dispath_result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [=](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
@@ -389,6 +392,8 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
     if (should_ignore_device_input_event()) {
         if (m_mousedown_target_is_drag_candidate) {
             auto result = handle_drag_and_drop_event(DragEvent::Type::Drop, visual_viewport_position, screen_position, button, buttons, modifiers, {});
+            if (result == EventResult::Dropped && should_ignore_device_input_event())
+                return cancel_drag_and_drop_event(visual_viewport_position, screen_position, button, buttons, modifiers);
             set_page_cursor(m_navigable->page(), Gfx::StandardCursor::Arrow);
             return result;
         }
@@ -660,11 +665,8 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
 EventResult EventHandler::handle_mouseleave()
 {
     if (should_ignore_device_input_event()) {
-        if (m_mousedown_target_is_drag_candidate) {
-            auto result = handle_drag_and_drop_event(DragEvent::Type::DragEnd, {}, {}, UIEvents::MouseButton::Primary, UIEvents::MouseButton::Primary, 0, {});
-            set_page_cursor(m_navigable->page(), Gfx::StandardCursor::Arrow);
-            return result;
-        }
+        if (m_mousedown_target_is_drag_candidate)
+            return cancel_drag_and_drop_event(m_last_known_mouse_visual_viewport_position.value_or({}), m_last_known_mouse_screen_position, UIEvents::MouseButton::Primary, UIEvents::MouseButton::Primary, 0);
 
         return EventResult::Dropped;
     }
@@ -800,6 +802,9 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         return EventResult::Dropped;
     if (!m_navigable->active_document()->is_fully_active())
         return EventResult::Dropped;
+
+    if (should_ignore_device_input_event() && m_mousedown_target_is_drag_candidate && key == UIEvents::KeyCode::Key_Escape)
+        return cancel_drag_and_drop_event(m_last_known_mouse_visual_viewport_position.value_or({}), m_last_known_mouse_screen_position, UIEvents::MouseButton::Primary, m_last_known_mouse_buttons, modifiers);
 
     auto dispatch_result = fire_keyboard_event(UIEvents::EventNames::keydown, m_navigable, key, modifiers, code_point, repeat);
     if (dispatch_result != EventResult::Accepted)
@@ -1091,6 +1096,23 @@ EventResult EventHandler::handle_drag_and_drop_event(DragEvent::Type type, CSSPi
     }
 
     VERIFY_NOT_REACHED();
+}
+
+EventResult EventHandler::cancel_drag_and_drop_event(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
+{
+    auto document = m_navigable->active_document();
+    if (!document)
+        return EventResult::Dropped;
+    if (!document->is_fully_active())
+        return EventResult::Dropped;
+
+    auto viewport_position = document->visual_viewport()->map_to_layout_viewport(visual_viewport_position);
+    auto page_offset = compute_mouse_event_page_offset(viewport_position);
+    auto result = m_drag_and_drop_event_handler->handle_drag_cancel(document->realm(), screen_position, page_offset, viewport_position, {}, button, buttons, modifiers);
+    set_page_cursor(m_navigable->page(), Gfx::StandardCursor::Arrow);
+    clear_mousedown_tracking();
+    stop_updating_selection();
+    return result;
 }
 
 bool EventHandler::should_ignore_device_input_event() const
@@ -2018,8 +2040,13 @@ void EventHandler::apply_mouse_selection(CSSPixelPoint visual_viewport_position)
     }
 }
 
+static void set_node_and_ancestors_being_activated(DOM::Node*, bool);
+
 void EventHandler::clear_mousedown_tracking()
 {
+    if (m_mousedown_target)
+        set_node_and_ancestors_being_activated(m_mousedown_target, false);
+
     m_mousedown_target = nullptr;
     m_mousedown_visual_viewport_position = {};
     m_mousedown_click_count = 0;

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -138,6 +138,7 @@ private:
 
     void update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget> chrome_widget);
     void record_last_known_mouse_position(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers);
+    EventResult cancel_drag_and_drop_event(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 
     void handle_gamepad_connected(SDL_JoystickID);
     void handle_gamepad_updated(SDL_JoystickID);

--- a/Tests/LibWeb/Text/expected/css/active-state-cleared-after-link-drag.txt
+++ b/Tests/LibWeb/Text/expected/css/active-state-cleared-after-link-drag.txt
@@ -1,0 +1,15 @@
+active after foo mousedown: html, body, foo
+active after releasing foo drag: (none)
+active after bar mousedown: html, body, bar
+active after bar mouseup: (none)
+active after foo drag leaves viewport: (none)
+bar clicks after viewport leave: 1
+active after untargetable viewport leave: (none)
+foo dragends after untargetable viewport leave: 1
+bar clicks after untargetable viewport leave: 1
+active after outside-viewport mouseup: (none)
+foo dragends after outside-viewport mouseup: 1
+bar clicks after outside-viewport mouseup: 1
+active after escape-canceled drag: (none)
+foo dragends after escape-canceled drag: 1
+bar clicks after escape-canceled drag: 1

--- a/Tests/LibWeb/Text/input/css/active-state-cleared-after-link-drag.html
+++ b/Tests/LibWeb/Text/input/css/active-state-cleared-after-link-drag.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+a {
+    display: inline-block;
+    padding: 10px;
+}
+</style>
+<a id="foo" href="#foo">foo</a>
+<a id="bar" href="#bar">bar</a>
+<script>
+function activeIds() {
+    const ids = Array.from(document.querySelectorAll(":active"), element => element.id || element.localName).join(", ");
+    return ids || "(none)";
+}
+
+test(() => {
+    let barClicks = 0;
+    bar.addEventListener("click", event => {
+        event.preventDefault();
+        ++barClicks;
+    });
+
+    let fooDragEnds = 0;
+    foo.addEventListener("dragend", () => {
+        ++fooDragEnds;
+    });
+
+    document.body.offsetWidth;
+
+    const fooRect = foo.getBoundingClientRect();
+    const barRect = bar.getBoundingClientRect();
+
+    internals.mouseDown(fooRect.x + fooRect.width / 2, fooRect.y + fooRect.height / 2);
+    println(`active after foo mousedown: ${activeIds()}`);
+
+    internals.mouseMove(fooRect.right + 20, fooRect.y + fooRect.height / 2);
+    internals.mouseUp(fooRect.right + 20, fooRect.y + fooRect.height / 2);
+    println(`active after releasing foo drag: ${activeIds()}`);
+
+    internals.mouseDown(barRect.x + barRect.width / 2, barRect.y + barRect.height / 2);
+    println(`active after bar mousedown: ${activeIds()}`);
+
+    internals.mouseUp(barRect.x + barRect.width / 2, barRect.y + barRect.height / 2);
+    println(`active after bar mouseup: ${activeIds()}`);
+
+    barClicks = 0;
+
+    internals.mouseDown(fooRect.x + fooRect.width / 2, fooRect.y + fooRect.height / 2);
+    internals.mouseMove(fooRect.right + 20, fooRect.y + fooRect.height / 2);
+    internals.mouseLeave();
+    println(`active after foo drag leaves viewport: ${activeIds()}`);
+
+    internals.click(barRect.x + barRect.width / 2, barRect.y + barRect.height / 2);
+    println(`bar clicks after viewport leave: ${barClicks}`);
+
+    barClicks = 0;
+
+    internals.mouseDown(fooRect.x + fooRect.width / 2, fooRect.y + fooRect.height / 2);
+    internals.mouseMove(fooRect.right + 20, fooRect.y + fooRect.height / 2);
+    fooDragEnds = 0;
+    document.documentElement.style.pointerEvents = "none";
+    internals.mouseLeave();
+    document.documentElement.style.pointerEvents = "";
+    println(`active after untargetable viewport leave: ${activeIds()}`);
+    println(`foo dragends after untargetable viewport leave: ${fooDragEnds}`);
+
+    internals.click(barRect.x + barRect.width / 2, barRect.y + barRect.height / 2);
+    println(`bar clicks after untargetable viewport leave: ${barClicks}`);
+
+    barClicks = 0;
+
+    internals.mouseDown(fooRect.x + fooRect.width / 2, fooRect.y + fooRect.height / 2);
+    internals.mouseMove(fooRect.right + 20, fooRect.y + fooRect.height / 2);
+    fooDragEnds = 0;
+    internals.mouseUp(-100, -100);
+    println(`active after outside-viewport mouseup: ${activeIds()}`);
+    println(`foo dragends after outside-viewport mouseup: ${fooDragEnds}`);
+
+    internals.click(barRect.x + barRect.width / 2, barRect.y + barRect.height / 2);
+    println(`bar clicks after outside-viewport mouseup: ${barClicks}`);
+
+    barClicks = 0;
+
+    internals.mouseDown(fooRect.x + fooRect.width / 2, fooRect.y + fooRect.height / 2);
+    internals.mouseMove(fooRect.right + 20, fooRect.y + fooRect.height / 2);
+    fooDragEnds = 0;
+    internals.sendKey(bar, "Escape");
+    println(`active after escape-canceled drag: ${activeIds()}`);
+    println(`foo dragends after escape-canceled drag: ${fooDragEnds}`);
+
+    internals.click(barRect.x + barRect.width / 2, barRect.y + barRect.height / 2);
+    println(`bar clicks after escape-canceled drag: ${barClicks}`);
+});
+</script>


### PR DESCRIPTION
Clear mousedown activation state whenever primary mousedown tracking is reset. Also reset the drag-and-drop handler when a local link drag ends via Escape, viewport leave, or mouseup outside the viewport.

These paths can otherwise leave drag input suppression active after the user has ended or canceled the drag.

Add an internals mouseLeave primitive and a focused text test. It covers stale :active state, viewport leave, outside-viewport mouseup, Escape canceling, and later click delivery after each canceled drag.