### PR TITLE
Compositor+LibWeb: Pass AVC trees separately from display lists

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -106,9 +106,10 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         painter->clear_rect(bitmap.rect().to_type<float>(), Color::Transparent);
 
         // Paint the cursor into a bitmap.
-        auto display_list = Painting::DisplayList::create(Painting::AccumulatedVisualContextTree::create());
+        auto visual_context_tree = Painting::AccumulatedVisualContextTree::create();
+        auto display_list = Painting::DisplayList::create(visual_context_tree);
         Painting::DisplayListResourceStorage resource_storage;
-        Painting::DisplayListRecorder display_list_recorder(display_list, resource_storage);
+        Painting::DisplayListRecorder display_list_recorder(display_list, visual_context_tree, resource_storage);
         DisplayListRecordingContext paint_context { display_list_recorder, document.page().palette(), document.page().client().device_pixels_per_css_pixel(), document.page().chrome_metrics() };
 
         image.resolve_for_size(layout_node, CSSPixelSize { bitmap.size() });
@@ -119,7 +120,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         case DisplayListPlayerType::SkiaCPU: {
             auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
             Painting::DisplayListPlayerSkia display_list_player;
-            display_list_player.execute(*display_list, resource_storage, {}, painting_surface);
+            display_list_player.execute(*display_list, visual_context_tree, resource_storage, {}, painting_surface);
             display_list_player.flush(*painting_surface);
             break;
         }

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -278,18 +278,18 @@ Vector<AsyncScrollOffset> AsyncScrollTree::apply_scroll_delta(AsyncScrollNodeID 
     return scroll_offsets;
 }
 
-void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayList const> const& display_list, Painting::AccumulatedVisualContextTree const* visual_context_tree, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
     m_cached_wheel_hit_test_targets.clear();
     m_cached_main_thread_wheel_event_targets.clear();
     m_cached_blocking_wheel_event_targets.clear();
     m_visual_context_tree = nullptr;
     m_scroll_state_snapshot = scroll_state_snapshot;
-    if (!display_list)
+    if (!display_list || !visual_context_tree)
         return;
 
-    auto const& visual_context_tree = display_list->visual_context_tree();
-    m_visual_context_tree = &visual_context_tree;
+    VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree->version());
+    m_visual_context_tree = visual_context_tree;
 
     m_cached_wheel_hit_test_targets.ensure_capacity(m_wheel_hit_test_regions.size());
     for (auto const& target : m_wheel_hit_test_regions) {
@@ -298,7 +298,7 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
             .visual_context_index = target.visual_context_index,
             .rect = target.rect,
             .corner_radii = target.corner_radii,
-            .viewport_rect = visual_context_tree.transform_rect_to_viewport(target.visual_context_index, target.rect, scroll_state_snapshot),
+            .viewport_rect = visual_context_tree->transform_rect_to_viewport(target.visual_context_index, target.rect, scroll_state_snapshot),
         });
     }
 
@@ -307,7 +307,7 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
         m_cached_main_thread_wheel_event_targets.append({
             .visual_context_index = region.visual_context_index,
             .rect = region.rect,
-            .viewport_rect = visual_context_tree.transform_rect_to_viewport(region.visual_context_index, region.rect, scroll_state_snapshot),
+            .viewport_rect = visual_context_tree->transform_rect_to_viewport(region.visual_context_index, region.rect, scroll_state_snapshot),
         });
     }
 
@@ -315,7 +315,7 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
         m_cached_blocking_wheel_event_targets.append({
             .visual_context_index = region.visual_context_index,
             .rect = region.rect,
-            .viewport_rect = visual_context_tree.transform_rect_to_viewport(region.visual_context_index, region.rect, scroll_state_snapshot),
+            .viewport_rect = visual_context_tree->transform_rect_to_viewport(region.visual_context_index, region.rect, scroll_state_snapshot),
         });
     }
 }

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -15,6 +15,7 @@
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/ScrollState.h>
 
 namespace Web::Compositor {
@@ -52,7 +53,7 @@ class WEB_API AsyncScrollTree {
 public:
     void set_state(AsyncScrollingState&&);
 
-    void rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&);
+    void rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayList const> const&, Painting::AccumulatedVisualContextTree const*, Painting::ScrollStateSnapshot const&);
     void clear_wheel_hit_test_targets();
 
     Optional<Gfx::FloatPoint> scroll_offset_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&) const;
@@ -87,7 +88,7 @@ private:
     Vector<BlockingWheelEventRegion> m_blocking_wheel_event_regions;
     Vector<CachedMainThreadWheelEventTarget> m_cached_main_thread_wheel_event_targets;
     Vector<CachedBlockingWheelEventTarget> m_cached_blocking_wheel_event_targets;
-    RefPtr<Painting::AccumulatedVisualContextTree const> m_visual_context_tree;
+    Painting::AccumulatedVisualContextTree const* m_visual_context_tree { nullptr };
     Painting::ScrollStateSnapshot m_scroll_state_snapshot;
     bool m_has_blocking_wheel_event_region_covering_viewport { false };
 };

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -185,7 +185,7 @@ StringView wheel_routing_admission_to_string(WheelRoutingAdmission admission)
     VERIFY_NOT_REACHED();
 }
 
-bool blocks_wheel_event_at_position(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position)
+bool blocks_wheel_event_at_position(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList const> const& display_list, Painting::AccumulatedVisualContextTree const* visual_context_tree, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position)
 {
     if (async_scrolling_state.has_blocking_wheel_event_region_covering_viewport)
         return true;
@@ -193,33 +193,33 @@ bool blocks_wheel_event_at_position(AsyncScrollingState const& async_scrolling_s
     // If a caller knows blocking wheel listeners exist but cannot provide a display list for visual-context hit
     // testing, async scrolling must fail closed. Sending the input to the main thread is slower, but it preserves
     // cancelability.
-    if (!display_list)
+    if (!display_list || !visual_context_tree)
         return async_scrolling_state.has_blocking_wheel_event_listeners;
 
-    auto const& visual_context_tree = display_list->visual_context_tree();
+    VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree->version());
     for (auto const& region : async_scrolling_state.blocking_wheel_event_regions) {
-        auto position_in_context = visual_context_tree.transform_point_for_hit_test(region.visual_context_index, position, scroll_state_snapshot);
+        auto position_in_context = visual_context_tree->transform_point_for_hit_test(region.visual_context_index, position, scroll_state_snapshot);
         if (position_in_context.has_value() && region.rect.contains(*position_in_context))
             return true;
     }
     return false;
 }
 
-static WheelHitTestResult hit_test_scroll_node_at_position(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta)
+static WheelHitTestResult hit_test_scroll_node_at_position(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList const> const& display_list, Painting::AccumulatedVisualContextTree const* visual_context_tree, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta)
 {
-    if (!display_list)
+    if (!display_list || !visual_context_tree)
         return {};
 
     AsyncScrollTree scroll_tree;
     auto async_scrolling_state_copy = async_scrolling_state;
     scroll_tree.set_state(move(async_scrolling_state_copy));
-    scroll_tree.rebuild_wheel_hit_test_targets(display_list, scroll_state_snapshot);
+    scroll_tree.rebuild_wheel_hit_test_targets(display_list, visual_context_tree, scroll_state_snapshot);
     return scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
 }
 
-WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool blocking_wheel_event_regions_are_current)
+WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList const> const& display_list, Painting::AccumulatedVisualContextTree const* visual_context_tree, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool blocking_wheel_event_regions_are_current)
 {
-    auto hit_test_result = hit_test_scroll_node_at_position(async_scrolling_state, display_list, scroll_state_snapshot, position, delta);
+    auto hit_test_result = hit_test_scroll_node_at_position(async_scrolling_state, display_list, visual_context_tree, scroll_state_snapshot, position, delta);
     if (hit_test_result.blocked_by_main_thread_region)
         return WheelScrollAdmission::BlockedByMainThreadRegion;
 
@@ -228,7 +228,7 @@ WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const& async_scrolli
     if (async_scrolling_state.has_blocking_wheel_event_listeners) {
         if (!blocking_wheel_event_regions_are_current)
             return WheelScrollAdmission::StaleBlockingWheelEventRegions;
-        if (blocks_wheel_event_at_position(async_scrolling_state, display_list, scroll_state_snapshot, position))
+        if (blocks_wheel_event_at_position(async_scrolling_state, display_list, visual_context_tree, scroll_state_snapshot, position))
             return WheelScrollAdmission::BlockedByWheelEventRegion;
     }
 

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -158,7 +158,7 @@ enum class WheelScrollAdmission {
 WEB_API AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayList const&);
 WEB_API WheelRoutingAdmission wheel_routing_admission_for(AsyncScrollingState const&);
 WEB_API StringView wheel_routing_admission_to_string(WheelRoutingAdmission);
-WEB_API bool blocks_wheel_event_at_position(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position);
-WEB_API WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool blocking_wheel_event_regions_are_current);
+WEB_API bool blocks_wheel_event_at_position(AsyncScrollingState const&, RefPtr<Painting::DisplayList const> const&, Painting::AccumulatedVisualContextTree const*, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position);
+WEB_API WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const&, RefPtr<Painting::DisplayList const> const&, Painting::AccumulatedVisualContextTree const*, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool blocking_wheel_event_regions_are_current);
 
 }

--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -26,9 +26,9 @@ void CompositorContextHandle::set_presentation_mode(PresentationMode mode)
     m_host.set_presentation_mode(m_context_id, move(mode));
 }
 
-void CompositorContextHandle::update_display_list(NonnullRefPtr<Painting::DisplayList> display_list, Painting::DisplayListResourceTransaction&& resource_transaction, Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+void CompositorContextHandle::update_display_list(NonnullRefPtr<Painting::DisplayList> display_list, Painting::AccumulatedVisualContextTree visual_context_tree, Painting::DisplayListResourceTransaction&& resource_transaction, Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    m_host.update_display_list(m_context_id, move(display_list), move(resource_transaction), move(scroll_state_snapshot));
+    m_host.update_display_list(m_context_id, move(display_list), move(visual_context_tree), move(resource_transaction), move(scroll_state_snapshot));
 }
 
 void CompositorContextHandle::update_video_frame(Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -35,7 +35,7 @@ public:
     CompositorContextId id() const { return m_context_id; }
     void set_presentation_mode(PresentationMode);
 
-    void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
+    void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::AccumulatedVisualContextTree, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
     void update_video_frame(Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
     void clear_video_frame(Painting::VideoFrameResourceId);
     void update_compositor_surface(Painting::CompositorSurfaceId, Gfx::SharedImage&&);
@@ -71,7 +71,7 @@ public:
     virtual void destroy_context(CompositorContextId) = 0;
     virtual void set_presentation_mode(CompositorContextId, PresentationMode) = 0;
 
-    virtual void update_display_list(CompositorContextId, NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&) = 0;
+    virtual void update_display_list(CompositorContextId, NonnullRefPtr<Painting::DisplayList>, Painting::AccumulatedVisualContextTree, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&) = 0;
     virtual void update_video_frame(CompositorContextId, Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>) = 0;
     virtual void clear_video_frame(CompositorContextId, Painting::VideoFrameResourceId) = 0;
     virtual void update_compositor_surface(CompositorContextId, Painting::CompositorSurfaceId, Gfx::SharedImage&&) = 0;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8242,7 +8242,7 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     VERIFY(paintable());
 
     auto display_list = Painting::DisplayList::create(paintable()->visual_context_tree());
-    Painting::DisplayListRecorder display_list_recorder(display_list, resource_storage);
+    Painting::DisplayListRecorder display_list_recorder(display_list, paintable()->visual_context_tree(), resource_storage);
 
     // https://drafts.csswg.org/css-color-adjust-1/#color-scheme-effect
     // On the root element, the used color scheme additionally must affect the surface color of the canvas, and the viewport’s scrollbars.
@@ -8651,7 +8651,7 @@ String Document::dump_display_list()
     StringBuilder builder;
     builder.append("AccumulatedVisualContext Tree:\n"sv);
 
-    auto const& visual_context_tree = display_list->visual_context_tree();
+    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
     HashTable<size_t> visited;
     HashMap<size_t, Vector<size_t>> children;
     Vector<size_t> root_contexts;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -43,6 +43,7 @@ AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(i64, UniqueNodeID, Comparison, Increment, Ca
 
 namespace Web::Painting {
 
+class AccumulatedVisualContextTree;
 class BackingStore;
 class ChromeWidget;
 class DevicePixelConverter;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3458,10 +3458,14 @@ bool Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
     RefPtr<Painting::DisplayList> display_list;
     Painting::DisplayListResourceSet display_list_resources;
     Painting::DisplayListResourceTransaction resource_transaction;
+    Optional<Painting::AccumulatedVisualContextTree> visual_context_tree;
     if (should_record_display_list) {
         display_list = document->record_display_list(paint_config, m_display_list_resource_storage);
         if (!display_list)
             return false;
+        auto recorded_document_paintable = document->paintable();
+        VERIFY(recorded_document_paintable);
+        visual_context_tree = recorded_document_paintable->visual_context_tree();
         display_list_resources = m_display_list_resource_storage.collect_referenced_resources(*display_list);
         resource_transaction = m_display_list_resource_storage.create_transaction(
             m_compositor_display_list_resources,
@@ -3474,7 +3478,7 @@ bool Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
     if (should_record_display_list) {
-        compositor_context().update_display_list(*display_list, move(resource_transaction), move(scroll_state_snapshot));
+        compositor_context().update_display_list(*display_list, visual_context_tree.release_value(), move(resource_transaction), move(scroll_state_snapshot));
         m_display_list_resource_storage.retain_only(display_list_resources);
         m_compositor_display_list_resources = move(display_list_resources);
         m_needs_to_record_display_list = false;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -726,7 +726,8 @@ WebIDL::UnsignedLongLong Internals::active_image_style_value_animation_count()
 
 struct AsyncScrollingStateSnapshot {
     Compositor::AsyncScrollingState state;
-    RefPtr<Painting::DisplayList> display_list;
+    RefPtr<Painting::DisplayList const> display_list;
+    Painting::AccumulatedVisualContextTree visual_context_tree;
     RefPtr<Painting::ViewportPaintable> document_paintable;
 };
 
@@ -744,6 +745,7 @@ static Optional<AsyncScrollingStateSnapshot> capture_async_scrolling_state(DOM::
     return AsyncScrollingStateSnapshot {
         .state = Compositor::async_scrolling_state_from_display_list(*display_list),
         .display_list = display_list,
+        .visual_context_tree = document_paintable->visual_context_tree(),
         .document_paintable = document_paintable,
     };
 }
@@ -800,7 +802,7 @@ bool Internals::async_scrolling_state_blocks_wheel_event_at(double x, double y)
     auto snapshot = capture_async_scrolling_state(window().associated_document());
     if (!snapshot.has_value())
         return false;
-    return Compositor::blocks_wheel_event_at_position(snapshot->state, snapshot->display_list, snapshot->document_paintable->scroll_state_snapshot(), { static_cast<float>(x), static_cast<float>(y) });
+    return Compositor::blocks_wheel_event_at_position(snapshot->state, snapshot->display_list, &snapshot->visual_context_tree, snapshot->document_paintable->scroll_state_snapshot(), { static_cast<float>(x), static_cast<float>(y) });
 }
 
 bool Internals::async_scrolling_state_can_wheel_scroll_at(double x, double y, double delta_x, double delta_y, bool force_stale_wheel_event_regions)
@@ -840,6 +842,7 @@ String Internals::async_scrolling_state_wheel_scroll_admission_at(double x, doub
     auto admission = Compositor::admit_wheel_scroll(
         snapshot->state,
         snapshot->display_list,
+        &snapshot->visual_context_tree,
         snapshot->document_paintable->scroll_state_snapshot(),
         { static_cast<float>(x), static_cast<float>(y) },
         { static_cast<float>(delta_x), static_cast<float>(delta_y) },
@@ -855,7 +858,7 @@ String Internals::async_scrolling_state_wheel_target_at(double x, double y, doub
 
     Compositor::AsyncScrollTree scroll_tree;
     scroll_tree.set_state(move(snapshot->state));
-    scroll_tree.rebuild_wheel_hit_test_targets(snapshot->display_list, snapshot->document_paintable->scroll_state_snapshot());
+    scroll_tree.rebuild_wheel_hit_test_targets(snapshot->display_list, &snapshot->visual_context_tree, snapshot->document_paintable->scroll_state_snapshot());
 
     auto target = scroll_tree.hit_test_scroll_node_for_wheel(
         { static_cast<float>(x), static_cast<float>(y) },

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -10,10 +10,26 @@
 #include <LibGfx/Matrix4x4.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
+#include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
+#include <LibWeb/CSS/StyleValues/TransformationStyleValue.h>
+#include <LibWeb/CSS/VisualViewport.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/Blending.h>
+#include <LibWeb/Painting/DevicePixelConverter.h>
+#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/ResolvedCSSFilter.h>
 #include <LibWeb/Painting/ScrollState.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 
 namespace Web::Painting {
+
+AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable&);
 
 bool ClipData::contains(DevicePixelPoint point) const
 {
@@ -31,6 +47,348 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::create()
         s_next_accumulated_visual_context_tree_version.fetch_add(1, AK::MemoryOrder::memory_order_relaxed),
         move(nodes)
     };
+}
+
+static CSSPixelRect effective_css_clip_rect(CSSPixelRect const& css_clip)
+{
+    if (css_clip.width() < 0 || css_clip.height() < 0)
+        return CSSPixelRect { 0, 0, 0, 0 };
+    return css_clip;
+}
+
+// Converts a CSS-pixel-space 4x4 matrix to device-pixel-space.
+// - Translation column (column 3, rows 0-2) is scaled up by DPR
+// - Perspective row (row 3, columns 0-2) is scaled down by DPR
+// - All other elements are unaffected (the scale factors cancel out)
+static FloatMatrix4x4 scale_matrix_for_device_pixels(FloatMatrix4x4 matrix, float scale)
+{
+    matrix[0, 3] *= scale;
+    matrix[1, 3] *= scale;
+    matrix[2, 3] *= scale;
+    matrix[3, 0] /= scale;
+    matrix[3, 1] /= scale;
+    matrix[3, 2] /= scale;
+    return matrix;
+}
+
+static Optional<TransformData> compute_transform(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, double pixel_ratio)
+{
+    if (!paintable_box.has_css_transform())
+        return {};
+
+    auto matrix = Gfx::FloatMatrix4x4::identity();
+    if (auto const& translate = computed_values.translate())
+        matrix = matrix * translate->to_matrix(paintable_box);
+    if (auto const& rotate = computed_values.rotate())
+        matrix = matrix * rotate->to_matrix(paintable_box);
+    if (auto const& scale = computed_values.scale())
+        matrix = matrix * scale->to_matrix(paintable_box);
+    for (auto const& transform : computed_values.transformations())
+        matrix = matrix * transform->to_matrix(paintable_box);
+    auto const& css_transform_origin = computed_values.transform_origin();
+    auto reference_box = paintable_box.transform_reference_box();
+    CSSPixelPoint origin {
+        reference_box.left() + css_transform_origin.x.to_px(paintable_box.layout_node(), reference_box.width()),
+        reference_box.top() + css_transform_origin.y.to_px(paintable_box.layout_node(), reference_box.height()),
+    };
+    auto scale = static_cast<float>(pixel_ratio);
+    auto device_origin = origin.to_type<float>() * scale;
+    return TransformData { scale_matrix_for_device_pixels(matrix, scale), device_origin };
+}
+
+// https://drafts.csswg.org/css-transforms-2/#perspective-matrix
+static Optional<Gfx::FloatMatrix4x4> compute_perspective_matrix(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values)
+{
+    auto perspective = computed_values.perspective();
+    if (!perspective.has_value())
+        return {};
+
+    // The perspective matrix is computed as follows:
+
+    // 1. Start with the identity matrix.
+    // 2. Translate by the computed X and Y values of 'perspective-origin'
+    // https://drafts.csswg.org/css-transforms-2/#perspective-origin-property
+    // Percentages: refer to the size of the reference box
+    auto reference_box = paintable_box.transform_reference_box();
+    auto perspective_origin = computed_values.perspective_origin().resolved(paintable_box.layout_node(), reference_box);
+    auto computed_x = perspective_origin.x().to_float();
+    auto computed_y = perspective_origin.y().to_float();
+    auto perspective_matrix = Gfx::translation_matrix(Vector3<float>(computed_x, computed_y, 0));
+
+    // 3. Multiply by the matrix that would be obtained from the 'perspective()' transform function, where the
+    //    length is provided by the value of the perspective property
+    // NB: Length values less than 1px being clamped to 1px is handled by the perspective() function already.
+    // FIXME: Create the matrix directly.
+    perspective_matrix = perspective_matrix * CSS::TransformationStyleValue::create(CSS::PropertyID::Transform, CSS::TransformFunction::Perspective, CSS::StyleValueVector { CSS::LengthStyleValue::create(CSS::Length::make_px(perspective.value())) })->to_matrix({});
+
+    // 4. Translate by the negated computed X and Y values of 'perspective-origin'
+    perspective_matrix = perspective_matrix * Gfx::translation_matrix(Vector3<float>(-computed_x, -computed_y, 0));
+    return perspective_matrix;
+}
+
+static Optional<ClipData> compute_clip_data(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, DevicePixelConverter const& converter)
+{
+    auto overflow_x = computed_values.overflow_x();
+    auto overflow_y = computed_values.overflow_y();
+
+    // https://drafts.csswg.org/css-contain-2/#paint-containment
+    // 1. The contents of the element including any ink or scrollable overflow must be clipped to the overflow clip
+    //    edge of the paint containment box, taking corner clipping into account. This does not include the creation of
+    //    any mechanism to access or indicate the presence of the clipped content; nor does it inhibit the creation of
+    //    any such mechanism through other properties, such as overflow, resize, or text-overflow.
+    //    NOTE: This clipping shape respects overflow-clip-margin, allowing an element with paint containment
+    //          to still slightly overflow its normal bounds.
+    if (paintable_box.layout_node().has_paint_containment()) {
+        // NOTE: Note: The behavior is described in this paragraph is equivalent to changing 'overflow-x: visible' into
+        //       'overflow-x: clip' and 'overflow-y: visible' into 'overflow-y: clip' at used value time, while leaving other
+        //       values of 'overflow-x' and 'overflow-y' unchanged.
+        overflow_x = CSS::Overflow::Clip;
+        overflow_y = CSS::Overflow::Clip;
+    }
+
+    auto has_hidden_overflow = overflow_x != CSS::Overflow::Visible || overflow_y != CSS::Overflow::Visible;
+
+    if (has_hidden_overflow && paintable_box.overflow_property_applies()) {
+        auto clip_rect = paintable_box.absolute_padding_box_rect();
+
+        // https://drafts.csswg.org/css-overflow-3/#propdef-overflow
+        // 'clip'
+        //    This value indicates that the box’s content is clipped to its overflow clip edge
+        auto overflow_clip_edge = paintable_box.overflow_clip_edge_rect();
+        if (overflow_x == CSS::Overflow::Visible) {
+            clip_rect.set_left(0);
+            clip_rect.set_right(CSSPixels::max_integer_value);
+        } else if (overflow_x == CSS::Overflow::Clip) {
+            clip_rect.set_left(overflow_clip_edge.left());
+            clip_rect.set_right(overflow_clip_edge.right());
+        }
+        if (overflow_y == CSS::Overflow::Visible) {
+            clip_rect.set_top(0);
+            clip_rect.set_bottom(CSSPixels::max_integer_value);
+        } else if (overflow_y == CSS::Overflow::Clip) {
+            clip_rect.set_top(overflow_clip_edge.top());
+            clip_rect.set_bottom(overflow_clip_edge.bottom());
+        }
+
+        // https://drafts.csswg.org/css-overflow-3/#corner-clipping
+        // As mentioned in CSS Backgrounds 3 § 4.3 Corner Clipping, the clipping region established by 'overflow' can be
+        // rounded:
+        // - When 'overflow-x' and 'overflow-y' compute to 'hidden', 'scroll', or 'auto', the clipping region is rounded
+        //   based on the border radius, adjusted to the padding edge, as described in CSS Backgrounds 3 § 4.2 Corner
+        //   Shaping.
+        // - When both 'overflow-x' and 'overflow-y' compute to 'clip', the clipping region is rounded as described in § 3.2
+        //   Expanding Clipping Bounds: the 'overflow-clip-margin' property.
+        // - However, when one of 'overflow-x' or 'overflow-y' computes to 'clip' and the other computes to 'visible', the
+        //   clipping region is not rounded.
+        // FIXME: Adjust the border radii for the overflow-clip-margin case. (see https://drafts.csswg.org/css-overflow-4/#valdef-overflow-clip-margin-length-0 )
+        auto radii = (overflow_x != CSS::Overflow::Visible && overflow_y != CSS::Overflow::Visible) ? paintable_box.normalized_border_radii_data(PaintableBox::ShrinkRadiiForBorders::Yes) : BorderRadiiData {};
+        return ClipData { converter.rounded_device_rect(clip_rect), radii.as_corners(converter) };
+    }
+
+    return {};
+}
+
+AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable& viewport_paintable)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+
+    auto& document = viewport_paintable.document();
+    auto pixel_ratio = document.page().client().device_pixels_per_css_pixel();
+    DevicePixelConverter converter { pixel_ratio };
+    auto scale = static_cast<float>(pixel_ratio);
+
+    auto append_node = [&](VisualContextIndex parent_index, VisualContextData data) -> VisualContextIndex {
+        return visual_context_tree.append(move(data), parent_index);
+    };
+
+    auto make_effects_data = [&](PaintableBox const& box) -> Optional<EffectsData> {
+        auto const& computed_values = box.computed_values();
+        auto gfx_filter = to_gfx_filter(box.filter(), pixel_ratio);
+        EffectsData effects {
+            computed_values.opacity(),
+            mix_blend_mode_to_compositing_and_blending_operator(computed_values.mix_blend_mode()),
+            move(gfx_filter)
+        };
+        if (!effects.needs_layer())
+            return {};
+        return effects;
+    };
+
+    // Create visual viewport transform as root (if not identity)
+    VisualContextIndex visual_viewport_context_index {};
+    auto transform = document.visual_viewport()->transform();
+    if (!transform.is_identity()) {
+        auto matrix = scale_matrix_for_device_pixels(transform.to_matrix(), scale);
+        visual_viewport_context_index = append_node({}, TransformData { matrix, { 0.f, 0.f } });
+    }
+
+    VisualContextIndex viewport_state_for_descendants = visual_viewport_context_index;
+    if (viewport_paintable.own_scroll_frame_index().value())
+        viewport_state_for_descendants = append_node(visual_viewport_context_index, ScrollData { viewport_paintable.own_scroll_frame_index(), false });
+    viewport_paintable.set_accumulated_visual_context({});
+    viewport_paintable.set_accumulated_visual_context_for_descendants(viewport_state_for_descendants);
+
+    viewport_paintable.for_each_in_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
+        auto visual_parent_paintable = paintable_box.parent();
+        auto* visual_parent = as_if<PaintableBox>(visual_parent_paintable.ptr());
+        if (!visual_parent)
+            return TraversalDecision::Continue;
+
+        // Resolve filters before make_effects_data reads them.
+        auto const& paintable_box_computed_values = paintable_box.computed_values();
+        if (paintable_box_computed_values.filter().has_filters())
+            paintable_box.set_filter(resolve_css_filter(paintable_box_computed_values.filter(), paintable_box));
+        else
+            paintable_box.set_filter({});
+
+        VisualContextIndex inherited_state;
+
+        if (paintable_box.is_fixed_position()) {
+            inherited_state = visual_viewport_context_index;
+        } else if (paintable_box.is_absolutely_positioned()) {
+            // For position: absolute, use containing block's state to correctly escape scroll containers.
+            auto containing = paintable_box.containing_block();
+            inherited_state = containing->accumulated_visual_context_for_descendants_index();
+
+            // Abspos elements escape scroll containers and overflow clips of non-positioned
+            // ancestors, but cannot escape stacking contexts created by intermediate effects
+            // (opacity, mix-blend-mode, isolation). Walk from visual parent to containing
+            // block and collect these intermediate effects.
+            // NOTE: transforms/perspectives/filters establish containing blocks for abspos,
+            //       so they cannot appear as intermediates.
+            Vector<VisualContextData, 4> intermediate_effects;
+            RefPtr<Paintable> containing_paintable = containing;
+            for (RefPtr<Paintable> paintable = visual_parent; paintable && paintable != containing_paintable; paintable = paintable->parent()) {
+                auto* ancestor_box = as_if<PaintableBox>(paintable.ptr());
+                if (!ancestor_box)
+                    continue;
+                if (auto effects = make_effects_data(*ancestor_box); effects.has_value())
+                    intermediate_effects.append(effects.release_value());
+            }
+            for (auto& effects : intermediate_effects.in_reverse())
+                inherited_state = append_node(inherited_state, move(effects));
+        } else {
+            // For position: relative/static, use visual parent's state directly.
+            // This avoids duplicate transform/perspective allocations that would occur with
+            // the containing block + intermediate walk approach.
+            inherited_state = visual_parent->accumulated_visual_context_for_descendants_index();
+        }
+
+        // Build this element's own state from inherited state.
+        VisualContextIndex own_state = inherited_state;
+
+        if (paintable_box.is_sticky_position()) {
+            // For sticky elements, use enclosing_scroll_frame which holds the sticky frame.
+            // own_scroll_frame may be a different scroll frame if the sticky element also has scrollable overflow.
+            if (auto sticky_idx = paintable_box.enclosing_scroll_frame_index(); sticky_idx.value() && viewport_paintable.scroll_state().frame_at(sticky_idx).is_sticky())
+                own_state = append_node(own_state, ScrollData { sticky_idx, true });
+        }
+
+        auto const& computed_values = paintable_box.computed_values();
+
+        if (auto effects = make_effects_data(paintable_box); effects.has_value())
+            own_state = append_node(own_state, effects.release_value());
+
+        if (auto transform_data = compute_transform(paintable_box, computed_values, pixel_ratio); transform_data.has_value()) {
+            paintable_box.set_has_non_invertible_css_transform(!transform_data->matrix.is_invertible());
+            own_state = append_node(own_state, *transform_data);
+        } else {
+            paintable_box.set_has_non_invertible_css_transform(false);
+        }
+
+        if (auto css_clip = paintable_box.get_clip_rect(); css_clip.has_value()) {
+            auto effective_rect = effective_css_clip_rect(*css_clip);
+            own_state = append_node(own_state, ClipData { converter.rounded_device_rect(effective_rect), {} });
+        }
+
+        // FIXME: Support other geometry boxes. See: https://drafts.fxtf.org/css-masking/#typedef-geometry-box
+        if (auto const& clip_path = computed_values.clip_path(); clip_path.has_value() && clip_path->is_basic_shape()) {
+            auto masking_area = paintable_box.absolute_border_box_rect();
+            auto reference_box = CSSPixelRect { {}, masking_area.size() };
+            auto const& basic_shape = clip_path->basic_shape();
+            auto path = basic_shape.to_path(reference_box, paintable_box.layout_node());
+            path.offset(masking_area.top_left().template to_type<float>());
+            auto fill_rule = basic_shape.basic_shape().visit(
+                [](CSS::Polygon const& polygon) { return polygon.fill_rule; },
+                [](CSS::Path const& path) { return path.fill_rule; },
+                [](auto const&) { return Gfx::WindingRule::Nonzero; });
+            auto device_path = path.copy_transformed(Gfx::AffineTransform {}.set_scale(scale, scale));
+            auto device_bounding_rect = converter.rounded_device_rect(masking_area);
+            own_state = append_node(own_state, ClipPathData { move(device_path), device_bounding_rect, fill_rule });
+        }
+
+        paintable_box.set_accumulated_visual_context(own_state);
+
+        Vector<CSS::BackgroundLayerData> const* background_layers = &computed_values.background_layers();
+        if (paintable_box.layout_node_with_style_and_box_metrics().is_root_element()) {
+            if (auto* html_element = as_if<HTML::HTMLHtmlElement>(paintable_box.dom_node().ptr())) {
+                if (html_element->should_use_body_background_properties())
+                    background_layers = paintable_box.document().background_layers();
+            }
+        }
+
+        if (background_layers) {
+            bool has_fixed_background = false;
+            for (auto const& layer : *background_layers) {
+                if (layer.attachment == CSS::BackgroundAttachment::Fixed) {
+                    has_fixed_background = true;
+                    break;
+                }
+            }
+
+            if (has_fixed_background) {
+                // https://drafts.csswg.org/css-transforms-1/#transform-rendering
+                // For elements that are effected by a transform (i.e. have a transform applied to them, or to any of
+                // their ancestor elements) and do not have their background propagated to the canvas, a value of fixed
+                // for the background-attachment property is treated as if it had a value of scroll.
+                auto has_transform_ancestor = false;
+                if (!paintable_box.layout_node_with_style_and_box_metrics().is_root_element()) {
+                    for (auto const* node = &paintable_box.layout_node(); node && !node->is_viewport(); node = node->parent()) {
+                        if (node->has_css_transform()) {
+                            has_transform_ancestor = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!has_transform_ancestor) {
+                    // Build a context that negates all scroll frames in the ancestor chain. This keeps the background
+                    // fixed relative to the viewport.
+                    auto fixed_background_context = own_state;
+                    for (auto index = own_state; index.value(); index = visual_context_tree.node_at(index).parent_index) {
+                        auto const& node = visual_context_tree.node_at(index);
+                        if (auto const* scroll = node.data.get_pointer<ScrollData>()) {
+                            fixed_background_context = append_node(fixed_background_context, ScrollCompensation { scroll->scroll_frame_index });
+                        }
+                    }
+                    paintable_box.set_fixed_background_visual_context(fixed_background_context);
+                }
+            }
+        }
+
+        // Build state for descendants: own state + perspective + clip + scroll.
+        VisualContextIndex state_for_descendants = own_state;
+
+        if (auto perspective_matrix = compute_perspective_matrix(paintable_box, computed_values); perspective_matrix.has_value()) {
+            auto scaled_matrix = scale_matrix_for_device_pixels(*perspective_matrix, scale);
+            state_for_descendants = append_node(state_for_descendants, PerspectiveData { scaled_matrix });
+        }
+
+        if (auto clip_data = compute_clip_data(paintable_box, computed_values, converter); clip_data.has_value())
+            state_for_descendants = append_node(state_for_descendants, clip_data.value());
+
+        if (paintable_box.own_scroll_frame_index().value()) {
+            auto is_sticky_without_scrollable_overflow = paintable_box.is_sticky_position() && paintable_box.enclosing_scroll_frame_index() == paintable_box.own_scroll_frame_index();
+            if (!is_sticky_without_scrollable_overflow)
+                state_for_descendants = append_node(state_for_descendants, ScrollData { paintable_box.own_scroll_frame_index(), false });
+        }
+
+        paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
+
+        return TraversalDecision::Continue;
+    });
+
+    return visual_context_tree;
 }
 
 VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, VisualContextIndex parent_index)

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Atomic.h>
 #include <AK/StringBuilder.h>
 #include <LibGfx/Matrix4x4.h>
 #include <LibIPC/Decoder.h>
@@ -19,12 +20,17 @@ bool ClipData::contains(DevicePixelPoint point) const
     return corner_radii.contains(point.to_type<int>(), rect.to_type<int>());
 }
 
-NonnullRefPtr<AccumulatedVisualContextTree> AccumulatedVisualContextTree::create()
+static Atomic<u64> s_next_accumulated_visual_context_tree_version { 1 };
+
+AccumulatedVisualContextTree AccumulatedVisualContextTree::create()
 {
-    auto visual_context_tree = adopt_ref(*new AccumulatedVisualContextTree());
+    Vector<AccumulatedVisualContextNode> nodes;
     // Sentinel at index 0 (null context). Data type doesn't matter; it's never accessed.
-    visual_context_tree->m_nodes.append({ ScrollData { {}, false }, {}, 0, false });
-    return visual_context_tree;
+    nodes.append({ ScrollData { {}, false }, {}, 0, false });
+    return AccumulatedVisualContextTree {
+        s_next_accumulated_visual_context_tree_version.fetch_add(1, AK::MemoryOrder::memory_order_relaxed),
+        move(nodes)
+    };
 }
 
 VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, VisualContextIndex parent_index)
@@ -412,19 +418,19 @@ ErrorOr<Web::Painting::AccumulatedVisualContextNode> decode(Decoder& decoder)
 template<>
 ErrorOr<void> encode(Encoder& encoder, Web::Painting::AccumulatedVisualContextTree const& tree)
 {
+    TRY(encoder.encode(tree.m_version));
     TRY(encoder.encode(tree.m_nodes));
     return {};
 }
 
 template<>
-ErrorOr<NonnullRefPtr<Web::Painting::AccumulatedVisualContextTree>> decode(Decoder& decoder)
+ErrorOr<Web::Painting::AccumulatedVisualContextTree> decode(Decoder& decoder)
 {
+    auto version = TRY(decoder.decode<u64>());
     auto nodes = TRY(decoder.decode<Vector<Web::Painting::AccumulatedVisualContextNode>>());
     if (nodes.is_empty())
         return Error::from_string_literal("IPC decode: AccumulatedVisualContextTree missing sentinel node");
-    auto visual_context_tree = adopt_ref(*new Web::Painting::AccumulatedVisualContextTree());
-    visual_context_tree->m_nodes = move(nodes);
-    return visual_context_tree;
+    return Web::Painting::AccumulatedVisualContextTree { version, move(nodes) };
 }
 
 }

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/AtomicRefCounted.h>
 #include <AK/DistinctNumeric.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
@@ -90,9 +89,17 @@ struct AccumulatedVisualContextNode {
     bool has_empty_effective_clip { false };
 };
 
-class AccumulatedVisualContextTree : public AtomicRefCounted<AccumulatedVisualContextTree> {
+class AccumulatedVisualContextTree {
 public:
-    static NonnullRefPtr<AccumulatedVisualContextTree> create();
+    static AccumulatedVisualContextTree create();
+
+    AccumulatedVisualContextTree(AccumulatedVisualContextTree const&) = default;
+    AccumulatedVisualContextTree& operator=(AccumulatedVisualContextTree const&) = default;
+    AccumulatedVisualContextTree(AccumulatedVisualContextTree&&) = default;
+    AccumulatedVisualContextTree& operator=(AccumulatedVisualContextTree&&) = default;
+    ~AccumulatedVisualContextTree() = default;
+
+    u64 version() const { return m_version; }
 
     VisualContextIndex append(VisualContextData data, VisualContextIndex parent_index);
 
@@ -108,10 +115,15 @@ public:
     bool has_empty_effective_clip(VisualContextIndex i) const { return m_nodes[i.value()].has_empty_effective_clip; }
 
 private:
-    AccumulatedVisualContextTree() = default;
+    AccumulatedVisualContextTree(u64 version, Vector<AccumulatedVisualContextNode>&& nodes)
+        : m_version(version)
+        , m_nodes(move(nodes))
+    {
+    }
 
     Vector<size_t, 8> build_ancestor_chain(VisualContextIndex index) const;
 
+    u64 m_version { 0 };
     Vector<AccumulatedVisualContextNode> m_nodes;
 
     template<typename T>
@@ -167,6 +179,6 @@ WEB_API ErrorOr<Web::Painting::AccumulatedVisualContextNode> decode(Decoder&);
 template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::AccumulatedVisualContextTree const&);
 template<>
-WEB_API ErrorOr<NonnullRefPtr<Web::Painting::AccumulatedVisualContextTree>> decode(Decoder&);
+WEB_API ErrorOr<Web::Painting::AccumulatedVisualContextTree> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -31,14 +31,14 @@ static void set_command_sequence_visual_context(Bytes command_bytes, VisualConte
 
 DisplayListCommandSequence::DisplayListCommandSequence() = default;
 
-DisplayList::DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree)
-    : m_visual_context_tree(move(visual_context_tree))
+DisplayList::DisplayList(u64 compatible_visual_context_tree_version)
+    : m_compatible_visual_context_tree_version(compatible_visual_context_tree_version)
     , m_id(s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
 {
 }
 
-DisplayList::DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree, u64 id, ByteBuffer&& command_bytes, Optional<AsyncScrollingMetadata> async_scrolling_metadata)
-    : m_visual_context_tree(move(visual_context_tree))
+DisplayList::DisplayList(u64 compatible_visual_context_tree_version, u64 id, ByteBuffer&& command_bytes, Optional<AsyncScrollingMetadata> async_scrolling_metadata)
+    : m_compatible_visual_context_tree_version(compatible_visual_context_tree_version)
     , m_id(id)
     , m_command_bytes(move(command_bytes))
     , m_async_scrolling_metadata(move(async_scrolling_metadata))
@@ -49,11 +49,13 @@ bool DisplayList::append_bytes(
     DisplayListCommandType type,
     ReadonlyBytes payload,
     ReadonlyBytes inline_data,
+    AccumulatedVisualContextTree const& visual_context_tree,
     VisualContextIndex context_index,
     Optional<Gfx::IntRect> bounding_rect,
     bool is_clip)
 {
-    if (context_index.value() && m_visual_context_tree->has_empty_effective_clip(context_index))
+    VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
+    if (context_index.value() && visual_context_tree.has_empty_effective_clip(context_index))
         return false;
     VERIFY(m_command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
     VERIFY(payload.size() <= NumericLimits<u32>::max());
@@ -82,9 +84,12 @@ bool DisplayList::append_bytes(
 
 void DisplayList::append_command_sequence(
     DisplayListCommandSequence const& sequence,
+    AccumulatedVisualContextTree const& visual_context_tree,
     VisualContextIndex context_index,
     DisplayListResourceStorage& resource_storage)
 {
+    VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
+
     auto command_bytes = MUST(ByteBuffer::copy(sequence.m_command_bytes.span()));
 
     set_command_sequence_visual_context(command_bytes.span(), context_index);
@@ -109,23 +114,29 @@ DisplayListCommandSequence DisplayList::copy_command_sequence_from(
 
 void DisplayListPlayer::execute(
     DisplayList const& display_list,
+    AccumulatedVisualContextTree const& visual_context_tree,
     DisplayListResourceStorage const& resource_storage,
     ScrollStateSnapshot const& scroll_state_snapshot,
     RefPtr<Gfx::PaintingSurface> surface)
 {
+    VERIFY(display_list.compatible_visual_context_tree_version() == visual_context_tree.version());
     m_surface = surface;
     m_active_display_list = &display_list;
+    m_active_visual_context_tree = &visual_context_tree;
     m_resource_storage = &resource_storage;
     execute_impl(display_list, scroll_state_snapshot);
     m_resource_storage = nullptr;
+    m_active_visual_context_tree = nullptr;
     m_active_display_list = nullptr;
     m_surface = nullptr;
 }
 
-void DisplayListPlayer::execute_display_list_into_surface(DisplayList const& display_list, Gfx::PaintingSurface& target_surface)
+void DisplayListPlayer::execute_display_list_into_surface(DisplayList const& display_list, AccumulatedVisualContextTree const& visual_context_tree, Gfx::PaintingSurface& target_surface)
 {
+    VERIFY(display_list.compatible_visual_context_tree_version() == visual_context_tree.version());
     TemporaryChange surface_change { m_surface, RefPtr<Gfx::PaintingSurface> { target_surface } };
     TemporaryChange display_list_change { m_active_display_list, &display_list };
+    TemporaryChange visual_context_tree_change { m_active_visual_context_tree, &visual_context_tree };
     VERIFY(m_resource_storage);
     ScrollStateSnapshot scroll_state_snapshot;
     execute_impl(display_list, scroll_state_snapshot);
@@ -133,10 +144,13 @@ void DisplayListPlayer::execute_display_list_into_surface(DisplayList const& dis
 
 void DisplayListPlayer::execute_nested_display_list(
     DisplayList const& display_list,
+    AccumulatedVisualContextTree const& visual_context_tree,
     ScrollStateSnapshot const& scroll_state_snapshot,
     ReadonlyBytes command_bytes)
 {
+    VERIFY(display_list.compatible_visual_context_tree_version() == visual_context_tree.version());
     TemporaryChange display_list_change { m_active_display_list, &display_list };
+    TemporaryChange visual_context_tree_change { m_active_visual_context_tree, &visual_context_tree };
     VERIFY(m_resource_storage);
     execute_impl(display_list, scroll_state_snapshot, command_bytes);
 }
@@ -151,7 +165,8 @@ void DisplayListPlayer::execute_impl(
     ScrollStateSnapshot const& scroll_state,
     ReadonlyBytes commands)
 {
-    auto const& visual_context_tree = display_list.visual_context_tree();
+    auto const& visual_context_tree = active_visual_context_tree();
+    VERIFY(display_list.compatible_visual_context_tree_version() == visual_context_tree.version());
 
     VERIFY(m_surface);
 
@@ -356,7 +371,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayList const& display
 {
     TRY(encoder.encode(display_list.m_id));
     TRY(encoder.encode(display_list.m_command_bytes));
-    TRY(encoder.encode(*display_list.m_visual_context_tree));
+    TRY(encoder.encode(display_list.m_compatible_visual_context_tree_version));
     TRY(encoder.encode(display_list.m_async_scrolling_metadata));
     return {};
 }
@@ -372,9 +387,9 @@ ErrorOr<NonnullRefPtr<Web::Painting::DisplayList>> decode(Decoder& decoder)
 {
     auto id = TRY(decoder.decode<u64>());
     auto command_bytes = TRY(decoder.decode<ByteBuffer>());
-    auto visual_context_tree = TRY(decoder.decode<NonnullRefPtr<Web::Painting::AccumulatedVisualContextTree>>());
+    auto compatible_visual_context_tree_version = TRY(decoder.decode<u64>());
     auto async_scrolling_metadata = TRY(decoder.decode<Optional<Web::Painting::DisplayList::AsyncScrollingMetadata>>());
-    return adopt_ref(*new Web::Painting::DisplayList(move(visual_context_tree), id, move(command_bytes), move(async_scrolling_metadata)));
+    return adopt_ref(*new Web::Painting::DisplayList(compatible_visual_context_tree_version, id, move(command_bytes), move(async_scrolling_metadata)));
 }
 
 }

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -68,12 +68,13 @@ class WEB_API DisplayListPlayer {
 public:
     virtual ~DisplayListPlayer() = default;
 
-    void execute(DisplayList const&, DisplayListResourceStorage const&, ScrollStateSnapshot const&, RefPtr<Gfx::PaintingSurface>);
+    void execute(DisplayList const&, AccumulatedVisualContextTree const&, DisplayListResourceStorage const&, ScrollStateSnapshot const&, RefPtr<Gfx::PaintingSurface>);
     virtual void flush(Gfx::PaintingSurface&) = 0;
 
 protected:
     Gfx::PaintingSurface& surface() const { return *m_surface; }
     DisplayList const& active_display_list() const { return *m_active_display_list; }
+    AccumulatedVisualContextTree const& active_visual_context_tree() const { return *m_active_visual_context_tree; }
     DisplayListResourceStorage const& resource_storage() const { return *m_resource_storage; }
     ReadonlyBytes inline_data(DisplayListDataSpan span) const
     {
@@ -90,8 +91,8 @@ protected:
     }
     void execute_impl(DisplayList const&, ScrollStateSnapshot const& scroll_state);
     void execute_impl(DisplayList const&, ScrollStateSnapshot const& scroll_state, ReadonlyBytes command_bytes);
-    void execute_display_list_into_surface(DisplayList const&, Gfx::PaintingSurface&);
-    void execute_nested_display_list(DisplayList const&, ScrollStateSnapshot const&, ReadonlyBytes command_bytes);
+    void execute_display_list_into_surface(DisplayList const&, AccumulatedVisualContextTree const&, Gfx::PaintingSurface&);
+    void execute_nested_display_list(DisplayList const&, AccumulatedVisualContextTree const&, ScrollStateSnapshot const&, ReadonlyBytes command_bytes);
 
 private:
     virtual void draw_glyph_run(DrawGlyphRun const&) = 0;
@@ -135,6 +136,7 @@ private:
     virtual void add_clip_path(Gfx::Path const&) = 0;
 
     DisplayList const* m_active_display_list { nullptr };
+    AccumulatedVisualContextTree const* m_active_visual_context_tree { nullptr };
     DisplayListResourceStorage const* m_resource_storage { nullptr };
     RefPtr<Gfx::PaintingSurface> m_surface;
     ReadonlyBytes m_current_command_payload;
@@ -149,24 +151,25 @@ public:
         bool has_blocking_wheel_event_region_covering_viewport { false };
     };
 
-    static NonnullRefPtr<DisplayList> create(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree)
+    static NonnullRefPtr<DisplayList> create(AccumulatedVisualContextTree const& visual_context_tree)
     {
-        return adopt_ref(*new DisplayList(move(visual_context_tree)));
+        return adopt_ref(*new DisplayList(visual_context_tree.version()));
     }
 
     template<DisplayListCommand Command>
-    bool append(Command const& command, VisualContextIndex context_index, ReadonlyBytes inline_data = {})
+    bool append(Command const& command, AccumulatedVisualContextTree const& visual_context_tree, VisualContextIndex context_index, ReadonlyBytes inline_data = {})
     {
         return append_bytes(
             Command::command_type,
             display_list_object_bytes(command),
             inline_data,
+            visual_context_tree,
             context_index,
             command_bounding_rectangle(command),
             command_is_clip(command));
     }
 
-    AccumulatedVisualContextTree const& visual_context_tree() const { return *m_visual_context_tree; }
+    u64 compatible_visual_context_tree_version() const { return m_compatible_visual_context_tree_version; }
     u64 id() const { return m_id; }
 
     ReadonlyBytes command_bytes() const { return m_command_bytes.span(); }
@@ -185,13 +188,13 @@ public:
         DisplayListCommandSequence::for_each_command_header(command_bytes(), move(callback));
     }
 
-    void append_command_sequence(DisplayListCommandSequence const&, VisualContextIndex, DisplayListResourceStorage&);
+    void append_command_sequence(DisplayListCommandSequence const&, AccumulatedVisualContextTree const&, VisualContextIndex, DisplayListResourceStorage&);
     DisplayListCommandSequence copy_command_sequence_from(size_t command_start_offset, DisplayListResourceStorage const&) const;
     size_t command_byte_size() const { return m_command_bytes.size(); }
 
 private:
-    explicit DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree);
-    DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const>, u64 id, ByteBuffer&& command_bytes, Optional<AsyncScrollingMetadata>);
+    explicit DisplayList(u64 compatible_visual_context_tree_version);
+    DisplayList(u64 compatible_visual_context_tree_version, u64 id, ByteBuffer&& command_bytes, Optional<AsyncScrollingMetadata>);
 
     static Optional<Gfx::IntRect> command_bounding_rectangle(auto const& command)
     {
@@ -213,11 +216,12 @@ private:
         DisplayListCommandType,
         ReadonlyBytes payload,
         ReadonlyBytes inline_data,
+        AccumulatedVisualContextTree const&,
         VisualContextIndex context_index,
         Optional<Gfx::IntRect> bounding_rect,
         bool is_clip);
 
-    NonnullRefPtr<AccumulatedVisualContextTree const> const m_visual_context_tree;
+    u64 m_compatible_visual_context_tree_version { 0 };
     u64 m_id { 0 };
     ByteBuffer m_command_bytes;
     Optional<AsyncScrollingMetadata> m_async_scrolling_metadata;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -625,8 +625,8 @@ SkPaint DisplayListPlayerSkia::paint_style_to_skia_paint(DisplayListPaintStyle c
 
         auto tile_surface = Gfx::PaintingSurface::create_with_size(tile_size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_skia_backend_context);
 
-        auto const& tile_display_list = resource_storage().display_list(paint_style.pattern_tile_display_list_id);
-        execute_display_list_into_surface(tile_display_list, *tile_surface);
+        auto const& tile_display_list = resource_storage().display_list_resource(paint_style.pattern_tile_display_list_id);
+        execute_display_list_into_surface(*tile_display_list.display_list, tile_display_list.visual_context_tree, *tile_surface);
 
         auto image = tile_surface->sk_surface().makeImageSnapshot();
 
@@ -861,8 +861,8 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
     canvas.translate(command.rect.x(), command.rect.y());
     ScrollStateSnapshot scroll_state_snapshot;
     auto command_bytes = inline_data(command.command_bytes);
-    auto& nested_display_list = resource_storage().display_list(command.display_list_id);
-    execute_nested_display_list(nested_display_list, scroll_state_snapshot, command_bytes);
+    auto const& nested_display_list = resource_storage().display_list_resource(command.display_list_id);
+    execute_nested_display_list(*nested_display_list.display_list, nested_display_list.visual_context_tree, scroll_state_snapshot, command_bytes);
 }
 
 void DisplayListPlayerSkia::compositor_scroll_node(CompositorScrollNode const&)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -12,8 +12,9 @@
 
 namespace Web::Painting {
 
-DisplayListRecorder::DisplayListRecorder(DisplayList& command_list, DisplayListResourceStorage& resource_storage)
+DisplayListRecorder::DisplayListRecorder(DisplayList& command_list, AccumulatedVisualContextTree const& visual_context_tree, DisplayListResourceStorage& resource_storage)
     : m_display_list(command_list)
+    , m_visual_context_tree(visual_context_tree)
     , m_resource_storage(resource_storage)
 {
 }
@@ -248,7 +249,8 @@ static DisplayListPaintStyle to_display_list_paint_style(
         },
         [&](PatternPaintStyle const& pattern) {
             display_list_paint_style.type = DisplayListPaintStyleType::Pattern;
-            display_list_paint_style.pattern_tile_display_list_id = resource_storage.add_display_list(pattern.tile_display_list());
+            auto const& tile_display_list = pattern.tile_display_list();
+            display_list_paint_style.pattern_tile_display_list_id = resource_storage.add_display_list(tile_display_list.display_list, tile_display_list.visual_context_tree);
             display_list_paint_style.pattern_tile_rect = pattern.tile_rect();
             display_list_paint_style.pattern_transform = pattern.pattern_transform();
         });
@@ -279,16 +281,14 @@ void DisplayListRecorder::replay_cached_commands(DisplayListCommandSequence cons
     commands.for_each_command_header([&](DisplayListCommandHeader const& header, ReadonlyBytes) {
         m_save_nesting_level += display_list_command_nesting_level_change(header.type);
     });
-    m_display_list.append_command_sequence(commands, m_accumulated_visual_context_index, m_resource_storage);
+    m_display_list.append_command_sequence(commands, m_visual_context_tree, m_accumulated_visual_context_index, m_resource_storage);
 }
 
-void DisplayListRecorder::paint_nested_display_list(RefPtr<DisplayList> display_list, Gfx::IntRect rect)
+void DisplayListRecorder::paint_nested_display_list(DisplayListResource const& display_list, Gfx::IntRect rect)
 {
-    if (!display_list)
-        return;
-    auto display_list_id = resource_storage().add_display_list(*display_list);
+    auto display_list_id = resource_storage().add_display_list(display_list.display_list, display_list.visual_context_tree);
     CommandPayloadBuilder<PaintNestedDisplayList> payload_builder(m_display_list);
-    auto command_bytes = payload_builder.append_data(display_list->command_bytes(), alignof(DisplayListCommandHeader));
+    auto command_bytes = payload_builder.append_data(display_list.display_list->command_bytes(), alignof(DisplayListCommandHeader));
     append_command(
         PaintNestedDisplayList {
             display_list_id,

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -117,12 +117,12 @@ public:
     void save_layer();
     void restore();
 
-    void paint_nested_display_list(RefPtr<DisplayList> display_list, Gfx::IntRect rect);
+    void paint_nested_display_list(DisplayListResource const&, Gfx::IntRect rect);
 
     void add_rounded_rect_clip(Gfx::CornerRadii corner_radii, Gfx::IntRect border_rect, Gfx::CornerClip corner_clip);
 
     struct MaskInfo {
-        RefPtr<DisplayList> display_list;
+        DisplayListResource display_list;
         Gfx::IntRect rect;
         Gfx::MaskKind kind;
     };
@@ -151,7 +151,7 @@ public:
 
     void apply_effects(float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Gfx::Filter> filter = {}, Optional<Gfx::MaskKind> mask_kind = {});
 
-    DisplayListRecorder(DisplayList&, DisplayListResourceStorage&);
+    DisplayListRecorder(DisplayList&, AccumulatedVisualContextTree const&, DisplayListResourceStorage&);
     ~DisplayListRecorder();
 
     DisplayListResourceStorage& resource_storage() { return m_resource_storage; }
@@ -165,11 +165,12 @@ private:
     void append_command(Command const& command, ReadonlyBytes inline_data = {})
     {
         m_save_nesting_level += display_list_command_nesting_level_change<Command>();
-        m_display_list.append(command, m_accumulated_visual_context_index, inline_data);
+        m_display_list.append(command, m_visual_context_tree, m_accumulated_visual_context_index, inline_data);
     }
 
     VisualContextIndex m_accumulated_visual_context_index {};
     DisplayList& m_display_list;
+    AccumulatedVisualContextTree const& m_visual_context_tree;
     DisplayListResourceStorage& m_resource_storage;
     bool m_is_capturing { false };
     size_t m_capture_start_command_offset { 0 };

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -13,6 +13,24 @@
 
 namespace Web::Painting {
 
+DisplayListResource::DisplayListResource(NonnullRefPtr<DisplayList> display_list, AccumulatedVisualContextTree visual_context_tree)
+    : display_list(move(display_list))
+    , visual_context_tree(move(visual_context_tree))
+{
+}
+
+DisplayListResource::DisplayListResource(NonnullRefPtr<DisplayList const> display_list, AccumulatedVisualContextTree visual_context_tree)
+    : display_list(move(display_list))
+    , visual_context_tree(move(visual_context_tree))
+{
+}
+
+DisplayListResource::DisplayListResource(DisplayList const& display_list, AccumulatedVisualContextTree visual_context_tree)
+    : display_list(display_list)
+    , visual_context_tree(move(visual_context_tree))
+{
+}
+
 DisplayListResourceStorage::~DisplayListResourceStorage() = default;
 
 FontResourceId DisplayListResourceStorage::add_font(Gfx::Font const& font)
@@ -35,10 +53,19 @@ VideoFrameResourceId DisplayListResourceStorage::add_video_frame(VideoFrameResou
     return id;
 }
 
-DisplayListResourceId DisplayListResourceStorage::add_display_list(NonnullRefPtr<DisplayList const> display_list)
+DisplayListResourceId DisplayListResourceStorage::add_display_list(NonnullRefPtr<DisplayList const> display_list, AccumulatedVisualContextTree const& visual_context_tree)
 {
     auto id = display_list->id();
-    m_display_lists.ensure(id, [&] { return move(display_list); });
+    m_display_lists.ensure(id, [&] {
+        return DisplayListResource { move(display_list), visual_context_tree };
+    });
+    return { id };
+}
+
+DisplayListResourceId DisplayListResourceStorage::add_display_list(DisplayListResource&& resource)
+{
+    auto id = resource.display_list->id();
+    m_display_lists.set(id, move(resource), AK::HashSetExistingEntryBehavior::Keep);
     return { id };
 }
 
@@ -69,8 +96,10 @@ void DisplayListResourceStorage::append_referenced_resources_from(
         add_image_frame(source.image_frame(id));
     for (auto id : referenced_resources.video_frames)
         add_video_frame(id, source.video_frame(id));
-    for (auto id : referenced_resources.display_lists)
-        add_display_list(source.display_list(id));
+    for (auto id : referenced_resources.display_lists) {
+        auto const& display_list_resource = source.display_list_resource(id);
+        add_display_list(display_list_resource.display_list, display_list_resource.visual_context_tree);
+    }
 }
 
 void DisplayListResourceStorage::collect_referenced_resources(
@@ -155,7 +184,7 @@ DisplayListResourceTransaction DisplayListResourceStorage::create_transaction(
     }
     for (auto id : current.display_lists) {
         if (!previous.display_lists.contains(id))
-            transaction.display_lists.append(display_list(id));
+            transaction.display_lists.append({ display_list_resource(id).display_list, display_list_visual_context_tree(id) });
     }
 
     for (auto id : previous.fonts) {

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -21,6 +21,7 @@
 #include <LibIPC/Forward.h>
 #include <LibMedia/VideoFrame.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayListResourceIds.h>
 
 namespace Web::Painting {
@@ -47,11 +48,20 @@ struct DisplayListVideoFrameResource {
     RefPtr<Media::VideoFrame const> frame;
 };
 
+struct DisplayListResource {
+    DisplayListResource(NonnullRefPtr<DisplayList>, AccumulatedVisualContextTree);
+    DisplayListResource(NonnullRefPtr<DisplayList const>, AccumulatedVisualContextTree);
+    DisplayListResource(DisplayList const&, AccumulatedVisualContextTree);
+
+    NonnullRefPtr<DisplayList const> display_list;
+    AccumulatedVisualContextTree visual_context_tree;
+};
+
 struct DisplayListResourceTransaction {
     Vector<DisplayListFontResource> fonts;
     Vector<DisplayListImageFrameResource> image_frames;
     Vector<DisplayListVideoFrameResource> video_frames;
-    Vector<NonnullRefPtr<DisplayList const>> display_lists;
+    Vector<DisplayListResource> display_lists;
 
     Vector<FontResourceId> font_ids_to_remove;
     Vector<ImageFrameResourceId> image_frame_ids_to_remove;
@@ -70,7 +80,8 @@ public:
     FontResourceId add_font(Gfx::Font const&);
     ImageFrameResourceId add_image_frame(Gfx::DecodedImageFrame const&);
     VideoFrameResourceId add_video_frame(VideoFrameResourceId, RefPtr<Media::VideoFrame const> = nullptr);
-    DisplayListResourceId add_display_list(NonnullRefPtr<DisplayList const>);
+    DisplayListResourceId add_display_list(NonnullRefPtr<DisplayList const>, AccumulatedVisualContextTree const&);
+    DisplayListResourceId add_display_list(DisplayListResource&&);
     void set_font(FontResourceId, NonnullRefPtr<Gfx::Font const>);
     void set_image_frame(ImageFrameResourceId, Gfx::DecodedImageFrame);
     void append_referenced_resources_from(DisplayListResourceStorage const& source, ReadonlyBytes command_bytes);
@@ -87,7 +98,9 @@ public:
     Gfx::Font const& font(FontResourceId id) const { return *m_fonts.get(id.value()).value(); }
     Gfx::DecodedImageFrame const& image_frame(ImageFrameResourceId id) const { return m_image_frames.get(id.value()).value(); }
     RefPtr<Media::VideoFrame const> video_frame(VideoFrameResourceId id) const { return m_video_frames.get(id.value()).value(); }
-    DisplayList const& display_list(DisplayListResourceId id) const { return *m_display_lists.get(id.value()).value(); }
+    DisplayListResource const& display_list_resource(DisplayListResourceId id) const { return m_display_lists.get(id.value()).value(); }
+    DisplayList const& display_list(DisplayListResourceId id) const { return *display_list_resource(id).display_list; }
+    AccumulatedVisualContextTree const& display_list_visual_context_tree(DisplayListResourceId id) const { return display_list_resource(id).visual_context_tree; }
     Optional<Gfx::DecodedImageFrame const&> compositor_surface(CompositorSurfaceId id) const { return m_compositor_surfaces.get(id.value()); }
 
 private:
@@ -96,7 +109,7 @@ private:
     HashMap<u64, NonnullRefPtr<Gfx::Font const>> m_fonts;
     HashMap<u64, Gfx::DecodedImageFrame> m_image_frames;
     HashMap<u64, RefPtr<Media::VideoFrame const>> m_video_frames;
-    HashMap<u64, NonnullRefPtr<DisplayList const>> m_display_lists;
+    HashMap<u64, DisplayListResource> m_display_lists;
     HashMap<u64, Gfx::DecodedImageFrame> m_compositor_surfaces;
 };
 

--- a/Libraries/LibWeb/Painting/DisplayListResourceTransaction.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceTransaction.cpp
@@ -118,8 +118,10 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayListResourceTransac
     TRY(encoder.encode(transaction.image_frames));
     TRY(encoder.encode(transaction.video_frames));
     TRY(encoder.encode_size(transaction.display_lists.size()));
-    for (auto const& display_list : transaction.display_lists)
-        TRY(encoder.encode(*display_list));
+    for (auto const& display_list : transaction.display_lists) {
+        TRY(encoder.encode(*display_list.display_list));
+        TRY(encoder.encode(display_list.visual_context_tree));
+    }
     TRY(encoder.encode(transaction.font_ids_to_remove));
     TRY(encoder.encode(transaction.image_frame_ids_to_remove));
     TRY(encoder.encode(transaction.video_frame_ids_to_remove));
@@ -135,10 +137,13 @@ ErrorOr<Web::Painting::DisplayListResourceTransaction> decode(Decoder& decoder)
     auto video_frames = TRY(decoder.decode<Vector<Web::Painting::DisplayListVideoFrameResource>>());
 
     auto display_list_count = TRY(decoder.decode_size());
-    Vector<NonnullRefPtr<Web::Painting::DisplayList const>> display_lists;
+    Vector<Web::Painting::DisplayListResource> display_lists;
     TRY(display_lists.try_ensure_capacity(display_list_count));
-    for (size_t i = 0; i < display_list_count; ++i)
-        display_lists.unchecked_append(TRY(decoder.decode<NonnullRefPtr<Web::Painting::DisplayList>>()));
+    for (size_t i = 0; i < display_list_count; ++i) {
+        auto display_list = TRY(decoder.decode<NonnullRefPtr<Web::Painting::DisplayList>>());
+        auto visual_context_tree = TRY(decoder.decode<Web::Painting::AccumulatedVisualContextTree>());
+        display_lists.unchecked_append({ move(display_list), move(visual_context_tree) });
+    }
 
     return Web::Painting::DisplayListResourceTransaction {
         .fonts = move(fonts),

--- a/Libraries/LibWeb/Painting/PaintStyle.cpp
+++ b/Libraries/LibWeb/Painting/PaintStyle.cpp
@@ -9,7 +9,7 @@
 
 namespace Web::Painting {
 
-PatternPaintStyle::PatternPaintStyle(NonnullRefPtr<DisplayList> tile_display_list, Gfx::FloatRect tile_rect, Optional<Gfx::AffineTransform> pattern_transform)
+PatternPaintStyle::PatternPaintStyle(DisplayListResource tile_display_list, Gfx::FloatRect tile_rect, Optional<Gfx::AffineTransform> pattern_transform)
     : m_tile_display_list(move(tile_display_list))
     , m_tile_rect(tile_rect)
     , m_pattern_transform(move(pattern_transform))

--- a/Libraries/LibWeb/Painting/PaintStyle.h
+++ b/Libraries/LibWeb/Painting/PaintStyle.h
@@ -97,15 +97,15 @@ private:
 };
 
 struct PatternPaintStyle final {
-    PatternPaintStyle(NonnullRefPtr<DisplayList> tile_display_list, Gfx::FloatRect tile_rect, Optional<Gfx::AffineTransform> pattern_transform);
+    PatternPaintStyle(DisplayListResource tile_display_list, Gfx::FloatRect tile_rect, Optional<Gfx::AffineTransform> pattern_transform);
     ~PatternPaintStyle();
 
-    NonnullRefPtr<DisplayList> const& tile_display_list() const { return m_tile_display_list; }
+    DisplayListResource const& tile_display_list() const { return m_tile_display_list; }
     Gfx::FloatRect const& tile_rect() const { return m_tile_rect; }
     Optional<Gfx::AffineTransform> const& pattern_transform() const { return m_pattern_transform; }
 
 private:
-    NonnullRefPtr<DisplayList> m_tile_display_list;
+    DisplayListResource m_tile_display_list;
     Gfx::FloatRect m_tile_rect;
     Optional<Gfx::AffineTransform> m_pattern_transform;
 };

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -54,10 +54,10 @@ public:
 
     virtual Optional<CSSPixelRect> get_mask_area() const { return {}; }
     virtual Optional<Gfx::MaskKind> get_mask_type() const { return {}; }
-    virtual RefPtr<DisplayList> calculate_mask(DisplayListRecordingContext&, CSSPixelRect const&) const { return {}; }
+    virtual Optional<DisplayListResource> calculate_mask(DisplayListRecordingContext&, CSSPixelRect const&) const { return {}; }
 
     virtual Optional<CSSPixelRect> get_clip_area() const { return {}; }
-    virtual RefPtr<DisplayList> calculate_clip(DisplayListRecordingContext&, CSSPixelRect const&) const { return {}; }
+    virtual Optional<DisplayListResource> calculate_clip(DisplayListRecordingContext&, CSSPixelRect const&) const { return {}; }
 
     Layout::NodeWithStyleAndBoxModelMetrics const& layout_node_with_style_and_box_metrics() const { return as<Layout::NodeWithStyleAndBoxModelMetrics const>(layout_node()); }
 

--- a/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.h
@@ -27,9 +27,9 @@ public:
     virtual GC::Ptr<DOM::Node const> dom_node_of_svg() const override { return dom_node(); }
     virtual Optional<CSSPixelRect> get_mask_area() const override { return get_svg_mask_area(); }
     virtual Optional<Gfx::MaskKind> get_mask_type() const override { return get_svg_mask_type(); }
-    virtual RefPtr<DisplayList> calculate_mask(DisplayListRecordingContext& context, CSSPixelRect const& mask_area) const override { return calculate_svg_mask_display_list(context, mask_area); }
+    virtual Optional<DisplayListResource> calculate_mask(DisplayListRecordingContext& context, CSSPixelRect const& mask_area) const override { return calculate_svg_mask_display_list(context, mask_area); }
     virtual Optional<CSSPixelRect> get_clip_area() const override { return get_svg_clip_area(); }
-    virtual RefPtr<DisplayList> calculate_clip(DisplayListRecordingContext& context, CSSPixelRect const& clip_area) const override { return calculate_svg_clip_display_list(context, clip_area); }
+    virtual Optional<DisplayListResource> calculate_clip(DisplayListRecordingContext& context, CSSPixelRect const& clip_area) const override { return calculate_svg_clip_display_list(context, clip_area); }
 
 protected:
     SVGForeignObjectPaintable(Layout::SVGForeignObjectBox const&);

--- a/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
@@ -51,9 +51,9 @@ public:
     virtual GC::Ptr<DOM::Node const> dom_node_of_svg() const override { return dom_node(); }
     virtual Optional<CSSPixelRect> get_mask_area() const override { return get_svg_mask_area(); }
     virtual Optional<Gfx::MaskKind> get_mask_type() const override { return get_svg_mask_type(); }
-    virtual RefPtr<DisplayList> calculate_mask(DisplayListRecordingContext& context, CSSPixelRect const& mask_area) const override { return calculate_svg_mask_display_list(context, mask_area); }
+    virtual Optional<DisplayListResource> calculate_mask(DisplayListRecordingContext& context, CSSPixelRect const& mask_area) const override { return calculate_svg_mask_display_list(context, mask_area); }
     virtual Optional<CSSPixelRect> get_clip_area() const override { return get_svg_clip_area(); }
-    virtual RefPtr<DisplayList> calculate_clip(DisplayListRecordingContext& context, CSSPixelRect const& clip_area) const override { return calculate_svg_clip_display_list(context, clip_area); }
+    virtual Optional<DisplayListResource> calculate_clip(DisplayListRecordingContext& context, CSSPixelRect const& clip_area) const override { return calculate_svg_clip_display_list(context, clip_area); }
 
     void set_computed_transforms(ComputedTransforms computed_transforms)
     {

--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -76,7 +76,7 @@ Optional<Gfx::MaskKind> SVGMaskable::get_svg_mask_type() const
     return {};
 }
 
-static RefPtr<DisplayList> paint_mask_or_clip_to_display_list(
+static Optional<DisplayListResource> paint_mask_or_clip_to_display_list(
     DisplayListRecordingContext& context,
     Gfx::AffineTransform const& target_svg_transform,
     PaintableBox const& paintable,
@@ -84,8 +84,9 @@ static RefPtr<DisplayList> paint_mask_or_clip_to_display_list(
     bool is_clip_path)
 {
     auto mask_rect = context.enclosing_device_rect(area);
-    auto display_list = DisplayList::create(AccumulatedVisualContextTree::create());
-    DisplayListRecorder display_list_recorder(*display_list, context.display_list_recorder().resource_storage());
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto display_list = DisplayList::create(visual_context_tree);
+    DisplayListRecorder display_list_recorder(*display_list, visual_context_tree, context.display_list_recorder().resource_storage());
     display_list_recorder.translate(-mask_rect.location().to_type<int>());
     auto paint_context = context.clone(display_list_recorder);
     auto const& mask_element = as<SVG::SVGGraphicsElement const>(*paintable.dom_node());
@@ -94,7 +95,7 @@ static RefPtr<DisplayList> paint_mask_or_clip_to_display_list(
     paint_context.set_svg_transform(svg_transform);
     paint_context.set_draw_svg_geometry_for_clip_path(is_clip_path);
     StackingContext::paint_svg(paint_context, paintable, PaintPhase::Foreground);
-    return display_list;
+    return DisplayListResource { *display_list, move(visual_context_tree) };
 }
 
 Gfx::AffineTransform SVGMaskable::target_svg_transform() const
@@ -105,22 +106,22 @@ Gfx::AffineTransform SVGMaskable::target_svg_transform() const
     return {};
 }
 
-RefPtr<DisplayList> SVGMaskable::calculate_svg_mask_display_list(DisplayListRecordingContext& context, CSSPixelRect const& mask_area) const
+Optional<DisplayListResource> SVGMaskable::calculate_svg_mask_display_list(DisplayListRecordingContext& context, CSSPixelRect const& mask_area) const
 {
     auto const& graphics_element = as<SVG::SVGGraphicsElement const>(*dom_node_of_svg());
     auto* mask_box = get_mask_box(graphics_element);
     if (!mask_box)
-        return nullptr;
+        return {};
     auto& mask_paintable = static_cast<PaintableBox const&>(*mask_box->first_paintable());
     return paint_mask_or_clip_to_display_list(context, target_svg_transform(), mask_paintable, mask_area, false);
 }
 
-RefPtr<DisplayList> SVGMaskable::calculate_svg_clip_display_list(DisplayListRecordingContext& context, CSSPixelRect const& clip_area) const
+Optional<DisplayListResource> SVGMaskable::calculate_svg_clip_display_list(DisplayListRecordingContext& context, CSSPixelRect const& clip_area) const
 {
     auto const& graphics_element = as<SVG::SVGGraphicsElement const>(*dom_node_of_svg());
     auto* clip_box = get_clip_box(graphics_element);
     if (!clip_box)
-        return nullptr;
+        return {};
     auto& clip_paintable = static_cast<PaintableBox const&>(*clip_box->first_paintable());
     return paint_mask_or_clip_to_display_list(context, target_svg_transform(), clip_paintable, clip_area, true);
 }

--- a/Libraries/LibWeb/Painting/SVGMaskable.h
+++ b/Libraries/LibWeb/Painting/SVGMaskable.h
@@ -8,6 +8,7 @@
 
 #include <LibGfx/Forward.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {
@@ -21,11 +22,11 @@ public:
     // For <mask> element
     Optional<CSSPixelRect> get_svg_mask_area() const;
     Optional<Gfx::MaskKind> get_svg_mask_type() const;
-    RefPtr<DisplayList> calculate_svg_mask_display_list(DisplayListRecordingContext&, CSSPixelRect const& mask_area) const;
+    Optional<DisplayListResource> calculate_svg_mask_display_list(DisplayListRecordingContext&, CSSPixelRect const& mask_area) const;
 
     // For <clipPath> element
     Optional<CSSPixelRect> get_svg_clip_area() const;
-    RefPtr<DisplayList> calculate_svg_clip_display_list(DisplayListRecordingContext&, CSSPixelRect const& clip_area) const;
+    Optional<DisplayListResource> calculate_svg_clip_display_list(DisplayListRecordingContext&, CSSPixelRect const& clip_area) const;
 
 private:
     Gfx::AffineTransform target_svg_transform() const;

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -40,10 +40,10 @@ void SVGSVGPaintable::paint_svg_box(DisplayListRecordingContext& context, Painta
     if (mask_area.has_value()) {
         if (mask_area->is_empty()) {
             skip_painting = true;
-        } else if (auto mask_display_list = svg_box.calculate_mask(context, *mask_area)) {
+        } else if (auto mask_display_list = svg_box.calculate_mask(context, *mask_area); mask_display_list.has_value()) {
             auto rect = context.enclosing_device_rect(*mask_area).to_type<int>();
             auto kind = svg_box.get_mask_type().value_or(Gfx::MaskKind::Alpha);
-            masks.append({ mask_display_list, rect, kind });
+            masks.append({ mask_display_list.release_value(), rect, kind });
         }
     }
 
@@ -51,9 +51,9 @@ void SVGSVGPaintable::paint_svg_box(DisplayListRecordingContext& context, Painta
     if (clip_area.has_value()) {
         if (clip_area->is_empty()) {
             skip_painting = true;
-        } else if (auto clip_display_list = svg_box.calculate_clip(context, *clip_area)) {
+        } else if (auto clip_display_list = svg_box.calculate_clip(context, *clip_area); clip_display_list.has_value()) {
             auto rect = context.enclosing_device_rect(*clip_area).to_type<int>();
-            masks.append({ clip_display_list, rect, Gfx::MaskKind::Alpha });
+            masks.append({ clip_display_list.release_value(), rect, Gfx::MaskKind::Alpha });
         }
     }
 

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -369,26 +369,27 @@ void StackingContext::paint(DisplayListRecordingContext& context) const
     Vector<DisplayListRecorder::MaskInfo> masks;
 
     if (mask_image) {
-        auto mask_display_list = DisplayList::create(AccumulatedVisualContextTree::create());
-        DisplayListRecorder display_list_recorder(*mask_display_list, context.display_list_recorder().resource_storage());
+        auto visual_context_tree = AccumulatedVisualContextTree::create();
+        auto mask_display_list = DisplayList::create(visual_context_tree);
+        DisplayListRecorder display_list_recorder(*mask_display_list, visual_context_tree, context.display_list_recorder().resource_storage());
         auto mask_painting_context = context.clone(display_list_recorder);
         auto mask_rect_in_device_pixels = context.enclosing_device_rect(paintable_box().absolute_padding_box_rect());
         mask_image->paint(mask_painting_context, { {}, mask_rect_in_device_pixels.size() }, CSS::ImageRendering::Auto);
-        masks.append({ mask_display_list, mask_rect_in_device_pixels.to_type<int>(), Gfx::MaskKind::Alpha });
+        masks.append({ { *mask_display_list, move(visual_context_tree) }, mask_rect_in_device_pixels.to_type<int>(), Gfx::MaskKind::Alpha });
     }
 
     if (auto mask_area = paintable_box().get_mask_area(); mask_area.has_value()) {
-        if (auto mask_display_list = paintable_box().calculate_mask(context, *mask_area)) {
+        if (auto mask_display_list = paintable_box().calculate_mask(context, *mask_area); mask_display_list.has_value()) {
             auto rect = context.enclosing_device_rect(*mask_area).to_type<int>();
             auto kind = paintable_box().get_mask_type().value_or(Gfx::MaskKind::Alpha);
-            masks.append({ mask_display_list, rect, kind });
+            masks.append({ mask_display_list.release_value(), rect, kind });
         }
     }
 
     if (auto clip_area = paintable_box().get_clip_area(); clip_area.has_value()) {
-        if (auto clip_display_list = paintable_box().calculate_clip(context, *clip_area)) {
+        if (auto clip_display_list = paintable_box().calculate_clip(context, *clip_area); clip_display_list.has_value()) {
             auto rect = context.enclosing_device_rect(*clip_area).to_type<int>();
-            masks.append({ clip_display_list, rect, Gfx::MaskKind::Alpha });
+            masks.append({ clip_display_list.release_value(), rect, Gfx::MaskKind::Alpha });
         }
     }
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -97,7 +97,7 @@ void ViewportPaintable::reset_for_relayout()
     m_scroll_state_snapshot = {};
     m_needs_to_refresh_scroll_state = true;
     m_paintable_boxes_with_auto_content_visibility.clear();
-    m_visual_context_tree = nullptr;
+    m_visual_context_tree.clear();
     m_visual_viewport_context_index = {};
 }
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -5,13 +5,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/CSS/PropertyID.h>
-#include <LibWeb/CSS/VisualViewport.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
-#include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/TextNode.h>
@@ -19,17 +16,16 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
-#include <LibWeb/Painting/Blending.h>
-#include <LibWeb/Painting/DevicePixelConverter.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
-#include <LibWeb/Painting/ResolvedCSSFilter.h>
 #include <LibWeb/Painting/ScrollFrame.h>
 #include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Selection/Selection.h>
 
 namespace Web::Painting {
+
+AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable&);
 
 NonnullRefPtr<ViewportPaintable> ViewportPaintable::create(Layout::Viewport const& layout_viewport)
 {
@@ -98,7 +94,6 @@ void ViewportPaintable::reset_for_relayout()
     m_needs_to_refresh_scroll_state = true;
     m_paintable_boxes_with_auto_content_visibility.clear();
     m_visual_context_tree.clear();
-    m_visual_viewport_context_index = {};
 }
 
 void ViewportPaintable::build_stacking_context_tree_if_needed()
@@ -216,343 +211,9 @@ void ViewportPaintable::assign_scroll_frames()
     });
 }
 
-static CSSPixelRect effective_css_clip_rect(CSSPixelRect const& css_clip)
-{
-    if (css_clip.width() < 0 || css_clip.height() < 0)
-        return CSSPixelRect { 0, 0, 0, 0 };
-    return css_clip;
-}
-
-// Converts a CSS-pixel-space 4x4 matrix to device-pixel-space.
-// - Translation column (column 3, rows 0-2) is scaled up by DPR
-// - Perspective row (row 3, columns 0-2) is scaled down by DPR
-// - All other elements are unaffected (the scale factors cancel out)
-static FloatMatrix4x4 scale_matrix_for_device_pixels(FloatMatrix4x4 matrix, float scale)
-{
-    matrix[0, 3] *= scale;
-    matrix[1, 3] *= scale;
-    matrix[2, 3] *= scale;
-    matrix[3, 0] /= scale;
-    matrix[3, 1] /= scale;
-    matrix[3, 2] /= scale;
-    return matrix;
-}
-
-static Optional<TransformData> compute_transform(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, double pixel_ratio)
-{
-    if (!paintable_box.has_css_transform())
-        return {};
-
-    auto matrix = Gfx::FloatMatrix4x4::identity();
-    if (auto const& translate = computed_values.translate())
-        matrix = matrix * translate->to_matrix(paintable_box);
-    if (auto const& rotate = computed_values.rotate())
-        matrix = matrix * rotate->to_matrix(paintable_box);
-    if (auto const& scale = computed_values.scale())
-        matrix = matrix * scale->to_matrix(paintable_box);
-    for (auto const& transform : computed_values.transformations())
-        matrix = matrix * transform->to_matrix(paintable_box);
-    auto const& css_transform_origin = computed_values.transform_origin();
-    auto reference_box = paintable_box.transform_reference_box();
-    CSSPixelPoint origin {
-        reference_box.left() + css_transform_origin.x.to_px(paintable_box.layout_node(), reference_box.width()),
-        reference_box.top() + css_transform_origin.y.to_px(paintable_box.layout_node(), reference_box.height()),
-    };
-    auto scale = static_cast<float>(pixel_ratio);
-    auto device_origin = origin.to_type<float>() * scale;
-    return TransformData { scale_matrix_for_device_pixels(matrix, scale), device_origin };
-}
-
-// https://drafts.csswg.org/css-transforms-2/#perspective-matrix
-static Optional<Gfx::FloatMatrix4x4> compute_perspective_matrix(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values)
-{
-    auto perspective = computed_values.perspective();
-    if (!perspective.has_value())
-        return {};
-
-    // The perspective matrix is computed as follows:
-
-    // 1. Start with the identity matrix.
-    // 2. Translate by the computed X and Y values of 'perspective-origin'
-    // https://drafts.csswg.org/css-transforms-2/#perspective-origin-property
-    // Percentages: refer to the size of the reference box
-    auto reference_box = paintable_box.transform_reference_box();
-    auto perspective_origin = computed_values.perspective_origin().resolved(paintable_box.layout_node(), reference_box);
-    auto computed_x = perspective_origin.x().to_float();
-    auto computed_y = perspective_origin.y().to_float();
-    auto perspective_matrix = Gfx::translation_matrix(Vector3<float>(computed_x, computed_y, 0));
-
-    // 3. Multiply by the matrix that would be obtained from the 'perspective()' transform function, where the
-    //    length is provided by the value of the perspective property
-    // NB: Length values less than 1px being clamped to 1px is handled by the perspective() function already.
-    // FIXME: Create the matrix directly.
-    perspective_matrix = perspective_matrix * CSS::TransformationStyleValue::create(CSS::PropertyID::Transform, CSS::TransformFunction::Perspective, CSS::StyleValueVector { CSS::LengthStyleValue::create(CSS::Length::make_px(perspective.value())) })->to_matrix({});
-
-    // 4. Translate by the negated computed X and Y values of 'perspective-origin'
-    perspective_matrix = perspective_matrix * Gfx::translation_matrix(Vector3<float>(-computed_x, -computed_y, 0));
-    return perspective_matrix;
-}
-
-static Optional<ClipData> compute_clip_data(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, DevicePixelConverter const& converter)
-{
-    auto overflow_x = computed_values.overflow_x();
-    auto overflow_y = computed_values.overflow_y();
-
-    // https://drafts.csswg.org/css-contain-2/#paint-containment
-    // 1. The contents of the element including any ink or scrollable overflow must be clipped to the overflow clip
-    //    edge of the paint containment box, taking corner clipping into account. This does not include the creation of
-    //    any mechanism to access or indicate the presence of the clipped content; nor does it inhibit the creation of
-    //    any such mechanism through other properties, such as overflow, resize, or text-overflow.
-    //    NOTE: This clipping shape respects overflow-clip-margin, allowing an element with paint containment
-    //          to still slightly overflow its normal bounds.
-    if (paintable_box.layout_node().has_paint_containment()) {
-        // NOTE: Note: The behavior is described in this paragraph is equivalent to changing 'overflow-x: visible' into
-        //       'overflow-x: clip' and 'overflow-y: visible' into 'overflow-y: clip' at used value time, while leaving other
-        //       values of 'overflow-x' and 'overflow-y' unchanged.
-        overflow_x = CSS::Overflow::Clip;
-        overflow_y = CSS::Overflow::Clip;
-    }
-
-    auto has_hidden_overflow = overflow_x != CSS::Overflow::Visible || overflow_y != CSS::Overflow::Visible;
-
-    if (has_hidden_overflow && paintable_box.overflow_property_applies()) {
-        auto clip_rect = paintable_box.absolute_padding_box_rect();
-
-        // https://drafts.csswg.org/css-overflow-3/#propdef-overflow
-        // 'clip'
-        //    This value indicates that the box’s content is clipped to its overflow clip edge
-        auto overflow_clip_edge = paintable_box.overflow_clip_edge_rect();
-        if (overflow_x == CSS::Overflow::Visible) {
-            clip_rect.set_left(0);
-            clip_rect.set_right(CSSPixels::max_integer_value);
-        } else if (overflow_x == CSS::Overflow::Clip) {
-            clip_rect.set_left(overflow_clip_edge.left());
-            clip_rect.set_right(overflow_clip_edge.right());
-        }
-        if (overflow_y == CSS::Overflow::Visible) {
-            clip_rect.set_top(0);
-            clip_rect.set_bottom(CSSPixels::max_integer_value);
-        } else if (overflow_y == CSS::Overflow::Clip) {
-            clip_rect.set_top(overflow_clip_edge.top());
-            clip_rect.set_bottom(overflow_clip_edge.bottom());
-        }
-
-        // https://drafts.csswg.org/css-overflow-3/#corner-clipping
-        // As mentioned in CSS Backgrounds 3 § 4.3 Corner Clipping, the clipping region established by 'overflow' can be
-        // rounded:
-        // - When 'overflow-x' and 'overflow-y' compute to 'hidden', 'scroll', or 'auto', the clipping region is rounded
-        //   based on the border radius, adjusted to the padding edge, as described in CSS Backgrounds 3 § 4.2 Corner
-        //   Shaping.
-        // - When both 'overflow-x' and 'overflow-y' compute to 'clip', the clipping region is rounded as described in § 3.2
-        //   Expanding Clipping Bounds: the 'overflow-clip-margin' property.
-        // - However, when one of 'overflow-x' or 'overflow-y' computes to 'clip' and the other computes to 'visible', the
-        //   clipping region is not rounded.
-        // FIXME: Adjust the border radii for the overflow-clip-margin case. (see https://drafts.csswg.org/css-overflow-4/#valdef-overflow-clip-margin-length-0 )
-        auto radii = (overflow_x != CSS::Overflow::Visible && overflow_y != CSS::Overflow::Visible) ? paintable_box.normalized_border_radii_data(PaintableBox::ShrinkRadiiForBorders::Yes) : BorderRadiiData {};
-        return ClipData { converter.rounded_device_rect(clip_rect), radii.as_corners(converter) };
-    }
-
-    return {};
-}
-
 void ViewportPaintable::assign_accumulated_visual_contexts()
 {
-    m_visual_context_tree = AccumulatedVisualContextTree::create();
-
-    auto pixel_ratio = document().page().client().device_pixels_per_css_pixel();
-    DevicePixelConverter converter { pixel_ratio };
-    auto scale = static_cast<float>(pixel_ratio);
-
-    auto append_node = [&](VisualContextIndex parent_index, VisualContextData data) -> VisualContextIndex {
-        return m_visual_context_tree->append(move(data), parent_index);
-    };
-
-    auto make_effects_data = [&](PaintableBox const& box) -> Optional<EffectsData> {
-        auto const& computed_values = box.computed_values();
-        auto gfx_filter = to_gfx_filter(box.filter(), pixel_ratio);
-        EffectsData effects {
-            computed_values.opacity(),
-            mix_blend_mode_to_compositing_and_blending_operator(computed_values.mix_blend_mode()),
-            move(gfx_filter)
-        };
-        if (!effects.needs_layer())
-            return {};
-        return effects;
-    };
-
-    // Create visual viewport transform as root (if not identity)
-    m_visual_viewport_context_index = {};
-    auto transform = document().visual_viewport()->transform();
-    if (!transform.is_identity()) {
-        auto matrix = scale_matrix_for_device_pixels(transform.to_matrix(), scale);
-        m_visual_viewport_context_index = append_node({}, TransformData { matrix, { 0.f, 0.f } });
-    }
-
-    VisualContextIndex viewport_state_for_descendants = m_visual_viewport_context_index;
-    if (own_scroll_frame_index().value())
-        viewport_state_for_descendants = append_node(m_visual_viewport_context_index, ScrollData { own_scroll_frame_index(), false });
-    set_accumulated_visual_context({});
-    set_accumulated_visual_context_for_descendants(viewport_state_for_descendants);
-
-    for_each_in_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
-        auto visual_parent_paintable = paintable_box.parent();
-        auto* visual_parent = as_if<PaintableBox>(visual_parent_paintable.ptr());
-        if (!visual_parent)
-            return TraversalDecision::Continue;
-
-        // Resolve filters before make_effects_data reads them.
-        auto const& paintable_box_computed_values = paintable_box.computed_values();
-        if (paintable_box_computed_values.filter().has_filters())
-            paintable_box.set_filter(resolve_css_filter(paintable_box_computed_values.filter(), paintable_box));
-        else
-            paintable_box.set_filter({});
-
-        VisualContextIndex inherited_state;
-
-        if (paintable_box.is_fixed_position()) {
-            inherited_state = m_visual_viewport_context_index;
-        } else if (paintable_box.is_absolutely_positioned()) {
-            // For position: absolute, use containing block's state to correctly escape scroll containers.
-            auto containing = paintable_box.containing_block();
-            inherited_state = containing->accumulated_visual_context_for_descendants_index();
-
-            // Abspos elements escape scroll containers and overflow clips of non-positioned
-            // ancestors, but cannot escape stacking contexts created by intermediate effects
-            // (opacity, mix-blend-mode, isolation). Walk from visual parent to containing
-            // block and collect these intermediate effects.
-            // NOTE: transforms/perspectives/filters establish containing blocks for abspos,
-            //       so they cannot appear as intermediates.
-            Vector<VisualContextData, 4> intermediate_effects;
-            RefPtr<Paintable> containing_paintable = containing;
-            for (RefPtr<Paintable> paintable = visual_parent; paintable && paintable != containing_paintable; paintable = paintable->parent()) {
-                auto* ancestor_box = as_if<PaintableBox>(paintable.ptr());
-                if (!ancestor_box)
-                    continue;
-                if (auto effects = make_effects_data(*ancestor_box); effects.has_value())
-                    intermediate_effects.append(effects.release_value());
-            }
-            for (auto& effects : intermediate_effects.in_reverse())
-                inherited_state = append_node(inherited_state, move(effects));
-        } else {
-            // For position: relative/static, use visual parent's state directly.
-            // This avoids duplicate transform/perspective allocations that would occur with
-            // the containing block + intermediate walk approach.
-            inherited_state = visual_parent->accumulated_visual_context_for_descendants_index();
-        }
-
-        // Build this element's own state from inherited state.
-        VisualContextIndex own_state = inherited_state;
-
-        if (paintable_box.is_sticky_position()) {
-            // For sticky elements, use enclosing_scroll_frame which holds the sticky frame.
-            // own_scroll_frame may be a different scroll frame if the sticky element also has scrollable overflow.
-            if (auto sticky_idx = paintable_box.enclosing_scroll_frame_index(); sticky_idx.value() && m_scroll_state.frame_at(sticky_idx).is_sticky())
-                own_state = append_node(own_state, ScrollData { sticky_idx, true });
-        }
-
-        auto const& computed_values = paintable_box.computed_values();
-
-        if (auto effects = make_effects_data(paintable_box); effects.has_value())
-            own_state = append_node(own_state, effects.release_value());
-
-        if (auto transform_data = compute_transform(paintable_box, computed_values, pixel_ratio); transform_data.has_value()) {
-            paintable_box.set_has_non_invertible_css_transform(!transform_data->matrix.is_invertible());
-            own_state = append_node(own_state, *transform_data);
-        } else {
-            paintable_box.set_has_non_invertible_css_transform(false);
-        }
-
-        if (auto css_clip = paintable_box.get_clip_rect(); css_clip.has_value()) {
-            auto effective_rect = effective_css_clip_rect(*css_clip);
-            own_state = append_node(own_state, ClipData { converter.rounded_device_rect(effective_rect), {} });
-        }
-
-        // FIXME: Support other geometry boxes. See: https://drafts.fxtf.org/css-masking/#typedef-geometry-box
-        if (auto const& clip_path = computed_values.clip_path(); clip_path.has_value() && clip_path->is_basic_shape()) {
-            auto masking_area = paintable_box.absolute_border_box_rect();
-            auto reference_box = CSSPixelRect { {}, masking_area.size() };
-            auto const& basic_shape = clip_path->basic_shape();
-            auto path = basic_shape.to_path(reference_box, paintable_box.layout_node());
-            path.offset(masking_area.top_left().template to_type<float>());
-            auto fill_rule = basic_shape.basic_shape().visit(
-                [](CSS::Polygon const& polygon) { return polygon.fill_rule; },
-                [](CSS::Path const& path) { return path.fill_rule; },
-                [](auto const&) { return Gfx::WindingRule::Nonzero; });
-            auto device_path = path.copy_transformed(Gfx::AffineTransform {}.set_scale(scale, scale));
-            auto device_bounding_rect = converter.rounded_device_rect(masking_area);
-            own_state = append_node(own_state, ClipPathData { move(device_path), device_bounding_rect, fill_rule });
-        }
-
-        paintable_box.set_accumulated_visual_context(own_state);
-
-        Vector<CSS::BackgroundLayerData> const* background_layers = &computed_values.background_layers();
-        if (paintable_box.layout_node_with_style_and_box_metrics().is_root_element()) {
-            if (auto* html_element = as_if<HTML::HTMLHtmlElement>(paintable_box.dom_node().ptr())) {
-                if (html_element->should_use_body_background_properties())
-                    background_layers = paintable_box.document().background_layers();
-            }
-        }
-
-        if (background_layers) {
-            bool has_fixed_background = false;
-            for (auto const& layer : *background_layers) {
-                if (layer.attachment == CSS::BackgroundAttachment::Fixed) {
-                    has_fixed_background = true;
-                    break;
-                }
-            }
-
-            if (has_fixed_background) {
-                // https://drafts.csswg.org/css-transforms-1/#transform-rendering
-                // For elements that are effected by a transform (i.e. have a transform applied to them, or to any of
-                // their ancestor elements) and do not have their background propagated to the canvas, a value of fixed
-                // for the background-attachment property is treated as if it had a value of scroll.
-                auto has_transform_ancestor = false;
-                if (!paintable_box.layout_node_with_style_and_box_metrics().is_root_element()) {
-                    for (auto const* node = &paintable_box.layout_node(); node && !node->is_viewport(); node = node->parent()) {
-                        if (node->has_css_transform()) {
-                            has_transform_ancestor = true;
-                            break;
-                        }
-                    }
-                }
-
-                if (!has_transform_ancestor) {
-                    // Build a context that negates all scroll frames in the ancestor chain. This keeps the background
-                    // fixed relative to the viewport.
-                    auto fixed_background_context = own_state;
-                    for (auto index = own_state; index.value(); index = m_visual_context_tree->node_at(index).parent_index) {
-                        auto const& node = m_visual_context_tree->node_at(index);
-                        if (auto const* scroll = node.data.get_pointer<ScrollData>()) {
-                            fixed_background_context = append_node(fixed_background_context, ScrollCompensation { scroll->scroll_frame_index });
-                        }
-                    }
-                    paintable_box.set_fixed_background_visual_context(fixed_background_context);
-                }
-            }
-        }
-
-        // Build state for descendants: own state + perspective + clip + scroll.
-        VisualContextIndex state_for_descendants = own_state;
-
-        if (auto perspective_matrix = compute_perspective_matrix(paintable_box, computed_values); perspective_matrix.has_value()) {
-            auto scaled_matrix = scale_matrix_for_device_pixels(*perspective_matrix, scale);
-            state_for_descendants = append_node(state_for_descendants, PerspectiveData { scaled_matrix });
-        }
-
-        if (auto clip_data = compute_clip_data(paintable_box, computed_values, converter); clip_data.has_value())
-            state_for_descendants = append_node(state_for_descendants, clip_data.value());
-
-        if (paintable_box.own_scroll_frame_index().value()) {
-            auto is_sticky_without_scrollable_overflow = paintable_box.is_sticky_position() && paintable_box.enclosing_scroll_frame_index() == paintable_box.own_scroll_frame_index();
-            if (!is_sticky_without_scrollable_overflow)
-                state_for_descendants = append_node(state_for_descendants, ScrollData { paintable_box.own_scroll_frame_index(), false });
-        }
-
-        paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
-
-        return TraversalDecision::Continue;
-    });
+    m_visual_context_tree = build_accumulated_visual_context_tree(*this);
 }
 
 void ViewportPaintable::refresh_scroll_state()

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -71,7 +71,6 @@ private:
     Vector<WeakPtr<PaintableBox>> m_paintable_boxes_with_auto_content_visibility;
 
     Optional<AccumulatedVisualContextTree> m_visual_context_tree;
-    VisualContextIndex m_visual_viewport_context_index {};
 };
 
 template<>

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Painting/ScrollState.h>
@@ -47,12 +48,12 @@ public:
 
     AccumulatedVisualContextTree const& visual_context_tree() const
     {
-        VERIFY(m_visual_context_tree);
+        VERIFY(m_visual_context_tree.has_value());
         return *m_visual_context_tree;
     }
     AccumulatedVisualContextTree& visual_context_tree()
     {
-        VERIFY(m_visual_context_tree);
+        VERIFY(m_visual_context_tree.has_value());
         return *m_visual_context_tree;
     }
 
@@ -69,7 +70,7 @@ private:
 
     Vector<WeakPtr<PaintableBox>> m_paintable_boxes_with_auto_content_visibility;
 
-    RefPtr<AccumulatedVisualContextTree> m_visual_context_tree;
+    Optional<AccumulatedVisualContextTree> m_visual_context_tree;
     VisualContextIndex m_visual_viewport_context_index {};
 };
 

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -25,6 +25,7 @@
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
 #include <LibWeb/XML/XMLDocumentBuilder.h>
@@ -135,11 +136,11 @@ size_t SVGDecodedImageData::external_memory_size() const
     return size;
 }
 
-RefPtr<Painting::DisplayList> SVGDecodedImageData::record_display_list(Gfx::IntSize size, Painting::DisplayListResourceStorage& resource_storage) const
+Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list(Gfx::IntSize size, Painting::DisplayListResourceStorage& resource_storage) const
 {
     if (auto it = m_cached_display_lists.find(size); it != m_cached_display_lists.end()) {
         resource_storage.append_referenced_resources_from(it->value.resource_storage, it->value.display_list->command_bytes());
-        return it->value.display_list;
+        return Painting::DisplayListResource { *it->value.display_list, it->value.visual_context_tree };
     }
 
     // FIXME: Evict least used entries.
@@ -151,11 +152,15 @@ RefPtr<Painting::DisplayList> SVGDecodedImageData::record_display_list(Gfx::IntS
     m_document->update_layout(DOM::UpdateLayoutReason::SVGDecodedImageDataRender);
     auto display_list = m_document->record_display_list({}, local_storage);
     if (!display_list)
-        return nullptr;
+        return {};
 
     resource_storage.append_referenced_resources_from(local_storage, display_list->command_bytes());
-    m_cached_display_lists.set(size, CachedDisplayList { display_list, move(local_storage) });
-    return display_list;
+    auto document_paintable = m_document->paintable();
+    VERIFY(document_paintable);
+    auto visual_context_tree = document_paintable->visual_context_tree();
+    auto display_list_resource = Painting::DisplayListResource { *display_list, visual_context_tree };
+    m_cached_display_lists.set(size, CachedDisplayList { NonnullRefPtr<Painting::DisplayList> { *display_list }, move(visual_context_tree), move(local_storage) });
+    return display_list_resource;
 }
 
 RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize size) const
@@ -176,14 +181,14 @@ RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize
     auto surface = Gfx::PaintingSurface::create_with_size(size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
     Painting::DisplayListResourceStorage resource_storage;
     auto display_list = record_display_list(size, resource_storage);
-    if (!display_list)
+    if (!display_list.has_value())
         return nullptr;
 
     switch (m_page_client->display_list_player_type()) {
     case DisplayListPlayerType::SkiaGPUIfAvailable:
     case DisplayListPlayerType::SkiaCPU: {
         Painting::DisplayListPlayerSkia display_list_player;
-        display_list_player.execute(*display_list, resource_storage, {}, surface);
+        display_list_player.execute(*display_list->display_list, display_list->visual_context_tree, resource_storage, {}, surface);
         display_list_player.flush(*surface);
         break;
     }
@@ -280,12 +285,12 @@ RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::surface(size_t, Gfx::IntSize s
 void SVGDecodedImageData::paint(DisplayListRecordingContext& context, size_t, Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::ScalingMode) const
 {
     auto display_list = record_display_list(dst_rect.size(), context.display_list_recorder().resource_storage());
-    if (!display_list)
+    if (!display_list.has_value())
         return;
 
     context.display_list_recorder().save();
     context.display_list_recorder().add_clip_rect(clip_rect);
-    context.display_list_recorder().paint_nested_display_list(display_list, dst_rect);
+    context.display_list_recorder().paint_nested_display_list(*display_list, dst_rect);
     context.display_list_recorder().restore();
 }
 

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Page/Page.h>
@@ -48,7 +49,7 @@ private:
 
     RefPtr<Gfx::PaintingSurface> surface(size_t frame_index, Gfx::IntSize) const;
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
-    RefPtr<Painting::DisplayList> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
+    Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
 
     // FIXME: Remove this once everything is using surfaces instead.
     mutable HashMap<Gfx::IntSize, Gfx::DecodedImageFrame> m_cached_rendered_frames;
@@ -56,7 +57,8 @@ private:
     mutable HashMap<Gfx::IntSize, NonnullRefPtr<Gfx::PaintingSurface>> m_cached_rendered_surfaces;
 
     struct CachedDisplayList {
-        RefPtr<Painting::DisplayList> display_list;
+        NonnullRefPtr<Painting::DisplayList> display_list;
+        Painting::AccumulatedVisualContextTree visual_context_tree;
         Painting::DisplayListResourceStorage resource_storage;
     };
     mutable HashMap<Gfx::IntSize, CachedDisplayList> m_cached_display_lists;

--- a/Libraries/LibWeb/SVG/SVGPatternElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.cpp
@@ -289,8 +289,9 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
     auto svg_offset = recording_context.rounded_device_point(svg_element_rect.location()).to_type<int>().to_type<float>();
     tile_rect.translate_by(svg_offset);
 
-    auto display_list = Painting::DisplayList::create(Painting::AccumulatedVisualContextTree::create());
-    Painting::DisplayListRecorder display_list_recorder(*display_list, recording_context.display_list_recorder().resource_storage());
+    auto visual_context_tree = Painting::AccumulatedVisualContextTree::create();
+    auto display_list = Painting::DisplayList::create(visual_context_tree);
+    Painting::DisplayListRecorder display_list_recorder(*display_list, visual_context_tree, recording_context.display_list_recorder().resource_storage());
     auto content_origin = paint_context.paint_transform.map(Gfx::FloatPoint { 0, 0 }) + svg_offset;
     display_list_recorder.translate(-Gfx::IntPoint(content_origin.to_type<int>()));
     auto paint_context_copy = recording_context.clone(display_list_recorder);
@@ -327,7 +328,7 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
         }
     }
 
-    return Painting::PaintStyle { Painting::PatternPaintStyle { display_list, tile_rect, device_pattern_transform } };
+    return Painting::PaintStyle { Painting::PatternPaintStyle { { *display_list, move(visual_context_tree) }, tile_rect, device_pattern_transform } };
 }
 
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementXAttribute

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -243,13 +243,13 @@ void CompositorState::set_presentation_mode(Web::Compositor::CompositorContextId
         context_state.presented_bitmap_id_awaiting_ack.clear();
 }
 
-void CompositorState::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+void CompositorState::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
     context->display_list_resource_storage.apply_transaction(move(resource_transaction));
-    install_display_list_update(*context, move(display_list), move(scroll_state_snapshot));
+    install_display_list_update(*context, move(display_list), move(visual_context_tree), move(scroll_state_snapshot));
 }
 
 void CompositorState::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
@@ -262,7 +262,7 @@ void CompositorState::update_scroll_state(Web::Compositor::CompositorContextId c
         return;
 
     auto reconciled_viewport_scroll_offset = reapply_pending_async_scroll_offsets(*context, context->pending_async_scroll_offsets);
-    context->async_scroll_tree.rebuild_wheel_hit_test_targets(context->display_list, context->scroll_state_snapshot);
+    context->async_scroll_tree.rebuild_wheel_hit_test_targets(context->display_list, context->visual_context_tree.has_value() ? &context->visual_context_tree.value() : nullptr, context->scroll_state_snapshot);
     if (reconciled_viewport_scroll_offset.has_value()) {
         auto reconciled_viewport_rect = context->async_scrolling_viewport_rect;
         reconciled_viewport_rect.set_location(reconciled_viewport_scroll_offset->to_type<int>());
@@ -422,7 +422,7 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorState::async_scroll_by(Web::
         return { true, operation_id };
     }
 
-    context_state.async_scroll_tree.rebuild_wheel_hit_test_targets(context_state.display_list, context_state.scroll_state_snapshot);
+    context_state.async_scroll_tree.rebuild_wheel_hit_test_targets(context_state.display_list, context_state.visual_context_tree.has_value() ? &context_state.visual_context_tree.value() : nullptr, context_state.scroll_state_snapshot);
     if (auto viewport_scroll_offset = viewport_scroll_offset_from(context_state, scroll_offsets); viewport_scroll_offset.has_value())
         async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     store_pending_async_scroll_offsets(context_state, scroll_offsets, operation_id);
@@ -456,7 +456,7 @@ bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId conte
     if (scroll_offsets.is_empty())
         return true;
 
-    context_state.async_scroll_tree.rebuild_wheel_hit_test_targets(context_state.display_list, context_state.scroll_state_snapshot);
+    context_state.async_scroll_tree.rebuild_wheel_hit_test_targets(context_state.display_list, context_state.visual_context_tree.has_value() ? &context_state.visual_context_tree.value() : nullptr, context_state.scroll_state_snapshot);
     if (auto viewport_scroll_offset = viewport_scroll_offset_from(context_state, scroll_offsets); viewport_scroll_offset.has_value())
         async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     store_pending_async_scroll_offsets(context_state, scroll_offsets);
@@ -531,7 +531,7 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
         return;
     }
 
-    if (!context.display_list || !context.backing_store_manager.is_valid()) {
+    if (!context.display_list || !context.visual_context_tree.has_value() || !context.backing_store_manager.is_valid()) {
         context.presented_frame = viewport_rect;
         return;
     }
@@ -544,7 +544,7 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
             Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
             painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
         });
-    m_display_list_player->execute(*context.display_list, context.display_list_resource_storage, context.scroll_state_snapshot, back_store);
+    m_display_list_player->execute(*context.display_list, context.visual_context_tree.value(), context.display_list_resource_storage, context.scroll_state_snapshot, back_store);
     paint_viewport_scrollbar_overlay(context, back_store);
     auto rendered_bitmap_id = context.backing_store_manager.back_bitmap_id();
     context.gpu_present_bitmap_id_awaiting_completion = rendered_bitmap_id;
@@ -584,11 +584,11 @@ bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId co
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    if (!context->display_list || !target_bitmap.is_valid() || !target_bitmap.bitmap())
+    if (!context->display_list || !context->visual_context_tree.has_value() || !target_bitmap.is_valid() || !target_bitmap.bitmap())
         return false;
 
     auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
-    m_display_list_player->execute(*context->display_list, context->display_list_resource_storage, context->scroll_state_snapshot, *target_surface);
+    m_display_list_player->execute(*context->display_list, context->visual_context_tree.value(), context->display_list_resource_storage, context->scroll_state_snapshot, *target_surface);
     paint_viewport_scrollbar_overlay(*context, *target_surface);
     m_display_list_player->flush(*target_surface);
     return true;
@@ -730,9 +730,11 @@ void CompositorState::remove_child_surface(ContextState& context, Web::Composito
     child_context->presentation_mode = Empty {};
 }
 
-void CompositorState::install_display_list_update(ContextState& context, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+void CompositorState::install_display_list_update(ContextState& context, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
+    VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree.version());
     context.display_list = move(display_list);
+    context.visual_context_tree = move(visual_context_tree);
     context.scroll_state_snapshot = move(scroll_state_snapshot);
 
     if (!m_async_scrolling_enabled) {
@@ -771,7 +773,7 @@ void CompositorState::install_display_list_update(ContextState& context, Nonnull
         if (auto viewport_scroll_offset = reapply_pending_async_scroll_offsets(context, context.pending_async_scroll_offsets); viewport_scroll_offset.has_value())
             async_scrolling_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     }
-    context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.display_list, context.scroll_state_snapshot);
+    context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.display_list, context.visual_context_tree.has_value() ? &context.visual_context_tree.value() : nullptr, context.scroll_state_snapshot);
     context.async_scrolling_viewport_rect = async_scrolling_viewport_rect;
     context.has_async_scrolling_state = true;
 }
@@ -927,7 +929,7 @@ bool CompositorState::apply_viewport_scrollbar_drag(Web::Compositor::CompositorC
     auto scroll_offsets = context.async_scroll_tree.apply_scroll_delta(scrollbar.scroll_node_id, delta, context.scroll_state_snapshot);
     if (scroll_offsets.is_empty())
         return false;
-    context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.display_list, context.scroll_state_snapshot);
+    context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.display_list, context.visual_context_tree.has_value() ? &context.visual_context_tree.value() : nullptr, context.scroll_state_snapshot);
 
     auto viewport_scroll_offset = viewport_scroll_offset_from(context, scroll_offsets);
     if (!viewport_scroll_offset.has_value())

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -27,6 +27,7 @@
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
@@ -75,7 +76,8 @@ public:
     void destroy_context(Web::Compositor::CompositorContextId);
 
     void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode);
-    void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::DisplayListResourceTransaction&&, Web::Painting::ScrollStateSnapshot&&);
+    void stop_presenting_to_client(Web::Compositor::CompositorContextId);
+    void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::AccumulatedVisualContextTree, Web::Painting::DisplayListResourceTransaction&&, Web::Painting::ScrollStateSnapshot&&);
     void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot&&);
     void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
     void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId);
@@ -120,7 +122,8 @@ private:
         Optional<PublishedSurface> published_surface;
         HashMap<Web::Painting::CompositorSurfaceId, Web::Compositor::CompositorContextId> child_contexts_by_surface_id;
 
-        RefPtr<Web::Painting::DisplayList> display_list;
+        RefPtr<Web::Painting::DisplayList const> display_list;
+        Optional<Web::Painting::AccumulatedVisualContextTree> visual_context_tree;
         Web::Painting::DisplayListResourceStorage display_list_resource_storage;
         Web::Painting::ScrollStateSnapshot scroll_state_snapshot;
         BackingStoreManager backing_store_manager;
@@ -173,7 +176,7 @@ private:
     ContextState const* context_if_present(Web::Compositor::CompositorContextId) const;
     void detach_from_parent_surface(Web::Compositor::CompositorContextId, ContextState&);
     void remove_child_surface(ContextState&, Web::Compositor::CompositorContextId parent_context_id, Web::Painting::CompositorSurfaceId);
-    void install_display_list_update(ContextState&, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::ScrollStateSnapshot&&);
+    void install_display_list_update(ContextState&, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::AccumulatedVisualContextTree, Web::Painting::ScrollStateSnapshot&&);
     Optional<Gfx::FloatPoint> viewport_scroll_offset_from(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&) const;
     Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&);
     void store_pending_async_scroll_offsets(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&, Optional<Web::Compositor::AsyncScrollOperationID> = {});

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -6,6 +6,7 @@
 #include <LibMedia/VideoFrame.h>
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/ScrollState.h>
@@ -15,7 +16,7 @@ endpoint CompositorWebContentServer
     set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode) =|
     destroy_context(Web::Compositor::CompositorContextId context_id) =|
 
-    update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
+    update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
     update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
 
     update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) =|

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -65,10 +65,10 @@ void ConnectionFromWebContent::destroy_context(Web::Compositor::CompositorContex
     m_compositor_state->destroy_context(context_id);
 }
 
-void ConnectionFromWebContent::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot)
+void ConnectionFromWebContent::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot)
 {
     verify_context_is_owned_by_this_connection(context_id);
-    m_compositor_state->update_display_list(context_id, move(display_list), move(resource_transaction), move(scroll_state_snapshot));
+    m_compositor_state->update_display_list(context_id, move(display_list), move(visual_context_tree), move(resource_transaction), move(scroll_state_snapshot));
 }
 
 void ConnectionFromWebContent::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot scroll_state_snapshot)

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -33,7 +33,7 @@ private:
 
     virtual void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode) override;
     virtual void destroy_context(Web::Compositor::CompositorContextId) override;
-    virtual void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::DisplayListResourceTransaction, Web::Painting::ScrollStateSnapshot) override;
+    virtual void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::AccumulatedVisualContextTree, Web::Painting::DisplayListResourceTransaction, Web::Painting::ScrollStateSnapshot) override;
     virtual void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot) override;
     virtual void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>) override;
     virtual void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId) override;

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -38,12 +38,12 @@ void CompositorConnection::destroy_context(Web::Compositor::CompositorContextId 
     async_destroy_context(context_id);
 }
 
-void CompositorConnection::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> const& display_list, Web::Painting::DisplayListResourceTransaction const& resource_transaction, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+void CompositorConnection::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> const& display_list, Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Web::Painting::DisplayListResourceTransaction const& resource_transaction, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
     if (!can_send_message_to_compositor())
         return;
 
-    auto encoded_message = MUST(Messages::CompositorWebContentServer::UpdateDisplayList::static_encode(context_id, display_list, resource_transaction, scroll_state_snapshot));
+    auto encoded_message = MUST(Messages::CompositorWebContentServer::UpdateDisplayList::static_encode(context_id, display_list, visual_context_tree, resource_transaction, scroll_state_snapshot));
     if (post_message(encoded_message).is_error())
         did_lose_compositor();
 }

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -38,7 +38,7 @@ public:
 
     void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode const&);
     void destroy_context(Web::Compositor::CompositorContextId);
-    void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList> const&, Web::Painting::DisplayListResourceTransaction const&, Web::Painting::ScrollStateSnapshot const&);
+    void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList> const&, Web::Painting::AccumulatedVisualContextTree const&, Web::Painting::DisplayListResourceTransaction const&, Web::Painting::ScrollStateSnapshot const&);
     void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot const&);
     void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const> const&);
     void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId);

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -35,10 +35,10 @@ private:
             connection->set_presentation_mode(context_id, mode);
     }
 
-    virtual void update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot) override
+    virtual void update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot) override
     {
         if (auto* connection = compositor_connection())
-            connection->update_display_list(context_id, display_list, resource_transaction, scroll_state_snapshot);
+            connection->update_display_list(context_id, display_list, visual_context_tree, resource_transaction, scroll_state_snapshot);
     }
 
     virtual void update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) override


### PR DESCRIPTION
Display lists owned the accumulated visual context tree through a
ref-counted pointer. That tied visual-context state to display-list
lifetime and made compositor updates treat the two as one unit, even
though AVC trees need to become independently updateable compositor
state.

Make accumulated visual context trees plain versioned values, have each
display list store the compatible tree version, and pass the matching
tree alongside display-list updates and replay calls. Replay verifies
that the provided tree matches the display list before executing it.

This prepares the compositor for receiving AVC tree updates separately
from display-list updates: it now accepts the tree as a separate update
parameter, stores it next to the display list, and uses that stored tree
for replay and async-scroll hit testing. Nested display-list resources
carry their own tree snapshots for the same version check.