### PR TITLE
LibURL: Replace WTF-8 surrogates before Rust URL parsing

### DIFF
--- a/Libraries/LibURL/Rust/src/ffi/url.rs
+++ b/Libraries/LibURL/Rust/src/ffi/url.rs
@@ -232,9 +232,8 @@ pub unsafe extern "C" fn rust_url_basic_parse(
     on_complete: FfiUrlResultFn,
 ) -> bool {
     abort_on_panic(|| {
-        // SAFETY: caller guarantees input and options are valid.
-        let input_bytes = unsafe { std::slice::from_raw_parts(input, input_length) };
-        let input_str = String::from_utf8_lossy(input_bytes);
+        // SAFETY: caller guarantees input is scalar-value UTF-8 and valid for input_length bytes.
+        let input_str = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(input, input_length)) };
 
         let options = unsafe { options.as_ref() };
 
@@ -258,9 +257,9 @@ pub unsafe extern "C" fn rust_url_basic_parse(
         parse_options.base_url = base_url.as_ref();
 
         let (did_succeed, maybe_url) = if let Some(mut existing_url) = existing_url {
-            let did_succeed = basic_parse_into(&input_str, &mut existing_url, &parse_options);
+            let did_succeed = basic_parse_into(input_str, &mut existing_url, &parse_options);
             (did_succeed, Some(existing_url))
-        } else if let Some(parsed) = basic_parse(&input_str, parse_options) {
+        } else if let Some(parsed) = basic_parse(input_str, parse_options) {
             (true, Some(parsed))
         } else {
             (false, None)
@@ -302,11 +301,10 @@ pub unsafe extern "C" fn rust_url_parse_host(
     on_complete: FfiHostResultFn,
 ) -> bool {
     abort_on_panic(|| {
-        // SAFETY: caller guarantees input is valid.
-        let input_bytes = unsafe { std::slice::from_raw_parts(input, input_length) };
-        let input_str = String::from_utf8_lossy(input_bytes);
+        // SAFETY: caller guarantees input is scalar-value UTF-8 and valid for input_length bytes.
+        let input_str = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(input, input_length)) };
 
-        let Some(host) = parse_host(&input_str, is_opaque) else {
+        let Some(host) = parse_host(input_str, is_opaque) else {
             // SAFETY: on_complete is a valid function pointer; ctx is caller-provided.
             unsafe { on_complete(ctx, std::ptr::null()) };
             return false;

--- a/Libraries/LibURL/RustIntegration.cpp
+++ b/Libraries/LibURL/RustIntegration.cpp
@@ -168,7 +168,7 @@ static FFI::FfiUrlHost host_to_ffi(Optional<Host> const& host)
         },
         [&](String const& str) {
             result.kind = FFI::RustUrlHostKind::String;
-            result.string_data = reinterpret_cast<uint8_t const*>(str.bytes().data());
+            result.string_data = reinterpret_cast<u8 const*>(str.bytes().data());
             result.string_length = str.bytes().size();
         });
     return result;
@@ -357,9 +357,9 @@ static UrlFfiStorage url_to_ffi(URL const& url)
 {
     UrlFfiStorage storage;
 
-    storage.ffi_url.scheme = { reinterpret_cast<uint8_t const*>(url.scheme().bytes().data()), url.scheme().bytes().size() };
-    storage.ffi_url.username = { reinterpret_cast<uint8_t const*>(url.username().bytes().data()), url.username().bytes().size() };
-    storage.ffi_url.password = { reinterpret_cast<uint8_t const*>(url.password().bytes().data()), url.password().bytes().size() };
+    storage.ffi_url.scheme = { reinterpret_cast<u8 const*>(url.scheme().bytes().data()), url.scheme().bytes().size() };
+    storage.ffi_url.username = { reinterpret_cast<u8 const*>(url.username().bytes().data()), url.username().bytes().size() };
+    storage.ffi_url.password = { reinterpret_cast<u8 const*>(url.password().bytes().data()), url.password().bytes().size() };
 
     storage.ffi_url.host = host_to_ffi(url.host());
 
@@ -369,7 +369,7 @@ static UrlFfiStorage url_to_ffi(URL const& url)
     storage.path_segments.ensure_capacity(url.paths().size());
     for (auto const& segment : url.paths()) {
         storage.path_segments.unchecked_append({
-            reinterpret_cast<uint8_t const*>(segment.bytes().data()),
+            reinterpret_cast<u8 const*>(segment.bytes().data()),
             segment.bytes().size(),
         });
     }
@@ -380,11 +380,11 @@ static UrlFfiStorage url_to_ffi(URL const& url)
 
     storage.ffi_url.has_query = url.query().has_value();
     if (url.query().has_value())
-        storage.ffi_url.query = { reinterpret_cast<uint8_t const*>(url.query()->bytes().data()), url.query()->bytes().size() };
+        storage.ffi_url.query = { reinterpret_cast<u8 const*>(url.query()->bytes().data()), url.query()->bytes().size() };
 
     storage.ffi_url.has_fragment = url.fragment().has_value();
     if (url.fragment().has_value())
-        storage.ffi_url.fragment = { reinterpret_cast<uint8_t const*>(url.fragment()->bytes().data()), url.fragment()->bytes().size() };
+        storage.ffi_url.fragment = { reinterpret_cast<u8 const*>(url.fragment()->bytes().data()), url.fragment()->bytes().size() };
 
     return storage;
 }
@@ -425,7 +425,7 @@ Optional<Host> parse_host(StringView input, bool is_opaque)
     Optional<Host> result;
     HostParseCallbackCtx ctx { .result = &result };
     bool const did_succeed = FFI::rust_url_parse_host(
-        reinterpret_cast<uint8_t const*>(processed_input_view.characters_without_null_termination()),
+        reinterpret_cast<u8 const*>(processed_input_view.characters_without_null_termination()),
         processed_input_view.length(),
         is_opaque,
         &ctx,
@@ -460,7 +460,7 @@ Optional<URL> parse_basic_url(StringView input, Optional<URL const&> base_url, U
         .has_state_override = state_override.has_value(),
         .state_override = state_override.map(state_override_from_cpp).value_or(FFI::State::SchemeStart),
         .encoding = {
-            reinterpret_cast<uint8_t const*>(encoding.has_value() ? encoding->characters_without_null_termination() : nullptr),
+            reinterpret_cast<u8 const*>(encoding.has_value() ? encoding->characters_without_null_termination() : nullptr),
             encoding.value_or(""sv).length(),
         },
     };
@@ -469,7 +469,7 @@ Optional<URL> parse_basic_url(StringView input, Optional<URL const&> base_url, U
     ParseCallbackCtx ctx { .result = &result, .url_inout = url };
     auto processed_input_view = processed_input.bytes_as_string_view();
     bool const did_succeed = rust_url_basic_parse(
-        reinterpret_cast<uint8_t const*>(processed_input_view.characters_without_null_termination()),
+        reinterpret_cast<u8 const*>(processed_input_view.characters_without_null_termination()),
         processed_input_view.length(),
         &options,
         &ctx,
@@ -483,7 +483,7 @@ Optional<URL> parse_basic_url(StringView input, Optional<URL const&> base_url, U
 
 namespace URL::FFI {
 
-extern "C" bool textcodec_rust_encode(uint8_t const* encoding, size_t encoding_length, uint8_t const* input, size_t input_length, void* ctx, FfiByteFn on_byte, FfiCodePointFn on_error)
+extern "C" bool textcodec_rust_encode(u8 const* encoding, size_t encoding_length, u8 const* input, size_t input_length, void* ctx, FfiByteFn on_byte, FfiCodePointFn on_error)
 {
     auto encoder = TextCodec::encoder_for(StringView { encoding, encoding_length });
     if (!encoder.has_value())

--- a/Libraries/LibURL/RustIntegration.cpp
+++ b/Libraries/LibURL/RustIntegration.cpp
@@ -418,11 +418,15 @@ static void on_parse_host_complete(void* ctx_ptr, FFI::FfiUrlHost const* ffi_res
 
 Optional<Host> parse_host(StringView input, bool is_opaque)
 {
+    // URL parsing expects a scalar-value UTF-8 string, but WTF-8 can be provided.
+    auto processed_input = String::from_utf8_with_replacement_character(input, String::WithBOMHandling::No);
+    auto processed_input_view = processed_input.bytes_as_string_view();
+
     Optional<Host> result;
     HostParseCallbackCtx ctx { .result = &result };
     bool const did_succeed = FFI::rust_url_parse_host(
-        reinterpret_cast<uint8_t const*>(input.characters_without_null_termination()),
-        input.length(),
+        reinterpret_cast<uint8_t const*>(processed_input_view.characters_without_null_termination()),
+        processed_input_view.length(),
         is_opaque,
         &ctx,
         on_parse_host_complete);
@@ -436,6 +440,9 @@ Optional<URL> parse_basic_url(StringView input, Optional<URL const&> base_url, U
     auto const state_override_from_cpp = [](Parser::State state) {
         return static_cast<FFI::State>(to_underlying(state));
     };
+
+    // URL parsing expects a scalar-value UTF-8 string, but WTF-8 can be provided.
+    auto processed_input = String::from_utf8_with_replacement_character(input, String::WithBOMHandling::No);
 
     Optional<UrlFfiStorage> base_storage;
     if (base_url.has_value())
@@ -460,9 +467,10 @@ Optional<URL> parse_basic_url(StringView input, Optional<URL const&> base_url, U
 
     Optional<URL> result;
     ParseCallbackCtx ctx { .result = &result, .url_inout = url };
+    auto processed_input_view = processed_input.bytes_as_string_view();
     bool const did_succeed = rust_url_basic_parse(
-        reinterpret_cast<uint8_t const*>(input.characters_without_null_termination()),
-        input.length(),
+        reinterpret_cast<uint8_t const*>(processed_input_view.characters_without_null_termination()),
+        processed_input_view.length(),
         &options,
         &ctx,
         on_basic_parse_complete);

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -374,6 +374,23 @@ TEST_CASE(unicode)
     EXPECT(!url->fragment().has_value());
 }
 
+TEST_CASE(wtf8_surrogates_are_replaced_before_url_parsing)
+{
+    {
+        auto url = URL::Parser::basic_parse("http://example.com/\xED\xA0\x80-\xED\xB0\x80?\xED\xBF\xBF"sv);
+        EXPECT(url.has_value());
+        EXPECT_EQ(url->serialize_path(), "/%EF%BF%BD-%EF%BF%BD");
+        EXPECT_EQ(url->query(), "%EF%BF%BD");
+        EXPECT_EQ(url->serialize(), "http://example.com/%EF%BF%BD-%EF%BF%BD?%EF%BF%BD");
+    }
+
+    {
+        auto host = URL::Parser::parse_host("\xED\xA0\x80host\xED\xBF\xBF"sv, true);
+        EXPECT(host.has_value());
+        EXPECT_EQ(host->serialize(), "%EF%BF%BDhost%EF%BF%BD");
+    }
+}
+
 TEST_CASE(query_with_non_ascii)
 {
     {


### PR DESCRIPTION
The Rust URL FFI used String::from_utf8_lossy() on raw bytes from C++. That was not equivalent to the old C++ parser behavior for WTF-8 encoded surrogates. For example a byte sequence such as ED A0 80 was treated as three invalid UTF-8 bytes, producing three U+FFFD replacement characters.

Instead use String::from_utf8_with_replacement_character and let Rust borrow the input as &str.

Fixes a regression with the rust port as I had believed these were equivalent.