### PR TITLE
WebContent: Buffer DevTools DOM mutations until layout is safe

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1724,8 +1724,11 @@ void Document::update_layout(UpdateLayoutReason reason)
         return;
 
     VERIFY(!m_is_running_update_layout);
-    ScopeGuard guard = [&] { m_is_running_update_layout = false; };
     m_is_running_update_layout = true;
+    ScopeGuard guard = [&] {
+        m_is_running_update_layout = false;
+        page().client().flush_pending_dom_mutations();
+    };
 
     auto needs_style_update_after_layout = [&] {
         return !m_query_containers_needing_container_query_evaluation_after_layout.is_empty()

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -528,6 +528,7 @@ public:
     virtual void close_worker_agent([[maybe_unused]] HTML::WorkerAgentId agent_id, [[maybe_unused]] HTML::WorkerAgentOwnerToken owner_token) { }
 
     virtual void page_did_mutate_dom([[maybe_unused]] FlyString const& type, [[maybe_unused]] DOM::Node const& target, [[maybe_unused]] DOM::NodeList& added_nodes, [[maybe_unused]] DOM::NodeList& removed_nodes, [[maybe_unused]] GC::Ptr<DOM::Node> previous_sibling, [[maybe_unused]] GC::Ptr<DOM::Node> next_sibling, [[maybe_unused]] Optional<String> const& attribute_name) { }
+    virtual void flush_pending_dom_mutations() { }
 
     virtual void page_did_take_screenshot(Gfx::ShareableBitmap const&) { }
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -719,6 +719,8 @@ void ConnectionFromClient::set_listen_for_dom_mutations(u64 page_id, bool listen
         return;
 
     page->page().set_listen_for_dom_mutations(listen_for_dom_mutations);
+    if (!listen_for_dom_mutations)
+        page->clear_pending_dom_mutations();
 }
 
 void ConnectionFromClient::did_connect_devtools_client(u64 page_id)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -52,6 +52,15 @@ static bool s_async_scrolling_enabled { false };
 
 GC_DEFINE_ALLOCATOR(PageClient);
 
+static String serialize_dom_mutation_target(Web::DOM::Node const& target)
+{
+    StringBuilder builder;
+    auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
+    target.serialize_tree_as_json(serializer);
+    MUST(serializer.finish());
+    return MUST(builder.to_string());
+}
+
 void PageClient::set_use_skia_painter(UseSkiaPainter use_skia_painter)
 {
     s_use_skia_painter = use_skia_painter;
@@ -98,6 +107,9 @@ void PageClient::visit_edges(JS::Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_page);
     visitor.visit(m_top_level_document_console_client);
+    m_pending_dom_mutations.for_each([&](auto& pending_mutation) {
+        visitor.visit(pending_mutation.target);
+    });
 
     if (m_webdriver)
         m_webdriver->visit_edges(visitor);
@@ -370,6 +382,7 @@ void PageClient::page_did_change_active_document_in_top_level_browsing_context(W
 {
     auto& realm = document.realm();
 
+    clear_pending_dom_mutations();
     m_web_ui.clear();
 
     if (auto console_client = document.console_client()) {
@@ -820,13 +833,40 @@ void PageClient::page_did_mutate_dom(FlyString const& type, Web::DOM::Node const
         VERIFY_NOT_REACHED();
     }
 
-    StringBuilder builder;
-    auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
-    target.serialize_tree_as_json(serializer);
-    MUST(serializer.finish());
-    auto serialized_target = MUST(builder.to_string());
+    auto mutation_message = WebView::Mutation { type.to_string(), target.unique_id(), {}, mutation.release_value() };
+    if (m_pending_dom_mutations.is_empty() && target.document().layout_is_up_to_date()) {
+        send_dom_mutation(target, move(mutation_message));
+        return;
+    }
 
-    client().async_did_mutate_dom(m_id, { type.to_string(), target.unique_id(), move(serialized_target), mutation.release_value() });
+    m_pending_dom_mutations.enqueue({ const_cast<Web::DOM::Node&>(target), move(mutation_message) });
+}
+
+void PageClient::flush_pending_dom_mutations()
+{
+    if (!page().listen_for_dom_mutations()) {
+        clear_pending_dom_mutations();
+        return;
+    }
+
+    while (!m_pending_dom_mutations.is_empty()) {
+        if (!m_pending_dom_mutations.head().target->document().layout_is_up_to_date())
+            break;
+
+        auto pending_mutation = m_pending_dom_mutations.dequeue();
+        send_dom_mutation(*pending_mutation.target, move(pending_mutation.mutation));
+    }
+}
+
+void PageClient::clear_pending_dom_mutations()
+{
+    m_pending_dom_mutations.clear();
+}
+
+void PageClient::send_dom_mutation(Web::DOM::Node const& target, WebView::Mutation mutation)
+{
+    mutation.serialized_target = serialize_dom_mutation_target(target);
+    client().async_did_mutate_dom(m_id, move(mutation));
 }
 
 void PageClient::page_did_take_screenshot(Gfx::ShareableBitmap const& screenshot)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -16,6 +16,7 @@
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/Mutation.h>
 #include <LibWebView/StorageSetResult.h>
 #include <WebContent/Forward.h>
 
@@ -108,8 +109,14 @@ public:
 
     void queue_screenshot_task(Optional<Web::UniqueNodeID> node_id);
     void send_current_needs_beforeunload_check();
+    void clear_pending_dom_mutations();
 
 private:
+    struct PendingDOMMutation {
+        GC::Ref<Web::DOM::Node> target;
+        WebView::Mutation mutation;
+    };
+
     PageClient(PageHost&, u64 id);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
@@ -200,6 +207,7 @@ private:
     virtual Web::HTML::WorkerAgentId start_worker_agent(Web::HTML::WorkerAgentStartRequest&&) override;
     virtual void close_worker_agent(Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken) override;
     virtual void page_did_mutate_dom(FlyString const& type, Web::DOM::Node const& target, Web::DOM::NodeList& added_nodes, Web::DOM::NodeList& removed_nodes, GC::Ptr<Web::DOM::Node> previous_sibling, GC::Ptr<Web::DOM::Node> next_sibling, Optional<String> const& attribute_name) override;
+    virtual void flush_pending_dom_mutations() override;
     virtual void page_did_take_screenshot(Gfx::ShareableBitmap const& screenshot) override;
     virtual void received_message_from_web_ui(String const& name, JS::Value data) override;
     virtual void page_did_start_network_request(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ReadonlyBytes, Optional<String>) override;
@@ -210,6 +218,7 @@ private:
 
     void setup_palette();
     ConnectionFromClient& client() const;
+    void send_dom_mutation(Web::DOM::Node const& target, WebView::Mutation mutation);
 
     PageHost& m_owner;
     GC::Ref<Web::Page> m_page;
@@ -236,6 +245,7 @@ private:
 
     RefPtr<Core::Timer> m_frame_timer;
     Optional<double> m_last_frame_dispatch_time;
+    Queue<PendingDOMMutation> m_pending_dom_mutations;
 
     u64 m_devtools_client_count { 0 };
 };


### PR DESCRIPTION
Snapshot DevTools DOM mutation payloads immediately, but defer subtree serialization until the target document's layout is up to date.

This avoids re-entering layout-backed DOM serialization from style and layout updates, which could crash WebContent while DevTools was listening for mutations.

Fixes #8280.