### PR TITLE
LibWeb: Restart media load after parser-created src insertion

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -201,6 +201,22 @@ void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<String>
     }
 }
 
+void HTMLMediaElement::inserted()
+{
+    Base::inserted();
+
+    // https://html.spec.whatwg.org/multipage/media.html#concept-media-load-algorithm-at-creation
+    // If a media element is created with a src attribute, the user agent must immediately invoke the
+    // media element's resource selection algorithm.
+    // NB: Parser-created media elements can reach inserted() in NETWORK_NO_SOURCE if that creation-time
+    //     load was missed.
+    if (is_connected() && m_needs_load_restart_when_connected && m_network_state == NetworkState::NoSource && has_attribute(HTML::AttributeNames::src)
+        && m_current_src.is_empty() && !m_error) {
+        m_needs_load_restart_when_connected = false;
+        select_resource();
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-srcobject
 OptionalMediaProvider HTMLMediaElement::src_object() const
 {
@@ -685,6 +701,7 @@ GC::Ref<TextTrack> HTMLMediaElement::add_text_track(Bindings::TextTrackKind kind
 WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
 {
     m_first_data_load_event_since_load_start = true;
+    m_needs_load_restart_when_connected = false;
 
     // 1. Abort any already-running instance of the resource selection algorithm for this element.
     //    NOTE: All deferred subroutines of the resource selection algorithm will be queued under the media element task

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -34,6 +34,7 @@ enum class MediaSeekMode : u8 {
 };
 
 class SourceElementSelector;
+class HTMLParser;
 
 using OptionalMediaProvider = Variant<Empty, GC::Ref<MediaSourceExtensions::MediaSource>, GC::Ref<FileAPI::Blob>>;
 
@@ -62,6 +63,7 @@ public:
 
     String const& current_src() const { return m_current_src; }
     void select_resource();
+    void set_needs_load_restart_when_connected(Badge<HTMLParser>) { m_needs_load_restart_when_connected = true; }
 
     OptionalMediaProvider src_object() const;
     WebIDL::ExceptionOr<void> set_src_object(OptionalMediaProvider);
@@ -188,6 +190,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+    virtual void inserted() override;
     virtual void removed_from(IsSubtreeRoot, DOM::Node* old_ancestor, DOM::Node& old_root) override;
     virtual void children_changed(ChildrenChangedMetadata const& metadata) override;
 
@@ -305,6 +308,7 @@ private:
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-networkstate
     NetworkState m_network_state { NetworkState::Empty };
+    bool m_needs_load_restart_when_connected { false };
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate
     ReadyState m_ready_state { ReadyState::HaveNothing };

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -199,6 +199,11 @@ void HTMLParser::configure_element_created_by_rust_parser(DOM::Element& element)
         return;
     }
 
+    if (m_parsing_fragment && element.is_html_media_element() && element.namespace_uri() == Namespace::HTML
+        && element.has_attribute(HTML::AttributeNames::src)) {
+        as<HTMLMediaElement>(element).set_needs_load_restart_when_connected({});
+    }
+
     if (element.local_name() != HTML::TagNames::script || element.namespace_uri() != Namespace::HTML)
         return;
 

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-play-parser-created-src.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-play-parser-created-src.txt
@@ -1,0 +1,19 @@
+document-parser networkState: 3
+document-parser error: 4
+document-parser emptied events: 0
+parser-created networkState: 3
+parser-created error: 4
+parser-created loadstart events: 1
+parser-created error events: 1
+parser-created emptied events: 0
+explicit-load parser-created networkState: 3
+explicit-load parser-created error: 4
+explicit-load parser-created loadstart events: 1
+explicit-load parser-created error events: 1
+changed-src parser-created networkState: 3
+changed-src parser-created error: 4
+changed-src parser-created loadstart events: 1
+changed-src parser-created error events: 1
+script-created networkState: 3
+script-created error: 4
+script-created emptied events: 0

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-play-parser-created-src.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-play-parser-created-src.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<video id="documentParserVideo" src=""></video>
+<script>
+    let documentParserEmptiedEvents = 0;
+    documentParserVideo.addEventListener("emptied", () => ++documentParserEmptiedEvents);
+
+    asyncTest(async done => {
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        println(`document-parser networkState: ${documentParserVideo.networkState}`);
+        println(`document-parser error: ${documentParserVideo.error?.code}`);
+        println(`document-parser emptied events: ${documentParserEmptiedEvents}`);
+
+        const container = document.createElement("div");
+        container.innerHTML = `<video src=""></video>`;
+        const parserCreatedVideo = container.querySelector("video");
+        let parserCreatedLoadStartEvents = 0;
+        let parserCreatedErrorEvents = 0;
+        let parserCreatedEmptiedEvents = 0;
+        parserCreatedVideo.addEventListener("loadstart", () => ++parserCreatedLoadStartEvents);
+        parserCreatedVideo.addEventListener("error", () => ++parserCreatedErrorEvents);
+        parserCreatedVideo.addEventListener("emptied", () => ++parserCreatedEmptiedEvents);
+
+        document.body.appendChild(container);
+
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        println(`parser-created networkState: ${parserCreatedVideo.networkState}`);
+        println(`parser-created error: ${parserCreatedVideo.error?.code}`);
+        println(`parser-created loadstart events: ${parserCreatedLoadStartEvents}`);
+        println(`parser-created error events: ${parserCreatedErrorEvents}`);
+        println(`parser-created emptied events: ${parserCreatedEmptiedEvents}`);
+
+        const explicitLoadContainer = document.createElement("div");
+        explicitLoadContainer.innerHTML = `<video src=""></video>`;
+        const explicitLoadVideo = explicitLoadContainer.querySelector("video");
+        let explicitLoadLoadStartEvents = 0;
+        let explicitLoadErrorEvents = 0;
+        explicitLoadVideo.addEventListener("loadstart", () => ++explicitLoadLoadStartEvents);
+        explicitLoadVideo.addEventListener("error", () => ++explicitLoadErrorEvents);
+        explicitLoadVideo.load();
+
+        document.body.appendChild(explicitLoadContainer);
+
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        println(`explicit-load parser-created networkState: ${explicitLoadVideo.networkState}`);
+        println(`explicit-load parser-created error: ${explicitLoadVideo.error?.code}`);
+        println(`explicit-load parser-created loadstart events: ${explicitLoadLoadStartEvents}`);
+        println(`explicit-load parser-created error events: ${explicitLoadErrorEvents}`);
+
+        const changedSrcContainer = document.createElement("div");
+        changedSrcContainer.innerHTML = `<video src=""></video>`;
+        const changedSrcVideo = changedSrcContainer.querySelector("video");
+        let changedSrcLoadStartEvents = 0;
+        let changedSrcErrorEvents = 0;
+        changedSrcVideo.addEventListener("loadstart", () => ++changedSrcLoadStartEvents);
+        changedSrcVideo.addEventListener("error", () => ++changedSrcErrorEvents);
+        changedSrcVideo.setAttribute("src", "#changed");
+
+        document.body.appendChild(changedSrcContainer);
+
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        println(`changed-src parser-created networkState: ${changedSrcVideo.networkState}`);
+        println(`changed-src parser-created error: ${changedSrcVideo.error?.code}`);
+        println(`changed-src parser-created loadstart events: ${changedSrcLoadStartEvents}`);
+        println(`changed-src parser-created error events: ${changedSrcErrorEvents}`);
+
+        const scriptCreatedVideo = document.createElement("video");
+        let scriptCreatedEmptiedEvents = 0;
+        scriptCreatedVideo.addEventListener("emptied", () => ++scriptCreatedEmptiedEvents);
+        scriptCreatedVideo.src = "";
+
+        document.body.appendChild(scriptCreatedVideo);
+
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        await animationFrame();
+        println(`script-created networkState: ${scriptCreatedVideo.networkState}`);
+        println(`script-created error: ${scriptCreatedVideo.error?.code}`);
+        println(`script-created emptied events: ${scriptCreatedEmptiedEvents}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Parser-created media elements can run the load algorithm before they are inserted into the active document. That leaves them in NETWORK_NO_SOURCE with no currentSrc or MediaError, so a later play() call appends a pending play promise but never reaches the source failure path.

Restart the load when such an element is inserted with a src attribute, and cover the case where play() must reject instead of timing out.

Visual progression on https://apple.com/os/macos/

Before:
<img width="1200" height="772" alt="image" src="https://github.com/user-attachments/assets/1f044cbe-2ffa-4710-b3f1-02d48232986b" />

After:
<img width="1200" height="772" alt="Screenshot from 2026-05-28 17-24-23" src="https://github.com/user-attachments/assets/6c3e6210-85e9-4b28-8fd1-318d7dec8ae2" />