### PR TITLE
LibIPC: Avoid InitTransport deadlocks on Windows during IPC communication

### DIFF
--- a/Libraries/LibCore/SystemServerTakeover.cpp
+++ b/Libraries/LibCore/SystemServerTakeover.cpp
@@ -14,6 +14,7 @@ namespace Core {
 
 HashMap<ByteString, int> s_overtaken_sockets {};
 bool s_overtaken_sockets_parsed { false };
+Optional<pid_t> s_parent_pid {};
 
 static void parse_sockets_from_system_server()
 {
@@ -28,14 +29,27 @@ static void parse_sockets_from_system_server()
 
     for (auto socket : sockets->split_view(';')) {
         auto params = socket.split_view(':');
-        VERIFY(params.size() == 2);
+        // Format is now name:fd or name:fd:parent_pid (for compatibility)
+        VERIFY(params.size() == 2 || params.size() == 3);
         s_overtaken_sockets.set(params[0].to_byte_string(), params[1].to_number<int>().value());
+
+        // Extract parent PID if present (third field)
+        if (params.size() == 3) {
+            s_parent_pid = params[2].to_number<pid_t>();
+        }
     }
 
     s_overtaken_sockets_parsed = true;
     // We wouldn't want our children to think we're passing
     // them a socket either, so unset the env variable.
     MUST(Environment::unset(socket_takeover));
+}
+
+Optional<pid_t> get_parent_pid_from_socket_takeover()
+{
+    VERIFY(s_overtaken_sockets_parsed);
+    VERIFY(s_parent_pid.has_value());
+    return s_parent_pid;
 }
 
 ErrorOr<NonnullOwnPtr<Core::LocalSocket>> take_over_socket_from_system_server(ByteString const& socket_path)

--- a/Libraries/LibCore/SystemServerTakeover.h
+++ b/Libraries/LibCore/SystemServerTakeover.h
@@ -12,5 +12,6 @@
 namespace Core {
 
 CORE_API ErrorOr<NonnullOwnPtr<Core::LocalSocket>> take_over_socket_from_system_server(ByteString const& socket_path = {});
+CORE_API Optional<pid_t> get_parent_pid_from_socket_takeover();
 
 }

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -57,8 +57,13 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
                 client->set_pid(process.pid());
 
             if constexpr (requires { client->transport().set_peer_pid(0); } && !IsSame<ClientType, WebWorkerClient>) {
+#if defined(AK_OS_WINDOWS)
+                // All helper processes skip the InitTransport message and set the pid via SOCKET_TAKEOVER on Windows
+                client->transport().set_peer_pid(process.pid());
+#else
                 auto response = client->template send_sync<typename ClientType::InitTransport>(Core::System::getpid());
                 client->transport().set_peer_pid(response->peer_pid());
+#endif
             }
 
             WebView::Application::the().add_child_process(move(process));

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -86,7 +86,8 @@ ErrorOr<Process::ProcessAndIPCTransport> Process::spawn_and_connect_to_process(C
     // Note: Core::System::socketpair creates inheritable sockets both on Linux and Windows unless SOCK_CLOEXEC is specified.
     TRY(Core::System::set_close_on_exec(socket_fds[0], true));
 
-    auto takeover_string = MUST(String::formatted("{}:{}", options.name, socket_fds[1]));
+    // Pass parent PID via SOCKET_TAKEOVER to avoid deadlock IPC messages on Windows
+    auto takeover_string = MUST(String::formatted("{}:{}:{}", options.name, socket_fds[1], Core::System::getpid()));
     TRY(Core::Environment::set("SOCKET_TAKEOVER"sv, takeover_string, Core::Environment::Overwrite::Yes));
 
     auto process = TRY(Core::Process::spawn(spawn_options));

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -13,6 +13,8 @@
 
 endpoint CompositorWebContentServer
 {
+    init_transport(int peer_pid) => (int peer_pid)
+
     set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode) =|
     destroy_context(Web::Compositor::CompositorContextId context_id) =|
 

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -42,10 +42,10 @@ void ConnectionFromClient::did_present_frame(Web::Compositor::CompositorContextI
 Messages::CompositorControlServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
 {
 #ifdef AK_OS_WINDOWS
-    m_transport->set_peer_pid(peer_pid);
-    return Core::System::getpid();
-#endif
+    // Connection gets parent PID via SOCKET_TAKEOVER
     VERIFY_NOT_REACHED();
+#endif
+    return Core::System::getpid();
 }
 
 Messages::CompositorControlServer::ConnectWebContentResponse ConnectionFromClient::connect_web_content()

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <Compositor/ConnectionFromWebContent.h>
+#include <LibCore/System.h>
 #include <LibWeb/Page/InputEvent.h>
 
 namespace Compositor {
@@ -21,6 +22,15 @@ void ConnectionFromWebContent::die()
     m_compositor_state->destroy_contexts_for_web_content_client(*this);
     if (m_on_death)
         m_on_death(*this);
+}
+
+Messages::CompositorWebContentServer::InitTransportResponse ConnectionFromWebContent::init_transport([[maybe_unused]] int peer_pid)
+{
+#ifdef AK_OS_WINDOWS
+    // Compositor-WebContent connections are peer-to-peer and need to exchange PIDs
+    m_transport->set_peer_pid(peer_pid);
+#endif
+    return Core::System::getpid();
 }
 
 void ConnectionFromWebContent::notify_compositor_lost()

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -31,6 +31,7 @@ private:
 
     virtual void die() override;
 
+    virtual Messages::CompositorWebContentServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode) override;
     virtual void destroy_context(Web::Compositor::CompositorContextId) override;
     virtual void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::AccumulatedVisualContextTree, Web::Painting::DisplayListResourceTransaction, Web::Painting::ScrollStateSnapshot) override;

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Process.h>
+#include <LibCore/SystemServerTakeover.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
 #include <LibGfx/SkiaBackendContext.h>
@@ -48,6 +49,12 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::EventLoop event_loop;
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<Compositor::ConnectionFromClient>(
         mach_server_name, move(skia_backend_context), !disable_async_scrolling));
+
+#if defined(AK_OS_WINDOWS)
+    auto parent_pid = Core::get_parent_pid_from_socket_takeover();
+    VERIFY(parent_pid.has_value());
+    client->transport().set_peer_pid(*parent_pid);
+#endif
 
     return event_loop.exec();
 }

--- a/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -49,10 +49,11 @@ void ConnectionFromClient::die()
 Messages::ImageDecoderServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
 {
 #ifdef AK_OS_WINDOWS
+    // On Windows: Primary connections configure transport via SOCKET_TAKEOVER in main()
+    // Secondary connections (peer-to-peer between child processes) use InitTransport to exchange PIDs
     m_transport->set_peer_pid(peer_pid);
-    return Core::System::getpid();
 #endif
-    VERIFY_NOT_REACHED();
+    return Core::System::getpid();
 }
 
 ErrorOr<IPC::TransportHandle> ConnectionFromClient::connect_new_client()
@@ -63,6 +64,7 @@ ErrorOr<IPC::TransportHandle> ConnectionFromClient::connect_new_client()
     // Note: A ref is stored in the static s_connections map
     auto client = adopt_ref(*new ConnectionFromClient(move(paired.local)));
 
+    // Secondary connections will exchange PIDs via InitTransport
     return handle;
 }
 

--- a/Services/ImageDecoder/main.cpp
+++ b/Services/ImageDecoder/main.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Process.h>
+#include <LibCore/SystemServerTakeover.h>
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
 
@@ -31,6 +32,13 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::EventLoop event_loop;
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<ImageDecoder::ConnectionFromClient>(mach_server_name));
+
+#if defined(AK_OS_WINDOWS)
+    // Configure primary connection transport with parent PID from SOCKET_TAKEOVER
+    auto parent_pid = Core::get_parent_pid_from_socket_takeover();
+    VERIFY(parent_pid.has_value());
+    client->transport().set_peer_pid(*parent_pid);
+#endif
 
     return event_loop.exec();
 }

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -162,10 +162,13 @@ void ConnectionFromClient::die()
 Messages::RequestServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
 {
 #ifdef AK_OS_WINDOWS
+    // Primary connections configure transport via SOCKET_TAKEOVER and should not call this
+    // Secondary connections (peer-to-peer between child processes) still need to exchange PIDs
+    VERIFY(g_primary_connection != this);
+
     m_transport->set_peer_pid(peer_pid);
-    return Core::System::getpid();
 #endif
-    VERIFY_NOT_REACHED();
+    return Core::System::getpid();
 }
 
 Messages::RequestServer::ConnectNewClientResponse ConnectionFromClient::connect_new_client()
@@ -205,6 +208,7 @@ ErrorOr<IPC::TransportHandle> ConnectionFromClient::create_client_socket()
     // Note: A ref is stored in the m_connections map
     auto client = adopt_ref(*new ConnectionFromClient(move(paired.local), IsPrimaryConnection::No, m_connections, m_disk_cache));
 
+    // Secondary connections will exchange PIDs via InitTransport
     return handle;
 }
 

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -13,6 +13,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
+#include <LibCore/SystemServerTakeover.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
@@ -104,6 +105,13 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<RequestServer::ConnectionFromClient>(
         mach_server_name,
         RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes, connections, disk_cache));
+
+#if defined(AK_OS_WINDOWS)
+    // Configure primary connection transport with parent PID from SOCKET_TAKEOVER
+    auto parent_pid = Core::get_parent_pid_from_socket_takeover();
+    VERIFY(parent_pid.has_value());
+    client->transport().set_peer_pid(*parent_pid);
+#endif
 
     return event_loop.exec();
 }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -14,6 +14,7 @@
 #include <AK/JsonObject.h>
 #include <AK/OwnPtr.h>
 #include <AK/QuickSort.h>
+#include <LibCore/Environment.h>
 #include <LibCore/System.h>
 #include <LibGC/Heap.h>
 #include <LibGfx/Bitmap.h>
@@ -105,10 +106,8 @@ void ConnectionFromClient::die()
 
 Messages::WebContentServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
 {
-#ifdef AK_OS_WINDOWS
-    m_transport->set_peer_pid(peer_pid);
-    return Core::System::getpid();
-#endif
+    // This should never be called for WebContent since we configure the transport
+    // via LADYBIRD_PARENT_PID environment variable to avoid a synchronous IPC call
     VERIFY_NOT_REACHED();
 }
 
@@ -178,6 +177,11 @@ void ConnectionFromClient::connect_to_compositor_process(IPC::TransportHandle ha
 {
     auto transport = MUST(handle.create_transport());
     m_compositor_connection = adopt_ref(*new CompositorConnection(move(transport)));
+#ifdef AK_OS_WINDOWS
+    // Compositor-WebContent connections are peer-to-peer and need to exchange PIDs
+    auto response = m_compositor_connection->send_sync<Messages::CompositorWebContentServer::InitTransport>(Core::System::getpid());
+    m_compositor_connection->transport().set_peer_pid(response->peer_pid());
+#endif
     m_compositor_connection->on_mouse_event = [this](u64 page_id, Web::MouseEvent event) {
         mouse_event(page_id, move(event));
     };

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -6,11 +6,13 @@
 
 #include <AK/LexicalPath.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Environment.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/Process.h>
 #include <LibCore/Resource.h>
 #include <LibCore/System.h>
+#include <LibCore/SystemServerTakeover.h>
 #include <LibCore/TimeZone.h>
 #include <LibCrypto/OpenSSLForward.h>
 #include <LibGfx/Font/FontDatabase.h>
@@ -263,6 +265,11 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         make<IPC::Transport>(move(transport_ports.receive_right), move(transport_ports.send_right)));
 #else
     auto webcontent_client = TRY(IPC::take_over_accepted_client_from_system_server<WebContent::ConnectionFromClient>(mach_server_name));
+
+#    if defined(AK_OS_WINDOWS)
+    // Configure transport with parent PID from SOCKET_TAKEOVER, avoiding the need for InitTransport sync
+    webcontent_client->transport().set_peer_pid(*Core::get_parent_pid_from_socket_takeover());
+#    endif
 #endif
 
     auto& heap = Web::Bindings::main_thread_vm().heap();


### PR DESCRIPTION
This PR fixes Ladybird to run natively on Windows again.

Background:
Ladybird uses a parent/child process architecture with lots of
inter-process communication (IPC) messages. On Windows, the message
handler currently runs synchronously and is therefore susceptible to
deadlocking if messages are sent before initialization is complete.

This is currently happening when the WebContent child process starts
up, causing Ladybird to crash or hang on startup.

PR 9450
(https://github.com/LadybirdBrowser/ladybird/pull/9450)
attempts to fix this in a perhaps preferable way by changing to an
asynchronous Windows socket implementation. However, this PR attempts
to solve the problem while maintaining the current architecture.

Changes:
Instead of sending an InitTransport message when spawning a new child
process, this PR uses the existing SOCKET_TAKEOVER environment
variable to pass ::<parent_pid> instead of only passing
(file descriptor).

I'd argue that this is acceptable, and maybe even preferred, because
all child processes are likely to need the parent pid anyway.

Unfortunately, the implementation was not quite that simple because
Ladybird also creates secondary connections between child processes.
For all secondary connections, this PR continues to process the
InitTransport message on Windows to exchange pids.

Alternatives:
I also considered having the WebContent child process delay creating
the tab until startup finished so the message loop could start
successfully. I decided this was too large of a departure from the
current architecture, and it would leave us vulnerable to similar
problems in the future if we do not address the broader concern.

I also considered passing the pid via a command-line argument or via
a new environment variable, but decided that extending the
SOCKET_TAKEOVER method was more elegant.