### PR TITLE
LibWeb+LibJS: Remove some more use of GC::Root

### DIFF
--- a/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -159,7 +159,7 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_matrix(JS::VM& vm, Bindi
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrix-fromfloat32array
-WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float32_array(JS::VM& vm, GC::Root<JS::Float32Array> const& array)
+WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float32_array(JS::VM& vm, GC::Ref<JS::Float32Array> array)
 {
     auto& realm = *vm.current_realm();
     ReadonlySpan<float> elements = array->data();
@@ -180,7 +180,7 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float32_array(JS::VM& vm
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrix-fromfloat64array
-WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float64_array(JS::VM& vm, GC::Root<JS::Float64Array> const& array)
+WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float64_array(JS::VM& vm, GC::Ref<JS::Float64Array> array)
 {
     auto& realm = *vm.current_realm();
     ReadonlySpan<double> elements = array->data();

--- a/Libraries/LibWeb/Geometry/DOMMatrix.h
+++ b/Libraries/LibWeb/Geometry/DOMMatrix.h
@@ -29,8 +29,8 @@ public:
     virtual ~DOMMatrix() override;
 
     static WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> from_matrix(JS::VM&, Bindings::DOMMatrixInit other = {});
-    static WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> from_float32_array(JS::VM&, GC::Root<JS::Float32Array> const&);
-    static WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> from_float64_array(JS::VM&, GC::Root<JS::Float64Array> const&);
+    static WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> from_float32_array(JS::VM&, GC::Ref<JS::Float32Array>);
+    static WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> from_float64_array(JS::VM&, GC::Ref<JS::Float64Array>);
 
     void set_m11(double value);
     void set_m12(double value);

--- a/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -230,7 +230,7 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_matrix(J
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-fromfloat32array
-WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float32_array(JS::VM& vm, GC::Root<JS::Float32Array> const& array)
+WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float32_array(JS::VM& vm, GC::Ref<JS::Float32Array> array)
 {
     auto& realm = *vm.current_realm();
     ReadonlySpan<float> elements = array->data();
@@ -251,7 +251,7 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float32_
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-fromfloat64array
-WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float64_array(JS::VM& vm, GC::Root<JS::Float64Array> const& array)
+WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float64_array(JS::VM& vm, GC::Ref<JS::Float64Array> array)
 {
     auto& realm = *vm.current_realm();
     ReadonlySpan<double> elements = array->data();

--- a/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
+++ b/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
@@ -34,8 +34,8 @@ public:
     virtual ~DOMMatrixReadOnly() override;
 
     static WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> from_matrix(JS::VM&, Bindings::DOMMatrixInit& other);
-    static WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> from_float32_array(JS::VM&, GC::Root<JS::Float32Array> const&);
-    static WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> from_float64_array(JS::VM&, GC::Root<JS::Float64Array> const&);
+    static WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> from_float32_array(JS::VM&, GC::Ref<JS::Float32Array>);
+    static WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> from_float64_array(JS::VM&, GC::Ref<JS::Float64Array>);
 
     // https://drafts.fxtf.org/geometry/#dommatrix-attributes
     double m11() const { return m_matrix[0, 0]; }

--- a/Libraries/LibWeb/HTML/ElementInternals.cpp
+++ b/Libraries/LibWeb/HTML/ElementInternals.cpp
@@ -84,13 +84,13 @@ WebIDL::ExceptionOr<void> ElementInternals::set_form_value(ElementInternalsFormV
     // 6. Otherwise, set element's state to state.
     else {
         auto state_value = state.value().visit(
-            [](GC::Root<FileAPI::File> const& file) -> FormAssociatedElement::FACESubmissionValue {
+            [](GC::Ref<FileAPI::File> file) -> FormAssociatedElement::FACESubmissionValue {
                 return GC::Ref { *file };
             },
             [](String const& string) -> FormAssociatedElement::FACESubmissionValue {
                 return string;
             },
-            [](GC::Root<XHR::FormData> const& form_data) -> FormAssociatedElement::FACESubmissionValue {
+            [](GC::Ref<XHR::FormData> form_data) -> FormAssociatedElement::FACESubmissionValue {
                 return form_data->entry_list();
             },
             [](Empty const& empty) -> FormAssociatedElement::FACESubmissionValue {

--- a/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -316,7 +316,7 @@ ErrorOr<SerializedFormData> serialize_to_multipart_form_data(GC::ConservativeVec
         auto escaped_name = TRY(escape_line_feed_carriage_return_double_quote(normalized_name));
 
         TRY(entry.value.visit(
-            [&](GC::Root<FileAPI::File> const& file) -> ErrorOr<void> {
+            [&](GC::Ref<FileAPI::File> file) -> ErrorOr<void> {
                 // For filenames replace any 0x0A (LF) bytes with the byte sequence `%0A`, 0x0D (CR) with `%0D` and 0x22 (") with `%22`
                 auto escaped_filename = TRY(escape_line_feed_carriage_return_double_quote(file->name()));
                 // Add a `Content-Disposition` header with a `name` set to entry's name and `filename` set to entry's filename.

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -754,7 +754,7 @@ static ErrorOr<Vector<DOMURL::QueryParam>> convert_to_list_of_name_value_pairs(G
         // 2. If entry's value is a File object, then let value be entry's value's name. Otherwise, let value be entry's value.
         String value;
         entry.value.visit(
-            [&value](GC::Root<FileAPI::File> const& file) {
+            [&value](GC::Ref<FileAPI::File> file) {
                 value = file->name();
             },
             [&value](String const& string) {

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
@@ -324,7 +324,7 @@ WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size, AK:
 }
 
 // https://w3c.github.io/media-source/#dom-sourcebuffer-appendbuffer
-WebIDL::ExceptionOr<void> SourceBuffer::append_buffer(GC::Root<WebIDL::BufferSource> const& data)
+WebIDL::ExceptionOr<void> SourceBuffer::append_buffer(GC::Ref<WebIDL::BufferSource> data)
 {
     // 1. Run the prepare append algorithm.
     TRY(prepare_append(data->byte_length(), m_media_source->media_element_assigned_to()->playback_manager().current_time()));

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
@@ -50,7 +50,7 @@ public:
     void set_content_type(String const& type);
 
     // https://w3c.github.io/media-source/#addsourcebuffer-method
-    WebIDL::ExceptionOr<void> append_buffer(GC::Root<WebIDL::BufferSource> const&);
+    WebIDL::ExceptionOr<void> append_buffer(GC::Ref<WebIDL::BufferSource>);
 
     // https://w3c.github.io/media-source/#dom-sourcebuffer-abort
     WebIDL::ExceptionOr<void> abort();

--- a/Libraries/LibWeb/ServiceWorker/Cache.cpp
+++ b/Libraries/LibWeb/ServiceWorker/Cache.cpp
@@ -104,7 +104,7 @@ GC::Ref<WebIDL::Promise> Cache::match_all(Optional<Fetch::RequestInfo> request, 
     if (request.has_value()) {
         TRY(request->visit(
             // 1. If request is a Request object, then:
-            [&](GC::Root<Fetch::Request> const& request) -> ErrorOr<void, GC::Ref<WebIDL::Promise>> {
+            [&](GC::Ref<Fetch::Request> request) -> ErrorOr<void, GC::Ref<WebIDL::Promise>> {
                 // 1. Set r to request’s request.
                 inner_request = request->request();
 
@@ -415,7 +415,7 @@ GC::Ref<WebIDL::Promise> Cache::put(Fetch::RequestInfo request, GC::Ref<Fetch::R
 
     TRY(request.visit(
         // 2. If request is a Request object, then set innerRequest to request’s request.
-        [&](GC::Root<Fetch::Request> const& request) -> ErrorOr<void, GC::Ref<WebIDL::Promise>> {
+        [&](GC::Ref<Fetch::Request> request) -> ErrorOr<void, GC::Ref<WebIDL::Promise>> {
             inner_request = request->request();
             return {};
         },
@@ -545,7 +545,7 @@ GC::Ref<WebIDL::Promise> Cache::delete_(Fetch::RequestInfo request, Bindings::Ca
 
     TRY(request.visit(
         // 2. If request is a Request object, then:
-        [&](GC::Root<Fetch::Request> const& request) -> ErrorOr<void, GC::Ref<WebIDL::Promise>> {
+        [&](GC::Ref<Fetch::Request> request) -> ErrorOr<void, GC::Ref<WebIDL::Promise>> {
             // 1. Set r to request’s request.
             inner_request = request->request();
 
@@ -633,7 +633,7 @@ GC::Ref<WebIDL::Promise> Cache::keys(Optional<Fetch::RequestInfo> request, Bindi
     if (request.has_value()) {
         TRY(request->visit(
             // 1. If request is a Request object, then:
-            [&](GC::Root<Fetch::Request> const& request) -> ErrorOr<void, GC::Ref<WebIDL::Promise>> {
+            [&](GC::Ref<Fetch::Request> request) -> ErrorOr<void, GC::Ref<WebIDL::Promise>> {
                 // 1. Set r to request’s request.
                 inner_request = request->request();
 

--- a/Libraries/LibWeb/WebAudio/AnalyserNode.cpp
+++ b/Libraries/LibWeb/WebAudio/AnalyserNode.cpp
@@ -135,7 +135,7 @@ Vector<f32> AnalyserNode::current_frequency_data()
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloatfrequencydata
-WebIDL::ExceptionOr<void> AnalyserNode::get_float_frequency_data(GC::Root<JS::Float32Array> const& array)
+WebIDL::ExceptionOr<void> AnalyserNode::get_float_frequency_data(GC::Ref<JS::Float32Array> array)
 {
     // Write the current frequency data into array. If array has fewer elements than the frequencyBinCount,
     // the excess elements will be dropped. If array has more elements than the frequencyBinCount, the
@@ -156,7 +156,7 @@ WebIDL::ExceptionOr<void> AnalyserNode::get_float_frequency_data(GC::Root<JS::Fl
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytefrequencydata
-WebIDL::ExceptionOr<void> AnalyserNode::get_byte_frequency_data(GC::Root<JS::Uint8Array> const& array)
+WebIDL::ExceptionOr<void> AnalyserNode::get_byte_frequency_data(GC::Ref<JS::Uint8Array> array)
 {
     // FIXME: If another call to getByteFrequencyData() or getFloatFrequencyData() occurs within the same render
     // quantum as a previous call, the current frequency data is not updated with the same data. Instead,
@@ -198,7 +198,7 @@ WebIDL::ExceptionOr<void> AnalyserNode::get_byte_frequency_data(GC::Root<JS::Uin
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloattimedomaindata
-WebIDL::ExceptionOr<void> AnalyserNode::get_float_time_domain_data(GC::Root<JS::Float32Array> const& array)
+WebIDL::ExceptionOr<void> AnalyserNode::get_float_time_domain_data(GC::Ref<JS::Float32Array> array)
 {
     // Write the current time-domain data (waveform data) into array. If array has fewer elements than the
     // value of fftSize, the excess elements will be dropped. If array has more elements than the value of
@@ -216,7 +216,7 @@ WebIDL::ExceptionOr<void> AnalyserNode::get_float_time_domain_data(GC::Root<JS::
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytetimedomaindata
-WebIDL::ExceptionOr<void> AnalyserNode::get_byte_time_domain_data(GC::Root<JS::Uint8Array> const& array)
+WebIDL::ExceptionOr<void> AnalyserNode::get_byte_time_domain_data(GC::Ref<JS::Uint8Array> array)
 {
     // Write the current time-domain data (waveform data) into array. If array’s byte length is less than
     // fftSize, the excess elements will be dropped. If array’s byte length is greater than the fftSize,

--- a/Libraries/LibWeb/WebAudio/AnalyserNode.h
+++ b/Libraries/LibWeb/WebAudio/AnalyserNode.h
@@ -26,10 +26,10 @@ public:
     virtual WebIDL::UnsignedLong number_of_inputs() override { return 1; }
     virtual WebIDL::UnsignedLong number_of_outputs() override { return 1; }
 
-    WebIDL::ExceptionOr<void> get_float_frequency_data(GC::Root<JS::Float32Array> const&);
-    WebIDL::ExceptionOr<void> get_byte_frequency_data(GC::Root<JS::Uint8Array> const&);
-    WebIDL::ExceptionOr<void> get_float_time_domain_data(GC::Root<JS::Float32Array> const&);
-    WebIDL::ExceptionOr<void> get_byte_time_domain_data(GC::Root<JS::Uint8Array> const&);
+    WebIDL::ExceptionOr<void> get_float_frequency_data(GC::Ref<JS::Float32Array>);
+    WebIDL::ExceptionOr<void> get_byte_frequency_data(GC::Ref<JS::Uint8Array>);
+    WebIDL::ExceptionOr<void> get_float_time_domain_data(GC::Ref<JS::Float32Array>);
+    WebIDL::ExceptionOr<void> get_byte_time_domain_data(GC::Ref<JS::Uint8Array>);
 
     unsigned long fft_size() const { return m_fft_size; }
     unsigned long frequency_bin_count() const { return m_fft_size / 2; }

--- a/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
@@ -87,7 +87,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Float32Array>> AudioBuffer::get_channel_data(Web
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-copyfromchannel
-WebIDL::ExceptionOr<void> AudioBuffer::copy_from_channel(GC::Root<JS::Float32Array> const& destination, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset) const
+WebIDL::ExceptionOr<void> AudioBuffer::copy_from_channel(GC::Ref<JS::Float32Array> destination, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset) const
 {
     // The copyFromChannel() method copies the samples from the specified channel of the AudioBuffer to the destination array.
     //
@@ -113,7 +113,7 @@ WebIDL::ExceptionOr<void> AudioBuffer::copy_from_channel(GC::Root<JS::Float32Arr
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-copytochannel
-WebIDL::ExceptionOr<void> AudioBuffer::copy_to_channel(GC::Root<JS::Float32Array> const& source, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset)
+WebIDL::ExceptionOr<void> AudioBuffer::copy_to_channel(GC::Ref<JS::Float32Array> source, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset)
 {
     // The copyToChannel() method copies the samples to the specified channel of the AudioBuffer from the source array.
     //

--- a/Libraries/LibWeb/WebAudio/AudioBuffer.h
+++ b/Libraries/LibWeb/WebAudio/AudioBuffer.h
@@ -31,8 +31,8 @@ public:
     double duration() const;
     WebIDL::UnsignedLong number_of_channels() const;
     WebIDL::ExceptionOr<GC::Ref<JS::Float32Array>> get_channel_data(WebIDL::UnsignedLong channel) const;
-    WebIDL::ExceptionOr<void> copy_from_channel(GC::Root<JS::Float32Array> const&, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset = 0) const;
-    WebIDL::ExceptionOr<void> copy_to_channel(GC::Root<JS::Float32Array> const&, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset = 0);
+    WebIDL::ExceptionOr<void> copy_from_channel(GC::Ref<JS::Float32Array>, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset = 0) const;
+    WebIDL::ExceptionOr<void> copy_to_channel(GC::Ref<JS::Float32Array>, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset = 0);
 
 private:
     explicit AudioBuffer(JS::Realm&, Bindings::AudioBufferOptions const&);

--- a/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
+++ b/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
@@ -227,7 +227,7 @@ void BaseAudioContext::queue_control_message(ControlMessage message)
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-decodeaudiodata
-GC::Ref<WebIDL::Promise> BaseAudioContext::decode_audio_data(GC::Root<JS::ArrayBuffer> const& audio_data, GC::Ptr<WebIDL::CallbackType> success_callback, GC::Ptr<WebIDL::CallbackType> error_callback)
+GC::Ref<WebIDL::Promise> BaseAudioContext::decode_audio_data(GC::Ref<JS::ArrayBuffer> audio_data, GC::Ptr<WebIDL::CallbackType> success_callback, GC::Ptr<WebIDL::CallbackType> error_callback)
 {
     auto& realm = this->realm();
 
@@ -281,7 +281,7 @@ GC::Ref<WebIDL::Promise> BaseAudioContext::decode_audio_data(GC::Root<JS::ArrayB
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-decodeaudiodata
-void BaseAudioContext::queue_a_decoding_operation(GC::Ref<JS::PromiseCapability> promise, [[maybe_unused]] GC::Root<JS::ArrayBuffer> audio_data, GC::Ptr<WebIDL::CallbackType> success_callback, GC::Ptr<WebIDL::CallbackType> error_callback)
+void BaseAudioContext::queue_a_decoding_operation(GC::Ref<JS::PromiseCapability> promise, [[maybe_unused]] GC::Ref<JS::ArrayBuffer> audio_data, GC::Ptr<WebIDL::CallbackType> success_callback, GC::Ptr<WebIDL::CallbackType> error_callback)
 {
     auto& realm = this->realm();
 

--- a/Libraries/LibWeb/WebAudio/BaseAudioContext.h
+++ b/Libraries/LibWeb/WebAudio/BaseAudioContext.h
@@ -89,7 +89,7 @@ public:
         WebIDL::UnsignedLong number_of_output_channels);
     WebIDL::ExceptionOr<GC::Ref<StereoPannerNode>> create_stereo_panner();
 
-    GC::Ref<WebIDL::Promise> decode_audio_data(GC::Root<JS::ArrayBuffer> const&, GC::Ptr<WebIDL::CallbackType>, GC::Ptr<WebIDL::CallbackType>);
+    GC::Ref<WebIDL::Promise> decode_audio_data(GC::Ref<JS::ArrayBuffer>, GC::Ptr<WebIDL::CallbackType>, GC::Ptr<WebIDL::CallbackType>);
 
     void queue_control_message(ControlMessage);
 
@@ -110,7 +110,7 @@ private:
     // https://webaudio.github.io/web-audio-api/#render-quantum-size
     static constexpr WebIDL::UnsignedLong s_render_quantum_size { 128 };
 
-    void queue_a_decoding_operation(GC::Ref<JS::PromiseCapability>, GC::Root<JS::ArrayBuffer>, GC::Ptr<WebIDL::CallbackType>, GC::Ptr<WebIDL::CallbackType>);
+    void queue_a_decoding_operation(GC::Ref<JS::PromiseCapability>, GC::Ref<JS::ArrayBuffer>, GC::Ptr<WebIDL::CallbackType>, GC::Ptr<WebIDL::CallbackType>);
 
     u64 m_next_node_id { 0 };
 

--- a/Libraries/LibWeb/WebAudio/BiquadFilterNode.cpp
+++ b/Libraries/LibWeb/WebAudio/BiquadFilterNode.cpp
@@ -66,7 +66,7 @@ GC::Ref<AudioParam> BiquadFilterNode::gain() const
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-getfrequencyresponse
-WebIDL::ExceptionOr<void> BiquadFilterNode::get_frequency_response(GC::Root<JS::Float32Array> const& frequency_hz, GC::Root<JS::Float32Array> const& mag_response, GC::Root<JS::Float32Array> const& phase_response)
+WebIDL::ExceptionOr<void> BiquadFilterNode::get_frequency_response(GC::Ref<JS::Float32Array> frequency_hz, GC::Ref<JS::Float32Array> mag_response, GC::Ref<JS::Float32Array> phase_response)
 {
     (void)frequency_hz;
     (void)mag_response;

--- a/Libraries/LibWeb/WebAudio/BiquadFilterNode.h
+++ b/Libraries/LibWeb/WebAudio/BiquadFilterNode.h
@@ -29,7 +29,7 @@ public:
     GC::Ref<AudioParam> detune() const;
     GC::Ref<AudioParam> q() const;
     GC::Ref<AudioParam> gain() const;
-    WebIDL::ExceptionOr<void> get_frequency_response(GC::Root<JS::Float32Array> const&, GC::Root<JS::Float32Array> const&, GC::Root<JS::Float32Array> const&);
+    WebIDL::ExceptionOr<void> get_frequency_response(GC::Ref<JS::Float32Array>, GC::Ref<JS::Float32Array>, GC::Ref<JS::Float32Array>);
 
     static WebIDL::ExceptionOr<GC::Ref<BiquadFilterNode>> create(JS::Realm&, GC::Ref<BaseAudioContext>, Bindings::BiquadFilterOptions const& = {});
     static WebIDL::ExceptionOr<GC::Ref<BiquadFilterNode>> construct_impl(JS::Realm&, GC::Ref<BaseAudioContext>, Bindings::BiquadFilterOptions const& = {});

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -266,25 +266,25 @@ Optional<Gfx::BitmapExportResult> WebGLRenderingContextBase::read_and_pixel_conv
     //        a SECURITY_ERR exception must be thrown. See Origin Restrictions.
     // FIXME: If source is null then an INVALID_VALUE error is generated.
     auto frame = source.visit(
-        [](GC::Root<HTML::HTMLImageElement> const& source) -> Optional<Gfx::DecodedImageFrame> {
+        [](GC::Ref<HTML::HTMLImageElement> source) -> Optional<Gfx::DecodedImageFrame> {
             return source->current_image_frame();
         },
-        [](GC::Root<HTML::HTMLCanvasElement> const& source) -> Optional<Gfx::DecodedImageFrame> {
+        [](GC::Ref<HTML::HTMLCanvasElement> source) -> Optional<Gfx::DecodedImageFrame> {
             auto surface = source->surface();
             if (!surface)
                 return Gfx::DecodedImageFrame { *source->get_bitmap_from_surface() };
             return Gfx::DecodedImageFrame { *surface->snapshot_bitmap() };
         },
-        [](GC::Root<HTML::OffscreenCanvas> const& source) -> Optional<Gfx::DecodedImageFrame> {
+        [](GC::Ref<HTML::OffscreenCanvas> source) -> Optional<Gfx::DecodedImageFrame> {
             return Gfx::DecodedImageFrame { *source->bitmap() };
         },
-        [](GC::Root<HTML::HTMLVideoElement> const& source) -> Optional<Gfx::DecodedImageFrame> {
+        [](GC::Ref<HTML::HTMLVideoElement> source) -> Optional<Gfx::DecodedImageFrame> {
             return source->current_decoded_image_frame();
         },
-        [](GC::Root<HTML::ImageBitmap> const& source) -> Optional<Gfx::DecodedImageFrame> {
+        [](GC::Ref<HTML::ImageBitmap> source) -> Optional<Gfx::DecodedImageFrame> {
             return Gfx::DecodedImageFrame { *source->bitmap() };
         },
-        [](GC::Root<HTML::ImageData> const& source) -> Optional<Gfx::DecodedImageFrame> {
+        [](GC::Ref<HTML::ImageData> source) -> Optional<Gfx::DecodedImageFrame> {
             return Gfx::DecodedImageFrame { source->bitmap() };
         });
     if (!frame.has_value())

--- a/Libraries/LibWeb/XHR/FormDataIterator.cpp
+++ b/Libraries/LibWeb/XHR/FormDataIterator.cpp
@@ -64,8 +64,8 @@ JS::Object* FormDataIterator::next()
         return create_iterator_result_object(vm, JS::PrimitiveString::create(vm, entry.name), false);
 
     auto entry_value = entry.value.visit(
-        [&](GC::Root<FileAPI::File> const& file) -> JS::Value {
-            return file.cell();
+        [&](GC::Ref<FileAPI::File> file) -> JS::Value {
+            return file;
         },
         [&](String const& string) -> JS::Value {
             return JS::PrimitiveString::create(vm, string);

--- a/Tests/LibJS/test-primitive-string.cpp
+++ b/Tests/LibJS/test-primitive-string.cpp
@@ -112,7 +112,7 @@ TEST_CASE(primitive_string_substring_reuses_cached_single_ascii_strings)
 {
     TestVM test_vm;
 
-    GC::Root<PrimitiveString> cached_b = PrimitiveString::create(*test_vm.vm, "b"_string);
+    auto cached_b = PrimitiveString::create(*test_vm.vm, "b"_string);
     auto string = PrimitiveString::create(*test_vm.vm, "abcd"_string);
     auto substring = PrimitiveString::create(*test_vm.vm, *string, 1, 1);
 
@@ -186,7 +186,7 @@ TEST_CASE(deferred_primitive_strings_do_not_evict_cached_strings)
 {
     TestVM test_vm;
 
-    GC::Root<PrimitiveString> cached_foo = PrimitiveString::create(*test_vm.vm, "foo"_string);
+    auto cached_foo = PrimitiveString::create(*test_vm.vm, "foo"_string);
 
     materialize_temporary_rope(*test_vm.vm);
     clobber_stack();


### PR DESCRIPTION
Continued tidy up from no longer emitting GC::Root in bindings. Now the main category of callers left are just things like `Vector<GC::Root<T>>`