### PR TITLE
LibWeb: Invalidate scoped styles when boundaries change

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSKeyframesRule.h>
 #include <LibWeb/CSS/CSSNestedDeclarations.h>
+#include <LibWeb/CSS/CSSScopeRule.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/FontComputer.h>
@@ -463,17 +464,31 @@ SelectorInsights const& CSSStyleSheet::selector_insights() const
         return *m_selector_insights;
 
     SelectorInsights insights;
-    for_each_effective_style_producing_rule([&](auto const& rule) {
-        SelectorList const& absolutized_selectors = [&]() -> SelectorList const& {
-            if (rule.type() == CSSRule::Type::Style)
-                return static_cast<CSSStyleRule const&>(rule).absolutized_selectors();
-            if (rule.type() == CSSRule::Type::NestedDeclarations)
-                return static_cast<CSSNestedDeclarations const&>(rule).absolutized_selectors();
-            VERIFY_NOT_REACHED();
-        }();
+    for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& rule) {
+        auto collect_selector_list = [&](SelectorList const& selectors) {
+            for (auto const& selector : selectors)
+                StyleScope::collect_selector_insights(selector, insights);
+        };
+        auto collect_optional_selector_list = [&](Optional<SelectorList> const& selectors) {
+            if (!selectors.has_value())
+                return;
+            collect_selector_list(*selectors);
+        };
 
-        for (auto const& selector : absolutized_selectors)
-            StyleScope::collect_selector_insights(selector, insights);
+        if (rule.type() == CSSRule::Type::Scope) {
+            auto const& scope_rule = as<CSSScopeRule>(rule);
+            collect_optional_selector_list(scope_rule.start_selectors_for_matching());
+            collect_optional_selector_list(scope_rule.end_selectors_for_matching());
+            return;
+        }
+
+        if (rule.type() == CSSRule::Type::Style) {
+            collect_selector_list(static_cast<CSSStyleRule const&>(rule).absolutized_selectors());
+            return;
+        }
+
+        if (rule.type() == CSSRule::Type::NestedDeclarations)
+            collect_selector_list(static_cast<CSSNestedDeclarations const&>(rule).absolutized_selectors());
     });
     m_selector_insights = insights;
     return *m_selector_insights;

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
@@ -92,8 +92,10 @@ void invalidate_element_if_affected_by_has(DOM::Element& element)
 {
     if (element.affected_by_has_pseudo_class_in_subject_position())
         element.set_needs_style_update(true);
-    if (element.affected_by_has_pseudo_class_in_non_subject_position())
+    if (element.affected_by_has_pseudo_class_in_subject_position()
+        || element.affected_by_has_pseudo_class_in_non_subject_position()) {
         element.invalidate_style(DOM::StyleInvalidationReason::Other, { { InvalidationSet::Property::Type::PseudoClass, PseudoClass::Has } }, {});
+    }
 }
 
 static bool is_in_has_scope(DOM::Element const& element)

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -248,12 +248,13 @@ Vector<HasInvalidationMetadata> const* StyleComputer::has_invalidation_metadata_
     return nullptr;
 }
 
-static bool scope_selector_matches(Selector const& selector, DOM::Element const& element, MatchingRule const& rule, GC::Ptr<DOM::Element const> shadow_host, GC::Ptr<DOM::ShadowRoot const> rule_root, GC::Ptr<DOM::ParentNode const> scope)
+static bool scope_selector_matches(Selector const& selector, DOM::Element const& element, DOM::Element const& subject, MatchingRule const& rule, GC::Ptr<DOM::Element const> shadow_host, GC::Ptr<DOM::ShadowRoot const> rule_root, GC::Ptr<DOM::ParentNode const> scope)
 {
     SelectorEngine::MatchContext context {
         .style_sheet_for_rule = *rule.sheet,
-        .subject = element,
+        .subject = subject,
         .rule_shadow_root = rule_root,
+        .collect_per_element_selector_involvement_metadata = true,
     };
     return SelectorEngine::matches(selector, DOM::AbstractElement(element), shadow_host, context, scope);
 }
@@ -276,7 +277,7 @@ static Optional<ResolvedScope> resolve_single_scope(DOM::AbstractElement abstrac
             if (outer_root && !outer_root->is_inclusive_ancestor_of(*candidate))
                 break;
             for (auto const& selector : *scope_rule.start_selectors_for_matching()) {
-                if (scope_selector_matches(selector, *candidate, rule, shadow_host, rule_root, outer_root)) {
+                if (scope_selector_matches(selector, *candidate, abstract_element.element(), rule, shadow_host, rule_root, outer_root)) {
                     root = candidate;
                     break;
                 }
@@ -320,7 +321,7 @@ static Optional<ResolvedScope> resolve_single_scope(DOM::AbstractElement abstrac
     if (scope_rule.end_selectors_for_matching().has_value()) {
         for (auto const* candidate = &abstract_element.element(); candidate; candidate = candidate->parent_element().ptr()) {
             for (auto const& selector : *scope_rule.end_selectors_for_matching()) {
-                if (scope_selector_matches(selector, *candidate, rule, shadow_host, rule_root, root))
+                if (scope_selector_matches(selector, *candidate, abstract_element.element(), rule, shadow_host, rule_root, root))
                     return {};
             }
             if (candidate == root)

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
@@ -346,7 +346,7 @@ static bool selector_contains_featureless_subtree_sensitive_selector(Selector co
     return false;
 }
 
-static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidationData& style_invalidation_data, Selector const& selector, InsideNthChildPseudoClass inside_nth_child_pseudo_class);
+static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidationData& style_invalidation_data, Selector const& selector, InsideNthChildPseudoClass inside_nth_child_pseudo_class, InvalidationPlan const& root_invalidation_plan);
 
 static void add_invalidation_sets_to_cover_scope_leakage_of_relative_selector_in_has_pseudo_class(Selector const& selector, StyleInvalidationData& style_invalidation_data);
 
@@ -356,6 +356,7 @@ static bool should_register_invalidation_property(InvalidationSet::Property cons
 }
 
 static void collect_guard_properties_for_simple_selector(Selector::SimpleSelector const&, InvalidationSet&);
+static void build_invalidation_sets_for_simple_selector_impl(Selector::SimpleSelector const&, InvalidationSet&, ExcludePropertiesNestedInNotPseudoClass, StyleInvalidationData&, InsideNthChildPseudoClass, InvalidationPlan const&);
 
 static Optional<InvalidationSet> build_invalidation_guard_property_set_for_selector_subject(Selector const& selector)
 {
@@ -412,11 +413,11 @@ static InvalidationGuard build_invalidation_guard_for_simple_selectors(Vector<Se
     return guard;
 }
 
-static InvalidationSet build_invalidation_set_for_simple_selectors(Vector<Selector::SimpleSelector const&> const& simple_selectors, ExcludePropertiesNestedInNotPseudoClass exclude_properties_nested_in_not_pseudo_class, StyleInvalidationData& style_invalidation_data, InsideNthChildPseudoClass inside_nth_child_pseudo_class)
+static InvalidationSet build_invalidation_set_for_simple_selectors(Vector<Selector::SimpleSelector const&> const& simple_selectors, ExcludePropertiesNestedInNotPseudoClass exclude_properties_nested_in_not_pseudo_class, StyleInvalidationData& style_invalidation_data, InsideNthChildPseudoClass inside_nth_child_pseudo_class, InvalidationPlan const& root_invalidation_plan)
 {
     InvalidationSet invalidation_set;
     for (auto const& simple_selector : simple_selectors)
-        build_invalidation_sets_for_simple_selector(simple_selector, invalidation_set, exclude_properties_nested_in_not_pseudo_class, style_invalidation_data, inside_nth_child_pseudo_class);
+        build_invalidation_sets_for_simple_selector_impl(simple_selector, invalidation_set, exclude_properties_nested_in_not_pseudo_class, style_invalidation_data, inside_nth_child_pseudo_class, root_invalidation_plan);
     return invalidation_set;
 }
 
@@ -501,7 +502,7 @@ static NonnullRefPtr<InvalidationPlan> build_invalidation_for_combinator(Selecto
     return invalidation;
 }
 
-void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector const& selector, InvalidationSet& invalidation_set, ExcludePropertiesNestedInNotPseudoClass exclude_properties_nested_in_not_pseudo_class, StyleInvalidationData& style_invalidation_data, InsideNthChildPseudoClass inside_nth_child_selector)
+static void build_invalidation_sets_for_simple_selector_impl(Selector::SimpleSelector const& selector, InvalidationSet& invalidation_set, ExcludePropertiesNestedInNotPseudoClass exclude_properties_nested_in_not_pseudo_class, StyleInvalidationData& style_invalidation_data, InsideNthChildPseudoClass inside_nth_child_selector, InvalidationPlan const& root_invalidation_plan)
 {
     switch (selector.type) {
     case Selector::SimpleSelector::Type::Class:
@@ -565,7 +566,7 @@ void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector const&
         if (AK::first_is_one_of(pseudo_class.type, PseudoClass::NthChild, PseudoClass::NthLastChild, PseudoClass::NthOfType, PseudoClass::NthLastOfType))
             inside_nth_child_pseudo_class_for_nested = InsideNthChildPseudoClass::Yes;
         for (auto const& nested_selector : pseudo_class.argument_selector_list) {
-            auto rightmost_invalidation_set_for_selector = build_invalidation_sets_for_selector_impl(style_invalidation_data, *nested_selector, inside_nth_child_pseudo_class_for_nested);
+            auto rightmost_invalidation_set_for_selector = build_invalidation_sets_for_selector_impl(style_invalidation_data, *nested_selector, inside_nth_child_pseudo_class_for_nested, root_invalidation_plan);
             invalidation_set.include_all_from(rightmost_invalidation_set_for_selector);
 
             // Propagate :has() from inner selectors where it appears in non-rightmost compounds.
@@ -595,7 +596,7 @@ void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector const&
         if (pseudo_element.type() == PseudoElement::Slotted) {
             for (auto const& compound_selector : pseudo_element.compound_selector().compound_selectors()) {
                 for (auto const& nested_simple : compound_selector.simple_selectors)
-                    build_invalidation_sets_for_simple_selector(nested_simple, invalidation_set, exclude_properties_nested_in_not_pseudo_class, style_invalidation_data, inside_nth_child_selector);
+                    build_invalidation_sets_for_simple_selector_impl(nested_simple, invalidation_set, exclude_properties_nested_in_not_pseudo_class, style_invalidation_data, inside_nth_child_selector, root_invalidation_plan);
             }
         }
         break;
@@ -603,6 +604,11 @@ void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector const&
     default:
         break;
     }
+}
+
+void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector const& selector, InvalidationSet& invalidation_set, ExcludePropertiesNestedInNotPseudoClass exclude_properties_nested_in_not_pseudo_class, StyleInvalidationData& style_invalidation_data, InsideNthChildPseudoClass inside_nth_child_selector)
+{
+    build_invalidation_sets_for_simple_selector_impl(selector, invalidation_set, exclude_properties_nested_in_not_pseudo_class, style_invalidation_data, inside_nth_child_selector, *make_invalidate_self_invalidation());
 }
 
 static void add_invalidation_sets_to_cover_scope_leakage_of_relative_selector_in_has_pseudo_class(Selector const& selector, StyleInvalidationData& style_invalidation_data)
@@ -618,7 +624,7 @@ static void add_invalidation_sets_to_cover_scope_leakage_of_relative_selector_in
             if (rightmost)
                 return;
 
-            auto invalidation_set = build_invalidation_set_for_simple_selectors(simple_selectors, ExcludePropertiesNestedInNotPseudoClass::No, style_invalidation_data, InsideNthChildPseudoClass::No);
+            auto invalidation_set = build_invalidation_set_for_simple_selectors(simple_selectors, ExcludePropertiesNestedInNotPseudoClass::No, style_invalidation_data, InsideNthChildPseudoClass::No, *make_invalidate_self_invalidation());
             add_invalidation_plan_for_properties(style_invalidation_data, invalidation_set, *make_invalidate_whole_subtree_invalidation());
         });
     };
@@ -636,7 +642,7 @@ static void add_invalidation_sets_to_cover_scope_leakage_of_relative_selector_in
     });
 }
 
-static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidationData& style_invalidation_data, Selector const& selector, InsideNthChildPseudoClass inside_nth_child_pseudo_class)
+static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidationData& style_invalidation_data, Selector const& selector, InsideNthChildPseudoClass inside_nth_child_pseudo_class, InvalidationPlan const& root_invalidation_plan)
 {
     auto const& compound_selectors = selector.compound_selectors();
     int compound_selector_index = compound_selectors.size() - 1;
@@ -652,8 +658,8 @@ static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidati
             collect_properties_used_in_has(simple_selector, style_invalidation_data, {});
         }
 
-        auto invalidation_properties = build_invalidation_set_for_simple_selectors(simple_selectors, ExcludePropertiesNestedInNotPseudoClass::No, style_invalidation_data, inside_nth_child_pseudo_class);
-        auto subject_match_set = build_invalidation_set_for_simple_selectors(simple_selectors, ExcludePropertiesNestedInNotPseudoClass::Yes, style_invalidation_data, inside_nth_child_pseudo_class);
+        auto invalidation_properties = build_invalidation_set_for_simple_selectors(simple_selectors, ExcludePropertiesNestedInNotPseudoClass::No, style_invalidation_data, inside_nth_child_pseudo_class, root_invalidation_plan);
+        auto subject_match_set = build_invalidation_set_for_simple_selectors(simple_selectors, ExcludePropertiesNestedInNotPseudoClass::Yes, style_invalidation_data, inside_nth_child_pseudo_class, root_invalidation_plan);
         auto subject_guard = build_invalidation_guard_for_simple_selectors(simple_selectors);
         bool subject_matches_any = subject_match_set.is_empty() && simple_selector_group_matches_any(simple_selectors);
 
@@ -666,7 +672,7 @@ static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidati
             //   :not(.foo) => produce invalidation set .foo { $ } ($ = invalidate self)
             //   .bar :not(.foo) => produce invalidation sets .foo { $ } and .bar { * } (* = invalidate subtree)
             //                      which means invalidation_set_for_rightmost_selector should be empty
-            auto root_plan = make_invalidate_self_invalidation();
+            auto root_plan = copy_invalidation_plan(root_invalidation_plan);
             if (inside_nth_child_pseudo_class == InsideNthChildPseudoClass::Yes) {
                 // When invalidation property is nested in nth-child selector like p:nth-child(even of #t1, #t2, #t3)
                 // we need to make sure all affected siblings are invalidated.
@@ -702,7 +708,12 @@ static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidati
 
 void StyleInvalidationData::build_invalidation_sets_for_selector(Selector const& selector)
 {
-    (void)build_invalidation_sets_for_selector_impl(*this, selector, InsideNthChildPseudoClass::No);
+    (void)build_invalidation_sets_for_selector_impl(*this, selector, InsideNthChildPseudoClass::No, *make_invalidate_self_invalidation());
+}
+
+void StyleInvalidationData::build_invalidation_sets_for_scope_boundary_selector(Selector const& selector)
+{
+    (void)build_invalidation_sets_for_selector_impl(*this, selector, InsideNthChildPseudoClass::No, *make_invalidate_whole_subtree_invalidation());
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.h
@@ -108,6 +108,7 @@ struct StyleInvalidationData {
     bool has_selectors_sensitive_to_featureless_subtree_changes { false };
 
     void build_invalidation_sets_for_selector(Selector const& selector);
+    void build_invalidation_sets_for_scope_boundary_selector(Selector const& selector);
 };
 
 }

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -244,6 +244,23 @@ static GC::Ptr<CSSContainerRule const> current_container_rule(Vector<GC::Ptr<CSS
     return container_rule_stack.last();
 }
 
+static void collect_scope_boundary_selector_dependencies(CSSScopeRule const& scope_rule, StyleCache& style_cache)
+{
+    auto collect_selector_list = [&](Optional<SelectorList> const& selector_list) {
+        if (!selector_list.has_value())
+            return;
+        for (auto const& selector : *selector_list) {
+            style_cache.style_invalidation_data.build_invalidation_sets_for_scope_boundary_selector(selector);
+            StyleScope::collect_selector_insights(selector, style_cache.selector_insights);
+        }
+    };
+
+    for (auto const* current_scope_rule = &scope_rule; current_scope_rule; current_scope_rule = current_scope_rule->nearest_ancestor_scope_rule().ptr()) {
+        collect_selector_list(current_scope_rule->start_selectors_for_matching());
+        collect_selector_list(current_scope_rule->end_selectors_for_matching());
+    }
+}
+
 using RuleCacheStyleRuleCallback = Function<void(CSSRule const&, GC::Ptr<CSSContainerRule const>, GC::Ptr<CSSScopeRule const>)>;
 
 static void for_each_style_producing_rule_for_rule_cache(
@@ -384,6 +401,8 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
             for (auto const& selector : absolutized_selectors) {
                 style_cache.style_invalidation_data.build_invalidation_sets_for_selector(selector);
             }
+            if (scope_rule)
+                collect_scope_boundary_selector_dependencies(*scope_rule, style_cache);
 
             for (CSS::Selector const& selector : absolutized_selectors) {
                 MatchingRule matching_rule {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/scope-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/scope-invalidation.txt
@@ -2,34 +2,33 @@ Harness status: OK
 
 Found 29 tests
 
-3 Pass
-26 Fail
-Fail	Element becoming scope root
-Fail	Element becoming scope root (selector list)
-Fail	Element becoming scope root, with inner :scope rule
-Fail	Parent element becoming scope limit
-Fail	Parent element becoming scope limit (selector list)
-Fail	Subject element becoming scope limit
-Fail	Parent element affecting scope limit
-Fail	Sibling element affecting scope limit
-Fail	Toggling inner/outer scope roots
-Fail	Element becoming root, with :scope in subject
-Fail	Scope root with :has()
-Fail	Scope root with :has(), :scope subject
-Fail	Scope root with :has(), :scope both subject and non-subject
-Fail	Scope limit with :has()
-Fail	Element becoming root, with :scope selected by ~ combinator
-Fail	Element becoming root via ~ combinator
-Fail	Element becoming root via + combinator
-Fail	:not(scope) in subject
-Fail	:not(scope) in ancestor
-Fail	:not(scope) in limit subject
-Fail	:not(scope) in limit ancestor
-Fail	:nth-child() in scope root
-Fail	:nth-child() in scope limit
+29 Pass
+Pass	Element becoming scope root
+Pass	Element becoming scope root (selector list)
+Pass	Element becoming scope root, with inner :scope rule
+Pass	Parent element becoming scope limit
+Pass	Parent element becoming scope limit (selector list)
+Pass	Subject element becoming scope limit
+Pass	Parent element affecting scope limit
+Pass	Sibling element affecting scope limit
+Pass	Toggling inner/outer scope roots
+Pass	Element becoming root, with :scope in subject
+Pass	Scope root with :has()
+Pass	Scope root with :has(), :scope subject
+Pass	Scope root with :has(), :scope both subject and non-subject
+Pass	Scope limit with :has()
+Pass	Element becoming root, with :scope selected by ~ combinator
+Pass	Element becoming root via ~ combinator
+Pass	Element becoming root via + combinator
+Pass	:not(scope) in subject
+Pass	:not(scope) in ancestor
+Pass	:not(scope) in limit subject
+Pass	:not(scope) in limit ancestor
+Pass	:nth-child() in scope root
+Pass	:nth-child() in scope limit
 Pass	Modifying selectorText invalidates affected elements
 Pass	Modifying selectorText invalidates affected elements (>)
 Pass	Relative selectors set with selectorText are relative to :scope and &
-Fail	Ancestor element affecting nested scope root (Through latter selector in list)
-Fail	Parent element of subject affecting scope limit
-Fail	Sandwiched deep implicit scope root, :scope in subject
+Pass	Ancestor element affecting nested scope root (Through latter selector in list)
+Pass	Parent element of subject affecting scope limit
+Pass	Sandwiched deep implicit scope root, :scope in subject


### PR DESCRIPTION
Scoped rules depend on their `@scope` start and end selectors, not just the selectors for the declarations inside the rule. Register those boundary selectors in the style invalidation data and selector insights so mutations that create or remove scope roots or limits invalidate descendant styles that may now match differently.

Scope boundary matching also needs to record selector involvement against the element being styled. That keeps :has(), sibling, and structural selector invalidation from treating the boundary candidate as the only affected subject.

Run the stored :has() invalidation plans for affected anchors as well as marking subject anchors dirty. This lets scope-boundary :has() changes invalidate scoped descendants instead of leaving stale styles.