### PR TITLE
Meta: Define helper processes for Ladybird and test-web in one place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ list(APPEND CMAKE_MODULE_PATH "${LADYBIRD_SOURCE_DIR}/Meta/CMake")
 include(compile_options)
 include(check_for_dependencies)
 include(cmake_options)
+include(ladybird_helper_processes)
 
 if(ENABLE_ALL_THE_DEBUG_MACROS)
     include(all_the_debug_macros)

--- a/Meta/CMake/ladybird_helper_processes.cmake
+++ b/Meta/CMake/ladybird_helper_processes.cmake
@@ -1,0 +1,7 @@
+set(ladybird_helper_processes
+    Compositor
+    ImageDecoder
+    RequestServer
+    WebContent
+    WebWorker
+)

--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SOURCES
 )
 
 add_executable(test-web ${SOURCES})
-add_dependencies(test-web ladybird_build_resource_files ImageDecoder RequestServer WebContent WebWorker)
+add_dependencies(test-web ladybird_build_resource_files ${ladybird_helper_processes})
 target_link_libraries(test-web PRIVATE AK LibCore LibDiff LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibRequests LibURL LibWeb LibWebView)
 
 if (APPLE)

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -99,8 +99,6 @@ else()
     )
 endif()
 
-set(ladybird_helper_processes Compositor ImageDecoder RequestServer WebContent WebWorker)
-
 add_dependencies(ladybird ${ladybird_helper_processes})
 # FIXME: Increase support for building targets on Windows
 if (NOT WIN32)


### PR DESCRIPTION
These both require the same helper processes, and maintaining the same list in multiple places is error-prone. For example, I spent too long debugging why test-web was crashing, when the issue was that Compositor hadn't been rebuilt as test-web didn't depend on it. That problem can no longer happen if we define the same dependency list for both.