### PR TITLE
LibWeb: Skip user-select:none in selection highlight and copy

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3241,25 +3241,32 @@ bool Navigable::is_focused() const
 
 static String visible_text_in_range(DOM::Range const& range)
 {
-    // NOTE: This is an adaption of Range stringification, but we skip over DOM nodes that don't have a corresponding layout node.
+    // NOTE: This is an adaption of Range stringification — but we skip over DOM nodes that don't have a corresponding
+    //       layout node, and over nodes whose used value of user-select is 'none'. The latter implements
+    //       https://drafts.csswg.org/css-ui/#valdef-user-select-none — applied at the clipboard-extraction boundary.
     StringBuilder builder;
 
+    auto is_user_select_none = [](DOM::Node const& node) {
+        auto const* layout = node.layout_node();
+        return layout && layout->user_select_used_value() == CSS::UserSelect::None;
+    };
+
     if (range.start_container() == range.end_container() && is<DOM::Text>(*range.start_container())) {
-        if (!range.start_container()->layout_node())
+        if (!range.start_container()->layout_node() || is_user_select_none(*range.start_container()))
             return String {};
         return static_cast<DOM::Text const&>(*range.start_container()).data().substring_view(range.start_offset(), range.end_offset() - range.start_offset()).to_utf8_but_should_be_ported_to_utf16();
     }
 
-    if (is<DOM::Text>(*range.start_container()) && range.start_container()->layout_node())
+    if (is<DOM::Text>(*range.start_container()) && range.start_container()->layout_node() && !is_user_select_none(*range.start_container()))
         builder.append(static_cast<DOM::Text const&>(*range.start_container()).data().substring_view(range.start_offset()));
 
     range.for_each_contained([&](GC::Ref<DOM::Node> node) {
-        if (is<DOM::Text>(*node) && node->layout_node())
+        if (is<DOM::Text>(*node) && node->layout_node() && !is_user_select_none(*node))
             builder.append(static_cast<DOM::Text const&>(*node).data());
         return IterationDecision::Continue;
     });
 
-    if (is<DOM::Text>(*range.end_container()) && range.end_container()->layout_node())
+    if (is<DOM::Text>(*range.end_container()) && range.end_container()->layout_node() && !is_user_select_none(*range.end_container()))
         builder.append(static_cast<DOM::Text const&>(*range.end_container()).data().substring_view(0, range.end_offset()));
 
     return MUST(builder.to_string());

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -410,6 +410,11 @@ String Internals::current_cursor()
         });
 }
 
+String Internals::selected_text_for_clipboard()
+{
+    return page().focused_navigable().selected_text();
+}
+
 WebIDL::ExceptionOr<bool> Internals::dispatch_user_activated_event(DOM::EventTarget& target, DOM::Event& event)
 {
     event.set_is_trusted(true);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -70,6 +70,8 @@ public:
 
     String current_cursor();
 
+    String selected_text_for_clipboard();
+
     WebIDL::ExceptionOr<bool> dispatch_user_activated_event(DOM::EventTarget&, DOM::Event& event);
 
     void spoof_current_url(String const& url);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -45,6 +45,10 @@ interface Internals {
 
     DOMString currentCursor();
 
+    // Returns the text that would be placed on the clipboard if the user copied the current selection now.
+    // Excludes nodes whose used value of user-select is 'none' — mirroring what browsers actually copy.
+    DOMString selectedTextForClipboard();
+
     boolean dispatchUserActivatedEvent(EventTarget target, Event event);
     undefined spoofCurrentURL(USVString url);
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -312,6 +312,17 @@ void ViewportPaintable::recompute_selection_states(DOM::Range& range)
         }
     };
 
+    // https://drafts.csswg.org/css-ui/#valdef-user-select-none
+    // "The content of the element must be excluded from selection by [...] the selection methods of the Selection API
+    // and the like." We honor this by leaving such nodes at SelectionState::None — even when they fall inside the
+    // range. So, the selection highlight skips them.
+    auto is_excluded_from_selection = [](DOM::Node const& node) {
+        if (node.is_inert())
+            return true;
+        auto const* layout = node.unsafe_layout_node();
+        return layout && layout->user_select_used_value() == CSS::UserSelect::None;
+    };
+
     auto start_container = range.start_container();
     auto end_container = range.end_container();
 
@@ -324,14 +335,14 @@ void ViewportPaintable::recompute_selection_states(DOM::Range& range)
         }
 
         // 2. If it's a text node, mark it as StartAndEnd and return.
-        if (is<DOM::Text>(*start_container) && !range.start().node->is_inert()) {
+        if (is<DOM::Text>(*start_container) && !is_excluded_from_selection(*start_container)) {
             set_selection_state_on_all_slices(*start_container, SelectionState::StartAndEnd);
             return;
         }
     }
 
     // 3. Mark the selection start node as Start (if text) or Full (if anything else).
-    if (!range.start().node->is_inert() && start_container->unsafe_layout_node()) {
+    if (!is_excluded_from_selection(*start_container) && start_container->unsafe_layout_node()) {
         if (is<DOM::Text>(*start_container))
             set_selection_state_on_all_slices(*start_container, SelectionState::Start);
         else
@@ -352,13 +363,13 @@ void ViewportPaintable::recompute_selection_states(DOM::Range& range)
     DOM::Node* stop_at = end_container->child_at_index(range.end_offset());
     // Only stop at the end container if it has no children that may need to be included.
     for (auto* node = start_at; node && (node != stop_at && !(node == end_container && !end_container->has_children())); node = node->next_in_pre_order(end_container)) {
-        if (node->is_inert())
+        if (is_excluded_from_selection(*node))
             continue;
         set_selection_state_on_all_slices(*node, SelectionState::Full);
     }
 
     // 5. Mark the selection end node as End if it is a text node.
-    if (!range.end().node->is_inert() && is<DOM::Text>(*end_container) && end_container->unsafe_layout_node()) {
+    if (!is_excluded_from_selection(*end_container) && is<DOM::Text>(*end_container) && end_container->unsafe_layout_node()) {
         set_selection_state_on_all_slices(*end_container, SelectionState::End);
     }
 }

--- a/Tests/LibWeb/Text/expected/select-all-respects-user-select-none.txt
+++ b/Tests/LibWeb/Text/expected/select-all-respects-user-select-none.txt
@@ -1,0 +1,2 @@
+selection.toString(): "hiddenvisiblealso hiddenalso visible"
+clipboard text: "visiblealso visible"

--- a/Tests/LibWeb/Text/input/select-all-respects-user-select-none.html
+++ b/Tests/LibWeb/Text/input/select-all-respects-user-select-none.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div id="container"><p style="user-select: none;">hidden</p><p>visible</p><p style="user-select: none;">also hidden</p><p>also visible</p></div>
+<script>
+    test(() => {
+        getSelection().selectAllChildren(document.getElementById("container"));
+
+        // Per the Selection API spec, the Range itself still spans the whole container, including user-select:none
+        // subtrees — so Selection.toString() returns everything.
+        println(`selection.toString(): "${getSelection().toString().replace(/\n/g, "\\n")}"`);
+
+        // But the clipboard/visible-selection path must exclude user-select: none content, per
+        // https://drafts.csswg.org/css-ui/#valdef-user-select-none.
+        println(`clipboard text: "${internals.selectedTextForClipboard().replace(/\n/g, "\\n")}"`);
+    });
+</script>


### PR DESCRIPTION
**Problem:** Select All (Ctrl+A or the context menu) doesn’t honor `user-select:none` — breaking compat with Chrome and Firefox. Two visible symptoms:

- The selection highlight is drawn across `user-select:none` content.
- Ctrl+C after Select All copies that content to the clipboard.

Mouse double-click already skips `user-select:none` correctly; only the keyboard / context-menu path was broken.

**Cause:** Both Ctrl+A and right-click “Select All” flow through `Selection::select_all_children(body)`, which sets a single `Range` from `(body, 0)` to `(body, childCount)` — including any `user-select:none` subtrees. Two downstream functions then fail to filter:

- `ViewportPaintable::recompute_selection_states` walks the range and assigns `SelectionState::Start`, `::Full`, or `::End` to each layout node within. The walk filters out `is_inert()` nodes — but not `user-select:none` nodes.
- `Navigable::selected_text()` walks the range via `visible_text_in_range()` and concatenates each text node’s data. Filters out nodes without a layout — but not `user-select:none`.

**Fix:** Add a `user-select:none` check at each walk point in both functions. The Selection range itself is left unchanged — `Selection.toString()` still returns the full text per spec — but:

- The paint path leaves `user-select:none` nodes at `SelectionState::None` from the initial reset, so the highlight skips them.
- The clipboard-extraction path excludes `user-select:none` subtrees.

This implements https://drafts.csswg.org/css-ui/#valdef-user-select-none (_“The content of the element must be excluded from selection by [...] the selection methods of the Selection API and the like”_) at the highlight and clipboard boundaries — matching Chrome and Firefox. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9695.
