### PR TITLE
LibWeb+LibWebView+UI: Integrate primary pasting with the selection clipboard

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -397,7 +397,7 @@
                             <input id="enable-autoscroll" type="checkbox" switch />
                         </div>
                     </div>
-                    <div class="card-group card-separator">
+                    <div class="card-group card-separator" id="enable-primary-paste-group">
                         <div class="inline-container">
                             <label for="enable-primary-paste">
                                 Enable primary pasting
@@ -738,6 +738,7 @@
             });
 
             document.addEventListener("WebUILoaded", () => {
+                ladybird.sendMessage("loadFeatures");
                 ladybird.sendMessage("loadCurrentSettings");
             });
         </script>

--- a/Base/res/ladybird/about-pages/settings/browsing-behavior.js
+++ b/Base/res/ladybird/about-pages/settings/browsing-behavior.js
@@ -1,7 +1,12 @@
 const enableAutoscroll = document.querySelector("#enable-autoscroll");
 const enablePrimaryPaste = document.querySelector("#enable-primary-paste");
+const enablePrimaryPasteGroup = document.querySelector("#enable-primary-paste-group");
 
 let BROWSING_BEHAVIOR = {};
+
+const loadFeatures = features => {
+    enablePrimaryPasteGroup.classList.toggle("hidden", !features?.primaryPaste);
+};
 
 const loadSettings = settings => {
     BROWSING_BEHAVIOR = settings.browsingBehavior || {};
@@ -21,7 +26,9 @@ addChangeHandler(enableAutoscroll, "enableAutoscroll");
 addChangeHandler(enablePrimaryPaste, "enablePrimaryPaste");
 
 document.addEventListener("WebUIMessage", event => {
-    if (event.detail.name === "loadSettings") {
+    if (event.detail.name === "loadFeatures") {
+        loadFeatures(event.detail.data);
+    } else if (event.detail.name === "loadSettings") {
         loadSettings(event.detail.data);
     }
 });

--- a/Libraries/LibWeb/DOM/SelectionchangeEventDispatching.h
+++ b/Libraries/LibWeb/DOM/SelectionchangeEventDispatching.h
@@ -10,6 +10,8 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::DOM {
 
@@ -56,6 +58,12 @@ void fire_a_selectionchange_event(T& target, Document& document)
 
     auto event = DOM::Event::create(document.realm(), HTML::EventNames::selectionchange, event_init);
     target.dispatch_event(event);
+
+    // AD-HOC: When the selection changes, inform the UI to update the primary pasteboard.
+    if (auto& page = document.page(); page.enable_primary_paste()) {
+        if (auto text = page.focused_navigable().selected_text(); !text.is_empty())
+            page.client().page_did_update_primary_selection(text);
+    }
 }
 
 }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1715,7 +1715,7 @@ bool EventHandler::maybe_request_paste_for_middle_click(DOM::Document& document,
         return false;
 
     target->set_selection_anchor(*hit_node, cursor_hit->index_in_node);
-    page.client().page_did_request_paste();
+    page.client().page_did_request_primary_paste();
     return true;
 }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -513,7 +513,7 @@ public:
 
     virtual void page_did_insert_clipboard_entry(Clipboard::SystemClipboardRepresentation const&, [[maybe_unused]] StringView presentation_style) { }
     virtual void page_did_request_clipboard_entries([[maybe_unused]] u64 request_id) { }
-    virtual void page_did_request_paste() { }
+    virtual void page_did_request_primary_paste() { }
 
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -514,6 +514,7 @@ public:
     virtual void page_did_insert_clipboard_entry(Clipboard::SystemClipboardRepresentation const&, [[maybe_unused]] StringView presentation_style) { }
     virtual void page_did_request_clipboard_entries([[maybe_unused]] u64 request_id) { }
     virtual void page_did_request_primary_paste() { }
+    virtual void page_did_update_primary_selection(String const&) { }
 
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1101,6 +1101,14 @@ Utf16String Application::clipboard_text(ClipboardType) const
     return Utf16String::from_utf8(m_clipboard->data);
 }
 
+void Application::set_clipboard_text(String text, ClipboardType)
+{
+    m_clipboard = Web::Clipboard::SystemClipboardRepresentation {
+        .data = text.to_byte_string(),
+        .mime_type = "text/plain"_string,
+    };
+}
+
 Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_entries() const
 {
     if (!m_clipboard.has_value())

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1087,7 +1087,7 @@ void Application::display_error_dialog(StringView error_message) const
     warnln("{}", error_message);
 }
 
-Utf16String Application::clipboard_text() const
+Utf16String Application::clipboard_text(ClipboardType) const
 {
     if (!m_clipboard.has_value())
         return {};

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1087,6 +1087,11 @@ void Application::display_error_dialog(StringView error_message) const
     warnln("{}", error_message);
 }
 
+bool Application::supports_clipboard_type(ClipboardType type) const
+{
+    return type == ClipboardType::Text;
+}
+
 Utf16String Application::clipboard_text(ClipboardType) const
 {
     if (!m_clipboard.has_value())

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -130,6 +130,7 @@ public:
     };
     virtual bool supports_clipboard_type(ClipboardType) const;
     virtual Utf16String clipboard_text(ClipboardType = ClipboardType::Text) const;
+    virtual void set_clipboard_text(String, ClipboardType = ClipboardType::Text);
 
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation);

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -124,7 +124,11 @@ public:
     virtual void display_error_dialog(StringView error_message) const;
 
     // FIXME: We should implement UI-agnostic platform APIs to interact with the system clipboard.
-    virtual Utf16String clipboard_text() const;
+    enum class ClipboardType : u8 {
+        Text,
+        Selection,
+    };
+    virtual Utf16String clipboard_text(ClipboardType = ClipboardType::Text) const;
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation);
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -128,7 +128,9 @@ public:
         Text,
         Selection,
     };
+    virtual bool supports_clipboard_type(ClipboardType) const;
     virtual Utf16String clipboard_text(ClipboardType = ClipboardType::Text) const;
+
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation);
 

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -464,6 +464,17 @@ BrowsingBehavior Settings::parse_browsing_behavior(JsonValue const& settings)
     return browsing_behavior;
 }
 
+BrowsingBehavior Settings::browsing_behavior() const
+{
+    auto browsing_behavior = m_browsing_behavior;
+
+    // Override browsing behaviors depending on what the system supports. We do this here, rather than persisting the
+    // setting override, so that we don't persist unsupported behavior when headless mode is used.
+    browsing_behavior.enable_primary_paste &= Application::the().supports_clipboard_type(Application::ClipboardType::Selection);
+
+    return browsing_behavior;
+}
+
 void Settings::set_browsing_behavior(BrowsingBehavior browsing_behavior)
 {
     m_browsing_behavior = browsing_behavior;

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -104,7 +104,7 @@ public:
     void set_languages(Vector<String>);
 
     static BrowsingBehavior parse_browsing_behavior(JsonValue const&);
-    BrowsingBehavior const& browsing_behavior() const { return m_browsing_behavior; }
+    BrowsingBehavior browsing_behavior() const;
     void set_browsing_behavior(BrowsingBehavior);
 
     Optional<SearchEngine> const& search_engine() const { return m_search_engine; }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1111,6 +1111,12 @@ void WebContentClient::did_request_primary_paste(u64 page_id)
     }
 }
 
+void WebContentClient::did_update_primary_selection(u64 page_id, String text)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        Application::the().set_clipboard_text(move(text), Application::ClipboardType::Selection);
+}
+
 void WebContentClient::did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1103,10 +1103,12 @@ void WebContentClient::did_request_clipboard_entries(u64 page_id, u64 request_id
     }
 }
 
-void WebContentClient::did_request_paste(u64 page_id)
+void WebContentClient::did_request_primary_paste(u64 page_id)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value())
-        view->paste_text_from_clipboard();
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        auto text = Application::the().clipboard_text(Application::ClipboardType::Selection);
+        view->client().async_paste(page_id, text);
+    }
 }
 
 void WebContentClient::did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -183,6 +183,7 @@ private:
     virtual void did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation, String presentation_style) override;
     virtual void did_request_clipboard_entries(u64 page_id, u64 request_id) override;
     virtual void did_request_primary_paste(u64 page_id) override;
+    virtual void did_update_primary_selection(u64 page_id, String) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual Messages::WebContentClient::StartWorkerAgentResponse start_worker_agent(u64 page_id, Web::HTML::WorkerAgentStartRequest request) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -182,7 +182,7 @@ private:
     virtual void did_change_background_color(u64 page_id, Gfx::Color color) override;
     virtual void did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation, String presentation_style) override;
     virtual void did_request_clipboard_entries(u64 page_id, u64 request_id) override;
-    virtual void did_request_paste(u64 page_id) override;
+    virtual void did_request_primary_paste(u64 page_id) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual Messages::WebContentClient::StartWorkerAgentResponse start_worker_agent(u64 page_id, Web::HTML::WorkerAgentStartRequest request) override;

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -34,6 +34,9 @@ static StringView config_variable_type_to_string(JsonValue::Type type)
 
 void SettingsUI::register_interfaces()
 {
+    register_interface("loadFeatures"sv, [this](auto const&) {
+        load_features();
+    });
     register_interface("loadCurrentSettings"sv, [this](auto const&) {
         load_current_settings();
     });
@@ -102,6 +105,14 @@ void SettingsUI::register_interfaces()
     register_interface("setDNSSettings"sv, [this](auto const& data) {
         set_dns_settings(data);
     });
+}
+
+void SettingsUI::load_features()
+{
+    JsonObject features;
+    features.set("primaryPaste"_string, Application::the().supports_clipboard_type(Application::ClipboardType::Selection));
+
+    async_send_message("loadFeatures"sv, move(features));
 }
 
 void SettingsUI::load_current_settings()

--- a/Libraries/LibWebView/WebUI/SettingsUI.h
+++ b/Libraries/LibWebView/WebUI/SettingsUI.h
@@ -17,6 +17,7 @@ class WEBVIEW_API SettingsUI : public WebUI {
 private:
     virtual void register_interfaces() override;
 
+    void load_features();
     void load_current_settings();
 
     void set_new_tab_page_url(JsonValue const&);

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -778,9 +778,9 @@ void PageClient::page_did_request_clipboard_entries(u64 request_id)
     client().async_did_request_clipboard_entries(m_id, request_id);
 }
 
-void PageClient::page_did_request_paste()
+void PageClient::page_did_request_primary_paste()
 {
-    client().async_did_request_paste(m_id);
+    client().async_did_request_primary_paste(m_id);
 }
 
 void PageClient::page_did_change_audio_play_state(Web::HTML::AudioPlayState play_state)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -783,6 +783,11 @@ void PageClient::page_did_request_primary_paste()
     client().async_did_request_primary_paste(m_id);
 }
 
+void PageClient::page_did_update_primary_selection(String const& text)
+{
+    client().async_did_update_primary_selection(m_id, text);
+}
+
 void PageClient::page_did_change_audio_play_state(Web::HTML::AudioPlayState play_state)
 {
     client().async_did_change_audio_play_state(m_id, play_state);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -203,6 +203,7 @@ private:
     virtual void page_did_insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation const&, StringView presentation_style) override;
     virtual void page_did_request_clipboard_entries(u64 request_id) override;
     virtual void page_did_request_primary_paste() override;
+    virtual void page_did_update_primary_selection(String const&) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual Web::HTML::WorkerAgentId start_worker_agent(Web::HTML::WorkerAgentStartRequest&&) override;
     virtual void close_worker_agent(Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -202,7 +202,7 @@ private:
     virtual void page_did_change_background_color(Gfx::Color color) override;
     virtual void page_did_insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation const&, StringView presentation_style) override;
     virtual void page_did_request_clipboard_entries(u64 request_id) override;
-    virtual void page_did_request_paste() override;
+    virtual void page_did_request_primary_paste() override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual Web::HTML::WorkerAgentId start_worker_agent(Web::HTML::WorkerAgentStartRequest&&) override;
     virtual void close_worker_agent(Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -120,7 +120,7 @@ endpoint WebContentClient
 
     did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation entry, String presentation_style) =|
     did_request_clipboard_entries(u64 page_id, u64 request_id) =|
-    did_request_paste(u64 page_id) =|
+    did_request_primary_paste(u64 page_id) =|
 
     did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
 

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -121,6 +121,7 @@ endpoint WebContentClient
     did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation entry, String presentation_style) =|
     did_request_clipboard_entries(u64 page_id, u64 request_id) =|
     did_request_primary_paste(u64 page_id) =|
+    did_update_primary_selection(u64 page_id, String text) =|
 
     did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
 

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -28,7 +28,7 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
-    virtual Utf16String clipboard_text() const override;
+    virtual Utf16String clipboard_text(ClipboardType) const override;
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
 

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -110,7 +110,7 @@ void Application::display_error_dialog(StringView error_message) const
                    completionHandler:nil];
 }
 
-Utf16String Application::clipboard_text() const
+Utf16String Application::clipboard_text(ClipboardType) const
 {
     auto* paste_board = [NSPasteboard generalPasteboard];
 

--- a/UI/Gtk/Application.cpp
+++ b/UI/Gtk/Application.cpp
@@ -251,7 +251,7 @@ static Optional<ByteString> read_clipboard_text_sync()
     return result;
 }
 
-Utf16String Application::clipboard_text() const
+Utf16String Application::clipboard_text(ClipboardType) const
 {
     if (browser_options().headless_mode.has_value())
         return WebView::Application::clipboard_text();

--- a/UI/Gtk/Application.h
+++ b/UI/Gtk/Application.h
@@ -53,7 +53,7 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
-    virtual Utf16String clipboard_text() const override;
+    virtual Utf16String clipboard_text(ClipboardType) const override;
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
 

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -235,6 +235,19 @@ Utf16String Application::clipboard_text(ClipboardType type) const
     return utf16_string_from_qstring(clipboard->text(mode));
 }
 
+void Application::set_clipboard_text(String text, ClipboardType type)
+{
+    if (browser_options().headless_mode.has_value()) {
+        WebView::Application::set_clipboard_text(text, type);
+        return;
+    }
+
+    auto* clipboard = QGuiApplication::clipboard();
+    auto mode = clipboard_mode(*clipboard, type);
+
+    clipboard->setText(qstring_from_ak_string(text), mode);
+}
+
 Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_entries() const
 {
     if (browser_options().headless_mode.has_value())

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -210,6 +210,20 @@ static QClipboard::Mode clipboard_mode(QClipboard const& clipboard, Application:
     VERIFY_NOT_REACHED();
 }
 
+bool Application::supports_clipboard_type(ClipboardType type) const
+{
+    if (browser_options().headless_mode.has_value())
+        return WebView::Application::supports_clipboard_type(type);
+
+    switch (type) {
+    case WebView::Application::ClipboardType::Text:
+        return true;
+    case WebView::Application::ClipboardType::Selection:
+        return QGuiApplication::clipboard()->supportsSelection();
+    }
+    VERIFY_NOT_REACHED();
+}
+
 Utf16String Application::clipboard_text(ClipboardType type) const
 {
     if (browser_options().headless_mode.has_value())

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -199,13 +199,26 @@ void Application::display_error_dialog(StringView error_message) const
     QMessageBox::warning(active_tab(), "Ladybird", qstring_from_ak_string(error_message));
 }
 
-Utf16String Application::clipboard_text() const
+static QClipboard::Mode clipboard_mode(QClipboard const& clipboard, Application::ClipboardType type)
+{
+    switch (type) {
+    case WebView::Application::ClipboardType::Text:
+        return QClipboard::Clipboard;
+    case WebView::Application::ClipboardType::Selection:
+        return clipboard.supportsSelection() ? QClipboard::Selection : QClipboard::Clipboard;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+Utf16String Application::clipboard_text(ClipboardType type) const
 {
     if (browser_options().headless_mode.has_value())
-        return WebView::Application::clipboard_text();
+        return WebView::Application::clipboard_text(type);
 
     auto const* clipboard = QGuiApplication::clipboard();
-    return utf16_string_from_qstring(clipboard->text());
+    auto mode = clipboard_mode(*clipboard, type);
+
+    return utf16_string_from_qstring(clipboard->text(mode));
 }
 
 Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_entries() const

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -52,7 +52,7 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
-    virtual Utf16String clipboard_text() const override;
+    virtual Utf16String clipboard_text(ClipboardType) const override;
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
 

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -52,7 +52,9 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
+    virtual bool supports_clipboard_type(ClipboardType) const override;
     virtual Utf16String clipboard_text(ClipboardType) const override;
+
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
 

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -54,6 +54,7 @@ private:
 
     virtual bool supports_clipboard_type(ClipboardType) const override;
     virtual Utf16String clipboard_text(ClipboardType) const override;
+    virtual void set_clipboard_text(String, ClipboardType = ClipboardType::Text) override;
 
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;


### PR DESCRIPTION
Commit 218d82cb65c636d1a56d6cb921ad1a4afe4f7202 added support for pasting text with the middle mouse button. But primary pasting is actually meant to interact with the selection clipboard, not the text clipboard.

This also now disables/hides the primary paste setting on systems that don't support it.

Fixes #9398 (round 2)