### PR TITLE
Tests: Wait for iframe paint in font face descriptor test

### DIFF
--- a/Tests/LibWeb/Ref/expected/font-face-descriptor-relative-length-iframe-ref.html
+++ b/Tests/LibWeb/Ref/expected/font-face-descriptor-relative-length-iframe-ref.html
@@ -27,7 +27,11 @@
         <script>
             function waitForFonts() {
                 iframe.contentDocument.fonts.ready.then(() => {
-                    document.documentElement.classList = "";
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(() => {
+                            document.documentElement.classList = "";
+                        });
+                    });
                 });
             }
         </script>

--- a/Tests/LibWeb/Ref/input/css/font-face-descriptor-relative-length-iframe.html
+++ b/Tests/LibWeb/Ref/input/css/font-face-descriptor-relative-length-iframe.html
@@ -42,7 +42,11 @@
         <script>
             function waitForFonts() {
                 iframe.contentDocument.fonts.ready.then(() => {
-                    document.documentElement.classList = "";
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(() => {
+                            document.documentElement.classList = "";
+                        });
+                    });
                 });
             }
         </script>


### PR DESCRIPTION
Wait for two animation frames after the iframe document's fonts are ready before allowing the reftest harness to snapshot the page. The parent document can otherwise unblock while the iframe content has not painted yet, making the test compare rendered content against an empty reference iframe.

This makes font-face-descriptor-relative-length-iframe.html stop flaking on my machine, and hopefully CI.