### PR TITLE
DevTools: Add debugging for grid layouts

### DIFF
--- a/Libraries/LibDevTools/Actors/HighlighterActor.cpp
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.cpp
@@ -28,6 +28,21 @@ HighlighterActor::HighlighterActor(DevToolsServer& devtools, String name, WeakPt
 
 HighlighterActor::~HighlighterActor() = default;
 
+void HighlighterActor::clear_current_highlight()
+{
+    if (auto tab = InspectorActor::tab_for(m_inspector)) {
+        if (m_type_name == "CssGridHighlighter"sv) {
+            if (m_highlighted_grid_node_id.has_value())
+                devtools().delegate().clear_grid_highlight(tab->description(), *m_highlighted_grid_node_id);
+        } else if (m_is_highlighting_dom_node) {
+            devtools().delegate().clear_highlighted_dom_node(tab->description());
+        }
+    }
+
+    m_highlighted_grid_node_id = {};
+    m_is_highlighting_dom_node = false;
+}
+
 void HighlighterActor::handle_message(Message const& message)
 {
     JsonObject response;
@@ -49,6 +64,7 @@ void HighlighterActor::handle_message(Message const& message)
                 m_highlighted_grid_node_id = dom_node->identifier.id;
             } else {
                 devtools().delegate().highlight_dom_node(dom_node->tab->description(), dom_node->identifier.id, dom_node->identifier.pseudo_element);
+                m_is_highlighting_dom_node = true;
             }
             response.set("value"sv, true);
         }
@@ -58,28 +74,23 @@ void HighlighterActor::handle_message(Message const& message)
     }
 
     if (message.type == "hide"sv) {
-        if (auto tab = InspectorActor::tab_for(m_inspector)) {
-            if (m_type_name == "CssGridHighlighter"sv) {
-                devtools().delegate().clear_grid_highlight(tab->description(), m_highlighted_grid_node_id.value_or(0));
-                m_highlighted_grid_node_id = {};
-            } else {
-                devtools().delegate().clear_highlighted_dom_node(tab->description());
-            }
-        }
+        clear_current_highlight();
 
         send_response(message, move(response));
         return;
     }
 
-    if (message.type == "release"sv || message.type == "finalize"sv) {
-        if (auto tab = InspectorActor::tab_for(m_inspector)) {
-            if (m_type_name == "CssGridHighlighter"sv)
-                devtools().delegate().clear_grid_highlight(tab->description(), m_highlighted_grid_node_id.value_or(0));
-            else
-                devtools().delegate().clear_highlighted_dom_node(tab->description());
-        }
+    if (message.type == "release"sv) {
+        clear_current_highlight();
 
         send_response(message, move(response));
+        devtools().unregister_actor(name());
+        return;
+    }
+
+    if (message.type == "finalize"sv) {
+        clear_current_highlight();
+        devtools().unregister_actor(name());
         return;
     }
 

--- a/Libraries/LibDevTools/Actors/HighlighterActor.cpp
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.cpp
@@ -14,14 +14,15 @@
 
 namespace DevTools {
 
-NonnullRefPtr<HighlighterActor> HighlighterActor::create(DevToolsServer& devtools, String name, WeakPtr<InspectorActor> inspector)
+NonnullRefPtr<HighlighterActor> HighlighterActor::create(DevToolsServer& devtools, String name, WeakPtr<InspectorActor> inspector, String type_name)
 {
-    return adopt_ref(*new HighlighterActor(devtools, move(name), move(inspector)));
+    return adopt_ref(*new HighlighterActor(devtools, move(name), move(inspector), move(type_name)));
 }
 
-HighlighterActor::HighlighterActor(DevToolsServer& devtools, String name, WeakPtr<InspectorActor> inspector)
+HighlighterActor::HighlighterActor(DevToolsServer& devtools, String name, WeakPtr<InspectorActor> inspector, String type_name)
     : Actor(devtools, move(name))
     , m_inspector(move(inspector))
+    , m_type_name(move(type_name))
 {
 }
 
@@ -39,7 +40,16 @@ void HighlighterActor::handle_message(Message const& message)
         response.set("value"sv, false);
 
         if (auto dom_node = WalkerActor::dom_node_for(InspectorActor::walker_for(m_inspector), *node); dom_node.has_value()) {
-            devtools().delegate().highlight_dom_node(dom_node->tab->description(), dom_node->identifier.id, dom_node->identifier.pseudo_element);
+            if (m_type_name == "CssGridHighlighter"sv) {
+                if (m_highlighted_grid_node_id.has_value() && *m_highlighted_grid_node_id != dom_node->identifier.id)
+                    devtools().delegate().clear_grid_highlight(dom_node->tab->description(), *m_highlighted_grid_node_id);
+
+                auto options = message.data.get("options"sv).value_or(JsonObject {});
+                devtools().delegate().highlight_grid(dom_node->tab->description(), dom_node->identifier.id, move(options));
+                m_highlighted_grid_node_id = dom_node->identifier.id;
+            } else {
+                devtools().delegate().highlight_dom_node(dom_node->tab->description(), dom_node->identifier.id, dom_node->identifier.pseudo_element);
+            }
             response.set("value"sv, true);
         }
 
@@ -48,8 +58,26 @@ void HighlighterActor::handle_message(Message const& message)
     }
 
     if (message.type == "hide"sv) {
-        if (auto tab = InspectorActor::tab_for(m_inspector))
-            devtools().delegate().clear_highlighted_dom_node(tab->description());
+        if (auto tab = InspectorActor::tab_for(m_inspector)) {
+            if (m_type_name == "CssGridHighlighter"sv) {
+                devtools().delegate().clear_grid_highlight(tab->description(), m_highlighted_grid_node_id.value_or(0));
+                m_highlighted_grid_node_id = {};
+            } else {
+                devtools().delegate().clear_highlighted_dom_node(tab->description());
+            }
+        }
+
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "release"sv || message.type == "finalize"sv) {
+        if (auto tab = InspectorActor::tab_for(m_inspector)) {
+            if (m_type_name == "CssGridHighlighter"sv)
+                devtools().delegate().clear_grid_highlight(tab->description(), m_highlighted_grid_node_id.value_or(0));
+            else
+                devtools().delegate().clear_highlighted_dom_node(tab->description());
+        }
 
         send_response(message, move(response));
         return;

--- a/Libraries/LibDevTools/Actors/HighlighterActor.h
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.h
@@ -7,8 +7,10 @@
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
 #include <LibDevTools/Actor.h>
 #include <LibDevTools/Forward.h>
+#include <LibWeb/Forward.h>
 
 namespace DevTools {
 
@@ -16,17 +18,19 @@ class DEVTOOLS_API HighlighterActor final : public Actor {
 public:
     static constexpr auto base_name = "highlighter"sv;
 
-    static NonnullRefPtr<HighlighterActor> create(DevToolsServer&, String name, WeakPtr<InspectorActor>);
+    static NonnullRefPtr<HighlighterActor> create(DevToolsServer&, String name, WeakPtr<InspectorActor>, String type_name);
     virtual ~HighlighterActor() override;
 
     JsonValue serialize_highlighter() const;
 
 private:
-    HighlighterActor(DevToolsServer&, String name, WeakPtr<InspectorActor>);
+    HighlighterActor(DevToolsServer&, String name, WeakPtr<InspectorActor>, String type_name);
 
     virtual void handle_message(Message const&) override;
 
     WeakPtr<InspectorActor> m_inspector;
+    String m_type_name;
+    Optional<Web::UniqueNodeID> m_highlighted_grid_node_id;
 };
 
 }

--- a/Libraries/LibDevTools/Actors/HighlighterActor.h
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.h
@@ -28,9 +28,12 @@ private:
 
     virtual void handle_message(Message const&) override;
 
+    void clear_current_highlight();
+
     WeakPtr<InspectorActor> m_inspector;
     String m_type_name;
     Optional<Web::UniqueNodeID> m_highlighted_grid_node_id;
+    bool m_is_highlighting_dom_node { false };
 };
 
 }

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -48,7 +48,7 @@ void InspectorActor::handle_message(Message const& message)
             return;
 
         auto highlighter = m_highlighters.ensure(*type_name, [&]() -> NonnullRefPtr<HighlighterActor> {
-            return devtools().register_actor<HighlighterActor>(*this);
+            return devtools().register_actor<HighlighterActor>(*this, *type_name);
         });
 
         response.set("highlighter"sv, highlighter->serialize_highlighter());

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -47,11 +47,9 @@ void InspectorActor::handle_message(Message const& message)
         if (!type_name.has_value())
             return;
 
-        auto highlighter = m_highlighters.ensure(*type_name, [&]() -> NonnullRefPtr<HighlighterActor> {
-            return devtools().register_actor<HighlighterActor>(*this, *type_name);
-        });
+        auto& highlighter = devtools().register_actor<HighlighterActor>(*this, *type_name);
 
-        response.set("highlighter"sv, highlighter->serialize_highlighter());
+        response.set("highlighter"sv, highlighter.serialize_highlighter());
         send_response(message, move(response));
         return;
     }

--- a/Libraries/LibDevTools/Actors/InspectorActor.h
+++ b/Libraries/LibDevTools/Actors/InspectorActor.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/HashMap.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibDevTools/Actor.h>
 #include <LibDevTools/Forward.h>
@@ -33,7 +32,6 @@ private:
     WeakPtr<TabActor> m_tab;
     WeakPtr<WalkerActor> m_walker;
     WeakPtr<PageStyleActor> m_page_style;
-    HashMap<String, WeakPtr<HighlighterActor>> m_highlighters;
 };
 
 }

--- a/Libraries/LibDevTools/Actors/LayoutInspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/LayoutInspectorActor.cpp
@@ -7,16 +7,72 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <LibDevTools/Actors/LayoutInspectorActor.h>
+#include <LibDevTools/Actors/TabActor.h>
+#include <LibDevTools/Actors/WalkerActor.h>
+#include <LibDevTools/DevToolsDelegate.h>
+#include <LibDevTools/DevToolsServer.h>
 
 namespace DevTools {
 
-NonnullRefPtr<LayoutInspectorActor> LayoutInspectorActor::create(DevToolsServer& devtools, String name)
+static constexpr auto grid_container_node_id_key = "containerNodeId"sv;
+
+static Optional<Web::UniqueNodeID> container_node_id_from_grid_layout(JsonObject const& grid_layout)
 {
-    return adopt_ref(*new LayoutInspectorActor(devtools, move(name)));
+    auto node_id = grid_layout.get_i64(grid_container_node_id_key);
+    if (!node_id.has_value())
+        return {};
+    return Web::UniqueNodeID { *node_id };
 }
 
-LayoutInspectorActor::LayoutInspectorActor(DevToolsServer& devtools, String name)
+NonnullRefPtr<GridActor> GridActor::create(DevToolsServer& devtools, String name, WeakPtr<LayoutInspectorActor> layout_inspector, WeakPtr<WalkerActor> walker, Web::UniqueNodeID container_node_id, JsonObject grid_layout)
+{
+    return adopt_ref(*new GridActor(devtools, move(name), move(layout_inspector), move(walker), container_node_id, move(grid_layout)));
+}
+
+GridActor::GridActor(DevToolsServer& devtools, String name, WeakPtr<LayoutInspectorActor> layout_inspector, WeakPtr<WalkerActor> walker, Web::UniqueNodeID container_node_id, JsonObject grid_layout)
     : Actor(devtools, move(name))
+    , m_layout_inspector(move(layout_inspector))
+    , m_walker(move(walker))
+    , m_container_node_id(container_node_id)
+    , m_grid_layout(move(grid_layout))
+{
+}
+
+GridActor::~GridActor() = default;
+
+void GridActor::update_grid_layout(JsonObject grid_layout)
+{
+    m_grid_layout = move(grid_layout);
+}
+
+void GridActor::handle_message(Message const& message)
+{
+    send_unrecognized_packet_type_error(message);
+}
+
+JsonValue GridActor::serialize_grid() const
+{
+    auto grid = m_grid_layout;
+    grid.remove(grid_container_node_id_key);
+    grid.set("actor"sv, name());
+
+    if (auto walker = m_walker.strong_ref()) {
+        if (auto node_actor_name = walker->node_actor_name_for(m_container_node_id); node_actor_name.has_value())
+            grid.set("containerNodeActorID"sv, node_actor_name.release_value());
+    }
+
+    return grid;
+}
+
+NonnullRefPtr<LayoutInspectorActor> LayoutInspectorActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<WalkerActor> walker)
+{
+    return adopt_ref(*new LayoutInspectorActor(devtools, move(name), move(tab), move(walker)));
+}
+
+LayoutInspectorActor::LayoutInspectorActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<WalkerActor> walker)
+    : Actor(devtools, move(name))
+    , m_tab(move(tab))
+    , m_walker(move(walker))
 {
 }
 
@@ -32,13 +88,96 @@ void LayoutInspectorActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "getCurrentGrid"sv) {
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
+            return;
+
+        auto dom_node = WalkerActor::dom_node_for(m_walker, *node);
+        if (!dom_node.has_value()) {
+            send_unknown_actor_error(message, *node);
+            return;
+        }
+
+        auto tab = m_tab.strong_ref();
+        if (!tab) {
+            response.set("grid"sv, JsonValue {});
+            send_response(message, move(response));
+            return;
+        }
+
+        devtools().delegate().inspect_current_grid(tab->description(), dom_node->identifier.id,
+            weak_callback(*this, [message](auto& self, Optional<JsonObject> grid_layout) {
+                JsonObject response;
+                if (grid_layout.has_value()) {
+                    if (auto grid_actor = self.actor_for_grid_layout(grid_layout.release_value()); grid_actor.has_value())
+                        response.set("grid"sv, grid_actor->serialize_grid());
+                    else
+                        response.set("grid"sv, JsonValue {});
+                } else {
+                    response.set("grid"sv, JsonValue {});
+                }
+
+                self.send_response(message, move(response));
+            }));
+
+        return;
+    }
+
     if (message.type == "getGrids"sv) {
-        response.set("grids"sv, JsonArray {});
-        send_response(message, move(response));
+        auto root_node = get_required_parameter<String>(message, "rootNode"sv);
+        if (!root_node.has_value())
+            return;
+
+        auto dom_node = WalkerActor::dom_node_for(m_walker, *root_node);
+        if (!dom_node.has_value()) {
+            send_unknown_actor_error(message, *root_node);
+            return;
+        }
+
+        auto tab = m_tab.strong_ref();
+        if (!tab) {
+            response.set("grids"sv, JsonArray {});
+            send_response(message, move(response));
+            return;
+        }
+
+        devtools().delegate().inspect_grid_layouts(tab->description(), dom_node->identifier.id,
+            weak_callback(*this, [message](auto& self, JsonArray grid_layouts) {
+                JsonArray grids;
+                grid_layouts.for_each([&](auto const& grid_layout) {
+                    if (!grid_layout.is_object())
+                        return;
+
+                    if (auto grid_actor = self.actor_for_grid_layout(grid_layout.as_object()); grid_actor.has_value())
+                        grids.must_append(grid_actor->serialize_grid());
+                });
+
+                JsonObject response;
+                response.set("grids"sv, move(grids));
+                self.send_response(message, move(response));
+            }));
+
         return;
     }
 
     send_unrecognized_packet_type_error(message);
+}
+
+Optional<GridActor&> LayoutInspectorActor::actor_for_grid_layout(JsonObject grid_layout)
+{
+    auto container_node_id = container_node_id_from_grid_layout(grid_layout);
+    if (!container_node_id.has_value())
+        return {};
+
+    if (auto* grid_actor = m_grid_actors.get(*container_node_id).value_or(nullptr)) {
+        grid_actor->update_grid_layout(move(grid_layout));
+        return *grid_actor;
+    }
+
+    auto& grid_actor = devtools().register_actor<GridActor>(make_weak_ptr<LayoutInspectorActor>(), m_walker, *container_node_id, move(grid_layout));
+    m_grid_actors.set(*container_node_id, grid_actor);
+    return grid_actor;
 }
 
 }

--- a/Libraries/LibDevTools/Actors/LayoutInspectorActor.h
+++ b/Libraries/LibDevTools/Actors/LayoutInspectorActor.h
@@ -6,23 +6,54 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
+#include <AK/JsonObject.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibDevTools/Actor.h>
 #include <LibDevTools/Forward.h>
+#include <LibWeb/Forward.h>
 
 namespace DevTools {
+
+class DEVTOOLS_API GridActor final : public Actor {
+public:
+    static constexpr auto base_name = "grid"sv;
+
+    static NonnullRefPtr<GridActor> create(DevToolsServer&, String name, WeakPtr<LayoutInspectorActor>, WeakPtr<WalkerActor>, Web::UniqueNodeID, JsonObject);
+    virtual ~GridActor() override;
+
+    void update_grid_layout(JsonObject);
+    Web::UniqueNodeID container_node_id() const { return m_container_node_id; }
+    JsonValue serialize_grid() const;
+
+private:
+    GridActor(DevToolsServer&, String name, WeakPtr<LayoutInspectorActor>, WeakPtr<WalkerActor>, Web::UniqueNodeID, JsonObject);
+
+    virtual void handle_message(Message const&) override;
+
+    WeakPtr<LayoutInspectorActor> m_layout_inspector;
+    WeakPtr<WalkerActor> m_walker;
+    Web::UniqueNodeID m_container_node_id;
+    JsonObject m_grid_layout;
+};
 
 class DEVTOOLS_API LayoutInspectorActor final : public Actor {
 public:
     static constexpr auto base_name = "layout-inspector"sv;
 
-    static NonnullRefPtr<LayoutInspectorActor> create(DevToolsServer&, String name);
+    static NonnullRefPtr<LayoutInspectorActor> create(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<WalkerActor>);
     virtual ~LayoutInspectorActor() override;
 
 private:
-    LayoutInspectorActor(DevToolsServer&, String name);
+    LayoutInspectorActor(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<WalkerActor>);
 
     virtual void handle_message(Message const&) override;
+
+    Optional<GridActor&> actor_for_grid_layout(JsonObject);
+
+    WeakPtr<TabActor> m_tab;
+    WeakPtr<WalkerActor> m_walker;
+    HashMap<Web::UniqueNodeID, WeakPtr<GridActor>> m_grid_actors;
 };
 
 }

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -208,6 +208,26 @@ void WalkerActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "getParentGridNode"sv) {
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
+            return;
+
+        auto dom_node = WalkerActor::dom_node_for(*this, *node);
+        if (!dom_node.has_value()) {
+            send_unknown_actor_error(message, *node);
+            return;
+        }
+
+        JsonValue parent_grid_node;
+        if (auto parent_grid = parent_grid_node_for_node(dom_node->node); parent_grid.has_value())
+            parent_grid_node = serialize_node(parent_grid.value());
+
+        response.set("node"sv, move(parent_grid_node));
+        send_response(message, move(response));
+        return;
+    }
+
     if (message.type == "innerHTML"sv) {
         auto node = get_required_parameter<String>(message, "node"sv);
         if (!node.has_value())
@@ -677,6 +697,24 @@ Optional<JsonObject const&> WalkerActor::next_sibling_for_node(JsonObject const&
     if (!parent.has_value() || !parent.value())
         return {};
     return sibling_for_node(*parent.value(), node, Direction::Next);
+}
+
+Optional<JsonObject const&> WalkerActor::parent_grid_node_for_node(JsonObject const& node) const
+{
+    auto parent = m_dom_node_to_parent_map.get(&node);
+    while (parent.has_value() && parent.value()) {
+        auto display = parent.value()->get_string("display"sv);
+        if (!display.has_value())
+            return {};
+        if (display->contains("grid"sv))
+            return *parent.value();
+        if (*display != "contents"sv)
+            return {};
+
+        parent = m_dom_node_to_parent_map.get(parent.value());
+    }
+
+    return {};
 }
 
 Optional<JsonObject const&> WalkerActor::remove_node(JsonObject const& node)

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -109,7 +109,7 @@ void WalkerActor::handle_message(Message const& message)
 
     if (message.type == "getLayoutInspector"sv) {
         if (!m_layout_inspector)
-            m_layout_inspector = devtools().register_actor<LayoutInspectorActor>();
+            m_layout_inspector = devtools().register_actor<LayoutInspectorActor>(m_tab, make_weak_ptr<WalkerActor>());
 
         JsonObject actor;
         actor.set("actor"sv, m_layout_inspector->name());
@@ -143,14 +143,41 @@ void WalkerActor::handle_message(Message const& message)
             if (first.is_string() && first.as_string() == "rawAccessible"sv
                 && second.is_string() && second.as_string() == "DOMNode"sv) {
 
-                auto maybe_accessibility_actor = devtools().actor_registry().find(actor_id.value());
-                if (maybe_accessibility_actor == devtools().actor_registry().end()) {
+                auto maybe_actor = devtools().actor_registry().find(actor_id.value());
+                if (maybe_actor == devtools().actor_registry().end()) {
                     send_unknown_actor_error(message, actor_id.value());
                     return;
                 }
 
-                auto accessibility_actor = as<AccessibilityNodeActor>(maybe_accessibility_actor->value.ptr());
+                auto accessibility_actor = as<AccessibilityNodeActor>(maybe_actor->value.ptr());
                 if (auto node_actor_name = m_dom_node_id_to_actor_map.get(accessibility_actor->node_identifier().id); node_actor_name.has_value()) {
+                    auto dom_node = dom_node_for(this, node_actor_name.value());
+                    if (!dom_node.has_value()) {
+                        send_unknown_actor_error(message, node_actor_name.value());
+                        return;
+                    }
+
+                    JsonObject node;
+                    node.set("node"sv, serialize_node(dom_node->node));
+                    node.set("newParents"sv, JsonArray {});
+
+                    response.set("node"sv, move(node));
+                    send_response(message, move(response));
+                    return;
+                }
+            }
+        }
+
+        // Firefox asks for ["containerEl"] on a GridActor when the grid form did not include a containerNodeActorID.
+        if (path->size() == 1 && path->at(0).is_string() && path->at(0).as_string() == "containerEl"sv) {
+            auto maybe_actor = devtools().actor_registry().find(actor_id.value());
+            if (maybe_actor == devtools().actor_registry().end()) {
+                send_unknown_actor_error(message, actor_id.value());
+                return;
+            }
+
+            if (auto* grid_actor = as_if<GridActor>(maybe_actor->value.ptr())) {
+                if (auto node_actor_name = m_dom_node_id_to_actor_map.get(grid_actor->container_node_id()); node_actor_name.has_value()) {
                     auto dom_node = dom_node_for(this, node_actor_name.value());
                     if (!dom_node.has_value()) {
                         send_unknown_actor_error(message, node_actor_name.value());
@@ -516,7 +543,7 @@ JsonValue WalkerActor::serialize_node(JsonObject const& node) const
     serialized.set("causesOverflow"sv, false);
     serialized.set("containerType"sv, JsonValue {});
     serialized.set("displayName"sv, name.to_ascii_lowercase());
-    serialized.set("displayType"sv, "block"sv);
+    serialized.set("displayType"sv, node.get_string("display"sv).value_or("block"_string));
     serialized.set("hasEventListeners"sv, false);
     serialized.set("isAfterPseudoElement"sv, is_after_pseudo_element);
     serialized.set("isAnonymous"sv, false);
@@ -574,6 +601,11 @@ Optional<Node> WalkerActor::dom_node(StringView actor)
     auto identifier = NodeIdentifier::for_node(dom_node);
 
     return Node { .node = dom_node, .identifier = move(identifier), .tab = tab.release_nonnull() };
+}
+
+Optional<String> WalkerActor::node_actor_name_for(Web::UniqueNodeID node_id) const
+{
+    return m_dom_node_id_to_actor_map.get(node_id).copy();
 }
 
 Optional<JsonObject const&> WalkerActor::find_node_by_selector(JsonObject const& node, StringView selector)

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -31,6 +31,7 @@ public:
 
     static Optional<Node> dom_node_for(WeakPtr<WalkerActor> const&, StringView actor);
     Optional<Node> dom_node(StringView actor);
+    Optional<String> node_actor_name_for(Web::UniqueNodeID) const;
 
 private:
     WalkerActor(DevToolsServer&, String name, WeakPtr<TabActor>, JsonObject dom_tree);

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -43,6 +43,7 @@ private:
 
     Optional<JsonObject const&> previous_sibling_for_node(JsonObject const& node);
     Optional<JsonObject const&> next_sibling_for_node(JsonObject const& node);
+    Optional<JsonObject const&> parent_grid_node_for_node(JsonObject const& node) const;
     Optional<JsonObject const&> remove_node(JsonObject const& node);
 
     void new_dom_node_mutation(WebView::Mutation);

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -8,6 +8,8 @@
 
 #include <AK/Error.h>
 #include <AK/Function.h>
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>
@@ -45,8 +47,15 @@ public:
     virtual void inspect_dom_node(TabDescription const&, WebView::DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>) const { }
     virtual void clear_inspected_dom_node(TabDescription const&) const { }
 
+    using OnGridLayoutsReceived = Function<void(JsonArray)>;
+    using OnCurrentGridReceived = Function<void(Optional<JsonObject>)>;
+    virtual void inspect_grid_layouts(TabDescription const&, Web::UniqueNodeID, OnGridLayoutsReceived) const { }
+    virtual void inspect_current_grid(TabDescription const&, Web::UniqueNodeID, OnCurrentGridReceived) const { }
+
     virtual void highlight_dom_node(TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>) const { }
     virtual void clear_highlighted_dom_node(TabDescription const&) const { }
+    virtual void highlight_grid(TabDescription const&, Web::UniqueNodeID, JsonValue) const { }
+    virtual void clear_grid_highlight(TabDescription const&, Web::UniqueNodeID) const { }
 
     using OnDOMMutationReceived = Function<void(WebView::Mutation)>;
     virtual void listen_for_dom_mutations(TabDescription const&, OnDOMMutationReceived) const { }

--- a/Libraries/LibDevTools/DevToolsServer.cpp
+++ b/Libraries/LibDevTools/DevToolsServer.cpp
@@ -62,6 +62,13 @@ void DevToolsServer::refresh_tab_list()
     m_root_actor->send_tab_list_changed_message();
 }
 
+void DevToolsServer::unregister_actor(String const& name)
+{
+    Core::deferred_invoke([this, name] {
+        m_actor_registry.remove(name);
+    });
+}
+
 ErrorOr<void> DevToolsServer::on_new_client()
 {
     if (m_connection)

--- a/Libraries/LibDevTools/DevToolsServer.h
+++ b/Libraries/LibDevTools/DevToolsServer.h
@@ -29,6 +29,7 @@ public:
     DevToolsDelegate const& delegate() const { return m_delegate; }
     ActorRegistry const& actor_registry() const { return m_actor_registry; }
     Optional<u16> local_port() const;
+    void unregister_actor(String const& name);
 
     template<typename ActorType, typename... Args>
     ActorType& register_actor(Args&&... args)

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -1065,14 +1065,16 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         // https://www.w3.org/TR/css-grid-2/#resolved-track-list-standalone
         if (property_id == PropertyID::GridTemplateColumns) {
             if (auto first_paintable = layout_node.first_paintable(); auto const* paintable_box = as_if<Painting::PaintableBox>(first_paintable.ptr())) {
-                if (auto used_values_for_grid_template_columns = paintable_box->used_values_for_grid_template_columns()) {
-                    return used_values_for_grid_template_columns;
+                if (auto const* grid_layout_data = paintable_box->grid_layout_data()) {
+                    if (auto const& resolved_grid_template_columns = grid_layout_data->resolved_grid_template_columns)
+                        return resolved_grid_template_columns;
                 }
             }
         } else if (property_id == PropertyID::GridTemplateRows) {
             if (auto first_paintable = layout_node.first_paintable(); auto const* paintable_box = as_if<Painting::PaintableBox>(first_paintable.ptr())) {
-                if (auto used_values_for_grid_template_rows = paintable_box->used_values_for_grid_template_rows()) {
-                    return used_values_for_grid_template_rows;
+                if (auto const* grid_layout_data = paintable_box->grid_layout_data()) {
+                    if (auto const& resolved_grid_template_rows = grid_layout_data->resolved_grid_template_rows)
+                        return resolved_grid_template_rows;
                 }
             }
         }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -674,6 +674,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_hovered_node);
     visitor.visit(m_inspected_node);
     visitor.visit(m_highlighted_node);
+    for (auto const& grid_highlight : m_grid_highlights)
+        visitor.visit(grid_highlight.node);
     visitor.visit(m_active_favicon);
     visitor.visit(m_browsing_context);
     visitor.visit(m_focused_area);
@@ -2605,6 +2607,44 @@ void Document::set_highlighted_node(GC::Ptr<Node> node, Optional<CSS::PseudoElem
 
     if (auto layout_node = highlighted_layout_node(); layout_node && layout_node->first_paintable())
         layout_node->first_paintable()->set_needs_repaint();
+}
+
+void Document::set_grid_highlighted_node(GC::Ptr<Node> node, Painting::GridInspectorOverlayOptions options)
+{
+    if (!node)
+        return;
+
+    for (auto& grid_highlight : m_grid_highlights) {
+        if (grid_highlight.node != node)
+            continue;
+
+        grid_highlight.options = options;
+        node->set_needs_repaint();
+        return;
+    }
+
+    m_grid_highlights.append({ node, options });
+    node->set_needs_repaint();
+}
+
+void Document::clear_grid_highlighted_node(GC::Ptr<Node> node)
+{
+    if (!node) {
+        for (auto const& grid_highlight : m_grid_highlights) {
+            if (grid_highlight.node)
+                grid_highlight.node->set_needs_repaint();
+        }
+        m_grid_highlights.clear();
+        return;
+    }
+
+    auto old_size = m_grid_highlights.size();
+    m_grid_highlights.remove_all_matching([&](auto const& grid_highlight) {
+        return grid_highlight.node == node;
+    });
+
+    if (m_grid_highlights.size() != old_size)
+        node->set_needs_repaint();
 }
 
 GC::Ptr<Layout::Node> Document::highlighted_layout_node()
@@ -8293,6 +8333,16 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
 
     if (highlighted_node() && highlighted_node()->paintable()) {
         highlighted_node()->paintable()->paint_inspector_overlay(context);
+    }
+
+    for (auto const& grid_highlight : m_grid_highlights) {
+        if (!grid_highlight.node)
+            continue;
+        auto paintable = grid_highlight.node->paintable();
+        auto const* paintable_box = as_if<Painting::PaintableBox>(paintable.ptr());
+        if (!paintable_box)
+            continue;
+        paintable_box->paint_grid_inspector_overlay(context, grid_highlight.options);
     }
 
     return display_list;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -46,6 +46,7 @@
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/InvalidateDisplayList.h>
+#include <LibWeb/Painting/GridInspectorOverlay.h>
 #include <LibWeb/ResizeObserver/ResizeObserver.h>
 #include <LibWeb/TrustedTypes/InjectionSink.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -119,6 +120,7 @@ enum class InvalidateLayoutTreeReason {
     X(HTMLLabelElementActivationBehavior)    \
     X(HostedDocumentBeforePaint)             \
     X(InspectDOMTree)                        \
+    X(InspectGridLayout)                     \
     X(InternalsHitTest)                      \
     X(MediaQueryListMatches)                 \
     X(NavigableSelectedText)                 \
@@ -304,6 +306,8 @@ public:
     GC::Ptr<Node const> highlighted_node() const { return m_highlighted_node; }
     GC::Ptr<Layout::Node> highlighted_layout_node();
     GC::Ptr<Layout::Node const> highlighted_layout_node() const { return const_cast<Document*>(this)->highlighted_layout_node(); }
+    void set_grid_highlighted_node(GC::Ptr<Node>, Painting::GridInspectorOverlayOptions);
+    void clear_grid_highlighted_node(GC::Ptr<Node>);
 
     Element* document_element();
     Element const* document_element() const;
@@ -1200,6 +1204,12 @@ private:
     GC::Ptr<Node> m_inspected_node;
     GC::Ptr<Node> m_highlighted_node;
     Optional<CSS::PseudoElement> m_highlighted_pseudo_element;
+
+    struct GridHighlight {
+        GC::Ptr<Node> node;
+        Painting::GridInspectorOverlayOptions options;
+    };
+    Vector<GridHighlight> m_grid_highlights;
 
     Optional<Color> m_normal_link_color;
     Optional<Color> m_active_link_color;

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2079,6 +2079,7 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
         }
 
         if (paintable_box()) {
+            MUST(object.add("display"sv, paintable_box()->computed_values().display().to_string()));
             if (paintable_box()->could_be_scrolled_by_wheel_event()) {
                 MUST(object.add("scrollable"sv, true));
             }

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2422,6 +2422,7 @@ void GridFormattingContext::save_grid_layout_data(CSS::GridTrackSizeList&& colum
 {
     auto data = make<GridLayoutData>();
     data->direction = grid_container().computed_values().direction();
+    data->is_subgrid = is_subgridded_axis(GridDimension::Column) || is_subgridded_axis(GridDimension::Row);
     data->writing_mode = grid_container().computed_values().writing_mode();
     data->resolved_grid_template_columns = CSS::GridTrackSizeListStyleValue::create(move(columns));
     data->resolved_grid_template_rows = CSS::GridTrackSizeListStyleValue::create(move(rows));

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -159,7 +159,7 @@ static Alignment to_alignment(CSS::AlignItems value)
     }
 }
 
-GridFormattingContext::GridTrack GridFormattingContext::GridTrack::create_from_definition(CSS::ExplicitGridTrack const& definition, bool is_auto_fit = false)
+GridFormattingContext::GridTrack GridFormattingContext::GridTrack::create_from_definition(CSS::ExplicitGridTrack const& definition, bool is_auto_fit, bool is_auto_repeat)
 {
     // NOTE: repeat() is expected to be expanded beforehand.
     VERIFY(!definition.is_repeat());
@@ -169,6 +169,7 @@ GridFormattingContext::GridTrack GridFormattingContext::GridTrack::create_from_d
             .min_track_sizing_function = definition.minmax().min_grid_size(),
             .max_track_sizing_function = definition.minmax().max_grid_size(),
             .is_auto_fit = is_auto_fit,
+            .is_auto_repeat = is_auto_repeat,
         };
     }
 
@@ -186,6 +187,7 @@ GridFormattingContext::GridTrack GridFormattingContext::GridTrack::create_from_d
         .min_track_sizing_function = min_track_sizing_function,
         .max_track_sizing_function = max_track_sizing_function,
         .is_auto_fit = is_auto_fit,
+        .is_auto_repeat = is_auto_repeat,
     };
 }
 
@@ -977,19 +979,22 @@ void GridFormattingContext::initialize_grid_tracks_from_definition(GridDimension
     for (auto const& track_definition : tracks_definition) {
         int repeat_count = 1;
         bool is_auto_fit = false;
+        bool is_auto_repeat = false;
         if (track_definition.is_repeat()) {
             is_auto_fit = track_definition.repeat().is_auto_fit();
-            if (track_definition.repeat().is_auto_fill() || is_auto_fit)
+            if (track_definition.repeat().is_auto_fill() || is_auto_fit) {
+                is_auto_repeat = true;
                 repeat_count = count_of_repeated_auto_fill_or_fit_tracks(dimension, track_definition);
-            else
+            } else {
                 repeat_count = track_definition.repeat().repeat_count();
+            }
         }
         for (auto _ = 0; _ < repeat_count; _++) {
             if (track_definition.is_default() || track_definition.is_minmax()) {
-                tracks.append(GridTrack::create_from_definition(track_definition, is_auto_fit));
+                tracks.append(GridTrack::create_from_definition(track_definition, is_auto_fit, is_auto_repeat));
             } else if (track_definition.is_repeat()) {
                 for (auto& explicit_grid_track : track_definition.repeat().grid_track_size_list().track_list()) {
-                    tracks.append(GridTrack::create_from_definition(explicit_grid_track, is_auto_fit));
+                    tracks.append(GridTrack::create_from_definition(explicit_grid_track, is_auto_fit, is_auto_repeat));
                 }
             } else {
                 VERIFY_NOT_REACHED();
@@ -1051,6 +1056,7 @@ void GridFormattingContext::initialize_grid_tracks_for_columns_and_rows()
         size_t implicit_column_index = 0;
         // NOTE: If there are implicit tracks created by items with negative indexes they should prepend explicitly defined tracks
         auto negative_index_implied_column_tracks_count = abs(m_occupation_grid.min_column_index());
+        m_explicit_columns_start_line_index = negative_index_implied_column_tracks_count;
         for (int i = 0; i < negative_index_implied_column_tracks_count; i++)
             m_column_lines.insert(0, {});
         for (int column_index = 0; column_index < negative_index_implied_column_tracks_count; column_index++) {
@@ -1081,6 +1087,7 @@ void GridFormattingContext::initialize_grid_tracks_for_columns_and_rows()
         size_t implicit_row_index = 0;
         // NOTE: If there are implicit tracks created by items with negative indexes they should prepend explicitly defined tracks
         auto negative_index_implied_row_tracks_count = abs(m_occupation_grid.min_row_index());
+        m_explicit_rows_start_line_index = negative_index_implied_row_tracks_count;
         for (int i = 0; i < negative_index_implied_row_tracks_count; i++)
             m_row_lines.insert(0, {});
         for (int row_index = 0; row_index < negative_index_implied_row_tracks_count; row_index++) {
@@ -2411,6 +2418,147 @@ void GridFormattingContext::resolve_track_spacing(GridDimension dimension)
     }
 }
 
+void GridFormattingContext::save_grid_layout_data(CSS::GridTrackSizeList&& columns, CSS::GridTrackSizeList&& rows)
+{
+    auto data = make<GridLayoutData>();
+    data->direction = grid_container().computed_values().direction();
+    data->writing_mode = grid_container().computed_values().writing_mode();
+    data->resolved_grid_template_columns = CSS::GridTrackSizeListStyleValue::create(move(columns));
+    data->resolved_grid_template_rows = CSS::GridTrackSizeListStyleValue::create(move(rows));
+
+    auto track_type_for_index = [](size_t index, size_t explicit_start_line_index, size_t explicit_line_count) {
+        if (explicit_line_count == 0)
+            return GridTrackType::Implicit;
+
+        auto explicit_track_count = explicit_line_count - 1;
+        if (index >= explicit_start_line_index && index < explicit_start_line_index + explicit_track_count)
+            return GridTrackType::Explicit;
+        return GridTrackType::Implicit;
+    };
+
+    auto line_type_for_index = [](size_t index, size_t explicit_start_line_index, size_t explicit_line_count) {
+        if (index >= explicit_start_line_index && index < explicit_start_line_index + explicit_line_count)
+            return GridTrackType::Explicit;
+        return GridTrackType::Implicit;
+    };
+
+    auto line_number_for_index = [](size_t index, size_t explicit_start_line_index) -> u32 {
+        if (index < explicit_start_line_index)
+            return 0;
+        return static_cast<u32>(index - explicit_start_line_index + 1);
+    };
+
+    auto negative_line_number_for_index = [](size_t index, size_t explicit_start_line_index, size_t explicit_line_count) -> i32 {
+        auto explicit_end_line_index = explicit_start_line_index + explicit_line_count;
+        if (index >= explicit_end_line_index)
+            return 0;
+        return -static_cast<i32>(explicit_end_line_index - index);
+    };
+
+    auto track_state = [&](GridTrack const& track, GridDimension dimension, size_t track_index) {
+        if (!track.is_auto_repeat)
+            return GridTrackState::Static;
+
+        if (track.is_auto_fit && !m_occupation_grid.is_occupied(dimension == GridDimension::Column ? track_index : 0, dimension == GridDimension::Row ? track_index : 0))
+            return GridTrackState::Removed;
+
+        return GridTrackState::Repeat;
+    };
+
+    auto axis_start_offset = [&](GridDimension dimension) -> CSSPixels {
+        auto const& tracks_and_gaps = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
+        auto grid_container_size = grid_container_size_for_track_alignment(dimension);
+
+        CSSPixels sum_of_base_sizes_including_gaps = 0;
+        for (auto const& track : tracks_and_gaps)
+            sum_of_base_sizes_including_gaps += track.base_size;
+
+        Alignment alignment;
+        if (dimension == GridDimension::Column)
+            alignment = to_alignment(grid_container().computed_values().justify_content());
+        else
+            alignment = to_alignment(grid_container().computed_values().align_content());
+
+        if (alignment == Alignment::Center) {
+            auto free_space = grid_container_size - sum_of_base_sizes_including_gaps;
+            return static_cast<CSSPixels>(free_space / 2);
+        }
+        if (alignment == Alignment::SpaceAround || alignment == Alignment::SpaceEvenly) {
+            auto free_space = grid_container_size - sum_of_base_sizes_including_gaps;
+            return static_cast<CSSPixels>(max(free_space, CSSPixels { 0 }) / 2);
+        }
+        if (alignment == Alignment::End) {
+            auto free_space = grid_container_size - sum_of_base_sizes_including_gaps;
+            return free_space;
+        }
+        return CSSPixels { 0 };
+    };
+
+    auto serialize_dimension = [&](GridDimension dimension) {
+        auto const& tracks = dimension == GridDimension::Column ? m_grid_columns : m_grid_rows;
+        auto const& gap_tracks = dimension == GridDimension::Column ? m_column_gap_tracks : m_row_gap_tracks;
+        auto const& lines = dimension == GridDimension::Column ? m_column_lines : m_row_lines;
+        auto explicit_start_line_index = dimension == GridDimension::Column ? m_explicit_columns_start_line_index : m_explicit_rows_start_line_index;
+        auto explicit_line_count = dimension == GridDimension::Column ? m_explicit_columns_line_count : m_explicit_rows_line_count;
+
+        GridLayoutDimension result;
+        auto line_start = axis_start_offset(dimension);
+
+        for (size_t i = 0; i < lines.size(); ++i) {
+            CSSPixels line_breadth = i == 0 || i - 1 >= gap_tracks.size() ? CSSPixels { 0 } : gap_tracks[i - 1].base_size;
+
+            GridLayoutLine line;
+            line.start = line_start;
+            line.breadth = line_breadth;
+            line.type = line_type_for_index(i, explicit_start_line_index, explicit_line_count);
+            line.number = line_number_for_index(i, explicit_start_line_index);
+            line.negative_number = negative_line_number_for_index(i, explicit_start_line_index, explicit_line_count);
+
+            for (auto const& line_name : lines[i])
+                line.names.append(line_name.name.to_string());
+
+            result.lines.append(move(line));
+
+            if (i < tracks.size()) {
+                GridLayoutTrack track;
+                track.start = line_start + line_breadth;
+                track.breadth = tracks[i].base_size;
+                track.type = track_type_for_index(i, explicit_start_line_index, explicit_line_count);
+                track.state = track_state(tracks[i], dimension, i);
+                result.tracks.append(track);
+
+                line_start = track.start + track.breadth;
+            }
+        }
+
+        return result;
+    };
+
+    GridLayoutFragment fragment;
+    fragment.columns = serialize_dimension(GridDimension::Column);
+    fragment.rows = serialize_dimension(GridDimension::Row);
+
+    auto const& grid_template_areas = grid_container().computed_values().grid_template_areas();
+    for (auto const& [name, area] : grid_template_areas.areas) {
+        auto row_start_index = m_explicit_rows_start_line_index + area.row_start;
+        auto row_end_index = m_explicit_rows_start_line_index + area.row_end;
+        auto column_start_index = m_explicit_columns_start_line_index + area.column_start;
+        auto column_end_index = m_explicit_columns_start_line_index + area.column_end;
+
+        fragment.areas.append(GridLayoutArea {
+            .name = name,
+            .type = GridTrackType::Explicit,
+            .row_start = line_number_for_index(row_start_index, m_explicit_rows_start_line_index),
+            .row_end = line_number_for_index(row_end_index, m_explicit_rows_start_line_index),
+            .column_start = line_number_for_index(column_start_index, m_explicit_columns_start_line_index),
+            .column_end = line_number_for_index(column_end_index, m_explicit_columns_start_line_index),
+        });
+    }
+
+    data->fragments.append(move(fragment));
+    m_grid_container_used_values.set_grid_layout_data(move(data));
+}
+
 CSSPixels GridFormattingContext::grid_container_size_for_track_alignment(GridDimension dimension) const
 {
     if (dimension == GridDimension::Column)
@@ -2762,8 +2910,7 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
 
     // getComputedStyle() needs to return the resolved values of grid-template-columns and grid-template-rows
     // so they need to be saved in the state, and then assigned to paintables in LayoutState::commit()
-    m_grid_container_used_values.set_grid_template_columns(CSS::GridTrackSizeListStyleValue::create(move(grid_track_columns)));
-    m_grid_container_used_values.set_grid_template_rows(CSS::GridTrackSizeListStyleValue::create(move(grid_track_rows)));
+    save_grid_layout_data(move(grid_track_columns), move(grid_track_rows));
 }
 
 // https://www.w3.org/TR/css-grid-2/#abspos-items

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -10,6 +10,7 @@
 #include <AK/Function.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/Layout/FormattingContext.h>
+#include <LibWeb/Layout/GridLayoutData.h>
 
 namespace Web::Layout {
 
@@ -204,8 +205,9 @@ private:
 
         bool is_gap { false };
         bool is_auto_fit { false };
+        bool is_auto_repeat { false };
 
-        static GridTrack create_from_definition(CSS::ExplicitGridTrack const& definition, bool is_auto_fit);
+        static GridTrack create_from_definition(CSS::ExplicitGridTrack const& definition, bool is_auto_fit = false, bool is_auto_repeat = false);
         static GridTrack create_auto();
         static GridTrack create_from_subgrid_parent_track(GridTrack const&);
         static GridTrack create_fixed(CSSPixels size);
@@ -291,6 +293,8 @@ private:
 
     size_t m_explicit_rows_line_count { 0 };
     size_t m_explicit_columns_line_count { 0 };
+    size_t m_explicit_rows_start_line_index { 0 };
+    size_t m_explicit_columns_start_line_index { 0 };
 
     bool m_has_flexible_row_tracks { false };
     bool m_has_flexible_column_tracks { false };
@@ -318,6 +322,7 @@ private:
     void resolve_grid_item_sizes(GridDimension dimension);
 
     void resolve_track_spacing(GridDimension dimension);
+    void save_grid_layout_data(CSS::GridTrackSizeList&& columns, CSS::GridTrackSizeList&& rows);
     CSSPixels grid_container_size_for_track_alignment(GridDimension dimension) const;
 
     AvailableSize get_free_space(AvailableSpace const&, GridDimension) const;

--- a/Libraries/LibWeb/Layout/GridLayoutData.h
+++ b/Libraries/LibWeb/Layout/GridLayoutData.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibWeb/CSS/Enums.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/PixelUnits.h>
+
+namespace Web::Layout {
+
+enum class GridTrackType : u8 {
+    Explicit,
+    Implicit,
+};
+
+enum class GridTrackState : u8 {
+    Static,
+    Repeat,
+    Removed,
+};
+
+struct GridLayoutLine {
+    Vector<String> names;
+    CSSPixels start { 0 };
+    CSSPixels breadth { 0 };
+    GridTrackType type { GridTrackType::Implicit };
+    u32 number { 0 };
+    i32 negative_number { 0 };
+};
+
+struct GridLayoutTrack {
+    CSSPixels start { 0 };
+    CSSPixels breadth { 0 };
+    GridTrackType type { GridTrackType::Implicit };
+    GridTrackState state { GridTrackState::Static };
+};
+
+struct GridLayoutArea {
+    String name;
+    GridTrackType type { GridTrackType::Explicit };
+    u32 row_start { 0 };
+    u32 row_end { 0 };
+    u32 column_start { 0 };
+    u32 column_end { 0 };
+};
+
+struct GridLayoutDimension {
+    Vector<GridLayoutLine> lines;
+    Vector<GridLayoutTrack> tracks;
+};
+
+struct GridLayoutFragment {
+    Vector<GridLayoutArea> areas;
+    GridLayoutDimension columns;
+    GridLayoutDimension rows;
+};
+
+struct GridLayoutData {
+    CSS::Direction direction { CSS::Direction::Ltr };
+    CSS::WritingMode writing_mode { CSS::WritingMode::HorizontalTb };
+    bool is_subgrid { false };
+    RefPtr<CSS::GridTrackSizeListStyleValue const> resolved_grid_template_columns;
+    RefPtr<CSS::GridTrackSizeListStyleValue const> resolved_grid_template_rows;
+    Vector<GridLayoutFragment> fragments;
+};
+
+}

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -565,8 +565,7 @@ void LayoutState::commit(Box& root)
             }
 
             if (node.display().is_grid_inside()) {
-                paintable_box->set_used_values_for_grid_template_columns(used_values.grid_template_columns());
-                paintable_box->set_used_values_for_grid_template_rows(used_values.grid_template_rows());
+                paintable_box->set_grid_layout_data(used_values.take_grid_layout_data());
             }
         }
     });

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashTable.h>
+#include <AK/OwnPtr.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/Point.h>
 #include <LibWeb/Layout/Box.h>
@@ -263,18 +264,16 @@ struct LayoutState {
             return m_rare ? m_rare->computed_svg_transforms : empty;
         }
 
-        void set_grid_template_columns(RefPtr<CSS::GridTrackSizeListStyleValue const> used_values_for_grid_template_columns) { ensure_rare_data().grid_template_columns = move(used_values_for_grid_template_columns); }
-        RefPtr<CSS::GridTrackSizeListStyleValue const> const& grid_template_columns() const
+        void set_grid_layout_data(OwnPtr<GridLayoutData> grid_layout_data) { ensure_rare_data().grid_layout_data = move(grid_layout_data); }
+        GridLayoutData const* grid_layout_data() const
         {
-            static RefPtr<CSS::GridTrackSizeListStyleValue const> const empty;
-            return m_rare ? m_rare->grid_template_columns : empty;
+            return m_rare ? m_rare->grid_layout_data.ptr() : nullptr;
         }
-
-        void set_grid_template_rows(RefPtr<CSS::GridTrackSizeListStyleValue const> used_values_for_grid_template_rows) { ensure_rare_data().grid_template_rows = move(used_values_for_grid_template_rows); }
-        RefPtr<CSS::GridTrackSizeListStyleValue const> const& grid_template_rows() const
+        OwnPtr<GridLayoutData> take_grid_layout_data()
         {
-            static RefPtr<CSS::GridTrackSizeListStyleValue const> const empty;
-            return m_rare ? m_rare->grid_template_rows : empty;
+            if (!m_rare)
+                return {};
+            return move(m_rare->grid_layout_data);
         }
 
         void set_grid_area_size(CSSPixelSize grid_area_size) { ensure_rare_data().grid_area_size = grid_area_size; }
@@ -306,11 +305,24 @@ struct LayoutState {
         CSSPixels border_bottom_collapsed() const { return use_collapsing_borders_model() ? round(border_bottom / 2) : border_bottom; }
 
         struct RareData {
+            RareData() = default;
+            RareData(RareData const& other)
+                : floating_descendants(other.floating_descendants)
+                , table_cell_coordinates(other.table_cell_coordinates)
+                , computed_svg_path(other.computed_svg_path)
+                , grid_area_size(other.grid_area_size)
+                , override_borders_data(other.override_borders_data)
+                , computed_svg_transforms(other.computed_svg_transforms)
+                , static_position_rect(other.static_position_rect)
+            {
+                if (other.grid_layout_data)
+                    grid_layout_data = make<GridLayoutData>(*other.grid_layout_data);
+            }
+
             HashTable<GC::Ptr<Box const>> floating_descendants;
             Optional<Painting::PaintableBox::TableCellCoordinates> table_cell_coordinates;
             Optional<Gfx::Path> computed_svg_path;
-            RefPtr<CSS::GridTrackSizeListStyleValue const> grid_template_columns;
-            RefPtr<CSS::GridTrackSizeListStyleValue const> grid_template_rows;
+            OwnPtr<GridLayoutData> grid_layout_data;
             Optional<CSSPixelSize> grid_area_size;
             Optional<Painting::PaintableBox::BordersDataWithElementKind> override_borders_data;
             Optional<Painting::SVGGraphicsPaintable::ComputedTransforms> computed_svg_transforms;

--- a/Libraries/LibWeb/Painting/GridInspectorOverlay.h
+++ b/Libraries/LibWeb/Painting/GridInspectorOverlay.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Color.h>
+
+namespace Web::Painting {
+
+struct GridInspectorOverlayOptions {
+    Gfx::Color color { 76, 179, 212 };
+    bool show_area_names { true };
+    bool show_line_numbers { true };
+    bool show_track_sizes { false };
+    bool show_infinite_lines { false };
+};
+
+}

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -147,7 +147,16 @@ RefPtr<StackingContext> Paintable::enclosing_stacking_context()
 
 void Paintable::paint_inspector_overlay(DisplayListRecordingContext& context) const
 {
+    paint_with_inspector_overlay_context(context, [&] {
+        paint_inspector_overlay_internal(context);
+    });
+}
+
+void Paintable::paint_with_inspector_overlay_context(DisplayListRecordingContext& context, Function<void()> const& callback) const
+{
     auto& display_list_recorder = context.display_list_recorder();
+    auto previous_visual_context_index = display_list_recorder.accumulated_visual_context();
+
     RefPtr<PaintableBox const> paintable_box;
     if (is<PaintableBox>(*this))
         paintable_box = static_cast<PaintableBox const&>(*this);
@@ -184,8 +193,8 @@ void Paintable::paint_inspector_overlay(DisplayListRecordingContext& context) co
         }
     }
 
-    paint_inspector_overlay_internal(context);
-    display_list_recorder.set_accumulated_visual_context({});
+    callback();
+    display_list_recorder.set_accumulated_visual_context(previous_visual_context_index);
 }
 
 void Paintable::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -171,6 +171,8 @@ public:
 protected:
     explicit Paintable(Layout::Node const&);
 
+    void paint_with_inspector_overlay_context(DisplayListRecordingContext&, Function<void()> const&) const;
+
     virtual void paint_inspector_overlay_internal(DisplayListRecordingContext&) const { }
     Optional<WeakPtr<PaintableBox>> mutable m_containing_block;
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -399,8 +399,7 @@ void PaintableBox::reset_for_relayout()
     m_accumulated_visual_context_for_descendants_index = {};
     m_fixed_background_visual_context = {};
 
-    m_used_values_for_grid_template_columns = nullptr;
-    m_used_values_for_grid_template_rows = nullptr;
+    m_grid_layout_data = nullptr;
 
     m_cached_phase_commands = {};
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -31,6 +31,7 @@
 #include <LibWeb/Painting/ChromeMetrics.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
+#include <LibWeb/Painting/GridInspectorOverlay.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ResizeHandle.h>
 #include <LibWeb/Painting/SVGPaintable.h>
@@ -1179,6 +1180,139 @@ void PaintableBox::paint_inspector_overlay_internal(DisplayListRecordingContext&
     context.display_list_recorder().fill_rect(size_text_device_rect, context.palette().color(Gfx::ColorRole::Tooltip));
     context.display_list_recorder().draw_rect(size_text_device_rect, context.palette().threed_shadow1());
     context.display_list_recorder().draw_text(size_text_device_rect, size_text, font->with_size(font->point_size() * context.device_pixels_per_css_pixel()), Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
+}
+
+void PaintableBox::paint_grid_inspector_overlay(DisplayListRecordingContext& context, GridInspectorOverlayOptions const& options) const
+{
+    if (!m_grid_layout_data)
+        return;
+
+    paint_with_inspector_overlay_context(context, [&] {
+        auto content_rect = absolute_united_content_rect();
+        auto const origin = content_rect.location();
+        auto const viewport_rect = document().viewport_rect();
+        auto const& color = options.color;
+        auto font = Platform::FontPlugin::the().default_font(10);
+        auto label_font = font->with_size(font->point_size() * context.device_pixels_per_css_pixel());
+        auto label_height = CSSPixels::nearest_value_for(font->pixel_size()) + 4;
+        auto label_padding = CSSPixels(4);
+
+        auto paint_rect = [&](CSSPixelRect const& rect, Gfx::Color rect_color) {
+            context.display_list_recorder().fill_rect(context.enclosing_device_rect(rect).to_type<int>(), rect_color);
+        };
+
+        auto paint_label = [&](CSSPixelPoint top_left, Utf16String const& text) {
+            auto label_width = CSSPixels::nearest_value_for(font->width(text)) + label_padding * 2;
+            auto label_rect = CSSPixelRect { top_left.x(), top_left.y(), label_width, label_height };
+            auto label_device_rect = context.enclosing_device_rect(label_rect).to_type<int>();
+            auto label_background = color.with_alpha(235);
+            context.display_list_recorder().fill_rect(label_device_rect, label_background);
+            context.display_list_recorder().draw_rect(label_device_rect, color.with_alpha(255));
+            context.display_list_recorder().draw_text(label_device_rect, text, label_font, Gfx::TextAlignment::Center, label_background.suggested_foreground_color());
+        };
+
+        auto paint_centered_label = [&](CSSPixelRect const& rect, Utf16String const& text) {
+            auto label_width = CSSPixels::nearest_value_for(font->width(text)) + label_padding * 2;
+            paint_label({ rect.center().x() - label_width / 2, rect.center().y() - label_height / 2 }, text);
+        };
+
+        auto line_start_for_number = [](Layout::GridLayoutDimension const& dimension, u32 number) -> Optional<CSSPixels> {
+            for (auto const& line : dimension.lines) {
+                if (line.number == number)
+                    return line.start;
+            }
+            return {};
+        };
+
+        auto line_number_label = [](Layout::GridLayoutLine const& line) {
+            if (line.negative_number < 0)
+                return MUST(String::formatted("{} / {}", line.number, line.negative_number));
+            return MUST(String::formatted("{}", line.number));
+        };
+
+        auto track_size_label = [](Layout::GridLayoutTrack const& track) {
+            return MUST(String::formatted("{:.2f}px", max(0.0, track.breadth.to_double())));
+        };
+
+        auto line_color = color.with_alpha(220);
+        auto gap_color = color.with_alpha(45);
+        auto line_thickness = CSSPixels(1);
+
+        for (auto const& fragment : m_grid_layout_data->fragments) {
+            for (auto const& column_line : fragment.columns.lines) {
+                auto x = origin.x() + column_line.start;
+                auto line_top = options.show_infinite_lines ? viewport_rect.y() : content_rect.y();
+                auto line_height = options.show_infinite_lines ? viewport_rect.height() : content_rect.height();
+
+                if (column_line.breadth > 0)
+                    paint_rect({ x, line_top, column_line.breadth, line_height }, gap_color);
+
+                paint_rect({ x, line_top, line_thickness, line_height }, line_color);
+
+                if (options.show_line_numbers)
+                    paint_label({ x + 2, line_top + 2 }, Utf16String::from_utf8(line_number_label(column_line)));
+            }
+
+            for (auto const& row_line : fragment.rows.lines) {
+                auto y = origin.y() + row_line.start;
+                auto line_left = options.show_infinite_lines ? viewport_rect.x() : content_rect.x();
+                auto line_width = options.show_infinite_lines ? viewport_rect.width() : content_rect.width();
+
+                if (row_line.breadth > 0)
+                    paint_rect({ line_left, y, line_width, row_line.breadth }, gap_color);
+
+                paint_rect({ line_left, y, line_width, line_thickness }, line_color);
+
+                if (options.show_line_numbers)
+                    paint_label({ line_left + 2, y + 2 }, Utf16String::from_utf8(line_number_label(row_line)));
+            }
+
+            if (options.show_track_sizes) {
+                for (auto const& column_track : fragment.columns.tracks) {
+                    auto track_rect = CSSPixelRect {
+                        origin.x() + column_track.start,
+                        content_rect.y(),
+                        column_track.breadth,
+                        min(content_rect.height(), label_height + 4),
+                    };
+                    paint_centered_label(track_rect, Utf16String::from_utf8(track_size_label(column_track)));
+                }
+
+                for (auto const& row_track : fragment.rows.tracks) {
+                    auto track_rect = CSSPixelRect {
+                        content_rect.x(),
+                        origin.y() + row_track.start,
+                        min(content_rect.width(), CSSPixels(72)),
+                        row_track.breadth,
+                    };
+                    paint_centered_label(track_rect, Utf16String::from_utf8(track_size_label(row_track)));
+                }
+            }
+
+            if (options.show_area_names) {
+                for (auto const& area : fragment.areas) {
+                    auto column_start = line_start_for_number(fragment.columns, area.column_start);
+                    auto column_end = line_start_for_number(fragment.columns, area.column_end);
+                    auto row_start = line_start_for_number(fragment.rows, area.row_start);
+                    auto row_end = line_start_for_number(fragment.rows, area.row_end);
+                    if (!column_start.has_value() || !column_end.has_value() || !row_start.has_value() || !row_end.has_value())
+                        continue;
+
+                    auto area_rect = CSSPixelRect {
+                        origin.x() + column_start.value(),
+                        origin.y() + row_start.value(),
+                        column_end.value() - column_start.value(),
+                        row_end.value() - row_start.value(),
+                    };
+                    paint_rect(area_rect, color.with_alpha(24));
+
+                    auto visible_area_rect = area_rect.intersected(viewport_rect);
+                    if (!visible_area_rect.is_empty())
+                        paint_centered_label(visible_area_rect, Utf16String::from_utf8(area.name));
+                }
+            }
+        }
+    });
 }
 
 void PaintableBox::set_stacking_context(NonnullRefPtr<StackingContext> stacking_context)

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -29,6 +29,7 @@
 
 namespace Web::Painting {
 
+struct GridInspectorOverlayOptions;
 class ResizeHandle;
 class Scrollbar;
 
@@ -279,6 +280,7 @@ public:
 
     void set_grid_layout_data(OwnPtr<Layout::GridLayoutData> grid_layout_data) { m_grid_layout_data = move(grid_layout_data); }
     Layout::GridLayoutData const* grid_layout_data() const { return m_grid_layout_data.ptr(); }
+    void paint_grid_inspector_overlay(DisplayListRecordingContext&, GridInspectorOverlayOptions const&) const;
 
     void set_enclosing_scroll_frame_index(ScrollFrameIndex index) { m_enclosing_scroll_frame_index = index; }
     void set_own_scroll_frame_index(ScrollFrameIndex index) { m_own_scroll_frame_index = index; }

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -9,11 +9,13 @@
 
 #include <AK/Array.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/GridLayoutData.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/BoxModelMetrics.h>
@@ -275,11 +277,8 @@ public:
     [[nodiscard]] bool could_be_scrolled_by_wheel_event() const;
     [[nodiscard]] bool could_be_scrolled_by_wheel_event(ScrollDirection direction) const;
 
-    void set_used_values_for_grid_template_columns(RefPtr<CSS::GridTrackSizeListStyleValue const> style_value) { m_used_values_for_grid_template_columns = move(style_value); }
-    RefPtr<CSS::GridTrackSizeListStyleValue const> const& used_values_for_grid_template_columns() const { return m_used_values_for_grid_template_columns; }
-
-    void set_used_values_for_grid_template_rows(RefPtr<CSS::GridTrackSizeListStyleValue const> style_value) { m_used_values_for_grid_template_rows = move(style_value); }
-    RefPtr<CSS::GridTrackSizeListStyleValue const> const& used_values_for_grid_template_rows() const { return m_used_values_for_grid_template_rows; }
+    void set_grid_layout_data(OwnPtr<Layout::GridLayoutData> grid_layout_data) { m_grid_layout_data = move(grid_layout_data); }
+    Layout::GridLayoutData const* grid_layout_data() const { return m_grid_layout_data.ptr(); }
 
     void set_enclosing_scroll_frame_index(ScrollFrameIndex index) { m_enclosing_scroll_frame_index = index; }
     void set_own_scroll_frame_index(ScrollFrameIndex index) { m_own_scroll_frame_index = index; }
@@ -374,8 +373,7 @@ private:
 
     OwnPtr<StickyInsets> m_sticky_insets;
 
-    RefPtr<CSS::GridTrackSizeListStyleValue const> m_used_values_for_grid_template_columns;
-    RefPtr<CSS::GridTrackSizeListStyleValue const> m_used_values_for_grid_template_rows;
+    OwnPtr<Layout::GridLayoutData> m_grid_layout_data;
 
     BoxModelMetrics m_box_model;
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -6,6 +6,8 @@
 
 #include <AK/Checked.h>
 #include <AK/Debug.h>
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Time.h>
 #include <LibCore/AnonymousBuffer.h>
@@ -1753,6 +1755,38 @@ void Application::inspect_dom_node(DevTools::TabDescription const& description, 
     view->inspect_dom_node(node_id, property_type, pseudo_element);
 }
 
+void Application::inspect_grid_layouts(DevTools::TabDescription const& description, Web::UniqueNodeID root_node_id, OnGridLayoutsReceived on_grid_layouts_received) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_grid_layouts_received({});
+        return;
+    }
+
+    view->on_received_grid_layouts = [&view = *view, on_grid_layouts_received = move(on_grid_layouts_received)](JsonArray grid_layouts) {
+        view.on_received_grid_layouts = nullptr;
+        on_grid_layouts_received(move(grid_layouts));
+    };
+
+    view->inspect_grid_layouts(root_node_id);
+}
+
+void Application::inspect_current_grid(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, OnCurrentGridReceived on_current_grid_received) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_current_grid_received({});
+        return;
+    }
+
+    view->on_received_current_grid = [&view = *view, on_current_grid_received = move(on_current_grid_received)](Optional<JsonObject> grid_layout) {
+        view.on_received_current_grid = nullptr;
+        on_current_grid_received(move(grid_layout));
+    };
+
+    view->inspect_current_grid(node_id);
+}
+
 void Application::clear_inspected_dom_node(DevTools::TabDescription const& description) const
 {
     if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
@@ -1769,6 +1803,18 @@ void Application::clear_highlighted_dom_node(DevTools::TabDescription const& des
 {
     if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
         view->clear_highlighted_dom_node();
+}
+
+void Application::highlight_grid(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, JsonValue options) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->highlight_grid(node_id, move(options));
+}
+
+void Application::clear_grid_highlight(DevTools::TabDescription const& description, Web::UniqueNodeID node_id) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->clear_grid_highlight(node_id);
 }
 
 void Application::listen_for_dom_mutations(DevTools::TabDescription const& description, OnDOMMutationReceived on_dom_mutation_received) const

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -251,8 +251,12 @@ private:
     virtual void stop_listening_for_dom_properties(DevTools::TabDescription const&) const override;
     virtual void inspect_dom_node(DevTools::TabDescription const&, DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>) const override;
     virtual void clear_inspected_dom_node(DevTools::TabDescription const&) const override;
+    virtual void inspect_grid_layouts(DevTools::TabDescription const&, Web::UniqueNodeID, OnGridLayoutsReceived) const override;
+    virtual void inspect_current_grid(DevTools::TabDescription const&, Web::UniqueNodeID, OnCurrentGridReceived) const override;
     virtual void highlight_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>) const override;
     virtual void clear_highlighted_dom_node(DevTools::TabDescription const&) const override;
+    virtual void highlight_grid(DevTools::TabDescription const&, Web::UniqueNodeID, JsonValue) const override;
+    virtual void clear_grid_highlight(DevTools::TabDescription const&, Web::UniqueNodeID) const override;
     virtual void listen_for_dom_mutations(DevTools::TabDescription const&, OnDOMMutationReceived) const override;
     virtual void stop_listening_for_dom_mutations(DevTools::TabDescription const&) const override;
     virtual void get_dom_node_inner_html(DevTools::TabDescription const&, Web::UniqueNodeID, OnDOMNodeHTMLReceived) const override;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -459,6 +459,16 @@ void ViewImplementation::inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProp
     client().async_inspect_dom_node(page_id(), property_type, node_id, pseudo_element);
 }
 
+void ViewImplementation::inspect_grid_layouts(Web::UniqueNodeID root_node_id)
+{
+    client().async_inspect_grid_layouts(page_id(), root_node_id);
+}
+
+void ViewImplementation::inspect_current_grid(Web::UniqueNodeID node_id)
+{
+    client().async_inspect_current_grid(page_id(), node_id);
+}
+
 void ViewImplementation::clear_inspected_dom_node()
 {
     client().async_clear_inspected_dom_node(page_id());
@@ -472,6 +482,16 @@ void ViewImplementation::highlight_dom_node(Web::UniqueNodeID node_id, Optional<
 void ViewImplementation::clear_highlighted_dom_node()
 {
     highlight_dom_node(0, {});
+}
+
+void ViewImplementation::highlight_grid(Web::UniqueNodeID node_id, JsonValue options)
+{
+    client().async_highlight_grid(page_id(), node_id, move(options));
+}
+
+void ViewImplementation::clear_grid_highlight(Web::UniqueNodeID node_id)
+{
+    client().async_clear_grid_highlight(page_id(), node_id);
 }
 
 void ViewImplementation::set_listen_for_dom_mutations(bool listen_for_dom_mutations)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -9,7 +9,9 @@
 
 #include <AK/Forward.h>
 #include <AK/Function.h>
+#include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
 #include <AK/LexicalPath.h>
 #include <AK/OwnPtr.h>
 #include <AK/Queue.h>
@@ -120,10 +122,14 @@ public:
     void get_hovered_node_id();
 
     void inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type, Optional<Web::CSS::PseudoElement> pseudo_element);
+    void inspect_grid_layouts(Web::UniqueNodeID root_node_id);
+    void inspect_current_grid(Web::UniqueNodeID node_id);
     void clear_inspected_dom_node();
 
     void highlight_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element);
     void clear_highlighted_dom_node();
+    void highlight_grid(Web::UniqueNodeID node_id, JsonValue options);
+    void clear_grid_highlight(Web::UniqueNodeID node_id);
 
     void set_listen_for_dom_mutations(bool);
     void did_connect_devtools_client();
@@ -232,6 +238,8 @@ public:
     Function<void()> on_request_dismiss_dialog;
     Function<void(JsonObject)> on_received_dom_tree;
     Function<void(DOMNodeProperties)> on_received_dom_node_properties;
+    Function<void(JsonArray)> on_received_grid_layouts;
+    Function<void(Optional<JsonObject>)> on_received_current_grid;
     Function<void(JsonObject)> on_received_accessibility_tree;
     Function<void(Web::UniqueNodeID)> on_received_hovered_node_id;
     Function<void(Mutation)> on_dom_mutation_received;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -5,6 +5,10 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/NeverDestroyed.h>
+#include <AK/WeakPtr.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/Timer.h>
 #include <LibHTTP/Cookie/ParsedCookie.h>
@@ -654,6 +658,41 @@ static JsonObject parse_json(StringView json, StringView name)
     return move(parsed_tree.release_value().as_object());
 }
 
+static JsonArray parse_json_array(StringView json, StringView name)
+{
+    auto parsed_tree = JsonValue::from_string(json);
+    if (parsed_tree.is_error()) {
+        dbgln("Unable to parse {}: {}", name, parsed_tree.error());
+        return {};
+    }
+
+    if (!parsed_tree.value().is_array()) {
+        dbgln("Expected {} to be an array: {}", name, parsed_tree.value());
+        return {};
+    }
+
+    return move(parsed_tree.release_value().as_array());
+}
+
+static Optional<JsonObject> parse_optional_json_object(StringView json, StringView name)
+{
+    auto parsed_tree = JsonValue::from_string(json);
+    if (parsed_tree.is_error()) {
+        dbgln("Unable to parse {}: {}", name, parsed_tree.error());
+        return {};
+    }
+
+    if (parsed_tree.value().is_null())
+        return {};
+
+    if (!parsed_tree.value().is_object()) {
+        dbgln("Expected {} to be an object or null: {}", name, parsed_tree.value());
+        return {};
+    }
+
+    return move(parsed_tree.release_value().as_object());
+}
+
 void WebContentClient::did_inspect_dom_tree(u64 page_id, String dom_tree)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
@@ -667,6 +706,22 @@ void WebContentClient::did_inspect_dom_node(u64 page_id, DOMNodeProperties prope
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_received_dom_node_properties)
             view->on_received_dom_node_properties(move(properties));
+    }
+}
+
+void WebContentClient::did_inspect_grid_layouts(u64 page_id, String grid_layouts)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_received_grid_layouts)
+            view->on_received_grid_layouts(parse_json_array(grid_layouts, "grid layouts"sv));
+    }
+}
+
+void WebContentClient::did_inspect_current_grid(u64 page_id, String grid_layout)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_received_current_grid)
+            view->on_received_current_grid(parse_optional_json_object(grid_layout, "current grid"sv));
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -119,6 +119,8 @@ private:
     virtual void did_get_source(u64 page_id, URL::URL, URL::URL, String) override;
     virtual void did_inspect_dom_tree(u64 page_id, String) override;
     virtual void did_inspect_dom_node(u64 page_id, DOMNodeProperties) override;
+    virtual void did_inspect_grid_layouts(u64 page_id, String) override;
+    virtual void did_inspect_current_grid(u64 page_id, String) override;
     virtual void did_inspect_accessibility_tree(u64 page_id, String) override;
     virtual void did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id) override;

--- a/Meta/Generators/generate_libweb_css_enums.py
+++ b/Meta/Generators/generate_libweb_css_enums.py
@@ -40,7 +40,7 @@ namespace Web::CSS {
         out.write(f"""}};
 Optional<{title_casify(name)}> keyword_to_{snake_casify(name)}(Keyword);
 Keyword to_keyword({title_casify(name)});
-StringView to_string({title_casify(name)});
+WEB_API StringView to_string({title_casify(name)});
 
 """)
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -45,6 +45,8 @@
 #include <LibWeb/HTML/BroadcastChannel.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/NavigableContainer.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/Storage.h>
@@ -761,6 +763,33 @@ static Optional<JsonObject> grid_layout_for_node(Web::DOM::Node const& node)
     return layout;
 }
 
+static void append_grid_layouts_for_node_and_frame_descendants(Web::DOM::Node& root_node, JsonArray& grid_layouts)
+{
+    root_node.for_each_in_inclusive_subtree([&](Web::DOM::Node& node) {
+        if (auto grid_layout = grid_layout_for_node(node); grid_layout.has_value())
+            grid_layouts.must_append(grid_layout.release_value());
+
+        auto* navigable_container = as_if<Web::HTML::NavigableContainer>(node);
+        if (!navigable_container)
+            return Web::TraversalDecision::Continue;
+
+        auto content_navigable = navigable_container->content_navigable();
+        if (!content_navigable)
+            return Web::TraversalDecision::Continue;
+
+        auto content_document = content_navigable->active_document();
+        if (!content_document)
+            return Web::TraversalDecision::Continue;
+
+        if (!content_document->origin().is_same_origin_domain(navigable_container->document().origin()))
+            return Web::TraversalDecision::Continue;
+
+        content_document->update_layout(Web::DOM::UpdateLayoutReason::InspectGridLayout);
+        append_grid_layouts_for_node_and_frame_descendants(*content_document, grid_layouts);
+        return Web::TraversalDecision::Continue;
+    });
+}
+
 void ConnectionFromClient::inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id)
 {
     auto page = this->page(page_id);
@@ -776,11 +805,7 @@ void ConnectionFromClient::inspect_grid_layouts(u64 page_id, Web::UniqueNodeID r
     root_node->document().update_layout(Web::DOM::UpdateLayoutReason::InspectGridLayout);
 
     JsonArray grid_layouts;
-    root_node->for_each_in_inclusive_subtree([&](Web::DOM::Node& node) {
-        if (auto grid_layout = grid_layout_for_node(node); grid_layout.has_value())
-            grid_layouts.must_append(grid_layout.release_value());
-        return Web::TraversalDecision::Continue;
-    });
+    append_grid_layouts_for_node_and_frame_descendants(*root_node, grid_layouts);
 
     async_did_inspect_grid_layouts(page_id, grid_layouts.serialized());
 }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -10,12 +10,14 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/OwnPtr.h>
 #include <AK/QuickSort.h>
 #include <LibCore/System.h>
 #include <LibGC/Heap.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibJS/Runtime/ConsoleObject.h>
@@ -50,6 +52,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WorkerAgentParent.h>
 #include <LibWeb/Infra/Strings.h>
+#include <LibWeb/Layout/GridLayoutData.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/ContentBlocker.h>
 #include <LibWeb/Loader/ProxyMappings.h>
@@ -635,6 +638,177 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
     async_did_inspect_dom_node(page_id, { property_type, move(serialized) });
 }
 
+static StringView grid_track_type_to_string(Web::Layout::GridTrackType type)
+{
+    switch (type) {
+    case Web::Layout::GridTrackType::Explicit:
+        return "explicit"sv;
+    case Web::Layout::GridTrackType::Implicit:
+        return "implicit"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static StringView grid_track_state_to_string(Web::Layout::GridTrackState state)
+{
+    switch (state) {
+    case Web::Layout::GridTrackState::Static:
+        return "static"sv;
+    case Web::Layout::GridTrackState::Repeat:
+        return "repeat"sv;
+    case Web::Layout::GridTrackState::Removed:
+        return "removed"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static JsonArray serialize_grid_line_names(Vector<String> const& names)
+{
+    JsonArray serialized_names;
+    for (auto const& name : names)
+        serialized_names.must_append(name);
+    return serialized_names;
+}
+
+static JsonObject serialize_grid_line(Web::Layout::GridLayoutLine const& line)
+{
+    JsonObject serialized_line;
+    serialized_line.set("breadth"sv, line.breadth.to_double());
+    serialized_line.set("names"sv, serialize_grid_line_names(line.names));
+    serialized_line.set("negativeNumber"sv, line.negative_number);
+    serialized_line.set("number"sv, line.number);
+    serialized_line.set("start"sv, line.start.to_double());
+    serialized_line.set("type"sv, grid_track_type_to_string(line.type));
+    return serialized_line;
+}
+
+static JsonObject serialize_grid_track(Web::Layout::GridLayoutTrack const& track)
+{
+    JsonObject serialized_track;
+    serialized_track.set("breadth"sv, track.breadth.to_double());
+    serialized_track.set("start"sv, track.start.to_double());
+    serialized_track.set("state"sv, grid_track_state_to_string(track.state));
+    serialized_track.set("type"sv, grid_track_type_to_string(track.type));
+    return serialized_track;
+}
+
+static JsonObject serialize_grid_area(Web::Layout::GridLayoutArea const& area)
+{
+    JsonObject serialized_area;
+    serialized_area.set("columnEnd"sv, area.column_end);
+    serialized_area.set("columnStart"sv, area.column_start);
+    serialized_area.set("name"sv, area.name);
+    serialized_area.set("rowEnd"sv, area.row_end);
+    serialized_area.set("rowStart"sv, area.row_start);
+    serialized_area.set("type"sv, grid_track_type_to_string(area.type));
+    return serialized_area;
+}
+
+static JsonObject serialize_grid_dimension(Web::Layout::GridLayoutDimension const& dimension)
+{
+    JsonArray lines;
+    for (auto const& line : dimension.lines)
+        lines.must_append(serialize_grid_line(line));
+
+    JsonArray tracks;
+    for (auto const& track : dimension.tracks)
+        tracks.must_append(serialize_grid_track(track));
+
+    JsonObject serialized_dimension;
+    serialized_dimension.set("lines"sv, move(lines));
+    serialized_dimension.set("tracks"sv, move(tracks));
+    return serialized_dimension;
+}
+
+static JsonObject serialize_grid_fragment(Web::Layout::GridLayoutFragment const& fragment)
+{
+    JsonArray areas;
+    for (auto const& area : fragment.areas)
+        areas.must_append(serialize_grid_area(area));
+
+    JsonObject serialized_fragment;
+    serialized_fragment.set("areas"sv, move(areas));
+    serialized_fragment.set("cols"sv, serialize_grid_dimension(fragment.columns));
+    serialized_fragment.set("rows"sv, serialize_grid_dimension(fragment.rows));
+    return serialized_fragment;
+}
+
+static JsonArray serialize_grid_fragments(Vector<Web::Layout::GridLayoutFragment> const& fragments)
+{
+    JsonArray serialized_fragments;
+    for (auto const& fragment : fragments)
+        serialized_fragments.must_append(serialize_grid_fragment(fragment));
+    return serialized_fragments;
+}
+
+static Optional<JsonObject> grid_layout_for_node(Web::DOM::Node const& node)
+{
+    auto paintable_box = node.paintable_box();
+    if (!paintable_box)
+        return {};
+
+    auto const* grid_layout_data = paintable_box->grid_layout_data();
+    if (!grid_layout_data)
+        return {};
+
+    JsonObject layout;
+    layout.set("containerNodeId"sv, node.unique_id().value());
+    layout.set("direction"sv, Web::CSS::to_string(grid_layout_data->direction));
+    layout.set("gridFragments"sv, serialize_grid_fragments(grid_layout_data->fragments));
+    layout.set("isSubgrid"sv, grid_layout_data->is_subgrid);
+    layout.set("writingMode"sv, Web::CSS::to_string(grid_layout_data->writing_mode));
+
+    return layout;
+}
+
+void ConnectionFromClient::inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto* root_node = Web::DOM::Node::from_unique_id(root_node_id);
+    if (!root_node) {
+        async_did_inspect_grid_layouts(page_id, "[]"_string);
+        return;
+    }
+
+    root_node->document().update_layout(Web::DOM::UpdateLayoutReason::InspectGridLayout);
+
+    JsonArray grid_layouts;
+    root_node->for_each_in_inclusive_subtree([&](Web::DOM::Node& node) {
+        if (auto grid_layout = grid_layout_for_node(node); grid_layout.has_value())
+            grid_layouts.must_append(grid_layout.release_value());
+        return Web::TraversalDecision::Continue;
+    });
+
+    async_did_inspect_grid_layouts(page_id, grid_layouts.serialized());
+}
+
+void ConnectionFromClient::inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto* node = Web::DOM::Node::from_unique_id(node_id);
+    if (!node) {
+        async_did_inspect_current_grid(page_id, "null"_string);
+        return;
+    }
+
+    node->document().update_layout(Web::DOM::UpdateLayoutReason::InspectGridLayout);
+
+    for (auto const* current = node; current; current = current->parent_or_shadow_host_node()) {
+        if (auto grid_layout = grid_layout_for_node(*current); grid_layout.has_value()) {
+            async_did_inspect_current_grid(page_id, grid_layout->serialized());
+            return;
+        }
+    }
+
+    async_did_inspect_current_grid(page_id, "null"_string);
+}
+
 void ConnectionFromClient::clear_inspected_dom_node(u64 page_id)
 {
     auto page = this->page(page_id);
@@ -665,6 +839,61 @@ void ConnectionFromClient::highlight_dom_node(u64 page_id, Web::UniqueNodeID nod
         return;
 
     node->document().set_highlighted_node(node, pseudo_element);
+}
+
+static Web::Painting::GridInspectorOverlayOptions grid_inspector_overlay_options_from_json(JsonValue const& options)
+{
+    Web::Painting::GridInspectorOverlayOptions result;
+
+    if (options.is_object()) {
+        auto const& object = options.as_object();
+        if (auto color = object.get_string("color"sv); color.has_value()) {
+            if (auto parsed_color = Gfx::Color::from_string(*color); parsed_color.has_value())
+                result.color = *parsed_color;
+        }
+
+        result.show_area_names = object.get_bool("showGridAreasOverlay"sv).value_or(result.show_area_names);
+        result.show_line_numbers = object.get_bool("showGridLineNumbers"sv).value_or(result.show_line_numbers);
+        result.show_infinite_lines = object.get_bool("showInfiniteLines"sv).value_or(result.show_infinite_lines);
+        result.show_track_sizes = object.get_bool("showGridTrackSizes"sv)
+                                      .value_or(object.get_bool("showGridTrackSizeLabels"sv)
+                                              .value_or(object.get_bool("showTrackSizes"sv)
+                                                      .value_or(result.show_track_sizes)));
+    }
+
+    return result;
+}
+
+void ConnectionFromClient::highlight_grid(u64 page_id, Web::UniqueNodeID node_id, JsonValue options)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto* node = Web::DOM::Node::from_unique_id(node_id);
+    if (!node || !node->layout_node())
+        return;
+
+    node->document().set_grid_highlighted_node(node, grid_inspector_overlay_options_from_json(options));
+}
+
+void ConnectionFromClient::clear_grid_highlight(u64 page_id, Web::UniqueNodeID node_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    if (node_id != 0) {
+        auto* node = Web::DOM::Node::from_unique_id(node_id);
+        if (node)
+            node->document().clear_grid_highlighted_node(node);
+        return;
+    }
+
+    for (auto& navigable : Web::HTML::all_navigables()) {
+        if (navigable->active_document())
+            navigable->active_document()->clear_grid_highlighted_node(nullptr);
+    }
 }
 
 void ConnectionFromClient::inspect_accessibility_tree(u64 page_id)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/JsonValue.h>
 #include <AK/Queue.h>
 #include <AK/RefPtr.h>
 #include <AK/SourceLocation.h>
@@ -90,8 +91,12 @@ private:
     virtual void get_source(u64 page_id) override;
     virtual void inspect_dom_tree(u64 page_id) override;
     virtual void inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) override;
+    virtual void inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) override;
+    virtual void inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void clear_inspected_dom_node(u64 page_id) override;
     virtual void highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) override;
+    virtual void highlight_grid(u64 page_id, Web::UniqueNodeID node_id, JsonValue options) override;
+    virtual void clear_grid_highlight(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void inspect_accessibility_tree(u64 page_id) override;
     virtual void get_hovered_node_id(u64 page_id) override;
 

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -67,6 +67,8 @@ endpoint WebContentClient
 
     did_inspect_dom_tree(u64 page_id, String dom_tree) =|
     did_inspect_dom_node(u64 page_id, WebView::DOMNodeProperties properties) =|
+    did_inspect_grid_layouts(u64 page_id, String grid_layouts) =|
+    did_inspect_current_grid(u64 page_id, String grid_layout) =|
     did_inspect_accessibility_tree(u64 page_id, String accessibility_tree) =|
     did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) =|
     did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -58,8 +58,12 @@ endpoint WebContentServer
     get_source(u64 page_id) =|
     inspect_dom_tree(u64 page_id) =|
     inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) =|
+    inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) =|
+    inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) =|
     clear_inspected_dom_node(u64 page_id) =|
     highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) =|
+    highlight_grid(u64 page_id, Web::UniqueNodeID node_id, JsonValue options) =|
+    clear_grid_highlight(u64 page_id, Web::UniqueNodeID node_id) =|
     inspect_accessibility_tree(u64 page_id) =|
     get_hovered_node_id(u64 page_id) =|
 

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -335,6 +335,19 @@ public:
         last_highlighted_pseudo_element = pseudo_element;
     }
 
+    virtual void highlight_grid(DevTools::TabDescription const&, Web::UniqueNodeID node_id, JsonValue options) const override
+    {
+        ++highlight_grid_call_count;
+        last_highlighted_grid_node = node_id;
+        last_grid_highlight_options = move(options);
+    }
+
+    virtual void clear_grid_highlight(DevTools::TabDescription const&, Web::UniqueNodeID node_id) const override
+    {
+        ++clear_grid_highlight_call_count;
+        last_cleared_grid_node = node_id;
+    }
+
     virtual void listen_for_dom_mutations(DevTools::TabDescription const&, OnDOMMutationReceived callback) const override
     {
         ++listen_for_dom_mutations_call_count;
@@ -583,6 +596,8 @@ public:
     mutable size_t inspect_current_grid_call_count { 0 };
     mutable size_t highlight_dom_node_call_count { 0 };
     mutable size_t clear_highlighted_dom_node_call_count { 0 };
+    mutable size_t highlight_grid_call_count { 0 };
+    mutable size_t clear_grid_highlight_call_count { 0 };
     mutable size_t listen_for_dom_mutations_call_count { 0 };
     mutable size_t stop_listening_for_dom_mutations_call_count { 0 };
     mutable size_t get_dom_node_inner_html_call_count { 0 };
@@ -615,6 +630,9 @@ public:
     mutable Optional<Web::CSS::PseudoElement> last_inspected_pseudo_element;
     mutable Optional<Web::UniqueNodeID> last_grid_root_node;
     mutable Optional<Web::UniqueNodeID> last_current_grid_node;
+    mutable Optional<Web::UniqueNodeID> last_highlighted_grid_node;
+    mutable Optional<Web::UniqueNodeID> last_cleared_grid_node;
+    mutable JsonValue last_grid_highlight_options;
     mutable Optional<Web::UniqueNodeID> last_edited_node;
     mutable Optional<Web::UniqueNodeID> last_parent_node;
     mutable Optional<Web::UniqueNodeID> last_sibling_node;
@@ -1015,6 +1033,45 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     show_unknown.set("node"sv, "missing-actor"sv);
     EXPECT(!client.request(move(show_unknown)).get_bool("value"sv).value());
     EXPECT_EQ(client.request(highlighter_actor, "hide"sv).get_string("from"sv).value(), highlighter_actor);
+
+    JsonObject grid_highlighter_request;
+    grid_highlighter_request.set("to"sv, inspector_actor);
+    grid_highlighter_request.set("type"sv, "getHighlighterByType"sv);
+    grid_highlighter_request.set("typeName"sv, "CssGridHighlighter"sv);
+    auto grid_highlighter_actor = client.request(move(grid_highlighter_request)).get_object("highlighter"sv)->get_string("actor"sv).release_value();
+
+    JsonObject second_grid_highlighter_request;
+    second_grid_highlighter_request.set("to"sv, inspector_actor);
+    second_grid_highlighter_request.set("type"sv, "getHighlighterByType"sv);
+    second_grid_highlighter_request.set("typeName"sv, "CssGridHighlighter"sv);
+    EXPECT_EQ(client.request(move(second_grid_highlighter_request)).get_object("highlighter"sv)->get_string("actor"sv).value(), grid_highlighter_actor);
+
+    JsonObject grid_options;
+    grid_options.set("showGridArea"sv, true);
+
+    JsonObject show_grid_highlighter;
+    show_grid_highlighter.set("to"sv, grid_highlighter_actor);
+    show_grid_highlighter.set("type"sv, "show"sv);
+    show_grid_highlighter.set("node"sv, div_actor);
+    show_grid_highlighter.set("options"sv, move(grid_options));
+    EXPECT(client.request(move(show_grid_highlighter)).get_bool("value"sv).value());
+    EXPECT_EQ(session->delegate.highlight_grid_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_highlighted_grid_node.value(), 4u);
+    EXPECT(session->delegate.last_grid_highlight_options.as_object().get_bool("showGridArea"sv).value());
+
+    JsonObject show_second_grid_highlighter;
+    show_second_grid_highlighter.set("to"sv, grid_highlighter_actor);
+    show_second_grid_highlighter.set("type"sv, "show"sv);
+    show_second_grid_highlighter.set("node"sv, span_actor);
+    EXPECT(client.request(move(show_second_grid_highlighter)).get_bool("value"sv).value());
+    EXPECT_EQ(session->delegate.clear_grid_highlight_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_cleared_grid_node.value(), 4u);
+    EXPECT_EQ(session->delegate.highlight_grid_call_count, 2u);
+    EXPECT_EQ(session->delegate.last_highlighted_grid_node.value(), 8u);
+
+    EXPECT_EQ(client.request(grid_highlighter_actor, "hide"sv).get_string("from"sv).value(), grid_highlighter_actor);
+    EXPECT_EQ(session->delegate.clear_grid_highlight_call_count, 2u);
+    EXPECT_EQ(session->delegate.last_cleared_grid_node.value(), 8u);
 
     auto layout_actor = client.request(walker_actor, "getLayoutInspector"sv).get_object("actor"sv)->get_string("actor"sv).release_value();
 

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -57,6 +57,7 @@ static JsonObject make_dom_tree()
     JsonObject target = make_node(4, "element"sv, "DIV"sv);
     target.set("visible"sv, true);
     target.set("scrollable"sv, true);
+    target.set("display"sv, "grid"sv);
 
     JsonObject target_attributes;
     target_attributes.set("id"sv, "target"sv);
@@ -76,11 +77,16 @@ static JsonObject make_dom_tree()
     before.set("parent-id"sv, 4);
     before.set("pseudo-element"sv, to_underlying(Web::CSS::PseudoElement::Before));
 
+    JsonObject subgrid = make_node(9, "element"sv, "SECTION"sv);
+    subgrid.set("visible"sv, true);
+    subgrid.set("display"sv, "grid"sv);
+
     JsonArray target_children;
     target_children.must_append(move(text));
     target_children.must_append(move(comment));
     target_children.must_append(move(whitespace));
     target_children.must_append(move(before));
+    target_children.must_append(move(subgrid));
     target.set("children"sv, move(target_children));
 
     JsonObject sibling = make_node(8, "element"sv, "SPAN"sv);
@@ -212,7 +218,7 @@ static JsonObject make_grid_dimension()
     return dimension;
 }
 
-static JsonObject make_grid_layout(Web::UniqueNodeID container_node_id, StringView area_name)
+static JsonObject make_grid_layout(Web::UniqueNodeID container_node_id, StringView area_name, bool is_subgrid = false)
 {
     JsonObject area;
     area.set("columnEnd"sv, 2);
@@ -237,7 +243,7 @@ static JsonObject make_grid_layout(Web::UniqueNodeID container_node_id, StringVi
     layout.set("containerNodeId"sv, container_node_id.value());
     layout.set("direction"sv, "ltr"sv);
     layout.set("gridFragments"sv, move(fragments));
-    layout.set("isSubgrid"sv, false);
+    layout.set("isSubgrid"sv, is_subgrid);
     layout.set("writingMode"sv, "horizontal-tb"sv);
     return layout;
 }
@@ -246,6 +252,7 @@ static JsonArray make_grid_layouts()
 {
     JsonArray grids;
     grids.must_append(make_grid_layout(Web::UniqueNodeID { 4 }, "content"sv));
+    grids.must_append(make_grid_layout(Web::UniqueNodeID { 9 }, "subgrid"sv, true));
     grids.must_append(make_grid_layout(Web::UniqueNodeID { 8 }, "subframe"sv));
     return grids;
 }
@@ -979,6 +986,7 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     EXPECT_EQ(children_response.get_array("nodes"sv)->size(), 1u);
 
     auto div_actor = query_selector(client, walker_actor, root_node_actor, "div"sv);
+    auto section_actor = query_selector(client, walker_actor, root_node_actor, "section"sv);
     auto span_actor = query_selector(client, walker_actor, root_node_actor, "span"sv);
     JsonObject previous_sibling;
     previous_sibling.set("to"sv, walker_actor);
@@ -1082,7 +1090,7 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     auto grids = client.request(move(get_grids)).get_array("grids"sv).release_value();
     EXPECT_EQ(session->delegate.inspect_grid_layouts_call_count, 1u);
     EXPECT_EQ(session->delegate.last_grid_root_node.value(), 1u);
-    EXPECT_EQ(grids.size(), 2u);
+    EXPECT_EQ(grids.size(), 3u);
 
     auto const& content_grid = grids.at(0).as_object();
     EXPECT(!content_grid.has("containerNodeId"sv));
@@ -1095,7 +1103,24 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     EXPECT_EQ(content_grid_fragment.get_array("areas"sv)->at(0).as_object().get_string("name"sv).value(), "content"sv);
     EXPECT_EQ(content_grid_fragment.get_object("cols"sv)->get_array("lines"sv)->at(0).as_object().get_integer<i32>("negativeNumber"sv).value(), -2);
 
-    auto const& subframe_grid = grids.at(1).as_object();
+    auto const& subgrid = grids.at(1).as_object();
+    EXPECT_EQ(subgrid.get_string("containerNodeActorID"sv).value(), section_actor);
+    EXPECT_EQ(subgrid.get_bool("isSubgrid"sv).value(), true);
+    EXPECT_EQ(subgrid.get_array("gridFragments"sv)->at(0).as_object().get_array("areas"sv)->at(0).as_object().get_string("name"sv).value(), "subgrid"sv);
+
+    JsonObject get_parent_grid_node;
+    get_parent_grid_node.set("to"sv, walker_actor);
+    get_parent_grid_node.set("type"sv, "getParentGridNode"sv);
+    get_parent_grid_node.set("node"sv, section_actor);
+    EXPECT_EQ(client.request(move(get_parent_grid_node)).get_object("node"sv)->get_string("actor"sv).value(), div_actor);
+
+    JsonObject get_missing_parent_grid_node;
+    get_missing_parent_grid_node.set("to"sv, walker_actor);
+    get_missing_parent_grid_node.set("type"sv, "getParentGridNode"sv);
+    get_missing_parent_grid_node.set("node"sv, div_actor);
+    EXPECT(client.request(move(get_missing_parent_grid_node)).get("node"sv).value().is_null());
+
+    auto const& subframe_grid = grids.at(2).as_object();
     EXPECT_EQ(subframe_grid.get_string("containerNodeActorID"sv).value(), span_actor);
     EXPECT_EQ(subframe_grid.get_array("gridFragments"sv)->at(0).as_object().get_array("areas"sv)->at(0).as_object().get_string("name"sv).value(), "subframe"sv);
 

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -175,6 +175,81 @@ static Web::CSS::StyleSheetIdentifier fixture_style_sheet()
         .rule_count = 2 };
 }
 
+static JsonObject make_grid_line(double start, i32 number, i32 negative_number)
+{
+    JsonObject line;
+    line.set("breadth"sv, 0);
+    line.set("names"sv, JsonArray {});
+    line.set("negativeNumber"sv, negative_number);
+    line.set("number"sv, number);
+    line.set("start"sv, start);
+    line.set("type"sv, "explicit"sv);
+    return line;
+}
+
+static JsonObject make_grid_track(double start, double breadth)
+{
+    JsonObject track;
+    track.set("breadth"sv, breadth);
+    track.set("start"sv, start);
+    track.set("state"sv, "static"sv);
+    track.set("type"sv, "explicit"sv);
+    return track;
+}
+
+static JsonObject make_grid_dimension()
+{
+    JsonArray lines;
+    lines.must_append(make_grid_line(0, 1, -2));
+    lines.must_append(make_grid_line(100, 2, -1));
+
+    JsonArray tracks;
+    tracks.must_append(make_grid_track(0, 100));
+
+    JsonObject dimension;
+    dimension.set("lines"sv, move(lines));
+    dimension.set("tracks"sv, move(tracks));
+    return dimension;
+}
+
+static JsonObject make_grid_layout(Web::UniqueNodeID container_node_id, StringView area_name)
+{
+    JsonObject area;
+    area.set("columnEnd"sv, 2);
+    area.set("columnStart"sv, 1);
+    area.set("name"sv, area_name);
+    area.set("rowEnd"sv, 2);
+    area.set("rowStart"sv, 1);
+    area.set("type"sv, "explicit"sv);
+
+    JsonArray areas;
+    areas.must_append(move(area));
+
+    JsonObject fragment;
+    fragment.set("areas"sv, move(areas));
+    fragment.set("cols"sv, make_grid_dimension());
+    fragment.set("rows"sv, make_grid_dimension());
+
+    JsonArray fragments;
+    fragments.must_append(move(fragment));
+
+    JsonObject layout;
+    layout.set("containerNodeId"sv, container_node_id.value());
+    layout.set("direction"sv, "ltr"sv);
+    layout.set("gridFragments"sv, move(fragments));
+    layout.set("isSubgrid"sv, false);
+    layout.set("writingMode"sv, "horizontal-tb"sv);
+    return layout;
+}
+
+static JsonArray make_grid_layouts()
+{
+    JsonArray grids;
+    grids.must_append(make_grid_layout(Web::UniqueNodeID { 4 }, "content"sv));
+    grids.must_append(make_grid_layout(Web::UniqueNodeID { 8 }, "subframe"sv));
+    return grids;
+}
+
 class TestDevToolsDelegate final : public DevTools::DevToolsDelegate {
 public:
     virtual Vector<DevTools::TabDescription> tab_list() const override
@@ -232,6 +307,26 @@ public:
 
     virtual void clear_inspected_dom_node(DevTools::TabDescription const&) const override { ++clear_inspected_dom_node_call_count; }
     virtual void clear_highlighted_dom_node(DevTools::TabDescription const&) const override { ++clear_highlighted_dom_node_call_count; }
+
+    virtual void inspect_grid_layouts(DevTools::TabDescription const&, Web::UniqueNodeID root_node_id, OnGridLayoutsReceived callback) const override
+    {
+        ++inspect_grid_layouts_call_count;
+        last_grid_root_node = root_node_id;
+        callback(make_grid_layouts());
+    }
+
+    virtual void inspect_current_grid(DevTools::TabDescription const&, Web::UniqueNodeID node_id, OnCurrentGridReceived callback) const override
+    {
+        ++inspect_current_grid_call_count;
+        last_current_grid_node = node_id;
+
+        if (node_id == Web::UniqueNodeID { 4 }) {
+            callback(make_grid_layout(node_id, "content"sv));
+            return;
+        }
+
+        callback({});
+    }
 
     virtual void highlight_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) const override
     {
@@ -484,6 +579,8 @@ public:
     mutable size_t stop_listening_for_dom_properties_call_count { 0 };
     mutable size_t inspect_dom_node_call_count { 0 };
     mutable size_t clear_inspected_dom_node_call_count { 0 };
+    mutable size_t inspect_grid_layouts_call_count { 0 };
+    mutable size_t inspect_current_grid_call_count { 0 };
     mutable size_t highlight_dom_node_call_count { 0 };
     mutable size_t clear_highlighted_dom_node_call_count { 0 };
     mutable size_t listen_for_dom_mutations_call_count { 0 };
@@ -516,6 +613,8 @@ public:
     mutable Optional<Web::CSS::PseudoElement> last_highlighted_pseudo_element;
     mutable Optional<Web::UniqueNodeID> last_inspected_dom_node;
     mutable Optional<Web::CSS::PseudoElement> last_inspected_pseudo_element;
+    mutable Optional<Web::UniqueNodeID> last_grid_root_node;
+    mutable Optional<Web::UniqueNodeID> last_current_grid_node;
     mutable Optional<Web::UniqueNodeID> last_edited_node;
     mutable Optional<Web::UniqueNodeID> last_parent_node;
     mutable Optional<Web::UniqueNodeID> last_sibling_node;
@@ -862,6 +961,7 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     EXPECT_EQ(children_response.get_array("nodes"sv)->size(), 1u);
 
     auto div_actor = query_selector(client, walker_actor, root_node_actor, "div"sv);
+    auto span_actor = query_selector(client, walker_actor, root_node_actor, "span"sv);
     JsonObject previous_sibling;
     previous_sibling.set("to"sv, walker_actor);
     previous_sibling.set("type"sv, "previousSibling"sv);
@@ -917,7 +1017,41 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     EXPECT_EQ(client.request(highlighter_actor, "hide"sv).get_string("from"sv).value(), highlighter_actor);
 
     auto layout_actor = client.request(walker_actor, "getLayoutInspector"sv).get_object("actor"sv)->get_string("actor"sv).release_value();
-    EXPECT(client.request(layout_actor, "getGrids"sv).get_array("grids"sv)->is_empty());
+
+    JsonObject get_grids;
+    get_grids.set("to"sv, layout_actor);
+    get_grids.set("type"sv, "getGrids"sv);
+    get_grids.set("rootNode"sv, root_node_actor);
+    auto grids = client.request(move(get_grids)).get_array("grids"sv).release_value();
+    EXPECT_EQ(session->delegate.inspect_grid_layouts_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_grid_root_node.value(), 1u);
+    EXPECT_EQ(grids.size(), 2u);
+
+    auto const& content_grid = grids.at(0).as_object();
+    EXPECT(!content_grid.has("containerNodeId"sv));
+    EXPECT(content_grid.has_string("actor"sv));
+    EXPECT_EQ(content_grid.get_string("containerNodeActorID"sv).value(), div_actor);
+    EXPECT_EQ(content_grid.get_string("direction"sv).value(), "ltr"sv);
+    EXPECT_EQ(content_grid.get_string("writingMode"sv).value(), "horizontal-tb"sv);
+    EXPECT_EQ(content_grid.get_bool("isSubgrid"sv).value(), false);
+    auto const& content_grid_fragment = content_grid.get_array("gridFragments"sv)->at(0).as_object();
+    EXPECT_EQ(content_grid_fragment.get_array("areas"sv)->at(0).as_object().get_string("name"sv).value(), "content"sv);
+    EXPECT_EQ(content_grid_fragment.get_object("cols"sv)->get_array("lines"sv)->at(0).as_object().get_integer<i32>("negativeNumber"sv).value(), -2);
+
+    auto const& subframe_grid = grids.at(1).as_object();
+    EXPECT_EQ(subframe_grid.get_string("containerNodeActorID"sv).value(), span_actor);
+    EXPECT_EQ(subframe_grid.get_array("gridFragments"sv)->at(0).as_object().get_array("areas"sv)->at(0).as_object().get_string("name"sv).value(), "subframe"sv);
+
+    JsonObject get_current_grid;
+    get_current_grid.set("to"sv, layout_actor);
+    get_current_grid.set("type"sv, "getCurrentGrid"sv);
+    get_current_grid.set("node"sv, div_actor);
+    auto current_grid = client.request(move(get_current_grid)).get_object("grid"sv).release_value();
+    EXPECT_EQ(session->delegate.inspect_current_grid_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_current_grid_node.value(), 4u);
+    EXPECT_EQ(current_grid.get_string("actor"sv).value(), content_grid.get_string("actor"sv).value());
+    EXPECT_EQ(current_grid.get_string("containerNodeActorID"sv).value(), div_actor);
+
     EXPECT(client.request(layout_actor, "getCurrentFlexbox"sv).get("flexbox"sv).value().is_null());
 
     JsonObject set_outer_html;

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1025,7 +1025,9 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     second_highlighter_request.set("typeName"sv, "BoxModelHighlighter"sv);
     auto second_highlighter_response = client.request(move(second_highlighter_request));
     VERIFY(second_highlighter_response.has_object("highlighter"sv));
-    EXPECT_EQ(second_highlighter_response.get_object("highlighter"sv)->get_string("actor"sv).value(), highlighter_actor);
+    EXPECT_NE(
+        second_highlighter_response.get_object("highlighter"sv)->get_string("actor"sv).value(),
+        highlighter_actor);
 
     JsonObject show_highlighter;
     show_highlighter.set("to"sv, highlighter_actor);
@@ -1052,7 +1054,11 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     second_grid_highlighter_request.set("to"sv, inspector_actor);
     second_grid_highlighter_request.set("type"sv, "getHighlighterByType"sv);
     second_grid_highlighter_request.set("typeName"sv, "CssGridHighlighter"sv);
-    EXPECT_EQ(client.request(move(second_grid_highlighter_request)).get_object("highlighter"sv)->get_string("actor"sv).value(), grid_highlighter_actor);
+    auto second_grid_highlighter_actor = client.request(move(second_grid_highlighter_request))
+                                             .get_object("highlighter"sv)
+                                             ->get_string("actor"sv)
+                                             .release_value();
+    EXPECT_NE(second_grid_highlighter_actor, grid_highlighter_actor);
 
     JsonObject grid_options;
     grid_options.set("showGridArea"sv, true);
@@ -1066,20 +1072,34 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     EXPECT_EQ(session->delegate.highlight_grid_call_count, 1u);
     EXPECT_EQ(session->delegate.last_highlighted_grid_node.value(), 4u);
     EXPECT(session->delegate.last_grid_highlight_options.as_object().get_bool("showGridArea"sv).value());
+    EXPECT_EQ(session->delegate.clear_grid_highlight_call_count, 0u);
 
     JsonObject show_second_grid_highlighter;
-    show_second_grid_highlighter.set("to"sv, grid_highlighter_actor);
+    show_second_grid_highlighter.set("to"sv, second_grid_highlighter_actor);
     show_second_grid_highlighter.set("type"sv, "show"sv);
     show_second_grid_highlighter.set("node"sv, span_actor);
     EXPECT(client.request(move(show_second_grid_highlighter)).get_bool("value"sv).value());
-    EXPECT_EQ(session->delegate.clear_grid_highlight_call_count, 1u);
-    EXPECT_EQ(session->delegate.last_cleared_grid_node.value(), 4u);
+    EXPECT_EQ(session->delegate.clear_grid_highlight_call_count, 0u);
     EXPECT_EQ(session->delegate.highlight_grid_call_count, 2u);
     EXPECT_EQ(session->delegate.last_highlighted_grid_node.value(), 8u);
 
     EXPECT_EQ(client.request(grid_highlighter_actor, "hide"sv).get_string("from"sv).value(), grid_highlighter_actor);
+    EXPECT_EQ(session->delegate.clear_grid_highlight_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_cleared_grid_node.value(), 4u);
+
+    JsonObject retarget_second_grid_highlighter;
+    retarget_second_grid_highlighter.set("to"sv, second_grid_highlighter_actor);
+    retarget_second_grid_highlighter.set("type"sv, "show"sv);
+    retarget_second_grid_highlighter.set("node"sv, div_actor);
+    EXPECT(client.request(move(retarget_second_grid_highlighter)).get_bool("value"sv).value());
     EXPECT_EQ(session->delegate.clear_grid_highlight_call_count, 2u);
     EXPECT_EQ(session->delegate.last_cleared_grid_node.value(), 8u);
+    EXPECT_EQ(session->delegate.highlight_grid_call_count, 3u);
+    EXPECT_EQ(session->delegate.last_highlighted_grid_node.value(), 4u);
+
+    EXPECT_EQ(client.request(second_grid_highlighter_actor, "release"sv).get_string("from"sv).value(), second_grid_highlighter_actor);
+    EXPECT_EQ(session->delegate.clear_grid_highlight_call_count, 3u);
+    EXPECT_EQ(session->delegate.last_cleared_grid_node.value(), 4u);
 
     auto layout_actor = client.request(walker_actor, "getLayoutInspector"sv).get_object("actor"sv)->get_string("actor"sv).release_value();
 


### PR DESCRIPTION
Supports line numbers, named areas, extending lines infinitely, changing colours for the grids, and subgrid hierarchies.

Previously we cached highlighter actors by type name, but this doesn't work with grid highlighting, because Firefox creates multiple actors of the same type, for different grids. So the final commit replaces that with creating a new actor whenever it's requested, which matches how Firefox behaves: It keeps its own cache and decides when to request a new actor or use an existing one.

<img width="2510" height="1080" alt="Screenshot_20260527_111500" src="https://github.com/user-attachments/assets/08de4a8f-b092-4cbb-80c4-874865d3b227" />

<img width="2510" height="1080" alt="Screenshot_20260527_111809" src="https://github.com/user-attachments/assets/6cba1a14-12de-4e32-917e-b18ec2f7782c" />