### PR TITLE
LibWebView: Polish the search filter for the advanced settings page

### DIFF
--- a/Base/res/ladybird/about-pages/bookmarks.html
+++ b/Base/res/ladybird/about-pages/bookmarks.html
@@ -226,43 +226,6 @@
                 min-width: 0;
             }
 
-            .search-container {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-
-                max-width: 65%;
-                margin: 0 auto 24px auto;
-                padding: 0px 12px;
-
-                background-color: var(--tree-hover-color);
-                border: none;
-                border-radius: 8px;
-            }
-
-            .search-icon {
-                flex-shrink: 0;
-                width: 16px;
-                height: 16px;
-                color: var(--empty-text-color);
-            }
-
-            .search-input {
-                flex-grow: 1;
-                min-width: 0;
-                font-size: 13px;
-                color: inherit;
-
-                background: none;
-                border: none;
-                outline: none;
-                padding: 0;
-            }
-
-            .search-input::placeholder {
-                color: var(--empty-text-color);
-            }
-
             .search-highlight {
                 color: inherit;
                 background-color: var(--tree-selected-color);

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -282,10 +282,6 @@
                 flex-grow: 1;
             }
 
-            #config-filter {
-                width: 100%;
-            }
-
             .config-name {
                 font-family: monospace;
                 font-size: 13px;
@@ -558,12 +554,22 @@
         </div>
 
         <div class="tab-panel" id="tab-advanced">
-            <h3 class="card-title">Configuration Variables</h3>
+            <div class="search-container">
+                <svg
+                    class="search-icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                >
+                    <circle cx="11" cy="11" r="7" />
+                    <line x1="16" y1="16" x2="22" y2="22" />
+                </svg>
+                <input id="config-filter" type="search" class="search-input" placeholder="Filter configuration keys" />
+            </div>
             <div class="card">
                 <div class="card-body">
-                    <div class="card-group">
-                        <input id="config-filter" type="search" placeholder="Filter configuration keys" />
-                    </div>
                     <div class="card-group" id="config-list"></div>
                 </div>
             </div>

--- a/Base/res/ladybird/about-pages/webui.css
+++ b/Base/res/ladybird/about-pages/webui.css
@@ -67,11 +67,11 @@ header img {
     margin: 0 8px 16px 8px;
 }
 
-.card-group + .card-group {
+.card-group:not(.hidden) ~ .card-group:not(.hidden) {
     margin-top: 16px;
 }
 
-.card-separator + .card-separator {
+.card-separator:not(.hidden) ~ .card-separator:not(.hidden) {
     border-top: 1px solid var(--border-color);
     padding-top: 16px;
 }

--- a/Base/res/ladybird/about-pages/webui.css
+++ b/Base/res/ladybird/about-pages/webui.css
@@ -75,3 +75,42 @@ header img {
     border-top: 1px solid var(--border-color);
     padding-top: 16px;
 }
+
+.search-container {
+    background-color: var(--card-background-color);
+
+    display: flex;
+    align-items: center;
+
+    max-width: 65%;
+    margin: 0 auto 24px auto;
+    padding: 0 12px;
+
+    border: none;
+    border-radius: 8px;
+}
+
+.search-container .search-icon {
+    color: var(--placeholder-color);
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+}
+
+.search-container .search-input {
+    background: none;
+    color: inherit;
+
+    flex-grow: 1;
+
+    border: none;
+    outline: none;
+
+    font-size: 14px;
+    line-height: 1.2;
+
+    width: auto;
+    min-width: 0;
+
+    padding: 10px 12px;
+}

--- a/Base/res/ladybird/ladybird.css
+++ b/Base/res/ladybird/ladybird.css
@@ -72,8 +72,8 @@ body {
 }
 
 .hidden {
-    display: none;
-    opacity: 0;
+    display: none !important;
+    opacity: 0 !important;
 }
 
 /**


### PR DESCRIPTION
* Actually hide the filtered-out container
* Use the same search box styling that we have on the bookmarks page

Before:
<img width="1016" height="773" alt="before" src="https://github.com/user-attachments/assets/4cb6f59d-b874-42f3-8869-47eaaa4f1c62" />

After:
<img width="1016" height="773" alt="after" src="https://github.com/user-attachments/assets/4dc56c1b-af1b-4280-b0c6-d041949822ca" />
