### PR TITLE
LibWeb: Recompute @font-face descriptors on viewport size change

### DIFF
--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -796,12 +796,17 @@ void FontComputer::unregister_font_face(GC::Ref<FontFace> face)
         .slope = face->declared_slope(),
         .width = face->declared_width(),
     };
+    unregister_font_face_with_key(face, key);
+    did_load_font(key.family_name);
+}
+
+void FontComputer::unregister_font_face_with_key(GC::Ref<FontFace> face, FontFaceKey const& key)
+{
     if (auto it = m_font_faces.find(key); it != m_font_faces.end()) {
         it->value.remove_all_matching([&](auto const& entry) { return entry == face; });
         if (it->value.is_empty())
             m_font_faces.remove(it);
     }
-    did_load_font(key.family_name);
 }
 
 GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load)

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -120,6 +120,7 @@ public:
 
     void register_font_face(GC::Ref<FontFace>);
     void unregister_font_face(GC::Ref<FontFace>);
+    void unregister_font_face_with_key(GC::Ref<FontFace>, FontFaceKey const&);
 
     GC::Ptr<FontLoader> load_font_face(ParsedFontFace const&, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load = {});
 

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -308,6 +308,40 @@ void FontFace::reparse_connected_css_font_face_rule_descriptors()
     set_line_gap_override_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::LineGapOverride)));
 }
 
+void FontFace::reevaluate_descriptors_for_viewport_change()
+{
+    if (!m_css_font_face_rule)
+        return;
+
+    auto previous_weight_range = m_cached_weight_range;
+    auto previous_slope = m_cached_slope;
+    auto previous_width = m_cached_width;
+    auto previous_family = m_family;
+
+    reparse_connected_css_font_face_rule_descriptors();
+
+    bool changed = previous_weight_range.min != m_cached_weight_range.min
+        || previous_weight_range.max != m_cached_weight_range.max
+        || previous_slope != m_cached_slope
+        || previous_width != m_cached_width
+        || previous_family != m_family;
+    if (!changed)
+        return;
+
+    auto computer = font_computer();
+    if (!computer.has_value() || !should_be_registered_with_font_computer())
+        return;
+
+    FontFaceKey previous_key {
+        .family_name = FlyString(previous_family),
+        .weight = previous_weight_range,
+        .slope = previous_slope,
+        .width = previous_width,
+    };
+    computer->unregister_font_face_with_key(*this, previous_key);
+    computer->register_font_face(*this);
+}
+
 ParsedFontFace FontFace::parsed_font_face() const
 {
     if (m_css_font_face_rule)

--- a/Libraries/LibWeb/CSS/FontFace.h
+++ b/Libraries/LibWeb/CSS/FontFace.h
@@ -76,6 +76,7 @@ public:
     bool is_css_connected() const { return m_css_font_face_rule != nullptr; }
     void disconnect_from_css_rule();
     void reparse_connected_css_font_face_rule_descriptors();
+    void reevaluate_descriptors_for_viewport_change();
 
     ParsedFontFace parsed_font_face() const;
 

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -167,6 +167,14 @@ void FontFaceSet::clear()
     }
 }
 
+void FontFaceSet::reevaluate_descriptors_for_viewport_change()
+{
+    for (auto font_face_value : *m_set_entries) {
+        auto& font_face = as<FontFace>(font_face_value.key.as_object());
+        font_face.reevaluate_descriptors_for_viewport_change();
+    }
+}
+
 // https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-onloading
 void FontFaceSet::set_onloading(WebIDL::CallbackType* event_handler)
 {

--- a/Libraries/LibWeb/CSS/FontFaceSet.h
+++ b/Libraries/LibWeb/CSS/FontFaceSet.h
@@ -32,6 +32,8 @@ public:
 
     void add_css_connected_font(GC::Ref<FontFace>);
 
+    void reevaluate_descriptors_for_viewport_change();
+
     void set_onloading(WebIDL::CallbackType*);
     WebIDL::CallbackType* onloading();
     void set_onloadingdone(WebIDL::CallbackType*);

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -8,6 +8,7 @@
 
 #include <LibCore/Timer.h>
 #include <LibWeb/CSS/ComputedProperties.h>
+#include <LibWeb/CSS/FontFaceSet.h>
 #include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/VisualViewport.h>
@@ -2942,6 +2943,7 @@ void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList inval
         else
             document->invalidate_style_for_viewport_change();
         document->set_needs_media_query_evaluation();
+        document->fonts()->reevaluate_descriptors_for_viewport_change();
         document->set_needs_layout_update(DOM::SetNeedsLayoutReason::NavigableSetViewportSize);
     }
 


### PR DESCRIPTION
**Problem:** The `font-face-descriptor-relative-length-iframe.html` reftest has recently been failing on most CI runs.

**Cause:** `@font-face` descriptors are evaluated once, at stylesheet-attach time, and involves a read of the document’s navigable viewport. For an iframe srcdoc, that read happens while the iframe’s `content_navigable` still has its default 0x0 viewport. The real size is only set later. The cached weight range is therefore wrong, and `set_viewport_size` already invalidates style and re-evaluates `@media` rules on the ensuing size change. But it never revisits `@font-face` descriptors — so the wrong weight stays cached for the life of the document.

**Fix:** `set_viewport_size` now walks the document’s `FontFaceSet` and asks each CSS-connected `FontFace` to re-evaluate its descriptors against the updated viewport. If any cached descriptor changed, the face is re-keyed in `FontComputer`’s `m_font_faces` map. So, subsequent font-matching sees the new values. A new helper lets the re-key path remove the stale entry without firing a second `did_load_font` invalidation; the `register_font_face` that follows already invalidates once.
