### PR TITLE
LibWeb: Let range inputs stretch in grid containers

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -782,6 +782,7 @@ set(SOURCES
     Layout/NavigableContainerViewport.cpp
     Layout/Node.cpp
     Layout/RadioButton.cpp
+    Layout/RangeInputBox.cpp
     Layout/ReplacedBox.cpp
     Layout/ReplacedWithChildrenFormattingContext.cpp
     Layout/SVGBox.cpp

--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -74,7 +74,6 @@ option {
 /* Custom <input type="range"> styles */
 input[type=range] {
     display: inline-block;
-    width: 20ch;
     height: 16px;
 
     &::slider-track {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -53,6 +53,7 @@
 #include <LibWeb/Layout/CheckBox.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/RadioButton.h>
+#include <LibWeb/Layout/RangeInputBox.h>
 #include <LibWeb/Layout/TextInputBox.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/MimeSniff/Resource.h>
@@ -168,6 +169,8 @@ GC::Ptr<Layout::Node> HTMLInputElement::create_layout_node(GC::Ref<CSS::Computed
     case TypeAttributeState::Number:
         // FIXME: text padding issues
         return heap().allocate<Layout::TextInputBox>(document(), *this, move(style));
+    case TypeAttributeState::Range:
+        return heap().allocate<Layout::RangeInputBox>(document(), *this, move(style));
     default:
         return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
     }

--- a/Libraries/LibWeb/Layout/RangeInputBox.cpp
+++ b/Libraries/LibWeb/Layout/RangeInputBox.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Layout/RangeInputBox.h>
+
+namespace Web::Layout {
+
+GC_DEFINE_ALLOCATOR(RangeInputBox);
+
+RangeInputBox::RangeInputBox(DOM::Document& document, GC::Ptr<DOM::Element> element, GC::Ref<CSS::ComputedProperties> style)
+    : BlockContainer(document, element, move(style))
+{
+}
+
+CSS::SizeWithAspectRatio RangeInputBox::compute_auto_content_box_size() const
+{
+    // AD-HOC: A slider has no in-flow content to size itself from, so provide a default content-box size for when
+    //         its `width` or `height` is `auto`.
+    // NB: We only support horizontal sliders, so the default size is not adjusted for the writing mode.
+    auto width = CSS::Length(20, CSS::LengthUnit::Ch).to_px(*this);
+    auto height = CSS::Length(16, CSS::LengthUnit::Px).to_px(*this);
+    return { width, height, {} };
+}
+
+}

--- a/Libraries/LibWeb/Layout/RangeInputBox.h
+++ b/Libraries/LibWeb/Layout/RangeInputBox.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/Layout/BlockContainer.h>
+
+namespace Web::Layout {
+
+class RangeInputBox final : public BlockContainer {
+    GC_CELL(RangeInputBox, BlockContainer);
+    GC_DECLARE_ALLOCATOR(RangeInputBox);
+
+public:
+    RangeInputBox(DOM::Document&, GC::Ptr<DOM::Element>, GC::Ref<CSS::ComputedProperties>);
+
+    virtual ~RangeInputBox() override = default;
+
+private:
+    virtual CSS::SizeWithAspectRatio compute_auto_content_box_size() const override;
+    virtual bool has_auto_content_box_size() const override { return true; }
+};
+
+}

--- a/Tests/LibWeb/Layout/expected/input-range-stretch-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/input-range-stretch-in-grid.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 39 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 23 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 400 0+0+384] [0+0+0 23 0+0+0] [GFC] children: not-inline
+        BlockContainer <span> at [8,8] [0+0+0 53.3125 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 53.3125x23] baseline: 17.5
+              "Label"
+          TextNode <#text> (not painted)
+        RangeInputBox <input> at [61.3125,8] [0+0+0 346.6875 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+          BlockContainer <div> at [62.3125,15] positioned [0+1+0 346.6875 0+1+-2] [6+1+0 4 0+1+0] children: not-inline
+            BlockContainer <div> at [62.3125,15] positioned [0+0+0 173.34375 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
+            BlockContainer <div> at [235.65625,9] [173.34375+0+0 16 0+0+157.34375] [-6+0+0 16 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,31] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
+      PaintableBox (Box<DIV>.grid) [8,8 400x23]
+        PaintableWithLines (BlockContainer<SPAN>) [8,8 53.3125x23]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (RangeInputBox<INPUT>) [61.3125,8 346.6875x16]
+          PaintableWithLines (BlockContainer<DIV>) [61.3125,14 348.6875x6]
+            PaintableWithLines (BlockContainer<DIV>) [62.3125,15 173.34375x4]
+            PaintableWithLines (BlockContainer<DIV>) [235.65625,9 16x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,31 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x39] [children: 1] (z-index: auto)
+  SC for BlockContainer<DIV> [235.65625,9 16x16] [children: 0] (z-index: auto), has_transform

--- a/Tests/LibWeb/Layout/expected/input-range.txt
+++ b/Tests/LibWeb/Layout/expected/input-range.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 39 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 23 0+0+8] children: inline
-      frag 0 from BlockContainer start: 0, length: 0, rect: [8,9 200x16] baseline: 16
-      frag 1 from BlockContainer start: 0, length: 0, rect: [208,9 200x16] baseline: 16
-      BlockContainer <input> at [8,9] inline-block [0+0+0 200 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+      frag 0 from RangeInputBox start: 0, length: 0, rect: [8,9 200x16] baseline: 16
+      frag 1 from RangeInputBox start: 0, length: 0, rect: [208,9 200x16] baseline: 16
+      RangeInputBox <input> at [8,9] inline-block [0+0+0 200 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
         BlockContainer <div> at [9,16] positioned [0+1+0 200 0+1+-2] [6+1+0 4 0+1+0] children: not-inline
           BlockContainer <div> at [9,16] positioned [0+0+0 100 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
           BlockContainer <div> at [109,10] [100+0+0 16 0+0+84] [-6+0+0 16 0+0+0] children: not-inline
-      BlockContainer <input> at [208,9] inline-block [0+0+0 200 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+      RangeInputBox <input> at [208,9] inline-block [0+0+0 200 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
         BlockContainer <div> at [209,16] positioned [0+1+0 200 0+1+-2] [6+1+0 4 0+1+0] children: not-inline
           BlockContainer <div> at [209,16] positioned [0+0+0 20 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
           BlockContainer <div> at [229,10] [20+0+0 16 0+0+164] [-6+0+0 16 0+0+0] children: not-inline
@@ -16,11 +16,11 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x39]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
-      PaintableWithLines (BlockContainer<INPUT>) [8,9 200x16]
+      PaintableWithLines (RangeInputBox<INPUT>) [8,9 200x16]
         PaintableWithLines (BlockContainer<DIV>) [8,15 202x6]
           PaintableWithLines (BlockContainer<DIV>) [9,16 100x4]
           PaintableWithLines (BlockContainer<DIV>) [109,10 16x16]
-      PaintableWithLines (BlockContainer<INPUT>) [208,9 200x16]
+      PaintableWithLines (RangeInputBox<INPUT>) [208,9 200x16]
         PaintableWithLines (BlockContainer<DIV>) [208,15 202x6]
           PaintableWithLines (BlockContainer<DIV>) [209,16 20x4]
           PaintableWithLines (BlockContainer<DIV>) [229,10 16x16]

--- a/Tests/LibWeb/Layout/input/input-range-stretch-in-grid.html
+++ b/Tests/LibWeb/Layout/input/input-range-stretch-in-grid.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><html><head><style>
+* {
+    font: 20px 'SerenitySans';
+}
+.grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    width: 400px;
+}
+</style></head><body><div class="grid"><span>Label</span><input type="range" min="0" max="100" value="50"></div>


### PR DESCRIPTION
Previously, the UA stylesheet gave range inputs a definite `width: 20ch`. This prevented range inputs from filling their grid track. We now source the default width and height from a new `RangeInputBox` type. This approach matches the implementation of other input types.

Here's an example from https://css-pattern.com/cubes-illusion/:

Before:

<img width="828" height="503" alt="image" src="https://github.com/user-attachments/assets/21f4ec9c-a87b-4c97-b026-6889e9922e01" />

After:

<img width="828" height="503" alt="image" src="https://github.com/user-attachments/assets/a37b4e5e-e76a-49d9-9d80-7352dd0484d8" />