### PR TITLE
LibWeb: Honor explicit first and last color stop positions in gradients

### DIFF
--- a/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -169,16 +169,19 @@ static ResolvedColorStopData resolve_color_stop_positions(Layout::NodeWithStyle 
             resolved_color_stops.append(resolved_stop);
     }
 
+    // https://drafts.csswg.org/css-images-3/#color-stop-fixup
     // 1. If the first color stop does not have a position, set its position to 0%.
-    resolved_color_stops.first().position = 0;
+    if (!color_stop_list.first().color_stop.position)
+        resolved_color_stops.first().position = 0;
     //    If the last color stop does not have a position, set its position to 100%
-    resolved_color_stops.last().position = 1.0f;
+    if (!color_stop_list.last().color_stop.second_position && !color_stop_list.last().color_stop.position)
+        resolved_color_stops.last().position = 1.0f;
 
     // 2. If a color stop or transition hint has a position that is less than the
     //    specified position of any color stop or transition hint before it in the list,
     //    set its position to be equal to the largest specified position of any color stop
     //    or transition hint before it.
-    auto max_previous_color_stop_or_hint = resolved_color_stops[0].position;
+    auto max_previous_color_stop_or_hint = -AK::Infinity<float>;
     auto resolve_stop_position = [&](CSS::StyleValue const& position) {
         float value = resolve_position_to_float(position);
         value = max(value, max_previous_color_stop_or_hint);

--- a/Tests/LibWeb/Ref/expected/css-gradient-negative-first-stop-ref.html
+++ b/Tests/LibWeb/Ref/expected/css-gradient-negative-first-stop-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<style>
+    div {
+        width: 200px;
+        height: 50px;
+        background: linear-gradient(to right, red 0, red 50px, green 50px, green 100px, red 100px, red 150px, green 150px, green 200px);
+    }
+</style>
+<div></div>
+</html>

--- a/Tests/LibWeb/Ref/input/css-gradient-negative-first-stop.html
+++ b/Tests/LibWeb/Ref/input/css-gradient-negative-first-stop.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<link rel="match" href="../expected/css-gradient-negative-first-stop-ref.html" />
+<style>
+    div {
+        width: 200px;
+        height: 50px;
+        background: repeating-linear-gradient(to right, green -25%, green 0%, red 0%, red 25%);
+    }
+</style>
+<div></div>
+</html>


### PR DESCRIPTION
When resolving the used positions of color stops, we were unconditionally overwriting the first position with 0% and the last position with 100%. We now only set these default values for color stops without an explicit position.

This fixes the gradient pattern from: https://css-pattern.com/rhombus-nested/.