### PR TITLE
Pause animated images in inactive tabs

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -177,6 +177,17 @@ void HTMLImageElement::initialize(JS::Realm& realm)
     m_document_observer->set_document_became_inactive([this]() {
         m_load_event_delayer.clear();
         m_animation_timer->stop();
+        m_animation_paused_by_visibility = false;
+    });
+    m_document_observer->set_document_visibility_state_observer([this](HTML::VisibilityState visibility_state) {
+        if (visibility_state == HTML::VisibilityState::Hidden) {
+            m_animation_paused_by_visibility = m_animation_timer->is_active();
+            m_animation_timer->stop();
+            return;
+        }
+
+        if (m_animation_paused_by_visibility)
+            start_animation_timer_if_visible();
     });
 }
 
@@ -1003,7 +1014,7 @@ void HTMLImageElement::add_callbacks_to_image_request(GC::Ref<ImageRequest> imag
                 m_animation_timer->stop();
                 if (image_data->is_animated() && image_data->frame_count() > 1) {
                     m_animation_timer->set_interval(image_data->frame_duration(0));
-                    m_animation_timer->start();
+                    start_animation_timer_if_visible();
                 }
 
                 m_load_event_delayer.clear();
@@ -1242,12 +1253,36 @@ void HTMLImageElement::restart_the_animation()
 {
     m_current_frame_index = 0;
 
-    auto image_data = m_current_request->image_data();
-    if (image_data && image_data->frame_count() > 1) {
-        m_animation_timer->start();
+    if (current_request_has_running_animation()) {
+        start_animation_timer_if_visible();
     } else {
         m_animation_timer->stop();
+        m_animation_paused_by_visibility = false;
     }
+}
+
+bool HTMLImageElement::current_request_has_running_animation() const
+{
+    auto image_data = m_current_request->image_data();
+    return image_data && image_data->is_animated() && image_data->frame_count() > 1;
+}
+
+void HTMLImageElement::start_animation_timer_if_visible()
+{
+    if (!current_request_has_running_animation()) {
+        m_animation_timer->stop();
+        m_animation_paused_by_visibility = false;
+        return;
+    }
+
+    if (document().visibility_state_value() == VisibilityState::Hidden) {
+        m_animation_timer->stop();
+        m_animation_paused_by_visibility = true;
+        return;
+    }
+
+    m_animation_paused_by_visibility = false;
+    m_animation_timer->start();
 }
 
 // https://html.spec.whatwg.org/multipage/images.html#update-the-source-set
@@ -1412,6 +1447,12 @@ void HTMLImageElement::set_source_set(SourceSet source_set)
 
 void HTMLImageElement::animate()
 {
+    if (document().visibility_state_value() == VisibilityState::Hidden) {
+        m_animation_timer->stop();
+        m_animation_paused_by_visibility = true;
+        return;
+    }
+
     auto image_data = m_current_request->image_data();
     if (!image_data) {
         return;
@@ -1429,6 +1470,7 @@ void HTMLImageElement::animate()
         ++m_loops_completed;
         if (m_loops_completed > 0 && m_loops_completed == image_data->loop_count()) {
             m_animation_timer->stop();
+            m_animation_paused_by_visibility = false;
         }
     }
 

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -145,11 +145,14 @@ private:
     void handle_failed_fetch();
     void add_callbacks_to_image_request(GC::Ref<ImageRequest>, bool maybe_omit_events, String const& url_string, String const& previous_url, u64 update_the_image_data_count);
 
+    bool current_request_has_running_animation() const;
+    void start_animation_timer_if_visible();
     void animate();
 
     RefPtr<Core::Timer> m_animation_timer;
     size_t m_current_frame_index { 0 };
     size_t m_loops_completed { 0 };
+    bool m_animation_paused_by_visibility { false };
 
     Optional<DOM::DocumentLoadEventDelayer> m_load_event_delayer;
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -184,6 +184,9 @@ void ViewImplementation::did_update_window_rect()
 
 void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState visibility_state)
 {
+    if (m_system_visibility_state == visibility_state)
+        return;
+
     m_system_visibility_state = visibility_state;
     client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
 }

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -918,6 +918,11 @@ static NSImage* location_field_globe_icon()
     [delegate setActiveTab:[self tab]];
 }
 
+- (void)windowDidChangeOcclusionState:(NSNotification*)notification
+{
+    [[[self tab] web_view] handleVisibility:([self.window occlusionState] & NSWindowOcclusionStateVisible) != 0];
+}
+
 - (void)windowDidResignKey:(NSNotification*)notification
 {
     [self.autocomplete close];

--- a/UI/Gtk/BrowserWindow.cpp
+++ b/UI/Gtk/BrowserWindow.cpp
@@ -270,6 +270,12 @@ void BrowserWindow::setup_keyboard_shortcuts()
 void BrowserWindow::on_tab_switched()
 {
     auto* tab = current_tab();
+    for (auto& existing_tab : m_tabs) {
+        existing_tab->view().set_system_visibility_state(existing_tab.ptr() == tab
+                ? Web::HTML::VisibilityState::Visible
+                : Web::HTML::VisibilityState::Hidden);
+    }
+
     if (!tab)
         return;
 
@@ -302,6 +308,7 @@ Tab& BrowserWindow::create_new_tab(URL::URL const& url, Web::HTML::ActivateTab a
     auto* page = adw_tab_view_append(m_tab_view, tab_ref.widget());
     adw_tab_page_set_title(page, "New Tab");
     tab_ref.set_tab_page(page);
+    m_tabs.append(move(tab));
 
     if (activate_tab == Web::HTML::ActivateTab::Yes) {
         adw_tab_view_set_selected_page(m_tab_view, page);
@@ -313,7 +320,6 @@ Tab& BrowserWindow::create_new_tab(URL::URL const& url, Web::HTML::ActivateTab a
         }
     }
 
-    m_tabs.append(move(tab));
     return tab_ref;
 }
 
@@ -325,11 +331,11 @@ Tab& BrowserWindow::create_child_tab(Web::HTML::ActivateTab activate_tab, Tab& p
     auto* page = adw_tab_view_append(m_tab_view, tab_ref.widget());
     adw_tab_page_set_title(page, "New Tab");
     tab_ref.set_tab_page(page);
+    m_tabs.append(move(tab));
 
     if (activate_tab == Web::HTML::ActivateTab::Yes)
         adw_tab_view_set_selected_page(m_tab_view, page);
 
-    m_tabs.append(move(tab));
     return tab_ref;
 }
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -637,7 +637,14 @@ void BrowserWindow::set_current_tab(Tab* tab)
     if (tab == m_current_tab)
         return;
 
+    if (m_current_tab)
+        m_current_tab->view().set_system_visibility_state(Web::HTML::VisibilityState::Hidden);
+
     m_current_tab = tab;
+
+    if (m_current_tab)
+        m_current_tab->view().set_system_visibility_state(Web::HTML::VisibilityState::Visible);
+
     WebView::Application::the().update_bookmark_action_for_current_web_view();
 }
 


### PR DESCRIPTION
Stop animated image timers when their document becomes hidden, and only resume them when the document becomes visible again.

This also updates tab-switch visibility plumbing so inactive tabs are reported as hidden to WebContent. AppKit uses window occlusion state so visible background windows keep a visible document state.

The change prevents animated images in inactive tabs from advancing frames and requesting more decoded frames from ImageDecoder.