### PR TITLE
Compositor: Drop redundant context state

### DIFF
--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -77,9 +77,9 @@ PendingAsyncScrollUpdates CompositorContextHandle::take_pending_async_scroll_upd
     return m_host.take_pending_async_scroll_updates(m_context_id);
 }
 
-void CompositorContextHandle::viewport_size_updated(Gfx::IntSize viewport_size, bool is_top_level_traversable, WindowResizingInProgress window_resize_in_progress)
+void CompositorContextHandle::viewport_size_updated(Gfx::IntSize viewport_size, WindowResizingInProgress window_resize_in_progress)
 {
-    m_host.viewport_size_updated(m_context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+    m_host.viewport_size_updated(m_context_id, viewport_size, window_resize_in_progress);
 }
 
 void CompositorContextHandle::present_frame(Gfx::IntRect viewport_rect)

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -46,7 +46,7 @@ public:
         Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
     bool should_defer_main_thread_present_for_async_scroll() const;
     PendingAsyncScrollUpdates take_pending_async_scroll_updates();
-    void viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
+    void viewport_size_updated(Gfx::IntSize, WindowResizingInProgress);
     void present_frame(Gfx::IntRect);
     void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
@@ -83,7 +83,7 @@ public:
         = 0;
     virtual bool should_defer_main_thread_present_for_async_scroll(CompositorContextId) const = 0;
     virtual PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId) = 0;
-    virtual void viewport_size_updated(CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress) = 0;
+    virtual void viewport_size_updated(CompositorContextId, Gfx::IntSize, WindowResizingInProgress) = 0;
     virtual void present_frame(CompositorContextId, Gfx::IntRect) = 0;
     virtual void request_screenshot(CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback) = 0;
 

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2932,7 +2932,6 @@ void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList inval
     if (has_compositor_context()) {
         compositor_context().viewport_size_updated(
             page().css_to_device_rect(viewport_rect()).size().to_type<int>(),
-            is_top_level_traversable(),
             Compositor::WindowResizingInProgress::Yes);
         m_pending_set_browser_zoom_request = false;
     }
@@ -3417,7 +3416,6 @@ void Navigable::repaint_after_compositor_process_reconnect()
         }
         compositor_context().viewport_size_updated(
             page().css_to_device_rect(viewport_rect()).size().to_type<int>(),
-            is_top_level_traversable(),
             Compositor::WindowResizingInProgress::No);
 
         m_needs_repaint = true;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -567,7 +567,7 @@ void Application::update_compositor_viewport(Web::Compositor::CompositorContextI
         return;
     VERIFY(m_compositor_client);
 
-    m_compositor_client->async_viewport_size_updated(context_id, viewport_size, true, window_resize_in_progress);
+    m_compositor_client->async_viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
 bool Application::send_async_scroll_to_compositor(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)

--- a/Services/Compositor/BackingStoreManager.cpp
+++ b/Services/Compositor/BackingStoreManager.cpp
@@ -89,14 +89,14 @@ static ErrorOr<DMABufBackingStorePair> create_linear_dmabuf_backing_stores(Gfx::
 #endif
 
 Optional<BackingStoreManager::Allocation> BackingStoreManager::resize_backing_stores_if_needed(
-    Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+    Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
     if (viewport_size.is_empty())
         return {};
 
     auto minimum_needed_size = viewport_size;
     bool force_reallocate = false;
-    if (window_resize_in_progress == Web::Compositor::WindowResizingInProgress::Yes && is_top_level_traversable) {
+    if (window_resize_in_progress == Web::Compositor::WindowResizingInProgress::Yes) {
         // Pad the minimum needed size so that we don't have to keep reallocating backing stores while the window is being resized.
         minimum_needed_size = { viewport_size.width() + 256, viewport_size.height() + 256 };
     } else {

--- a/Services/Compositor/BackingStoreManager.h
+++ b/Services/Compositor/BackingStoreManager.h
@@ -37,7 +37,7 @@ public:
     BackingStoreManager() = default;
 
     Optional<Allocation> resize_backing_stores_if_needed(
-        Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress);
+        Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress);
     Optional<Publication> allocate_backing_stores(Allocation const&, RefPtr<Gfx::SkiaBackendContext> const&, bool should_publish);
 
     bool is_valid() const;

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -13,7 +13,7 @@ endpoint CompositorControlServer
 
     create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, i32 web_content_connection_id) => ()
 
-    viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
+    viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
 
     handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) => (bool handled)
     dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) => (bool dispatched)

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -184,7 +184,6 @@ void CompositorState::create_context(Web::Compositor::CompositorContextId contex
     auto& context = *m_contexts.ensure(context_id, [] {
         return make<ContextState>();
     });
-    context.is_registered = true;
     context.web_content_client = &web_content_client;
     context.page_id = page_id;
     context.page_presentation_registration = page_presentation_registration;
@@ -503,17 +502,19 @@ Web::Compositor::PendingAsyncScrollUpdates CompositorState::take_pending_async_s
     return updates;
 }
 
-void CompositorState::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+void CompositorState::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
     auto* context = context_if_present(context_id);
     if (!context)
         return;
 
     context->viewport_size = viewport_size;
-    context->is_top_level_traversable = is_top_level_traversable;
-    context->window_resize_in_progress = window_resize_in_progress;
+    auto is_page_presentation_context = context->page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes;
+    context->window_resize_in_progress = is_page_presentation_context
+        ? window_resize_in_progress
+        : Web::Compositor::WindowResizingInProgress::No;
     resize_backing_stores_if_needed(context_id, *context);
-    if (window_resize_in_progress == Web::Compositor::WindowResizingInProgress::Yes)
+    if (context->window_resize_in_progress == Web::Compositor::WindowResizingInProgress::Yes)
         schedule_backing_store_shrink(context_id, *context);
 }
 
@@ -976,10 +977,7 @@ bool CompositorState::paint_viewport_scrollbar_overlay(ContextState& context, Gf
 
 void CompositorState::resize_backing_stores_if_needed(Web::Compositor::CompositorContextId context_id, ContextState& context)
 {
-    if (!context.is_registered)
-        return;
-
-    auto allocation = context.backing_store_manager.resize_backing_stores_if_needed(context.viewport_size, context.is_top_level_traversable, context.window_resize_in_progress);
+    auto allocation = context.backing_store_manager.resize_backing_stores_if_needed(context.viewport_size, context.window_resize_in_progress);
     if (!allocation.has_value())
         return;
     if (auto publication = context.backing_store_manager.allocate_backing_stores(

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -91,7 +91,7 @@ public:
     void present_deferred_async_scroll_frame(Web::Compositor::CompositorContextId);
     bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) const;
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
-    void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress);
+    void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
     void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect);
     bool request_screenshot(Web::Compositor::CompositorContextId, Gfx::ShareableBitmap&);
     void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
@@ -113,7 +113,6 @@ private:
             Web::Painting::CompositorSurfaceId surface_id;
         };
 
-        bool is_registered { false };
         CompositorStateWebContentClient* web_content_client { nullptr };
         Optional<u64> page_id;
         Web::Compositor::PagePresentationRegistration page_presentation_registration { Web::Compositor::PagePresentationRegistration::No };
@@ -144,7 +143,6 @@ private:
         Web::Compositor::WheelRoutingAdmission wheel_routing_admission { Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState };
 
         Gfx::IntSize viewport_size;
-        bool is_top_level_traversable { false };
         Web::Compositor::WindowResizingInProgress window_resize_in_progress { Web::Compositor::WindowResizingInProgress::No };
         RefPtr<Core::Timer> backing_store_shrink_timer;
 

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -30,7 +30,7 @@ endpoint CompositorWebContentServer
     should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) => (bool should_defer)
     take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) => (Web::Compositor::PendingAsyncScrollUpdates updates)
 
-    viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
+    viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
     present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) =|
     request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) =|
 }

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -69,9 +69,9 @@ void ConnectionFromClient::create_context(Web::Compositor::CompositorContextId c
     m_compositor_state->create_context(context_id, page_id, page_presentation_registration, *connection);
 }
 
-void ConnectionFromClient::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+void ConnectionFromClient::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
-    m_compositor_state->viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+    m_compositor_state->viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
 Messages::CompositorControlServer::HandleMouseEventResponse ConnectionFromClient::handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event)

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -38,7 +38,7 @@ private:
     virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;
     virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration, i32 web_content_connection_id) override;
-    virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress) override;
+    virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress) override;
     virtual Messages::CompositorControlServer::HandleMouseEventResponse handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
     virtual Messages::CompositorControlServer::DispatchMouseEventToWebContentResponse dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
     virtual Messages::CompositorControlServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) override;

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -128,10 +128,10 @@ Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse Conn
     return m_compositor_state->take_pending_async_scroll_updates(context_id);
 }
 
-void ConnectionFromWebContent::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+void ConnectionFromWebContent::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
     verify_context_is_owned_by_this_connection(context_id);
-    m_compositor_state->viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+    m_compositor_state->viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
 void ConnectionFromWebContent::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -43,7 +43,7 @@ private:
     virtual Messages::CompositorWebContentServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
     virtual Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScrollResponse should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) override;
     virtual Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
-    virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress) override;
+    virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress) override;
     virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect) override;
     virtual void request_screenshot(Web::Compositor::CompositorContextId, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) override;
 

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -132,11 +132,11 @@ Web::Compositor::PendingAsyncScrollUpdates CompositorConnection::take_pending_as
     return response->take_updates();
 }
 
-void CompositorConnection::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+void CompositorConnection::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
     if (!can_send_message_to_compositor())
         return;
-    async_viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+    async_viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
 void CompositorConnection::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -48,7 +48,7 @@ public:
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
     bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
-    void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress);
+    void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
     void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect);
     void request_screenshot(Web::Compositor::CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&&);
     Function<void(u64 page_id, Web::MouseEvent)> on_mouse_event;

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -99,10 +99,10 @@ private:
         return {};
     }
 
-    virtual void viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) override
+    virtual void viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) override
     {
         if (auto* connection = compositor_connection())
-            connection->viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+            connection->viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
     }
 
     virtual void present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) override


### PR DESCRIPTION
CompositorState treats presence in m_contexts as the lifetime state for a compositor context. create_context() creates the entry and destroy_context() removes it, so ContextState::is_registered duplicated the map membership invariant.

The top-level-traversable bit was also duplicate information. The only compositor use was backing-store padding while a window resize is in progress, and page-presenting contexts are already identified by PagePresentationRegistration::Yes. Normalize resize-in-progress to No for non-page-presenting contexts, then remove the flag from CompositorState, the backing-store API, and the compositor IPC boundary.