### PR TITLE
Tests: Bump timeout for high-volume structural-child stress tests

### DIFF
--- a/Tests/LibWeb/Text/input/css/style-invalidation/structural-child-mutations.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/structural-child-mutations.html
@@ -3,6 +3,11 @@
 <script src="../../include.js"></script>
 <script src="structural-matrix.js"></script>
 <script>
+    // Large amount of time spent in flushPendingStyleWork() pushes this high-volume stress test past the harness's
+    // default 120s per-test ceiling on Sanitizer builds. Give it more room.
+    internals.setTestTimeout(300000);
+</script>
+<script>
     test(() => {
         const scopes = [
             "document",

--- a/Tests/LibWeb/Text/input/css/style-invalidation/structural-child-part-document-stress.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/structural-child-part-document-stress.html
@@ -3,6 +3,11 @@
 <script src="../../include.js"></script>
 <script src="structural-matrix.js"></script>
 <script>
+    // Large amount of time spent in flushPendingStyleWork() pushes this high-volume stress test past the harness's
+    // default 120s per-test ceiling on Sanitizer builds. Give it more room.
+    internals.setTestTimeout(300000);
+</script>
+<script>
     test(() => {
         const stressScopes = [
             "part-document",

--- a/Tests/LibWeb/Text/input/css/style-invalidation/structural-child-stress.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/structural-child-stress.html
@@ -3,6 +3,11 @@
 <script src="../../include.js"></script>
 <script src="structural-matrix.js"></script>
 <script>
+    // Large amount of time spent in flushPendingStyleWork() pushes this high-volume stress test past the harness's
+    // default 120s per-test ceiling on Sanitizer builds. Give it more room.
+    internals.setTestTimeout(300000);
+</script>
+<script>
     test(() => {
         const stressScopes = [
             "document",

--- a/Tests/LibWeb/Text/input/css/style-invalidation/structural-child-svg-use-stress.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/structural-child-svg-use-stress.html
@@ -3,6 +3,11 @@
 <script src="../../include.js"></script>
 <script src="structural-matrix.js"></script>
 <script>
+    // Large amount of time spent in flushPendingStyleWork() pushes this high-volume stress test past the harness's
+    // default 120s per-test ceiling on Sanitizer builds. Give it more room.
+    internals.setTestTimeout(300000);
+</script>
+<script>
     test(() => {
         const stressModes = ["warm", "cold", "pseudo-warm", "pseudo-cold", "detached", "detached-pseudo"];
         for (const selectorCase of childMutationCases) {


### PR DESCRIPTION
**Problem:** Several high-volume style-invalidation stress tests intermittently time out on Linux Sanitizer CI runs.

**Cause:** `f9ef74bb0a` added a synchronous `internals.updateStyle()` call to the per-case “`finally`” block in `structural-matrix.js` — via a new `flushPendingStyleWork()` helper. The now-timing-out problematic tests each run hundreds of cases via nested loops. So, the new per-case flush roughly doubles the synchronous style work — tipping the (already slow) Sanitizer builds past the harness’s default 120s per-test ceiling.

**Fix:** Bump the per-test timeout for each problematic case to 300000 ms.
