### PR TITLE
LibWeb: Reduce heavy style and layout work on Hacker News

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -151,6 +151,9 @@ void StyleComputer::visit_edges(Visitor& visitor)
         m_cached_line_height_computation_context->visit_edges(visitor);
     if (m_cached_generic_computation_context.has_value())
         m_cached_generic_computation_context->visit_edges(visitor);
+
+    for (auto& rule : m_rules_to_run_scratch)
+        rule.visit_edges(visitor);
 }
 
 Optional<String> StyleComputer::user_agent_style_sheet_source(StringView name)
@@ -371,7 +374,11 @@ Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules(
     else if (shadow_root)
         shadow_host = shadow_root->host();
 
-    Vector<ScopedMatchingRule, 512> rules_to_run;
+    auto& rules_to_run = m_rules_to_run_scratch;
+    VERIFY(rules_to_run.is_empty());
+    ScopeGuard clear_rules_to_run = [&] {
+        rules_to_run.clear_with_capacity();
+    };
 
     auto add_rule_to_run = [&](MatchingRule const& rule_to_run, GC::Ptr<DOM::ShadowRoot const> rule_root) {
         // FIXME: This needs to be revised when adding support for the ::shadow selector, as it needs to cross shadow boundaries.
@@ -3315,6 +3322,14 @@ void RuleCache::for_each_matching_rules(DOM::AbstractElement abstract_element, F
         return;
 
     (void)callback(other_rules);
+}
+
+void StyleComputer::ScopedMatchingRule::visit_edges(GC::Cell::Visitor& visitor)
+{
+    if (rule)
+        rule->visit_edges(visitor);
+    visitor.visit(shadow_root);
+    visitor.visit(scope_root);
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -111,6 +111,8 @@ public:
         GC::Ptr<DOM::ShadowRoot const> shadow_root;
         GC::Ptr<DOM::Element const> scope_root;
         size_t scope_proximity { NumericLimits<size_t>::max() };
+
+        void visit_edges(GC::Cell::Visitor& visitor);
     };
 
     [[nodiscard]] Vector<ScopedMatchingRule> collect_matching_rules(DOM::AbstractElement, CascadeOrigin, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name = {}) const;
@@ -230,6 +232,8 @@ private:
     }
 
     CSSPixelRect m_viewport_rect;
+
+    mutable Vector<ScopedMatchingRule> m_rules_to_run_scratch;
 
     OwnPtr<CountingBloomFilter<u8, 14>> m_ancestor_filter;
     OwnPtr<SelectorEngine::HasResultCache> m_has_result_cache;

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -74,7 +74,7 @@ void StyleScope::visit_edges(GC::Cell::Visitor& visitor)
     visitor.visit(m_pending_has_invalidations);
 }
 
-void MatchingRule::visit_edges(GC::Cell::Visitor& visitor)
+void MatchingRule::visit_edges(GC::Cell::Visitor& visitor) const
 {
     visitor.visit(rule);
     visitor.visit(sheet);

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -49,7 +49,7 @@ struct MatchingRule {
     SelectorList const& absolutized_selectors() const;
     FlyString const& qualified_layer_name() const;
 
-    void visit_edges(GC::Cell::Visitor&);
+    void visit_edges(GC::Cell::Visitor&) const;
 };
 
 struct RuleCache {

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -643,7 +643,9 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     table_box_state.padding_right = table_box_computed_values.padding().right().to_px_or_zero(*table_box, width_of_containing_block);
 
     auto context = make<TableFormattingContext>(throwaway_state, LayoutMode::IntrinsicSizing, *table_box, this);
-    context->run_until_width_calculation(m_state.get(*table_box).available_inner_space_or_constraints_from(available_space));
+    context->run_until_width_calculation(
+        m_state.get(*table_box).available_inner_space_or_constraints_from(available_space),
+        TableFormattingContext::RowMeasurement::Skip);
 
     auto table_used_width = throwaway_state.get(*table_box).border_box_width();
     if (table_wrapper_width_mode == TableWrapperWidthMode::UseTableUsedWidthIfNotAuto

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -158,7 +158,7 @@ void InlineLevelIterator::skip_to_next()
     compute_next();
 }
 
-Optional<InlineLevelIterator::Item> InlineLevelIterator::next()
+Optional<InlineLevelIterator::Item&> InlineLevelIterator::next()
 {
     if (m_next_item_index >= m_items.size())
         return {};
@@ -194,8 +194,9 @@ Gfx::GlyphRun::TextType InlineLevelIterator::resolve_text_direction_from_context
     // Search forward in the pre-generated chunks array to find the next chunk with known direction.
     // Since chunks are pre-generated, this is just O(1) array access per iteration.
     Optional<Gfx::GlyphRun::TextType> next_known_direction;
-    for (size_t i = m_text_node_context->next_chunk_index; i < m_text_node_context->chunks.size(); ++i) {
-        auto const& chunk = m_text_node_context->chunks[i];
+    auto const& chunks = m_text_node_context->chunk_list->chunks;
+    for (size_t i = m_text_node_context->next_chunk_index; i < chunks.size(); ++i) {
+        auto const& chunk = chunks[i];
         if (chunk.text_type == Gfx::GlyphRun::TextType::Ltr || chunk.text_type == Gfx::GlyphRun::TextType::Rtl) {
             next_known_direction = chunk.text_type;
             break;
@@ -235,11 +236,12 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
 
         // Get the next chunk from the pre-generated array
         Optional<TextNode::Chunk> chunk_opt;
-        if (m_text_node_context->next_chunk_index < m_text_node_context->chunks.size()) {
-            chunk_opt = m_text_node_context->chunks[m_text_node_context->next_chunk_index++];
+        auto const& chunks = m_text_node_context->chunk_list->chunks;
+        if (m_text_node_context->next_chunk_index < chunks.size()) {
+            chunk_opt = chunks[m_text_node_context->next_chunk_index++];
         }
 
-        bool is_last_chunk = (m_text_node_context->next_chunk_index >= m_text_node_context->chunks.size());
+        bool is_last_chunk = (m_text_node_context->next_chunk_index >= chunks.size());
 
         auto is_empty_editable = false;
         if (!chunk_opt.has_value()) {
@@ -426,7 +428,9 @@ void InlineLevelIterator::enter_text_node(Layout::TextNode const& text_node)
     auto const& chunks = text_node.chunks_for_layout(do_wrap_lines, do_respect_linebreaks);
 
     m_text_node_context = TextNodeContext {
-        .chunks = chunks.chunks,
+        // OPTIMIZATION: The chunk list is cached by the TextNode and only read by this iterator, so keep a pointer
+        //               to it instead of copying every chunk when entering a text node.
+        .chunk_list = &chunks,
         .next_chunk_index = 0,
         .should_collapse_whitespace = chunks.should_collapse_whitespace,
         .should_wrap_lines = do_wrap_lines,

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -52,7 +52,7 @@ public:
 
     InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutMode);
 
-    Optional<Item> next();
+    Optional<Item&> next();
     CSSPixels next_non_whitespace_sequence_width();
 
 private:
@@ -80,7 +80,7 @@ private:
     LayoutMode const m_layout_mode;
 
     struct TextNodeContext {
-        Vector<TextNode::Chunk> chunks;
+        TextNode::ChunkList const* chunk_list { nullptr };
         size_t next_chunk_index { 0 };
         bool should_collapse_whitespace {};
         bool should_wrap_lines {};

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -140,7 +140,7 @@ void TableFormattingContext::compute_constrainedness()
     }
 }
 
-void TableFormattingContext::compute_cell_measures()
+void TableFormattingContext::compute_cell_measures(RowMeasurement row_measurement)
 {
     // Implements https://www.w3.org/TR/css-tables-3/#computing-cell-measures.
     auto containing_block_width = table_wrapper_containing_block_width();
@@ -165,13 +165,7 @@ void TableFormattingContext::compute_cell_measures()
 
         auto min_content_width = calculate_min_content_width(cell.box);
         auto max_content_width = calculate_max_content_width(cell.box);
-        auto min_content_height = calculate_min_content_height(cell.box, max_content_width);
-        auto max_content_height = calculate_max_content_height(cell.box, min_content_width);
 
-        // The outer min-content height of a table-cell is max(min-height, min-content height) adjusted by the cell intrinsic offsets.
-        auto min_height = computed_values.min_height().to_px(cell.box, containing_block_height);
-        auto cell_intrinsic_height_offsets = padding_top + padding_bottom + border_top + border_bottom;
-        cell.outer_min_height = max(min_height, min_content_height) + cell_intrinsic_height_offsets;
         // The outer min-content width of a table-cell is max(min-width, min-content width) adjusted by the cell intrinsic offsets.
         auto min_width = computed_values.min_width().to_px(cell.box, containing_block_width);
         auto cell_intrinsic_width_offsets = padding_left + padding_right + border_left + border_right;
@@ -183,20 +177,30 @@ void TableFormattingContext::compute_cell_measures()
             cell.outer_min_width = max(min_width, min_content_width) + cell_intrinsic_width_offsets;
         }
 
-        // The tables specification isn't explicit on how to use the height and max-height CSS properties in the outer max-content formulas.
-        // However, during this early phase we don't have enough information to resolve percentage sizes yet and the formulas for outer sizes
-        // in the specification give enough clues to pick defaults in a way that makes sense.
-        auto height = computed_values.height().is_length() ? computed_values.height().to_px(cell.box, containing_block_height) : 0;
-        auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(cell.box, containing_block_height) : CSSPixels::max();
-        if (m_rows[cell.row_index].is_constrained) {
-            // The outer max-content height of a table-cell in a constrained row is
-            // max(min-height, height, min-content height, min(max-height, height)) adjusted by the cell intrinsic offsets.
-            // NB: min(max-height, height) doesn't have any effect here, we can simplify the expression to max(min-height, height, min-content height).
-            cell.outer_max_height = max(min_height, max(height, min_content_height)) + cell_intrinsic_height_offsets;
-        } else {
-            // The outer max-content height of a table-cell in a non-constrained row is
-            // max(min-height, height, min-content height, min(max-height, max-content height)) adjusted by the cell intrinsic offsets.
-            cell.outer_max_height = max(min_height, max(height, max(min_content_height, min(max_height, max_content_height)))) + cell_intrinsic_height_offsets;
+        if (row_measurement == RowMeasurement::Include) {
+            auto min_content_height = calculate_min_content_height(cell.box, max_content_width);
+            auto max_content_height = calculate_max_content_height(cell.box, min_content_width);
+
+            // The outer min-content height of a table-cell is max(min-height, min-content height) adjusted by the cell intrinsic offsets.
+            auto min_height = computed_values.min_height().to_px(cell.box, containing_block_height);
+            auto cell_intrinsic_height_offsets = padding_top + padding_bottom + border_top + border_bottom;
+            cell.outer_min_height = max(min_height, min_content_height) + cell_intrinsic_height_offsets;
+
+            // The tables specification isn't explicit on how to use the height and max-height CSS properties in the outer max-content formulas.
+            // However, during this early phase we don't have enough information to resolve percentage sizes yet and the formulas for outer sizes
+            // in the specification give enough clues to pick defaults in a way that makes sense.
+            auto height = computed_values.height().is_length() ? computed_values.height().to_px(cell.box, containing_block_height) : 0;
+            auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(cell.box, containing_block_height) : CSSPixels::max();
+            if (m_rows[cell.row_index].is_constrained) {
+                // The outer max-content height of a table-cell in a constrained row is
+                // max(min-height, height, min-content height, min(max-height, height)) adjusted by the cell intrinsic offsets.
+                // NB: min(max-height, height) doesn't have any effect here, we can simplify the expression to max(min-height, height, min-content height).
+                cell.outer_max_height = max(min_height, max(height, min_content_height)) + cell_intrinsic_height_offsets;
+            } else {
+                // The outer max-content height of a table-cell in a non-constrained row is
+                // max(min-height, height, min-content height, min(max-height, max-content height)) adjusted by the cell intrinsic offsets.
+                cell.outer_max_height = max(min_height, max(height, max(min_content_height, min(max_height, max_content_height)))) + cell_intrinsic_height_offsets;
+            }
         }
 
         // See the explanation for height and max_height above.
@@ -940,6 +944,35 @@ void TableFormattingContext::distribute_excess_width_to_columns_fixed_mode(CSSPi
     }
     // otherwise, the excess width is distributed equally to the zero-sized columns
     distribute_excess_width_equally(excess_width, [](auto const& column) { return column.used_width == 0; });
+}
+
+bool TableFormattingContext::can_skip_row_intrinsic_measurement() const
+{
+    for (auto const& row : m_rows) {
+        if (row.is_collapsed)
+            return false;
+
+        auto const& computed_values = row.box->computed_values();
+        if (!computed_values.height().is_auto()
+            || !computed_values.min_height().is_auto()
+            || !computed_values.max_height().is_none()) {
+            return false;
+        }
+    }
+
+    for (auto const& cell : m_cells) {
+        if (cell.row_span != 1)
+            return false;
+
+        auto const& computed_values = cell.box->computed_values();
+        if (!computed_values.height().is_auto()
+            || !computed_values.min_height().is_auto()
+            || !computed_values.max_height().is_none()) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 void TableFormattingContext::compute_table_height()
@@ -1739,7 +1772,7 @@ void TableFormattingContext::finish_grid_initialization(TableGrid const& table_g
     }
 }
 
-void TableFormattingContext::run_until_width_calculation(AvailableSpace const& available_space)
+void TableFormattingContext::run_until_width_calculation(AvailableSpace const& available_space, RowMeasurement row_measurement)
 {
     m_available_space = available_space;
 
@@ -1748,18 +1781,26 @@ void TableFormattingContext::run_until_width_calculation(AvailableSpace const& a
 
     border_conflict_resolution();
 
+    auto effective_row_measurement = row_measurement;
+    // OPTIMIZATION: Row intrinsic measurements are only needed when row height constraints or rowspans can affect
+    //               the later row height distribution. Simple tables get their actual row heights from cell layout.
+    if (effective_row_measurement == RowMeasurement::Include && can_skip_row_intrinsic_measurement())
+        effective_row_measurement = RowMeasurement::Skip;
+
     // Compute the minimum width of each column.
-    compute_cell_measures();
+    compute_cell_measures(effective_row_measurement);
     compute_outer_content_sizes();
     compute_table_measures<Column>();
 
-    // https://www.w3.org/TR/css-tables-3/#row-layout
-    // Since during row layout the specified heights of cells in the row were ignored and cells that were spanning more than one rows
-    // have not been sized correctly, their height will need to be eventually distributed to the set of rows they spanned. This is done
-    // by running the same algorithm as the column measurement, with the span=1 value being initialized (for min-content) with the largest
-    // of the resulting height of the previous row layout, the height specified on the corresponding table-row (if any), and the largest
-    // height specified on cells that span this row only (the algorithm starts by considering cells of span 2 on top of that assignment).
-    compute_table_measures<Row>();
+    if (effective_row_measurement == RowMeasurement::Include) {
+        // https://www.w3.org/TR/css-tables-3/#row-layout
+        // Since during row layout the specified heights of cells in the row were ignored and cells that were spanning more than one rows
+        // have not been sized correctly, their height will need to be eventually distributed to the set of rows they spanned. This is done
+        // by running the same algorithm as the column measurement, with the span=1 value being initialized (for min-content) with the largest
+        // of the resulting height of the previous row layout, the height specified on the corresponding table-row (if any), and the largest
+        // height specified on cells that span this row only (the algorithm starts by considering cells of span 2 on top of that assignment).
+        compute_table_measures<Row>();
+    }
 
     // Compute the width of the table.
     compute_table_width();

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -20,10 +20,15 @@ enum class TableDimension {
 
 class TableFormattingContext final : public FormattingContext {
 public:
+    enum class RowMeasurement {
+        Include,
+        Skip,
+    };
+
     explicit TableFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent);
     ~TableFormattingContext();
 
-    void run_until_width_calculation(AvailableSpace const& available_space);
+    void run_until_width_calculation(AvailableSpace const& available_space, RowMeasurement = RowMeasurement::Include);
 
     virtual void run(AvailableSpace const&) override;
     virtual CSSPixels automatic_content_width() const override;
@@ -44,7 +49,7 @@ private:
     CSSPixels run_caption_layout(CSS::CaptionSide, AvailableSpace const&);
     CSSPixels compute_capmin();
     void compute_constrainedness();
-    void compute_cell_measures();
+    void compute_cell_measures(RowMeasurement);
     void compute_outer_content_sizes();
     template<class RowOrColumn>
     void initialize_table_measures();
@@ -56,6 +61,7 @@ private:
     void distribute_width_to_columns();
     void distribute_excess_width_to_columns(CSSPixels available_width);
     void distribute_excess_width_to_columns_fixed_mode(CSSPixels excess_width);
+    bool can_skip_row_intrinsic_measurement() const;
     void compute_table_height();
     void distribute_height_to_rows();
     void position_row_boxes();


### PR DESCRIPTION
Reduce avoidable work in hot style and layout paths that show up on large pages with many nested tables and inline text, such as large Hacker News threads.

Table wrapper width probes now skip row intrinsic measurement, since those probes only need column sizing to determine the used table width. Simple tables without rowspans or row and cell height constraints also skip row intrinsic sizing during normal layout, leaving actual row heights to the later cell layout pass.

Inline layout now reuses cached TextNode chunk lists instead of copying them into each iterator context, and returns generated inline items by reference so line box generation can consume them without copying glyph run references on every iteration.

Style matching now keeps scoped rule matching scratch storage on StyleComputer. This lets repeated matching reuse the allocation and avoids creating a large automatically-zeroed stack object in collect_matching_rules() on every call.