### PR TITLE
Compositor+LibWeb+LibWebView: Simplify compositor context IDs

### DIFF
--- a/Libraries/LibWeb/Compositor/Types.h
+++ b/Libraries/LibWeb/Compositor/Types.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Assertions.h>
-#include <AK/Atomic.h>
 #include <AK/DistinctNumeric.h>
 #include <AK/Optional.h>
 #include <AK/Types.h>
@@ -23,29 +22,10 @@ namespace Web::Compositor {
 AK_TYPEDEF_DISTINCT_ORDERED_ID(u64, CompositorContextId);
 AK_TYPEDEF_DISTINCT_ORDERED_ID(u64, ScreenshotRequestId);
 
-static constexpr u64 page_presenting_context_id_tag = 1ull << 63;
-
-inline CompositorContextId allocate_compositor_context_id()
-{
-    static Atomic<u64> s_next_id { 1 };
-    return CompositorContextId { s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed) };
-}
-
 inline CompositorContextId compositor_context_id_for_page(u64 page_id)
 {
-    VERIFY((page_id & page_presenting_context_id_tag) == 0);
-    return CompositorContextId { page_presenting_context_id_tag | page_id };
-}
-
-inline bool is_page_presenting_compositor_context_id(CompositorContextId context_id)
-{
-    return (context_id.value() & page_presenting_context_id_tag) != 0;
-}
-
-inline u64 page_id_for_compositor_context_id(CompositorContextId context_id)
-{
-    VERIFY(is_page_presenting_compositor_context_id(context_id));
-    return context_id.value() & ~page_presenting_context_id_tag;
+    VERIFY(page_id > 0);
+    return CompositorContextId { page_id };
 }
 
 enum class WindowResizingInProgress : u8 {

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -431,9 +431,7 @@ public:
     {
         if (page_presentation_registration == Compositor::PagePresentationRegistration::Yes)
             return Compositor::compositor_context_id_for_page(id());
-        auto context_id = Compositor::allocate_compositor_context_id();
-        VERIFY(!Compositor::is_page_presenting_compositor_context_id(context_id));
-        return context_id;
+        VERIFY_NOT_REACHED();
     }
     virtual void request_frame() = 0;
     virtual void page_did_change_title(Utf16String const&) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -504,20 +504,27 @@ void Application::open_url_in_new_window(URL::URL const& url)
     dbgln("open_url_in_new_window() is unsupported on this platform (url: {})", url);
 }
 
-static ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&> view)
+ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, u64 initial_page_id)
 {
     auto request_server_handle = TRY(connect_new_request_server_client());
     auto image_decoder_handle = TRY(connect_new_image_decoder_client());
 
-    NonnullRefPtr<WebContentClient> client = view.has_value()
-        ? TRY(WebView::launch_web_content_process(*view))
-        : TRY(WebView::launch_spare_web_content_process());
+    auto client = TRY(WebView::launch_web_content_process(initial_page_id));
+    client->async_initialize(initial_page_id);
+    if (view.has_value())
+        client->assign_view({}, *view);
 
     client->async_connect_to_request_server(move(request_server_handle));
     client->async_connect_to_image_decoder(move(image_decoder_handle));
     TRY(Application::the().connect_web_content_to_compositor(*client));
 
     return client;
+}
+
+u64 Application::allocate_page_id()
+{
+    VERIFY(m_next_page_id < Web::Compositor::page_presenting_context_id_tag);
+    return m_next_page_id++;
 }
 
 static bool can_send_compositor_process_ipc(RefPtr<CompositorClient> const& compositor_client)
@@ -652,7 +659,7 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process
     }
 
     launch_spare_web_content_process();
-    return create_web_content_client(view);
+    return create_web_content_client(view, allocate_page_id());
 }
 
 void Application::launch_spare_web_content_process()
@@ -676,7 +683,7 @@ void Application::launch_spare_web_content_process()
     Core::deferred_invoke([this]() {
         m_has_queued_task_to_launch_spare_web_content_process = false;
 
-        auto web_content_client = create_web_content_client({});
+        auto web_content_client = create_web_content_client({}, allocate_page_id());
         if (web_content_client.is_error()) {
             dbgln("Unable to create spare web content client: {}", web_content_client.error());
             return;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -523,8 +523,14 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(
 
 u64 Application::allocate_page_id()
 {
-    VERIFY(m_next_page_id < Web::Compositor::page_presenting_context_id_tag);
-    return m_next_page_id++;
+    VERIFY(m_next_page_or_compositor_context_id > 0);
+    return m_next_page_or_compositor_context_id++;
+}
+
+Web::Compositor::CompositorContextId Application::allocate_compositor_context_id()
+{
+    VERIFY(m_next_page_or_compositor_context_id > 0);
+    return Web::Compositor::CompositorContextId { m_next_page_or_compositor_context_id++ };
 }
 
 static bool can_send_compositor_process_ipc(RefPtr<CompositorClient> const& compositor_client)
@@ -552,7 +558,7 @@ ErrorOr<void> Application::connect_web_content_to_compositor(WebContentClient& w
     return {};
 }
 
-void Application::register_compositor_context(WebContentClient& web_content_client, Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
+void Application::register_compositor_context(WebContentClient& web_content_client, Web::Compositor::CompositorContextId context_id, Optional<u64> page_id)
 {
     if (!can_send_compositor_process_ipc(m_compositor_client))
         return;
@@ -565,10 +571,10 @@ void Application::register_compositor_context(WebContentClient& web_content_clie
     }
     VERIFY(web_content_connection_id.has_value());
 
-    m_compositor_client->create_context(context_id, page_id, page_presentation_registration, *web_content_connection_id);
+    m_compositor_client->create_context(context_id, page_id, *web_content_connection_id);
 }
 
-ErrorOr<void> Application::try_register_compositor_context(WebContentClient& web_content_client, Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
+ErrorOr<void> Application::try_register_compositor_context(WebContentClient& web_content_client, Web::Compositor::CompositorContextId context_id, Optional<u64> page_id)
 {
     if (!m_compositor_client)
         return Error::from_string_literal("Compositor process is not available");
@@ -580,7 +586,7 @@ ErrorOr<void> Application::try_register_compositor_context(WebContentClient& web
     }
     VERIFY(web_content_connection_id.has_value());
 
-    auto result = m_compositor_client->try_create_context(context_id, page_id, page_presentation_registration, *web_content_connection_id);
+    auto result = m_compositor_client->try_create_context(context_id, page_id, *web_content_connection_id);
     if (result.is_error())
         return Error::from_string_literal("Compositor process disconnected while creating context");
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -92,6 +92,7 @@ public:
 #endif
 
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
+    u64 allocate_page_id();
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);
     void register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
     ErrorOr<void> try_register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
@@ -231,6 +232,7 @@ protected:
     Main::Arguments& arguments() { return m_arguments; }
 
 private:
+    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, u64 initial_page_id);
     ErrorOr<void> launch_services();
     void launch_spare_web_content_process();
     ErrorOr<void> launch_compositor_process();
@@ -327,6 +329,7 @@ private:
 
     RefPtr<WebContentClient> m_spare_web_content_process;
     bool m_has_queued_task_to_launch_spare_web_content_process { false };
+    u64 m_next_page_id { 1 };
 
     RefPtr<Database::Database> m_database;
     RefPtr<Database::Database> m_history_database;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -93,9 +93,10 @@ public:
 
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
     u64 allocate_page_id();
+    Web::Compositor::CompositorContextId allocate_compositor_context_id();
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);
-    void register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
-    ErrorOr<void> try_register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
+    void register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id);
+    ErrorOr<void> try_register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id);
     void update_compositor_viewport(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress = Web::Compositor::WindowResizingInProgress::No);
     void update_compositor_display_metadata(Web::Compositor::CompositorContextId, Optional<u64> display_id, double refresh_rate);
     bool send_async_scroll_to_compositor(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
@@ -329,7 +330,7 @@ private:
 
     RefPtr<WebContentClient> m_spare_web_content_process;
     bool m_has_queued_task_to_launch_spare_web_content_process { false };
-    u64 m_next_page_id { 1 };
+    u64 m_next_page_or_compositor_context_id { 1 };
 
     RefPtr<Database::Database> m_database;
     RefPtr<Database::Database> m_history_database;

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -82,8 +82,7 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
     VERIFY_NOT_REACHED();
 }
 
-template<typename... ClientArguments>
-static ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process_impl(ClientArguments&&... client_arguments)
+ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(u64 initial_page_id)
 {
     auto const& browser_options = WebView::Application::browser_options();
     auto const& web_content_options = WebView::Application::web_content_options();
@@ -142,17 +141,7 @@ static ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_proc
         arguments.append("--mach-server-name"sv);
         arguments.append(server.value());
     }
-    return launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), forward<ClientArguments>(client_arguments)...);
-}
-
-ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(WebView::ViewImplementation& view)
-{
-    return launch_web_content_process_impl(view);
-}
-
-ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_spare_web_content_process()
-{
-    return launch_web_content_process_impl();
+    return launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), initial_page_id);
 }
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process()

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -13,15 +13,12 @@
 #include <LibRequests/RequestClient.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWebView/Forward.h>
-#include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
 #include <LibWebView/WebWorkerClient.h>
 
 namespace WebView {
 
-WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(WebView::ViewImplementation&);
-
-WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_spare_web_content_process();
+WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(u64 initial_page_id);
 
 WEBVIEW_API ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process();
 WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process();

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -79,21 +79,24 @@ void WebContentClient::die()
 
 Web::Compositor::CompositorContextId WebContentClient::compositor_context_id_for_page(u64 page_id)
 {
-    if (auto context_id = m_page_compositor_context_ids.get(page_id); context_id.has_value())
-        return *context_id;
+    auto context_id = Web::Compositor::compositor_context_id_for_page(page_id);
+    if (auto registered_page_id = m_compositor_contexts.get(context_id); registered_page_id.has_value()) {
+        VERIFY(registered_page_id->has_value());
+        VERIFY(**registered_page_id == page_id);
+        return context_id;
+    }
 
-    auto context_id = Web::Compositor::allocate_compositor_context_id();
-    VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
-    remember_compositor_context(context_id, page_id, Web::Compositor::PagePresentationRegistration::Yes);
-    Application::the().register_compositor_context(*this, context_id, page_id, Web::Compositor::PagePresentationRegistration::Yes);
+    remember_compositor_context(context_id, page_id);
+    Application::the().register_compositor_context(*this, context_id, page_id);
     return context_id;
 }
 
 Optional<u64> WebContentClient::page_id_for_compositor_context_id(Web::Compositor::CompositorContextId context_id) const
 {
-    if (auto page_id = m_page_ids_for_compositor_context_ids.get(context_id); page_id.has_value())
-        return *page_id;
-    return {};
+    auto page_id = m_compositor_contexts.get(context_id);
+    if (!page_id.has_value())
+        return {};
+    return *page_id;
 }
 
 Messages::WebContentClient::AllocateCompositorContextIdResponse WebContentClient::allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
@@ -101,10 +104,9 @@ Messages::WebContentClient::AllocateCompositorContextIdResponse WebContentClient
     if (page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes)
         return compositor_context_id_for_page(page_id);
 
-    auto context_id = Web::Compositor::allocate_compositor_context_id();
-    VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
-    remember_compositor_context(context_id, {}, page_presentation_registration);
-    Application::the().register_compositor_context(*this, context_id, {}, page_presentation_registration);
+    auto context_id = Application::the().allocate_compositor_context_id();
+    remember_compositor_context(context_id, {});
+    Application::the().register_compositor_context(*this, context_id, {});
     return context_id;
 }
 
@@ -117,22 +119,12 @@ bool WebContentClient::forget_compositor_context(Web::Compositor::CompositorCont
 {
     if (!m_compositor_contexts.remove(context_id))
         return false;
-    if (auto page_id = m_page_ids_for_compositor_context_ids.take(context_id); page_id.has_value())
-        m_page_compositor_context_ids.remove(*page_id);
     return true;
 }
 
-void WebContentClient::remember_compositor_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
+void WebContentClient::remember_compositor_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id)
 {
-    m_compositor_contexts.set(context_id, CompositorContextRegistration {
-                                              .page_id = page_id,
-                                              .page_presentation_registration = page_presentation_registration,
-                                          });
-
-    if (page_id.has_value()) {
-        m_page_compositor_context_ids.set(*page_id, context_id);
-        m_page_ids_for_compositor_context_ids.set(context_id, *page_id);
-    }
+    m_compositor_contexts.set(context_id, page_id);
 }
 
 void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
@@ -160,8 +152,7 @@ void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 
 void WebContentClient::unregister_view(u64 page_id)
 {
-    if (auto context_id = m_page_compositor_context_ids.get(page_id); context_id.has_value())
-        forget_compositor_context(*context_id);
+    forget_compositor_context(Web::Compositor::compositor_context_id_for_page(page_id));
 
     // A page that still needs a beforeunload check is not a detached
     // background close. It is being closed without waiting for WebContent,
@@ -223,8 +214,6 @@ void WebContentClient::web_ui_disconnected(Badge<WebUI>)
 void WebContentClient::destroy_all_compositor_contexts()
 {
     m_compositor_contexts.clear();
-    m_page_compositor_context_ids.clear();
-    m_page_ids_for_compositor_context_ids.clear();
 }
 
 ErrorOr<void> WebContentClient::reconnect_to_compositor_process(Badge<Application>)
@@ -242,8 +231,8 @@ ErrorOr<void> WebContentClient::recreate_compositor_contexts(Badge<Application>)
     if (!is_open())
         return {};
 
-    for (auto const& [context_id, registration] : m_compositor_contexts)
-        TRY(Application::the().try_register_compositor_context(*this, context_id, registration.page_id, registration.page_presentation_registration));
+    for (auto const& [context_id, page_id] : m_compositor_contexts)
+        TRY(Application::the().try_register_compositor_context(*this, context_id, page_id));
 
     return {};
 }
@@ -254,10 +243,10 @@ void WebContentClient::update_compositor_viewports_after_reconnect(Badge<Applica
         return;
 
     for (auto const& [page_id, view] : m_views) {
-        auto context_id = m_page_compositor_context_ids.get(page_id);
-        if (!context_id.has_value())
+        auto context_id = Web::Compositor::compositor_context_id_for_page(page_id);
+        if (!m_compositor_contexts.contains(context_id))
             continue;
-        Application::the().update_compositor_viewport(*context_id, view->viewport_size().to_type<int>());
+        Application::the().update_compositor_viewport(context_id, view->viewport_size().to_type<int>());
     }
 }
 
@@ -317,25 +306,20 @@ bool WebContentClient::handle_mouse_event_in_compositor(u64 page_id, Web::MouseE
 
 void WebContentClient::dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const& event)
 {
-    auto context_id = m_page_compositor_context_ids.get(page_id);
-    if (context_id.has_value() && Application::the().dispatch_mouse_event_to_web_content(*context_id, event))
+    auto context_id = compositor_context_id_for_page(page_id);
+    if (Application::the().dispatch_mouse_event_to_web_content(context_id, event))
         return;
-    if (!context_id.has_value()) {
-        auto new_context_id = compositor_context_id_for_page(page_id);
-        if (Application::the().dispatch_mouse_event_to_web_content(new_context_id, event))
-            return;
-    }
 
     async_mouse_event(page_id, event.clone_without_browser_data());
 }
 
 void WebContentClient::notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
 {
-    auto context_id = m_page_compositor_context_ids.get(page_id);
-    if (!context_id.has_value())
+    auto context_id = Web::Compositor::compositor_context_id_for_page(page_id);
+    if (!m_compositor_contexts.contains(context_id))
         return;
 
-    Application::the().notify_compositor_presented_bitmap_ready_to_paint(*context_id, bitmap_id);
+    Application::the().notify_compositor_presented_bitmap_ready_to_paint(context_id, bitmap_id);
 }
 
 void WebContentClient::did_present_bitmap(u64 page_id, Gfx::IntRect rect, i32 bitmap_id)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -46,16 +46,11 @@ static Optional<String> history_title(Utf16String const& title, URL::URL const& 
     return title_utf8;
 }
 
-WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, ViewImplementation& view)
+WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, u64 initial_page_id)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
+    , m_initial_page_id(initial_page_id)
 {
-    s_clients.set(this);
-    m_views.set(0, view);
-}
-
-WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport)
-    : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
-{
+    VERIFY(m_initial_page_id > 0);
     s_clients.set(this);
 }
 
@@ -143,7 +138,8 @@ void WebContentClient::remember_compositor_context(Web::Compositor::CompositorCo
 void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
 {
     VERIFY(m_views.is_empty());
-    m_views.set(0, view);
+    view.m_client_state.page_index = m_initial_page_id;
+    m_views.set(m_initial_page_id, view);
 }
 
 void WebContentClient::set_compositor_connection_id(Badge<Application>, i32 compositor_connection_id)
@@ -157,6 +153,7 @@ void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
     if (m_detached_page_close_timer)
         m_detached_page_close_timer->stop();
     Application::process_manager().cancel_forced_exit(pid());
+    view.m_client_state.page_index = page_id;
     m_views.set(page_id, view);
     m_history_recorded_urls_for_current_load.remove(page_id);
 }
@@ -405,7 +402,7 @@ void WebContentClient::did_start_loading(u64 page_id, URL::URL url, bool is_redi
 void WebContentClient::did_finish_loading(u64 page_id, URL::URL url)
 {
     if (url.scheme() == "about"sv && url.paths().size() == 1) {
-        if (auto web_ui = WebUI::create(*this, url.paths().first()); web_ui.is_error())
+        if (auto web_ui = WebUI::create(*this, page_id, url.paths().first()); web_ui.is_error())
             warnln("Could not create WebUI for {}: {}", url, web_ui.error());
         else
             m_web_ui = web_ui.release_value();
@@ -1016,14 +1013,16 @@ void WebContentClient::did_post_broadcast_channel_message(u64, Web::HTML::Broadc
     WorkerProcessManager::the().broadcast_channel_message_from_web_content(message);
 }
 
-Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index)
+Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints)
 {
+    auto new_page_id = Application::the().allocate_page_id();
+    String handle;
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_new_web_view)
-            return view->on_new_web_view(activate_tab, hints, page_index);
+            handle = view->on_new_web_view(activate_tab, hints, new_page_id);
     }
 
-    return String {};
+    return { new_page_id, move(handle) };
 }
 
 void WebContentClient::did_request_activate_tab(u64 page_id)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -54,8 +54,7 @@ public:
     static size_t client_count() { return s_clients.size(); }
     static Optional<WebContentClient&> client_for_compositor_context_id(Web::Compositor::CompositorContextId);
 
-    explicit WebContentClient(NonnullOwnPtr<IPC::Transport>);
-    WebContentClient(NonnullOwnPtr<IPC::Transport>, ViewImplementation&);
+    WebContentClient(NonnullOwnPtr<IPC::Transport>, u64 initial_page_id);
     ~WebContentClient();
 
     void assign_view(Badge<Application>, ViewImplementation&);
@@ -161,7 +160,7 @@ private:
     virtual Messages::WebContentClient::DidRequestStorageKeysResponse did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
     virtual void did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
     virtual void did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) override;
-    virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints, Optional<u64> page_index) override;
+    virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints) override;
     virtual void did_request_activate_tab(u64 page_id) override;
     virtual void did_close_browsing_context(u64 page_id) override;
     virtual void did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) override;
@@ -211,6 +210,7 @@ private:
     HashMap<Web::Compositor::CompositorContextId, u64> m_page_ids_for_compositor_context_ids;
     HashMap<u64, String> m_history_recorded_urls_for_current_load;
     Optional<i32> m_compositor_connection_id;
+    u64 m_initial_page_id { 0 };
 
     ProcessHandle m_process_handle;
     RefPtr<Core::Timer> m_detached_page_close_timer;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -196,18 +196,11 @@ private:
 
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());
 
-    struct CompositorContextRegistration {
-        Optional<u64> page_id;
-        Web::Compositor::PagePresentationRegistration page_presentation_registration { Web::Compositor::PagePresentationRegistration::No };
-    };
-
-    void remember_compositor_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
+    void remember_compositor_context(Web::Compositor::CompositorContextId, Optional<u64> page_id);
 
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
     HashTable<u64> m_detached_pages_pending_close;
-    HashMap<Web::Compositor::CompositorContextId, CompositorContextRegistration> m_compositor_contexts;
-    HashMap<u64, Web::Compositor::CompositorContextId> m_page_compositor_context_ids;
-    HashMap<Web::Compositor::CompositorContextId, u64> m_page_ids_for_compositor_context_ids;
+    HashMap<Web::Compositor::CompositorContextId, Optional<u64>> m_compositor_contexts;
     HashMap<u64, String> m_history_recorded_urls_for_current_load;
     Optional<i32> m_compositor_connection_id;
     u64 m_initial_page_id { 0 };

--- a/Libraries/LibWebView/WebUI.cpp
+++ b/Libraries/LibWebView/WebUI.cpp
@@ -16,29 +16,31 @@
 namespace WebView {
 
 template<typename WebUIType>
-static ErrorOr<NonnullRefPtr<WebUIType>> create_web_ui(WebContentClient& client, String host)
+static ErrorOr<NonnullRefPtr<WebUIType>> create_web_ui(WebContentClient& client, u64 page_id, String host)
 {
+    VERIFY(page_id > 0);
+
     auto paired = TRY(IPC::Transport::create_paired());
     auto handle = move(paired.remote_handle);
 
     auto web_ui = WebUIType::create(client, move(paired.local), move(host));
-    client.async_connect_to_web_ui(0, move(handle));
+    client.async_connect_to_web_ui(page_id, move(handle));
 
     return web_ui;
 }
 
-ErrorOr<RefPtr<WebUI>> WebUI::create(WebContentClient& client, String host)
+ErrorOr<RefPtr<WebUI>> WebUI::create(WebContentClient& client, u64 page_id, String host)
 {
     RefPtr<WebUI> web_ui;
 
     if (host == "bookmarks"sv)
-        web_ui = TRY(create_web_ui<BookmarksUI>(client, move(host)));
+        web_ui = TRY(create_web_ui<BookmarksUI>(client, page_id, move(host)));
     else if (host == "processes"sv)
-        web_ui = TRY(create_web_ui<ProcessesUI>(client, move(host)));
+        web_ui = TRY(create_web_ui<ProcessesUI>(client, page_id, move(host)));
     else if (host == "settings"sv)
-        web_ui = TRY(create_web_ui<SettingsUI>(client, move(host)));
+        web_ui = TRY(create_web_ui<SettingsUI>(client, page_id, move(host)));
     else if (host == "version"sv)
-        web_ui = TRY(create_web_ui<VersionUI>(client, move(host)));
+        web_ui = TRY(create_web_ui<VersionUI>(client, page_id, move(host)));
 
     if (web_ui)
         web_ui->register_interfaces();

--- a/Libraries/LibWebView/WebUI.h
+++ b/Libraries/LibWebView/WebUI.h
@@ -12,6 +12,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
+#include <AK/Types.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibIPC/Transport.h>
 #include <LibWebView/Forward.h>
@@ -24,7 +25,7 @@ class WEBVIEW_API WebUI
     : public IPC::ConnectionToServer<WebUIClientEndpoint, WebUIServerEndpoint>
     , public WebUIClientEndpoint {
 public:
-    static ErrorOr<RefPtr<WebUI>> create(WebContentClient&, String host);
+    static ErrorOr<RefPtr<WebUI>> create(WebContentClient&, u64 page_id, String host);
     virtual ~WebUI();
 
     String const& host() const { return m_host; }

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -11,7 +11,7 @@ endpoint CompositorControlServer
 
     connect_web_content() => (IPC::TransportHandle handle, i32 web_content_connection_id)
 
-    create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, i32 web_content_connection_id) => ()
+    create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, i32 web_content_connection_id) => ()
 
     viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
     set_display_metadata(Web::Compositor::CompositorContextId context_id, Optional<u64> display_id, double refresh_rate) =|

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -172,23 +172,18 @@ void CompositorState::destroy_contexts_for_web_content_client(CompositorStateWeb
     }
 }
 
-void CompositorState::create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, CompositorStateWebContentClient& web_content_client)
+void CompositorState::create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, CompositorStateWebContentClient& web_content_client)
 {
     VERIFY(!m_contexts.contains(context_id));
-    if (page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes) {
-        VERIFY(page_id.has_value());
-    } else {
-        VERIFY(!page_id.has_value());
-        VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
-    }
+    if (page_id.has_value())
+        VERIFY(context_id == Web::Compositor::compositor_context_id_for_page(*page_id));
 
     auto& context = *m_contexts.ensure(context_id, [] {
         return make<ContextState>();
     });
     context.web_content_client = &web_content_client;
     context.page_id = page_id;
-    context.page_presentation_registration = page_presentation_registration;
-    if (page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes)
+    if (page_id.has_value())
         context.presentation_mode = Web::Compositor::PresentToClient {};
     resize_backing_stores_if_needed(context_id, context);
 }
@@ -224,7 +219,7 @@ void CompositorState::set_presentation_mode(Web::Compositor::CompositorContextId
     presentation_mode.visit(
         [](Empty const&) {},
         [&](Web::Compositor::PresentToClient const&) {
-            VERIFY(context_state.page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes);
+            VERIFY(context_state.page_id.has_value());
         },
         [&](Web::Compositor::PublishToCompositorSurface const& mode) {
             auto* parent_context = context_if_present(mode.target_context_id);
@@ -384,8 +379,6 @@ bool CompositorState::dispatch_mouse_event_to_web_content(Web::Compositor::Compo
     VERIFY(context->web_content_client);
 
     auto page_id = context->page_id;
-    if (!page_id.has_value() && Web::Compositor::is_page_presenting_compositor_context_id(context_id))
-        page_id = Web::Compositor::page_id_for_compositor_context_id(context_id);
     VERIFY(page_id.has_value());
 
     context->web_content_client->dispatch_mouse_event_to_web_content(*page_id, event);
@@ -497,7 +490,7 @@ void CompositorState::viewport_size_updated(Web::Compositor::CompositorContextId
         return;
 
     context->viewport_size = viewport_size;
-    auto is_page_presentation_context = context->page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes;
+    auto is_page_presentation_context = context->page_id.has_value();
     context->window_resize_in_progress = is_page_presentation_context
         ? window_resize_in_progress
         : Web::Compositor::WindowResizingInProgress::No;

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -73,7 +73,7 @@ public:
     ContextOwnerCheckResult check_context_owner(Web::Compositor::CompositorContextId, CompositorStateWebContentClient&);
     void destroy_contexts_for_web_content_client(CompositorStateWebContentClient&);
 
-    void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration, CompositorStateWebContentClient&);
+    void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, CompositorStateWebContentClient&);
     void destroy_context(Web::Compositor::CompositorContextId);
 
     void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode);
@@ -116,7 +116,6 @@ private:
 
         CompositorStateWebContentClient* web_content_client { nullptr };
         Optional<u64> page_id;
-        Web::Compositor::PagePresentationRegistration page_presentation_registration { Web::Compositor::PagePresentationRegistration::No };
 
         Web::Compositor::PresentationMode presentation_mode { Empty {} };
         Optional<PublishedSurface> published_surface;

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -62,11 +62,11 @@ Messages::CompositorControlServer::ConnectWebContentResponse ConnectionFromClien
     return { move(paired_transport.remote_handle), web_content_connection_id };
 }
 
-void ConnectionFromClient::create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, i32 web_content_connection_id)
+void ConnectionFromClient::create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, i32 web_content_connection_id)
 {
     auto* connection = web_content_connection(web_content_connection_id);
     VERIFY(connection);
-    m_compositor_state->create_context(context_id, page_id, page_presentation_registration, *connection);
+    m_compositor_state->create_context(context_id, page_id, *connection);
 }
 
 void ConnectionFromClient::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -37,7 +37,7 @@ private:
 
     virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;
-    virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration, i32 web_content_connection_id) override;
+    virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, i32 web_content_connection_id) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress) override;
     virtual void set_display_metadata(Web::Compositor::CompositorContextId, Optional<u64>, double) override;
     virtual Messages::CompositorControlServer::HandleMouseEventResponse handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -112,6 +112,11 @@ Messages::WebContentServer::InitTransportResponse ConnectionFromClient::init_tra
     VERIFY_NOT_REACHED();
 }
 
+void ConnectionFromClient::initialize(u64 initial_page_id)
+{
+    m_page_host->initialize(initial_page_id);
+}
+
 Optional<PageClient&> ConnectionFromClient::page(u64 index, SourceLocation location)
 {
     if (auto page = m_page_host->page(index); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -66,6 +66,7 @@ private:
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;
 
     virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
+    virtual void initialize(u64 initial_page_id) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
     virtual void set_window_handle(u64 page_id, String handle) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -702,22 +702,18 @@ void PageClient::page_did_update_resource_count(i32 count_waiting)
 
 PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Web::HTML::TokenizedFeature::NoOpener no_opener)
 {
-    auto& new_client = m_owner.create_page();
-
-    Optional<u64> page_id;
     if (no_opener == Web::HTML::TokenizedFeature::NoOpener::Yes) {
         // FIXME: Create an abstraction to let this WebContent process know about a new process we create?
         // FIXME: For now, just create a new page in the same process anyway
     }
 
-    page_id = new_client.m_id;
-
-    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestNewWebView>(m_id, activate_tab, hints, page_id);
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestNewWebView>(m_id, activate_tab, hints);
     if (!response) {
         dbgln("WebContent client disconnected during DidRequestNewWebView. Exiting peacefully.");
         exit(0);
     }
 
+    auto& new_client = m_owner.create_page(response->new_page_id());
     return { &new_client.page(), response->take_handle() };
 }
 

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -20,25 +20,31 @@ namespace WebContent {
 PageHost::PageHost(ConnectionFromClient& client)
     : m_client(client)
 {
-    auto& first_page = create_page();
+}
+
+void PageHost::initialize(u64 initial_page_id)
+{
+    VERIFY(m_pages.is_empty());
+    auto& first_page = create_page(initial_page_id);
     Web::HTML::TraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank());
 }
 
-PageClient& PageHost::create_page()
+PageClient& PageHost::create_page(u64 page_id)
 {
-    m_pages.set(m_next_id, PageClient::create(Web::Bindings::main_thread_vm(), *this, m_next_id));
-    ++m_next_id;
-    return *m_pages.get(m_next_id - 1).value();
+    VERIFY(page_id > 0);
+    VERIFY(!m_pages.contains(page_id));
+    m_pages.set(page_id, PageClient::create(Web::Bindings::main_thread_vm(), *this, page_id));
+    return *m_pages.get(page_id).value();
 }
 
-void PageHost::remove_page(Badge<PageClient>, u64 index)
+void PageHost::remove_page(Badge<PageClient>, u64 page_id)
 {
-    m_pages.remove(index);
+    m_pages.remove(page_id);
 }
 
-Optional<PageClient&> PageHost::page(u64 index)
+Optional<PageClient&> PageHost::page(u64 page_id)
 {
-    return m_pages.get(index).map([](auto& value) -> PageClient& {
+    return m_pages.get(page_id).map([](auto& value) -> PageClient& {
         return *value;
     });
 }

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -35,9 +35,10 @@ public:
     static NonnullOwnPtr<PageHost> create(ConnectionFromClient& client) { return adopt_own(*new PageHost(client)); }
     virtual ~PageHost();
 
-    Optional<PageClient&> page(u64 index);
-    PageClient& create_page();
-    void remove_page(Badge<PageClient>, u64 index);
+    void initialize(u64 initial_page_id);
+    Optional<PageClient&> page(u64 page_id);
+    PageClient& create_page(u64 page_id);
+    void remove_page(Badge<PageClient>, u64 page_id);
 
     ConnectionFromClient& client() const { return m_client; }
     void ensure_compositor_host();
@@ -51,7 +52,6 @@ private:
     ConnectionFromClient& m_client;
     OwnPtr<Web::Compositor::CompositorHost> m_compositor_host;
     HashMap<u64, GC::Root<PageClient>> m_pages;
-    u64 m_next_id { 0 };
 };
 
 }

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -107,7 +107,7 @@ endpoint WebContentClient
     did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) =|
 
     did_update_resource_count(u64 page_id, i32 count_waiting) =|
-    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) => (String handle)
+    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints) => (u64 new_page_id, String handle)
     did_request_activate_tab(u64 page_id) =|
     did_close_browsing_context(u64 page_id) =|
     did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -26,6 +26,7 @@
 endpoint WebContentServer
 {
     init_transport(int peer_pid) => (int peer_pid)
+    initialize(u64 initial_page_id) =|
     close_server() =|
 
     get_window_handle(u64 page_id) => (String handle)

--- a/Tests/LibWeb/test-web/TestWebView.cpp
+++ b/Tests/LibWeb/test-web/TestWebView.cpp
@@ -41,7 +41,7 @@ NonnullRefPtr<Core::Promise<RefPtr<Gfx::Bitmap const>>> TestWebView::take_screen
     VERIFY(!m_pending_screenshot);
 
     m_pending_screenshot = Core::Promise<RefPtr<Gfx::Bitmap const>>::construct();
-    client().async_take_document_screenshot(0);
+    client().async_take_document_screenshot(page_id());
 
     return *m_pending_screenshot;
 }


### PR DESCRIPTION
Page-presenting compositor contexts still carried a separate tagged ID
namespace and Browser-side page/context maps even though page IDs are
now allocated globally by the UI process. That made context
registration keep two ways to describe the same relationship and
forced compositor IPC to pass an extra presentation bit.

Use each page ID directly as its page-presenting compositor context ID
and allocate non-page compositor contexts from the same Browser-owned
counter. The registration path now sends only the optional page ID, and
Compositor infers client presentation from that page ID.