### PR TITLE
LibWeb: Avoid white flashes during dark-mode loads

### DIFF
--- a/Libraries/LibWeb/CSS/SystemColor.h
+++ b/Libraries/LibWeb/CSS/SystemColor.h
@@ -19,7 +19,7 @@ Color active_text(PreferredColorScheme);
 Color button_border(PreferredColorScheme);
 Color button_face(PreferredColorScheme);
 Color button_text(PreferredColorScheme);
-Color canvas(PreferredColorScheme);
+WEB_API Color canvas(PreferredColorScheme);
 Color canvas_text(PreferredColorScheme);
 Color field(PreferredColorScheme);
 Color field_text(PreferredColorScheme);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1390,12 +1390,14 @@ Color Document::canvas_background_color() const
 CSS::PreferredColorScheme Document::canvas_color_scheme() const
 {
     auto color_scheme = CSS::PreferredColorScheme::Light;
+    auto root_color_scheme_is_normal = true;
     if (auto* html_element = this->html_element(); html_element && html_element->layout_node()) {
         auto const& computed_values = html_element->layout_node()->computed_values();
+        auto const& color_scheme_value = html_element->computed_properties()->property(CSS::PropertyID::ColorScheme).as_color_scheme();
+        root_color_scheme_is_normal = color_scheme_value.schemes().is_empty();
         if (computed_values.color_scheme() == CSS::PreferredColorScheme::Dark) {
             color_scheme = CSS::PreferredColorScheme::Dark;
-        } else if (auto const& color_scheme_value = html_element->computed_properties()->property(CSS::PropertyID::ColorScheme).as_color_scheme();
-            color_scheme_value.schemes().is_empty() && m_supported_color_schemes.has_value()) {
+        } else if (root_color_scheme_is_normal && m_supported_color_schemes.has_value()) {
             auto preferred_color_scheme = page().preferred_color_scheme();
             if (m_supported_color_schemes->contains_slow(CSS::preferred_color_scheme_to_string(preferred_color_scheme)))
                 color_scheme = preferred_color_scheme;
@@ -1403,6 +1405,7 @@ CSS::PreferredColorScheme Document::canvas_color_scheme() const
     }
 
     if (color_scheme == CSS::PreferredColorScheme::Light
+        && root_color_scheme_is_normal
         && !m_supported_color_schemes.has_value()
         && readiness() == HTML::DocumentReadyState::Loading) {
         if (auto navigable = this->navigable(); navigable && navigable->is_top_level_traversable())

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1384,13 +1384,25 @@ Color Document::background_color() const
 
 Color Document::canvas_background_color() const
 {
+    return CSS::SystemColor::canvas(canvas_color_scheme()).blend(background_color());
+}
+
+CSS::PreferredColorScheme Document::canvas_color_scheme() const
+{
     auto color_scheme = CSS::PreferredColorScheme::Light;
     if (auto* html_element = this->html_element(); html_element && html_element->layout_node()) {
         if (html_element->layout_node()->computed_values().color_scheme() == CSS::PreferredColorScheme::Dark)
             color_scheme = CSS::PreferredColorScheme::Dark;
     }
 
-    return CSS::SystemColor::canvas(color_scheme).blend(background_color());
+    if (color_scheme == CSS::PreferredColorScheme::Light
+        && !m_supported_color_schemes.has_value()
+        && readiness() == HTML::DocumentReadyState::Loading) {
+        if (auto navigable = this->navigable(); navigable && navigable->is_top_level_traversable())
+            color_scheme = page().preferred_color_scheme();
+    }
+
+    return color_scheme;
 }
 
 Vector<CSS::BackgroundLayerData> const* Document::background_layers() const
@@ -2494,13 +2506,23 @@ Optional<Vector<String> const&> Document::supported_color_schemes() const
 
 void Document::set_supported_color_schemes(Vector<String> supported_color_schemes)
 {
+    set_supported_color_schemes(Optional<Vector<String>> { move(supported_color_schemes) });
+}
+
+void Document::set_supported_color_schemes(Optional<Vector<String>> supported_color_schemes)
+{
+    if (m_supported_color_schemes == supported_color_schemes)
+        return;
+
     m_supported_color_schemes = move(supported_color_schemes);
+    invalidate_style(StyleInvalidationReason::SettingsChange);
+    set_needs_media_query_evaluation();
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme
 void Document::obtain_supported_color_schemes()
 {
-    m_supported_color_schemes = {};
+    Optional<Vector<String>> supported_color_schemes;
 
     // 1. Let candidate elements be the list of all meta elements that meet the following criteria, in tree order:
     for_each_in_subtree_of_type<HTML::HTMLMetaElement>([&](HTML::HTMLMetaElement& element) {
@@ -2517,7 +2539,7 @@ void Document::obtain_supported_color_schemes()
 
             // 2. If parsed is a valid CSS 'color-scheme' property value, then return parsed.
             if (!parsed.is_null() && parsed->is_color_scheme()) {
-                m_supported_color_schemes = parsed->as_color_scheme().schemes();
+                supported_color_schemes = parsed->as_color_scheme().schemes();
                 return TraversalDecision::Break;
             }
         }
@@ -2526,6 +2548,7 @@ void Document::obtain_supported_color_schemes()
     });
 
     // 3. Return null.
+    set_supported_color_schemes(move(supported_color_schemes));
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#meta-theme-color
@@ -8291,11 +8314,7 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
 
     // https://drafts.csswg.org/css-color-adjust-1/#color-scheme-effect
     // On the root element, the used color scheme additionally must affect the surface color of the canvas, and the viewport’s scrollbars.
-    auto color_scheme = CSS::PreferredColorScheme::Light;
-    if (auto* html_element = this->html_element(); html_element && html_element->layout_node()) {
-        if (html_element->layout_node()->computed_values().color_scheme() == CSS::PreferredColorScheme::Dark)
-            color_scheme = CSS::PreferredColorScheme::Dark;
-    }
+    auto color_scheme = canvas_color_scheme();
 
     // .. in the case of embedded documents typically rendered over a transparent canvas
     // (such as provided via an HTML iframe element), if the used color scheme of the element

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2492,6 +2492,11 @@ Optional<Vector<String> const&> Document::supported_color_schemes() const
     return m_supported_color_schemes;
 }
 
+void Document::set_supported_color_schemes(Vector<String> supported_color_schemes)
+{
+    m_supported_color_schemes = move(supported_color_schemes);
+}
+
 // https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme
 void Document::obtain_supported_color_schemes()
 {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1391,8 +1391,15 @@ CSS::PreferredColorScheme Document::canvas_color_scheme() const
 {
     auto color_scheme = CSS::PreferredColorScheme::Light;
     if (auto* html_element = this->html_element(); html_element && html_element->layout_node()) {
-        if (html_element->layout_node()->computed_values().color_scheme() == CSS::PreferredColorScheme::Dark)
+        auto const& computed_values = html_element->layout_node()->computed_values();
+        if (computed_values.color_scheme() == CSS::PreferredColorScheme::Dark) {
             color_scheme = CSS::PreferredColorScheme::Dark;
+        } else if (auto const& color_scheme_value = html_element->computed_properties()->property(CSS::PropertyID::ColorScheme).as_color_scheme();
+            color_scheme_value.schemes().is_empty() && m_supported_color_schemes.has_value()) {
+            auto preferred_color_scheme = page().preferred_color_scheme();
+            if (m_supported_color_schemes->contains_slow(CSS::preferred_color_scheme_to_string(preferred_color_scheme)))
+                color_scheme = preferred_color_scheme;
+        }
     }
 
     if (color_scheme == CSS::PreferredColorScheme::Light

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1391,7 +1391,9 @@ CSS::PreferredColorScheme Document::canvas_color_scheme() const
 {
     auto color_scheme = CSS::PreferredColorScheme::Light;
     auto root_color_scheme_is_normal = true;
+    auto root_color_scheme_was_computed = false;
     if (auto* html_element = this->html_element(); html_element && html_element->layout_node()) {
+        root_color_scheme_was_computed = true;
         auto const& computed_values = html_element->layout_node()->computed_values();
         auto const& color_scheme_value = html_element->computed_properties()->property(CSS::PropertyID::ColorScheme).as_color_scheme();
         root_color_scheme_is_normal = color_scheme_value.schemes().is_empty();
@@ -1405,6 +1407,7 @@ CSS::PreferredColorScheme Document::canvas_color_scheme() const
     }
 
     if (color_scheme == CSS::PreferredColorScheme::Light
+        && !root_color_scheme_was_computed
         && root_color_scheme_is_normal
         && !m_supported_color_schemes.has_value()
         && readiness() == HTML::DocumentReadyState::Loading) {

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -372,6 +372,7 @@ public:
     void set_visited_link_color(Color);
 
     Optional<Vector<String> const&> supported_color_schemes() const;
+    void set_supported_color_schemes(Vector<String>);
     void obtain_supported_color_schemes();
 
     void obtain_theme_color();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -30,6 +30,7 @@
 #include <LibWeb/Bindings/NavigationType.h>
 #include <LibWeb/CSS/CustomPropertyRegistration.h>
 #include <LibWeb/CSS/EnvironmentVariable.h>
+#include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/StyleScope.h>
 #include <LibWeb/DOM/AnchorNameMap.h>
 #include <LibWeb/DOM/HoverEventData.h>
@@ -359,6 +360,7 @@ public:
 
     Color background_color() const;
     Color canvas_background_color() const;
+    CSS::PreferredColorScheme canvas_color_scheme() const;
     Vector<CSS::BackgroundLayerData> const* background_layers() const;
     CSS::ImageRendering background_image_rendering() const;
 
@@ -373,6 +375,7 @@ public:
 
     Optional<Vector<String> const&> supported_color_schemes() const;
     void set_supported_color_schemes(Vector<String>);
+    void set_supported_color_schemes(Optional<Vector<String>>);
     void obtain_supported_color_schemes();
 
     void obtain_theme_color();

--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -97,6 +97,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::Navi
     if (document->url_string() == "about:blank"_string
         && navigation_params.response->body()->length().value_or(0) == 0) {
         TRY(document->populate_with_html_head_and_body());
+        document->set_supported_color_schemes({ "light"_string, "dark"_string });
         HTML::HTMLParser::the_end(document);
     }
 

--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -97,7 +97,8 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::Navi
     if (document->url_string() == "about:blank"_string
         && navigation_params.response->body()->length().value_or(0) == 0) {
         TRY(document->populate_with_html_head_and_body());
-        document->set_supported_color_schemes({ "light"_string, "dark"_string });
+        if (navigation_params.navigable && navigation_params.navigable->is_top_level_traversable())
+            document->set_supported_color_schemes({ "light"_string, "dark"_string });
         HTML::HTMLParser::the_end(document);
     }
 

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -278,7 +278,8 @@ BrowsingContext::BrowsingContextAndDocument BrowsingContext::create_a_new_browsi
 
     // 19. Populate with html/head/body given document.
     populate_with_html_head_body(*document);
-    document->set_supported_color_schemes({ "light"_string, "dark"_string });
+    if (!embedder)
+        document->set_supported_color_schemes({ "light"_string, "dark"_string });
 
     // 20. Make active document.
     document->make_active();

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -278,6 +278,7 @@ BrowsingContext::BrowsingContextAndDocument BrowsingContext::create_a_new_browsi
 
     // 19. Populate with html/head/body given document.
     populate_with_html_head_body(*document);
+    document->set_supported_color_schemes({ "light"_string, "dark"_string });
 
     // 20. Make active document.
     document->make_active();

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
+#include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
@@ -712,6 +713,27 @@ void Internals::reset_style_invalidation_counters()
 void Internals::update_style()
 {
     window().associated_document().update_style();
+}
+
+void Internals::set_preferred_color_scheme(StringView color_scheme)
+{
+    auto preferred_color_scheme = CSS::preferred_color_scheme_from_string(color_scheme);
+
+    Optional<CSS::PreferredColorScheme> preferred_color_scheme_override;
+    if (preferred_color_scheme != CSS::PreferredColorScheme::Auto)
+        preferred_color_scheme_override = preferred_color_scheme;
+    page().set_preferred_color_scheme_override_for_testing(preferred_color_scheme_override);
+
+    auto& document = window().associated_document();
+    document.invalidate_style(DOM::StyleInvalidationReason::SettingsChange);
+    document.set_needs_media_query_evaluation();
+}
+
+String Internals::canvas_color_scheme()
+{
+    auto& document = window().associated_document();
+    document.update_layout(DOM::UpdateLayoutReason::Debugging);
+    return MUST(String::from_utf8(CSS::preferred_color_scheme_to_string(document.canvas_color_scheme())));
 }
 
 bool Internals::style_sheet_may_have_has_selectors(CSS::CSSStyleSheet& style_sheet)

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -122,6 +122,8 @@ public:
     JS::Object* get_style_invalidation_counters();
     void reset_style_invalidation_counters();
     void update_style();
+    void set_preferred_color_scheme(StringView color_scheme);
+    String canvas_color_scheme();
     bool style_sheet_may_have_has_selectors(CSS::CSSStyleSheet&);
     WebIDL::UnsignedLongLong active_image_style_value_animation_count();
     JS::Object* async_scrolling_state();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -97,6 +97,8 @@ interface Internals {
     undefined resetStyleInvalidationCounters();
     // Flushes pending style work without forcing layout.
     undefined updateStyle();
+    undefined setPreferredColorScheme(DOMString colorScheme);
+    DOMString canvasColorScheme();
     // Returns the selector-insight cache state for stylesheet invalidation tests.
     boolean styleSheetMayHaveHasSelectors(CSSStyleSheet sheet);
     unsigned long long activeImageStyleValueAnimationCount();

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -216,6 +216,9 @@ CSSPixelRect Page::web_exposed_available_screen_area() const
 
 CSS::PreferredColorScheme Page::preferred_color_scheme() const
 {
+    if (m_preferred_color_scheme_override_for_testing.has_value())
+        return *m_preferred_color_scheme_override_for_testing;
+
     auto preferred_color_scheme = m_client->preferred_color_scheme();
 
     if (preferred_color_scheme == CSS::PreferredColorScheme::Auto)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -132,6 +132,7 @@ public:
     CSSPixelRect web_exposed_screen_area() const;
     CSSPixelRect web_exposed_available_screen_area() const;
     CSS::PreferredColorScheme preferred_color_scheme() const;
+    void set_preferred_color_scheme_override_for_testing(Optional<CSS::PreferredColorScheme> color_scheme) { m_preferred_color_scheme_override_for_testing = color_scheme; }
     CSS::PreferredContrast preferred_contrast() const;
     CSS::PreferredMotion preferred_motion() const;
 
@@ -370,6 +371,7 @@ private:
     URL::URL m_last_find_in_page_url;
 
     bool m_listen_for_dom_mutations { false };
+    Optional<CSS::PreferredColorScheme> m_preferred_color_scheme_override_for_testing;
 
     struct PendingFullscreenEnter {
         GC::Ref<DOM::Element> element;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -14,6 +14,7 @@
 #include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibGfx/SharedImageBuffer.h>
 #include <LibURL/Parser.h>
+#include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWebView/Application.h>
@@ -348,6 +349,13 @@ void ViewImplementation::did_finish_handling_input_event(Badge<WebContentClient>
 
 void ViewImplementation::set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme)
 {
+    if (color_scheme == Web::CSS::PreferredColorScheme::Dark)
+        set_page_background_color(Web::CSS::SystemColor::canvas(Web::CSS::PreferredColorScheme::Dark));
+    else if (color_scheme == Web::CSS::PreferredColorScheme::Light)
+        set_page_background_color(Web::CSS::SystemColor::canvas(Web::CSS::PreferredColorScheme::Light));
+    else
+        set_page_background_color(m_system_canvas_background_color);
+
     client().async_set_preferred_color_scheme(page_id(), color_scheme);
 }
 
@@ -702,9 +710,21 @@ void ViewImplementation::did_change_needs_beforeunload_check(Badge<WebContentCli
 
 void ViewImplementation::did_change_background_color(Badge<WebContentClient>, Gfx::Color color)
 {
+    set_page_background_color(color);
+}
+
+void ViewImplementation::set_page_background_color_to_system_canvas(bool dark)
+{
+    auto color_scheme = dark ? Web::CSS::PreferredColorScheme::Dark : Web::CSS::PreferredColorScheme::Light;
+    m_system_canvas_background_color = Web::CSS::SystemColor::canvas(color_scheme);
+    set_page_background_color(m_system_canvas_background_color);
+}
+
+void ViewImplementation::set_page_background_color(Gfx::Color color)
+{
     m_page_background_color = color;
     if (on_page_background_color_change)
-        on_page_background_color_change(color);
+        on_page_background_color_change(m_page_background_color);
 }
 
 void ViewImplementation::did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -349,12 +349,8 @@ void ViewImplementation::did_finish_handling_input_event(Badge<WebContentClient>
 
 void ViewImplementation::set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme)
 {
-    if (color_scheme == Web::CSS::PreferredColorScheme::Dark)
-        set_page_background_color(Web::CSS::SystemColor::canvas(Web::CSS::PreferredColorScheme::Dark));
-    else if (color_scheme == Web::CSS::PreferredColorScheme::Light)
-        set_page_background_color(Web::CSS::SystemColor::canvas(Web::CSS::PreferredColorScheme::Light));
-    else
-        set_page_background_color(m_system_canvas_background_color);
+    m_preferred_color_scheme = color_scheme;
+    set_page_background_color(preferred_canvas_background_color());
 
     client().async_set_preferred_color_scheme(page_id(), color_scheme);
 }
@@ -717,7 +713,7 @@ void ViewImplementation::set_page_background_color_to_system_canvas(bool dark)
 {
     auto color_scheme = dark ? Web::CSS::PreferredColorScheme::Dark : Web::CSS::PreferredColorScheme::Light;
     m_system_canvas_background_color = Web::CSS::SystemColor::canvas(color_scheme);
-    set_page_background_color(m_system_canvas_background_color);
+    set_page_background_color(preferred_canvas_background_color());
 }
 
 void ViewImplementation::set_page_background_color(Gfx::Color color)
@@ -725,6 +721,15 @@ void ViewImplementation::set_page_background_color(Gfx::Color color)
     m_page_background_color = color;
     if (on_page_background_color_change)
         on_page_background_color_change(m_page_background_color);
+}
+
+Gfx::Color ViewImplementation::preferred_canvas_background_color() const
+{
+    if (m_preferred_color_scheme == Web::CSS::PreferredColorScheme::Dark)
+        return Web::CSS::SystemColor::canvas(Web::CSS::PreferredColorScheme::Dark);
+    if (m_preferred_color_scheme == Web::CSS::PreferredColorScheme::Light)
+        return Web::CSS::SystemColor::canvas(Web::CSS::PreferredColorScheme::Light);
+    return m_system_canvas_background_color;
 }
 
 void ViewImplementation::did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -131,6 +131,12 @@ void ViewImplementation::set_favicon(Badge<WebContentClient>, Gfx::Bitmap const&
 
 void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL const& url)
 {
+    if (m_client_state.has_usable_bitmap) {
+        // Keep showing the old page until the new WebContent process paints its first frame.
+        m_backup_shared_image_buffer = move(m_client_state.front_bitmap.shared_image_buffer);
+        m_backup_bitmap_size = m_client_state.front_bitmap.last_painted_size;
+    }
+
     if (m_client_state.client) {
         m_client_state.client->unregister_view(m_client_state.page_index);
     }
@@ -141,8 +147,6 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
     if (on_web_content_process_change_for_cross_site_navigation)
         on_web_content_process_change_for_cross_site_navigation();
 
-    // Don't keep a stale backup bitmap around.
-    m_backup_shared_image_buffer = nullptr;
     handle_resize();
 
     load(url);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -315,6 +315,8 @@ protected:
     void apply_zoom_for_current_host();
 
     void handle_resize();
+    void set_page_background_color_to_system_canvas(bool dark);
+    void set_page_background_color(Gfx::Color);
     void load_crash_page_html(StringView, URL::URL const& crashed_url);
 
     enum class CreateNewClient {
@@ -411,6 +413,7 @@ protected:
     OwnPtr<Gfx::SharedImageBuffer> m_backup_shared_image_buffer;
     Web::DevicePixelSize m_backup_bitmap_size;
     Gfx::Color m_page_background_color { 255, 255, 255 };
+    Gfx::Color m_system_canvas_background_color { 255, 255, 255 };
 
     bool m_should_suppress_history_for_current_load { false };
     bool m_should_suppress_history_for_next_load { false };

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -317,6 +317,7 @@ protected:
     void handle_resize();
     void set_page_background_color_to_system_canvas(bool dark);
     void set_page_background_color(Gfx::Color);
+    Gfx::Color preferred_canvas_background_color() const;
     void load_crash_page_html(StringView, URL::URL const& crashed_url);
 
     enum class CreateNewClient {
@@ -414,6 +415,7 @@ protected:
     Web::DevicePixelSize m_backup_bitmap_size;
     Gfx::Color m_page_background_color { 255, 255, 255 };
     Gfx::Color m_system_canvas_background_color { 255, 255, 255 };
+    Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
 
     bool m_should_suppress_history_for_current_load { false };
     bool m_should_suppress_history_for_next_load { false };

--- a/Tests/LibWeb/Text/expected/css/embedded-about-blank-color-scheme.txt
+++ b/Tests/LibWeb/Text/expected/css/embedded-about-blank-color-scheme.txt
@@ -1,0 +1,3 @@
+Parent root color-scheme: normal
+Initial iframe canvas color-scheme: light
+Navigated iframe canvas color-scheme: light

--- a/Tests/LibWeb/Text/expected/css/root-color-scheme-loading-canvas.txt
+++ b/Tests/LibWeb/Text/expected/css/root-color-scheme-loading-canvas.txt
@@ -1,3 +1,5 @@
 Ready state: loading
 Computed root color-scheme: light
 Canvas color-scheme: light
+Computed root color-scheme without opt-in: normal
+Canvas color-scheme without opt-in: light

--- a/Tests/LibWeb/Text/expected/css/root-color-scheme-loading-canvas.txt
+++ b/Tests/LibWeb/Text/expected/css/root-color-scheme-loading-canvas.txt
@@ -1,0 +1,3 @@
+Ready state: loading
+Computed root color-scheme: light
+Canvas color-scheme: light

--- a/Tests/LibWeb/Text/expected/meta-color-scheme-invalidates-style.txt
+++ b/Tests/LibWeb/Text/expected/meta-color-scheme-invalidates-style.txt
@@ -1,0 +1,2 @@
+Before: rgb(0, 0, 0)
+After: rgb(235, 235, 235)

--- a/Tests/LibWeb/Text/input/css/embedded-about-blank-color-scheme.html
+++ b/Tests/LibWeb/Text/input/css/embedded-about-blank-color-scheme.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<body>
+    <pre id="out"></pre>
+    <script>
+        function println(line) {
+            out.appendChild(document.createTextNode(`${line}\n`));
+        }
+
+        function finish() {
+            const output = out.innerText;
+            internals.setPreferredColorScheme("auto");
+            internals.signalTestIsDone(output);
+        }
+
+        function iframeCanvasColorScheme(iframe) {
+            return iframe.contentWindow.internals.canvasColorScheme();
+        }
+
+        internals.setPreferredColorScheme("dark");
+        internals.updateStyle();
+
+        const initialIframe = document.createElement("iframe");
+        document.body.append(initialIframe);
+
+        println(`Parent root color-scheme: ${getComputedStyle(document.documentElement).colorScheme}`);
+        println(`Initial iframe canvas color-scheme: ${iframeCanvasColorScheme(initialIframe)}`);
+
+        const navigatedIframe = document.createElement("iframe");
+        let sawInitialLoad = false;
+        navigatedIframe.addEventListener("load", () => {
+            if (!sawInitialLoad) {
+                sawInitialLoad = true;
+                navigatedIframe.src = "about:blank";
+                return;
+            }
+
+            println(`Navigated iframe canvas color-scheme: ${iframeCanvasColorScheme(navigatedIframe)}`);
+            finish();
+        });
+        document.body.append(navigatedIframe);
+    </script>
+</body>

--- a/Tests/LibWeb/Text/input/css/root-color-scheme-loading-canvas.html
+++ b/Tests/LibWeb/Text/input/css/root-color-scheme-loading-canvas.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<style>
+    html {
+        color-scheme: light;
+    }
+</style>
+<body>
+    <pre id="out"></pre>
+    <script>
+        function println(line) {
+            out.appendChild(document.createTextNode(`${line}\n`));
+        }
+
+        internals.setPreferredColorScheme("dark");
+        internals.updateStyle();
+
+        println(`Ready state: ${document.readyState}`);
+        println(`Computed root color-scheme: ${getComputedStyle(document.documentElement).colorScheme}`);
+        println(`Canvas color-scheme: ${internals.canvasColorScheme()}`);
+
+        internals.signalTestIsDone(out.innerText);
+    </script>
+</body>

--- a/Tests/LibWeb/Text/input/css/root-color-scheme-loading-canvas.html
+++ b/Tests/LibWeb/Text/input/css/root-color-scheme-loading-canvas.html
@@ -18,6 +18,14 @@
         println(`Computed root color-scheme: ${getComputedStyle(document.documentElement).colorScheme}`);
         println(`Canvas color-scheme: ${internals.canvasColorScheme()}`);
 
-        internals.signalTestIsDone(out.innerText);
+        document.querySelector("style").remove();
+        internals.updateStyle();
+
+        println(`Computed root color-scheme without opt-in: ${getComputedStyle(document.documentElement).colorScheme}`);
+        println(`Canvas color-scheme without opt-in: ${internals.canvasColorScheme()}`);
+
+        const output = out.innerText;
+        internals.setPreferredColorScheme("auto");
+        internals.signalTestIsDone(output);
     </script>
 </body>

--- a/Tests/LibWeb/Text/input/meta-color-scheme-invalidates-style.html
+++ b/Tests/LibWeb/Text/input/meta-color-scheme-invalidates-style.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<body style="color: CanvasText"></body>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        println(`Before: ${getComputedStyle(document.body).color}`);
+
+        const meta = document.createElement("meta");
+        meta.name = "color-scheme";
+        meta.content = "dark";
+        document.head.append(meta);
+
+        println(`After: ${getComputedStyle(document.body).color}`);
+    });
+</script>

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -968,6 +968,7 @@ struct HideCursor {
     if (!m_metal_device) {
         CALayer* layer = [LadybirdWebViewContentLayer layer];
         layer.contentsGravity = kCAGravityTopLeft;
+        layer.backgroundColor = [Ladybird::gfx_color_to_ns_color(m_web_view_bridge->page_background_color()) CGColor];
         return layer;
     }
 
@@ -977,6 +978,7 @@ struct HideCursor {
     layer.framebufferOnly = YES;
     layer.displaySyncEnabled = YES;
     layer.contentsGravity = kCAGravityTopLeft;
+    layer.backgroundColor = [Ladybird::gfx_color_to_ns_color(m_web_view_bridge->page_background_color()) CGColor];
     return layer;
 }
 

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -30,6 +30,7 @@ WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, double d
 {
     m_device_pixel_ratio = device_pixel_ratio;
     m_maximum_frames_per_second = static_cast<double>(maximum_frames_per_second);
+    set_page_background_color_to_system_canvas(is_using_dark_system_theme());
 }
 
 WebViewBridge::~WebViewBridge() = default;
@@ -66,6 +67,7 @@ void WebViewBridge::exit_fullscreen()
 
 void WebViewBridge::update_palette()
 {
+    set_page_background_color_to_system_canvas(is_using_dark_system_theme());
     auto theme = create_system_palette();
     client().async_update_system_theme(m_client_state.page_index, move(theme));
 }

--- a/UI/Gtk/WebContentView.cpp
+++ b/UI/Gtk/WebContentView.cpp
@@ -37,6 +37,7 @@ WebContentView::WebContentView(LadybirdWebView* widget, RefPtr<WebView::WebConte
     m_client_state.page_index = page_index;
 
     m_device_pixel_ratio = gtk_widget_get_scale_factor(GTK_WIDGET(widget));
+    set_page_background_color_to_system_canvas(adw_style_manager_get_dark(adw_style_manager_get_default()));
 
     // Store ourselves in the GObject widget
     ladybird_web_view_set_impl(widget, this);
@@ -284,6 +285,7 @@ void WebContentView::set_has_focus(bool has_focus)
 void WebContentView::update_palette()
 {
     auto is_dark = adw_style_manager_get_dark(adw_style_manager_get_default());
+    set_page_background_color_to_system_canvas(is_dark);
     auto theme_file = is_dark ? "Dark"sv : "Default"sv;
     auto theme_ini = MUST(Core::Resource::load_from_uri(MUST(String::formatted("resource://themes/{}.ini", theme_file))));
     auto theme_or_error = Gfx::load_system_theme(theme_ini->filesystem_path().to_byte_string());

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -66,6 +66,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
 
     m_device_pixel_ratio = devicePixelRatio();
     m_maximum_frames_per_second = initial_state.maximum_frames_per_second;
+    set_page_background_color_to_system_canvas(is_using_dark_system_theme(*this));
 
     QObject::connect(qGuiApp, &QGuiApplication::screenRemoved, [this](QScreen*) {
         update_screen_rects();
@@ -676,6 +677,7 @@ static Core::AnonymousBuffer make_system_theme_from_qt_palette(QWidget& widget, 
 
 void WebContentView::update_palette(PaletteMode mode)
 {
+    set_page_background_color_to_system_canvas(is_using_dark_system_theme(*this));
     client().async_update_system_theme(m_client_state.page_index, make_system_theme_from_qt_palette(*this, mode));
 }
 


### PR DESCRIPTION
Make initial and loading document backgrounds respect dark mode more consistently, including about:blank, web view fallback fills, and documents whose color-scheme state is still being established.

This keeps the previous frame visible across process swaps, defers WebContent frames until the system theme is initialized, and makes canvas color selection use the document-supported color schemes where appropriate.

Also adds coverage for meta color-scheme changes invalidating style.
