### PR TITLE
LibWeb: Propagate blocking wheel regions to descendants

### DIFF
--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -28,6 +28,7 @@
 #include <LibWeb/DOM/EventDispatcher.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/DOM/IDLEventListener.h>
+#include <LibWeb/DOM/Node.h>
 #include <LibWeb/HTML/BeforeUnloadEvent.h>
 #include <LibWeb/HTML/CloseWatcherManager.h>
 #include <LibWeb/HTML/ErrorEvent.h>
@@ -207,6 +208,7 @@ static void invalidate_compositor_wheel_event_listener_state(EventTarget& event_
     }
 
     if (auto* node = as_if<Node>(event_target)) {
+        node->update_inside_blocking_wheel_event_handler_state_for_subtree();
         node->set_needs_repaint();
         node->document().page().invalidate_compositor_wheel_event_listener_state();
     }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1800,6 +1800,7 @@ void Node::inserted()
         m_is_connected = parent()->is_connected();
 
     recompute_editable_subtree_flag();
+    update_inside_blocking_wheel_event_handler_state();
     set_needs_style_update(true);
 }
 
@@ -1807,6 +1808,7 @@ void Node::removed_from(IsSubtreeRoot, Node*, Node&)
 {
     m_is_connected = false;
     m_in_editable_subtree = false;
+    m_inside_blocking_wheel_event_handler = false;
     m_layout_node = nullptr;
     m_paintable = nullptr;
 }
@@ -1815,6 +1817,36 @@ void Node::removed_from(IsSubtreeRoot, Node*, Node&)
 void Node::moved_from(IsSubtreeRoot, GC::Ptr<Node>)
 {
     recompute_editable_subtree_flag();
+    update_inside_blocking_wheel_event_handler_state();
+}
+
+static bool is_root_wheel_event_target(Node const& node)
+{
+    auto& document = node.document();
+    return &node == &document || &node == document.document_element() || &node == document.body();
+}
+
+void Node::update_inside_blocking_wheel_event_handler_state()
+{
+    m_inside_blocking_wheel_event_handler = false;
+    if (auto* parent = parent_or_shadow_host_node())
+        m_inside_blocking_wheel_event_handler = parent->inside_blocking_wheel_event_handler();
+
+    if (!m_inside_blocking_wheel_event_handler && !is_root_wheel_event_target(*this) && has_blocking_wheel_event_listener())
+        m_inside_blocking_wheel_event_handler = true;
+}
+
+void Node::update_inside_blocking_wheel_event_handler_state_for_subtree()
+{
+    if (is_root_wheel_event_target(*this)) {
+        update_inside_blocking_wheel_event_handler_state();
+        return;
+    }
+
+    for_each_shadow_including_inclusive_descendant([](Node& node) {
+        node.update_inside_blocking_wheel_event_handler_state();
+        return TraversalDecision::Continue;
+    });
 }
 
 ParentNode* Node::parent_or_shadow_host()

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -288,6 +288,9 @@ public:
 
     bool is_connected() const { return m_is_connected; }
     void set_is_connected(bool is_connected) { m_is_connected = is_connected; }
+    bool inside_blocking_wheel_event_handler() const { return m_inside_blocking_wheel_event_handler; }
+    void update_inside_blocking_wheel_event_handler_state();
+    void update_inside_blocking_wheel_event_handler_state_for_subtree();
 
     [[nodiscard]] bool is_browsing_context_connected() const;
 
@@ -515,6 +518,7 @@ protected:
     bool m_children_may_depend_on_non_inherited_property_inheritance { false };
     bool m_in_editable_subtree { false };
     bool m_is_connected { false };
+    bool m_inside_blocking_wheel_event_handler { false };
 
     UniqueNodeID m_unique_id;
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -274,10 +274,24 @@ static void record_viewport_scrollbar_state(PaintableBox const& paintable_box, D
     }
 }
 
-static bool is_root_wheel_event_target(DOM::Node const& node)
+static void record_blocking_wheel_event_region(PaintableBox const& paintable_box, DisplayListRecordingContext& context)
 {
-    auto& document = node.document();
-    return &node == document.document_element() || &node == document.body();
+    if (context.has_blocking_wheel_event_region_covering_viewport())
+        return;
+    if (!paintable_box.is_visible() || !paintable_box.visible_for_hit_testing())
+        return;
+    auto node = paintable_box.dom_node();
+    if (!node || !node->inside_blocking_wheel_event_handler())
+        return;
+
+    auto rect = css_rect_to_device_rect(paintable_box.absolute_united_border_box_rect(), context.device_pixels_per_css_pixel());
+    if (rect.is_empty())
+        return;
+
+    context.set_has_blocking_wheel_event_listeners(true);
+    context.display_list_recorder().compositor_blocking_wheel_event_region({
+        .rect = rect,
+    });
 }
 
 ResolvedCSSFilter resolve_css_filter(CSS::Filter const& computed_filter, PaintableBox const& paintable_box)
@@ -945,14 +959,7 @@ void PaintableBox::record_async_scrolling_metadata(DisplayListRecordingContext& 
 
     record_wheel_hit_test_target(*this, context);
 
-    if (!context.has_blocking_wheel_event_region_covering_viewport()) {
-        if (auto node = dom_node(); node && !is_root_wheel_event_target(*node) && node->has_blocking_wheel_event_listener()) {
-            context.set_has_blocking_wheel_event_listeners(true);
-            recorder.compositor_blocking_wheel_event_region({
-                .rect = css_rect_to_device_rect(absolute_united_border_box_rect(), device_pixels_per_css_pixel),
-            });
-        }
-    }
+    record_blocking_wheel_event_region(*this, context);
 
     if (is_nested_navigable_container(*this)) {
         record_main_thread_wheel_event_region(*this, context);
@@ -989,9 +996,6 @@ void PaintableBox::record_async_scrolling_metadata(DisplayListRecordingContext& 
 
 void PaintableBox::paint(DisplayListRecordingContext& context, PaintPhase phase) const
 {
-    if (phase == PaintPhase::Background)
-        record_async_scrolling_metadata(context);
-
     if (!is_visible())
         return;
 

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -40,6 +40,9 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
             context.display_list_recorder().set_accumulated_visual_context(paintable_box->accumulated_visual_context_index());
     }
 
+    if (paintable_box && phase == PaintPhase::Background)
+        paintable_box->record_async_scrolling_metadata(context);
+
     bool const skip_cache = !paintable_box || context.should_show_line_box_borders() || paintable_box->fixed_background_visual_context().has_value();
     if (!skip_cache && paintable_box->has_cached_commands(phase)) {
         context.display_list_recorder().replay_cached_commands(paintable_box->cached_commands(phase));

--- a/Tests/LibWeb/Text/expected/async-scrolling/non-scrollable-wheel-listener-prevents-viewport-scroll.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/non-scrollable-wheel-listener-prevents-viewport-scroll.txt
@@ -1,0 +1,7 @@
+wheel routing admission: accepted
+wheel scroll admission over map: blocked-by-wheel-event-region
+window scrollY before wheel: 900
+wheel event count: 1
+wheel event cancelable: true
+wheel event defaultPrevented: true
+window scrollY: 900

--- a/Tests/LibWeb/Text/input/async-scrolling/non-scrollable-wheel-listener-prevents-viewport-scroll.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/non-scrollable-wheel-listener-prevents-viewport-scroll.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #before {
+        height: 1000px;
+    }
+
+    #map {
+        position: relative;
+        width: 400px;
+        height: 400px;
+        overflow: hidden;
+        background: tan;
+    }
+
+    #canvas-container {
+        position: relative;
+    }
+
+    #canvas {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 400px;
+        height: 400px;
+        background: darkseagreen;
+    }
+
+    #page-spacer {
+        height: 2000px;
+    }
+</style>
+<div id="before"></div>
+<div id="map">
+    <div id="canvas-container">
+        <div id="canvas"></div>
+    </div>
+</div>
+<div id="page-spacer"></div>
+<script>
+    promiseTest(async () => {
+        let wheelEventCount = 0;
+        let wheelEventWasCancelable = false;
+        let wheelEventWasDefaultPrevented = false;
+
+        document.getElementById("canvas-container").addEventListener("wheel", event => {
+            wheelEventCount++;
+            wheelEventWasCancelable = event.cancelable;
+            event.preventDefault();
+            wheelEventWasDefaultPrevented = event.defaultPrevented;
+        }, { passive: false });
+
+        window.scrollTo(0, 900);
+        await animationFrame();
+        await animationFrame();
+
+        println(`wheel routing admission: ${internals.asyncScrollingStateWheelRoutingAdmission()}`);
+        println(`wheel scroll admission over map: ${internals.asyncScrollingStateWheelScrollAdmissionAt(200, 200, 0, 100)}`);
+        println(`window scrollY before wheel: ${window.scrollY}`);
+
+        await internals.wheel(200, 200, 0, 100);
+
+        println(`wheel event count: ${wheelEventCount}`);
+        println(`wheel event cancelable: ${wheelEventWasCancelable}`);
+        println(`wheel event defaultPrevented: ${wheelEventWasDefaultPrevented}`);
+        println(`window scrollY: ${window.scrollY}`);
+    });
+</script>


### PR DESCRIPTION
Async scrolling only recorded compositor blocking wheel event regions for the paintable attached to the element with the listener. Sites that attach a non-passive wheel listener to an otherwise non-painting container, then put the visible interactive content in descendants, could still let the compositor scroll the page before the main thread handled the wheel event.