### PR TITLE
Compositor: Present nested surfaces synchronously for screenshots

### DIFF
--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -627,6 +627,70 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
     }
 }
 
+void CompositorState::flush_descendant_surfaces_for_screenshot(Web::Compositor::CompositorContextId context_id)
+{
+    // Presents are scheduled on a vsync timer rather than performed synchronously — so a nested navigable's latest
+    // paint may not yet be published to its parent's compositor surface. A screenshot re-executes the top-level display
+    // list, whose embedded-content commands read those child surfaces. So, flush any descendant with a deferred
+    // present synchronously (deepest-first) — to capture a complete frame instead of a stale/blank iframe.
+    auto* context = context_if_present(context_id);
+    if (!context)
+        return;
+    for (auto& child : context->child_contexts_by_surface_id)
+        present_subtree_for_screenshot(child.value);
+}
+
+bool CompositorState::present_subtree_for_screenshot(Web::Compositor::CompositorContextId context_id)
+{
+    auto* context = context_if_present(context_id);
+    if (!context)
+        return false;
+
+    bool needs_present = context->pending_present_frame.has_value() || context->pending_present_frame_scheduled;
+    for (auto& child : context->child_contexts_by_surface_id) {
+        if (present_subtree_for_screenshot(child.value))
+            needs_present = true;
+    }
+
+    if (!needs_present || !context->presentation_mode.has<Web::Compositor::PublishToCompositorSurface>())
+        return false;
+
+    present_context_synchronously(*context);
+    return true;
+}
+
+void CompositorState::present_context_synchronously(ContextState& context)
+{
+    auto* publish_mode = context.presentation_mode.get_pointer<Web::Compositor::PublishToCompositorSurface>();
+    if (!publish_mode)
+        return;
+    if (!context.display_list || !context.visual_context_tree.has_value() || !context.backing_store_manager.is_valid())
+        return;
+    // Don't race an async present already in flight for this context; its own completion will publish.
+    if (context.gpu_present_bitmap_id_awaiting_completion.has_value() || context.presented_bitmap_id_awaiting_ack.has_value())
+        return;
+
+    auto viewport_rect = context.pending_present_frame;
+    if (!viewport_rect.has_value())
+        viewport_rect = context.presented_frame;
+    if (!viewport_rect.has_value())
+        return;
+
+    auto& back_store = context.backing_store_manager.back_store();
+    {
+        Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
+        painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
+    }
+    m_display_list_player->execute(*context.display_list, context.visual_context_tree.value(), context.display_list_resource_storage, context.scroll_state_snapshot, back_store);
+    paint_viewport_scrollbar_overlay(context, back_store);
+    m_display_list_player->flush(back_store);
+    context.backing_store_manager.swap();
+    context.presented_frame = viewport_rect;
+    context.pending_present_frame.clear();
+    context.pending_present_frame_scheduled = false;
+    publish_to_parent_surface(context, *publish_mode);
+}
+
 bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId context_id, Gfx::ShareableBitmap& target_bitmap)
 {
     auto* context = context_if_present(context_id);
@@ -634,6 +698,8 @@ bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId co
 
     if (!context->display_list || !context->visual_context_tree.has_value() || !target_bitmap.is_valid() || !target_bitmap.bitmap())
         return false;
+
+    flush_descendant_surfaces_for_screenshot(context_id);
 
     auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
     m_display_list_player->execute(*context->display_list, context->visual_context_tree.value(), context->display_list_resource_storage, context->scroll_state_snapshot, *target_surface);

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -199,6 +199,9 @@ private:
     void schedule_pending_present_frame_if_unblocked(Web::Compositor::CompositorContextId, ContextState&);
     VSyncScheduler& vsync_scheduler_for_display(Optional<u64> display_id);
     void present_pending_frames_on_vsync(Optional<u64> display_id);
+    void flush_descendant_surfaces_for_screenshot(Web::Compositor::CompositorContextId);
+    bool present_subtree_for_screenshot(Web::Compositor::CompositorContextId);
+    void present_context_synchronously(ContextState&);
     void publish_backing_stores(Web::Compositor::CompositorContextId, ContextState&, BackingStoreManager::Publication&&);
     void did_finish_async_present(PendingAsyncPresent&);
     void cancel_pending_async_presents_for_context(Web::Compositor::CompositorContextId);


### PR DESCRIPTION
**Problem:** Some reftests whose content lives in an iframe (for example, `font-face-descriptor-relative-length-iframe.html` and `sandbox-parse-noscript.html`) intermittently fail — because the iframe is captured blank.

**Cause:** bc331318377 made the compositor schedule presents on a timer-backed vsync source — rather than presenting synchronously. With a present deferred to a later vsync tick, a child’s newest paint may not have been published when the screenshot composites — so the iframe is captured from a stale or empty surface.

**Fix:** Before `request_screenshot` composites the capture, synchronously present and publish any descendant context that has a deferred present — deepest-first, so every nested surface is current. Live rendering keeps the vsync-timer deferral; only the one-shot screenshot forces a synchronous flush. A context whose async present is already in flight is left untouched — since that present publishes on its own completion.
