### PR TITLE
LibJS: Pass actual argument lists through Proxy calls

### DIFF
--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -105,6 +105,11 @@ public:
         return { arguments_data(), argument_count };
     }
 
+    ReadonlySpan<Value> passed_arguments_span() const
+    {
+        return { arguments_data(), passed_argument_count };
+    }
+
     Value* arguments_data()
     {
         return registers_and_constants_and_locals_and_arguments() + (registers_and_constants_and_locals_and_arguments_count - argument_count);

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -798,11 +798,11 @@ ThrowCompletionOr<Value> ProxyObject::internal_call(ExecutionContext& callee_con
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? Call(target, thisArgument, argumentsList).
-        return call(vm, m_target, this_argument, callee_context.arguments_span());
+        return call(vm, m_target, this_argument, callee_context.passed_arguments_span());
     }
 
     // 7. Let argArray be CreateArrayFromList(argumentsList).
-    auto arguments_array = Array::create_from(realm, callee_context.arguments_span());
+    auto arguments_array = Array::create_from(realm, callee_context.passed_arguments_span());
 
     // 8. Return ? Call(trap, handler, « target, thisArgument, argArray »).
     return call(vm, trap, m_handler, m_target, this_argument, arguments_array);
@@ -846,7 +846,7 @@ ThrowCompletionOr<GC::Ref<Object>> ProxyObject::internal_construct(ExecutionCont
     }
 
     // 8. Let argArray be CreateArrayFromList(argumentsList).
-    auto arguments_array = Array::create_from(realm, callee_context.arguments_span());
+    auto arguments_array = Array::create_from(realm, callee_context.passed_arguments_span());
 
     // 9. Let newObj be ? Call(trap, handler, « target, argArray, newTarget »).
     auto new_object = TRY(call(vm, trap, m_handler, m_target, arguments_array, &new_target));

--- a/Tests/LibJS/Runtime/builtins/Proxy/Proxy.handler-apply.js
+++ b/Tests/LibJS/Runtime/builtins/Proxy/Proxy.handler-apply.js
@@ -25,6 +25,32 @@ describe("[[Call]] trap normal behavior", () => {
         expect(p(2, 4)).toBe(6);
         expect(p(2, 4, true)).toBe(8);
     });
+
+    test("trap receives only passed arguments", () => {
+        let receivedArguments;
+        const p = new Proxy(function (_formalParameter) {}, {
+            apply(_target, _thisValue, arguments_) {
+                receivedArguments = arguments_;
+            },
+        });
+
+        p();
+        expect(receivedArguments.length).toBe(0);
+
+        p(1, 2);
+        expect(receivedArguments.length).toBe(2);
+        expect(receivedArguments[0]).toBe(1);
+        expect(receivedArguments[1]).toBe(2);
+    });
+
+    test("forwarding uses only passed arguments", () => {
+        const p = new Proxy(function (_formalParameter) {
+            return arguments.length;
+        }, {});
+
+        expect(p()).toBe(0);
+        expect(p(1, 2)).toBe(2);
+    });
 });
 
 describe("[[Call]] invariants", () => {

--- a/Tests/LibJS/Runtime/builtins/Proxy/Proxy.handler-construct.js
+++ b/Tests/LibJS/Runtime/builtins/Proxy/Proxy.handler-construct.js
@@ -63,6 +63,47 @@ describe("[[Construct]] trap normal behavior", () => {
 
         Reflect.construct(p, [15], theNewTarget);
     });
+
+    test("trap receives only passed arguments", () => {
+        let receivedArguments;
+        const p = new Proxy(
+            class {
+                constructor(_formalParameter) {}
+            },
+            {
+                construct(target, arguments_, newTarget) {
+                    receivedArguments = arguments_;
+                    return Reflect.construct(target, arguments_, newTarget);
+                },
+            }
+        );
+
+        new p();
+        expect(receivedArguments.length).toBe(0);
+
+        new p(1, 2);
+        expect(receivedArguments.length).toBe(2);
+        expect(receivedArguments[0]).toBe(1);
+        expect(receivedArguments[1]).toBe(2);
+    });
+
+    test("bound proxy constructor preserves empty argument list", () => {
+        let receivedArguments;
+        const p = new Proxy(
+            class {
+                constructor(_formalParameter) {}
+            },
+            {
+                construct(target, arguments_, newTarget) {
+                    receivedArguments = arguments_;
+                    return Reflect.construct(target, arguments_, newTarget);
+                },
+            }
+        );
+
+        new (p.bind(undefined))();
+        expect(receivedArguments.length).toBe(0);
+    });
 });
 
 describe("[[Construct]] invariants", () => {


### PR DESCRIPTION
Proxy call and construct paths used ExecutionContext::arguments_span() when forwarding through proxy traps. That span includes padding for formal parameters that were not passed, so handlers could observe arguments that were never supplied by the caller.

Use the passed-argument count to build proxy trap argument arrays and to forward calls without an apply trap. This keeps proxy apply and construct behavior aligned with the ECMAScript argument list. It also fixes bound proxy constructors receiving a synthetic undefined argument in their trap list.