### PR TITLE
LibWeb+UI: Add Regex support for the "Find in Page" feature

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -30,6 +30,7 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
+#include <LibRegex/ECMAScriptRegex.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibURL/Origin.h>
 #include <LibURL/Parser.h>
@@ -7796,6 +7797,66 @@ Vector<GC::Root<Range>> Document::find_matching_text(String const& query, CaseSe
             offset = match_index.value() + utf16_query.length_in_code_units() + 1;
             if (offset >= text_view.length_in_code_units())
                 break;
+        }
+    }
+
+    return matches;
+}
+
+Vector<GC::Root<Range>> Document::find_matching_regex(String const& pattern, CaseSensitivity case_sensitivity)
+{
+    // Ensure the layout tree exists before searching for text matches.
+    update_layout(UpdateLayoutReason::DocumentFindMatchingText);
+
+    if (!layout_node())
+        return {};
+
+    auto const& text_blocks = layout_node()->text_blocks();
+    if (text_blocks.is_empty())
+        return {};
+
+    regex::ECMAScriptCompileFlags flags {};
+    flags.global = true;
+    flags.ignore_case = case_sensitivity == CaseSensitivity::CaseInsensitive;
+    flags.multiline = true;
+    flags.unicode = true;
+
+    auto regex_or_error = regex::ECMAScriptRegex::compile(pattern, flags);
+    if (regex_or_error.is_error())
+        // FIXME: May want to report regex compilation errors to the user.
+        return {};
+
+    auto regex = regex_or_error.release_value();
+
+    Vector<GC::Root<Range>> matches;
+    for (auto const& text_block : text_blocks) {
+        Utf16View text_view { text_block.text };
+
+        auto match_count = regex.find_all(text_view, 0);
+        if (match_count <= 0)
+            continue;
+
+        for (int match_idx = 0; match_idx < match_count; ++match_idx) {
+            auto [start_offset, end_offset] = regex.find_all_match(match_idx);
+            if (start_offset < 0 || end_offset < 0 || static_cast<size_t>(start_offset) >= text_view.length_in_code_units())
+                continue;
+
+            size_t i = 0;
+            auto* match_start_position = text_block.positions.data();
+            for (; i < text_block.positions.size() - 1 && static_cast<size_t>(start_offset) > text_block.positions[i + 1].start_offset; ++i)
+                match_start_position = &text_block.positions[i + 1];
+
+            auto start_position = static_cast<size_t>(start_offset) - match_start_position->start_offset + match_start_position->dom_offset_within_node;
+            auto& start_dom_node = match_start_position->dom_node;
+
+            auto* match_end_position = match_start_position;
+            for (; i < text_block.positions.size() - 1 && (static_cast<size_t>(end_offset) > text_block.positions[i + 1].start_offset); ++i)
+                match_end_position = &text_block.positions[i + 1];
+
+            auto& end_dom_node = match_end_position->dom_node;
+            auto end_position = static_cast<size_t>(end_offset) - match_end_position->start_offset + match_end_position->dom_offset_within_node;
+
+            matches.append(Range::create(start_dom_node, start_position, end_dom_node, end_position));
         }
     }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -951,6 +951,7 @@ public:
     [[nodiscard]] bool is_decoded_svg() const { return m_is_decoded_svg; }
 
     Vector<GC::Root<Range>> find_matching_text(String const&, CaseSensitivity);
+    Vector<GC::Root<Range>> find_matching_regex(String const& pattern, CaseSensitivity);
 
     void parse_html_from_a_string(StringView);
     static WebIDL::ExceptionOr<GC::Root<DOM::Document>> parse_html_unsafe(JS::VM&, TrustedTypes::TrustedHTMLOrString const&);

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -900,7 +900,9 @@ Page::FindInPageResult Page::perform_find_in_page_query(FindInPageQuery const& q
 
     auto should_update_match_index = false;
     for (auto const& document : documents_in_active_window()) {
-        auto matches = document->find_matching_text(query.string, query.case_sensitivity);
+        auto matches = query.use_regex
+            ? document->find_matching_regex(query.string, query.case_sensitivity)
+            : document->find_matching_text(query.string, query.case_sensitivity);
         if (document == top_level_traversable()->active_document()) {
             if (auto range = active_range(*document)) {
                 auto new_match_index = find_current_match_index(*range, matches);

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -271,6 +271,7 @@ public:
         CaseSensitivity case_sensitivity { CaseSensitivity::CaseInsensitive };
         WrapAround wrap_around { WrapAround::Yes };
         ClearSelectionOnNoMatch clear_selection_on_no_match { ClearSelectionOnNoMatch::Yes };
+        bool use_regex { false };
     };
     struct FindInPageResult {
         size_t current_match_index { 0 };

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -430,9 +430,9 @@ void ViewImplementation::select_all()
     client().async_select_all(page_id());
 }
 
-void ViewImplementation::find_in_page(String const& query, CaseSensitivity case_sensitivity)
+void ViewImplementation::find_in_page(String const& query, CaseSensitivity case_sensitivity, bool regex)
 {
-    client().async_find_in_page(page_id(), query, case_sensitivity);
+    client().async_find_in_page(page_id(), query, case_sensitivity, regex);
 }
 
 void ViewImplementation::find_in_page_next_match()

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -112,7 +112,7 @@ public:
     ByteString cut_selected_text();
     Optional<String> selected_text_with_whitespace_collapsed();
     void select_all();
-    void find_in_page(String const& query, CaseSensitivity = CaseSensitivity::CaseInsensitive);
+    void find_in_page(String const& query, CaseSensitivity = CaseSensitivity::CaseInsensitive, bool regex = false);
     void find_in_page_next_match();
     void find_in_page_previous_match();
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1592,13 +1592,13 @@ void ConnectionFromClient::select_all(u64 page_id)
         page->page().focused_navigable().select_all();
 }
 
-void ConnectionFromClient::find_in_page(u64 page_id, String query, CaseSensitivity case_sensitivity)
+void ConnectionFromClient::find_in_page(u64 page_id, String query, CaseSensitivity case_sensitivity, bool regex)
 {
     auto page = this->page(page_id);
     if (!page.has_value())
         return;
 
-    auto result = page->page().find_in_page({ .string = query, .case_sensitivity = case_sensitivity });
+    auto result = page->page().find_in_page({ .string = query, .case_sensitivity = case_sensitivity, .use_regex = regex });
     async_did_find_in_page(page_id, result.current_match_index, result.total_match_count);
 }
 

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -175,7 +175,7 @@ private:
     virtual Messages::WebContentServer::CutSelectedTextResponse cut_selected_text(u64 page_id) override;
     virtual void select_all(u64 page_id) override;
 
-    virtual void find_in_page(u64 page_id, String query, CaseSensitivity) override;
+    virtual void find_in_page(u64 page_id, String query, CaseSensitivity, bool regex) override;
     virtual void find_in_page_next_match(u64 page_id) override;
     virtual void find_in_page_previous_match(u64 page_id) override;
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -103,7 +103,7 @@ endpoint WebContentServer
     select_all(u64 page_id) =|
     paste(u64 page_id, Utf16String text) =|
 
-    find_in_page(u64 page_id, String query, AK::CaseSensitivity case_sensitivity) =|
+    find_in_page(u64 page_id, String query, AK::CaseSensitivity case_sensitivity, bool regex) =|
     find_in_page_next_match(u64 page_id) =|
     find_in_page_previous_match(u64 page_id) =|
 

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -66,7 +66,8 @@
 - (void)handleVisibility:(BOOL)is_visible;
 
 - (void)findInPage:(NSString*)query
-    caseSensitivity:(CaseSensitivity)case_sensitivity;
+    caseSensitivity:(CaseSensitivity)case_sensitivity
+              regex:(bool)regex;
 - (void)findInPageNextMatch;
 - (void)findInPagePreviousMatch;
 

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -252,8 +252,9 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 
 - (void)findInPage:(NSString*)query
     caseSensitivity:(CaseSensitivity)case_sensitivity
+              regex:(bool)regex
 {
-    m_web_view_bridge->find_in_page(Ladybird::ns_string_to_string(query), case_sensitivity);
+    m_web_view_bridge->find_in_page(Ladybird::ns_string_to_string(query), case_sensitivity, regex);
 }
 
 - (void)findInPageNextMatch

--- a/UI/AppKit/Interface/SearchPanel.mm
+++ b/UI/AppKit/Interface/SearchPanel.mm
@@ -21,10 +21,12 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
 @interface SearchPanel () <NSSearchFieldDelegate>
 {
     CaseSensitivity m_case_sensitivity;
+    bool m_use_regex;
 }
 
 @property (nonatomic, strong) NSSearchField* search_field;
 @property (nonatomic, strong) NSButton* search_match_case;
+@property (nonatomic, strong) NSButton* search_regex;
 @property (nonatomic, strong) NSTextField* result_label;
 
 @end
@@ -56,6 +58,12 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
         [self.search_match_case setState:NSControlStateValueOff];
         m_case_sensitivity = CaseSensitivity::CaseInsensitive;
 
+        self.search_regex = [NSButton checkboxWithTitle:@"Regex"
+                                                 target:self
+                                                 action:@selector(find:)];
+        [self.search_regex setState:NSControlStateValueOff];
+        m_use_regex = false;
+
         self.result_label = [NSTextField labelWithString:@""];
         [self.result_label setHidden:YES];
 
@@ -69,6 +77,7 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
         [self addView:search_previous inGravity:NSStackViewGravityLeading];
         [self addView:search_next inGravity:NSStackViewGravityLeading];
         [self addView:self.search_match_case inGravity:NSStackViewGravityLeading];
+        [self addView:self.search_regex inGravity:NSStackViewGravityLeading];
         [self addView:self.result_label inGravity:NSStackViewGravityLeading];
         [self addView:search_done inGravity:NSStackViewGravityTrailing];
 
@@ -119,7 +128,7 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
 
     if (![self isHidden]) {
         [self.search_field setStringValue:query];
-        [[[self tab] web_view] findInPage:query caseSensitivity:m_case_sensitivity];
+        [[[self tab] web_view] findInPage:query caseSensitivity:m_case_sensitivity regex:m_use_regex];
 
         [self.window makeFirstResponder:self.search_field];
     }
@@ -170,12 +179,14 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
         auto case_sensitivity = [self.search_match_case state] == NSControlStateValueOff
             ? CaseSensitivity::CaseInsensitive
             : CaseSensitivity::CaseSensitive;
+        auto use_regex = [self.search_regex state] == NSControlStateValueOn;
 
-        if (case_sensitivity != m_case_sensitivity || ![[self.search_field stringValue] isEqual:query]) {
+        if (use_regex != m_use_regex || case_sensitivity != m_case_sensitivity || ![[self.search_field stringValue] isEqual:query]) {
             [self.search_field setStringValue:query];
             m_case_sensitivity = case_sensitivity;
+            m_use_regex = use_regex;
 
-            [[[self tab] web_view] findInPage:query caseSensitivity:m_case_sensitivity];
+            [[[self tab] web_view] findInPage:query caseSensitivity:m_case_sensitivity regex:m_use_regex];
             return YES;
         }
     }
@@ -193,7 +204,7 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
 - (void)controlTextDidChange:(NSNotification*)notification
 {
     auto* query = [self.search_field stringValue];
-    [[[self tab] web_view] findInPage:query caseSensitivity:m_case_sensitivity];
+    [[[self tab] web_view] findInPage:query caseSensitivity:m_case_sensitivity regex:m_use_regex];
 
     [self setPasteBoardContents:query];
 }

--- a/UI/Qt/FindInPageWidget.cpp
+++ b/UI/Qt/FindInPageWidget.cpp
@@ -78,6 +78,17 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
         find_text_changed();
     });
 
+    m_regex = new QCheckBox(this);
+    m_regex->setText("Regex");
+    m_regex->setChecked(false);
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    connect(m_regex, &QCheckBox::checkStateChanged, this, [this] {
+#else
+    connect(m_regex, &QCheckBox::stateChanged, this, [this] {
+#endif
+        find_text_changed();
+    });
+
     m_result_label = new QLabel(this);
     m_result_label->setVisible(false);
     m_result_label->setStyleSheet("font-weight: bold;");
@@ -86,6 +97,7 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     layout->addWidget(m_previous_button);
     layout->addWidget(m_next_button);
     layout->addWidget(m_match_case);
+    layout->addWidget(m_regex);
     layout->addWidget(m_result_label);
     layout->addStretch(1);
     layout->addWidget(m_exit_button);
@@ -119,7 +131,8 @@ void FindInPageWidget::find_text_changed()
 {
     auto query = ak_string_from_qstring(m_find_text->text());
     auto case_sensitive = m_match_case->isChecked() ? CaseSensitivity::CaseSensitive : CaseSensitivity::CaseInsensitive;
-    m_content_view->find_in_page(query, case_sensitive);
+    auto regex = m_regex->isChecked();
+    m_content_view->find_in_page(query, case_sensitive, regex);
 }
 
 void FindInPageWidget::keyPressEvent(QKeyEvent* event)

--- a/UI/Qt/FindInPageWidget.h
+++ b/UI/Qt/FindInPageWidget.h
@@ -53,6 +53,7 @@ private:
     QPushButton* m_next_button { nullptr };
     QPushButton* m_exit_button { nullptr };
     QCheckBox* m_match_case { nullptr };
+    QCheckBox* m_regex { nullptr };
     QLabel* m_result_label { nullptr };
     bool m_is_updating_chrome_style { false };
 };


### PR DESCRIPTION
Fixes #5479 

- LibWeb: Add `Document::find_matching_regex()` function using `ECMAScriptRegex`
- LibWebView+IPC: Pass regex flag through `find_in_page` IPC
- UI/Qt: Add "Regex" checkbox to FindInPageWidget
- UI/AppKit: Add "Regex" checkbox to SearchPanel

Skipped support for GTK, since it has not even support "Find in Page" and I have no device to compile and test that version. :(

**Qt**:
<img width="1180" height="875" alt="Screenshot 2026-05-30 at 18 48 25" src="https://github.com/user-attachments/assets/d5445cc0-6571-4f34-ac30-c4c6910fd513" />

**AppKit**:
<img width="1379" height="942" alt="Screenshot 2026-05-30 at 18 49 44" src="https://github.com/user-attachments/assets/ca681420-a295-453d-b98e-d24fc4d9c6d0" />
