### PR TITLE
LibWeb+Tests: Update layout before accessibility tree dumps

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5828,6 +5828,8 @@ GC::Ref<DOM::Document> Document::appropriate_template_contents_owner_document()
 
 String Document::dump_accessibility_tree_as_json()
 {
+    update_layout(UpdateLayoutReason::InspectAccessibilityTree);
+
     StringBuilder builder;
     auto accessibility_tree = AccessibilityTreeNode::create(this, nullptr);
     build_accessibility_tree(*&accessibility_tree);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -121,6 +121,7 @@ enum class InvalidateLayoutTreeReason {
     X(HTMLInputElementWidth)                 \
     X(HTMLLabelElementActivationBehavior)    \
     X(HostedDocumentBeforePaint)             \
+    X(InspectAccessibilityTree)              \
     X(InspectDOMTree)                        \
     X(InspectFlexboxLayout)                  \
     X(InspectGridLayout)                     \

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -564,6 +564,11 @@ String Internals::dump_display_list()
     return window().associated_document().dump_display_list();
 }
 
+String Internals::dump_accessibility_tree()
+{
+    return window().associated_document().dump_accessibility_tree_as_json();
+}
+
 String Internals::dump_layout_tree(GC::Ref<DOM::Node> node)
 {
     node->document().update_layout(DOM::UpdateLayoutReason::Debugging);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -101,6 +101,7 @@ public:
     bool headless();
 
     String dump_display_list();
+    String dump_accessibility_tree();
     String dump_layout_tree(GC::Ref<DOM::Node>);
     String dump_paintable_tree(GC::Ref<DOM::Node>);
     String dump_stacking_context_tree();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -75,6 +75,7 @@ interface Internals {
     readonly attribute boolean headless;
 
     DOMString dumpDisplayList();
+    DOMString dumpAccessibilityTree();
     DOMString dumpLayoutTree(Node node);
     DOMString dumpPaintableTree(Node node);
     DOMString dumpStackingContextTree();

--- a/Tests/LibWeb/Crash/Internals/dump-accessibility-tree-updates-layout.html
+++ b/Tests/LibWeb/Crash/Internals/dump-accessibility-tree-updates-layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<div id="target" role="button">Label</div>
+<script>
+    document.body.offsetWidth;
+    target.style.display = "none";
+    internals.dumpAccessibilityTree();
+</script>


### PR DESCRIPTION
The accessibility tree builder consults layout nodes while applying inclusion and exclusion rules. DevTools can request an accessibility tree after style or layout has been dirtied, which made those layout-node lookups trip the stale-layout verification.

Update layout before serializing the accessibility tree, matching the DOM tree dump path. Add an internals regression test that dirties layout before requesting an accessibility dump.