### PR TITLE
LibWeb: Preserve CryptoKey algorithm types during serialization

### DIFF
--- a/Libraries/LibWeb/Crypto/CryptoKey.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoKey.cpp
@@ -7,10 +7,12 @@
 
 #include <AK/Memory.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/CryptoKey.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Crypto/CryptoKey.h>
+#include <LibWeb/Crypto/KeyAlgorithms.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 
 namespace Web::Crypto {
@@ -29,6 +31,132 @@ enum class HandleTag : u8 {
     MLKEMPublicKey = 8,
     MLKEMPrivateKey = 9,
 };
+
+enum class KeyAlgorithmTag : u8 {
+    KeyAlgorithm = 0,
+    RsaKeyAlgorithm = 1,
+    RsaHashedKeyAlgorithm = 2,
+    EcKeyAlgorithm = 3,
+    AesKeyAlgorithm = 4,
+    HmacKeyAlgorithm = 5,
+    KmacKeyAlgorithm = 6,
+};
+
+::Crypto::UnsignedBigInteger big_integer_from_api_big_integer(JS::Uint8Array const& big_integer)
+{
+    auto buffer = big_integer.viewed_array_buffer()->bytes().slice(big_integer.byte_offset(), big_integer.byte_length().length());
+    if (!buffer.is_empty())
+        return ::Crypto::UnsignedBigInteger::import_data(buffer);
+    return ::Crypto::UnsignedBigInteger(0);
+}
+
+void serialize_key_algorithm(HTML::TransferDataEncoder& encoder, JS::Object const& object)
+{
+    if (auto const* algorithm = as_if<RsaHashedKeyAlgorithm>(object)) {
+        encoder.encode(KeyAlgorithmTag::RsaHashedKeyAlgorithm);
+        encoder.encode(algorithm->name());
+        encoder.encode(algorithm->modulus_length());
+        encoder.encode_unsigned_big_integer(big_integer_from_api_big_integer(*algorithm->public_exponent()));
+        encoder.encode(MUST(algorithm->hash().name(algorithm->vm())));
+        return;
+    }
+
+    if (auto const* algorithm = as_if<RsaKeyAlgorithm>(object)) {
+        encoder.encode(KeyAlgorithmTag::RsaKeyAlgorithm);
+        encoder.encode(algorithm->name());
+        encoder.encode(algorithm->modulus_length());
+        encoder.encode_unsigned_big_integer(big_integer_from_api_big_integer(*algorithm->public_exponent()));
+        return;
+    }
+
+    if (auto const* algorithm = as_if<EcKeyAlgorithm>(object)) {
+        encoder.encode(KeyAlgorithmTag::EcKeyAlgorithm);
+        encoder.encode(algorithm->name());
+        encoder.encode(algorithm->named_curve());
+        return;
+    }
+
+    if (auto const* algorithm = as_if<AesKeyAlgorithm>(object)) {
+        encoder.encode(KeyAlgorithmTag::AesKeyAlgorithm);
+        encoder.encode(algorithm->name());
+        encoder.encode(algorithm->length());
+        return;
+    }
+
+    if (auto const* algorithm = as_if<HmacKeyAlgorithm>(object)) {
+        encoder.encode(KeyAlgorithmTag::HmacKeyAlgorithm);
+        encoder.encode(algorithm->name());
+        encoder.encode(algorithm->hash()->name());
+        encoder.encode(algorithm->length());
+        return;
+    }
+
+    if (auto const* algorithm = as_if<KmacKeyAlgorithm>(object)) {
+        encoder.encode(KeyAlgorithmTag::KmacKeyAlgorithm);
+        encoder.encode(algorithm->name());
+        encoder.encode(algorithm->length());
+        return;
+    }
+
+    auto const& algorithm = as<KeyAlgorithm>(object);
+    encoder.encode(KeyAlgorithmTag::KeyAlgorithm);
+    encoder.encode(algorithm.name());
+}
+
+WebIDL::ExceptionOr<GC::Ref<JS::Object>> deserialize_key_algorithm(HTML::TransferDataDecoder& decoder, JS::Realm& realm)
+{
+    auto tag = decoder.decode<KeyAlgorithmTag>();
+    switch (tag) {
+    case KeyAlgorithmTag::KeyAlgorithm: {
+        auto algorithm = KeyAlgorithm::create(realm);
+        algorithm->set_name(decoder.decode<String>());
+        return algorithm;
+    }
+    case KeyAlgorithmTag::RsaKeyAlgorithm: {
+        auto algorithm = RsaKeyAlgorithm::create(realm);
+        algorithm->set_name(decoder.decode<String>());
+        algorithm->set_modulus_length(decoder.decode<u32>());
+        TRY(algorithm->set_public_exponent(TRY(decoder.decode_unsigned_big_integer(realm))));
+        return algorithm;
+    }
+    case KeyAlgorithmTag::RsaHashedKeyAlgorithm: {
+        auto algorithm = RsaHashedKeyAlgorithm::create(realm);
+        algorithm->set_name(decoder.decode<String>());
+        algorithm->set_modulus_length(decoder.decode<u32>());
+        TRY(algorithm->set_public_exponent(TRY(decoder.decode_unsigned_big_integer(realm))));
+        algorithm->set_hash(decoder.decode<String>());
+        return algorithm;
+    }
+    case KeyAlgorithmTag::EcKeyAlgorithm: {
+        auto algorithm = EcKeyAlgorithm::create(realm);
+        algorithm->set_name(decoder.decode<String>());
+        algorithm->set_named_curve(decoder.decode<String>());
+        return algorithm;
+    }
+    case KeyAlgorithmTag::AesKeyAlgorithm: {
+        auto algorithm = AesKeyAlgorithm::create(realm);
+        algorithm->set_name(decoder.decode<String>());
+        algorithm->set_length(decoder.decode<u16>());
+        return algorithm;
+    }
+    case KeyAlgorithmTag::HmacKeyAlgorithm: {
+        auto algorithm = HmacKeyAlgorithm::create(realm);
+        algorithm->set_name(decoder.decode<String>());
+        auto hash = KeyAlgorithm::create(realm);
+        hash->set_name(decoder.decode<String>());
+        algorithm->set_hash(hash);
+        algorithm->set_length(decoder.decode<WebIDL::UnsignedLong>());
+        return algorithm;
+    }
+    case KeyAlgorithmTag::KmacKeyAlgorithm: {
+        auto algorithm = KmacKeyAlgorithm::create(realm);
+        algorithm->set_name(decoder.decode<String>());
+        algorithm->set_length(decoder.decode<WebIDL::UnsignedLong>());
+        return algorithm;
+    }
+    }
+    VERIFY_NOT_REACHED();
+}
 
 void serialize_handle(HTML::TransferDataEncoder& encoder, ByteBuffer const& buffer)
 {
@@ -155,11 +283,16 @@ WebIDL::ExceptionOr<::Crypto::PK::RSAPrivateKey> deserialize_rsa_private_key(HTM
     return ::Crypto::PK::RSAPrivateKey { move(modulus), move(private_exponent), move(public_exponent), move(prime1), move(prime2), move(exponent1), move(exponent2), move(coefficient) };
 }
 
+void serialize_ec_public_key(HTML::TransferDataEncoder& encoder, ::Crypto::PK::ECPublicKey const& key)
+{
+    encoder.encode(MUST(key.x_bytes()));
+    encoder.encode(MUST(key.y_bytes()));
+}
+
 void serialize_handle(HTML::TransferDataEncoder& encoder, ::Crypto::PK::ECPublicKey const& key)
 {
     encoder.encode(HandleTag::ECPublicKey);
-    encoder.encode(MUST(key.x_bytes()));
-    encoder.encode(MUST(key.y_bytes()));
+    serialize_ec_public_key(encoder, key);
 }
 
 WebIDL::ExceptionOr<::Crypto::PK::ECPublicKey> deserialize_ec_public_key(HTML::TransferDataDecoder& decoder, JS::Realm& realm)
@@ -177,7 +310,7 @@ void serialize_handle(HTML::TransferDataEncoder& encoder, ::Crypto::PK::ECPrivat
     encoder.encode(key.parameters());
     encoder.encode(key.public_key().has_value());
     if (key.public_key().has_value())
-        serialize_handle(encoder, *key.public_key());
+        serialize_ec_public_key(encoder, *key.public_key());
 }
 
 WebIDL::ExceptionOr<::Crypto::PK::ECPrivateKey> deserialize_ec_private_key(HTML::TransferDataDecoder& decoder, JS::Realm& realm)
@@ -372,10 +505,8 @@ JS_DEFINE_NATIVE_FUNCTION(CryptoKeyPair::private_key_getter)
     return TRY(Bindings::throw_dom_exception_if_needed(vm, [&] { return impl->private_key(); }));
 }
 
-WebIDL::ExceptionOr<void> CryptoKey::serialization_steps(HTML::TransferDataEncoder& serialized, bool for_storage, HTML::SerializationMemory& memory)
+WebIDL::ExceptionOr<void> CryptoKey::serialization_steps(HTML::TransferDataEncoder& serialized, bool, HTML::SerializationMemory&)
 {
-    auto& vm = this->vm();
-
     // 1. Set serialized.[[Type]] to the [[type]] internal slot of value.
     serialized.encode(m_type);
 
@@ -383,8 +514,7 @@ WebIDL::ExceptionOr<void> CryptoKey::serialization_steps(HTML::TransferDataEncod
     serialized.encode(m_extractable);
 
     // 3. Set serialized.[[Algorithm]] to the sub-serialization of the [[algorithm]] internal slot of value.
-    auto serialized_algorithm = TRY(HTML::structured_serialize_internal(vm, m_algorithm_cached, for_storage, memory));
-    serialized.append(move(serialized_algorithm));
+    serialize_key_algorithm(serialized, m_algorithm_cached);
 
     // 4. Set serialized.[[Usages]] to the sub-serialization of the [[usages]] internal slot of value.
     serialized.encode(m_usages);
@@ -395,9 +525,8 @@ WebIDL::ExceptionOr<void> CryptoKey::serialization_steps(HTML::TransferDataEncod
     return {};
 }
 
-WebIDL::ExceptionOr<void> CryptoKey::deserialization_steps(HTML::TransferDataDecoder& serialized, HTML::DeserializationMemory& memory)
+WebIDL::ExceptionOr<void> CryptoKey::deserialization_steps(HTML::TransferDataDecoder& serialized, HTML::DeserializationMemory&)
 {
-    auto& vm = this->vm();
     auto& realm = this->realm();
 
     // 1. Initialize the [[type]] internal slot of value to serialized.[[Type]].
@@ -407,8 +536,7 @@ WebIDL::ExceptionOr<void> CryptoKey::deserialization_steps(HTML::TransferDataDec
     m_extractable = serialized.decode<bool>();
 
     // 3. Initialize the [[algorithm]] internal slot of value to the sub-deserialization of serialized.[[Algorithm]].
-    auto deserialized = TRY(HTML::structured_deserialize_internal(vm, serialized, realm, memory));
-    m_algorithm_cached = deserialized.as_object();
+    m_algorithm_cached = TRY(deserialize_key_algorithm(serialized, realm));
 
     // 4. Initialize the [[usages]] internal slot of value to the sub-deserialization of serialized.[[Usages]].
     auto usages = serialized.decode<Vector<Bindings::KeyUsage>>();

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-cbc.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-cbc.https.any.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	serialization test {length: 128, name: AES-CBC}
+Pass	serialization test {length: 192, name: AES-CBC}
+Pass	serialization test {length: 256, name: AES-CBC}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-ctr.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-ctr.https.any.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	serialization test {length: 128, name: AES-CTR}
+Pass	serialization test {length: 192, name: AES-CTR}
+Pass	serialization test {length: 256, name: AES-CTR}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-gcm.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-gcm.https.any.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	serialization test {length: 128, name: AES-GCM}
+Pass	serialization test {length: 192, name: AES-GCM}
+Pass	serialization test {length: 256, name: AES-GCM}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-kw.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-kw.https.any.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	serialization test {length: 128, name: AES-KW}
+Pass	serialization test {length: 192, name: AES-KW}
+Pass	serialization test {length: 256, name: AES-KW}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-ocb.tentative.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/aes-ocb.tentative.https.any.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	serialization test {length: 128, name: AES-OCB}
+Pass	serialization test {length: 192, name: AES-OCB}
+Pass	serialization test {length: 256, name: AES-OCB}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/chacha20-poly1305.tentative.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/chacha20-poly1305.tentative.https.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	serialization test ChaCha20-Poly1305
+Pass	serialization test {name: ChaCha20-Poly1305}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/ecdh.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/ecdh.https.any.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	serialization test {name: ECDH, namedCurve: P-256}
+Pass	serialization test {name: ECDH, namedCurve: P-384}
+Pass	serialization test {name: ECDH, namedCurve: P-521}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/ecdsa.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/ecdsa.https.any.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	serialization test {name: ECDSA, namedCurve: P-256}
+Pass	serialization test {name: ECDSA, namedCurve: P-384}
+Pass	serialization test {name: ECDSA, namedCurve: P-521}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/ed25519.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/ed25519.https.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	serialization test Ed25519
+Pass	serialization test {name: Ed25519}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/ed448.tentative.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/ed448.tentative.https.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	serialization test Ed448
+Pass	serialization test {name: Ed448}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/hmac.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/hmac.https.any.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Pass
+Pass	serialization test {hash: SHA-1, length: 160, name: HMAC}
+Pass	serialization test {hash: SHA-256, length: 256, name: HMAC}
+Pass	serialization test {hash: SHA-384, length: 384, name: HMAC}
+Pass	serialization test {hash: SHA-512, length: 512, name: HMAC}
+Pass	serialization test {hash: SHA-1, name: HMAC}
+Pass	serialization test {hash: SHA-256, name: HMAC}
+Pass	serialization test {hash: SHA-384, name: HMAC}
+Pass	serialization test {hash: SHA-512, name: HMAC}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/kmac.tentative.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/kmac.tentative.https.any.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	serialization test {length: 128, name: KMAC128}
+Pass	serialization test {length: 160, name: KMAC128}
+Pass	serialization test {length: 256, name: KMAC128}
+Pass	serialization test {length: 128, name: KMAC256}
+Pass	serialization test {length: 160, name: KMAC256}
+Pass	serialization test {length: 256, name: KMAC256}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/mldsa.tentative.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/mldsa.tentative.https.any.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	serialization test ML-DSA-44
+Pass	serialization test {name: ML-DSA-44}
+Pass	serialization test ML-DSA-65
+Pass	serialization test {name: ML-DSA-65}
+Pass	serialization test ML-DSA-87
+Pass	serialization test {name: ML-DSA-87}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/mlkem.tentative.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/mlkem.tentative.https.any.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	serialization test ML-KEM-512
+Pass	serialization test {name: ML-KEM-512}
+Pass	serialization test ML-KEM-768
+Pass	serialization test {name: ML-KEM-768}
+Pass	serialization test ML-KEM-1024
+Pass	serialization test {name: ML-KEM-1024}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/rsa-oaep.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/rsa-oaep.https.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	serialization test {hash: SHA-1, modulusLength: 2048, name: RSA-OAEP, publicExponent: {0: 1, 1: 0, 2: 1}}
+Pass	serialization test {hash: SHA-256, modulusLength: 2048, name: RSA-OAEP, publicExponent: {0: 1, 1: 0, 2: 1}}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/rsa-pss.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/rsa-pss.https.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	serialization test {hash: SHA-1, modulusLength: 2048, name: RSA-PSS, publicExponent: {0: 1, 1: 0, 2: 1}}
+Pass	serialization test {hash: SHA-256, modulusLength: 2048, name: RSA-PSS, publicExponent: {0: 1, 1: 0, 2: 1}}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/rsassa-pkcs1-v1_5.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/rsassa-pkcs1-v1_5.https.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	serialization test {hash: SHA-1, modulusLength: 2048, name: RSASSA-PKCS1-v1_5, publicExponent: {0: 1, 1: 0, 2: 1}}
+Pass	serialization test {hash: SHA-256, modulusLength: 2048, name: RSASSA-PKCS1-v1_5, publicExponent: {0: 1, 1: 0, 2: 1}}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/x25519.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/x25519.https.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	serialization test X25519
+Pass	serialization test {name: X25519}

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/x448.tentative.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/serialization/x448.tentative.https.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	serialization test X448
+Pass	serialization test {name: X448}

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-cbc.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-cbc.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/aes-cbc.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-cbc.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-cbc.https.any.js
@@ -1,0 +1,11 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'AES-CBC',
+    resultType: 'CryptoKey',
+    usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+    exportFormat: 'raw'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-ctr.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-ctr.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/aes-ctr.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-ctr.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-ctr.https.any.js
@@ -1,0 +1,11 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'AES-CTR',
+    resultType: 'CryptoKey',
+    usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+    exportFormat: 'raw'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-gcm.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-gcm.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/aes-gcm.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-gcm.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-gcm.https.any.js
@@ -1,0 +1,11 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'AES-GCM',
+    resultType: 'CryptoKey',
+    usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+    exportFormat: 'raw'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-kw.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-kw.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/aes-kw.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-kw.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-kw.https.any.js
@@ -1,0 +1,11 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'AES-KW',
+    resultType: 'CryptoKey',
+    usages: ['wrapKey', 'unwrapKey'],
+    exportFormat: 'raw'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-ocb.tentative.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-ocb.tentative.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/aes-ocb.tentative.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-ocb.tentative.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/aes-ocb.tentative.https.any.js
@@ -1,0 +1,11 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'AES-OCB',
+    resultType: 'CryptoKey',
+    usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+    exportFormat: 'raw-secret'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/chacha20-poly1305.tentative.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/chacha20-poly1305.tentative.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/chacha20-poly1305.tentative.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/chacha20-poly1305.tentative.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/chacha20-poly1305.tentative.https.any.js
@@ -1,0 +1,11 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'ChaCha20-Poly1305',
+    resultType: 'CryptoKey',
+    usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+    exportFormat: 'raw-secret'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ecdh.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ecdh.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/ecdh.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ecdh.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ecdh.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'ECDH',
+    resultType: 'CryptoKeyPair',
+    usages: ['deriveKey', 'deriveBits'],
+    publicFormat: 'raw',
+    privateFormat: 'pkcs8'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ecdsa.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ecdsa.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/ecdsa.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ecdsa.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ecdsa.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'ECDSA',
+    resultType: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+    publicFormat: 'raw',
+    privateFormat: 'pkcs8'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ed25519.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ed25519.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/ed25519.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ed25519.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ed25519.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'Ed25519',
+    resultType: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+    publicFormat: 'raw',
+    privateFormat: 'pkcs8'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ed448.tentative.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ed448.tentative.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/ed448.tentative.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ed448.tentative.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/ed448.tentative.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'Ed448',
+    resultType: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+    publicFormat: 'raw',
+    privateFormat: 'pkcs8'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/hmac.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/hmac.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/hmac.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/hmac.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/hmac.https.any.js
@@ -1,0 +1,11 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'HMAC',
+    resultType: 'CryptoKey',
+    usages: ['sign', 'verify'],
+    exportFormat: 'raw'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/kmac.tentative.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/kmac.tentative.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/kmac.tentative.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/kmac.tentative.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/kmac.tentative.https.any.js
@@ -1,0 +1,17 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'KMAC128',
+    resultType: 'CryptoKey',
+    usages: ['sign', 'verify'],
+    exportFormat: 'raw-secret'
+  },
+  {
+    name: 'KMAC256',
+    resultType: 'CryptoKey',
+    usages: ['sign', 'verify'],
+    exportFormat: 'raw-secret'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/mldsa.tentative.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/mldsa.tentative.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/mldsa.tentative.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/mldsa.tentative.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/mldsa.tentative.https.any.js
@@ -1,0 +1,27 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+
+run_test([
+  {
+    name: 'ML-DSA-44',
+    resultType: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+    publicFormat: 'raw-public',
+    privateFormat: 'raw-seed'
+  },
+  {
+    name: 'ML-DSA-65',
+    resultType: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+    publicFormat: 'raw-public',
+    privateFormat: 'raw-seed'
+  },
+  {
+    name: 'ML-DSA-87',
+    resultType: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+    publicFormat: 'raw-public',
+    privateFormat: 'raw-seed'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/mlkem.tentative.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/mlkem.tentative.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/mlkem.tentative.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/mlkem.tentative.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/mlkem.tentative.https.any.js
@@ -1,0 +1,32 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'ML-KEM-512',
+    resultType: 'CryptoKeyPair',
+    usages: [
+      'decapsulateBits', 'decapsulateKey', 'encapsulateBits', 'encapsulateKey'
+    ],
+    publicFormat: 'raw-public',
+    privateFormat: 'raw-seed'
+  },
+  {
+    name: 'ML-KEM-768',
+    resultType: 'CryptoKeyPair',
+    usages: [
+      'decapsulateBits', 'decapsulateKey', 'encapsulateBits', 'encapsulateKey'
+    ],
+    publicFormat: 'raw-public',
+    privateFormat: 'raw-seed'
+  },
+  {
+    name: 'ML-KEM-1024',
+    resultType: 'CryptoKeyPair',
+    usages: [
+      'decapsulateBits', 'decapsulateKey', 'encapsulateBits', 'encapsulateKey'
+    ],
+    publicFormat: 'raw-public',
+    privateFormat: 'raw-seed'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsa-oaep.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsa-oaep.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/rsa-oaep.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsa-oaep.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsa-oaep.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'RSA-OAEP',
+    resultType: 'CryptoKeyPair',
+    usages: ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'],
+    publicFormat: 'spki',
+    privateFormat: 'pkcs8'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsa-pss.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsa-pss.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/rsa-pss.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsa-pss.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsa-pss.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'RSA-PSS',
+    resultType: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+    publicFormat: 'spki',
+    privateFormat: 'pkcs8'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsassa-pkcs1-v1_5.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsassa-pkcs1-v1_5.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/rsassa-pkcs1-v1_5.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsassa-pkcs1-v1_5.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/rsassa-pkcs1-v1_5.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'RSASSA-PKCS1-v1_5',
+    resultType: 'CryptoKeyPair',
+    usages: ['sign', 'verify'],
+    publicFormat: 'spki',
+    privateFormat: 'pkcs8'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/serialization.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/serialization.js
@@ -1,0 +1,55 @@
+function run_test(vectors) {
+  function testCryptoKeySerialization(
+      generateKeyAlgorithm, generateKeyUsages, exportFormat) {
+    promise_test(async t => {
+      var cryptoKey = await crypto.subtle.generateKey(
+          generateKeyAlgorithm, true, generateKeyUsages);
+      const keyExported =
+          await crypto.subtle.exportKey(exportFormat, cryptoKey);
+
+      const {key} = structuredClone({key: cryptoKey});
+      const newKeyExported =
+          await crypto.subtle.exportKey(exportFormat, key);
+      assert_true(equalBuffers(keyExported, newKeyExported));
+    }, 'serialization test ' + objectToString(generateKeyAlgorithm));
+  };
+
+  function testCryptoKeyPairSerialization(
+      generateKeyAlgorithm, generateKeyUsages, publicExportFormat,
+      privateExportFormat) {
+    promise_test(async t => {
+      var keyPair = await crypto.subtle.generateKey(
+          generateKeyAlgorithm, true, generateKeyUsages);
+      const publicKeyExported =
+          await crypto.subtle.exportKey(publicExportFormat, keyPair.publicKey);
+      const privateKeyExported = await crypto.subtle.exportKey(
+          privateExportFormat, keyPair.privateKey);
+
+      const {publicKey, privateKey} = structuredClone(
+          {publicKey: keyPair.publicKey, privateKey: keyPair.privateKey});
+      const newPublicKeyExported =
+          await crypto.subtle.exportKey(publicExportFormat, publicKey);
+      assert_true(equalBuffers(publicKeyExported, newPublicKeyExported));
+      const newPrivateKeyExported = await crypto.subtle.exportKey(
+          privateExportFormat, privateKey);
+      assert_true(equalBuffers(privateKeyExported, newPrivateKeyExported));
+    }, 'serialization test ' + objectToString(generateKeyAlgorithm));
+  };
+
+  vectors.forEach(function(vector) {
+    if (vector.resultType === 'CryptoKey') {
+      allAlgorithmSpecifiersFor(vector.name)
+          .forEach(function(generateKeyAlgorithm) {
+            testCryptoKeySerialization(
+                generateKeyAlgorithm, vector.usages, vector.exportFormat);
+          });
+    } else {
+      allAlgorithmSpecifiersFor(vector.name)
+          .forEach(function(generateKeyAlgorithm) {
+            testCryptoKeyPairSerialization(
+                generateKeyAlgorithm, vector.usages, vector.publicFormat,
+                vector.privateFormat);
+          });
+    }
+  });
+}

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/x25519.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/x25519.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/x25519.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/x25519.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/x25519.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'X25519',
+    resultType: 'CryptoKeyPair',
+    usages: ['deriveKey', 'deriveBits'],
+    publicFormat: 'raw',
+    privateFormat: 'pkcs8'
+  },
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/x448.tentative.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/x448.tentative.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: CryptoKey serialization</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../util/helpers.js"></script>
+<script src="serialization.js"></script>
+<div id=log></div>
+<script src="../../WebCryptoAPI/serialization/x448.tentative.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/x448.tentative.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/serialization/x448.tentative.https.any.js
@@ -1,0 +1,12 @@
+// META: title=WebCryptoAPI: CryptoKey serialization
+// META: script=../util/helpers.js
+// META: script=serialization.js
+run_test([
+  {
+    name: 'X448',
+    resultType: 'CryptoKeyPair',
+    usages: ['deriveKey', 'deriveBits'],
+    publicFormat: 'raw',
+    privateFormat: 'pkcs8'
+  },
+]);


### PR DESCRIPTION
CryptoKey structured serialization was cloning the internal algorithm slot as a generic JS object. After deserialization, WebCrypto operations such as exportKey() expected the slot to still be a native KeyAlgorithm subclass and crashed when downcasting it.

Serialize the stored key algorithm with an explicit tag and reconstruct the appropriate KeyAlgorithm subclass during deserialization. Also keep EC private-key serialization aligned by encoding nested public keys as EC public-key payloads rather than tagged top-level handles.