### PR TITLE
LibWeb/CSS: Implement `@scope` implicit element scope

### DIFF
--- a/Libraries/LibWeb/CSS/CSSNestedDeclarations.cpp
+++ b/Libraries/LibWeb/CSS/CSSNestedDeclarations.cpp
@@ -48,7 +48,7 @@ void CSSNestedDeclarations::visit_edges(Cell::Visitor& visitor)
 
 static SelectorList absolutize_parent_selectors(CSSNestedDeclarations const& nested_declarations)
 {
-    static SelectorList s_root_selector_list {
+    static SelectorList s_where_scope_selector_list {
         Selector::create({
             Selector::CompoundSelector {
                 .combinator = Selector::Combinator::None,
@@ -56,7 +56,22 @@ static SelectorList absolutize_parent_selectors(CSSNestedDeclarations const& nes
                     Selector::SimpleSelector {
                         .type = Selector::SimpleSelector::Type::PseudoClass,
                         .value = Selector::SimpleSelector::PseudoClassSelector {
-                            .type = PseudoClass::Root,
+                            .type = PseudoClass::Where,
+                            .argument_selector_list = {
+                                Selector::create({
+                                    Selector::CompoundSelector {
+                                        .combinator = Selector::Combinator::None,
+                                        .simple_selectors = {
+                                            Selector::SimpleSelector {
+                                                .type = Selector::SimpleSelector::Type::PseudoClass,
+                                                .value = Selector::SimpleSelector::PseudoClassSelector {
+                                                    .type = PseudoClass::Scope,
+                                                },
+                                            },
+                                        },
+                                    },
+                                }),
+                            },
                         },
                     },
                 },
@@ -67,43 +82,11 @@ static SelectorList absolutize_parent_selectors(CSSNestedDeclarations const& nes
     for (auto const* parent_rule = nested_declarations.parent_rule(); parent_rule; parent_rule = parent_rule->parent_rule()) {
         if (auto const* parent_style_rule = as_if<CSSStyleRule>(parent_rule))
             return parent_style_rule->absolutized_selectors();
-        if (auto const* parent_scope_rule = as_if<CSSScopeRule>(parent_rule)) {
-            // https://drafts.csswg.org/css-cascade-6/#scope-limits
-            // Finding the scoping root(s)
-            auto scoping_root_selector = [&] {
-                // For each element matched by <scope-start>, create a scope using that element as the scoping root.
-                if (auto const& scope_start = parent_scope_rule->start_selectors_for_matching(); scope_start.has_value())
-                    return scope_start.value();
-
-                // If no <scope-start> is specified, the scoping root is the parent element of the owner node of the
-                // stylesheet where the @scope rule is defined.
-                // FIXME: This means the scoping root is the `<style>` element's parent element. Implement this!
-
-                // (If no such element exists and the containing node tree is a shadow tree, then the scoping root is
-                // the shadow host. Otherwise, the scoping root is the root of the containing node tree.)
-                return s_root_selector_list;
-            }();
-
+        if (is<CSSScopeRule>(parent_rule)) {
             // https://drafts.csswg.org/css-cascade-6/#scoped-declarations
             // Declarations may be used directly with the body of a @scope rule. Contiguous runs of declarations are
             // wrapped in nested declarations rules, which match the scoping root with zero specificity.
-            // NB: We achieve zero specificity by wrapping it in `:where()`.
-            return SelectorList {
-                Selector::create({
-                    Selector::CompoundSelector {
-                        .combinator = Selector::Combinator::None,
-                        .simple_selectors = {
-                            Selector::SimpleSelector {
-                                .type = Selector::SimpleSelector::Type::PseudoClass,
-                                .value = Selector::SimpleSelector::PseudoClassSelector {
-                                    .type = PseudoClass::Where,
-                                    .argument_selector_list = scoping_root_selector,
-                                },
-                            },
-                        },
-                    },
-                }),
-            };
+            return s_where_scope_selector_list;
         }
     }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -285,16 +285,29 @@ static Optional<ResolvedScope> resolve_single_scope(DOM::AbstractElement abstrac
                 break;
         }
     } else {
-        // If no <scope-start> is specified, the scoping root is the parent element of the owner node of the
-        // stylesheet where the @scope rule is defined.
-        // FIXME: This means the scoping root is the `<style>` element's parent element. Implement this!
+        root = [&] -> GC::Ptr<DOM::Element const> {
+            // If no <scope-start> is specified, the scoping root is the parent element of the owner node of the
+            // stylesheet where the @scope rule is defined.
+            if (auto* owner_node = const_cast<CSSStyleSheet&>(*rule.sheet).owner_node()) {
+                if (auto parent = owner_node->parent_element())
+                    return parent;
+            }
 
-        // (If no such element exists and the containing node tree is a shadow tree, then the scoping root is
-        // the shadow host. Otherwise, the scoping root is the root of the containing node tree.)
-        root = abstract_element.element().document().document_element();
-        if (!root || !root->is_inclusive_ancestor_of(abstract_element.element()))
+            // If no such element exists and the containing node tree is a shadow tree, then the scoping root is the
+            // shadow host.
+            if (rule_root)
+                return rule_root->host();
+
+            // Otherwise, the scoping root is the root of the containing node tree.
+            if (auto document = rule.sheet->owning_document())
+                return document->document_element();
+            return nullptr;
+        }();
+        if (!root || !root->is_shadow_including_inclusive_ancestor_of(abstract_element.element()))
             return {};
-        for (auto const* candidate = &abstract_element.element(); candidate && candidate != root; candidate = candidate->parent_element().ptr())
+        if (outer_root && !outer_root->is_shadow_including_inclusive_ancestor_of(*root))
+            return {};
+        for (auto const* candidate = &abstract_element.element(); candidate && candidate != root; candidate = candidate->parent_or_shadow_host_element())
             ++proximity;
     }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/scope-declarations.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/scope-declarations.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-4 Pass
-1 Fail
+5 Pass
 Pass	Scoped declarations apply to the scoping root
-Fail	Scoped declarations apply to implicit scoping root
+Pass	Scoped declarations apply to implicit scoping root
 Pass	Scoped declarations apply with zero specificity
 Pass	Declarations are parsed into CSSNestedDeclarations, prelude=(.a)
 Pass	Declarations are parsed into CSSNestedDeclarations, prelude=

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/scope-shadow.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/scope-shadow.txt
@@ -2,14 +2,14 @@ Harness status: OK
 
 Found 9 tests
 
-2 Pass
-7 Fail
+4 Pass
+5 Fail
 Fail	@scope can match :host
 Fail	@scope can match :host(...)
 Pass	:scope matches host via the scoping root
 Fail	:scope within :is() matches host via the scoping root
-Fail	Implicit @scope as direct child of shadow root
-Fail	Implicit @scope in construted stylesheet
+Pass	Implicit @scope as direct child of shadow root
+Pass	Implicit @scope in construted stylesheet
 Pass	Matching :host via &, :scope (subject)
 Fail	Matching :host via &, :scope (non-subject)
 Fail	Matching :host via &, :scope (non-subject, >)


### PR DESCRIPTION
`@scope` without a selector for the scoping root uses the parent element of the `<style>` as the scoping root. Implement that, and simplify the CSSNestedDeclarations code as `:where(:scope)` is actually sufficient.