### PR TITLE
LibWebView+UI: Hide the debug menu behind an option, and add an item to crash current page

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -285,13 +285,14 @@
             .config-name {
                 font-family: monospace;
                 font-size: 13px;
+
+                margin-top: 6px;
+
                 opacity: 0.7;
                 overflow-wrap: anywhere;
             }
 
             .config-title {
-                margin-top: 6px;
-
                 font-size: 14px;
             }
 

--- a/Base/res/ladybird/about-pages/settings/advanced.js
+++ b/Base/res/ladybird/about-pages/settings/advanced.js
@@ -68,13 +68,13 @@ function createRow(variable) {
     row.classList.add("inline-container");
     row.dataset.filterText = `${variable.name} ${variable.title} ${variable.description}`.toLowerCase();
 
-    const name = document.createElement("p");
-    name.classList.add("config-name");
-    name.textContent = variable.name;
-
     const title = document.createElement("p");
     title.classList.add("config-title");
     title.textContent = variable.title;
+
+    const name = document.createElement("p");
+    name.classList.add("config-name");
+    name.textContent = variable.name;
 
     const description = document.createElement("p");
     description.classList.add("description");
@@ -82,7 +82,7 @@ function createRow(variable) {
 
     const label = document.createElement("label");
     label.htmlFor = variable.name;
-    label.append(name, title, description);
+    label.append(title, name, description);
 
     row.append(label, createControl(variable));
     return row;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -88,6 +88,14 @@ struct ApplicationSettingsObserver final : public SettingsObserver {
                 Application::request_server_client().async_set_dns_server(dns_over_udp.server_address, dns_over_udp.port, false, dns_over_udp.validate_dnssec_locally);
             });
     }
+
+    virtual void config_variable_changed(ConfigVariableID variable) override
+    {
+        if (variable == ConfigVariableID::ShowAdvancedDebugMenu) {
+            auto enabled = Application::settings().config_variable_as_bool(ConfigVariableID::ShowAdvancedDebugMenu);
+            Application::the().debug_menu().set_visible(enabled);
+        }
+    }
 };
 
 struct ApplicationBookmarkStoreObserver final : public BookmarkStoreObserver {
@@ -1478,6 +1486,7 @@ void Application::initialize_actions()
     m_inspect_menu->add_action(*m_toggle_devtools_action);
 
     m_debug_menu = Menu::create("Debug"sv);
+    m_debug_menu->set_visible(m_settings.config_variable_as_bool(ConfigVariableID::ShowAdvancedDebugMenu));
     m_debug_menu->add_action(Action::create("Dump Session History Tree"sv, ActionID::DumpSessionHistoryTree, debug_request("dump-session-history"sv)));
     m_debug_menu->add_action(Action::create("Dump DOM Tree"sv, ActionID::DumpDOMTree, debug_request("dump-dom-tree"sv)));
     m_debug_menu->add_action(Action::create("Dump Layout Tree"sv, ActionID::DumpLayoutTree, debug_request("dump-layout-tree"sv)));

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1518,6 +1518,7 @@ void Application::initialize_actions()
     m_debug_menu->add_separator();
 
     m_debug_menu->add_action(Action::create("Collect Garbage"sv, ActionID::CollectGarbage, debug_request("collect-garbage"sv)));
+    m_debug_menu->add_action(Action::create("Crash Current Page"sv, ActionID::CrashCurrentPage, debug_request("crash-current-page"sv)));
     m_debug_menu->add_separator();
 
     auto spoof_user_agent_menu = Menu::create_group("Spoof User Agent"sv);

--- a/Libraries/LibWebView/Menu.cpp
+++ b/Libraries/LibWebView/Menu.cpp
@@ -134,4 +134,28 @@ void Menu::add_action(NonnullRefPtr<Action> action)
     m_items.append(move(action));
 }
 
+void Menu::set_visible(bool visible)
+{
+    if (m_visible == visible)
+        return;
+    m_visible = visible;
+
+    for (auto& observer : m_observers)
+        observer->on_visible_state_changed(*this);
+}
+
+void Menu::add_observer(NonnullOwnPtr<Observer> observer)
+{
+    observer->on_visible_state_changed(*this);
+
+    m_observers.append(move(observer));
+}
+
+void Menu::remove_observer(Observer const& observer)
+{
+    m_observers.remove_first_matching([&](auto const& candidate) {
+        return candidate.ptr() == &observer;
+    });
+}
+
 }

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -101,6 +101,7 @@ enum class ActionID {
     DumpWasmStats,
     ShowLineBoxBorders,
     CollectGarbage,
+    CrashCurrentPage,
     SpoofUserAgent,
     NavigatorCompatibilityMode,
     EnableScripting,

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -224,6 +224,9 @@ public:
     void set_render_group_icon(bool render_group_icon) { m_render_group_icon = render_group_icon; }
     bool render_group_icon() const { return m_render_group_icon; }
 
+    bool visible() const { return m_visible; }
+    void set_visible(bool);
+
     template<typename Callback>
     void for_each_action(Callback const& callback)
     {
@@ -234,6 +237,15 @@ public:
                 [&](Separator) {});
         }
     }
+
+    struct Observer {
+        virtual ~Observer() = default;
+
+        virtual void on_visible_state_changed(Menu&) { }
+    };
+
+    void add_observer(NonnullOwnPtr<Observer>);
+    void remove_observer(Observer const& observer);
 
     Function<void(Gfx::IntPoint)> on_activation;
 
@@ -247,9 +259,11 @@ private:
     Vector<MenuItem> m_items;
 
     HashMap<StringView, String> m_properties;
+    Vector<NonnullOwnPtr<Observer>, 1> m_observers;
 
     bool m_is_group { false };
     bool m_render_group_icon { false };
+    bool m_visible { true };
 };
 
 }

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -70,6 +70,14 @@ static Array<ConfigVariableDefinition, static_cast<size_t>(ConfigVariableID::Cou
         .array_element_type = {},
     },
     {
+        .id = ConfigVariableID::ShowAdvancedDebugMenu,
+        .name = "debug.ui.show_advanced_debug_menu"sv,
+        .title = "Show Advanced Debug Menu"sv,
+        .description = "Show the advanced Debug menu in the application menu."sv,
+        .default_value = false,
+        .array_element_type = {},
+    },
+    {
         .id = ConfigVariableID::ContentBlockerListPaths,
         .name = "content_blocking.list_paths"sv,
         .title = "Content blocker list paths"sv,

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -45,7 +45,9 @@ enum class GlobalPrivacyControl {
 
 enum class ConfigVariableID : u8 {
     ShowWebContentProcessIDInTabTitle,
+    ShowAdvancedDebugMenu,
     ContentBlockerListPaths,
+
     Count,
 };
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -449,6 +449,13 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
         return;
     }
 
+    if (request == "crash-current-page") {
+        Core::deferred_invoke([] {
+            VERIFY_NOT_REACHED();
+        });
+        return;
+    }
+
     if (request == "set-line-box-borders") {
         bool state = argument == "on";
         auto traversable = page->page().top_level_traversable();

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -339,35 +339,11 @@
     auto* menu = [[NSMenuItem alloc] init];
     auto* submenu = [[NSMenu alloc] initWithTitle:@"View"];
 
-    auto* zoom_menu = Ladybird::create_application_menu(WebView::Application::the().zoom_menu());
-    auto* zoom_menu_item = [[NSMenuItem alloc] initWithTitle:[zoom_menu title]
-                                                      action:nil
-                                               keyEquivalent:@""];
-    [zoom_menu_item setSubmenu:zoom_menu];
-
-    auto* color_scheme_menu = Ladybird::create_application_menu(WebView::Application::the().color_scheme_menu());
-    auto* color_scheme_menu_item = [[NSMenuItem alloc] initWithTitle:[color_scheme_menu title]
-                                                              action:nil
-                                                       keyEquivalent:@""];
-    [color_scheme_menu_item setSubmenu:color_scheme_menu];
-
-    auto* contrast_menu = Ladybird::create_application_menu(WebView::Application::the().contrast_menu());
-    auto* contrast_menu_item = [[NSMenuItem alloc] initWithTitle:[contrast_menu title]
-                                                          action:nil
-                                                   keyEquivalent:@""];
-    [contrast_menu_item setSubmenu:contrast_menu];
-
-    auto* motion_menu = Ladybird::create_application_menu(WebView::Application::the().motion_menu());
-    auto* motion_menu_item = [[NSMenuItem alloc] initWithTitle:[motion_menu title]
-                                                        action:nil
-                                                 keyEquivalent:@""];
-    [motion_menu_item setSubmenu:motion_menu];
-
-    [submenu addItem:zoom_menu_item];
+    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().zoom_menu())];
     [submenu addItem:[NSMenuItem separatorItem]];
-    [submenu addItem:color_scheme_menu_item];
-    [submenu addItem:contrast_menu_item];
-    [submenu addItem:motion_menu_item];
+    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().color_scheme_menu())];
+    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().contrast_menu())];
+    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().motion_menu())];
     [submenu addItem:[NSMenuItem separatorItem]];
 
     [menu setSubmenu:submenu];
@@ -394,32 +370,19 @@
 
 - (NSMenuItem*)createBookmarksMenu
 {
-    auto* menu = [[NSMenuItem alloc] init];
-
-    self.bookmarks_menu = Ladybird::create_application_menu(WebView::Application::the().bookmarks_menu());
-    [menu setSubmenu:self.bookmarks_menu];
-
+    auto* menu = Ladybird::create_application_menu_item(WebView::Application::the().bookmarks_menu());
+    self.bookmarks_menu = [menu submenu];
     return menu;
 }
 
 - (NSMenuItem*)createInspectMenu
 {
-    auto* menu = [[NSMenuItem alloc] init];
-
-    auto* submenu = Ladybird::create_application_menu(WebView::Application::the().inspect_menu());
-    [menu setSubmenu:submenu];
-
-    return menu;
+    return Ladybird::create_application_menu_item(WebView::Application::the().inspect_menu());
 }
 
 - (NSMenuItem*)createDebugMenu
 {
-    auto* menu = [[NSMenuItem alloc] init];
-
-    auto* submenu = Ladybird::create_application_menu(WebView::Application::the().debug_menu());
-    [menu setSubmenu:submenu];
-
-    return menu;
+    return Ladybird::create_application_menu_item(WebView::Application::the().debug_menu());
 }
 
 - (NSMenuItem*)createWindowMenu

--- a/UI/AppKit/Interface/BookmarksBar.mm
+++ b/UI/AppKit/Interface/BookmarksBar.mm
@@ -191,14 +191,7 @@ static Optional<WebView::Menu&> find_bookmark_folder_by_id(WebView::Menu& menu, 
                         [_overflow_menu addItem:Ladybird::create_application_menu_item(action)];
                     },
                     [&](NonnullRefPtr<WebView::Menu> const& folder) {
-                        auto* folder_item = [[NSMenuItem alloc] initWithTitle:Ladybird::string_to_ns_string(folder->title())
-                                                                       action:nil
-                                                                keyEquivalent:@""];
-
-                        auto* submenu = Ladybird::create_application_menu(folder);
-                        [folder_item setSubmenu:submenu];
-
-                        [_overflow_menu addItem:folder_item];
+                        [_overflow_menu addItem:Ladybird::create_application_menu_item(*folder)];
                     },
                     [](WebView::Separator) {});
             }

--- a/UI/AppKit/Interface/Menu.h
+++ b/UI/AppKit/Interface/Menu.h
@@ -21,6 +21,8 @@ void repopulate_application_menu(NSMenu*, WebView::Menu&);
 NSMenu* create_context_menu(LadybirdWebView*, WebView::Menu&);
 
 NSMenuItem* create_application_menu_item(WebView::Action&);
+NSMenuItem* create_application_menu_item(WebView::Menu&);
+
 NSButton* create_application_button(WebView::Action&);
 NSImageView* create_application_icon(WebView::Action&);
 

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -357,30 +357,18 @@ static void initialize_native_control(WebView::Action& action, id control)
     action.add_observer(move(observer));
 }
 
-static void add_items_to_menu(NSMenu* menu, Span<WebView::Menu::MenuItem> menu_items)
+static void add_items_to_menu(NSMenu* nsmenu, WebView::Menu& menu)
 {
-    for (auto& menu_item : menu_items) {
+    for (auto& menu_item : menu.items()) {
         menu_item.visit(
             [&](NonnullRefPtr<WebView::Action>& action) {
-                [menu addItem:create_application_menu_item(action)];
+                [nsmenu addItem:create_application_menu_item(action)];
             },
             [&](NonnullRefPtr<WebView::Menu> const& submenu) {
-                auto* application_submenu = [[NSMenu alloc] init];
-                set_properties(application_submenu, *submenu);
-                add_items_to_menu(application_submenu, submenu->items());
-
-                auto* item = [[NSMenuItem alloc] initWithTitle:string_to_ns_string(submenu->title())
-                                                        action:nil
-                                                 keyEquivalent:@""];
-                [item setSubmenu:application_submenu];
-
-                if (submenu->render_group_icon())
-                    set_control_image(item, @"folder");
-
-                [menu addItem:item];
+                [nsmenu addItem:create_application_menu_item(*submenu)];
             },
             [&](WebView::Separator) {
-                [menu addItem:[NSMenuItem separatorItem]];
+                [nsmenu addItem:[NSMenuItem separatorItem]];
             });
     }
 }
@@ -389,14 +377,14 @@ NSMenu* create_application_menu(WebView::Menu& menu)
 {
     auto* application_menu = [[NSMenu alloc] initWithTitle:string_to_ns_string(menu.title())];
     set_properties(application_menu, menu);
-    add_items_to_menu(application_menu, menu.items());
+    add_items_to_menu(application_menu, menu);
     return application_menu;
 }
 
 void repopulate_application_menu(NSMenu* menu, WebView::Menu& source)
 {
     [menu removeAllItems];
-    add_items_to_menu(menu, source.items());
+    add_items_to_menu(menu, source);
 }
 
 NSMenu* create_context_menu(LadybirdWebView* view, WebView::Menu& menu)
@@ -424,6 +412,19 @@ NSMenuItem* create_application_menu_item(WebView::Action& action)
     auto* item = [[NSMenuItem alloc] init];
     initialize_native_control(action, item);
     set_properties(item, action);
+    return item;
+}
+
+NSMenuItem* create_application_menu_item(WebView::Menu& menu)
+{
+    auto* item = [[NSMenuItem alloc] initWithTitle:string_to_ns_string(menu.title())
+                                            action:nil
+                                     keyEquivalent:@""];
+    [item setSubmenu:create_application_menu(menu)];
+
+    if (menu.render_group_icon())
+        set_control_image(item, @"folder");
+
     return item;
 }
 

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -187,6 +187,27 @@ private:
     __weak id m_control { nil };
 };
 
+class MenuObserver final : public WebView::Menu::Observer {
+public:
+    static NonnullOwnPtr<MenuObserver> create(NSMenuItem* item)
+    {
+        return adopt_own(*new MenuObserver(item));
+    }
+
+    virtual void on_visible_state_changed(WebView::Menu& menu) override
+    {
+        [m_item setHidden:!menu.visible()];
+    }
+
+private:
+    explicit MenuObserver(NSMenuItem* item)
+        : m_item(item)
+    {
+    }
+
+    __weak NSMenuItem* m_item { nil };
+};
+
 static void initialize_native_icon(WebView::Action& action, id control)
 {
     static constexpr CGFloat const MENU_ICON_SIZE = 16;
@@ -357,6 +378,21 @@ static void initialize_native_control(WebView::Action& action, id control)
     action.add_observer(move(observer));
 }
 
+static void initialize_native_menu(WebView::Menu& menu, NSMenuItem* item)
+{
+    auto observer = MenuObserver::create(item);
+
+    auto* guard = [[DeallocGuard alloc] init:[menu = menu.make_weak_ptr(), observer = observer.ptr()]() {
+        if (menu)
+            menu->remove_observer(*observer);
+    }];
+
+    static char guard_key = 0;
+    objc_setAssociatedObject(item, &guard_key, guard, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    menu.add_observer(move(observer));
+}
+
 static void add_items_to_menu(NSMenu* nsmenu, WebView::Menu& menu)
 {
     for (auto& menu_item : menu.items()) {
@@ -421,6 +457,7 @@ NSMenuItem* create_application_menu_item(WebView::Menu& menu)
                                             action:nil
                                      keyEquivalent:@""];
     [item setSubmenu:create_application_menu(menu)];
+    initialize_native_menu(menu, item);
 
     if (menu.render_group_icon())
         set_control_image(item, @"folder");

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -97,6 +97,28 @@ private:
     IncludeActionIcon m_include_action_icon { IncludeActionIcon::Yes };
 };
 
+class MenuObserver final : public WebView::Menu::Observer {
+public:
+    static NonnullOwnPtr<MenuObserver> create(QMenu& qmenu)
+    {
+        return adopt_own(*new MenuObserver(qmenu));
+    }
+
+    virtual void on_visible_state_changed(WebView::Menu& menu) override
+    {
+        if (m_menu && m_menu->menuAction())
+            m_menu->menuAction()->setVisible(menu.visible());
+    }
+
+private:
+    explicit MenuObserver(QMenu& qmenu)
+        : m_menu(&qmenu)
+    {
+    }
+
+    QPointer<QMenu> m_menu;
+};
+
 template<typename T>
 static void add_properties(QObject& object, T& menu_or_action)
 {
@@ -224,6 +246,7 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
 
 static void add_items_to_menu(QMenu& qmenu, QWidget& parent, WebView::Menu& menu)
 {
+    menu.add_observer(MenuObserver::create(qmenu));
     add_properties(qmenu, menu);
 
     for (auto& menu_item : menu.items()) {


### PR DESCRIPTION
As we approach an alpha release, it will generally make less sense to show all of the debug options in the application menu. Add a persistent setting to show this menu, disabled by default.

Then add a debug menu item to crash the current page. It's a strange one, but one I've found useful many times see what happens when we crash at various points.

[debug.webm](https://github.com/user-attachments/assets/828c8aba-abd8-490e-a516-24ca7ffc7248)


