### PR TITLE
CI: Avoid in-place nightly toolchain update in lint setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -114,11 +114,15 @@ runs:
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
       uses: dtolnay/rust-toolchain@stable
 
-      # TODO: Remove once `imports_granularity` rustfmt option is stable. https://rust-lang.github.io/rustfmt/?version=v1.9.0&search=group#imports_granularity
-    - name: 'Install Nightly Rust toolchain for linting'
+      # Avoid 'rustup toolchain install nightly'. When a newer nightly is published, it triggers an in-place toolchain
+      # update whose component swap renames files from /opt/rustup/toolchains/ to /opt/rustup/tmp/. And those land on
+      # different overlayfs mounts inside the runner container — producing "Invalid cross-device link (os error 18)".
+      # TODO: Remove once 'imports_granularity' rustfmt option is stable:
+      #       https://rust-lang.github.io/rustfmt/?version=v1.9.0&search=group#imports_granularity
+    - name: 'Ensure rustfmt is available on the nightly toolchain'
       if: ${{ inputs.type == 'lint' }}
       shell: bash
-      run: rustup toolchain install nightly --component rustfmt
+      run: rustup component add rustfmt --toolchain nightly
 
     - name: 'Install wasm-tools'
       if: ${{ inputs.type == 'build' }}


### PR DESCRIPTION
**Problem:** A new upstream nightly Rust release made all CI lint code checks fail in the `Set Up Environment` step.

**Cause:** CI runs `rustup toolchain install nightly --component rustfmt`. The runner container ships nightly with `rustfmt` and `clippy` preinstalled. But `rustup toolchain install` treats an existing channel as an upgrade target, and tries to refresh it whenever a newer nightly is available. The refresh removes the old `clippy` component first, renaming `/opt/rustup/toolchains/.../share/doc/clippy` into `/opt/rustup/tmp/`, and those two directories live on different overlayfs mounts in the container — so the rename fails with `EXDEV`.

**Fix:** Replace `rustup toolchain install nightly --component rustfmt` with `rustup component add rustfmt --toolchain nightly`. That adds the component to the existing toolchain without checking for or applying a channel update — so the cross-mount-rename path is never reached. Because the container already provisions `rustfmt` + `clippy` at build time, the new command is effectively a no-op on healthy containers, and fails loudly only if a future container loses the nightly toolchain.
