### PR TITLE
LibHTTP+LibWeb: Parse structured headers

### DIFF
--- a/Libraries/LibHTTP/CMakeLists.txt
+++ b/Libraries/LibHTTP/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
     HTTP.cpp
     HttpRequest.cpp
     Method.cpp
+    StructuredField.cpp
 )
 
 ladybird_lib(LibHTTP http)

--- a/Libraries/LibHTTP/HeaderList.cpp
+++ b/Libraries/LibHTTP/HeaderList.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "HeaderList.h"
 #include <AK/GenericLexer.h>
 #include <AK/HashTable.h>
 #include <AK/StringUtils.h>
@@ -349,6 +350,32 @@ Vector<ByteString> HeaderList::unique_names() const
     }
 
     return header_names;
+}
+
+// https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header
+Optional<StructuredFieldValue> HeaderList::get_a_structured_field_value(StringView name, StructuredFieldType type) const
+{
+    // 1. Assert: type is one of "dictionary", "list", or "item".
+    // NOTE: We enforce this by using an enum.
+
+    // 2. Let value be the result of getting name from list.
+    auto value = this->get(name);
+
+    // 3. If value is null, then return null.
+    if (!value.has_value()) {
+        return {};
+    }
+
+    // 4. Let result be the result of parsing structured fields with input_string set to value and header_type set to type.
+    auto result = HTTP::parse_structured_fields(value.value(), type);
+
+    // 5. If parsing failed, then return null.
+    if (result.is_error()) {
+        return {};
+    }
+
+    // 6. Return result.
+    return result.release_value();
 }
 
 }

--- a/Libraries/LibHTTP/HeaderList.h
+++ b/Libraries/LibHTTP/HeaderList.h
@@ -14,6 +14,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibHTTP/Header.h>
+#include <LibHTTP/StructuredField.h>
 
 namespace HTTP {
 
@@ -90,6 +91,8 @@ public:
             return result;
         });
     }
+
+    [[nodiscard]] Optional<StructuredFieldValue> get_a_structured_field_value(StringView name, StructuredFieldType type) const;
 
 private:
     explicit HeaderList(Vector<Header>);

--- a/Libraries/LibHTTP/StructuredField.cpp
+++ b/Libraries/LibHTTP/StructuredField.cpp
@@ -1,0 +1,667 @@
+/*
+ * Copyright (c) 2026, Glenn Skrzypczak <glenn.skrzypczak@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Base64.h>
+#include <AK/ByteString.h>
+#include <AK/Error.h>
+#include <AK/Forward.h>
+#include <AK/GenericLexer.h>
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <AK/StringConversions.h>
+#include <AK/Try.h>
+#include <AK/Tuple.h>
+#include <AK/Types.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibHTTP/StructuredField.h>
+
+namespace HTTP {
+
+static constexpr bool is_sp_character(char c)
+{
+    return c == 0x20;
+}
+
+// https://www.rfc-editor.org/info/rfc9110/#name-whitespace
+static constexpr bool is_ows_character(char c)
+{
+    return c == 0x20 || c == 0x09;
+}
+
+// https://www.rfc-editor.org/info/rfc9110/#name-tokens
+static constexpr bool is_tchar(char c)
+{
+    return c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\'' || c == '*'
+        || c == '+' || c == '-' || c == '.' || c == '^' || c == '_' || c == '`' || c == '|' || c == '~'
+        || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= 0x21 && c <= 0x7e && c != '"' && c != '(' && c != ')' && c != ',' && c != '/' && c != ':' && c != ';' && c != '<' && c != '=' && c != '>' && c != '?' && c != '@' && c != '[' && c != '\\' && c != ']' && c != '{' && c != '}');
+}
+
+enum class NumberType : u8 {
+    Integer,
+    Decimal
+};
+
+// https://httpwg.org/specs/rfc9651.html#parse-number
+static ErrorOr<Variant<StructuredFieldInteger, StructuredFieldDecimal>> parse_an_integer_or_decimal(GenericLexer lexer)
+{
+    // 1. Let type be "integer".
+    auto type = NumberType::Integer;
+
+    // 2. Let sign be 1.
+    auto sign = 1;
+
+    // 3. Let input_number be an empty string.
+    StringBuilder input_number {};
+
+    // 4. If the first character of input_string is "-", consume it and set sign to -1.
+    if (lexer.peek() == '-') {
+        lexer.consume();
+        sign = -1;
+    }
+
+    // 5. If input_string is empty, there is an empty integer; fail parsing.
+    if (lexer.is_eof())
+        return Error::from_string_view("A number cannot be empty"sv);
+
+    // 6. If the first character of input_string is not a DIGIT, fail parsing.
+    auto first_character = lexer.peek();
+    if (first_character < '0' || first_character > '9')
+        return Error::from_string_view("A number must start with a digit"sv);
+
+    // 7. While input_string is not empty:
+    while (!lexer.is_eof()) {
+        // 1. Let char be the result of consuming the first character of input_string.
+        auto c = lexer.consume();
+
+        // 2. If char is a DIGIT, append it to input_number.
+        if (c >= '0' && c <= '9') {
+            input_number.append(c);
+        }
+
+        // 3. Else, if type is "integer" and char is ".":
+        else if (type == NumberType::Integer && c == '.') {
+            // 1. If input_number contains more than 12 characters, fail parsing.
+            if (input_number.length() > 12)
+                return Error::from_string_view("A number cannot contain more than 12 digits"sv);
+
+            // 2. Otherwise, append char to input_number and set type to "decimal".
+            input_number.append(c);
+            type = NumberType::Decimal;
+        }
+
+        // 4. Otherwise, prepend char to input_string, and exit the loop.
+        else {
+            lexer.retreat();
+            break;
+        }
+    }
+
+    // 5. If type is "integer" and input_number contains more than 15 characters, fail parsing.
+    if (type == NumberType::Integer && input_number.length() > 15)
+        return Error::from_string_view("An integer cannot contain more than 15 characters"sv);
+
+    // 6. If type is "decimal" and input_number contains more than 16 characters, fail parsing.
+    if (type == NumberType::Decimal && input_number.length() > 16)
+        return Error::from_string_view("A double cannot contain more than 16 characters"sv);
+
+    // 8. If type is "integer":
+    double output_number = 0;
+    if (type == NumberType::Integer) {
+        // 1. Let output_number be an Integer that is the result of parsing input_number as an integer.
+        auto parsed_number = AK::parse_number<i64>(input_number.string_view());
+        if (!parsed_number.has_value())
+            return Error::from_string_view("Unable to parse integer"sv);
+        output_number = (double)parsed_number.value();
+    }
+
+    // 9. Otherwise:
+    else {
+        // 1. If the final character of input_number is ".", fail parsing.
+        auto dot_index = input_number.string_view().find_last('.').value();
+        if (dot_index == input_number.length() - 1)
+            return Error::from_string_view("The dot cannot be the last character of a double"sv);
+
+        // 2. If the number of characters after "." in input_number is greater than three, fail parsing.
+        if (dot_index >= input_number.length() - 4)
+            return Error::from_string_view("There can at most be 3 digits after the dot in a double"sv);
+
+        // 3. Let output_number be a Decimal that is the result of parsing input_number as a decimal number.
+        auto parsed_number = AK::parse_number<double>(input_number.string_view());
+        if (!parsed_number.has_value())
+            return Error::from_string_view("Unable to parse double"sv);
+        output_number = parsed_number.value();
+    }
+
+    // 10. Let output_number be the product of output_number and sign.
+    output_number = sign * output_number;
+
+    // 11. Return output_number.
+    if (type == NumberType::Integer) {
+        return StructuredFieldInteger { (i64)output_number };
+    }
+    return StructuredFieldDecimal { output_number };
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-string
+static ErrorOr<StructuredFieldString> parse_a_string(GenericLexer lexer)
+{
+    // 1. Let output_string be an empty string.
+    StringBuilder output_string {};
+
+    // 2. If the first character of input_string is not DQUOTE, fail parsing.
+    if (lexer.peek() != '"')
+        return Error::from_string_view("A string must start with a double quote"sv);
+
+    // 3. Discard the first character of input_string.
+    lexer.consume();
+
+    // 4. While input_string is not empty:
+    while (!lexer.is_eof()) {
+        // 1. Let char be the result of consuming the first character of input_string.
+        auto c = lexer.consume();
+
+        // 2. If char is a backslash ("\"):
+        if (c == '\\') {
+            // 1. If input_string is now empty, fail parsing.
+            if (lexer.is_eof())
+                return Error::from_string_view("Unterminated escape sequence"sv);
+
+            // 2. Let next_char be the result of consuming the first character of input_string.
+            char escaped = lexer.consume();
+
+            // 3. If next_char is not DQUOTE or "\", fail parsing.
+            if (escaped != '"' && escaped != '\\')
+                return Error::from_string_view("Invalid escape sequence"sv);
+
+            // 4. Append next_char to output_string.
+            output_string.append(escaped);
+        }
+
+        // 3. Else, if char is DQUOTE, return output_string.
+        else if (c == '"') {
+            return StructuredFieldString { TRY(output_string.to_string()) };
+        }
+
+        // 4. Else, if char is in the range %x00-1f or %x7f-ff (i.e., it is not in VCHAR or SP), fail parsing.
+        else if (c <= 0x1f || c >= 0x7f) {
+            return Error::from_string_view("String contains invalid characters"sv);
+        }
+
+        // 5. Else, append char to output_string.
+        else {
+            output_string.append(c);
+        }
+    }
+
+    // 5. Reached the end of input_string without finding a closing DQUOTE; fail parsing.
+    return Error::from_string_view("Unterminated string"sv);
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-token
+static ErrorOr<StructuredFieldToken> parse_a_token(GenericLexer lexer)
+{
+    // 1. If the first character of input_string is not ALPHA or "*", fail parsing.
+    auto first_character = lexer.peek();
+    if ((first_character < 'a' || first_character > 'z') && (first_character < 'A' || first_character > 'Z') && first_character != '*')
+        return Error::from_string_view("A token must start with a alphanumeric character or star"sv);
+
+    // 2. Let output_string be an empty string.
+    // 3. While input_string is not empty:
+    //     1. If the first character of input_string is not in tchar, ":", or "/", return output_string.
+    //     2. Let char be the result of consuming the first character of input_string.
+    //     3. Append char to output_string.
+    // 4. Return output_string.
+    auto output = lexer.consume_until([](char c) { return !is_tchar(c) && c != ':' && c != '/'; });
+    return StructuredFieldToken { TRY(String::from_utf8(output)) };
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-binary
+static ErrorOr<StructuredFieldByteSequence> parse_a_byte_sequence(GenericLexer lexer)
+{
+    // 1. If the first character of input_string is not ":", fail parsing.
+    if (lexer.peek() != ':')
+        return Error::from_string_view("A byte sequence must start with a colon"sv);
+
+    // 2. Discard the first character of input_string.
+    lexer.consume();
+
+    // 3. If there is not a ":" character before the end of input_string, fail parsing.
+    if (!lexer.remaining().contains(':'))
+        return Error::from_string_view("There must be a colon before the end of the input"sv);
+
+    // 4. Let b64_content be the result of consuming content of input_string up to but not including the first instance of the character ":".
+    auto b64_content = lexer.consume_until(':');
+
+    // 5. Consume the ":" character at the beginning of input_string.
+    lexer.consume();
+
+    // 6. If b64_content contains a character not included in ALPHA, DIGIT, "+", "/", and "=", fail parsing.
+    // 7. Let binary_content be the result of base64-decoding [RFC4648] b64_content, synthesizing padding if necessary (note the requirements about recipient behavior below). If base64 decoding fails, parsing fails.
+    auto binary_content = TRY(decode_base64(b64_content));
+
+    // 8. Return binary_content.
+    return StructuredFieldByteSequence { binary_content };
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-boolean
+static ErrorOr<StructuredFieldBoolean> parse_a_boolean(GenericLexer lexer)
+{
+    // 1. If the first character of input_string is not "?", fail parsing.
+    if (lexer.peek() != '?')
+        return Error::from_string_view("A boolean must start with a question mark"sv);
+
+    // 2. Discard the first character of input_string.
+    lexer.consume();
+
+    // 3. If the first character of input_string matches "1", discard the first character, and return true.
+    auto first_character = lexer.peek();
+    if (first_character == '1') {
+        lexer.consume();
+        return StructuredFieldBoolean { true };
+    }
+
+    // 4. If the first character of input_string matches "0", discard the first character, and return false.
+    if (first_character == '0') {
+        lexer.consume();
+        return StructuredFieldBoolean { false };
+    }
+
+    // 5. No value has matched; fail parsing.
+    return Error::from_string_view("Invalid boolean value"sv);
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-date
+static ErrorOr<StructuredFieldDate> parse_a_date(GenericLexer lexer)
+{
+    // 1. If the first character of input_string is not "@", fail parsing.
+    if (lexer.peek() != '@')
+        return Error::from_string_view("A boolean must start with an at sign"sv);
+
+    // 2. Discard the first character of input_string.
+    lexer.consume();
+
+    // 3. Let output_date be the result of running Parsing an Integer or Decimal (Section 4.2.4) with input_string.
+    auto output_date = TRY(parse_an_integer_or_decimal(lexer));
+
+    // 4. If output_date is a Decimal, fail parsing.
+    if (!output_date.has<StructuredFieldInteger>())
+        return Error::from_string_view("The date must have an integer value"sv);
+
+    // 5. Return output_date.
+    return StructuredFieldDate { output_date.get<StructuredFieldInteger>().value };
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-display
+static ErrorOr<StructuredFieldDisplayString> parse_a_display_string(GenericLexer lexer)
+{
+    // 1. If the first two characters of input_string are not "%" followed by DQUOTE, fail parsing.
+    if (lexer.peek_string(2) != "%\""sv)
+        return Error::from_string_view("A boolean must start with an empercent and a double quote"sv);
+
+    // 2. Discard the first two characters of input_string.
+    lexer.consume(2);
+
+    // 3. Let byte_array be an empty byte array.
+    ByteBuffer byte_array;
+
+    // 4. While input_string is not empty:
+    while (!lexer.is_eof()) {
+        // 1. Let char be the result of consuming the first character of input_string.
+        auto c = lexer.consume();
+
+        // 2. If char is in the range %x00-1f or %x7f-ff (i.e., it is not in VCHAR or SP), fail parsing.
+        if (c <= 0x1f || c >= 0x7f)
+            return Error::from_string_view("Display string contains invalid character"sv);
+
+        // 3. If char is "%":
+        if (c == '%') {
+            // 1. Let octet_hex be the result of consuming two characters from input_string. If there are not two characters, fail parsing.
+            auto octet_hex = lexer.consume(2);
+            if (octet_hex.length() < 2)
+                return Error::from_string_view("Unterminated hex octet in display string"sv);
+
+            // 2. If octet_hex contains characters outside the range %x30-39 or %x61-66 (i.e., it is not in 0-9 or lowercase a-f), fail parsing.
+            if (!all_of(octet_hex, is_ascii_hex_digit))
+                return Error::from_string_view("Invalid character in hex octet"sv);
+
+            // 3. Let octet be the result of hex decoding octet_hex (Section 8 of [RFC4648]).
+            auto octet = AK::parse_hexadecimal_number<u8>(octet_hex);
+            if (!octet.has_value())
+                return Error::from_string_view("Invalid hex octet"sv);
+
+            // 4. Append octet to byte_array.
+            byte_array.append(octet.value());
+        }
+
+        // 4. If char is DQUOTE:
+        else if (c == '"') {
+            // 1. Let unicode_sequence be the result of decoding byte_array as a UTF-8 string (Section 3 of [UTF8]). Fail parsing if decoding fails.
+            auto unicode_sequence = TRY(String::from_utf8(byte_array));
+
+            // 2. Return unicode_sequence.
+            return StructuredFieldDisplayString { unicode_sequence };
+        }
+
+        // 5. Otherwise, if char is not "%" or DQUOTE:
+        else {
+            // 1. Let byte be the result of applying ASCII encoding to char.
+            u8 byte = c;
+
+            // 2. Append byte to byte_array.
+            byte_array.append(byte);
+        }
+    }
+
+    // 5. Reached the end of input_string without finding a closing DQUOTE; fail parsing.
+    return Error::from_string_view("Reached the end of a display string without finding a closing double quote"sv);
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-bare-item
+static ErrorOr<StructuredFieldBareItem> parse_a_bare_item(GenericLexer lexer)
+{
+    // 1. If the first character of input_string is a "-" or a DIGIT, return the result of running Parsing an Integer or Decimal (Section 4.2.4) with input_string.
+    auto first_character = lexer.peek();
+    if (first_character == '-' || (first_character >= '0' && first_character <= '9')) {
+        return parse_an_integer_or_decimal(lexer);
+    }
+
+    // 2. If the first character of input_string is a DQUOTE, return the result of running Parsing a String (Section 4.2.5) with input_string.
+    if (first_character == '"') {
+        return parse_a_string(lexer);
+    }
+
+    // 3. If the first character of input_string is an ALPHA or "*", return the result of running Parsing a Token (Section 4.2.6) with input_string.
+    if ((first_character >= 'a' && first_character <= 'z') || (first_character >= 'A' && first_character <= 'Z') || first_character == '*') {
+        return parse_a_token(lexer);
+    }
+
+    // 4. If the first character of input_string is ":", return the result of running Parsing a Byte Sequence (Section 4.2.7) with input_string.
+    if (first_character == ':') {
+        return parse_a_byte_sequence(lexer);
+    }
+
+    // 5. If the first character of input_string is "?", return the result of running Parsing a Boolean (Section 4.2.8) with input_string.
+    if (first_character == '?') {
+        return parse_a_boolean(lexer);
+    }
+
+    // 6. If the first character of input_string is "@", return the result of running Parsing a Date (Section 4.2.9) with input_string.
+    if (first_character == '@') {
+        return parse_a_date(lexer);
+    }
+
+    // 7. If the first character of input_string is "%", return the result of running Parsing a Display String (Section 4.2.10) with input_string.
+    if (first_character == '%') {
+        return parse_a_display_string(lexer);
+    }
+
+    // 8. Otherwise, the item type is unrecognized; fail parsing.
+    return Error::from_string_view("Could not recognize the item type"sv);
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-key
+static ErrorOr<String> parse_a_key(GenericLexer lexer)
+{
+    // 1. If the first character of input_string is not lcalpha or "*", fail parsing.
+    auto first_character = lexer.peek();
+    if ((first_character < 'a' || first_character > 'z') && first_character != '*')
+        return Error::from_string_view("Invalid start of a key"sv);
+
+    // 2. Let output_string be an empty string.
+    // 3. While input_string is not empty:
+    //     1. If the first character of input_string is not one of lcalpha, DIGIT, "_", "-", ".", or "*", return output_string.
+    //     2. Let char be the result of consuming the first character of input_string.
+    //     3. Append char to output_string.
+    // 4. Return output_string.
+    auto output_string = lexer.consume_until([](char c) { return (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '_' && c != '-' && c != '.' && c != '*'; });
+    return TRY(String::from_utf8(output_string));
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-param
+static ErrorOr<Parameters> parse_parameters(GenericLexer lexer)
+{
+    // 1. Let parameters be an empty, ordered map.
+    HashMap<String, StructuredFieldBareItem> parameters {};
+
+    // 2. While input_string is not empty:
+    while (!lexer.is_eof()) {
+        // 1. If the first character of input_string is not ";", exit the loop.
+        if (lexer.peek() != ';')
+            break;
+
+        // 2. Consume the ";" character from the beginning of input_string.
+        lexer.consume();
+
+        // 3. Discard any leading SP characters from input_string.
+        lexer.consume_while(is_sp_character);
+
+        // 4. Let param_key be the result of running Parsing a Key (Section 4.2.3.3) with input_string.
+        auto param_key = TRY(parse_a_key(lexer));
+
+        // 5. Let param_value be Boolean true.
+        StructuredFieldBareItem param_value = StructuredFieldBoolean { true };
+
+        // 6. If the first character of input_string is "=":
+        if (lexer.peek() == '=') {
+            // 1. Consume the "=" character at the beginning of input_string.
+            lexer.consume();
+
+            // 2. Let param_value be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
+            param_value = TRY(parse_a_bare_item(lexer));
+        }
+
+        // 7. If parameters already contains a key param_key (comparing character for character), overwrite its value with param_value.
+        // 8. Otherwise, append key param_key with value param_value to parameters.
+        parameters.set(param_key, param_value);
+    }
+
+    // 3. Return parameters.
+    return parameters;
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-item
+static ErrorOr<StructuredFieldItem> parse_an_item(GenericLexer lexer)
+{
+    // 1. Let bare_item be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
+    auto bare_item = TRY(parse_a_bare_item(lexer));
+
+    // 2. Let parameters be the result of running Parsing Parameters (Section 4.2.3.2) with input_string.
+    auto parameters = TRY(parse_parameters(lexer));
+
+    // 3. Return the tuple (bare_item, parameters).
+    return StructuredFieldItem { .item = bare_item, .parameters = parameters };
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-innerlist
+static ErrorOr<StructuredFieldInnerList> parse_an_inner_list(GenericLexer lexer)
+{
+    // 1. Consume the first character of input_string; if it is not "(", fail parsing.
+    lexer.consume('(');
+
+    // 2. Let inner_list be an empty array.
+    Vector<StructuredFieldItem> inner_list;
+
+    // 3. While input_string is not empty:
+    while (!lexer.is_eof()) {
+        // 1. Discard any leading SP characters from input_string.
+        lexer.consume_while(is_sp_character);
+
+        // 2. If the first character of input_string is ")":
+        if (lexer.peek() == ')') {
+            // 1. Consume the first character of input_string.
+            lexer.consume();
+
+            // 2. Let parameters be the result of running Parsing Parameters (Section 4.2.3.2) with input_string.
+            auto parameters = TRY(parse_parameters(lexer));
+
+            // 3. Return the tuple (inner_list, parameters).
+            return StructuredFieldInnerList {
+                .members = inner_list,
+                .parameters = parameters
+            };
+        }
+
+        // 3. Let item be the result of running Parsing an Item (Section 4.2.3) with input_string.
+        auto item = TRY(parse_an_item(lexer));
+
+        // 4. Append item to inner_list.
+        inner_list.append(item);
+
+        // 5. If the first character of input_string is not SP or ")", fail parsing.
+        auto first_character = lexer.peek();
+        if (!is_sp_character(first_character) && first_character != ')')
+            return Error::from_string_view("Expected a closing bracket or space after an inner list entry"sv);
+    }
+
+    // 4. The end of the Inner List was not found; fail parsing.
+    return Error::from_string_view("The end of the inner list was not found"sv);
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-item-or-list
+static ErrorOr<StructuredFieldItemOrInnerList> parse_an_item_or_inner_list(GenericLexer lexer)
+{
+    // 1. If the first character of input_string is "(", return the result of running Parsing an Inner List (Section 4.2.1.2) with input_string.
+    if (lexer.peek() == '(')
+        return TRY(parse_an_inner_list(lexer));
+
+    // 2. Return the result of running Parsing an Item (Section 4.2.3) with input_string.
+    return TRY(parse_an_item(lexer));
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-list
+static ErrorOr<StructuredFieldList> parse_a_list(GenericLexer lexer)
+{
+    // 1. Let dictionary be an empty, ordered map.
+    Vector<StructuredFieldItemOrInnerList> members;
+
+    // 2. While input_string is not empty:
+    while (!lexer.is_eof()) {
+        // 1. Append the result of running Parsing an Item or Inner List (Section 4.2.1.1) with input_string to members.
+        members.append(TRY(parse_an_item_or_inner_list(lexer)));
+
+        // 2. Discard any leading OWS characters from input_string.
+        lexer.consume_while(is_ows_character);
+
+        // 3. If input_string is empty, return dictionary.
+        if (lexer.is_eof())
+            return StructuredFieldList { members };
+
+        // 4. Consume the first character of input_string; if it is not ",", fail parsing.
+        if (lexer.consume() != ',')
+            return Error::from_string_view("Expected a comma after a list entry"sv);
+
+        // 5. Discard any leading OWS characters from input_string.
+        lexer.consume_while(is_ows_character);
+
+        // 6. If input_string is empty, there is a trailing comma; fail parsing.
+        if (lexer.is_eof())
+            return Error::from_string_view("There is a trailing comma"sv);
+    }
+
+    // 3. No structured data has been found; return members (which is empty).
+    return StructuredFieldList { members };
+}
+
+// https://httpwg.org/specs/rfc9651.html#parse-dictionary
+static ErrorOr<StructuredFieldDictionary> parse_a_dictionary(GenericLexer lexer)
+{
+    // 1. Let dictionary be an empty, ordered map.
+    HashMap<String, StructuredFieldItemOrInnerList> dictionary;
+
+    // 2. While input_string is not empty:
+    while (!lexer.is_eof()) {
+        // 1. Let this_key be the result of running Parsing a Key (Section 4.2.3.3) with input_string.
+        auto key = TRY(parse_a_key(lexer));
+
+        // 2. If the first character of input_string is "=":
+        Optional<StructuredFieldItemOrInnerList> member;
+        if (lexer.peek() == '=') {
+            // 1. Consume the first character of input_string.
+            lexer.consume();
+
+            // 2. Let member be the result of running Parsing an Item or Inner List (Section 4.2.1.1) with input_string.
+            member = TRY(parse_an_item_or_inner_list(lexer));
+        }
+
+        // 3. Otherwise:
+        else {
+            // 1. Let value be Boolean true.
+            StructuredFieldBareItem value = StructuredFieldBoolean { true };
+
+            // 2. Let parameters be the result of running Parsing Parameters (Section 4.2.3.2) with input_string.
+            auto parameters = TRY(parse_parameters(lexer));
+
+            // 3. Let member be the tuple (value, parameters).
+            member = StructuredFieldItem { .item = value, .parameters = parameters };
+        }
+
+        // 4. If dictionary already contains a key this_key (comparing character for character), overwrite its value with member.
+        // 5. Otherwise, append key this_key with value member to dictionary.
+        dictionary.set(key, member.value());
+
+        // 6. Discard any leading OWS characters from input_string.
+        lexer.consume_while(is_ows_character);
+
+        // 7. If input_string is empty, return dictionary.
+        if (lexer.is_eof())
+            return StructuredFieldDictionary { dictionary };
+
+        // 8. Consume the first character of input_string; if it is not ",", fail parsing.
+        if (lexer.consume() != ',')
+            return Error::from_string_view("Expected a comma after a dictionary entry"sv);
+
+        // 9. Discard any leading OWS characters from input_string.
+        lexer.consume_while(is_ows_character);
+
+        // 10. If input_string is empty, there is a trailing comma; fail parsing.
+        if (lexer.is_eof())
+            return Error::from_string_view("There is a trailing comma"sv);
+    }
+    // 3. No structured data has been found; return dictionary (which is empty).
+    return StructuredFieldDictionary { dictionary };
+}
+
+// https://httpwg.org/specs/rfc9651.html#text-parse
+ErrorOr<StructuredFieldValue> parse_structured_fields(StringView input_string, StructuredFieldType header_type)
+{
+    // 1. Convert input_bytes into an ASCII string input_string; if conversion fails, fail parsing.
+    if (!input_string.is_ascii())
+        return Error::from_string_view("Structured field is not an ASCII string"sv);
+
+    // 2. Discard any leading SP characters from input_string.
+    GenericLexer lexer { input_string };
+    lexer.consume_while(is_sp_character);
+
+    // 3. If field_type is "list", let output be the result of running Parsing a List (Section 4.2.1) with input_string.
+    Optional<StructuredFieldValue> output;
+    if (header_type == StructuredFieldType::List) {
+        output = TRY(parse_a_list(lexer));
+    }
+
+    // 4. If field_type is "dictionary", let output be the result of running Parsing a Dictionary (Section 4.2.2) with input_string.
+    else if (header_type == StructuredFieldType::Dictionary) {
+        output = TRY(parse_a_dictionary(lexer));
+    }
+
+    // 5. If field_type is "item", let output be the result of running Parsing an Item (Section 4.2.3) with input_string.
+    else if (header_type == StructuredFieldType::Item) {
+        output = TRY(parse_an_item(lexer));
+    }
+
+    // 6. Discard any leading SP characters from input_string.
+    lexer.consume_while(is_sp_character);
+
+    // 7. If input_string is not empty, fail parsing.
+    if (!lexer.is_eof())
+        return Error::from_string_view("Structured field contains extra characters"sv);
+
+    // 8. Otherwise, return output.
+    return output.value();
+}
+
+}

--- a/Libraries/LibHTTP/StructuredField.h
+++ b/Libraries/LibHTTP/StructuredField.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, Glenn Skrzypczak <glenn.skrzypczak@gmail.com>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Error.h>
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Variant.h>
+
+namespace HTTP {
+
+enum class StructuredFieldType : u8 {
+    Dictionary,
+    List,
+    Item
+};
+
+// https://httpwg.org/specs/rfc9651.html#integer
+struct StructuredFieldInteger {
+    i64 value;
+};
+
+// https://httpwg.org/specs/rfc9651.html#decimal
+struct StructuredFieldDecimal {
+    double value;
+};
+
+// https://httpwg.org/specs/rfc9651.html#string
+struct StructuredFieldString {
+    String value;
+};
+
+// https://httpwg.org/specs/rfc9651.html#token
+struct StructuredFieldToken {
+    String value;
+};
+
+// https://httpwg.org/specs/rfc9651.html#binary
+struct StructuredFieldByteSequence {
+    ByteBuffer value;
+};
+
+// https://httpwg.org/specs/rfc9651.html#boolean
+struct StructuredFieldBoolean {
+    bool value;
+};
+
+// https://httpwg.org/specs/rfc9651.html#date
+struct StructuredFieldDate {
+    i64 value;
+};
+
+// https://httpwg.org/specs/rfc9651.html#displaystring
+struct StructuredFieldDisplayString {
+    String value;
+};
+
+using StructuredFieldBareItem = Variant<StructuredFieldInteger, StructuredFieldDecimal, StructuredFieldString, StructuredFieldToken, StructuredFieldByteSequence, StructuredFieldBoolean, StructuredFieldDate, StructuredFieldDisplayString>;
+
+// https://httpwg.org/specs/rfc9651.html#param
+using Parameters = HashMap<String, StructuredFieldBareItem>;
+
+// https://httpwg.org/specs/rfc9651.html#item
+struct StructuredFieldItem {
+    StructuredFieldBareItem item;
+    Parameters parameters;
+};
+
+// https://httpwg.org/specs/rfc9651.html#inner-list
+struct StructuredFieldInnerList {
+    Vector<StructuredFieldItem> members;
+    Parameters parameters;
+};
+
+using StructuredFieldItemOrInnerList = Variant<StructuredFieldItem, StructuredFieldInnerList>;
+
+// https://httpwg.org/specs/rfc9651.html#dictionary
+struct StructuredFieldDictionary {
+    HashMap<String, StructuredFieldItemOrInnerList> members;
+};
+
+// https://httpwg.org/specs/rfc9651.html#list
+struct StructuredFieldList {
+    Vector<StructuredFieldItemOrInnerList> members;
+};
+
+// https://httpwg.org/specs/rfc9651.html#rfc.section.2
+using StructuredFieldValue = Variant<StructuredFieldList, StructuredFieldDictionary, StructuredFieldItem>;
+
+ErrorOr<StructuredFieldValue> parse_structured_fields(StringView input_string, StructuredFieldType header_type);
+
+}

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -353,10 +353,13 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
     }
     // 7. Otherwise:
     else {
-        // FIXME: 1. Let oacHeader be the result of getting a structured field value given `Origin-Agent-Cluster` and "item" from response's header list.
+        // 1. Let oacHeader be the result of getting a structured field value given `Origin-Agent-Cluster` and "item" from navigationParams's response's header list.
+        auto oacHeader = navigation_params.response->header_list()->get_a_structured_field_value("Origin-Agent-Cluster"sv, HTTP::StructuredFieldType::Item);
 
-        // FIXME: 2. Let requestsOAC be true if oacHeader is not null and oacHeader[0] is the boolean true; otherwise false.
-        [[maybe_unused]] auto requests_oac = false;
+        // 2. Let requestsOAC be true if oacHeader is not null and oacHeader[0] is the boolean true; otherwise false.
+        [[maybe_unused]] auto requests_oac = oacHeader.has_value()
+            && oacHeader->get<HTTP::StructuredFieldItem>().item.has<HTTP::StructuredFieldBoolean>()
+            && oacHeader->get<HTTP::StructuredFieldItem>().item.get<HTTP::StructuredFieldBoolean>().value;
 
         // FIXME: 3. If navigationParams's reserved environment is a non-secure context, then set requestsOAC to false.
 

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -946,7 +946,7 @@ static GC::Ref<PolicyContainer> determine_navigation_params_policy_container(URL
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#obtain-coop
-static OpenerPolicy obtain_an_opener_policy(GC::Ref<Fetch::Infrastructure::Response>, Fetch::Infrastructure::Request::ReservedClientType const& reserved_client)
+static OpenerPolicy obtain_an_opener_policy(GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::Request::ReservedClientType const& reserved_client)
 {
 
     // 1. Let policy be a new opener policy.
@@ -962,13 +962,70 @@ static OpenerPolicy obtain_an_opener_policy(GC::Ref<Fetch::Infrastructure::Respo
     if (is_non_secure_context(reserved_environment))
         return policy;
 
-    // FIXME: We don't yet have the technology to extract structured data from Fetch headers
-    // FIXME: 3. Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list.
-    // FIXME: 4. If parsedItem is not null, then:
-    //     FIXME: nested steps...
-    // FIXME: 5. Set parsedItem to the result of getting a structured field value given `Cross-Origin-Opener-Policy-Report-Only` and "item" from response's header list.
-    // FIXME: 6. If parsedItem is not null, then:
-    //     FIXME: nested steps...
+    // 3. Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list.
+    auto parsed_item = response->header_list()->get_a_structured_field_value("Cross-Origin-Opener-Policy"sv, HTTP::StructuredFieldType::Item);
+
+    // 4. If parsedItem is not null, then:
+    if (parsed_item.has_value()) {
+        auto item = parsed_item->get<HTTP::StructuredFieldItem>();
+        if (item.item.has<HTTP::StructuredFieldToken>()) {
+            // 1. If parsedItem[0] is "same-origin":
+            auto token = item.item.get<HTTP::StructuredFieldToken>();
+            if (token.value == "same-origin"sv) {
+                // FIXME: 1. Let coep be the result of obtaining a cross-origin embedder policy from response and reservedEnvironment.
+                // FIXME: 2. If coep's value is compatible with cross-origin isolation, then set policy's value to "same-origin-plus-COEP".
+
+                // 3. Otherwise, set policy's value to "same-origin".
+                policy.value = OpenerPolicyValue::SameOrigin;
+            }
+
+            // 2. If parsedItem[0] is "same-origin-allow-popups", then set policy's value to "same-origin-allow-popups".
+            if (token.value == "same-origin-allow-popups") {
+                policy.value = OpenerPolicyValue::SameOriginAllowPopups;
+            }
+
+            // 3. If parsedItem[0] is "noopener-allow-popups", then set policy's value to "noopener-allow-popups".
+            if (token.value == "noopener-allow-popups") {
+                policy.value = OpenerPolicyValue::NoopenerAllowPopups;
+            }
+
+            // 4. If parsedItem[1]["report-to"] exists and it is a string, then set policy's reporting endpoint to parsedItem[1]["report-to"].
+            auto reports_to = item.parameters.get("reports-to"sv);
+            if (reports_to.has_value() && reports_to->has<HTTP::StructuredFieldString>()) {
+                policy.reporting_endpoint = reports_to->get<HTTP::StructuredFieldString>().value;
+            }
+        }
+    }
+
+    // 5. Set parsedItem to the result of getting a structured field value given `Cross-Origin-Opener-Policy-Report-Only` and "item" from response's header list.
+    parsed_item = response->header_list()->get_a_structured_field_value("Cross-Origin-Opener-Policy-Report-Only"sv, HTTP::StructuredFieldType::Item);
+
+    // 6. If parsedItem is not null, then:
+    if (parsed_item.has_value()) {
+        auto item = parsed_item->get<HTTP::StructuredFieldItem>();
+        if (item.item.has<HTTP::StructuredFieldToken>()) {
+            // 1. If parsedItem[0] is "same-origin":
+            auto token = item.item.get<HTTP::StructuredFieldToken>();
+            if (token.value == "same-origin"sv) {
+                // FIXME: 1. Let coep be the result of obtaining a cross-origin embedder policy from response and reservedEnvironment.
+                // FIXME: 2. If coep's value is compatible with cross-origin isolation or coep's report-only value is compatible with cross-origin isolation, then set policy's report-only value to "same-origin-plus-COEP".
+
+                // 3. Otherwise, set policy's report-only value to "same-origin".
+                policy.report_only_value = OpenerPolicyValue::SameOrigin;
+            }
+
+            // 2. If parsedItem[0] is "same-origin-allow-popups", then set policy's report-only value to "same-origin-allow-popups".
+            if (token.value == "same-origin-allow-popups") {
+                policy.report_only_value = OpenerPolicyValue::SameOriginAllowPopups;
+            }
+
+            // 3. If parsedItem[1]["report-to"] exists and it is a string, then set policy's report-only reporting endpoint to parsedItem[1]["report-to"].
+            auto reports_to = item.parameters.get("reports-to"sv);
+            if (reports_to.has_value() && reports_to->has<HTTP::StructuredFieldString>()) {
+                policy.report_only_reporting_endpoint = reports_to->get<HTTP::StructuredFieldString>().value;
+            }
+        }
+    }
 
     // 7. Return policy.
     return policy;

--- a/Libraries/LibWeb/HTML/PolicyContainers.cpp
+++ b/Libraries/LibWeb/HTML/PolicyContainers.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibHTTP/StructuredField.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibURL/URL.h>
 #include <LibWeb/ContentSecurityPolicy/Policy.h>
@@ -36,6 +37,79 @@ bool url_requires_storing_the_policy_container_in_history(URL::URL const& url)
     return Fetch::Infrastructure::is_local_url(url);
 }
 
+// https://w3c.github.io/webappsec-subresource-integrity/#processing-an-integrity-policy
+static IntegrityPolicy process_an_integrity_policy(AK::NonnullRefPtr<HTTP::HeaderList> const& headers, StringView header_name)
+{
+    // 1. Let integrityPolicy be a new integrity policy.
+    IntegrityPolicy integrity_policy {};
+
+    // 2. Let dictionary be the result of getting a structured field value from headers given headerName and "dictionary".
+    auto parsed_dictionary = headers->get_a_structured_field_value(header_name, HTTP::StructuredFieldType::Dictionary);
+    if (!parsed_dictionary.has_value()) {
+        return integrity_policy;
+    }
+    auto dictionary = parsed_dictionary.value().get<HTTP::StructuredFieldDictionary>();
+
+    // 3. If dictionary["sources"] does not exist or if its value contains "inline", append "inline" to integrityPolicy’s sources.
+    auto sources = dictionary.members.get("sources"sv);
+    if (!sources.has_value() || (sources->has<HTTP::StructuredFieldInnerList>() && any_of(sources->get<HTTP::StructuredFieldInnerList>().members, [](auto const& member) {
+            return member.item.template has<HTTP::StructuredFieldToken>() && member.item.template get<HTTP::StructuredFieldToken>().value == "inline"sv;
+        }))) {
+        integrity_policy.sources.append("inline"_string);
+    }
+
+    // 4. If dictionary["blocked-destinations"] exists:
+    auto blocked_destinations = dictionary.members.get("blocked-destinations"sv);
+    if (blocked_destinations.has_value() && blocked_destinations->has<HTTP::StructuredFieldInnerList>()) {
+        auto blocked_destinations_list = blocked_destinations->get<HTTP::StructuredFieldInnerList>();
+        // 1. If its value contains "script", append "script" to integrityPolicy’s blocked destinations.
+        if (any_of(blocked_destinations_list.members, [](auto const& member) {
+                return member.item.template has<HTTP::StructuredFieldToken>() && member.item.template get<HTTP::StructuredFieldToken>().value == "script"sv;
+            })) {
+            integrity_policy.blocked_destinations.append(Fetch::Infrastructure::Request::Destination::Script);
+        }
+
+        // 2. If its value contains "style", append "style" to integrityPolicy’s blocked destinations.
+        if (any_of(blocked_destinations_list.members, [](auto const& member) {
+                return member.item.template has<HTTP::StructuredFieldToken>() && member.item.template get<HTTP::StructuredFieldToken>().value == "style"sv;
+            })) {
+            integrity_policy.blocked_destinations.append(Fetch::Infrastructure::Request::Destination::Style);
+        }
+    }
+
+    // 5. If dictionary["endpoints"] exists:
+    auto endpoints = dictionary.members.get("endpoints"sv);
+    if (endpoints.has_value() && endpoints->has<HTTP::StructuredFieldInnerList>()) {
+        // 1. Set integrityPolicy’s endpoints to dictionary['endpoints'].
+        auto endpoints_list = endpoints->get<HTTP::StructuredFieldInnerList>();
+        for (auto const& member : endpoints_list.members) {
+            if (member.item.has<HTTP::StructuredFieldToken>()) {
+                integrity_policy.endpoints.append(member.item.get<HTTP::StructuredFieldToken>().value);
+            }
+        }
+    }
+
+    // 6. Return integrityPolicy.
+    return integrity_policy;
+}
+
+// https://w3c.github.io/webappsec-subresource-integrity/#parse-integrity-policy-headers-section
+static void parse_integrity_policy_headers(GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<PolicyContainer> container)
+{
+    // 1. Let headers be response’s header list.
+    auto const& headers = response->header_list();
+
+    // 2. If headers contains integrity-policy, set container’s integrity policy be the result of running processing an integrity policy with the corresponding header value.
+    if (headers->contains("integrity-policy"sv)) {
+        container->integrity_policy = process_an_integrity_policy(headers, "integrity-policy"sv);
+    }
+
+    // 3. If headers contains integrity-policy-report-only, set container’s report only integrity policy be the result of running processing an integrity policy with the corresponding header value.
+    if (headers->contains("integrity-policy-report-only"sv)) {
+        container->report_only_integrity_policy = process_an_integrity_policy(headers, "integrity-policy-report-only"sv);
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/browsers.html#creating-a-policy-container-from-a-fetch-response
 GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(GC::Heap& heap, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ptr<Environment>)
 {
@@ -57,7 +131,8 @@ GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(GC::Hea
     if (parsed_referrer_policy != ReferrerPolicy::ReferrerPolicy::EmptyString)
         result->referrer_policy = parsed_referrer_policy;
 
-    // FIXME: 6. Parse Integrity-Policy headers with response and result.
+    // 6. Parse Integrity-Policy headers with response and result.
+    parse_integrity_policy_headers(response, result);
 
     // 7. Return result.
     return result;


### PR DESCRIPTION
This PR serves as the foundation for future developments at it implements a parser for HTTP structured header fields.

Most features using these headers are however not fully implemented yet. This PR is therefore intended to add one of the many pieces required for these features.