### PR TITLE
LibWeb: Use premultiplied alpha when interpolating gradient color stops

### DIFF
--- a/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -82,7 +82,7 @@ static ColorStopList replace_transition_hints_with_normal_color_stops(ColorStopL
         for (auto const& transition_hint_relative_sampling_position : transition_hint_relative_sampling_positions) {
             auto position = previous_color_stop.position + transition_hint_relative_sampling_position * distance_between_stops;
             auto value = Gfx::color_stop_step(previous_color_stop, next_color_stop, position);
-            auto color = previous_color_stop.color.interpolate(next_color_stop.color, value);
+            auto color = previous_color_stop.color.mixed_with(next_color_stop.color, value);
             stops_with_replaced_transition_hints.empend(color, position);
         }
 
@@ -109,7 +109,7 @@ static ColorStopList expand_repeat_length(ColorStopList const& color_stop_list, 
     auto get_color_between_stops = [](float position, auto const& current_stop, auto const& previous_stop) {
         auto distance_between_stops = current_stop.position - previous_stop.position;
         auto percentage = (position - previous_stop.position) / distance_between_stops;
-        return previous_stop.color.interpolate(current_stop.color, percentage);
+        return previous_stop.color.mixed_with(current_stop.color, percentage);
     };
 
     for (auto repeat_count = 1; repeat_count <= negative_repeat_count; repeat_count++) {

--- a/Tests/LibWeb/Ref/expected/css/gradient-premultiplied-alpha-repeating-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/gradient-premultiplied-alpha-repeating-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+  html, body { margin: 0; padding: 0; }
+  div { width: 200px; height: 200px; display: inline-block; }
+  .conic  { background: conic-gradient(from 0deg at center,
+      #ff0000 0deg, #0000ff19 144deg,
+      #ff0000 144deg, #0000ff19 288deg,
+      #ff0000 288deg, #e800178c 360deg); }
+  .radial { background: radial-gradient(circle farthest-corner at center,
+      #ff0000 0%, #0000ff19 40%,
+      #ff0000 40%, #0000ff19 80%,
+      #ff0000 80%, #e800178c 100%); }
+</style>
+<div class="conic"></div><div class="radial"></div>

--- a/Tests/LibWeb/Ref/expected/css/gradient-premultiplied-alpha-transition-hint-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/gradient-premultiplied-alpha-transition-hint-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+  html, body { margin: 0; padding: 0; }
+  div { width: 300px; height: 80px; }
+  .linear { background: linear-gradient(to right, #ff0000, #0000ff1a); }
+  .radial { background: radial-gradient(circle farthest-side at left center, #ff0000, #0000ff1a); }
+  .conic  { background: conic-gradient(from 0deg at center, #ff0000, #0000ff1a); }
+</style>
+<div class="linear"></div>
+<div class="radial"></div>
+<div class="conic"></div>

--- a/Tests/LibWeb/Ref/input/css/gradient-premultiplied-alpha-repeating.html
+++ b/Tests/LibWeb/Ref/input/css/gradient-premultiplied-alpha-repeating.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/gradient-premultiplied-alpha-repeating-ref.html" />
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-4000" />
+<style>
+  html, body { margin: 0; padding: 0; }
+  div { width: 200px; height: 200px; display: inline-block; }
+  .conic  { background: repeating-conic-gradient(from 0deg at center, #ff0000 0deg, #0000ff19 144deg); }
+  .radial { background: repeating-radial-gradient(circle farthest-corner at center, #ff0000 0%, #0000ff19 40%); }
+</style>
+<div class="conic"></div><div class="radial"></div>

--- a/Tests/LibWeb/Ref/input/css/gradient-premultiplied-alpha-transition-hint.html
+++ b/Tests/LibWeb/Ref/input/css/gradient-premultiplied-alpha-transition-hint.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/gradient-premultiplied-alpha-transition-hint-ref.html" />
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-50000" />
+<style>
+  html, body { margin: 0; padding: 0; }
+  div { width: 300px; height: 80px; }
+  .linear { background: linear-gradient(to right, #ff0000, 50%, #0000ff1a); }
+  .radial { background: radial-gradient(circle farthest-side at left center, #ff0000, 50%, #0000ff1a); }
+  .conic  { background: conic-gradient(from 0deg at center, #ff0000, 50%, #0000ff1a); }
+</style>
+<div class="linear"></div>
+<div class="radial"></div>
+<div class="conic"></div>


### PR DESCRIPTION
When a transition hint in a gradient was being interpolated into color stops, Ladybird was using simple color interpolation via `interpolate()` rather than proper color mixing via `mixed_with()` that takes the alpha channel into account. This was resulting in incorrect rendering for example 7 on this page: https://esbuild.github.io/gradient-tests/.

Before:

<img width="696" height="426" alt="image" src="https://github.com/user-attachments/assets/934efaa7-bf8a-4c7f-8687-f5ca6432c30d" />


After:

<img width="696" height="426" alt="image" src="https://github.com/user-attachments/assets/d22d0fef-4511-4e92-90c7-c2ba17d8e7ce" />
