### PR TITLE
Compositor+LibWeb: Share Skia scrollbar painting with compositor

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -122,6 +122,39 @@ void DisplayListPlayerSkia::flush_async(Gfx::PaintingSurface& surface, Function<
     m_image_cache.prune();
 }
 
+static void paint_scrollbar_into_surface(Gfx::PaintingSurface& surface, PaintScrollBar const& command)
+{
+    auto gutter_rect = to_skia_rect(command.gutter_rect);
+
+    auto thumb_rect = to_skia_rect(command.thumb_rect);
+    auto radius = thumb_rect.width() / 2;
+    auto thumb_rrect = SkRRect::MakeRectXY(thumb_rect, radius, radius);
+
+    auto& canvas = surface.canvas();
+
+    auto gutter_fill_color = command.track_color;
+    SkPaint gutter_fill_paint;
+    gutter_fill_paint.setColor(to_skia_color(gutter_fill_color));
+    canvas.drawRect(gutter_rect, gutter_fill_paint);
+
+    SkPaint thumb_fill_paint;
+    thumb_fill_paint.setColor(to_skia_color(command.thumb_color));
+    canvas.drawRRect(thumb_rrect, thumb_fill_paint);
+
+    auto stroke_color = command.thumb_color.lightened();
+    SkPaint stroke_paint;
+    stroke_paint.setStroke(true);
+    stroke_paint.setStrokeWidth(1);
+    stroke_paint.setAntiAlias(true);
+    stroke_paint.setColor(to_skia_color(stroke_color));
+    canvas.drawRRect(thumb_rrect, stroke_paint);
+}
+
+void DisplayListPlayerSkia::paint_scrollbar(Gfx::PaintingSurface& surface, PaintScrollBar const& command)
+{
+    paint_scrollbar_into_surface(surface, command);
+}
+
 void DisplayListPlayerSkia::draw_glyph_run(DrawGlyphRun const& command)
 {
     auto const& font = resource_storage().font(command.font_id);
@@ -858,30 +891,7 @@ void DisplayListPlayerSkia::compositor_blocking_wheel_event_region(CompositorBlo
 
 void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)
 {
-    auto gutter_rect = to_skia_rect(command.gutter_rect);
-
-    auto thumb_rect = to_skia_rect(command.thumb_rect);
-    auto radius = thumb_rect.width() / 2;
-    auto thumb_rrect = SkRRect::MakeRectXY(thumb_rect, radius, radius);
-
-    auto& canvas = surface().canvas();
-
-    auto gutter_fill_color = command.track_color;
-    SkPaint gutter_fill_paint;
-    gutter_fill_paint.setColor(to_skia_color(gutter_fill_color));
-    canvas.drawRect(gutter_rect, gutter_fill_paint);
-
-    SkPaint thumb_fill_paint;
-    thumb_fill_paint.setColor(to_skia_color(command.thumb_color));
-    canvas.drawRRect(thumb_rrect, thumb_fill_paint);
-
-    auto stroke_color = command.thumb_color.lightened();
-    SkPaint stroke_paint;
-    stroke_paint.setStroke(true);
-    stroke_paint.setStrokeWidth(1);
-    stroke_paint.setAntiAlias(true);
-    stroke_paint.setColor(to_skia_color(stroke_color));
-    canvas.drawRRect(thumb_rrect, stroke_paint);
+    paint_scrollbar_into_surface(surface(), command);
 }
 
 void DisplayListPlayerSkia::apply_effects(ApplyEffects const& command, Gfx::Filter const* filter)

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -25,6 +25,7 @@ public:
 
     void flush(Gfx::PaintingSurface&) override;
     void flush_async(Gfx::PaintingSurface&, Function<void()>&&);
+    void paint_scrollbar(Gfx::PaintingSurface&, PaintScrollBar const&);
 
 private:
     void draw_glyph_run(DrawGlyphRun const&) override;

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -12,7 +12,6 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/PainterSkia.h>
 #include <LibGfx/PaintingSurface.h>
-#include <LibGfx/Path.h>
 #include <LibWeb/Page/InputEvent.h>
 
 namespace Compositor {
@@ -102,44 +101,6 @@ static Gfx::IntRect scrollbar_hit_rect(Web::Compositor::ViewportScrollbar const&
         rect.unite(expanded_gutter_rect);
     rect.inflate(scrollbar_hit_slop, scrollbar_hit_slop);
     return rect;
-}
-
-static Gfx::Path rounded_rect_path(Gfx::FloatRect rect, float radius)
-{
-    Gfx::Path path;
-    if (rect.is_empty())
-        return path;
-
-    radius = min(min(radius, rect.width() / 2), rect.height() / 2);
-
-    path.move_to({ rect.left() + radius, rect.top() });
-    if (radius > 0) {
-        path.line_to({ rect.right() - radius, rect.top() });
-        path.arc_to({ rect.right(), rect.top() + radius }, radius, false, true);
-        path.line_to({ rect.right(), rect.bottom() - radius });
-        path.arc_to({ rect.right() - radius, rect.bottom() }, radius, false, true);
-        path.line_to({ rect.left() + radius, rect.bottom() });
-        path.arc_to({ rect.left(), rect.bottom() - radius }, radius, false, true);
-        path.line_to({ rect.left(), rect.top() + radius });
-        path.arc_to({ rect.left() + radius, rect.top() }, radius, false, true);
-    } else {
-        path.line_to({ rect.right(), rect.top() });
-        path.line_to({ rect.right(), rect.bottom() });
-        path.line_to({ rect.left(), rect.bottom() });
-        path.line_to({ rect.left(), rect.top() });
-    }
-    path.close();
-    return path;
-}
-
-static void paint_viewport_scrollbar(Gfx::Painter& painter, Web::Compositor::ViewportScrollbar const& scrollbar, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot, bool expanded)
-{
-    painter.fill_rect(scrollbar_gutter_rect(scrollbar, expanded).to_type<float>(), scrollbar.track_color);
-
-    auto thumb_rect = translated_thumb_rect(scrollbar, scroll_state_snapshot, expanded);
-    auto thumb_path = rounded_rect_path(thumb_rect.to_type<float>(), static_cast<float>(thumb_rect.width()) / 2);
-    painter.fill_path(thumb_path, scrollbar.thumb_color, Gfx::WindingRule::Nonzero);
-    painter.stroke_path(thumb_path, scrollbar.thumb_color.lightened(), 1);
 }
 
 NonnullRefPtr<CompositorState> CompositorState::create(RefPtr<Gfx::SkiaBackendContext> skia_backend_context, bool async_scrolling_enabled)
@@ -988,12 +949,20 @@ bool CompositorState::paint_viewport_scrollbar_overlay(ContextState& context, Gf
     if (context.viewport_scrollbars.is_empty())
         return false;
 
-    Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { surface } };
     for (size_t i = 0; i < context.viewport_scrollbars.size(); ++i) {
-        paint_viewport_scrollbar(painter, context.viewport_scrollbars[i], context.scroll_state_snapshot,
-            context.hovered_viewport_scrollbar_index == i || context.captured_viewport_scrollbar_index == i);
+        auto const& scrollbar = context.viewport_scrollbars[i];
+        auto expanded = context.hovered_viewport_scrollbar_index == i || context.captured_viewport_scrollbar_index == i;
+        Web::Painting::PaintScrollBar paint_scrollbar {
+            .scroll_frame_index = scrollbar.scroll_frame_index,
+            .gutter_rect = scrollbar_gutter_rect(scrollbar, expanded),
+            .thumb_rect = translated_thumb_rect(scrollbar, context.scroll_state_snapshot, expanded),
+            .scroll_size = scrollbar_scroll_size(scrollbar, expanded),
+            .thumb_color = scrollbar.thumb_color,
+            .track_color = scrollbar.track_color,
+            .vertical = scrollbar.vertical,
+        };
+        m_display_list_player->paint_scrollbar(surface, paint_scrollbar);
     }
-    painter.reset();
     return true;
 }
 


### PR DESCRIPTION
Viewport scrollbar overlay painting had its own rounded-rect drawing implementation in the compositor, separate from the normal display-list scrollbar command painter. That kept two rendering paths for the same visual primitive and left the compositor service with local path drawing code just to render the overlay after display-list replay.

Expose a narrow DisplayListPlayerSkia helper that paints a PaintScrollBar into an explicit surface, and make both replayed scrollbar commands and viewport overlay painting use the same Skia drawing routine. CompositorState still owns hover/capture expansion and scroll-offset translation, then passes the resolved geometry to the player before the frame is flushed.