### PR TITLE
Compositor: Fold client presentation into presentation mode

### DIFF
--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -21,11 +21,6 @@ CompositorContextHandle::~CompositorContextHandle()
     m_host.destroy_context(m_context_id);
 }
 
-void CompositorContextHandle::stop_presenting_to_client()
-{
-    m_host.stop_presenting_to_client(m_context_id);
-}
-
 void CompositorContextHandle::set_presentation_mode(PresentationMode mode)
 {
     m_host.set_presentation_mode(m_context_id, move(mode));

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -33,7 +33,6 @@ public:
     ~CompositorContextHandle();
 
     CompositorContextId id() const { return m_context_id; }
-    void stop_presenting_to_client();
     void set_presentation_mode(PresentationMode);
 
     void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
@@ -70,7 +69,6 @@ public:
     OwnPtr<CompositorContextHandle> create_context(CompositorContextId);
 
     virtual void destroy_context(CompositorContextId) = 0;
-    virtual void stop_presenting_to_client(CompositorContextId) = 0;
     virtual void set_presentation_mode(CompositorContextId, PresentationMode) = 0;
 
     virtual void update_display_list(CompositorContextId, NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&) = 0;

--- a/Libraries/LibWeb/Compositor/Types.cpp
+++ b/Libraries/LibWeb/Compositor/Types.cpp
@@ -99,4 +99,16 @@ ErrorOr<Web::Compositor::PublishToCompositorSurface> decode(Decoder& decoder)
     };
 }
 
+template<>
+ErrorOr<void> encode(Encoder&, Web::Compositor::PresentToClient const&)
+{
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::PresentToClient> decode(Decoder&)
+{
+    return Web::Compositor::PresentToClient {};
+}
+
 }

--- a/Libraries/LibWeb/Compositor/Types.h
+++ b/Libraries/LibWeb/Compositor/Types.h
@@ -78,7 +78,10 @@ struct PublishToCompositorSurface {
     Painting::CompositorSurfaceId surface_id;
 };
 
-using PresentationMode = Variant<Empty, PublishToCompositorSurface>;
+struct PresentToClient {
+};
+
+using PresentationMode = Variant<Empty, PresentToClient, PublishToCompositorSurface>;
 
 }
 
@@ -108,5 +111,10 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::PublishToCompositorSurface const&);
 template<>
 WEB_API ErrorOr<Web::Compositor::PublishToCompositorSurface> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::PresentToClient const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::PresentToClient> decode(Decoder&);
 
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -19,6 +19,11 @@ namespace Compositor {
 
 static constexpr int gpu_completion_check_interval_ms = 1;
 
+static bool presentation_mode_presents_to_client(Web::Compositor::PresentationMode const& presentation_mode)
+{
+    return presentation_mode.has<Web::Compositor::PresentToClient>();
+}
+
 static void set_or_append_pending_scroll_offset(Vector<Web::Compositor::AsyncScrollOffset>& pending_scroll_offsets, Web::Compositor::AsyncScrollOffset const& scroll_offset)
 {
     for (auto& existing : pending_scroll_offsets) {
@@ -222,7 +227,8 @@ void CompositorState::create_context(Web::Compositor::CompositorContextId contex
     context.web_content_client = &web_content_client;
     context.page_id = page_id;
     context.page_presentation_registration = page_presentation_registration;
-    context.presents_to_client = page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes;
+    if (page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes)
+        context.presentation_mode = Web::Compositor::PresentToClient {};
     resize_backing_stores_if_needed(context_id, context);
 }
 
@@ -250,10 +256,15 @@ void CompositorState::set_presentation_mode(Web::Compositor::CompositorContextId
     VERIFY(context);
 
     auto& context_state = *context;
+    auto was_presenting_to_client = presentation_mode_presents_to_client(context_state.presentation_mode);
+    auto will_present_to_client = presentation_mode_presents_to_client(presentation_mode);
     detach_from_parent_surface(context_id, context_state);
 
     presentation_mode.visit(
         [](Empty const&) {},
+        [&](Web::Compositor::PresentToClient const&) {
+            VERIFY(context_state.page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes);
+        },
         [&](Web::Compositor::PublishToCompositorSurface const& mode) {
             auto* parent_context = context_if_present(mode.target_context_id);
             VERIFY(parent_context);
@@ -264,16 +275,11 @@ void CompositorState::set_presentation_mode(Web::Compositor::CompositorContextId
             };
         });
     context_state.presentation_mode = move(presentation_mode);
-}
 
-void CompositorState::stop_presenting_to_client(Web::Compositor::CompositorContextId context_id)
-{
-    auto* context = context_if_present(context_id);
-    VERIFY(context);
-    if (context->gpu_present_bitmap_id_awaiting_completion.has_value()
-        && context->presented_bitmap_id_awaiting_ack == context->gpu_present_bitmap_id_awaiting_completion)
-        context->presented_bitmap_id_awaiting_ack.clear();
-    context->presents_to_client = false;
+    if (was_presenting_to_client && !will_present_to_client
+        && context_state.gpu_present_bitmap_id_awaiting_completion.has_value()
+        && context_state.presented_bitmap_id_awaiting_ack == context_state.gpu_present_bitmap_id_awaiting_completion)
+        context_state.presented_bitmap_id_awaiting_ack.clear();
 }
 
 void CompositorState::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
@@ -352,7 +358,7 @@ bool CompositorState::handle_mouse_event(Web::Compositor::CompositorContextId co
         return false;
 
     auto& context_state = *context;
-    if (!context_state.presents_to_client)
+    if (!presentation_mode_presents_to_client(context_state.presentation_mode))
         return false;
 
     auto position = Gfx::FloatPoint {
@@ -474,7 +480,7 @@ bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId conte
         return false;
 
     auto& context_state = *context;
-    if (!context_state.presents_to_client)
+    if (!presentation_mode_presents_to_client(context_state.presentation_mode))
         return false;
     VERIFY(context_state.web_content_client);
     if (!context_state.can_accept_async_wheel_events)
@@ -572,6 +578,7 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
     auto& back_store = context.backing_store_manager.back_store();
     context.presentation_mode.visit(
         [](Empty const&) {},
+        [](Web::Compositor::PresentToClient const&) {},
         [&](Web::Compositor::PublishToCompositorSurface const&) {
             Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
             painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
@@ -580,7 +587,7 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
     paint_viewport_scrollbar_overlay(context, back_store);
     auto rendered_bitmap_id = context.backing_store_manager.back_bitmap_id();
     context.gpu_present_bitmap_id_awaiting_completion = rendered_bitmap_id;
-    if (context.presents_to_client)
+    if (presentation_mode_presents_to_client(context.presentation_mode))
         context.presented_bitmap_id_awaiting_ack = rendered_bitmap_id;
     m_pending_async_presents.append(context_id, viewport_rect, rendered_bitmap_id);
     auto* pending_present = &m_pending_async_presents.last();
@@ -664,17 +671,16 @@ void CompositorState::did_finish_async_present(PendingAsyncPresent& pending_pres
     VERIFY(context->gpu_present_bitmap_id_awaiting_completion == bitmap_id);
 
     context->gpu_present_bitmap_id_awaiting_completion.clear();
-    if (context->presents_to_client) {
-        VERIFY(m_client);
-        VERIFY(context->presented_bitmap_id_awaiting_ack == bitmap_id);
-        m_client->did_present_frame(context_id, viewport_rect, bitmap_id);
-    } else {
-        context->presentation_mode.visit(
-            [](Empty const&) {},
-            [&](Web::Compositor::PublishToCompositorSurface const& mode) {
-                publish_to_parent_surface(*context, mode);
-            });
-    }
+    context->presentation_mode.visit(
+        [](Empty const&) {},
+        [&](Web::Compositor::PresentToClient const&) {
+            VERIFY(m_client);
+            VERIFY(context->presented_bitmap_id_awaiting_ack == bitmap_id);
+            m_client->did_present_frame(context_id, viewport_rect, bitmap_id);
+        },
+        [&](Web::Compositor::PublishToCompositorSurface const& mode) {
+            publish_to_parent_surface(*context, mode);
+        });
 
     drain_pending_present_frame_if_unblocked(context_id, *context);
 }
@@ -1005,7 +1011,9 @@ void CompositorState::resize_backing_stores_if_needed(Web::Compositor::Composito
     auto allocation = context.backing_store_manager.resize_backing_stores_if_needed(context.viewport_size, context.is_top_level_traversable, context.window_resize_in_progress);
     if (!allocation.has_value())
         return;
-    if (auto publication = context.backing_store_manager.allocate_backing_stores(*allocation, m_skia_backend_context, context.presents_to_client); publication.has_value()) {
+    if (auto publication = context.backing_store_manager.allocate_backing_stores(
+            *allocation, m_skia_backend_context, presentation_mode_presents_to_client(context.presentation_mode));
+        publication.has_value()) {
         publish_backing_stores(context_id, context, publication.release_value());
         present_current_frame(context_id, context);
     }
@@ -1056,7 +1064,7 @@ void CompositorState::publish_to_parent_surface(ContextState& context, Web::Comp
 void CompositorState::publish_backing_stores(Web::Compositor::CompositorContextId context_id, ContextState& context, BackingStoreManager::Publication&& publication)
 {
     VERIFY(m_client);
-    if (!context.presents_to_client)
+    if (!presentation_mode_presents_to_client(context.presentation_mode))
         return;
 
     m_client->did_allocate_backing_stores(context_id, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image));

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -75,7 +75,6 @@ public:
     void destroy_context(Web::Compositor::CompositorContextId);
 
     void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode);
-    void stop_presenting_to_client(Web::Compositor::CompositorContextId);
     void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::DisplayListResourceTransaction&&, Web::Painting::ScrollStateSnapshot&&);
     void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot&&);
     void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
@@ -117,7 +116,6 @@ private:
         Optional<u64> page_id;
         Web::Compositor::PagePresentationRegistration page_presentation_registration { Web::Compositor::PagePresentationRegistration::No };
 
-        bool presents_to_client { false };
         Web::Compositor::PresentationMode presentation_mode { Empty {} };
         Optional<PublishedSurface> published_surface;
         HashMap<Web::Painting::CompositorSurfaceId, Web::Compositor::CompositorContextId> child_contexts_by_surface_id;

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -13,7 +13,6 @@
 endpoint CompositorWebContentServer
 {
     set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode) =|
-    stop_presenting_to_client(Web::Compositor::CompositorContextId context_id) =|
     destroy_context(Web::Compositor::CompositorContextId context_id) =|
 
     update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -59,12 +59,6 @@ void ConnectionFromWebContent::set_presentation_mode(Web::Compositor::Compositor
     m_compositor_state->set_presentation_mode(context_id, move(presentation_mode));
 }
 
-void ConnectionFromWebContent::stop_presenting_to_client(Web::Compositor::CompositorContextId context_id)
-{
-    verify_context_is_owned_by_this_connection(context_id);
-    m_compositor_state->stop_presenting_to_client(context_id);
-}
-
 void ConnectionFromWebContent::destroy_context(Web::Compositor::CompositorContextId context_id)
 {
     verify_context_is_owned_by_this_connection(context_id);

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -32,7 +32,6 @@ private:
     virtual void die() override;
 
     virtual void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode) override;
-    virtual void stop_presenting_to_client(Web::Compositor::CompositorContextId) override;
     virtual void destroy_context(Web::Compositor::CompositorContextId) override;
     virtual void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::DisplayListResourceTransaction, Web::Painting::ScrollStateSnapshot) override;
     virtual void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot) override;

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -31,13 +31,6 @@ void CompositorConnection::set_presentation_mode(Web::Compositor::CompositorCont
     async_set_presentation_mode(context_id, presentation_mode);
 }
 
-void CompositorConnection::stop_presenting_to_client(Web::Compositor::CompositorContextId context_id)
-{
-    if (!can_send_message_to_compositor())
-        return;
-    async_stop_presenting_to_client(context_id);
-}
-
 void CompositorConnection::destroy_context(Web::Compositor::CompositorContextId context_id)
 {
     if (!can_send_message_to_compositor())

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -37,7 +37,6 @@ public:
     explicit CompositorConnection(NonnullOwnPtr<IPC::Transport>);
 
     void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode const&);
-    void stop_presenting_to_client(Web::Compositor::CompositorContextId);
     void destroy_context(Web::Compositor::CompositorContextId);
     void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList> const&, Web::Painting::DisplayListResourceTransaction const&, Web::Painting::ScrollStateSnapshot const&);
     void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot const&);

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -700,7 +700,7 @@ void PageClient::page_did_request_activate_tab()
 
 void PageClient::page_did_close_top_level_traversable()
 {
-    page().top_level_traversable()->compositor_context().stop_presenting_to_client();
+    page().top_level_traversable()->compositor_context().set_presentation_mode(Empty {});
 
     // FIXME: Rename this IPC call
     client().async_did_close_browsing_context(m_id);

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -29,12 +29,6 @@ private:
         m_client.did_destroy_compositor_context(context_id);
     }
 
-    virtual void stop_presenting_to_client(Web::Compositor::CompositorContextId context_id) override
-    {
-        if (auto* connection = compositor_connection())
-            connection->stop_presenting_to_client(context_id);
-    }
-
     virtual void set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode mode) override
     {
         if (auto* connection = compositor_connection())


### PR DESCRIPTION
The WebContent compositor server exposed stop_presenting_to_client() next to destroy_context(), even though only the latter controls context lifetime. The former moved a live top-level context out of the client- facing presentation path, making the IPC boundary look like it had two ways to tear down a live compositor context.

Make client presentation an explicit PresentationMode alternative. Top-level contexts start as PresentToClient. Tab close switches them to Empty, while destroy_context() remains the only API that removes compositor state. This keeps the existing lifetime behavior while routing all presentation target changes through set_presentation_mode().