### PR TITLE
LibWeb: Skip non-rendered elements before querying view transition name

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4803,7 +4803,9 @@ Optional<FlyString> Element::document_scoped_view_transition_name()
     // To get the document-scoped view transition name for an Element element:
 
     // 1. Let scopedViewTransitionName be the computed value of view-transition-name for element.
-    auto scoped_view_transition_name = computed_properties()->view_transition_name();
+    auto computed_properties = this->computed_properties();
+    VERIFY(computed_properties);
+    auto scoped_view_transition_name = computed_properties->view_transition_name();
 
     // 2. If scopedViewTransitionName is associated with element’s node document, then return
     //    scopedViewTransitionName.

--- a/Libraries/LibWeb/ViewTransition/ViewTransition.cpp
+++ b/Libraries/LibWeb/ViewTransition/ViewTransition.cpp
@@ -251,11 +251,16 @@ ErrorOr<void> ViewTransition::capture_the_old_state()
         // 2. If element has more than one box fragment, then continue.
         // FIXME: Implement this once we have fragments.
 
+        // OPTIMIZATION: Continue early if the element is not rendered, so we don't have to ensure the computed
+        //               properties are up to date.
+        if (element.not_rendered())
+            return TraversalDecision::Continue;
+
         // 3. Let transitionName be the element’s document-scoped view transition name.
         auto transition_name = element.document_scoped_view_transition_name();
 
         // 4. If transitionName is none, or element is not rendered, then continue.
-        if (!transition_name.has_value() || element.not_rendered())
+        if (!transition_name.has_value())
             return TraversalDecision::Continue;
 
         // 5. If usedTransitionNames contains transitionName, then:
@@ -370,11 +375,16 @@ ErrorOr<void> ViewTransition::capture_the_new_state()
     auto result = document.document_element()->for_each_in_inclusive_subtree_of_type<DOM::Element>([&](auto& element) {
         // NOTE: Step 1 is handled at the end of this function.
 
+        // OPTIMIZATION: Continue early if the element is not rendered, so we don't have to ensure the computed
+        //               properties are up to date.
+        if (element.not_rendered())
+            return TraversalDecision::Continue;
+
         // 2. Let transitionName be the element’s document-scoped view transition name.
         auto transition_name = element.document_scoped_view_transition_name();
 
         // 3. If transitionName is none, or element is not rendered, then continue.
-        if (!transition_name.has_value() || element.not_rendered())
+        if (!transition_name.has_value())
             return TraversalDecision::Continue;
 
         // 4. If element has more than one box fragment, then continue.

--- a/Tests/LibWeb/Crash/CSS/view-transition-display-none-child.html
+++ b/Tests/LibWeb/Crash/CSS/view-transition-display-none-child.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<div id="host" style="display: none"></div>
+<script>
+    document.body.offsetWidth;
+    host.appendChild(document.createElement("span"));
+    document.startViewTransition(() => {});
+</script>


### PR DESCRIPTION
Previously, starting a view transition on an element inside a `display:none` subtree  would crash because querying the view transition name unconditionally accessed `computed_properties()`, which is not calculated for these elements unless explicitly requested. We now skip these non-rendered elements early, before querying the view transition name, to avoid the crash.

This prevents a crash on https://wheelofnames.com, when hiding the right pane.