### PR TITLE
LibGC+LibJS: Introduce ConservativeHashTable and use it for PropertyKey storage in LibJS

### DIFF
--- a/Libraries/LibGC/CMakeLists.txt
+++ b/Libraries/LibGC/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     Cell.cpp
     CellAllocator.cpp
     ConservativeHashMap.cpp
+    ConservativeHashTable.cpp
     ConservativeVector.cpp
     Root.cpp
     RootHashMap.cpp

--- a/Libraries/LibGC/ConservativeHashTable.cpp
+++ b/Libraries/LibGC/ConservativeHashTable.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGC/ConservativeHashTable.h>
+#include <LibGC/Heap.h>
+
+namespace GC {
+
+ConservativeHashTableBase::ConservativeHashTableBase()
+    : ConservativeHashTableBase(Heap::the())
+{
+}
+
+ConservativeHashTableBase::ConservativeHashTableBase(Heap& heap)
+    : m_heap(&heap)
+{
+    m_heap->did_create_conservative_hash_table({}, *this);
+}
+
+ConservativeHashTableBase::~ConservativeHashTableBase()
+{
+    m_heap->did_destroy_conservative_hash_table({}, *this);
+}
+
+}

--- a/Libraries/LibGC/ConservativeHashTable.h
+++ b/Libraries/LibGC/ConservativeHashTable.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/HashTable.h>
+#include <AK/IntrusiveList.h>
+#include <LibGC/Forward.h>
+
+namespace GC {
+
+class GC_API ConservativeHashTableBase {
+    AK_MAKE_NONCOPYABLE(ConservativeHashTableBase);
+
+public:
+    virtual void for_each_possible_value(AK::Function<void(FlatPtr)> callback) const = 0;
+
+protected:
+    ConservativeHashTableBase();
+    explicit ConservativeHashTableBase(Heap&);
+    ~ConservativeHashTableBase();
+
+    Heap* m_heap { nullptr };
+    IntrusiveListNode<ConservativeHashTableBase> m_list_node;
+
+public:
+    using List = IntrusiveList<&ConservativeHashTableBase::m_list_node>;
+};
+
+template<typename T, typename TraitsForT = Traits<T>, bool IsOrdered = false>
+class GC_API ConservativeHashTable final
+    : public ConservativeHashTableBase
+    , public HashTable<T, TraitsForT, IsOrdered> {
+
+    using HashTableBase = HashTable<T, TraitsForT, IsOrdered>;
+
+public:
+    ConservativeHashTable()
+        : ConservativeHashTableBase()
+    {
+    }
+
+    ConservativeHashTable(ConservativeHashTable const& other)
+        : ConservativeHashTableBase(*other.m_heap)
+        , HashTableBase(static_cast<HashTableBase const&>(other))
+    {
+    }
+
+    ConservativeHashTable(ConservativeHashTable&& other)
+        : ConservativeHashTableBase(*other.m_heap)
+        , HashTableBase(move(static_cast<HashTableBase&>(other)))
+    {
+    }
+
+    ConservativeHashTable& operator=(ConservativeHashTable const& other)
+    {
+        if (&other == this)
+            return *this;
+        HashTableBase::operator=(static_cast<HashTableBase const&>(other));
+        return *this;
+    }
+
+    ~ConservativeHashTable() = default;
+
+    virtual void for_each_possible_value(AK::Function<void(FlatPtr)> callback) const override
+    {
+        for (auto& entry : *this) {
+            auto entry_bytes = ReadonlyBytes { &entry, sizeof(T) };
+            for (size_t i = 0; i + sizeof(FlatPtr) <= entry_bytes.size(); i += sizeof(FlatPtr)) {
+                FlatPtr value;
+                memcpy(&value, entry_bytes.offset(i), sizeof(FlatPtr));
+                callback(value);
+            }
+        }
+    }
+};
+
+template<typename T, typename TraitsForT = Traits<T>>
+using OrderedConservativeHashTable = ConservativeHashTable<T, TraitsForT, true>;
+
+}

--- a/Libraries/LibGC/Forward.h
+++ b/Libraries/LibGC/Forward.h
@@ -43,6 +43,9 @@ class ConservativeVector;
 template<typename K, typename V, typename KeyTraits, typename ValueTraits, bool IsOrdered>
 class ConservativeHashMap;
 
+template<typename T, typename TraitsForT, bool IsOrdered>
+class ConservativeHashTable;
+
 template<class T>
 class HeapVector;
 

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -479,6 +479,9 @@ public:
                 case HeapRoot::Type::ConservativeHashMap:
                     node.set("root"sv, "ConservativeHashMap"sv);
                     break;
+                case HeapRoot::Type::ConservativeHashTable:
+                    node.set("root"sv, "ConservativeHashTable"sv);
+                    break;
                 case HeapRoot::Type::ConservativeVector:
                     node.set("root"sv, "ConservativeVector"sv);
                     break;
@@ -974,6 +977,12 @@ NO_SANITIZE_ADDRESS void Heap::gather_conservative_roots(HashMap<Cell*, HeapRoot
     for (auto& hash_map : m_conservative_hash_maps) {
         hash_map.for_each_possible_value([&](FlatPtr possible_value) {
             add_possible_value(possible_pointers, possible_value, HeapRoot { .type = HeapRoot::Type::ConservativeHashMap }, min_block_address, max_block_address);
+        });
+    }
+
+    for (auto& hash_table : m_conservative_hash_tables) {
+        hash_table.for_each_possible_value([&](FlatPtr possible_value) {
+            add_possible_value(possible_pointers, possible_value, HeapRoot { .type = HeapRoot::Type::ConservativeHashTable }, min_block_address, max_block_address);
         });
     }
 

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -20,6 +20,7 @@
 #include <LibGC/Cell.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/ConservativeHashMap.h>
+#include <LibGC/ConservativeHashTable.h>
 #include <LibGC/ConservativeVector.h>
 #include <LibGC/Forward.h>
 #include <LibGC/HeapRoot.h>
@@ -91,6 +92,8 @@ public:
 
     void did_create_conservative_hash_map(Badge<ConservativeHashMapBase>, ConservativeHashMapBase&);
     void did_destroy_conservative_hash_map(Badge<ConservativeHashMapBase>, ConservativeHashMapBase&);
+    void did_create_conservative_hash_table(Badge<ConservativeHashTableBase>, ConservativeHashTableBase&);
+    void did_destroy_conservative_hash_table(Badge<ConservativeHashTableBase>, ConservativeHashTableBase&);
     void did_create_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase&);
     void did_destroy_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase&);
 
@@ -185,6 +188,7 @@ private:
     RootHashMapBase::List m_root_hash_maps;
     RootHashTableBase::List m_root_hash_tables;
     ConservativeHashMapBase::List m_conservative_hash_maps;
+    ConservativeHashTableBase::List m_conservative_hash_tables;
     ConservativeVectorBase::List m_conservative_vectors;
     WeakContainer::List m_weak_containers;
 
@@ -275,6 +279,18 @@ inline void Heap::did_destroy_conservative_hash_map(Badge<ConservativeHashMapBas
 {
     VERIFY(m_conservative_hash_maps.contains(hash_map));
     m_conservative_hash_maps.remove(hash_map);
+}
+
+inline void Heap::did_create_conservative_hash_table(Badge<ConservativeHashTableBase>, ConservativeHashTableBase& hash_table)
+{
+    VERIFY(!m_conservative_hash_tables.contains(hash_table));
+    m_conservative_hash_tables.append(hash_table);
+}
+
+inline void Heap::did_destroy_conservative_hash_table(Badge<ConservativeHashTableBase>, ConservativeHashTableBase& hash_table)
+{
+    VERIFY(m_conservative_hash_tables.contains(hash_table));
+    m_conservative_hash_tables.remove(hash_table);
 }
 
 inline void Heap::did_create_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase& vector)

--- a/Libraries/LibGC/HeapRoot.h
+++ b/Libraries/LibGC/HeapRoot.h
@@ -15,6 +15,7 @@ namespace GC {
 struct GC_API HeapRoot {
     enum class Type {
         ConservativeHashMap,
+        ConservativeHashTable,
         ConservativeVector,
         HeapFunctionCapturedPointer,
         MustSurviveGC,

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -9,6 +9,7 @@
 #include <AK/HashTable.h>
 #include <AK/NumericLimits.h>
 #include <AK/TemporaryChange.h>
+#include <LibGC/ConservativeHashTable.h>
 #include <LibGC/RootHashMap.h>
 #include <LibGC/RootHashTable.h>
 #include <LibJS/Bytecode/AsmInterpreter/AsmInterpreter.h>
@@ -1632,15 +1633,15 @@ static ThrowCompletionOr<Optional<FastPropertyNameIteratorData>> try_get_fast_pr
 
     result.properties.ensure_capacity(estimated_properties_count);
 
-    HashTable<PropertyKey> seen_non_enumerable_properties;
-    Optional<HashTable<PropertyKey>> seen_properties;
+    GC::ConservativeHashTable<PropertyKey> seen_non_enumerable_properties;
+    Optional<GC::ConservativeHashTable<PropertyKey>> seen_properties;
     auto ensure_seen_properties = [&] {
         if (seen_properties.has_value())
             return;
         // Prototype shadowing ignores enumerability, so once we start looking
         // above the receiver we need an explicit visited set for names we have
         // already decided to expose from lower objects.
-        seen_properties = HashTable<PropertyKey> {};
+        seen_properties.emplace();
         seen_properties->ensure_capacity(result.properties.size());
         for (auto const& property : result.properties)
             seen_properties->set(property);
@@ -1746,15 +1747,15 @@ inline ThrowCompletionOr<GC::Ref<PropertyNameIterator>> get_object_property_iter
     }
     seen_objects.clear_with_capacity();
 
-    Vector<PropertyKey> properties;
+    GC::ConservativeVector<PropertyKey> properties;
     properties.ensure_capacity(estimated_properties_count);
 
-    HashTable<PropertyKey> seen_non_enumerable_properties;
-    Optional<HashTable<PropertyKey>> seen_properties;
+    GC::ConservativeHashTable<PropertyKey> seen_non_enumerable_properties;
+    Optional<GC::ConservativeHashTable<PropertyKey>> seen_properties;
     auto ensure_seen_properties = [&] {
         if (seen_properties.has_value())
             return;
-        seen_properties = HashTable<PropertyKey> {};
+        seen_properties.emplace();
         seen_properties->ensure_capacity(properties.size());
         for (auto const& property : properties)
             seen_properties->set(property);
@@ -2356,7 +2357,7 @@ ThrowCompletionOr<void> CopyObjectExcludingProperties::execute_impl(VM& vm) cons
 
     auto to_object = Object::create(realm, realm.intrinsics().object_prototype());
 
-    HashTable<PropertyKey> excluded_names;
+    GC::ConservativeHashTable<PropertyKey> excluded_names;
     for (size_t i = 0; i < m_excluded_names_count; ++i) {
         excluded_names.set(TRY(vm.get(m_excluded_names[i]).to_property_key(vm)));
     }

--- a/Libraries/LibJS/Console.cpp
+++ b/Libraries/LibJS/Console.cpp
@@ -146,7 +146,7 @@ ThrowCompletionOr<Value> Console::log()
 }
 
 // To [create table row] given tabularDataItem, rowIndex, list finalColumns, and optional list properties, perform the following steps:
-static ThrowCompletionOr<GC::Ref<Object>> create_table_row(Realm& realm, Value row_index, Value tabular_data_item, GC::RootVector<Value>& final_columns, HashMap<PropertyKey, bool>& visited_columns, HashMap<PropertyKey, bool>& properties)
+static ThrowCompletionOr<GC::Ref<Object>> create_table_row(Realm& realm, Value row_index, Value tabular_data_item, GC::RootVector<Value>& final_columns, GC::ConservativeHashTable<PropertyKey>& visited_columns, GC::ConservativeHashTable<PropertyKey>& properties)
 {
     auto& vm = realm.vm();
 
@@ -156,7 +156,7 @@ static ThrowCompletionOr<GC::Ref<Object>> create_table_row(Realm& realm, Value r
         // if a column is already visited without needing to loop through the whole
         // array.
         if (!visited_columns.contains(column_name)) {
-            visited_columns.set(column_name, true);
+            visited_columns.set(column_name);
 
             if (column_name.is_string()) {
                 final_columns.append(PrimitiveString::create(vm, column_name.as_string()));
@@ -253,7 +253,7 @@ ThrowCompletionOr<Value> Console::table()
         auto tabular_data = vm.argument(0);
         auto properties_arg = vm.argument(1);
 
-        HashMap<PropertyKey, bool> properties;
+        GC::ConservativeHashTable<PropertyKey> properties;
 
         if (TRY(properties_arg.is_array(vm))) {
             auto& properties_arr = properties_arg.as_object();
@@ -261,7 +261,7 @@ ThrowCompletionOr<Value> Console::table()
             for (size_t index = 0; index < properties_length; ++index) {
                 auto value = TRY(properties_arr.get(index));
                 if (!value.is_undefined())
-                    properties.set(TRY(PropertyKey::from_value(vm, value)), true);
+                    properties.set(TRY(PropertyKey::from_value(vm, value)));
             }
         }
 
@@ -271,7 +271,7 @@ ThrowCompletionOr<Value> Console::table()
         // 2. Let `finalColumns` be the new list, initially empty
         GC::RootVector<Value> final_columns;
 
-        HashMap<PropertyKey, bool> visited_columns;
+        GC::ConservativeHashTable<PropertyKey> visited_columns;
 
         // 3. If `tabularData` is a list, then:
         if (TRY(tabular_data.is_array(vm))) {

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -681,7 +681,7 @@ ThrowCompletionOr<GC::RootVector<Value>> ProxyObject::internal_own_property_keys
     auto trap_result_array = TRY(call(vm, *trap, m_handler, m_target));
 
     // 8. Let trapResult be ? CreateListFromArrayLike(trapResultArray, « String, Symbol »).
-    HashTable<PropertyKey> unique_keys;
+    GC::ConservativeHashTable<PropertyKey> unique_keys;
     auto trap_result = TRY(create_list_from_array_like(vm, trap_result_array, [&](auto value) -> ThrowCompletionOr<void> {
         if (!value.is_string() && !value.is_symbol())
             return vm.throw_completion<TypeError>(ErrorType::ProxyOwnPropertyKeysNotStringOrSymbol);

--- a/Meta/Lagom/ClangPlugins/LibJSGCPluginAction.cpp
+++ b/Meta/Lagom/ClangPlugins/LibJSGCPluginAction.cpp
@@ -122,6 +122,8 @@ static ContainsGCPtrResult record_contains_gc_ptr(clang::CXXRecordDecl const* re
         "GC::ConservativeVector",
         "GC::ConservativeHashMap",
         "GC::ConservativeHashMapBase",
+        "GC::ConservativeHashTable",
+        "GC::ConservativeHashTableBase",
     };
     if (gc_infrastructure_types.contains(qualified_name)) {
         s_contains_gc_ptr_cache[record] = ContainsGCPtrResult::No;
@@ -193,7 +195,7 @@ static ContainsGCPtrResult type_contains_gc_ptr(clang::QualType const& type, std
             return ContainsGCPtrResult::No;
 
         // Root types handle their own visiting
-        if (template_name == "GC::Root" || template_name == "GC::RootVector" || template_name == "GC::ConservativeHashMap" || template_name == "GC::RootHashTable")
+        if (template_name == "GC::Root" || template_name == "GC::RootVector" || template_name == "GC::ConservativeHashMap" || template_name == "GC::ConservativeHashTable" || template_name == "GC::RootHashTable")
             return ContainsGCPtrResult::No;
 
         // Check template arguments recursively for containers
@@ -234,6 +236,7 @@ static std::vector<clang::QualType> get_all_qualified_types(clang::QualType cons
             "GC::RawRef",
             "GC::RootVector",
             "GC::ConservativeHashMap",
+            "GC::ConservativeHashTable",
             "GC::RootHashTable",
             "GC::Root",
         };

--- a/Tests/LibGC/TestGCContainers.cpp
+++ b/Tests/LibGC/TestGCContainers.cpp
@@ -8,6 +8,7 @@
 #include <LibGC/Cell.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/ConservativeHashMap.h>
+#include <LibGC/ConservativeHashTable.h>
 #include <LibGC/ConservativeVector.h>
 #include <LibGC/Heap.h>
 #include <LibGC/HeapHashTable.h>
@@ -60,6 +61,17 @@ static bool possible_values_contain(GC::ConservativeVectorBase const& container,
 }
 
 static bool possible_values_contain(GC::ConservativeHashMapBase const& container, GC::Cell* cell)
+{
+    bool found = false;
+    auto target = bit_cast<FlatPtr>(cell);
+    container.for_each_possible_value([&](FlatPtr value) {
+        if (value == target)
+            found = true;
+    });
+    return found;
+}
+
+static bool possible_values_contain(GC::ConservativeHashTableBase const& container, GC::Cell* cell)
 {
     bool found = false;
     auto target = bit_cast<FlatPtr>(cell);
@@ -475,4 +487,39 @@ TEST_CASE(weak_hash_map_ensure_handles_non_cell_value)
 
     default_value = 13;
     EXPECT_EQ(map.get(*default_key).value(), 13);
+}
+
+TEST_CASE(conservative_hash_table_reports_possible_values)
+{
+    auto& heap = test_heap();
+    GC::ConservativeHashTable<GC::Ref<TestCell>> table;
+
+    auto cell = heap.allocate<TestCell>();
+    table.set(cell);
+
+    EXPECT(possible_values_contain(table, cell.ptr()));
+}
+
+TEST_CASE(cleared_conservative_hash_table_reports_no_stale_values)
+{
+    auto& heap = test_heap();
+    GC::ConservativeHashTable<GC::Ref<TestCell>> table;
+
+    auto cell = heap.allocate<TestCell>();
+    table.set(cell);
+    table.clear();
+
+    EXPECT(!possible_values_contain(table, cell.ptr()));
+}
+
+TEST_CASE(removed_conservative_hash_table_entry_not_reported)
+{
+    auto& heap = test_heap();
+    GC::ConservativeHashTable<GC::Ref<TestCell>> table;
+
+    auto cell = heap.allocate<TestCell>();
+    table.set(cell);
+    table.remove(cell);
+
+    EXPECT(!possible_values_contain(table, cell.ptr()));
 }


### PR DESCRIPTION
This is part 6 of fixing GC issues. The previous part was https://github.com/LadybirdBrowser/ladybird/pull/9650

This introduces `GC::ConservativeHashTable`, which is the singular version of `GC::ConservativeHashMap`, and uses it for PropertyKey storage in LibJS