### PR TITLE
LibWeb: Follow explicit cell widths when calculating fixed table layouts

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -130,7 +130,9 @@ void TableFormattingContext::compute_constrainedness()
 
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box->computed_values();
-        if (computed_values.width().is_length()) {
+        // https://drafts.csswg.org/css-tables-3/#computing-column-measures
+        // For the purpose of measuring a column when laid out in fixed mode, only cells which originate in the first row of the table (after reordering the header and footer) will be considered, if any.
+        if (computed_values.width().is_length() && (!use_fixed_mode_layout() || cell.row_index == 0)) {
             m_columns[cell.column_index].is_constrained = true;
         }
 
@@ -175,10 +177,27 @@ void TableFormattingContext::compute_cell_measures()
         // The outer min-content width of a table-cell is max(min-width, min-content width) adjusted by the cell intrinsic offsets.
         auto min_width = computed_values.min_width().to_px(cell.box, containing_block_width);
         auto cell_intrinsic_width_offsets = padding_left + padding_right + border_left + border_right;
-        // For fixed mode, according to https://www.w3.org/TR/css-tables-3/#computing-column-measures:
+        // For fixed mode, according to https://drafts.csswg.org/css-tables-3/#computing-column-measures:
         // The min-content and max-content width of cells is considered zero unless they are directly specified as a length-percentage,
         // in which case they are resolved based on the table width (if it is definite, otherwise use 0).
         auto width_is_specified_length_or_percentage = computed_values.width().is_length() || computed_values.width().is_percentage();
+        if (use_fixed_mode_layout()) {
+            if (computed_values.width().is_percentage()) {
+                CSSPixels reference_width = 0;
+                auto table_width = table_box().computed_values().width();
+                if (table_width.is_length() || table_width.is_percentage())
+                    reference_width = table_width.to_px(table_box(), containing_block_width);
+                min_content_width = max_content_width = computed_values.width().to_px(cell.box, reference_width);
+            } else if (computed_values.width().is_length()) {
+                min_content_width = max_content_width = computed_values.width().to_px(cell.box, containing_block_width);
+            } else {
+                min_content_width = max_content_width = 0;
+            }
+
+            if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox)
+                min_content_width = max_content_width = max(CSSPixels(0), min_content_width - cell_intrinsic_width_offsets);
+        }
+
         if (!use_fixed_mode_layout() || width_is_specified_length_or_percentage) {
             cell.outer_min_width = max(min_width, min_content_width) + cell_intrinsic_width_offsets;
         }
@@ -277,8 +296,11 @@ void TableFormattingContext::initialize_table_measures<TableFormattingContext::C
     // Implement the following parts of the specification, accounting for fixed layout mode:
     // https://www.w3.org/TR/css-tables-3/#min-content-width-of-a-column-based-on-cells-of-span-up-to-1
     // https://www.w3.org/TR/css-tables-3/#max-content-width-of-a-column-based-on-cells-of-span-up-to-1
+    bool const fixed = use_fixed_mode_layout();
     for (auto& cell : m_cells) {
-        if (cell.column_span == 1 && (cell.row_index == 0 || !use_fixed_mode_layout())) {
+        // https://drafts.csswg.org/css-tables-3/#computing-column-measures
+        // For the purpose of measuring a column when laid out in fixed mode, only cells which originate in the first row of the table (after reordering the header and footer) will be considered, if any.
+        if (cell.column_span == 1 && (cell.row_index == 0 || !fixed)) {
             m_columns[cell.column_index].min_size = max(m_columns[cell.column_index].min_size, cell.outer_min_width);
             m_columns[cell.column_index].max_size = max(m_columns[cell.column_index].max_size, cell.outer_max_width);
         }
@@ -301,9 +323,16 @@ void TableFormattingContext::compute_intrinsic_percentage(size_t max_cell_span)
         intrinsic_percentage_contribution_by_index[rc_index] = rows_or_columns[rc_index].intrinsic_percentage;
     }
 
+    [[maybe_unused]] bool const fixed_layout = use_fixed_mode_layout();
     for (size_t current_span = 2; current_span <= max_cell_span; current_span++) {
         // https://www.w3.org/TR/css-tables-3/#intrinsic-percentage-width-of-a-column-based-on-cells-of-span-up-to-n-n--1
         for (auto& cell : m_cells) {
+            if constexpr (IsSame<RowOrColumn, Column>) {
+                // https://drafts.csswg.org/css-tables-3/#computing-column-measures
+                // For the purpose of measuring a column when laid out in fixed mode, only cells which originate in the first row of the table (after reordering the header and footer) will be considered, if any.
+                if (fixed_layout && cell.row_index != 0)
+                    continue;
+            }
             auto cell_span_value = cell_span<RowOrColumn>(cell);
             if (cell_span_value != current_span) {
                 continue;
@@ -372,8 +401,15 @@ void TableFormattingContext::compute_table_measures()
 
     auto& rows_or_columns = table_rows_or_columns<RowOrColumn>();
 
+    [[maybe_unused]] bool const fixed_layout = use_fixed_mode_layout();
     size_t max_cell_span = 1;
     for (auto& cell : m_cells) {
+        if constexpr (IsSame<RowOrColumn, Column>) {
+            // https://drafts.csswg.org/css-tables-3/#computing-column-measures
+            // For the purpose of measuring a column when laid out in fixed mode, only cells which originate in the first row of the table (after reordering the header and footer) will be considered, if any.
+            if (fixed_layout && cell.row_index != 0)
+                continue;
+        }
         max_cell_span = max(max_cell_span, cell_span<RowOrColumn>(cell));
     }
 
@@ -389,6 +425,12 @@ void TableFormattingContext::compute_table_measures()
         Vector<Vector<CSSPixels>> cell_max_contributions_by_rc_index;
         cell_max_contributions_by_rc_index.resize(rows_or_columns.size());
         for (auto& cell : m_cells) {
+            if constexpr (IsSame<RowOrColumn, Column>) {
+                // https://drafts.csswg.org/css-tables-3/#computing-column-measures
+                // For the purpose of measuring a column when laid out in fixed mode, only cells which originate in the first row of the table (after reordering the header and footer) will be considered, if any.
+                if (fixed_layout && cell.row_index != 0)
+                    continue;
+            }
             auto cell_span_value = cell_span<RowOrColumn>(cell);
             if (cell_span_value == current_span) {
                 // Define the baseline max-content size as the sum of the max-content sizes based on cells of span up to N-1 of all columns that the cell spans.
@@ -598,17 +640,21 @@ void TableFormattingContext::compute_table_width()
         // https://www.w3.org/TR/CSS22/tables.html#auto-table-layout
         // A percentage value for a column width is relative to the table width. If the table has 'width: auto',
         // a percentage represents a constraint on the column's width, which a UA should try to satisfy.
-        for (auto& cell : m_cells) {
-            auto const& cell_width = cell.box->computed_values().width();
-            if (cell_width.is_percentage()) {
-                CSSPixels adjusted_used_width = undistributable_space;
-                if (cell_width.percentage().value() != 0)
-                    adjusted_used_width += CSSPixels::nearest_value_for(ceil(100 / cell_width.percentage().value() * cell.outer_max_width));
+        if (!use_fixed_mode_layout()) {
+            for (auto& cell : m_cells) {
+                auto const& cell_width = cell.box->computed_values().width();
+                if (cell_width.is_percentage()) {
+                    auto const pct = cell_width.percentage().value();
+                    if (pct == 0)
+                        continue;
 
-                if (width_of_table_containing_block.is_definite())
-                    used_width = min(max(used_width, adjusted_used_width), width_of_table_containing_block.to_px_or_zero());
-                else
+                    CSSPixels adjusted_used_width = undistributable_space
+                        + CSSPixels::nearest_value_for(ceil(100 / pct * cell.outer_max_width));
+
                     used_width = max(used_width, adjusted_used_width);
+                    if (width_of_table_containing_block.is_definite())
+                        used_width = min(used_width, width_of_table_containing_block.to_px_or_zero());
+                }
             }
         }
     } else if (computed_values.width().is_max_content()) {
@@ -1955,7 +2001,14 @@ void TableFormattingContext::initialize_intrinsic_percentages_from_cells()
 {
     auto& rows_or_columns = table_rows_or_columns<RowOrColumn>();
 
+    [[maybe_unused]] bool const fixed_layout = use_fixed_mode_layout();
     for (auto& cell : m_cells) {
+        if constexpr (IsSame<RowOrColumn, Column>) {
+            // https://drafts.csswg.org/css-tables-3/#computing-column-measures
+            // For the purpose of measuring a column when laid out in fixed mode, only cells which originate in the first row of the table (after reordering the header and footer) will be considered, if any.
+            if (fixed_layout && cell.row_index != 0)
+                continue;
+        }
         auto cell_span_value = cell_span<RowOrColumn>(cell);
         auto cell_start_rc_index = cell_index<RowOrColumn>(cell);
         auto cell_end_rc_index = cell_start_rc_index + cell_span_value;

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-cell-specified-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-cell-specified-width.txt
@@ -1,0 +1,39 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 26 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 10 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 50 0+0+734] [0+0+0 10 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,8] table-box [0+0+0 50 0+0+50] [0+0+0 10 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [8,8] table-row-group [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+            Box <tr> at [8,8] table-row [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [8,8] table-cell [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+                BlockContainer <(anonymous)> at [8,8] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+                  TextNode <#text> (not painted)
+                BlockContainer <div> at [8,8] [0+0+0 10 0+0+40] [0+0+0 10 0+0+0] children: not-inline
+                BlockContainer <(anonymous)> at [8,18] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+                  TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,18] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x26]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x10]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 50x10]
+        PaintableBox (Box<TABLE>) [8,8 50x10]
+          PaintableBox (Box<TBODY>) [8,8 50x10]
+            PaintableBox (Box<TR>) [8,8 50x10]
+              PaintableWithLines (BlockContainer<TD>) [8,8 50x10]
+                PaintableWithLines (BlockContainer(anonymous)) [8,8 50x0]
+                PaintableWithLines (BlockContainer<DIV>) [8,8 10x10]
+                PaintableWithLines (BlockContainer(anonymous)) [8,18 50x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,18 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x26] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
@@ -5,59 +5,59 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         Box <table> at [9,9] table-box [0+1+0 598 0+1+0] [0+1+0 44 0+1+0] [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
-          Box <tbody> at [9,9] table-row-group [0+0+0 598 0+0+0] [0+0+0 44 0+0+0] children: not-inline
-            Box <tr> at [9,9] table-row [0+0+0 598 0+0+0] [0+0+0 22 0+0+0] children: not-inline
+          Box <tbody> at [9,9] table-row-group [0+0+0 597.984375 0+0+0] [0+0+0 44 0+0+0] children: not-inline
+            Box <tr> at [9,9] table-row [0+0+0 597.984375 0+0+0] [0+0+0 22 0+0+0] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [11,11] table-cell [0+1+1 62.4375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
+              BlockContainer <td> at [11,11] table-cell [0+1+1 64.828125 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
                     "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [77.4375,11] table-cell [0+1+1 62.4375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [77.4375,11 26.078125x18] baseline: 13.796875
+              BlockContainer <td> at [79.828125,11] table-cell [0+1+1 64.828125 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [79.828125,11 26.078125x18] baseline: 13.796875
                     "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [143.875,11] table-cell [0+1+1 128.890625 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [143.875,11 94.96875x18] baseline: 13.796875
+              BlockContainer <td> at [148.65625,11] table-cell [0+1+1 129.359375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [148.65625,11 94.96875x18] baseline: 13.796875
                     "A table cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [276.765625,11] table-cell [0+1+1 328.234375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [276.765625,11 94.96875x18] baseline: 13.796875
+              BlockContainer <td> at [282.015625,11] table-cell [0+1+1 322.96875 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [282.015625,11 94.96875x18] baseline: 13.796875
                     "A table cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
-            Box <tr> at [9,31] table-row [0+0+0 598 0+0+0] [0+0+0 22 0+0+0] children: not-inline
+            Box <tr> at [9,31] table-row [0+0+0 597.984375 0+0+0] [0+0+0 22 0+0+0] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [11,33] table-cell [0+1+1 62.4375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
+              BlockContainer <td> at [11,33] table-cell [0+1+1 64.828125 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
                     "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [77.4375,33] table-cell [0+1+1 62.4375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [77.4375,33 26.078125x18] baseline: 13.796875
+              BlockContainer <td> at [79.828125,33] table-cell [0+1+1 64.828125 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [79.828125,33 26.078125x18] baseline: 13.796875
                     "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [143.875,33] table-cell [0+1+1 128.890625 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [143.875,33 94.96875x18] baseline: 13.796875
+              BlockContainer <td> at [148.65625,33] table-cell [0+1+1 129.359375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [148.65625,33 94.96875x18] baseline: 13.796875
                     "A table cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [276.765625,33] table-cell [0+1+1 328.234375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [276.765625,33 94.96875x18] baseline: 13.796875
+              BlockContainer <td> at [282.015625,33] table-cell [0+1+1 322.96875 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [282.015625,33 94.96875x18] baseline: 13.796875
                     "A table cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -70,24 +70,24 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x46]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x46]
         PaintableBox (Box<TABLE>) [8,8 600x46]
-          PaintableBox (Box<TBODY>) [9,9 598x44]
-            PaintableBox (Box<TR>) [9,9 598x22]
-              PaintableWithLines (BlockContainer<TD>) [9,9 66.4375x22]
+          PaintableBox (Box<TBODY>) [9,9 597.984375x44]
+            PaintableBox (Box<TR>) [9,9 597.984375x22]
+              PaintableWithLines (BlockContainer<TD>) [9,9 68.828125x22]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [75.4375,9 66.4375x22]
+              PaintableWithLines (BlockContainer<TD>) [77.828125,9 68.828125x22]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [141.875,9 132.890625x22]
+              PaintableWithLines (BlockContainer<TD>) [146.65625,9 133.359375x22]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [274.765625,9 332.234375x22]
+              PaintableWithLines (BlockContainer<TD>) [280.015625,9 326.96875x22]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [9,31 598x22]
-              PaintableWithLines (BlockContainer<TD>) [9,31 66.4375x22]
+            PaintableBox (Box<TR>) [9,31 597.984375x22]
+              PaintableWithLines (BlockContainer<TD>) [9,31 68.828125x22]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [75.4375,31 66.4375x22]
+              PaintableWithLines (BlockContainer<TD>) [77.828125,31 68.828125x22]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [141.875,31 132.890625x22]
+              PaintableWithLines (BlockContainer<TD>) [146.65625,31 133.359375x22]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [274.765625,31 332.234375x22]
+              PaintableWithLines (BlockContainer<TD>) [280.015625,31 326.96875x22]
                 TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
@@ -1,63 +1,67 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 62 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 46 0+0+8] children: not-inline
-      TableWrapper <(anonymous)> at [8,8] [0+0+0 600 0+0+184] [0+0+0 46 0+0+0] [BFC] children: not-inline
-        Box <table> at [9,9] table-box [0+1+0 598 0+1+0] [0+1+0 44 0+1+0] [TFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 98 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 82 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 600 0+0+184] [0+0+0 82 0+0+0] [BFC] children: not-inline
+        Box <table> at [9,9] table-box [0+1+0 598 0+1+0] [0+1+0 80 0+1+0] [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
-          Box <tbody> at [9,9] table-row-group [0+0+0 597.96875 0+0+0] [0+0+0 44 0+0+0] children: not-inline
-            Box <tr> at [9,9] table-row [0+0+0 597.96875 0+0+0] [0+0+0 22 0+0+0] children: not-inline
+          Box <tbody> at [9,9] table-row-group [0+0+0 598 0+0+0] [0+0+0 80 0+0+0] children: not-inline
+            Box <tr> at [9,9] table-row [0+0+0 598 0+0+0] [0+0+0 40 0+0+0] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [11,11] table-cell [0+1+1 95.65625 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
+              BlockContainer <td> at [11,20] table-cell [0+1+1 94 1+1+0] [0+1+10 18 10+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,20 26.078125x18] baseline: 13.796875
                     "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [110.65625,11] table-cell [0+1+1 95.65625 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [110.65625,11 26.078125x18] baseline: 13.796875
+              BlockContainer <td> at [109,20] table-cell [0+1+1 94 1+1+0] [0+1+10 18 10+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [109,20 26.078125x18] baseline: 13.796875
                     "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [210.3125,11] table-cell [0+1+1 95.65625 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [210.3125,11 94.96875x18] baseline: 13.796875
-                    "A table cell"
+              BlockContainer <td> at [207,11] table-cell [0+1+1 94 1+1+0] [0+1+1 36 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [207,11 60.890625x18] baseline: 13.796875
+                    "A table"
+                frag 1 from TextNode start: 8, length: 4, rect: [207,29 26.078125x18] baseline: 13.796875
+                    "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [309.96875,11] table-cell [0+1+1 295 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x18] baseline: 13.796875
+              BlockContainer <td> at [305,20] table-cell [0+1+1 300 1+1+0] [0+1+10 18 10+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [305,20 94.96875x18] baseline: 13.796875
                     "A table cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
-            Box <tr> at [9,31] table-row [0+0+0 597.96875 0+0+0] [0+0+0 22 0+0+0] children: not-inline
+            Box <tr> at [9,49] table-row [0+0+0 598 0+0+0] [0+0+0 40 0+0+0] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [11,33] table-cell [0+1+1 95.65625 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
+              BlockContainer <td> at [11,60] table-cell [0+1+1 94 1+1+0] [0+1+10 18 10+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,60 26.078125x18] baseline: 13.796875
                     "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [110.65625,33] table-cell [0+1+1 95.65625 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [110.65625,33 26.078125x18] baseline: 13.796875
+              BlockContainer <td> at [109,60] table-cell [0+1+1 94 1+1+0] [0+1+10 18 10+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [109,60 26.078125x18] baseline: 13.796875
                     "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [210.3125,33] table-cell [0+1+1 95.65625 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [210.3125,33 94.96875x18] baseline: 13.796875
-                    "A table cell"
+              BlockContainer <td> at [207,51] table-cell [0+1+1 94 1+1+0] [0+1+1 36 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [207,51 60.890625x18] baseline: 13.796875
+                    "A table"
+                frag 1 from TextNode start: 8, length: 4, rect: [207,69 26.078125x18] baseline: 13.796875
+                    "cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [309.96875,33] table-cell [0+1+1 295 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [309.96875,33 94.96875x18] baseline: 13.796875
+              BlockContainer <td> at [305,60] table-cell [0+1+1 300 1+1+0] [0+1+10 18 10+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [305,60 94.96875x18] baseline: 13.796875
                     "A table cell"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -66,29 +70,29 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x62]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x46]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 600x46]
-        PaintableBox (Box<TABLE>) [8,8 600x46]
-          PaintableBox (Box<TBODY>) [9,9 597.96875x44]
-            PaintableBox (Box<TR>) [9,9 597.96875x22]
-              PaintableWithLines (BlockContainer<TD>) [9,9 99.65625x22]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x98]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x82]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 600x82]
+        PaintableBox (Box<TABLE>) [8,8 600x82]
+          PaintableBox (Box<TBODY>) [9,9 598x80]
+            PaintableBox (Box<TR>) [9,9 598x40]
+              PaintableWithLines (BlockContainer<TD>) [9,9 98x40]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [108.65625,9 99.65625x22]
+              PaintableWithLines (BlockContainer<TD>) [107,9 98x40]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [208.3125,9 99.65625x22]
+              PaintableWithLines (BlockContainer<TD>) [205,9 98x40]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [307.96875,9 299x22]
+              PaintableWithLines (BlockContainer<TD>) [303,9 304x40]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [9,31 597.96875x22]
-              PaintableWithLines (BlockContainer<TD>) [9,31 99.65625x22]
+            PaintableBox (Box<TR>) [9,49 598x40]
+              PaintableWithLines (BlockContainer<TD>) [9,49 98x40]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [108.65625,31 99.65625x22]
+              PaintableWithLines (BlockContainer<TD>) [107,49 98x40]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [208.3125,31 99.65625x22]
+              PaintableWithLines (BlockContainer<TD>) [205,49 98x40]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [307.96875,31 299x22]
+              PaintableWithLines (BlockContainer<TD>) [303,49 304x40]
                 TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x98] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-subsequent-rows-ignored.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-subsequent-rows-ignored.txt
@@ -1,0 +1,57 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 100 0+0+684] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,8] table-box [0+0+0 100 0+0+0] [0+0+0 20 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [8,8] table-row-group [0+0+0 100 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            Box <tr> at [8,8] table-row [0+0+0 100 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [8,8] table-cell [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+                BlockContainer <div> at [8,8] [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [58,8] table-cell [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+                BlockContainer <div> at [58,8] [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [8,18] table-row [0+0+0 100 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td.row2-cell> at [8,18] table-cell [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+                BlockContainer <div> at [8,18] [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [58,18] table-cell [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+                BlockContainer <div> at [58,18] [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,28] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x20]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 100x20]
+        PaintableBox (Box<TABLE>) [8,8 100x20]
+          PaintableBox (Box<TBODY>) [8,8 100x20]
+            PaintableBox (Box<TR>) [8,8 100x10]
+              PaintableWithLines (BlockContainer<TD>) [8,8 50x10]
+                PaintableWithLines (BlockContainer<DIV>) [8,8 50x10]
+              PaintableWithLines (BlockContainer<TD>) [58,8 50x10]
+                PaintableWithLines (BlockContainer<DIV>) [58,8 50x10]
+            PaintableBox (Box<TR>) [8,18 100x10]
+              PaintableWithLines (BlockContainer<TD>.row2-cell) [8,18 50x10]
+                PaintableWithLines (BlockContainer<DIV>) [8,18 50x10]
+              PaintableWithLines (BlockContainer<TD>) [58,18 50x10]
+                PaintableWithLines (BlockContainer<DIV>) [58,18 50x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,28 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x36] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/table/fixed-layout-cell-specified-width.html
+++ b/Tests/LibWeb/Layout/input/table/fixed-layout-cell-specified-width.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<!-- This test ensures that in fixed table layouts, explicit cell widths take precedence over intrinsic content size. 
+     Previously, the table would incorrectly squash to 10px instead of honoring the 50px cell width. -->
+<style>
+table {
+    table-layout: fixed;
+    width: 0;
+    border-collapse: collapse;
+}
+td {
+    width: 50px;
+    padding: 0;
+    border: none;
+}
+div {
+    width: 10px;
+    height: 10px;
+    background: red;
+}
+</style>
+<table>
+    <tr>
+        <td>
+            <div></div>
+        </td>
+    </tr>
+</table>

--- a/Tests/LibWeb/Layout/input/table/fixed-layout-subsequent-rows-ignored.html
+++ b/Tests/LibWeb/Layout/input/table/fixed-layout-subsequent-rows-ignored.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!-- This test ensures that in fixed table layouts, only cells in the first row are considered for column measurement.
+     Any width specified on cells in subsequent rows must be ignored for column layout, so the columns remain equal width (50px each). -->
+<style>
+table {
+    table-layout: fixed;
+    width: 100px;
+    border-collapse: collapse;
+}
+td {
+    padding: 0;
+    border: none;
+}
+.row2-cell {
+    width: 80px;
+}
+div {
+    height: 10px;
+    background: blue;
+}
+</style>
+<table>
+    <tr>
+        <td><div></div></td>
+        <td><div></div></td>
+    </tr>
+    <tr>
+        <td class="row2-cell"><div></div></td>
+        <td><div></div></td>
+    </tr>
+</table>


### PR DESCRIPTION
This PR fixes a bug in the fixed table layout, where cells with
explicitly specified length/percentage widths were ignoring their
explicit width and falling back to the content size.

Specifications referred:
https://www.w3.org/TR/css-tables-3/#computing-column-measures
https://www.w3.org/TR/CSS2/tables.html#fixed-table-layout
https://www.w3.org/TR/CSS22/tables.html#auto-table-layout

The fix resolves horizontal squashing layout issues seen on live
websites, such as the JS Crossword grid at:
https://lyra.horse/fun/jscrossword/

Added a regression test:
Tests/LibWeb/Layout/input/table/fixed-layout-cell-specified-width.html