### PR TITLE
LibWeb: Collapse whitespace when gathering find in page text

### DIFF
--- a/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Libraries/LibWeb/Layout/Viewport.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/Dump.h>
@@ -57,9 +58,33 @@ Vector<Viewport::TextBlock> const& Viewport::text_blocks()
 void Viewport::update_text_blocks()
 {
     StringBuilder builder(StringBuilder::Mode::UTF16);
-    size_t current_start_position = 0;
     Vector<TextPosition> text_positions;
     Vector<TextBlock> text_blocks;
+
+    DOM::Text* pending_space_dom_node = nullptr;
+    DOM::Text const* current_dom_node = nullptr;
+    size_t pending_space_dom_offset = 0;
+    size_t expected_dom_offset = 0;
+    size_t builder_length_in_code_units = 0;
+
+    auto flush_block = [&] {
+        if (!builder.is_empty())
+            text_blocks.append({ builder.to_utf16_string(), text_positions });
+        text_positions.clear_with_capacity();
+        builder.clear();
+        builder_length_in_code_units = 0;
+        pending_space_dom_node = nullptr;
+        current_dom_node = nullptr;
+    };
+
+    auto append_code_unit = [&](DOM::Text& dom_node, char16_t code_unit, size_t dom_offset) {
+        if (current_dom_node != &dom_node || dom_offset != expected_dom_offset)
+            text_positions.empend(dom_node, builder_length_in_code_units, dom_offset);
+        builder.append_code_unit(code_unit);
+        builder_length_in_code_units++;
+        current_dom_node = &dom_node;
+        expected_dom_offset = dom_offset + 1;
+    };
 
     for_each_in_inclusive_subtree([&](auto const& layout_node) {
         if (layout_node.display().is_none() || !layout_node.first_paintable() || !layout_node.first_paintable()->is_visible())
@@ -69,12 +94,7 @@ void Viewport::update_text_blocks()
         auto const wraps_dom_text = pseudo == CSS::PseudoElement::FirstLetter;
 
         if (layout_node.is_box() || (pseudo.has_value() && !wraps_dom_text)) {
-            if (!builder.is_empty()) {
-                text_blocks.append({ builder.to_utf16_string(), text_positions });
-                current_start_position = 0;
-                text_positions.clear_with_capacity();
-                builder.clear();
-            }
+            flush_block();
             return TraversalDecision::Continue;
         }
 
@@ -82,22 +102,44 @@ void Viewport::update_text_blocks()
             // https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees
             // When a node is inert:
             // - The user agent should ignore the node for the purposes of find-in-page.
-            if (auto& dom_node = const_cast<DOM::Text&>(text_node->dom_node()); !dom_node.is_inert()) {
-                auto const dom_offset = text_node->dom_start_offset();
-                auto const builder_offset = text_positions.is_empty() ? size_t { 0 } : current_start_position;
-                text_positions.empend(dom_node, builder_offset, dom_offset);
+            auto& dom_node = const_cast<DOM::Text&>(text_node->dom_node());
+            if (dom_node.is_inert())
+                return TraversalDecision::Continue;
 
-                auto const& current_node_text = text_node->text_for_rendering();
-                current_start_position += current_node_text.length_in_code_units();
-                builder.append(current_node_text);
+            auto white_space_collapse = text_node->computed_values().white_space_collapse();
+            auto const should_collapse = first_is_one_of(white_space_collapse,
+                CSS::WhiteSpaceCollapse::Collapse,
+                CSS::WhiteSpaceCollapse::PreserveBreaks);
+            auto const dom_start_offset = text_node->dom_start_offset();
+            auto const& text = text_node->text_for_rendering();
+            auto const text_view = text.utf16_view();
+
+            for (size_t i = 0; i < text_view.length_in_code_units(); ++i) {
+                auto const code_unit = text_view.code_unit_at(i);
+                auto const dom_offset = dom_start_offset + i;
+
+                if (should_collapse && is_ascii_space(code_unit) && code_unit != '\n') {
+                    if (!pending_space_dom_node) {
+                        pending_space_dom_node = &dom_node;
+                        pending_space_dom_offset = dom_offset;
+                    }
+                    continue;
+                }
+
+                if (pending_space_dom_node) {
+                    if (!text_positions.is_empty())
+                        append_code_unit(*pending_space_dom_node, ' ', pending_space_dom_offset);
+                    pending_space_dom_node = nullptr;
+                }
+
+                append_code_unit(dom_node, code_unit, dom_offset);
             }
         }
 
         return TraversalDecision::Continue;
     });
 
-    if (!builder.is_empty())
-        text_blocks.append({ builder.to_utf16_string(), text_positions });
+    flush_block();
 
     m_text_blocks = move(text_blocks);
 }

--- a/Tests/LibWeb/Text/expected/HTML/window-find-whitespace-collapse.txt
+++ b/Tests/LibWeb/Text/expected/HTML/window-find-whitespace-collapse.txt
@@ -1,0 +1,12 @@
+collapsed query 'alpha beta': true
+raw query 'alpha     beta': false
+offset-case startContainer is text node: true
+offset-case startOffset: 0
+offset-case endOffset: 15
+split inline query 'epsilon zeta': true
+cross-node query 'sigma x': true
+cross-node-case endOffset within node: true
+first-letter query 'kappa lambda': true
+first-letter-case endOffset within node: true
+pre raw query 'mu     nu': true
+pre collapsed query 'mu nu': false

--- a/Tests/LibWeb/Text/input/HTML/window-find-whitespace-collapse.html
+++ b/Tests/LibWeb/Text/input/HTML/window-find-whitespace-collapse.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<style>
+    #first-letter-case::first-letter { color: red; }
+    #pre-case { white-space: pre; }
+</style>
+<script src="../include.js"></script>
+<p id="collapse-case">
+alpha     beta
+</p>
+<p id="offset-case">gamma     delta</p>
+<p id="split-inline-case">epsilon <span> zeta</span></p>
+<p id="cross-node-space-case"><span>sigma   </span><span>x</span></p>
+<p id="first-letter-case">kappa lambda</p>
+<p id="pre-case">mu     nu</p>
+<script>
+    test(() => {
+        function find(query) {
+            window.getSelection().removeAllRanges();
+            return window.find(query);
+        }
+
+        // Searching against collapsed whitespace finds the rendered text, not the raw text.
+        println("collapsed query 'alpha beta': " + find("alpha beta"));
+        println("raw query 'alpha     beta': " + find("alpha     beta"));
+
+        // A match maps back to the original (uncollapsed) DOM offsets.
+        find("gamma delta");
+        let range = window.getSelection().getRangeAt(0);
+        println("offset-case startContainer is text node: " + (range.startContainer.nodeType === Node.TEXT_NODE));
+        println("offset-case startOffset: " + range.startOffset);
+        println("offset-case endOffset: " + range.endOffset);
+
+        // Whitespace collapses across adjacent inline text nodes.
+        println("split inline query 'epsilon zeta': " + find("epsilon zeta"));
+        println("cross-node query 'sigma x': " + find("sigma x"));
+
+        // A match ending on a collapsed space that straddles a node boundary must produce an in-bounds DOM offset,
+        // even when the following node is shorter than the offset would be.
+        find("sigma ");
+        range = window.getSelection().getRangeAt(0);
+        println("cross-node-case endOffset within node: " + (range.endOffset <= range.endContainer.length));
+
+        // Searching works across a ::first-letter boundary.
+        println("first-letter query 'kappa lambda': " + find("kappa lambda"));
+        range = window.getSelection().getRangeAt(0);
+        println("first-letter-case endOffset within node: " + (range.endOffset <= range.endContainer.length));
+
+        // 'white-space: pre' preserves whitespace, so the raw text matches and the collapsed text does not.
+        println("pre raw query 'mu     nu': " + find("mu     nu"));
+        println("pre collapsed query 'mu nu': " + find("mu nu"));
+    });
+</script>


### PR DESCRIPTION
Previously, the text searched by find-in-page was gathered from each text node's rendered string, which still contains uncollapsed whitespace. We now collapse runs of whitespace to a single space and trim leading and trailing whitespace per block when building the searchable text, while keeping each character mapped back to its DOM position so matches still resolve to correct ranges.