### PR TITLE
Drive macOS presents from display-linked vsync

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -8,6 +8,7 @@
 #include <AK/Debug.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
+#include <AK/Math.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Time.h>
 #include <LibCore/AnonymousBuffer.h>
@@ -50,6 +51,15 @@
 namespace WebView {
 
 Application* Application::s_the = nullptr;
+
+static constexpr double default_display_refresh_rate = 60.0;
+
+static double sanitized_display_refresh_rate(double refresh_rate)
+{
+    if (refresh_rate != refresh_rate || refresh_rate <= 0 || refresh_rate >= AK::Infinity<double>)
+        return default_display_refresh_rate;
+    return refresh_rate;
+}
 
 struct ApplicationSettingsObserver final : public SettingsObserver {
     virtual void show_bookmarks_bar_changed() override
@@ -568,6 +578,15 @@ void Application::update_compositor_viewport(Web::Compositor::CompositorContextI
     VERIFY(m_compositor_client);
 
     m_compositor_client->async_viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
+}
+
+void Application::update_compositor_display_metadata(Web::Compositor::CompositorContextId context_id, Optional<u64> display_id, double refresh_rate)
+{
+    if (!can_send_compositor_process_ipc(m_compositor_client))
+        return;
+    VERIFY(m_compositor_client);
+
+    m_compositor_client->async_set_display_metadata(context_id, display_id, sanitized_display_refresh_rate(refresh_rate));
 }
 
 bool Application::send_async_scroll_to_compositor(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -95,6 +95,7 @@ public:
     void register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
     ErrorOr<void> try_register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
     void update_compositor_viewport(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress = Web::Compositor::WindowResizingInProgress::No);
+    void update_compositor_display_metadata(Web::Compositor::CompositorContextId, Optional<u64> display_id, double refresh_rate);
     bool send_async_scroll_to_compositor(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
     bool handle_mouse_event_in_compositor(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
     bool dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);

--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     CompositorState.cpp
     ConnectionFromClient.cpp
     ConnectionFromWebContent.cpp
+    VSyncScheduler.cpp
 )
 
 set(GENERATED_SOURCES

--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -24,6 +24,10 @@ target_include_directories(compositorservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Serv
 target_link_libraries(Compositor PRIVATE compositorservice LibCore LibMain LibWebView)
 target_link_libraries(compositorservice PRIVATE LibCore LibGfx LibIPC LibMedia LibSync LibWeb)
 
+if (APPLE)
+    target_link_libraries(Compositor PRIVATE "-framework CoreGraphics" "-framework CoreVideo")
+endif()
+
 if (WIN32)
     target_include_directories(Compositor PRIVATE $<BUILD_INTERFACE:${PTHREAD_INCLUDE_DIR}>)
     target_include_directories(compositorservice PRIVATE $<BUILD_INTERFACE:${PTHREAD_INCLUDE_DIR}>)

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -14,6 +14,7 @@ endpoint CompositorControlServer
     create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, i32 web_content_connection_id) => ()
 
     viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
+    set_display_metadata(Web::Compositor::CompositorContextId context_id, Optional<u64> display_id, double refresh_rate) =|
 
     handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) => (bool handled)
     dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) => (bool dispatched)

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
 #include <AK/StdLibExtras.h>
 #include <Compositor/CompositorState.h>
 #include <LibCore/EventLoop.h>
@@ -516,6 +517,20 @@ void CompositorState::viewport_size_updated(Web::Compositor::CompositorContextId
     resize_backing_stores_if_needed(context_id, *context);
     if (context->window_resize_in_progress == Web::Compositor::WindowResizingInProgress::Yes)
         schedule_backing_store_shrink(context_id, *context);
+}
+
+void CompositorState::set_display_metadata(Web::Compositor::CompositorContextId context_id, Optional<u64> display_id, double refresh_rate)
+{
+    auto* context = context_if_present(context_id);
+    if (!context)
+        return;
+
+    VERIFY(refresh_rate == refresh_rate);
+    VERIFY(refresh_rate > 0);
+    VERIFY(refresh_rate < AK::Infinity<double>);
+
+    context->display_id = display_id;
+    context->display_refresh_rate = refresh_rate;
 }
 
 void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -427,7 +427,7 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorState::async_scroll_by(Web::
         async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     store_pending_async_scroll_offsets(context_state, scroll_offsets, operation_id);
     context_state.async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    present_frame(context_id, context_state, async_scroll_viewport_rect);
+    schedule_present_frame(context_id, context_state, async_scroll_viewport_rect);
     return { true, operation_id };
 }
 
@@ -461,21 +461,9 @@ bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId conte
         async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     store_pending_async_scroll_offsets(context_state, scroll_offsets);
     context_state.async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    context_state.deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
-    context_state.has_deferred_async_scroll_present = true;
+    schedule_present_frame(context_id, context_state, async_scroll_viewport_rect);
     context_state.web_content_client->request_rendering_update();
     return true;
-}
-
-void CompositorState::present_deferred_async_scroll_frame(Web::Compositor::CompositorContextId context_id)
-{
-    auto* context = context_if_present(context_id);
-    if (!context || !context->has_deferred_async_scroll_present)
-        return;
-
-    auto viewport_rect = context->deferred_async_scroll_present_viewport_rect;
-    context->has_deferred_async_scroll_present = false;
-    present_frame(context_id, *context, viewport_rect);
 }
 
 bool CompositorState::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) const
@@ -486,8 +474,7 @@ bool CompositorState::should_defer_main_thread_present_for_async_scroll(Web::Com
     if (context->pending_async_scroll_offsets.is_empty())
         return false;
 
-    return context->has_deferred_async_scroll_present
-        || context->pending_present_frame.has_value()
+    return context->pending_present_frame.has_value()
         || context->gpu_present_bitmap_id_awaiting_completion.has_value()
         || context->presented_bitmap_id_awaiting_ack.has_value();
 }
@@ -531,13 +518,15 @@ void CompositorState::set_display_metadata(Web::Compositor::CompositorContextId 
 
     context->display_id = display_id;
     context->display_refresh_rate = refresh_rate;
+    if (context->pending_present_frame_scheduled)
+        schedule_pending_present_frame_on_vsync(context_id, *context);
 }
 
 void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    present_frame(context_id, *context, viewport_rect);
+    schedule_present_frame(context_id, *context, viewport_rect);
 }
 
 void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect viewport_rect)
@@ -584,15 +573,58 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
     schedule_gpu_completion_check();
 }
 
-void CompositorState::drain_pending_present_frame_if_unblocked(Web::Compositor::CompositorContextId context_id, ContextState& context)
+void CompositorState::schedule_present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect viewport_rect)
+{
+    context.pending_present_frame = viewport_rect;
+    schedule_pending_present_frame_on_vsync(context_id, context);
+}
+
+void CompositorState::schedule_pending_present_frame_on_vsync(Web::Compositor::CompositorContextId, ContextState& context)
+{
+    context.pending_present_frame_scheduled = true;
+    vsync_scheduler_for_display(context.display_id).schedule(context.display_refresh_rate);
+}
+
+void CompositorState::schedule_pending_present_frame_if_unblocked(Web::Compositor::CompositorContextId context_id, ContextState& context)
 {
     if (context.gpu_present_bitmap_id_awaiting_completion.has_value() || context.presented_bitmap_id_awaiting_ack.has_value())
         return;
     if (!context.pending_present_frame.has_value())
         return;
+    if (context.pending_present_frame_scheduled)
+        return;
 
-    auto pending_present_frame = context.pending_present_frame.release_value();
-    present_frame(context_id, context, pending_present_frame);
+    schedule_pending_present_frame_on_vsync(context_id, context);
+}
+
+VSyncScheduler& CompositorState::vsync_scheduler_for_display(Optional<u64> display_id)
+{
+    return *m_vsync_schedulers_by_display.ensure(display_id, [this, display_id] {
+        return create_vsync_scheduler(display_id, [this, display_id] {
+            present_pending_frames_on_vsync(display_id);
+        });
+    });
+}
+
+void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
+{
+    for (auto& context_entry : m_contexts) {
+        auto context_id = context_entry.key;
+        auto& context = *context_entry.value;
+        if (!context.pending_present_frame_scheduled)
+            continue;
+        if (context.display_id != display_id)
+            continue;
+
+        context.pending_present_frame_scheduled = false;
+        if (context.gpu_present_bitmap_id_awaiting_completion.has_value() || context.presented_bitmap_id_awaiting_ack.has_value())
+            continue;
+        if (!context.pending_present_frame.has_value())
+            continue;
+
+        auto pending_present_frame = context.pending_present_frame.release_value();
+        present_frame(context_id, context, pending_present_frame);
+    }
 }
 
 bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId context_id, Gfx::ShareableBitmap& target_bitmap)
@@ -620,7 +652,7 @@ void CompositorState::presented_bitmap_ready_to_paint(Web::Compositor::Composito
         return;
 
     context->presented_bitmap_id_awaiting_ack.clear();
-    drain_pending_present_frame_if_unblocked(context_id, *context);
+    schedule_pending_present_frame_if_unblocked(context_id, *context);
 }
 
 void CompositorState::did_finish_async_present(PendingAsyncPresent& pending_present)
@@ -659,7 +691,7 @@ void CompositorState::did_finish_async_present(PendingAsyncPresent& pending_pres
             publish_to_parent_surface(*context, mode);
         });
 
-    drain_pending_present_frame_if_unblocked(context_id, *context);
+    schedule_pending_present_frame_if_unblocked(context_id, *context);
 }
 
 void CompositorState::cancel_pending_async_presents_for_context(Web::Compositor::CompositorContextId context_id)
@@ -955,7 +987,7 @@ bool CompositorState::apply_viewport_scrollbar_drag(Web::Compositor::CompositorC
     auto async_scroll_viewport_rect = context.async_scrolling_viewport_rect;
     async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     context.async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    present_frame(context_id, context, async_scroll_viewport_rect);
+    schedule_present_frame(context_id, context, async_scroll_viewport_rect);
     VERIFY(context.web_content_client);
     context.web_content_client->request_rendering_update();
     return true;
@@ -965,7 +997,7 @@ void CompositorState::present_viewport_scrollbar_overlay(Web::Compositor::Compos
 {
     if (context.async_scrolling_viewport_rect.is_empty())
         return;
-    present_frame(context_id, context, context.async_scrolling_viewport_rect);
+    schedule_present_frame(context_id, context, context.async_scrolling_viewport_rect);
 }
 
 bool CompositorState::paint_viewport_scrollbar_overlay(ContextState& context, Gfx::PaintingSurface& surface)
@@ -1031,7 +1063,7 @@ void CompositorState::present_current_frame(Web::Compositor::CompositorContextId
         return;
     if (!context.presented_frame.has_value())
         return;
-    present_frame(context_id, context, *context.presented_frame);
+    schedule_present_frame(context_id, context, *context.presented_frame);
 }
 
 void CompositorState::publish_to_parent_surface(ContextState& context, Web::Compositor::PublishToCompositorSurface const& mode)

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -14,6 +14,7 @@
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
 #include <Compositor/BackingStoreManager.h>
+#include <Compositor/VSyncScheduler.h>
 #include <LibCore/Forward.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/Point.h>
@@ -88,7 +89,6 @@ public:
     bool dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
     bool async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta);
-    void present_deferred_async_scroll_frame(Web::Compositor::CompositorContextId);
     bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) const;
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
@@ -150,11 +150,10 @@ private:
         double display_refresh_rate { 60.0 };
 
         Optional<Gfx::IntRect> pending_present_frame;
+        bool pending_present_frame_scheduled { false };
         Optional<Gfx::IntRect> presented_frame;
         Optional<i32> gpu_present_bitmap_id_awaiting_completion;
         Optional<i32> presented_bitmap_id_awaiting_ack;
-        bool has_deferred_async_scroll_present { false };
-        Gfx::IntRect deferred_async_scroll_present_viewport_rect;
 
         void stop_backing_store_shrink_timer();
     };
@@ -195,9 +194,13 @@ private:
     void present_current_frame(Web::Compositor::CompositorContextId, ContextState&);
     void publish_to_parent_surface(ContextState&, Web::Compositor::PublishToCompositorSurface const&);
     void present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect);
+    void schedule_present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect);
+    void schedule_pending_present_frame_on_vsync(Web::Compositor::CompositorContextId, ContextState&);
+    void schedule_pending_present_frame_if_unblocked(Web::Compositor::CompositorContextId, ContextState&);
+    VSyncScheduler& vsync_scheduler_for_display(Optional<u64> display_id);
+    void present_pending_frames_on_vsync(Optional<u64> display_id);
     void publish_backing_stores(Web::Compositor::CompositorContextId, ContextState&, BackingStoreManager::Publication&&);
     void did_finish_async_present(PendingAsyncPresent&);
-    void drain_pending_present_frame_if_unblocked(Web::Compositor::CompositorContextId, ContextState&);
     void cancel_pending_async_presents_for_context(Web::Compositor::CompositorContextId);
     void schedule_gpu_completion_check();
     void check_gpu_completions();
@@ -206,6 +209,7 @@ private:
     DoublyLinkedList<PendingAsyncPresent> m_pending_async_presents;
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
     OwnPtr<Web::Painting::DisplayListPlayerSkia> m_display_list_player;
+    HashMap<Optional<u64>, OwnPtr<VSyncScheduler>> m_vsync_schedulers_by_display;
     RefPtr<Core::Timer> m_gpu_completion_timer;
     CompositorStateClient* m_client { nullptr };
     bool m_async_scrolling_enabled { true };

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -92,6 +92,7 @@ public:
     bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) const;
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
+    void set_display_metadata(Web::Compositor::CompositorContextId, Optional<u64> display_id, double refresh_rate);
     void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect);
     bool request_screenshot(Web::Compositor::CompositorContextId, Gfx::ShareableBitmap&);
     void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
@@ -145,6 +146,8 @@ private:
         Gfx::IntSize viewport_size;
         Web::Compositor::WindowResizingInProgress window_resize_in_progress { Web::Compositor::WindowResizingInProgress::No };
         RefPtr<Core::Timer> backing_store_shrink_timer;
+        Optional<u64> display_id;
+        double display_refresh_rate { 60.0 };
 
         Optional<Gfx::IntRect> pending_present_frame;
         Optional<Gfx::IntRect> presented_frame;

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -91,15 +91,7 @@ Messages::CompositorControlServer::DispatchMouseEventToWebContentResponse Connec
 
 Messages::CompositorControlServer::AsyncScrollByResponse ConnectionFromClient::async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
-    auto handled = m_compositor_state->async_scroll_by(context_id, position, delta_in_device_pixels);
-    if (handled) {
-        deferred_invoke([this, context_id] {
-            if (!is_open())
-                return;
-            m_compositor_state->present_deferred_async_scroll_frame(context_id);
-        });
-    }
-    return handled;
+    return m_compositor_state->async_scroll_by(context_id, position, delta_in_device_pixels);
 }
 
 void ConnectionFromClient::presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id)

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -74,6 +74,11 @@ void ConnectionFromClient::viewport_size_updated(Web::Compositor::CompositorCont
     m_compositor_state->viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
+void ConnectionFromClient::set_display_metadata(Web::Compositor::CompositorContextId context_id, Optional<u64> display_id, double refresh_rate)
+{
+    m_compositor_state->set_display_metadata(context_id, display_id, refresh_rate);
+}
+
 Messages::CompositorControlServer::HandleMouseEventResponse ConnectionFromClient::handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event)
 {
     return m_compositor_state->handle_mouse_event(context_id, event);

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -39,6 +39,7 @@ private:
     virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;
     virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration, i32 web_content_connection_id) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress) override;
+    virtual void set_display_metadata(Web::Compositor::CompositorContextId, Optional<u64>, double) override;
     virtual Messages::CompositorControlServer::HandleMouseEventResponse handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
     virtual Messages::CompositorControlServer::DispatchMouseEventToWebContentResponse dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
     virtual Messages::CompositorControlServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) override;

--- a/Services/Compositor/VSyncScheduler.cpp
+++ b/Services/Compositor/VSyncScheduler.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <AK/Math.h>
+#include <Compositor/VSyncScheduler.h>
+#include <LibCore/Timer.h>
+
+namespace Compositor {
+
+class TimerVSyncScheduler final : public VSyncScheduler {
+public:
+    explicit TimerVSyncScheduler(Function<void()>&& tick_callback)
+        : m_tick_callback(move(tick_callback))
+        , m_timer(Core::Timer::create_single_shot(fallback_interval_ms(), [this] {
+            fire();
+        }))
+    {
+    }
+
+    virtual ~TimerVSyncScheduler() override
+    {
+        m_timer->on_timeout = {};
+        m_timer->stop();
+    }
+
+    virtual void schedule(double refresh_rate) override
+    {
+        VERIFY(refresh_rate == refresh_rate);
+        VERIFY(refresh_rate > 0);
+        VERIFY(refresh_rate < AK::Infinity<double>);
+
+        m_refresh_rate = refresh_rate;
+        if (m_timer->is_active())
+            return;
+
+        m_timer->restart(fallback_interval_ms());
+    }
+
+private:
+    void fire()
+    {
+        m_tick_callback();
+    }
+
+    int fallback_interval_ms() const
+    {
+        auto interval = static_cast<int>((1000.0 / m_refresh_rate) + 0.5);
+        return interval > 0 ? interval : 1;
+    }
+
+    Function<void()> m_tick_callback;
+    double m_refresh_rate { 60.0 };
+    RefPtr<Core::Timer> m_timer;
+};
+
+OwnPtr<VSyncScheduler> create_vsync_scheduler(Optional<u64>, Function<void()>&& tick_callback)
+{
+    return make<TimerVSyncScheduler>(move(tick_callback));
+}
+
+}

--- a/Services/Compositor/VSyncScheduler.cpp
+++ b/Services/Compositor/VSyncScheduler.cpp
@@ -6,8 +6,19 @@
 
 #include <AK/Assertions.h>
 #include <AK/Math.h>
+#include <AK/Platform.h>
 #include <Compositor/VSyncScheduler.h>
 #include <LibCore/Timer.h>
+
+#if defined(AK_OS_MACOS)
+#    include <AK/Atomic.h>
+#    include <AK/AtomicRefCounted.h>
+#    include <AK/NonnullRefPtr.h>
+#    include <AK/RefPtr.h>
+#    include <CoreGraphics/CoreGraphics.h>
+#    include <CoreVideo/CoreVideo.h>
+#    include <LibCore/EventLoop.h>
+#endif
 
 namespace Compositor {
 
@@ -57,9 +68,216 @@ private:
     RefPtr<Core::Timer> m_timer;
 };
 
+#if defined(AK_OS_MACOS)
+
+static constexpr int display_link_idle_stop_delay_ms = 250;
+
+static CVReturn display_link_callback(CVDisplayLinkRef, CVTimeStamp const*, CVTimeStamp const*, CVOptionFlags, CVOptionFlags*, void* context);
+
+class DisplayLinkState final : public AtomicRefCounted<DisplayLinkState> {
+public:
+    static RefPtr<DisplayLinkState> create(u64 display_id, NonnullRefPtr<Core::WeakEventLoopReference> event_loop, Function<void()>&& tick_callback)
+    {
+        CVDisplayLinkRef display_link = nullptr;
+
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        auto result = CVDisplayLinkCreateWithCGDisplay(static_cast<CGDirectDisplayID>(display_id), &display_link);
+#    pragma clang diagnostic pop
+
+        if (result != kCVReturnSuccess || !display_link)
+            return nullptr;
+
+        auto state = adopt_ref(*new DisplayLinkState(move(event_loop), display_link));
+
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        result = CVDisplayLinkSetOutputCallback(display_link, display_link_callback, state.ptr());
+#    pragma clang diagnostic pop
+
+        if (result != kCVReturnSuccess)
+            return nullptr;
+
+        state->tick_callback = move(tick_callback);
+        return state;
+    }
+
+    ~DisplayLinkState()
+    {
+        stop_display_link();
+    }
+
+    bool request_tick();
+    void stop_display_link();
+    void schedule_display_link_stop_if_idle();
+    void stop_display_link_if_idle();
+    bool consume_tick_request();
+    bool is_valid() const;
+
+    NonnullRefPtr<Core::WeakEventLoopReference> event_loop;
+    Function<void()> tick_callback;
+    Atomic<bool> invalidated { false };
+    Atomic<bool> tick_requested { false };
+    CVDisplayLinkRef display_link { nullptr };
+    NonnullRefPtr<Core::Timer> idle_stop_timer;
+
+private:
+    DisplayLinkState(NonnullRefPtr<Core::WeakEventLoopReference> event_loop, CVDisplayLinkRef display_link)
+        : event_loop(move(event_loop))
+        , display_link(display_link)
+        , idle_stop_timer(Core::Timer::create_single_shot(display_link_idle_stop_delay_ms, [this] {
+            stop_display_link_if_idle();
+        }))
+    {
+    }
+};
+
+bool DisplayLinkState::request_tick()
+{
+    if (invalidated.load() || !display_link)
+        return false;
+
+    tick_requested.store(true);
+    idle_stop_timer->stop();
+
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    auto is_running = CVDisplayLinkIsRunning(display_link);
+#    pragma clang diagnostic pop
+
+    if (is_running)
+        return true;
+
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    auto result = CVDisplayLinkStart(display_link);
+#    pragma clang diagnostic pop
+
+    if (result == kCVReturnSuccess || result == kCVReturnDisplayLinkAlreadyRunning)
+        return true;
+
+    tick_requested.store(false);
+    return false;
+}
+
+void DisplayLinkState::stop_display_link()
+{
+    invalidated.store(true);
+    tick_requested.store(false);
+    idle_stop_timer->on_timeout = {};
+    idle_stop_timer->stop();
+
+    if (!display_link)
+        return;
+
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    CVDisplayLinkStop(display_link);
+#    pragma clang diagnostic pop
+    CVDisplayLinkRelease(display_link);
+    display_link = nullptr;
+}
+
+void DisplayLinkState::schedule_display_link_stop_if_idle()
+{
+    if (invalidated.load() || tick_requested.load() || !display_link)
+        return;
+
+    idle_stop_timer->restart(display_link_idle_stop_delay_ms);
+}
+
+void DisplayLinkState::stop_display_link_if_idle()
+{
+    if (invalidated.load() || tick_requested.load() || !display_link)
+        return;
+
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    CVDisplayLinkStop(display_link);
+#    pragma clang diagnostic pop
+}
+
+bool DisplayLinkState::consume_tick_request()
+{
+    if (invalidated.load())
+        return false;
+
+    if (!tick_requested.exchange(false))
+        return false;
+
+    return true;
+}
+
+bool DisplayLinkState::is_valid() const
+{
+    return !invalidated.load();
+}
+
+class CVDisplayLinkVSyncScheduler final : public VSyncScheduler {
+public:
+    static OwnPtr<CVDisplayLinkVSyncScheduler> try_create(u64 display_id, Function<void()>&& tick_callback)
+    {
+        auto state = DisplayLinkState::create(display_id, Core::EventLoop::current_weak(), move(tick_callback));
+        if (!state)
+            return nullptr;
+        return adopt_own(*new CVDisplayLinkVSyncScheduler(state.release_nonnull()));
+    }
+
+    explicit CVDisplayLinkVSyncScheduler(NonnullRefPtr<DisplayLinkState> state)
+        : m_state(move(state))
+    {
+    }
+
+    virtual ~CVDisplayLinkVSyncScheduler() override
+    {
+        m_state->stop_display_link();
+    }
+
+    virtual void schedule(double) override
+    {
+        m_state->request_tick();
+    }
+
+private:
+    NonnullRefPtr<DisplayLinkState> m_state;
+};
+
+static CVReturn display_link_callback(CVDisplayLinkRef, CVTimeStamp const*, CVTimeStamp const*, CVOptionFlags, CVOptionFlags*, void* context)
+{
+    auto state = NonnullRefPtr { *static_cast<DisplayLinkState*>(context) };
+    if (!state->consume_tick_request())
+        return kCVReturnSuccess;
+
+    auto event_loop = state->event_loop->take();
+    if (!event_loop.is_alive())
+        return kCVReturnSuccess;
+
+    event_loop->deferred_invoke([state = move(state)] {
+        if (!state->is_valid())
+            return;
+        state->tick_callback();
+        state->schedule_display_link_stop_if_idle();
+    });
+    return kCVReturnSuccess;
+}
+
+OwnPtr<VSyncScheduler> create_vsync_scheduler(Optional<u64> display_id, Function<void()>&& tick_callback)
+{
+    if (display_id.has_value()) {
+        if (auto scheduler = CVDisplayLinkVSyncScheduler::try_create(*display_id, move(tick_callback)); scheduler)
+            return scheduler;
+    }
+
+    return make<TimerVSyncScheduler>(move(tick_callback));
+}
+
+#else
+
 OwnPtr<VSyncScheduler> create_vsync_scheduler(Optional<u64>, Function<void()>&& tick_callback)
 {
     return make<TimerVSyncScheduler>(move(tick_callback));
 }
+
+#endif
 
 }

--- a/Services/Compositor/VSyncScheduler.h
+++ b/Services/Compositor/VSyncScheduler.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Optional.h>
+#include <AK/OwnPtr.h>
+
+namespace Compositor {
+
+class VSyncScheduler {
+    AK_MAKE_NONCOPYABLE(VSyncScheduler);
+    AK_MAKE_NONMOVABLE(VSyncScheduler);
+
+public:
+    virtual ~VSyncScheduler() = default;
+
+    virtual void schedule(double refresh_rate) = 0;
+
+protected:
+    VSyncScheduler() = default;
+};
+
+OwnPtr<VSyncScheduler> create_vsync_scheduler(Optional<u64> display_id, Function<void()>&&);
+
+}

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -39,6 +39,18 @@ struct HideCursor {
     }
 };
 
+static Optional<u64> display_id_for_screen(NSScreen* screen)
+{
+    if (screen == nil)
+        return {};
+
+    NSNumber* screen_number = [[screen deviceDescription] objectForKey:@"NSScreenNumber"];
+    if (screen_number == nil)
+        return {};
+
+    return static_cast<u64>([screen_number unsignedLongLongValue]);
+}
+
 @interface LadybirdWebViewContentLayer : CALayer
 @end
 
@@ -131,8 +143,9 @@ struct HideCursor {
         // This returns device pixel ratio of the screen the window is opened in
         auto device_pixel_ratio = [[NSScreen mainScreen] backingScaleFactor];
         auto maximum_frames_per_second = [[NSScreen mainScreen] maximumFramesPerSecond];
+        auto display_id = display_id_for_screen([NSScreen mainScreen]);
 
-        m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, maximum_frames_per_second));
+        m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, maximum_frames_per_second, display_id));
         [self setWebViewCallbacks];
 
         self.page_context_menu = Ladybird::create_context_menu(self, [self view].page_context_menu());
@@ -203,7 +216,8 @@ struct HideCursor {
 
 - (void)handleDisplayRefreshRateChange
 {
-    m_web_view_bridge->set_maximum_frames_per_second([[[self window] screen] maximumFramesPerSecond]);
+    auto* screen = [[self window] screen];
+    m_web_view_bridge->set_display_metadata([screen maximumFramesPerSecond], display_id_for_screen(screen));
 }
 
 - (void)handleEnteredFullScreen

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -20,13 +20,14 @@ static T scale_for_device(T size, double device_pixel_ratio)
     return size.template to_type<double>().scaled(device_pixel_ratio).template to_type<int>();
 }
 
-ErrorOr<NonnullOwnPtr<WebViewBridge>> WebViewBridge::create(Vector<Web::DevicePixelRect> screen_rects, double device_pixel_ratio, u64 maximum_frames_per_second)
+ErrorOr<NonnullOwnPtr<WebViewBridge>> WebViewBridge::create(Vector<Web::DevicePixelRect> screen_rects, double device_pixel_ratio, u64 maximum_frames_per_second, Optional<u64> display_id)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) WebViewBridge(move(screen_rects), device_pixel_ratio, maximum_frames_per_second));
+    return adopt_nonnull_own_or_enomem(new (nothrow) WebViewBridge(move(screen_rects), device_pixel_ratio, maximum_frames_per_second, display_id));
 }
 
-WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, double device_pixel_ratio, u64 maximum_frames_per_second)
+WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, double device_pixel_ratio, u64 maximum_frames_per_second, Optional<u64> display_id)
     : m_screen_rects(move(screen_rects))
+    , m_display_id(display_id)
 {
     m_device_pixel_ratio = device_pixel_ratio;
     m_maximum_frames_per_second = static_cast<double>(maximum_frames_per_second);
@@ -54,10 +55,12 @@ void WebViewBridge::set_viewport_rect(Gfx::IntRect viewport_rect)
     handle_resize();
 }
 
-void WebViewBridge::set_maximum_frames_per_second(u64 maximum_frames_per_second)
+void WebViewBridge::set_display_metadata(u64 maximum_frames_per_second, Optional<u64> display_id)
 {
     m_maximum_frames_per_second = static_cast<double>(maximum_frames_per_second);
+    m_display_id = display_id;
     client().async_set_maximum_frames_per_second(m_client_state.page_index, maximum_frames_per_second);
+    update_compositor_display_metadata();
 }
 
 void WebViewBridge::exit_fullscreen()
@@ -141,6 +144,7 @@ void WebViewBridge::initialize_client(CreateNewClient create_new_client)
 {
     ViewImplementation::initialize_client(create_new_client);
     update_palette();
+    update_compositor_display_metadata();
 
     if (!m_screen_rects.is_empty()) {
         // FIXME: Update the screens again if they ever change.
@@ -154,6 +158,15 @@ void WebViewBridge::initialize_client_as_child(WebViewBridge& parent, u64 page_i
     m_client_state.page_index = page_index;
 
     initialize_client(CreateNewClient::No);
+}
+
+void WebViewBridge::update_compositor_display_metadata()
+{
+    if (!m_client_state.client)
+        return;
+
+    auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
+    WebView::Application::the().update_compositor_display_metadata(compositor_context_id, m_display_id, m_maximum_frames_per_second);
 }
 
 }

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.h
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
@@ -17,7 +18,7 @@ namespace Ladybird {
 
 class WebViewBridge final : public WebView::ViewImplementation {
 public:
-    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, double device_pixel_ratio, u64 maximum_frames_per_second);
+    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, double device_pixel_ratio, u64 maximum_frames_per_second, Optional<u64> display_id);
     virtual ~WebViewBridge() override;
 
     virtual void initialize_client(CreateNewClient = CreateNewClient::Yes) override;
@@ -29,7 +30,7 @@ public:
 
     void set_viewport_rect(Gfx::IntRect);
 
-    void set_maximum_frames_per_second(u64 maximum_frames_per_second);
+    void set_display_metadata(u64 maximum_frames_per_second, Optional<u64> display_id);
 
     void exit_fullscreen();
 
@@ -49,7 +50,9 @@ public:
     Function<void()> on_zoom_level_changed;
 
 private:
-    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, double device_pixel_ratio, u64 maximum_frames_per_second);
+    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, double device_pixel_ratio, u64 maximum_frames_per_second, Optional<u64> display_id);
+
+    void update_compositor_display_metadata();
 
     virtual void update_zoom() override;
     virtual Web::DevicePixelSize viewport_size() const override;
@@ -57,6 +60,7 @@ private:
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const override;
 
     Vector<Web::DevicePixelRect> m_screen_rects;
+    Optional<u64> m_display_id;
     Gfx::IntSize m_viewport_size;
 };
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashMap.h>
 #include <AK/RefPtr.h>
 #include <AK/StdLibExtras.h>
 #include <AK/TypeCasts.h>
@@ -61,6 +62,20 @@ static bool should_use_screen_signal_for_dpi_changes()
 #else
     return true;
 #endif
+}
+
+static Optional<u64> display_id_for_screen(QScreen* screen)
+{
+    if (!screen)
+        return {};
+
+    // Qt does not expose a portable physical display identifier. The compositor only
+    // needs a stable per-process grouping key for Qt-backed windows.
+    static u64 next_display_id = 1;
+    static HashMap<QScreen*, u64> display_ids;
+    return display_ids.ensure(screen, [] {
+        return next_display_id++;
+    });
 }
 
 static QString reopen_recently_closed_action_text(Optional<WebView::RecentlyClosedEntry const&> entry)
@@ -215,6 +230,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     // Listen for DPI changes
     m_device_pixel_ratio = devicePixelRatio();
     m_current_screen = screen();
+    m_display_id = display_id_for_screen(m_current_screen);
     if (m_current_screen)
         m_refresh_rate = m_current_screen->refreshRate();
 
@@ -583,7 +599,7 @@ void BrowserWindow::adopt_tab(Tab& tab, int index)
     tab_title_changed(index, tab.title());
 
     tab.view().set_device_pixel_ratio(m_device_pixel_ratio);
-    tab.view().set_maximum_frames_per_second(m_refresh_rate);
+    tab.view().set_display_metadata(m_display_id, m_refresh_rate);
 
     m_tabs_container->set_current_tab(&tab);
 }
@@ -769,16 +785,23 @@ void BrowserWindow::screen_changed(QScreen* screen)
     if (m_device_pixel_ratio != devicePixelRatio())
         device_pixel_ratio_changed(devicePixelRatio());
 
+    auto display_id = display_id_for_screen(m_current_screen);
     auto refresh_rate = m_current_screen ? m_current_screen->refreshRate() : m_refresh_rate;
-    if (m_refresh_rate != refresh_rate)
-        refresh_rate_changed(refresh_rate);
+    if (m_display_id != display_id || m_refresh_rate != refresh_rate)
+        display_metadata_changed(display_id, refresh_rate);
 }
 
 void BrowserWindow::refresh_rate_changed(qreal refresh_rate)
 {
+    display_metadata_changed(m_display_id, refresh_rate);
+}
+
+void BrowserWindow::display_metadata_changed(Optional<u64> display_id, qreal refresh_rate)
+{
+    m_display_id = display_id;
     m_refresh_rate = refresh_rate;
     for_each_tab([this](auto& tab) {
-        tab.view().set_maximum_frames_per_second(m_refresh_rate);
+        tab.view().set_display_metadata(m_display_id, m_refresh_rate);
     });
 }
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -36,6 +36,7 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QMouseEvent>
+#include <QPlatformSurfaceEvent>
 #include <QPropertyAnimation>
 #include <QPushButton>
 #include <QScreen>
@@ -52,6 +53,15 @@ namespace Ladybird {
 
 static constexpr auto AUDIO_STATE_BUTTON_POSITION = QTabBar::LeftSide;
 static constexpr auto TAB_CLOSE_BUTTON_POSITION = QTabBar::RightSide;
+
+static bool should_use_screen_signal_for_dpi_changes()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    return QGuiApplication::platformName() != "wayland";
+#else
+    return true;
+#endif
+}
 
 static QString reopen_recently_closed_action_text(Optional<WebView::RecentlyClosedEntry const&> entry)
 {
@@ -205,28 +215,15 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     // Listen for DPI changes
     m_device_pixel_ratio = devicePixelRatio();
     m_current_screen = screen();
-    m_refresh_rate = m_current_screen->refreshRate();
+    if (m_current_screen)
+        m_refresh_rate = m_current_screen->refreshRate();
 
-    if (QT_VERSION < QT_VERSION_CHECK(6, 6, 0) || QGuiApplication::platformName() != "wayland") {
+    if (should_use_screen_signal_for_dpi_changes()) {
         setAttribute(Qt::WA_NativeWindow);
         setAttribute(Qt::WA_DontCreateNativeAncestors);
-        QObject::connect(m_current_screen, &QScreen::logicalDotsPerInchChanged, this, &BrowserWindow::device_pixel_ratio_changed);
-        QObject::connect(m_current_screen, &QScreen::refreshRateChanged, this, &BrowserWindow::refresh_rate_changed);
-        QObject::connect(windowHandle(), &QWindow::screenChanged, this, [this](QScreen* screen) {
-            if (m_device_pixel_ratio != devicePixelRatio())
-                device_pixel_ratio_changed(devicePixelRatio());
-
-            if (m_refresh_rate != screen->refreshRate())
-                refresh_rate_changed(screen->refreshRate());
-
-            // Listen for logicalDotsPerInchChanged and refreshRateChanged signals on new screen
-            QObject::disconnect(m_current_screen, &QScreen::logicalDotsPerInchChanged, nullptr, nullptr);
-            QObject::disconnect(m_current_screen, &QScreen::refreshRateChanged, nullptr, nullptr);
-            m_current_screen = screen;
-            QObject::connect(m_current_screen, &QScreen::logicalDotsPerInchChanged, this, &BrowserWindow::device_pixel_ratio_changed);
-            QObject::connect(m_current_screen, &QScreen::refreshRateChanged, this, &BrowserWindow::refresh_rate_changed);
-        });
     }
+    connect_screen_signals(m_current_screen);
+    connect_window_screen_changed_signal();
 
     m_hamburger_menu = new QMenu(this);
 
@@ -715,6 +712,68 @@ void BrowserWindow::device_pixel_ratio_changed(qreal dpi)
     });
 }
 
+bool BrowserWindow::connect_window_screen_changed_signal()
+{
+    auto* window = windowHandle();
+    if (!window)
+        return false;
+    if (m_window_screen_changed_signal_window == window)
+        return true;
+
+    disconnect_window_screen_changed_signal();
+
+    m_window_screen_changed_signal_window = window;
+    QObject::connect(window, &QWindow::screenChanged, this, [this](QScreen* screen) {
+        screen_changed(screen);
+    });
+    screen_changed(window->screen());
+    return true;
+}
+
+void BrowserWindow::disconnect_window_screen_changed_signal()
+{
+    if (!m_window_screen_changed_signal_window)
+        return;
+
+    QObject::disconnect(m_window_screen_changed_signal_window, &QWindow::screenChanged, this, nullptr);
+    m_window_screen_changed_signal_window = nullptr;
+}
+
+void BrowserWindow::connect_screen_signals(QScreen* screen)
+{
+    if (!screen)
+        return;
+
+    if (should_use_screen_signal_for_dpi_changes())
+        QObject::connect(screen, &QScreen::logicalDotsPerInchChanged, this, &BrowserWindow::device_pixel_ratio_changed);
+    QObject::connect(screen, &QScreen::refreshRateChanged, this, &BrowserWindow::refresh_rate_changed);
+}
+
+void BrowserWindow::disconnect_screen_signals(QScreen* screen)
+{
+    if (!screen)
+        return;
+
+    QObject::disconnect(screen, &QScreen::logicalDotsPerInchChanged, this, &BrowserWindow::device_pixel_ratio_changed);
+    QObject::disconnect(screen, &QScreen::refreshRateChanged, this, &BrowserWindow::refresh_rate_changed);
+}
+
+void BrowserWindow::screen_changed(QScreen* screen)
+{
+    if (m_current_screen != screen) {
+        disconnect_screen_signals(m_current_screen);
+        m_current_screen = screen;
+        connect_screen_signals(m_current_screen);
+    }
+
+    if (m_device_pixel_ratio != devicePixelRatio())
+        device_pixel_ratio_changed(devicePixelRatio());
+
+    auto refresh_rate = m_current_screen ? m_current_screen->refreshRate() : m_refresh_rate;
+    if (m_refresh_rate != refresh_rate)
+        refresh_rate_changed(refresh_rate);
+}
+
 void BrowserWindow::refresh_rate_changed(qreal refresh_rate)
 {
     m_refresh_rate = refresh_rate;
@@ -976,6 +1035,17 @@ bool BrowserWindow::event(QEvent* event)
             device_pixel_ratio_changed(devicePixelRatio());
     }
 #endif
+    if (event->type() == QEvent::WinIdChange)
+        connect_window_screen_changed_signal();
+    if (event->type() == QEvent::PlatformSurface) {
+        auto* platform_surface_event = static_cast<QPlatformSurfaceEvent*>(event);
+        if (platform_surface_event->surfaceEventType() == QPlatformSurfaceEvent::SurfaceCreated)
+            connect_window_screen_changed_signal();
+        else if (platform_surface_event->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed)
+            disconnect_window_screen_changed_signal();
+    }
+    if (event->type() == QEvent::ScreenChangeInternal)
+        screen_changed(screen());
 
     if (event->type() == QEvent::WindowActivate)
         Application::the().set_active_window(*this);

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -19,6 +19,7 @@
 #include <QTabBar>
 
 class QPropertyAnimation;
+class QWindow;
 class QToolButton;
 class QWidget;
 
@@ -172,11 +173,17 @@ private:
     void update_menu_bar_window_control_icons();
     void toggle_window_maximized();
     bool start_window_move();
+    bool connect_window_screen_changed_signal();
+    void disconnect_window_screen_changed_signal();
+    void connect_screen_signals(QScreen*);
+    void disconnect_screen_signals(QScreen*);
+    void screen_changed(QScreen*);
 
     QIcon icon_for_page_mute_state(Tab&) const;
     QString tool_tip_for_page_mute_state(Tab&) const;
 
     QScreen* m_current_screen { nullptr };
+    QWindow* m_window_screen_changed_signal_window { nullptr };
     double m_device_pixel_ratio { 0 };
     double m_refresh_rate { 60.0 };
 

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/Forward.h>
@@ -113,6 +114,7 @@ public:
     void adopt_tab(Tab&, int index);
 
     double refresh_rate() const { return m_refresh_rate; }
+    Optional<u64> display_id() const { return m_display_id; }
 
     void on_devtools_enabled();
     void on_devtools_disabled();
@@ -178,12 +180,14 @@ private:
     void connect_screen_signals(QScreen*);
     void disconnect_screen_signals(QScreen*);
     void screen_changed(QScreen*);
+    void display_metadata_changed(Optional<u64> display_id, qreal refresh_rate);
 
     QIcon icon_for_page_mute_state(Tab&) const;
     QString tool_tip_for_page_mute_state(Tab&) const;
 
     QScreen* m_current_screen { nullptr };
     QWindow* m_window_screen_changed_signal_window { nullptr };
+    Optional<u64> m_display_id;
     double m_device_pixel_ratio { 0 };
     double m_refresh_rate { 60.0 };
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -96,6 +96,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     auto view_initial_state = WebContentViewInitialState {
         .maximum_frames_per_second = window->refresh_rate(),
+        .display_id = window->display_id(),
     };
 
     m_view = new WebContentView(this, parent_client, page_index, AK::move(view_initial_state));

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -66,6 +66,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
 
     m_device_pixel_ratio = devicePixelRatio();
     m_maximum_frames_per_second = initial_state.maximum_frames_per_second;
+    m_display_id = initial_state.display_id;
     set_page_background_color_to_system_canvas(is_using_dark_system_theme(*this));
 
     QObject::connect(qGuiApp, &QGuiApplication::screenRemoved, [this](QScreen*) {
@@ -612,8 +613,24 @@ void WebContentView::set_zoom_level(double zoom_level)
 
 void WebContentView::set_maximum_frames_per_second(double maximum_frames_per_second)
 {
+    set_display_metadata(m_display_id, maximum_frames_per_second);
+}
+
+void WebContentView::set_display_metadata(Optional<u64> display_id, double maximum_frames_per_second)
+{
+    m_display_id = display_id;
     m_maximum_frames_per_second = maximum_frames_per_second;
     client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
+    update_compositor_display_metadata();
+}
+
+void WebContentView::update_compositor_display_metadata()
+{
+    if (!m_client_state.client)
+        return;
+
+    auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
+    WebView::Application::the().update_compositor_display_metadata(compositor_context_id, m_display_id, m_maximum_frames_per_second);
 }
 
 void WebContentView::update_viewport_size()
@@ -706,6 +723,7 @@ void WebContentView::initialize_client(WebView::ViewImplementation::CreateNewCli
 {
     ViewImplementation::initialize_client(create_new_client);
 
+    update_compositor_display_metadata();
     update_palette();
     update_screen_rects();
 }

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -9,6 +9,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/Function.h>
+#include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Cursor.h>
 #include <LibGfx/Forward.h>
@@ -29,6 +30,7 @@ namespace Ladybird {
 
 struct WebContentViewInitialState {
     double maximum_frames_per_second { 60.0 };
+    Optional<u64> display_id;
 };
 
 class WebContentView final
@@ -65,6 +67,7 @@ public:
     void set_device_pixel_ratio(double);
     void set_zoom_level(double);
     void set_maximum_frames_per_second(double);
+    void set_display_metadata(Optional<u64> display_id, double maximum_frames_per_second);
 
     enum class PaletteMode {
         Default,
@@ -92,6 +95,7 @@ private:
 
     void update_viewport_size();
     void update_cursor(Gfx::Cursor cursor);
+    void update_compositor_display_metadata();
 
     void enqueue_native_event(Web::MouseEvent::Type, QSinglePointEvent const& event);
 
@@ -114,6 +118,7 @@ private:
     int m_click_count { 0 };
 
     QMenu* m_select_dropdown { nullptr };
+    Optional<u64> m_display_id;
 };
 
 }


### PR DESCRIPTION
- Avoid repainting faster than frames can be displayed by queueing compositor presents behind a vsync scheduler instead of presenting immediately.
- Correctly detect and propagate high-refresh-rate display metadata in Qt, including after a window moves between screens.
- Use CVDisplayLink for macOS compositor vsync when a concrete display ID is available, with timer fallback for unsupported cases.