### PR TITLE
DevTools: Implement "pick element" button

### DIFF
--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -39,6 +39,8 @@ WalkerActor::WalkerActor(DevToolsServer& devtools, String name, WeakPtr<TabActor
 
 WalkerActor::~WalkerActor()
 {
+    stop_node_picker();
+
     if (auto tab = m_tab.strong_ref())
         devtools().delegate().stop_listening_for_dom_mutations(tab->description());
 }
@@ -395,6 +397,33 @@ void WalkerActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "pick"sv) {
+        if (auto tab = m_tab.strong_ref()) {
+            m_is_picking_node = true;
+            m_picker_hovered_node_id.clear();
+            devtools().delegate().start_node_picker(tab->description(), weak_callback(*this, [](auto& self, DevToolsDelegate::NodePickerEvent event) {
+                self.handle_node_picker_event(event);
+            }));
+        }
+
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "cancelPick"sv) {
+        stop_node_picker();
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "clearPicker"sv) {
+        if (auto tab = m_tab.strong_ref())
+            devtools().delegate().clear_node_picker(tab->description());
+        m_picker_hovered_node_id.clear();
+        send_response(message, move(response));
+        return;
+    }
+
     if (message.type == "querySelector"sv) {
         auto node = get_required_parameter<String>(message, "node"sv);
         if (!node.has_value())
@@ -659,6 +688,120 @@ Optional<Node> WalkerActor::dom_node(StringView actor)
 Optional<String> WalkerActor::node_actor_name_for(Web::UniqueNodeID node_id) const
 {
     return m_dom_node_id_to_actor_map.get(node_id).copy();
+}
+
+Optional<JsonObject const&> WalkerActor::element_node_for_picker_node(JsonObject const& node) const
+{
+    // To match Firefox, don't make text nodes pickable. Instead, find their nearest ancestor element node.
+    auto const* candidate = &node;
+    while (candidate) {
+        if (candidate->get_string("type"sv).value_or({}) == "element"sv)
+            return *candidate;
+
+        auto parent = m_dom_node_to_parent_map.get(candidate);
+        if (!parent.has_value())
+            break;
+        candidate = parent.value();
+    }
+
+    return {};
+}
+
+JsonObject WalkerActor::serialize_disconnected_node(JsonObject const& node) const
+{
+    JsonArray new_parents;
+    for (auto parent = m_dom_node_to_parent_map.get(&node); parent.has_value() && parent.value() && parent.value() != &m_dom_tree; parent = m_dom_node_to_parent_map.get(parent.value()))
+        new_parents.must_append(serialize_node(*parent.value()));
+
+    JsonObject disconnected_node;
+    disconnected_node.set("node"sv, serialize_node(node));
+    disconnected_node.set("newParents"sv, move(new_parents));
+    return disconnected_node;
+}
+
+void WalkerActor::handle_node_picker_event(DevToolsDelegate::NodePickerEvent event)
+{
+    if (!m_is_picking_node && event.type != DevToolsDelegate::NodePickerEvent::Type::Canceled)
+        return;
+
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return;
+
+    if (event.type == DevToolsDelegate::NodePickerEvent::Type::Canceled) {
+        stop_node_picker();
+
+        JsonObject packet;
+        packet.set("type"sv, "pickerNodeCanceled"sv);
+        send_message(move(packet));
+        return;
+    }
+
+    if (!event.node_id.has_value() || *event.node_id == 0) {
+        if (event.type == DevToolsDelegate::NodePickerEvent::Type::Hovered)
+            devtools().delegate().clear_node_picker(tab->description());
+        return;
+    }
+
+    auto actor_name = node_actor_name_for(*event.node_id);
+    if (!actor_name.has_value())
+        return;
+
+    auto dom_node = this->dom_node(actor_name.value());
+    if (!dom_node.has_value())
+        return;
+
+    auto picker_node = element_node_for_picker_node(dom_node->node);
+    if (!picker_node.has_value())
+        return;
+
+    auto picker_node_id = picker_node->get_integer<Web::UniqueNodeID::Type>("id"sv);
+    if (!picker_node_id.has_value())
+        return;
+    Web::UniqueNodeID picked_node_id { *picker_node_id };
+
+    if (event.type == DevToolsDelegate::NodePickerEvent::Type::Hovered) {
+        if (m_picker_hovered_node_id == picked_node_id)
+            return;
+
+        m_picker_hovered_node_id = picked_node_id;
+        devtools().delegate().highlight_dom_node(tab->description(), picked_node_id, {});
+    }
+
+    JsonObject packet;
+    switch (event.type) {
+    case DevToolsDelegate::NodePickerEvent::Type::Hovered:
+        packet.set("type"sv, "pickerNodeHovered"sv);
+        break;
+    case DevToolsDelegate::NodePickerEvent::Type::Picked:
+        packet.set("type"sv, "pickerNodePicked"sv);
+        break;
+    case DevToolsDelegate::NodePickerEvent::Type::Previewed:
+        packet.set("type"sv, "pickerNodePreviewed"sv);
+        break;
+    case DevToolsDelegate::NodePickerEvent::Type::Canceled:
+        VERIFY_NOT_REACHED();
+    }
+
+    packet.set("node"sv, serialize_disconnected_node(*picker_node));
+    send_message(move(packet));
+
+    if (event.type == DevToolsDelegate::NodePickerEvent::Type::Picked)
+        stop_node_picker();
+}
+
+void WalkerActor::stop_node_picker()
+{
+    if (!m_is_picking_node)
+        return;
+
+    if (auto tab = m_tab.strong_ref()) {
+        devtools().delegate().stop_node_picker(tab->description());
+        devtools().delegate().clear_node_picker(tab->description());
+    }
+
+    m_is_picking_node = false;
+    m_picker_hovered_node_id.clear();
 }
 
 Optional<JsonObject const&> WalkerActor::find_node_by_selector(JsonObject const& node, StringView selector)

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -12,6 +12,7 @@
 #include <AK/Optional.h>
 #include <LibDevTools/Actor.h>
 #include <LibDevTools/Actors/NodeActor.h>
+#include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/Forward.h>
 #include <LibDevTools/Node.h>
 #include <LibWeb/Forward.h>
@@ -55,6 +56,10 @@ private:
     void populate_dom_tree_cache(JsonObject& node, JsonObject const* parent);
 
     NodeActor const& actor_for_node(JsonObject const& node);
+    void handle_node_picker_event(DevToolsDelegate::NodePickerEvent);
+    void stop_node_picker();
+    Optional<JsonObject const&> element_node_for_picker_node(JsonObject const&) const;
+    JsonObject serialize_disconnected_node(JsonObject const&) const;
 
     WeakPtr<TabActor> m_tab;
     WeakPtr<LayoutInspectorActor> m_layout_inspector;
@@ -69,6 +74,9 @@ private:
     HashMap<Web::UniqueNodeID, String> m_dom_node_id_to_actor_map;
 
     HashMap<NodeIdentifier, WeakPtr<NodeActor>> m_node_actors;
+
+    bool m_is_picking_node { false };
+    Optional<Web::UniqueNodeID> m_picker_hovered_node_id;
 };
 
 }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -47,6 +47,23 @@ public:
     virtual void inspect_dom_node(TabDescription const&, WebView::DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>) const { }
     virtual void clear_inspected_dom_node(TabDescription const&) const { }
 
+    struct NodePickerEvent {
+        enum class Type : u8 {
+            Hovered,
+            Picked,
+            Previewed,
+            Canceled,
+        };
+
+        Type type;
+        Optional<Web::UniqueNodeID> node_id;
+    };
+
+    using OnNodePickerEvent = Function<void(NodePickerEvent)>;
+    virtual void start_node_picker(TabDescription const&, OnNodePickerEvent) const { }
+    virtual void stop_node_picker(TabDescription const&) const { }
+    virtual void clear_node_picker(TabDescription const&) const { }
+
     using OnGridLayoutsReceived = Function<void(JsonArray)>;
     using OnCurrentGridReceived = Function<void(Optional<JsonObject>)>;
     using OnCurrentFlexboxReceived = Function<void(Optional<JsonObject>)>;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1490,6 +1490,15 @@ Optional<EventHandler::Target> EventHandler::target_for_mouse_position(CSSPixelP
     return {};
 }
 
+GC::Ptr<DOM::Node> EventHandler::target_node_for_mouse_position(CSSPixelPoint position)
+{
+    auto target = target_for_mouse_position(position);
+    if (!target.has_value() || !target->paintable)
+        return {};
+
+    return target->paintable->dom_node();
+}
+
 GC::Ptr<DOM::Node> EventHandler::focus_candidate_for_position(CSSPixelPoint visual_viewport_position) const
 {
     auto exact_hit = paint_root()->hit_test(visual_viewport_position, Painting::HitTestType::Exact);

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -49,6 +49,7 @@ public:
     EventResult handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false, Optional<AsyncScrollOperation>* async_scroll_operation = nullptr);
     EventResult handle_mouseleave();
     void update_hover_after_scroll();
+    GC::Ptr<DOM::Node> target_node_for_mouse_position(CSSPixelPoint);
 
     EventResult handle_keydown(UIEvents::KeyCode, unsigned modifiers, u32 code_point, bool repeat);
     EventResult handle_keyup(UIEvents::KeyCode, unsigned modifiers, u32 code_point, bool repeat);

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -327,6 +327,15 @@ EventResult Page::handle_mouseleave()
     return top_level_traversable()->event_handler().handle_mouseleave();
 }
 
+UniqueNodeID Page::node_id_at_position(DevicePixelPoint position)
+{
+    auto node = top_level_traversable()->event_handler().target_node_for_mouse_position(device_to_css_point(position));
+    if (!node)
+        return 0;
+
+    return node->unique_id();
+}
+
 EventResult Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action, Optional<AsyncScrollOperation>* async_scroll_operation)
 {
     return top_level_traversable()->event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action, async_scroll_operation);

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -118,6 +118,7 @@ public:
     EventResult handle_mousedown(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count);
     EventResult handle_mousemove(DevicePixelPoint, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult handle_mouseleave();
+    UniqueNodeID node_id_at_position(DevicePixelPoint);
     EventResult handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false, Optional<AsyncScrollOperation>* async_scroll_operation = nullptr);
 
     EventResult handle_drag_and_drop_event(DragEvent::Type, DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1841,6 +1841,24 @@ void Application::clear_inspected_dom_node(DevTools::TabDescription const& descr
         view->clear_inspected_dom_node();
 }
 
+void Application::start_node_picker(DevTools::TabDescription const& description, OnNodePickerEvent on_node_picker_event) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->start_node_picker(move(on_node_picker_event));
+}
+
+void Application::stop_node_picker(DevTools::TabDescription const& description) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->stop_node_picker();
+}
+
+void Application::clear_node_picker(DevTools::TabDescription const& description) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->clear_node_picker();
+}
+
 void Application::highlight_dom_node(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) const
 {
     if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -259,6 +259,9 @@ private:
     virtual void stop_listening_for_dom_properties(DevTools::TabDescription const&) const override;
     virtual void inspect_dom_node(DevTools::TabDescription const&, DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>) const override;
     virtual void clear_inspected_dom_node(DevTools::TabDescription const&) const override;
+    virtual void start_node_picker(DevTools::TabDescription const&, OnNodePickerEvent) const override;
+    virtual void stop_node_picker(DevTools::TabDescription const&) const override;
+    virtual void clear_node_picker(DevTools::TabDescription const&) const override;
     virtual void inspect_grid_layouts(DevTools::TabDescription const&, Web::UniqueNodeID, OnGridLayoutsReceived) const override;
     virtual void inspect_current_grid(DevTools::TabDescription const&, Web::UniqueNodeID, OnCurrentGridReceived) const override;
     virtual void inspect_current_flexbox(DevTools::TabDescription const&, Web::UniqueNodeID, bool, OnCurrentFlexboxReceived) const override;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -465,6 +465,110 @@ void ViewImplementation::get_hovered_node_id()
     client().async_get_hovered_node_id(page_id());
 }
 
+void ViewImplementation::start_node_picker(DevTools::DevToolsDelegate::OnNodePickerEvent on_node_picker_event)
+{
+    m_node_picker_active = true;
+    m_node_picker_hovered_node_id.clear();
+    m_pending_node_picker_requests.clear();
+    m_on_node_picker_event = move(on_node_picker_event);
+}
+
+void ViewImplementation::stop_node_picker()
+{
+    if (!m_node_picker_active)
+        return;
+
+    clear_node_picker();
+    m_node_picker_active = false;
+    m_pending_node_picker_requests.clear();
+    m_on_node_picker_event = nullptr;
+}
+
+void ViewImplementation::clear_node_picker()
+{
+    m_node_picker_hovered_node_id.clear();
+    clear_highlighted_dom_node();
+}
+
+void ViewImplementation::node_picker_hover(Web::DevicePixelPoint position)
+{
+    request_node_picker_hit_test(NodePickerRequestType::Hovered, position);
+}
+
+void ViewImplementation::node_picker_pick(Web::DevicePixelPoint position)
+{
+    request_node_picker_hit_test(NodePickerRequestType::Picked, position);
+}
+
+void ViewImplementation::node_picker_preview(Web::DevicePixelPoint position)
+{
+    request_node_picker_hit_test(NodePickerRequestType::Previewed, position);
+}
+
+void ViewImplementation::node_picker_cancel()
+{
+    if (!m_node_picker_active)
+        return;
+
+    if (m_on_node_picker_event) {
+        m_on_node_picker_event({
+            .type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Canceled,
+            .node_id = {},
+        });
+    }
+}
+
+void ViewImplementation::request_node_picker_hit_test(NodePickerRequestType type, Web::DevicePixelPoint position)
+{
+    if (!m_node_picker_active)
+        return;
+
+    auto request_id = m_next_node_picker_request_id++;
+    m_pending_node_picker_requests.set(request_id, type);
+    client().async_get_node_id_at_position(page_id(), request_id, position);
+}
+
+void ViewImplementation::did_receive_node_picker_hit_test(u64 request_id, Web::UniqueNodeID node_id)
+{
+    auto request_type = m_pending_node_picker_requests.take(request_id);
+    if (!request_type.has_value() || !m_node_picker_active)
+        return;
+
+    if (*request_type == NodePickerRequestType::Hovered) {
+        if (node_id == m_node_picker_hovered_node_id.value_or(0))
+            return;
+
+        m_node_picker_hovered_node_id = node_id;
+        if (node_id == 0) {
+            clear_node_picker();
+            return;
+        }
+    } else if (node_id == 0) {
+        return;
+    }
+
+    if (!m_on_node_picker_event)
+        return;
+
+    DevTools::DevToolsDelegate::NodePickerEvent::Type event_type;
+    switch (*request_type) {
+    case NodePickerRequestType::Hovered:
+        event_type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Hovered;
+        break;
+    case NodePickerRequestType::Picked:
+        event_type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Picked;
+        break;
+    case NodePickerRequestType::Previewed:
+        event_type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Previewed;
+        break;
+    }
+
+    m_on_node_picker_event({
+        .type = event_type,
+        .node_id = node_id,
+    });
+}
+
 void ViewImplementation::inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type property_type, Optional<Web::CSS::PseudoElement> pseudo_element)
 {
     client().async_inspect_dom_node(page_id(), property_type, node_id, pseudo_element);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -21,6 +21,7 @@
 #include <LibCore/Forward.h>
 #include <LibCore/Promise.h>
 #include <LibCore/SharedVersion.h>
+#include <LibDevTools/DevToolsDelegate.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Cursor.h>
 #include <LibGfx/Forward.h>
@@ -120,6 +121,14 @@ public:
     void inspect_dom_tree();
     void inspect_accessibility_tree();
     void get_hovered_node_id();
+    void start_node_picker(DevTools::DevToolsDelegate::OnNodePickerEvent);
+    void stop_node_picker();
+    void clear_node_picker();
+    bool is_node_picker_active() const { return m_node_picker_active; }
+    void node_picker_hover(Web::DevicePixelPoint);
+    void node_picker_pick(Web::DevicePixelPoint);
+    void node_picker_preview(Web::DevicePixelPoint);
+    void node_picker_cancel();
 
     void inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type, Optional<Web::CSS::PseudoElement> pseudo_element);
     void inspect_grid_layouts(Web::UniqueNodeID root_node_id);
@@ -246,7 +255,6 @@ public:
     Function<void(Optional<JsonObject>)> on_received_current_flexbox;
     Function<void(JsonObject)> on_received_accessibility_tree;
     Function<void(Web::UniqueNodeID)> on_received_hovered_node_id;
-    Function<void(u64 request_id, Web::UniqueNodeID)> on_received_node_id_at_position;
     Function<void(Mutation)> on_dom_mutation_received;
     Function<void(Optional<Web::UniqueNodeID> const& node_id)> on_finished_editing_dom_node;
     Function<void(String)> on_received_dom_node_html;
@@ -448,6 +456,20 @@ protected:
 
     HashMap<u64, NavigationListener> m_navigation_listeners;
     u64 m_next_navigation_listener_id { 1 };
+
+    enum class NodePickerRequestType : u8 {
+        Hovered,
+        Picked,
+        Previewed,
+    };
+    void request_node_picker_hit_test(NodePickerRequestType, Web::DevicePixelPoint);
+    void did_receive_node_picker_hit_test(u64 request_id, Web::UniqueNodeID);
+
+    bool m_node_picker_active { false };
+    Optional<Web::UniqueNodeID> m_node_picker_hovered_node_id;
+    u64 m_next_node_picker_request_id { 1 };
+    HashMap<u64, NodePickerRequestType> m_pending_node_picker_requests;
+    DevTools::DevToolsDelegate::OnNodePickerEvent m_on_node_picker_event;
 
     bool m_devtools_connected { false };
     bool m_needs_beforeunload_check { true };

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -246,6 +246,7 @@ public:
     Function<void(Optional<JsonObject>)> on_received_current_flexbox;
     Function<void(JsonObject)> on_received_accessibility_tree;
     Function<void(Web::UniqueNodeID)> on_received_hovered_node_id;
+    Function<void(u64 request_id, Web::UniqueNodeID)> on_received_node_id_at_position;
     Function<void(Mutation)> on_dom_mutation_received;
     Function<void(Optional<Web::UniqueNodeID> const& node_id)> on_finished_editing_dom_node;
     Function<void(String)> on_received_dom_node_html;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -749,6 +749,14 @@ void WebContentClient::did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID no
     }
 }
 
+void WebContentClient::did_get_node_id_at_position(u64 page_id, u64 request_id, Web::UniqueNodeID node_id)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_received_node_id_at_position)
+            view->on_received_node_id_at_position(request_id, node_id);
+    }
+}
+
 void WebContentClient::did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -752,8 +752,7 @@ void WebContentClient::did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID no
 void WebContentClient::did_get_node_id_at_position(u64 page_id, u64 request_id, Web::UniqueNodeID node_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_received_node_id_at_position)
-            view->on_received_node_id_at_position(request_id, node_id);
+        view->did_receive_node_picker_hit_test(request_id, node_id);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -124,6 +124,7 @@ private:
     virtual void did_inspect_current_flexbox(u64 page_id, String) override;
     virtual void did_inspect_accessibility_tree(u64 page_id, String) override;
     virtual void did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) override;
+    virtual void did_get_node_id_at_position(u64 page_id, u64 request_id, Web::UniqueNodeID node_id) override;
     virtual void did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id) override;
     virtual void did_mutate_dom(u64 page_id, Mutation) override;
     virtual void did_get_dom_node_html(u64 page_id, String html) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1115,6 +1115,17 @@ void ConnectionFromClient::get_hovered_node_id(u64 page_id)
     async_did_get_hovered_node_id(page_id, node_id);
 }
 
+void ConnectionFromClient::get_node_id_at_position(u64 page_id, u64 request_id, Web::DevicePixelPoint position)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value()) {
+        async_did_get_node_id_at_position(page_id, request_id, 0);
+        return;
+    }
+
+    async_did_get_node_id_at_position(page_id, request_id, page->page().node_id_at_position(position));
+}
+
 void ConnectionFromClient::list_style_sheets(u64 page_id)
 {
     auto page = this->page(page_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -102,6 +102,7 @@ private:
     virtual void clear_grid_highlight(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void inspect_accessibility_tree(u64 page_id) override;
     virtual void get_hovered_node_id(u64 page_id) override;
+    virtual void get_node_id_at_position(u64 page_id, u64 request_id, Web::DevicePixelPoint position) override;
 
     virtual void list_style_sheets(u64 page_id) override;
     virtual void request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -72,6 +72,7 @@ endpoint WebContentClient
     did_inspect_current_flexbox(u64 page_id, String flexbox_layout) =|
     did_inspect_accessibility_tree(u64 page_id, String accessibility_tree) =|
     did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) =|
+    did_get_node_id_at_position(u64 page_id, u64 request_id, Web::UniqueNodeID node_id) =|
     did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id) =|
     did_mutate_dom(u64 page_id, WebView::Mutation mutation) =|
     did_get_dom_node_html(u64 page_id, String html) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -69,6 +69,7 @@ endpoint WebContentServer
     clear_grid_highlight(u64 page_id, Web::UniqueNodeID node_id) =|
     inspect_accessibility_tree(u64 page_id) =|
     get_hovered_node_id(u64 page_id) =|
+    get_node_id_at_position(u64 page_id, u64 request_id, Web::DevicePixelPoint position) =|
 
     js_console_input(u64 page_id, String js_source) =|
     run_javascript(u64 page_id, String js_source) =|

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -385,6 +385,22 @@ public:
     virtual void clear_inspected_dom_node(DevTools::TabDescription const&) const override { ++clear_inspected_dom_node_call_count; }
     virtual void clear_highlighted_dom_node(DevTools::TabDescription const&) const override { ++clear_highlighted_dom_node_call_count; }
 
+    virtual void start_node_picker(DevTools::TabDescription const&, OnNodePickerEvent callback) const override
+    {
+        ++start_node_picker_call_count;
+        on_node_picker_event = move(callback);
+    }
+
+    virtual void stop_node_picker(DevTools::TabDescription const&) const override
+    {
+        ++stop_node_picker_call_count;
+    }
+
+    virtual void clear_node_picker(DevTools::TabDescription const&) const override
+    {
+        ++clear_node_picker_call_count;
+    }
+
     virtual void inspect_grid_layouts(DevTools::TabDescription const&, Web::UniqueNodeID root_node_id, OnGridLayoutsReceived callback) const override
     {
         ++inspect_grid_layouts_call_count;
@@ -681,6 +697,12 @@ public:
         on_navigation_finished("https://example.test/next"_string, "Next page"_string);
     }
 
+    void emit_node_picker_event(DevToolsDelegate::NodePickerEvent event) const
+    {
+        VERIFY(on_node_picker_event);
+        on_node_picker_event(move(event));
+    }
+
     mutable Function<void(WebView::DOMNodeProperties)> on_dom_node_properties;
     mutable Function<void(WebView::Mutation)> on_dom_mutation;
     mutable Function<void(Web::CSS::StyleSheetIdentifier const&, String)> on_style_sheet_source;
@@ -691,6 +713,7 @@ public:
     mutable Function<void(DevToolsDelegate::NetworkRequestCompleteData)> on_network_request_finished;
     mutable Function<void(String)> on_navigation_started;
     mutable Function<void(String, String)> on_navigation_finished;
+    mutable Function<void(DevToolsDelegate::NodePickerEvent)> on_node_picker_event;
 
     mutable size_t inspect_tab_call_count { 0 };
     mutable size_t inspect_accessibility_tree_call_count { 0 };
@@ -698,6 +721,9 @@ public:
     mutable size_t stop_listening_for_dom_properties_call_count { 0 };
     mutable size_t inspect_dom_node_call_count { 0 };
     mutable size_t clear_inspected_dom_node_call_count { 0 };
+    mutable size_t start_node_picker_call_count { 0 };
+    mutable size_t stop_node_picker_call_count { 0 };
+    mutable size_t clear_node_picker_call_count { 0 };
     mutable size_t inspect_grid_layouts_call_count { 0 };
     mutable size_t inspect_current_grid_call_count { 0 };
     mutable size_t inspect_current_flexbox_call_count { 0 };
@@ -820,6 +846,10 @@ private:
             || *type == "resources-available-array"sv
             || *type == "resources-updated-array"sv
             || *type == "newMutations"sv
+            || *type == "pickerNodeCanceled"sv
+            || *type == "pickerNodeHovered"sv
+            || *type == "pickerNodePicked"sv
+            || *type == "pickerNodePreviewed"sv
             || *type == "tabListChanged"sv;
     }
 
@@ -957,6 +987,15 @@ static JsonObject read_resource(ProtocolClient& client, StringView resource_type
     }
 }
 
+static JsonObject read_packet_with_type(ProtocolClient& client, StringView packet_type)
+{
+    while (true) {
+        auto message = client.read_message();
+        if (message.get_string("type"sv).value_or({}) == packet_type)
+            return message;
+    }
+}
+
 TEST_CASE(root_actor_and_connection_errors)
 {
     auto session = create_session();
@@ -1065,6 +1104,92 @@ TEST_CASE(target_bootstrap_and_lifetime)
     EXPECT_EQ(session->delegate.stop_listening_for_dom_mutations_call_count, 1u);
     EXPECT_EQ(session->delegate.clear_highlighted_dom_node_call_count, 1u);
     EXPECT_EQ(session->delegate.clear_inspected_dom_node_call_count, 1u);
+}
+
+TEST_CASE(walker_node_picker)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto target = get_frame_target(client, actor_from(get_tab(client), "actor"sv));
+    auto inspector_actor = actor_from(target, "inspectorActor"sv);
+    auto walker = get_walker(client, inspector_actor);
+    auto walker_actor = actor_from(walker, "actor"sv);
+    auto root_node_actor = walker.get_object("root"sv)->get_string("actor"sv).release_value();
+
+    EXPECT_EQ(client.request(walker_actor, "pick"sv).get_string("from"sv).value(), walker_actor);
+    EXPECT_EQ(session->delegate.start_node_picker_call_count, 1u);
+
+    session->delegate.emit_node_picker_event({
+        .type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Hovered,
+        .node_id = Web::UniqueNodeID { 5 },
+    });
+
+    auto hover_event = read_packet_with_type(client, "pickerNodeHovered"sv);
+    EXPECT_EQ(hover_event.get_string("type"sv).value(), "pickerNodeHovered"sv);
+    EXPECT_EQ(hover_event.get_object("node"sv)->get_object("node"sv)->get_string("nodeName"sv).value(), "DIV"sv);
+    auto const& hover_new_parents = *hover_event.get_object("node"sv)->get_array("newParents"sv);
+    EXPECT_EQ(hover_new_parents.size(), 2u);
+    EXPECT_EQ(hover_new_parents.at(0).as_object().get_string("nodeName"sv).value(), "BODY"sv);
+    EXPECT_EQ(hover_new_parents.at(1).as_object().get_string("nodeName"sv).value(), "HTML"sv);
+    EXPECT_EQ(session->delegate.highlight_dom_node_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_highlighted_dom_node.value(), Web::UniqueNodeID { 4 });
+
+    session->delegate.emit_node_picker_event({
+        .type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Hovered,
+        .node_id = Web::UniqueNodeID { 4 },
+    });
+    EXPECT_EQ(session->delegate.highlight_dom_node_call_count, 1u);
+
+    session->delegate.emit_node_picker_event({
+        .type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Previewed,
+        .node_id = Web::UniqueNodeID { 8 },
+    });
+
+    auto preview_event = read_packet_with_type(client, "pickerNodePreviewed"sv);
+    EXPECT_EQ(preview_event.get_string("type"sv).value(), "pickerNodePreviewed"sv);
+    EXPECT_EQ(preview_event.get_object("node"sv)->get_object("node"sv)->get_string("nodeName"sv).value(), "SPAN"sv);
+    EXPECT_EQ(preview_event.get_object("node"sv)->get_array("newParents"sv)->size(), 2u);
+    EXPECT_EQ(session->delegate.stop_node_picker_call_count, 0u);
+
+    session->delegate.emit_node_picker_event({
+        .type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Picked,
+        .node_id = Web::UniqueNodeID { 5 },
+    });
+
+    auto picked_event = read_packet_with_type(client, "pickerNodePicked"sv);
+    EXPECT_EQ(picked_event.get_string("type"sv).value(), "pickerNodePicked"sv);
+    EXPECT_EQ(picked_event.get_object("node"sv)->get_object("node"sv)->get_string("nodeName"sv).value(), "DIV"sv);
+    EXPECT_EQ(picked_event.get_object("node"sv)->get_array("newParents"sv)->size(), 2u);
+    EXPECT_EQ(session->delegate.stop_node_picker_call_count, 1u);
+    EXPECT_EQ(session->delegate.clear_node_picker_call_count, 1u);
+
+    EXPECT_EQ(client.request(walker_actor, "pick"sv).get_string("from"sv).value(), walker_actor);
+    EXPECT_EQ(session->delegate.start_node_picker_call_count, 2u);
+
+    session->delegate.emit_node_picker_event({
+        .type = DevTools::DevToolsDelegate::NodePickerEvent::Type::Canceled,
+        .node_id = {},
+    });
+
+    auto canceled_event = read_packet_with_type(client, "pickerNodeCanceled"sv);
+    EXPECT_EQ(canceled_event.get_string("type"sv).value(), "pickerNodeCanceled"sv);
+    EXPECT_EQ(session->delegate.stop_node_picker_call_count, 2u);
+    EXPECT_EQ(session->delegate.clear_node_picker_call_count, 2u);
+
+    EXPECT_EQ(client.request(walker_actor, "pick"sv).get_string("from"sv).value(), walker_actor);
+    EXPECT_EQ(client.request(walker_actor, "clearPicker"sv).get_string("from"sv).value(), walker_actor);
+    EXPECT_EQ(session->delegate.clear_node_picker_call_count, 3u);
+    EXPECT_EQ(client.request(walker_actor, "cancelPick"sv).get_string("from"sv).value(), walker_actor);
+    EXPECT_EQ(session->delegate.stop_node_picker_call_count, 3u);
+    EXPECT_EQ(session->delegate.clear_node_picker_call_count, 4u);
+
+    JsonObject children;
+    children.set("to"sv, walker_actor);
+    children.set("type"sv, "children"sv);
+    children.set("node"sv, root_node_actor);
+    EXPECT_EQ(client.request(move(children)).get_array("nodes"sv)->size(), 1u);
 }
 
 TEST_CASE(inspector_walker_highlighter_layout_and_editing)

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -51,6 +51,14 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
     return static_cast<u64>([screen_number unsignedLongLongValue]);
 }
 
+static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge const& web_view_bridge, Web::DevicePixelPoint widget_position)
+{
+    return {
+        widget_position.x().value() * web_view_bridge.device_pixel_ratio(),
+        widget_position.y().value() * web_view_bridge.device_pixel_ratio(),
+    };
+}
+
 @interface LadybirdWebViewContentLayer : CALayer
 @end
 
@@ -931,6 +939,11 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
     if (!self.current_key_down_event)
         return;
 
+    if (m_web_view_bridge->is_node_picker_active()) {
+        self.current_key_down_event = nil;
+        return;
+    }
+
     auto key_event = Ladybird::ns_event_to_key_event(Web::KeyEvent::Type::KeyDown, self.current_key_down_event);
     m_web_view_bridge->enqueue_input_event(move(key_event));
 
@@ -1128,6 +1141,11 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
 
 - (void)mouseExited:(NSEvent*)event
 {
+    if (m_web_view_bridge->is_node_picker_active()) {
+        m_web_view_bridge->clear_node_picker();
+        return;
+    }
+
     Web::MouseEvent mouse_event { Web::MouseEvent::Type::MouseLeave, {}, {}, Web::UIEvents::MouseButton::None, Web::UIEvents::MouseButton::None, Web::UIEvents::KeyModifier::Mod_None, 0, 0, 0, nullptr };
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
@@ -1135,11 +1153,19 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
 - (void)mouseMoved:(NSEvent*)event
 {
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, Web::UIEvents::MouseButton::None);
+    if (m_web_view_bridge->is_node_picker_active()) {
+        m_web_view_bridge->node_picker_hover(node_picker_position_for(*m_web_view_bridge, mouse_event.position));
+        return;
+    }
+
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)scrollWheel:(NSEvent*)event
 {
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseWheel, event, self, Web::UIEvents::MouseButton::Middle);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
@@ -1149,17 +1175,31 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
     [[self window] makeFirstResponder:self];
 
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseDown, event, self, Web::UIEvents::MouseButton::Primary);
+    if (m_web_view_bridge->is_node_picker_active()) {
+        if ((event.modifierFlags & NSEventModifierFlagCommand) != 0)
+            m_web_view_bridge->node_picker_preview(node_picker_position_for(*m_web_view_bridge, mouse_event.position));
+        else
+            m_web_view_bridge->node_picker_pick(node_picker_position_for(*m_web_view_bridge, mouse_event.position));
+        return;
+    }
+
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)mouseUp:(NSEvent*)event
 {
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseUp, event, self, Web::UIEvents::MouseButton::Primary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)mouseDragged:(NSEvent*)event
 {
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, Web::UIEvents::MouseButton::Primary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
@@ -1168,18 +1208,27 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
 {
     [[self window] makeFirstResponder:self];
 
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseDown, event, self, Web::UIEvents::MouseButton::Secondary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)rightMouseUp:(NSEvent*)event
 {
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseUp, event, self, Web::UIEvents::MouseButton::Secondary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)rightMouseDragged:(NSEvent*)event
 {
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, Web::UIEvents::MouseButton::Secondary);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
@@ -1191,6 +1240,9 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
 
     [[self window] makeFirstResponder:self];
 
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseDown, event, self, Web::UIEvents::MouseButton::Middle);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
@@ -1200,6 +1252,9 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
     if (event.buttonNumber != 2)
         return;
 
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseUp, event, self, Web::UIEvents::MouseButton::Middle);
     m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
@@ -1207,6 +1262,9 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
 - (void)otherMouseDragged:(NSEvent*)event
 {
     if (event.buttonNumber != 2)
+        return;
+
+    if (m_web_view_bridge->is_node_picker_active())
         return;
 
     auto mouse_event = Ladybird::ns_event_to_mouse_event(Web::MouseEvent::Type::MouseMove, event, self, Web::UIEvents::MouseButton::Middle);
@@ -1235,6 +1293,13 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
         return;
     }
 
+    if (m_web_view_bridge->is_node_picker_active()) {
+        auto key_event = Ladybird::ns_event_to_key_event(Web::KeyEvent::Type::KeyDown, event);
+        if (key_event.key == Web::UIEvents::KeyCode::Key_Escape)
+            m_web_view_bridge->node_picker_cancel();
+        return;
+    }
+
     self.current_key_down_event = event;
     [self interpretKeyEvents:@[ event ]];
 }
@@ -1245,6 +1310,9 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
         return;
     }
 
+    if (m_web_view_bridge->is_node_picker_active())
+        return;
+
     auto key_event = Ladybird::ns_event_to_key_event(Web::KeyEvent::Type::KeyUp, event);
     m_web_view_bridge->enqueue_input_event(move(key_event));
 }
@@ -1252,6 +1320,11 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
 - (void)flagsChanged:(NSEvent*)event
 {
     if (self.event_being_redispatched == event) {
+        return;
+    }
+
+    if (m_web_view_bridge->is_node_picker_active()) {
+        m_modifier_flags = event.modifierFlags;
         return;
     }
 

--- a/UI/Gtk/Widgets/LadybirdWebView.cpp
+++ b/UI/Gtk/Widgets/LadybirdWebView.cpp
@@ -87,6 +87,12 @@ static gboolean on_key_pressed(GtkEventControllerKey*, guint keyval, guint, GdkM
     if (!self->impl)
         return GDK_EVENT_PROPAGATE;
 
+    if (self->impl->is_node_picker_active()) {
+        if (keyval == GDK_KEY_Escape)
+            self->impl->node_picker_cancel();
+        return GDK_EVENT_STOP;
+    }
+
     self->impl->enqueue_native_event(Web::KeyEvent::Type::KeyDown, keyval, state);
     return GDK_EVENT_STOP;
 }
@@ -95,6 +101,9 @@ static void on_key_released(GtkEventControllerKey*, guint keyval, guint, GdkModi
 {
     auto* self = LADYBIRD_WEB_VIEW(user_data);
     if (!self->impl)
+        return;
+
+    if (self->impl->is_node_picker_active())
         return;
 
     self->impl->enqueue_native_event(Web::KeyEvent::Type::KeyUp, keyval, state);
@@ -110,6 +119,18 @@ static void on_mouse_pressed(GtkGestureClick* gesture, gint n_press, gdouble x, 
 
     auto button = gtk_gesture_single_get_current_button(GTK_GESTURE_SINGLE(gesture));
     auto state = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(gesture));
+    if (self->impl->is_node_picker_active()) {
+        if (button == GDK_BUTTON_PRIMARY) {
+            auto position = Web::DevicePixelPoint { static_cast<int>(x * self->impl->device_pixel_ratio()), static_cast<int>(y * self->impl->device_pixel_ratio()) };
+            if (state & GDK_CONTROL_MASK)
+                self->impl->node_picker_preview(position);
+            else
+                self->impl->node_picker_pick(position);
+        }
+        gtk_gesture_set_state(GTK_GESTURE(gesture), GTK_EVENT_SEQUENCE_CLAIMED);
+        return;
+    }
+
     self->impl->enqueue_native_event(Web::MouseEvent::Type::MouseDown, x, y, button, state, n_press);
 }
 
@@ -118,6 +139,11 @@ static void on_mouse_released(GtkGestureClick* gesture, gint n_press, gdouble x,
     auto* self = LADYBIRD_WEB_VIEW(user_data);
     if (!self->impl)
         return;
+
+    if (self->impl->is_node_picker_active()) {
+        gtk_gesture_set_state(GTK_GESTURE(gesture), GTK_EVENT_SEQUENCE_CLAIMED);
+        return;
+    }
 
     auto button = gtk_gesture_single_get_current_button(GTK_GESTURE_SINGLE(gesture));
     auto state = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(gesture));
@@ -132,6 +158,12 @@ static void on_mouse_motion(GtkEventControllerMotion* controller, gdouble x, gdo
     if (!self->impl)
         return;
 
+    if (self->impl->is_node_picker_active()) {
+        auto position = Web::DevicePixelPoint { static_cast<int>(x * self->impl->device_pixel_ratio()), static_cast<int>(y * self->impl->device_pixel_ratio()) };
+        self->impl->node_picker_hover(position);
+        return;
+    }
+
     auto state = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(controller));
     self->impl->enqueue_native_event(Web::MouseEvent::Type::MouseMove, x, y, 0, state, 0);
 }
@@ -142,6 +174,11 @@ static void on_mouse_leave(GtkEventControllerMotion*, gpointer user_data)
     if (!self->impl)
         return;
 
+    if (self->impl->is_node_picker_active()) {
+        self->impl->clear_node_picker();
+        return;
+    }
+
     self->impl->enqueue_native_event(Web::MouseEvent::Type::MouseLeave, 0, 0, 0, static_cast<GdkModifierType>(0), 0);
 }
 
@@ -150,6 +187,9 @@ static gboolean on_scroll(GtkEventControllerScroll* controller, gdouble dx, gdou
     auto* self = LADYBIRD_WEB_VIEW(user_data);
     if (!self->impl)
         return GDK_EVENT_PROPAGATE;
+
+    if (self->impl->is_node_picker_active())
+        return GDK_EVENT_STOP;
 
     auto state = gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(controller));
 

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -420,16 +420,33 @@ static bool is_browser_reserved_shortcut(QKeyEvent const& event)
 
 void WebContentView::keyPressEvent(QKeyEvent* event)
 {
+    if (is_node_picker_active()) {
+        if (event->key() == Qt::Key_Escape)
+            node_picker_cancel();
+        event->accept();
+        return;
+    }
+
     enqueue_native_event(Web::KeyEvent::Type::KeyDown, *event);
 }
 
 void WebContentView::keyReleaseEvent(QKeyEvent* event)
 {
+    if (is_node_picker_active()) {
+        event->accept();
+        return;
+    }
+
     enqueue_native_event(Web::KeyEvent::Type::KeyUp, *event);
 }
 
 void WebContentView::inputMethodEvent(QInputMethodEvent* event)
 {
+    if (is_node_picker_active()) {
+        event->accept();
+        return;
+    }
+
     if (!event->commitString().isEmpty()) {
         QKeyEvent keyEvent(QEvent::KeyPress, 0, Qt::NoModifier, event->commitString());
         keyPressEvent(&keyEvent);
@@ -444,6 +461,12 @@ QVariant WebContentView::inputMethodQuery(Qt::InputMethodQuery) const
 
 void WebContentView::leaveEvent(QEvent* event)
 {
+    if (is_node_picker_active()) {
+        clear_node_picker();
+        QWidget::leaveEvent(event);
+        return;
+    }
+
     static QMouseEvent mouse_event { QEvent::Type::Leave, {}, {}, Qt::MouseButton::NoButton, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier };
     enqueue_native_event(Web::MouseEvent::Type::MouseLeave, mouse_event);
 
@@ -452,6 +475,12 @@ void WebContentView::leaveEvent(QEvent* event)
 
 void WebContentView::mouseMoveEvent(QMouseEvent* event)
 {
+    if (is_node_picker_active()) {
+        node_picker_hover(node_picker_position_for(*event));
+        event->accept();
+        return;
+    }
+
     if (!m_tooltip_override) {
         if (QToolTip::isVisible())
             QToolTip::hideText();
@@ -464,6 +493,18 @@ void WebContentView::mouseMoveEvent(QMouseEvent* event)
 
 void WebContentView::mousePressEvent(QMouseEvent* event)
 {
+    if (is_node_picker_active()) {
+        if (event->button() == Qt::MouseButton::LeftButton) {
+            auto position = node_picker_position_for(*event);
+            if (event->modifiers().testFlag(Qt::ControlModifier))
+                node_picker_preview(position);
+            else
+                node_picker_pick(position);
+        }
+        event->accept();
+        return;
+    }
+
     auto elapsed = event->timestamp() - m_last_click_timestamp;
     auto distance = (event->position() - m_last_click_position).manhattanLength();
 
@@ -482,6 +523,11 @@ void WebContentView::mousePressEvent(QMouseEvent* event)
 
 void WebContentView::mouseReleaseEvent(QMouseEvent* event)
 {
+    if (is_node_picker_active()) {
+        event->accept();
+        return;
+    }
+
     enqueue_native_event(Web::MouseEvent::Type::MouseUp, *event);
 
     if (event->button() == Qt::MouseButton::BackButton)
@@ -492,6 +538,11 @@ void WebContentView::mouseReleaseEvent(QMouseEvent* event)
 
 void WebContentView::wheelEvent(QWheelEvent* event)
 {
+    if (is_node_picker_active()) {
+        event->accept();
+        return;
+    }
+
     if (event->modifiers().testFlag(Qt::ControlModifier)) {
         event->ignore();
         return;
@@ -509,6 +560,11 @@ void WebContentView::mouseDoubleClickEvent(QMouseEvent* event)
 
 void WebContentView::dragEnterEvent(QDragEnterEvent* event)
 {
+    if (is_node_picker_active()) {
+        event->ignore();
+        return;
+    }
+
     if (!event->mimeData()->hasUrls())
         return;
 
@@ -518,12 +574,20 @@ void WebContentView::dragEnterEvent(QDragEnterEvent* event)
 
 void WebContentView::dragMoveEvent(QDragMoveEvent* event)
 {
+    if (is_node_picker_active()) {
+        event->ignore();
+        return;
+    }
+
     enqueue_native_event(Web::DragEvent::Type::DragMove, *event);
     event->acceptProposedAction();
 }
 
 void WebContentView::dragLeaveEvent(QDragLeaveEvent*)
 {
+    if (is_node_picker_active())
+        return;
+
     // QDragLeaveEvent does not contain any mouse position or button information.
     Web::DragEvent event {};
     event.type = Web::DragEvent::Type::DragEnd;
@@ -533,6 +597,11 @@ void WebContentView::dragLeaveEvent(QDragLeaveEvent*)
 
 void WebContentView::dropEvent(QDropEvent* event)
 {
+    if (is_node_picker_active()) {
+        event->ignore();
+        return;
+    }
+
     enqueue_native_event(Web::DragEvent::Type::Drop, *event);
     event->acceptProposedAction();
 }
@@ -811,6 +880,11 @@ void WebContentView::update_cursor(Gfx::Cursor cursor)
             }
             setCursor(QCursor { qpixmap, image_cursor.hotspot.x(), image_cursor.hotspot.y() });
         });
+}
+
+Web::DevicePixelPoint WebContentView::node_picker_position_for(QSinglePointEvent const& event) const
+{
+    return { event.position().x() * m_device_pixel_ratio, event.position().y() * m_device_pixel_ratio };
 }
 
 Web::DevicePixelSize WebContentView::viewport_size() const

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -97,6 +97,8 @@ private:
     void update_cursor(Gfx::Cursor cursor);
     void update_compositor_display_metadata();
 
+    Web::DevicePixelPoint node_picker_position_for(QSinglePointEvent const&) const;
+
     void enqueue_native_event(Web::MouseEvent::Type, QSinglePointEvent const& event);
 
     void enqueue_native_event(Web::DragEvent::Type, QDropEvent const& event);


### PR DESCRIPTION
Having "inspect element" in the context menu unfortunately seems to not be an option right now, with Firefox itself implementing this with internal APIs we can't use remotely. But, we can implement the "pick element" button, which is almost as good.

That's the "cursor in a box" button at the top left of the inspector here:
<img width="367" height="242" alt="image" src="https://github.com/user-attachments/assets/4822b15c-43f3-4194-86ec-813490aa3f9e" />

This PR implements this for Qt, AppKit and Gtk. You click the button, then hovering over an element in Ladybird will highlight it, and clicking will select it. In macOS this is a little more fiddly because you have to first focus the Ladybird window, but it still works.