### PR TITLE
LibWeb: Delay load event during CSS @import fetch

### DIFF
--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -139,6 +139,13 @@ void CSSImportRule::fetch()
 
     // AD-HOC: Track pending import rules to block rendering until they are done.
     m_document->add_pending_css_import_rule({}, *this);
+    // FIXME: This dedicated load-event delayer shouldn't be needed. The style-sheet critical-subresource mechanism
+    //        already delays the document load event via the owning element. However, it only does that delay when
+    //        contributes_a_script_blocking_style_sheet() is true. But HTMLStyleElement currently always returns false
+    //        for that. Once HTMLStyleElement actually has working contributes_a_script_blocking_style_sheet() behavior
+    //        implemented (as HTMLLinkElement element already does), the owning style element's delayer will cover the
+    //        @import fetch — and then at that time, this dedicated load-event delayer can go away.
+    m_load_event_delayer.emplace(*m_document);
     set_loading_state(CSSStyleSheet::LoadingState::Loading);
 
     // 3. Fetch a style resource from rule’s URL, with ruleOrDeclaration rule, destination "style", CORS mode "no-cors", and
@@ -154,6 +161,7 @@ void CSSImportRule::fetch()
             // AD-HOC: Stop delaying the load event.
             ScopeGuard guard = [strong_this, document] {
                 document->remove_pending_css_import_rule({}, strong_this);
+                strong_this->m_load_event_delayer.clear();
                 if (strong_this->loading_state() != CSSStyleSheet::LoadingState::Error) {
                     // If we have no critical subresources, or they're loaded already, we can report that immediately.
                     auto sheet_loading_state = strong_this->m_style_sheet->loading_state();

--- a/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -11,6 +11,7 @@
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/URL.h>
+#include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 
@@ -66,6 +67,7 @@ private:
     RefPtr<Supports> m_supports;
     GC::Ref<MediaList> m_media;
     GC::Ptr<CSSStyleSheet> m_style_sheet;
+    Optional<DOM::DocumentLoadEventDelayer> m_load_event_delayer;
 };
 
 template<>


### PR DESCRIPTION
**Problem:** `Ref/input/css/images-load-relative-to-imported-style-sheet.html` intermittently fails on the Linux Sanitizer with a deterministic 398px screenshot mismatch — the entire 20x20 background-image div is unpainted in the test pass, while the reference paints the checkerboard.

**Cause:** `CSSImportRule::fetch()` added to the document’s render-blocking set (`m_pending_css_import_rules`) — but didn’t delay the load event. The load event could fire before the imported stylesheet had finished fetching — so the background image referenced from inside that sheet hadn’t even been requested yet when test-web’s `on_load_finish` callback ran `wait_for_reftest_completion` and proceeded to take the screenshot. By contrast, `<link rel="stylesheet">` already delays the load event for its own duration via `m_document_load_event_delayer` in `HTMLLinkElement` — which is why the sibling test using `<link>` doesn’t flake.

**Fix:** Hold a `DocumentLoadEventDelayer` in `CSSImportRule` for the duration of the import fetch, paralleling `HTMLLinkElement`. By the time the import rule’s delayer clears in the `ScopeGuard`, the imported sheet’s image fetches have already been kicked off via `SharedResourceRequest`, each of which takes over load-event delaying through its own delayer — so there’s no race between the two delayers releasing.
