### PR TITLE
Tests: Stop dropping post-navigation load events in Text-mode tests

### DIFF
--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -676,10 +676,12 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
                 on_test_complete();
         };
 
-        view.on_load_finish = [&view, &context, test_index, on_test_complete, url](auto const& loaded_url) {
-            // We don't want subframe loads to trigger the test finish.
-            if (!url.equals(loaded_url, URL::ExcludeFragment::Yes))
-                return;
+        view.on_load_finish = [&view, &context, test_index, on_test_complete](auto const& loaded_url) {
+            // page_did_finish_loading is already top-level-only (Document.cpp gates it on navigable->is_traversable()).
+            // We accept *any* top-level URL here — not just the test's original URL; otherwise a test that navigates
+            // away will hang forever — because the original page's load IPC may arrive after the navigation target's
+            // signal, and the URL filter will then mask the load event for the new page, too.
+            (void)loaded_url;
 
             auto& test = context.tests[test_index];
             test.did_finish_loading = true;


### PR DESCRIPTION
**Problem:** Text-mode tests that perform a top-level cross-document navigation can hang forever — even when the target page reports PASS. For example, the connect-src test in `Tests/LibWeb/Text/input/navigation/` has been intermittently timing out on CI for months, and has its own in-test workaround. But that’s a mitigation that just narrows the race.

**Cause:** The Text-mode `on_load_finish` handler in `test-web/main.cpp` filters by URL and bails out if the loaded URL doesn’t match the test’s original URL — to ignore subframe loads. But `page_did_finish_loading` is already gated on `navigable->is_traversable()`. So, it’s top-level-only — and the URL filter is actually rejecting load events from top-level navigations away from the original test URL.

When the original page’s `did_finish_loading` IPC hasn’t reached test-web by the time the navigation target loads and signals PASS, the target’s `did_finish_loading` is the only surviving load notification — and the URL filter masks it. So, `did_finish_loading` is never set test-side. And so the test-finish handler then bails on the `did_finish_loading && did_check_variants` check — and the test hangs.

**Fix:** Drop the URL filter from the Text-mode `on_load_finish` handler. Any top-level load (the original page, or any subsequent navigation) now sets `did_finish_loading`. The variant-loading logic is unchanged: The second variant-check just no-ops — because `test.variant` is already set from the first response.
