### PR TITLE
UI/Qt: Render icons better on high DPI devices, slightly enlarge a few icons

### DIFF
--- a/UI/Qt/Icon.cpp
+++ b/UI/Qt/Icon.cpp
@@ -117,10 +117,17 @@ static void draw_star_icon(QPainter& painter, QColor const& color, bool filled)
     painter.drawPath(path);
 }
 
-static QPixmap create_chrome_icon_pixmap(ChromeIcon icon, QColor color)
+static QPixmap create_transparent_icon_pixmap(QSize logical_size, qreal device_pixel_ratio)
 {
-    QPixmap pixmap(20, 20);
+    QPixmap pixmap(physical_size_for_device_pixel_ratio(logical_size, device_pixel_ratio));
+    pixmap.setDevicePixelRatio(device_pixel_ratio);
     pixmap.fill(Qt::transparent);
+    return pixmap;
+}
+
+static QPixmap create_chrome_icon_pixmap(ChromeIcon icon, QColor color, qreal device_pixel_ratio)
+{
+    auto pixmap = create_transparent_icon_pixmap({ 20, 20 }, device_pixel_ratio);
 
     QPainter painter(&pixmap);
     painter.setRenderHint(QPainter::Antialiasing, true);
@@ -209,20 +216,23 @@ static QIcon create_y_offset_icon(QIcon const& source, int y_offset)
 {
     constexpr int icon_size = 20;
 
-    auto create_pixmap = [&](QIcon::Mode mode) {
-        QPixmap pixmap(icon_size, icon_size);
-        pixmap.fill(Qt::transparent);
+    auto create_pixmap = [&](QIcon::Mode mode, int device_pixel_ratio) {
+        auto pixmap = create_transparent_icon_pixmap({ icon_size, icon_size }, device_pixel_ratio);
 
         QPainter painter(&pixmap);
-        source.paint(&painter, QRect(0, y_offset, icon_size, icon_size), Qt::AlignCenter, mode);
+        painter.drawPixmap(
+            QRect(0, y_offset, icon_size, icon_size),
+            source.pixmap({ icon_size, icon_size }, static_cast<qreal>(device_pixel_ratio), mode));
         return pixmap;
     };
 
     QIcon icon;
-    icon.addPixmap(create_pixmap(QIcon::Normal), QIcon::Normal);
-    icon.addPixmap(create_pixmap(QIcon::Active), QIcon::Active);
-    icon.addPixmap(create_pixmap(QIcon::Disabled), QIcon::Disabled);
-    icon.addPixmap(create_pixmap(QIcon::Selected), QIcon::Selected);
+    for (auto device_pixel_ratio : ICON_DEVICE_PIXEL_RATIOS) {
+        icon.addPixmap(create_pixmap(QIcon::Normal, device_pixel_ratio), QIcon::Normal);
+        icon.addPixmap(create_pixmap(QIcon::Active, device_pixel_ratio), QIcon::Active);
+        icon.addPixmap(create_pixmap(QIcon::Disabled, device_pixel_ratio), QIcon::Disabled);
+        icon.addPixmap(create_pixmap(QIcon::Selected, device_pixel_ratio), QIcon::Selected);
+    }
     return icon;
 }
 
@@ -253,22 +263,25 @@ QIcon create_chrome_icon(ChromeIcon icon, QPalette const& palette)
     disabled.setAlpha(icon == ChromeIcon::Close ? 78 : 96);
 
     QIcon qicon;
-    qicon.addPixmap(create_chrome_icon_pixmap(icon, normal), QIcon::Normal);
-    qicon.addPixmap(create_chrome_icon_pixmap(icon, active), QIcon::Active);
-    qicon.addPixmap(create_chrome_icon_pixmap(icon, disabled), QIcon::Disabled);
-    qicon.addPixmap(create_chrome_icon_pixmap(icon, active), QIcon::Selected);
+
+    for (auto device_pixel_ratio : ICON_DEVICE_PIXEL_RATIOS) {
+        qicon.addPixmap(create_chrome_icon_pixmap(icon, normal, device_pixel_ratio), QIcon::Normal);
+        qicon.addPixmap(create_chrome_icon_pixmap(icon, active, device_pixel_ratio), QIcon::Active);
+        qicon.addPixmap(create_chrome_icon_pixmap(icon, disabled, device_pixel_ratio), QIcon::Disabled);
+        qicon.addPixmap(create_chrome_icon_pixmap(icon, active, device_pixel_ratio), QIcon::Selected);
+    }
+
     if (icon == ChromeIcon::NewTab)
         return create_y_offset_icon(qicon, -1);
     return qicon;
 }
 
-QIcon loading_spinner_icon(QPalette const& palette, int frame)
+static QPixmap create_loading_spinner_icon_pixmap(QPalette const& palette, int frame, int device_pixel_ratio)
 {
     static constexpr int icon_size = 16;
     static constexpr int segment_count = 12;
 
-    QPixmap pixmap(icon_size, icon_size);
-    pixmap.fill(Qt::transparent);
+    auto pixmap = create_transparent_icon_pixmap({ icon_size, icon_size }, device_pixel_ratio);
 
     QPainter painter(&pixmap);
     painter.setRenderHint(QPainter::Antialiasing);
@@ -286,7 +299,23 @@ QIcon loading_spinner_icon(QPalette const& palette, int frame)
         painter.restore();
     }
 
-    return QIcon(pixmap);
+    return pixmap;
+}
+
+QIcon loading_spinner_icon(QPalette const& palette, int frame)
+{
+    QIcon icon;
+    for (auto device_pixel_ratio : ICON_DEVICE_PIXEL_RATIOS)
+        icon.addPixmap(create_loading_spinner_icon_pixmap(palette, frame, device_pixel_ratio));
+    return icon;
+}
+
+QSize physical_size_for_device_pixel_ratio(QSize size, qreal device_pixel_ratio)
+{
+    return {
+        static_cast<int>(ceil(size.width() * device_pixel_ratio)),
+        static_cast<int>(ceil(size.height() * device_pixel_ratio)),
+    };
 }
 
 }

--- a/UI/Qt/Icon.cpp
+++ b/UI/Qt/Icon.cpp
@@ -156,20 +156,20 @@ static QPixmap create_chrome_icon_pixmap(ChromeIcon icon, QColor color, qreal de
         painter.drawLine(QPointF(14.0, 6.0), QPointF(6.0, 14.0));
         break;
     case ChromeIcon::NewTab:
-        painter.setPen(chrome_icon_pen(color, 1.75));
-        painter.drawLine(QPointF(10.0, 5.0), QPointF(10.0, 15.0));
-        painter.drawLine(QPointF(5.0, 10.0), QPointF(15.0, 10.0));
+        painter.setPen(chrome_icon_pen(color, 1.9));
+        painter.drawLine(QPointF(10.0, 4.3), QPointF(10.0, 15.7));
+        painter.drawLine(QPointF(4.3, 10.0), QPointF(15.7, 10.0));
         break;
     case ChromeIcon::Close:
-        painter.setPen(chrome_icon_pen(color, 1.75));
-        painter.drawLine(QPointF(6.0, 6.4), QPointF(14.0, 14.4));
-        painter.drawLine(QPointF(14.0, 6.4), QPointF(6.0, 14.4));
+        painter.setPen(chrome_icon_pen(color, 1.9));
+        painter.drawLine(QPointF(5.5, 5.9), QPointF(14.5, 14.9));
+        painter.drawLine(QPointF(14.5, 5.9), QPointF(5.5, 14.9));
         break;
     case ChromeIcon::Menu:
-        painter.setPen(chrome_icon_pen(color, 1.8));
-        painter.drawLine(QPointF(3.8, 7.4), QPointF(16.2, 7.4));
-        painter.drawLine(QPointF(3.8, 11.0), QPointF(16.2, 11.0));
-        painter.drawLine(QPointF(3.8, 14.6), QPointF(16.2, 14.6));
+        painter.setPen(chrome_icon_pen(color, 2.0));
+        painter.drawLine(QPointF(3.0, 5.9), QPointF(17.0, 5.9));
+        painter.drawLine(QPointF(3.0, 10.9), QPointF(17.0, 10.9));
+        painter.drawLine(QPointF(3.0, 15.9), QPointF(17.0, 15.9));
         break;
     case ChromeIcon::Star:
         draw_star_icon(painter, color, false);

--- a/UI/Qt/Icon.h
+++ b/UI/Qt/Icon.h
@@ -6,9 +6,11 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/StringView.h>
 
 #include <QIcon>
+#include <QSize>
 
 class QPalette;
 
@@ -32,9 +34,13 @@ enum class ChromeIcon {
     WindowClose,
 };
 
+constexpr inline auto ICON_DEVICE_PIXEL_RATIOS = to_array({ 1, 2, 3 });
+
 QIcon load_icon_from_uri(StringView);
 QIcon create_tvg_icon_with_theme_colors(QString const& name, QPalette const& palette);
 QIcon create_chrome_icon(ChromeIcon, QPalette const&);
 QIcon loading_spinner_icon(QPalette const& palette, int frame);
+
+QSize physical_size_for_device_pixel_ratio(QSize size, qreal device_pixel_ratio);
 
 }

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -116,7 +116,14 @@ static QIcon icon_from_base64_png(StringView favicon_base64_png)
     if (!pixmap.loadFromData(decoded.value().data(), static_cast<uint>(decoded.value().size()), "PNG"))
         return {};
 
-    return pixmap.scaled(MENU_ICON_SIZE, MENU_ICON_SIZE, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    QIcon icon;
+    for (auto device_pixel_ratio : ICON_DEVICE_PIXEL_RATIOS) {
+        auto size = MENU_ICON_SIZE * device_pixel_ratio;
+        auto scaled_pixmap = pixmap.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        scaled_pixmap.setDevicePixelRatio(device_pixel_ratio);
+        icon.addPixmap(scaled_pixmap);
+    }
+    return icon;
 }
 
 static void initialize_native_control(WebView::Action& action, QAction& qaction, QPalette const& palette, IncludeActionIcon include_action_icon)

--- a/UI/Qt/TVGIconEngine.cpp
+++ b/UI/Qt/TVGIconEngine.cpp
@@ -7,6 +7,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/String.h>
 #include <LibGfx/Rect.h>
+#include <UI/Qt/Icon.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/TVGIconEngine.h>
 
@@ -19,7 +20,9 @@ namespace Ladybird {
 
 void TVGIconEngine::paint(QPainter* qpainter, QRect const& rect, QIcon::Mode mode, QIcon::State state)
 {
-    qpainter->drawPixmap(rect, pixmap(rect.size(), mode, state));
+    auto device_pixel_ratio = qpainter->device() ? qpainter->device()->devicePixelRatioF() : 1.0;
+    auto physical_size = physical_size_for_device_pixel_ratio(rect.size(), device_pixel_ratio);
+    qpainter->drawPixmap(rect, render_pixmap(physical_size, device_pixel_ratio, mode, state));
 }
 
 QIconEngine* TVGIconEngine::clone() const
@@ -29,11 +32,27 @@ QIconEngine* TVGIconEngine::clone() const
 
 QPixmap TVGIconEngine::pixmap(QSize const& size, QIcon::Mode mode, QIcon::State state)
 {
+    return render_pixmap(size, 1.0, mode, state);
+}
+
+QPixmap TVGIconEngine::scaledPixmap(QSize const& size, QIcon::Mode mode, QIcon::State state, qreal scale)
+{
+    auto device_pixel_ratio = scale > 0.0 ? scale : 1.0;
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+    auto physical_size = size;
+#else
+    auto physical_size = physical_size_for_device_pixel_ratio(size, device_pixel_ratio);
+#endif
+    return render_pixmap(physical_size, device_pixel_ratio, mode, state);
+}
+
+QPixmap TVGIconEngine::render_pixmap(QSize physical_size, qreal device_pixel_ratio, QIcon::Mode mode, QIcon::State state)
+{
     QPixmap pixmap;
-    auto key = pixmap_cache_key(size, mode, state);
+    auto key = pixmap_cache_key(physical_size, device_pixel_ratio, mode, state);
     if (QPixmapCache::find(key, &pixmap))
         return pixmap;
-    auto bitmap = MUST(m_image_data->bitmap({ size.width(), size.height() }));
+    auto bitmap = MUST(m_image_data->bitmap({ physical_size.width(), physical_size.height() }));
 
     for (auto const& filter : m_filters) {
         if (filter->mode() == mode) {
@@ -56,14 +75,16 @@ QPixmap TVGIconEngine::pixmap(QSize const& size, QIcon::Mode mode, QIcon::State 
         QImage::Format::Format_ARGB32);
 
     pixmap = QPixmap::fromImage(qimage);
+    pixmap.setDevicePixelRatio(device_pixel_ratio);
     if (!pixmap.isNull())
         QPixmapCache::insert(key, pixmap);
     return pixmap;
 }
 
-QString TVGIconEngine::pixmap_cache_key(QSize const& size, QIcon::Mode mode, QIcon::State state)
+QString TVGIconEngine::pixmap_cache_key(QSize physical_size, qreal device_pixel_ratio, QIcon::Mode mode, QIcon::State state)
 {
-    return qformatted("$sernity_tvgicon_{}_{}x{}_{}_{}", m_cache_id, size.width(), size.height(), to_underlying(mode), to_underlying(state));
+    return qformatted("$sernity_tvgicon_{}_{}x{}_dpr{}_{}_{}",
+        m_cache_id, physical_size.width(), physical_size.height(), static_cast<int>(device_pixel_ratio * 1000), to_underlying(mode), to_underlying(state));
 }
 
 void TVGIconEngine::add_filter(QIcon::Mode mode, Function<Color(Color)> filter)

--- a/UI/Qt/TVGIconEngine.h
+++ b/UI/Qt/TVGIconEngine.h
@@ -27,6 +27,7 @@ public:
     void paint(QPainter* painter, QRect const& rect, QIcon::Mode mode, QIcon::State state) override;
     QIconEngine* clone() const override;
     QPixmap pixmap(QSize const& size, QIcon::Mode mode, QIcon::State state) override;
+    QPixmap scaledPixmap(QSize const& size, QIcon::Mode mode, QIcon::State state, qreal scale) override;
 
     void add_filter(QIcon::Mode mode, Function<Color(Color)> filter);
 
@@ -57,7 +58,8 @@ private:
         Function<Color(Color)> m_function;
     };
 
-    QString pixmap_cache_key(QSize const& size, QIcon::Mode mode, QIcon::State state);
+    QPixmap render_pixmap(QSize physical_size, qreal device_pixel_ratio, QIcon::Mode mode, QIcon::State state);
+    QString pixmap_cache_key(QSize physical_size, qreal device_pixel_ratio, QIcon::Mode mode, QIcon::State state);
 
     Vector<NonnullRefPtr<Filter>> m_filters;
     NonnullRefPtr<Gfx::TinyVGDecodedImageData const> m_image_data;

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -490,7 +490,7 @@ TabWidget::TabWidget(QWidget* parent)
 
     m_new_tab_button = new QToolButton(this);
     m_new_tab_button->setObjectName("LadybirdNewTabButton");
-    m_new_tab_button->setIconSize(QSize(18, 18));
+    m_new_tab_button->setIconSize(QSize(20, 20));
     m_new_tab_button->setFixedSize(32, 32);
     m_new_tab_button->setFocusPolicy(Qt::NoFocus);
     m_new_tab_button->setToolTip("New Tab");
@@ -778,7 +778,7 @@ TabBarButton::TabBarButton(QIcon const& icon, QWidget* parent)
 {
     setObjectName("LadybirdTabButton");
     setFixedSize({ 22, 22 });
-    setIconSize({ 14, 14 });
+    setIconSize({ 16, 16 });
     setFocusPolicy(Qt::NoFocus);
     setFlat(true);
 }


### PR DESCRIPTION
Generate DPR-tagged pixmap variants for generated icons (this includes chrome icons, TVG icons, and bookmark favicons). Previously, these icons would render very blurry on macOS.

Before:
<img width="1118" height="721" alt="before" src="https://github.com/user-attachments/assets/ea809be7-44a5-40a8-9107-81d5b71bde98" />

After:
<img width="1118" height="721" alt="after" src="https://github.com/user-attachments/assets/ed4421f5-5b7f-4cbb-9677-d8237936e78a" />

