### PR TITLE
UI/Qt: Paint web view fallback at device size

### DIFF
--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -570,18 +570,18 @@ void WebContentView::paintEvent(QPaintEvent*)
 
         auto background_color = page_background_color();
         auto fallback_color = QColor(background_color.red(), background_color.green(), background_color.blue());
-        if (bitmap_size.width() < width()) {
-            painter.fillRect(bitmap_size.width(), 0, width() - bitmap_size.width(), bitmap->height(), fallback_color);
+        if (bitmap_size.width() < m_viewport_size.width()) {
+            painter.fillRect(bitmap_size.width(), 0, m_viewport_size.width() - bitmap_size.width(), bitmap->height(), fallback_color);
         }
-        if (bitmap_size.height() < height()) {
-            painter.fillRect(0, bitmap_size.height(), width(), height() - bitmap_size.height(), fallback_color);
+        if (bitmap_size.height() < m_viewport_size.height()) {
+            painter.fillRect(0, bitmap_size.height(), m_viewport_size.width(), m_viewport_size.height() - bitmap_size.height(), fallback_color);
         }
 
         return;
     }
 
     auto background_color = page_background_color();
-    painter.fillRect(rect(), QColor(background_color.red(), background_color.green(), background_color.blue()));
+    painter.fillRect(QRect(0, 0, m_viewport_size.width(), m_viewport_size.height()), QColor(background_color.red(), background_color.green(), background_color.blue()));
 }
 
 void WebContentView::resizeEvent(QResizeEvent* event)


### PR DESCRIPTION
WebContentView scales its painter into device-pixel coordinates before painting page bitmaps. When no page bitmap was available, the fallback fill still used the widget rect in CSS pixels. On high-DPI displays, it only filled the top-left portion of the viewport.

Use the stored device-pixel viewport size for the no-bitmap fill and for the fallback area around a smaller bitmap.

Fixes an issue where new tabs look like this for a split second on HiDPI displays:

<img width="2342" height="1430" alt="Screenshot from 2026-05-29 12-46-17" src="https://github.com/user-attachments/assets/0c3ba6b4-13c2-4555-b29d-9812049f52bb" />
