### PR TITLE
Compositor: Extract per-context state handling

### DIFF
--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     BackingStoreManager.cpp
     CompositorState.cpp
+    ContextState.cpp
     ConnectionFromClient.cpp
     ConnectionFromWebContent.cpp
     VSyncScheduler.cpp

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -70,7 +70,7 @@ void CompositorState::create_context(Web::Compositor::CompositorContextId contex
         VERIFY(context_id == Web::Compositor::compositor_context_id_for_page(*page_id));
 
     auto& context = *m_contexts.ensure(context_id, [&] {
-        return make<ContextState>(page_id, web_content_client);
+        return make<ContextState>(page_id, web_content_client, m_async_scrolling_enabled);
     });
     resize_backing_stores_if_needed(context_id, context);
 }
@@ -122,7 +122,7 @@ void CompositorState::update_display_list(Web::Compositor::CompositorContextId c
     VERIFY(context);
 
     context->apply_display_list_resource_transaction(move(resource_transaction));
-    context->install_display_list_update(move(display_list), move(visual_context_tree), move(scroll_state_snapshot), m_async_scrolling_enabled);
+    context->install_display_list_update(move(display_list), move(visual_context_tree), move(scroll_state_snapshot));
 }
 
 void CompositorState::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -9,32 +9,10 @@
 #include <Compositor/CompositorState.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Timer.h>
-#include <LibGfx/Bitmap.h>
-#include <LibGfx/Color.h>
-#include <LibGfx/PainterSkia.h>
-#include <LibGfx/PaintingSurface.h>
-#include <LibWeb/Page/InputEvent.h>
 
 namespace Compositor {
 
 static constexpr int gpu_completion_check_interval_ms = 1;
-
-static bool presentation_mode_presents_to_client(Web::Compositor::PresentationMode const& presentation_mode)
-{
-    return presentation_mode.has<Web::Compositor::PresentToClient>();
-}
-
-static void set_or_append_pending_scroll_offset(Vector<Web::Compositor::AsyncScrollOffset>& pending_scroll_offsets, Web::Compositor::AsyncScrollOffset const& scroll_offset)
-{
-    for (auto& existing : pending_scroll_offsets) {
-        if (existing.stable_node_id == scroll_offset.stable_node_id) {
-            existing.compositor_scroll_offset = scroll_offset.compositor_scroll_offset;
-            existing.unadopted_scroll_delta.translate_by(scroll_offset.unadopted_scroll_delta);
-            return;
-        }
-    }
-    pending_scroll_offsets.append(scroll_offset);
-}
 
 NonnullRefPtr<CompositorState> CompositorState::create(RefPtr<Gfx::SkiaBackendContext> skia_backend_context, bool async_scrolling_enabled)
 {
@@ -56,19 +34,6 @@ CompositorState::~CompositorState()
     m_gpu_completion_timer->stop();
 }
 
-CompositorState::ContextState::~ContextState()
-{
-    stop_backing_store_shrink_timer();
-}
-
-void CompositorState::ContextState::stop_backing_store_shrink_timer()
-{
-    if (!backing_store_shrink_timer)
-        return;
-    backing_store_shrink_timer->on_timeout = {};
-    backing_store_shrink_timer->stop();
-}
-
 void CompositorState::set_client(CompositorStateClient& client)
 {
     m_client = &client;
@@ -79,8 +44,7 @@ CompositorState::ContextOwnerCheckResult CompositorState::check_context_owner(We
     auto* context = context_if_present(context_id);
     if (!context)
         return ContextOwnerCheckResult::ContextUnavailable;
-    VERIFY(context->web_content_client);
-    if (context->web_content_client != &client)
+    if (!context->is_owned_by(client))
         return ContextOwnerCheckResult::ConflictingOwner;
 
     return ContextOwnerCheckResult::OwnedByClient;
@@ -90,7 +54,7 @@ void CompositorState::destroy_contexts_for_web_content_client(CompositorStateWeb
 {
     Vector<Web::Compositor::CompositorContextId> context_ids;
     for (auto& context : m_contexts) {
-        if (context.value->web_content_client == &client)
+        if (context.value->is_owned_by(client))
             context_ids.append(context.key);
     }
 
@@ -108,10 +72,7 @@ void CompositorState::create_context(Web::Compositor::CompositorContextId contex
     auto& context = *m_contexts.ensure(context_id, [] {
         return make<ContextState>();
     });
-    context.web_content_client = &web_content_client;
-    context.page_id = page_id;
-    if (page_id.has_value())
-        context.presentation_mode = Web::Compositor::PresentToClient {};
+    context.initialize(page_id, web_content_client);
     resize_backing_stores_if_needed(context_id, context);
 }
 
@@ -122,13 +83,10 @@ void CompositorState::destroy_context(Web::Compositor::CompositorContextId conte
 
     cancel_pending_async_presents_for_context(context_id);
     detach_from_parent_surface(context_id, *context);
-    for (auto& child_context_entry : context->child_contexts_by_surface_id) {
-        auto* child_context = context_if_present(child_context_entry.value);
+    for (auto& child_context_entry : context->child_contexts()) {
+        auto* child_context = context_if_present(child_context_entry.child_context_id);
         VERIFY(child_context);
-        VERIFY(child_context->published_surface.has_value());
-        VERIFY(child_context->published_surface->parent_context_id == context_id);
-        child_context->published_surface.clear();
-        child_context->presentation_mode = Empty {};
+        child_context->did_detach_from_parent_surface(context_id, child_context_entry.surface_id);
     }
     m_contexts.remove(context_id);
 }
@@ -139,30 +97,24 @@ void CompositorState::set_presentation_mode(Web::Compositor::CompositorContextId
     VERIFY(context);
 
     auto& context_state = *context;
-    auto was_presenting_to_client = presentation_mode_presents_to_client(context_state.presentation_mode);
-    auto will_present_to_client = presentation_mode_presents_to_client(presentation_mode);
+    auto was_presenting_to_client = context_state.presents_to_client();
+    auto will_present_to_client = ContextState::presentation_mode_presents_to_client(presentation_mode);
     detach_from_parent_surface(context_id, context_state);
 
     presentation_mode.visit(
         [](Empty const&) {},
-        [&](Web::Compositor::PresentToClient const&) {
-            VERIFY(context_state.page_id.has_value());
-        },
+        [](Web::Compositor::PresentToClient const&) {},
         [&](Web::Compositor::PublishToCompositorSurface const& mode) {
             auto* parent_context = context_if_present(mode.target_context_id);
             VERIFY(parent_context);
-            parent_context->child_contexts_by_surface_id.set(mode.surface_id, context_id);
-            context_state.published_surface = ContextState::PublishedSurface {
+            parent_context->attach_child_surface(mode.surface_id, context_id);
+            context_state.set_published_surface({
                 .parent_context_id = mode.target_context_id,
                 .surface_id = mode.surface_id,
-            };
+            });
         });
-    context_state.presentation_mode = move(presentation_mode);
-
-    if (was_presenting_to_client && !will_present_to_client
-        && context_state.gpu_present_bitmap_id_awaiting_completion.has_value()
-        && context_state.presented_bitmap_id_awaiting_ack == context_state.gpu_present_bitmap_id_awaiting_completion)
-        context_state.presented_bitmap_id_awaiting_ack.clear();
+    context_state.set_presentation_mode(move(presentation_mode));
+    context_state.did_stop_presenting_to_client_if_needed(was_presenting_to_client, will_present_to_client);
 }
 
 void CompositorState::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
@@ -170,8 +122,8 @@ void CompositorState::update_display_list(Web::Compositor::CompositorContextId c
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    context->display_list_resource_storage.apply_transaction(move(resource_transaction));
-    install_display_list_update(*context, move(display_list), move(visual_context_tree), move(scroll_state_snapshot));
+    context->apply_display_list_resource_transaction(move(resource_transaction));
+    context->install_display_list_update(move(display_list), move(visual_context_tree), move(scroll_state_snapshot), m_async_scrolling_enabled);
 }
 
 void CompositorState::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
@@ -179,24 +131,14 @@ void CompositorState::update_scroll_state(Web::Compositor::CompositorContextId c
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    context->scroll_state_snapshot = move(scroll_state_snapshot);
-    if (!context->has_async_scrolling_state)
-        return;
-
-    auto reconciled_viewport_scroll_offset = reapply_pending_async_scroll_offsets(*context, context->pending_async_scroll_offsets);
-    context->async_scroll_tree.rebuild_wheel_hit_test_targets(context->display_list, context->visual_context_tree.has_value() ? &context->visual_context_tree.value() : nullptr, context->scroll_state_snapshot);
-    if (reconciled_viewport_scroll_offset.has_value()) {
-        auto reconciled_viewport_rect = context->async_scrolling_viewport_rect;
-        reconciled_viewport_rect.set_location(reconciled_viewport_scroll_offset->to_type<int>());
-        context->async_scrolling_viewport_rect = reconciled_viewport_rect;
-    }
+    context->update_scroll_state(move(scroll_state_snapshot));
 }
 
 void CompositorState::update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    context->display_list_resource_storage.update_video_frame(frame_id, move(frame));
+    context->update_video_frame(frame_id, move(frame));
     present_current_frame(context_id, *context);
 }
 
@@ -204,7 +146,7 @@ void CompositorState::clear_video_frame(Web::Compositor::CompositorContextId con
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    context->display_list_resource_storage.clear_video_frame(frame_id);
+    context->clear_video_frame(frame_id);
     present_current_frame(context_id, *context);
 }
 
@@ -212,7 +154,7 @@ void CompositorState::update_compositor_surface(Web::Compositor::CompositorConte
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    context->display_list_resource_storage.update_compositor_surface(surface_id, move(shared_image));
+    context->update_compositor_surface(surface_id, move(shared_image));
     present_current_frame(context_id, *context);
 }
 
@@ -220,7 +162,7 @@ void CompositorState::clear_compositor_surface(Web::Compositor::CompositorContex
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    context->display_list_resource_storage.clear_compositor_surface(surface_id);
+    context->clear_compositor_surface(surface_id);
     remove_child_surface(*context, context_id, surface_id);
     present_current_frame(context_id, *context);
 }
@@ -229,9 +171,7 @@ void CompositorState::invalidate_wheel_event_listener_state(Web::Compositor::Com
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    context->wheel_event_listener_state_generation = max(context->wheel_event_listener_state_generation, generation);
-    context->wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::StaleWheelEventListeners;
-    context->can_accept_async_wheel_events = false;
+    context->invalidate_wheel_event_listener_state(generation);
 }
 
 bool CompositorState::handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
@@ -240,65 +180,7 @@ bool CompositorState::handle_mouse_event(Web::Compositor::CompositorContextId co
     if (!context)
         return false;
 
-    auto& context_state = *context;
-    if (!presentation_mode_presents_to_client(context_state.presentation_mode))
-        return false;
-
-    auto position = Gfx::FloatPoint {
-        static_cast<float>(event.position.x().value()),
-        static_cast<float>(event.position.y().value()),
-    };
-
-    switch (event.type) {
-    case Web::MouseEvent::Type::MouseDown: {
-        if (event.button != Web::UIEvents::MouseButton::Primary)
-            return false;
-
-        auto drag = context_state.viewport_scrollbar_controller.begin_drag(context_state.async_scroll_tree, context_state.scroll_state_snapshot, position);
-        if (!drag.has_value())
-            return false;
-
-        if (!context_state.async_scrolling_viewport_rect.is_empty())
-            schedule_present_frame(context_id, context_state, context_state.async_scrolling_viewport_rect);
-        apply_viewport_scrollbar_drag(context_id, context_state, *drag);
-        return true;
-    }
-    case Web::MouseEvent::Type::MouseMove: {
-        auto had_capture = context_state.viewport_scrollbar_controller.has_captured_scrollbar();
-        if (had_capture) {
-            auto drag = context_state.viewport_scrollbar_controller.captured_drag(position);
-            if (!drag.has_value())
-                return false;
-            apply_viewport_scrollbar_drag(context_id, context_state, *drag);
-            return true;
-        }
-
-        auto hovered_scrollbar_index = context_state.viewport_scrollbar_controller.hit_test(context_state.async_scroll_tree, context_state.scroll_state_snapshot, position);
-        if (context_state.viewport_scrollbar_controller.set_hovered_scrollbar(hovered_scrollbar_index) && !context_state.async_scrolling_viewport_rect.is_empty())
-            schedule_present_frame(context_id, context_state, context_state.async_scrolling_viewport_rect);
-        return hovered_scrollbar_index.has_value();
-    }
-    case Web::MouseEvent::Type::MouseUp: {
-        auto drag = context_state.viewport_scrollbar_controller.release_captured_drag(position);
-        if (!drag.has_value())
-            return false;
-
-        if (!context_state.async_scrolling_viewport_rect.is_empty())
-            schedule_present_frame(context_id, context_state, context_state.async_scrolling_viewport_rect);
-        apply_viewport_scrollbar_drag(context_id, context_state, *drag);
-        return true;
-    }
-    case Web::MouseEvent::Type::MouseLeave: {
-        auto had_capture = context_state.viewport_scrollbar_controller.has_captured_scrollbar();
-        if (context_state.viewport_scrollbar_controller.set_hovered_scrollbar({}) && !context_state.async_scrolling_viewport_rect.is_empty())
-            schedule_present_frame(context_id, context_state, context_state.async_scrolling_viewport_rect);
-        return had_capture;
-    }
-    case Web::MouseEvent::Type::MouseWheel:
-        return false;
-    }
-
-    VERIFY_NOT_REACHED();
+    return apply_context_update_result(context_id, *context, context->handle_mouse_event(event));
 }
 
 bool CompositorState::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
@@ -307,12 +189,7 @@ bool CompositorState::dispatch_mouse_event_to_web_content(Web::Compositor::Compo
     if (!context)
         return false;
 
-    VERIFY(context->web_content_client);
-
-    auto page_id = context->page_id;
-    VERIFY(page_id.has_value());
-
-    context->web_content_client->dispatch_mouse_event_to_web_content(*page_id, event);
+    context->dispatch_mouse_event_to_web_content(event);
     return true;
 }
 
@@ -324,35 +201,10 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorState::async_scroll_by(Web::
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    auto& context_state = *context;
-    if (!context_state.can_accept_async_wheel_events)
-        return {};
-
-    auto scroll_target = context_state.async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
-    if (scroll_target.blocked_by_main_thread_region || scroll_target.blocked_by_wheel_event_region || !scroll_target.node_id.has_value())
-        return {};
-    if (scroll_target.node_id->document_id != expected_document_id)
-        return {};
-
-    Optional<Web::Compositor::AsyncScrollOperationID> operation_id;
-    if (operation_tracking == Web::Compositor::AsyncScrollOperationTracking::Yes)
-        operation_id = ++context_state.next_async_scroll_operation_id;
-
-    auto async_scroll_viewport_rect = viewport_rect;
-    auto scroll_offsets = context_state.async_scroll_tree.apply_scroll_delta(*scroll_target.node_id, delta, context_state.scroll_state_snapshot);
-    if (scroll_offsets.is_empty()) {
-        if (operation_id.has_value())
-            context_state.completed_async_scroll_operation_ids.append(*operation_id);
-        return { true, operation_id };
-    }
-
-    context_state.async_scroll_tree.rebuild_wheel_hit_test_targets(context_state.display_list, context_state.visual_context_tree.has_value() ? &context_state.visual_context_tree.value() : nullptr, context_state.scroll_state_snapshot);
-    if (auto viewport_scroll_offset = viewport_scroll_offset_from(context_state, scroll_offsets); viewport_scroll_offset.has_value())
-        async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
-    store_pending_async_scroll_offsets(context_state, scroll_offsets, operation_id);
-    context_state.async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    schedule_present_frame(context_id, context_state, async_scroll_viewport_rect);
-    return { true, operation_id };
+    auto result = context->async_scroll_by(expected_document_id, position, delta, viewport_rect, operation_tracking);
+    if (result.frame_to_present.has_value())
+        schedule_present_frame(context_id, *context, *result.frame_to_present);
+    return result.enqueue_result;
 }
 
 bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta)
@@ -364,30 +216,7 @@ bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId conte
     if (!context)
         return false;
 
-    auto& context_state = *context;
-    if (!presentation_mode_presents_to_client(context_state.presentation_mode))
-        return false;
-    VERIFY(context_state.web_content_client);
-    if (!context_state.can_accept_async_wheel_events)
-        return false;
-
-    auto scroll_target = context_state.async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
-    if (scroll_target.blocked_by_main_thread_region || scroll_target.blocked_by_wheel_event_region || !scroll_target.node_id.has_value())
-        return false;
-
-    auto async_scroll_viewport_rect = context_state.async_scrolling_viewport_rect;
-    auto scroll_offsets = context_state.async_scroll_tree.apply_scroll_delta(*scroll_target.node_id, delta, context_state.scroll_state_snapshot);
-    if (scroll_offsets.is_empty())
-        return true;
-
-    context_state.async_scroll_tree.rebuild_wheel_hit_test_targets(context_state.display_list, context_state.visual_context_tree.has_value() ? &context_state.visual_context_tree.value() : nullptr, context_state.scroll_state_snapshot);
-    if (auto viewport_scroll_offset = viewport_scroll_offset_from(context_state, scroll_offsets); viewport_scroll_offset.has_value())
-        async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
-    store_pending_async_scroll_offsets(context_state, scroll_offsets);
-    context_state.async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    schedule_present_frame(context_id, context_state, async_scroll_viewport_rect);
-    context_state.web_content_client->request_rendering_update();
-    return true;
+    return apply_context_update_result(context_id, *context, context->async_scroll_by(position, delta));
 }
 
 bool CompositorState::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) const
@@ -395,12 +224,7 @@ bool CompositorState::should_defer_main_thread_present_for_async_scroll(Web::Com
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    if (context->pending_async_scroll_offsets.is_empty())
-        return false;
-
-    return context->pending_present_frame.has_value()
-        || context->gpu_present_bitmap_id_awaiting_completion.has_value()
-        || context->presented_bitmap_id_awaiting_ack.has_value();
+    return context->should_defer_main_thread_present_for_async_scroll();
 }
 
 Web::Compositor::PendingAsyncScrollUpdates CompositorState::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
@@ -408,10 +232,7 @@ Web::Compositor::PendingAsyncScrollUpdates CompositorState::take_pending_async_s
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    Web::Compositor::PendingAsyncScrollUpdates updates;
-    AK::swap(updates.scroll_offsets, context->pending_async_scroll_offsets);
-    AK::swap(updates.completed_operation_ids, context->completed_async_scroll_operation_ids);
-    return updates;
+    return context->take_pending_async_scroll_updates();
 }
 
 void CompositorState::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
@@ -420,13 +241,9 @@ void CompositorState::viewport_size_updated(Web::Compositor::CompositorContextId
     if (!context)
         return;
 
-    context->viewport_size = viewport_size;
-    auto is_page_presentation_context = context->page_id.has_value();
-    context->window_resize_in_progress = is_page_presentation_context
-        ? window_resize_in_progress
-        : Web::Compositor::WindowResizingInProgress::No;
+    context->viewport_size_updated(viewport_size, window_resize_in_progress);
     resize_backing_stores_if_needed(context_id, *context);
-    if (context->window_resize_in_progress == Web::Compositor::WindowResizingInProgress::Yes)
+    if (context->should_shrink_backing_stores_after_resize())
         schedule_backing_store_shrink(context_id, *context);
 }
 
@@ -440,9 +257,7 @@ void CompositorState::set_display_metadata(Web::Compositor::CompositorContextId 
     VERIFY(refresh_rate > 0);
     VERIFY(refresh_rate < AK::Infinity<double>);
 
-    context->display_id = display_id;
-    context->display_refresh_rate = refresh_rate;
-    if (context->pending_present_frame_scheduled)
+    if (context->set_display_metadata(display_id, refresh_rate))
         schedule_pending_present_frame_on_vsync(context_id, *context);
 }
 
@@ -455,36 +270,16 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
 
 void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect viewport_rect)
 {
-    if (context.gpu_present_bitmap_id_awaiting_completion.has_value() || context.presented_bitmap_id_awaiting_ack.has_value()) {
-        context.pending_present_frame = viewport_rect;
+    auto prepared_frame = context.prepare_frame(*m_display_list_player, viewport_rect);
+    if (!prepared_frame.has_value())
         return;
-    }
 
-    if (!context.display_list || !context.visual_context_tree.has_value() || !context.backing_store_manager.is_valid()) {
-        context.presented_frame = viewport_rect;
-        return;
-    }
-
-    auto& back_store = context.backing_store_manager.back_store();
-    context.presentation_mode.visit(
-        [](Empty const&) {},
-        [](Web::Compositor::PresentToClient const&) {},
-        [&](Web::Compositor::PublishToCompositorSurface const&) {
-            Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
-            painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
-        });
-    m_display_list_player->execute(*context.display_list, context.visual_context_tree.value(), context.display_list_resource_storage, context.scroll_state_snapshot, back_store);
-    context.viewport_scrollbar_controller.paint(back_store, *m_display_list_player, context.scroll_state_snapshot);
-    auto rendered_bitmap_id = context.backing_store_manager.back_bitmap_id();
-    context.gpu_present_bitmap_id_awaiting_completion = rendered_bitmap_id;
-    if (presentation_mode_presents_to_client(context.presentation_mode))
-        context.presented_bitmap_id_awaiting_ack = rendered_bitmap_id;
-    m_pending_async_presents.append(context_id, viewport_rect, rendered_bitmap_id);
+    m_pending_async_presents.append(context_id, viewport_rect, prepared_frame->bitmap_id);
     auto* pending_present = &m_pending_async_presents.last();
 
     auto event_loop_reference = Core::EventLoop::current_weak();
     auto self = NonnullRefPtr { *this };
-    m_display_list_player->flush_async(back_store, [self = move(self), event_loop_reference = move(event_loop_reference), pending_present] {
+    m_display_list_player->flush_async(*prepared_frame->rendered_surface, [self = move(self), event_loop_reference = move(event_loop_reference), pending_present] {
         auto event_loop = event_loop_reference->take();
         if (!event_loop.is_alive())
             return;
@@ -492,30 +287,25 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
             self->did_finish_async_present(*pending_present);
         });
     });
-    context.backing_store_manager.swap();
-    context.presented_frame = viewport_rect;
+    context.did_submit_prepared_frame(viewport_rect);
     schedule_gpu_completion_check();
 }
 
 void CompositorState::schedule_present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect viewport_rect)
 {
-    context.pending_present_frame = viewport_rect;
+    context.queue_present_frame(viewport_rect);
     schedule_pending_present_frame_on_vsync(context_id, context);
 }
 
 void CompositorState::schedule_pending_present_frame_on_vsync(Web::Compositor::CompositorContextId, ContextState& context)
 {
-    context.pending_present_frame_scheduled = true;
-    vsync_scheduler_for_display(context.display_id).schedule(context.display_refresh_rate);
+    context.mark_pending_present_frame_scheduled();
+    vsync_scheduler_for_display(context.display_id()).schedule(context.display_refresh_rate());
 }
 
 void CompositorState::schedule_pending_present_frame_if_unblocked(Web::Compositor::CompositorContextId context_id, ContextState& context)
 {
-    if (context.gpu_present_bitmap_id_awaiting_completion.has_value() || context.presented_bitmap_id_awaiting_ack.has_value())
-        return;
-    if (!context.pending_present_frame.has_value())
-        return;
-    if (context.pending_present_frame_scheduled)
+    if (!context.can_schedule_pending_present_frame_if_unblocked())
         return;
 
     schedule_pending_present_frame_on_vsync(context_id, context);
@@ -535,19 +325,13 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
     for (auto& context_entry : m_contexts) {
         auto context_id = context_entry.key;
         auto& context = *context_entry.value;
-        if (!context.pending_present_frame_scheduled)
-            continue;
-        if (context.display_id != display_id)
+        if (!context.has_pending_present_frame_scheduled_on(display_id))
             continue;
 
-        context.pending_present_frame_scheduled = false;
-        if (context.gpu_present_bitmap_id_awaiting_completion.has_value() || context.presented_bitmap_id_awaiting_ack.has_value())
+        auto pending_present_frame = context.take_pending_present_frame_if_unblocked();
+        if (!pending_present_frame.has_value())
             continue;
-        if (!context.pending_present_frame.has_value())
-            continue;
-
-        auto pending_present_frame = context.pending_present_frame.release_value();
-        present_frame(context_id, context, pending_present_frame);
+        present_frame(context_id, context, *pending_present_frame);
     }
 }
 
@@ -560,8 +344,8 @@ void CompositorState::flush_descendant_surfaces_for_screenshot(Web::Compositor::
     auto* context = context_if_present(context_id);
     if (!context)
         return;
-    for (auto& child : context->child_contexts_by_surface_id)
-        present_subtree_for_screenshot(child.value);
+    for (auto& child : context->child_contexts())
+        present_subtree_for_screenshot(child.child_context_id);
 }
 
 bool CompositorState::present_subtree_for_screenshot(Web::Compositor::CompositorContextId context_id)
@@ -570,13 +354,13 @@ bool CompositorState::present_subtree_for_screenshot(Web::Compositor::Compositor
     if (!context)
         return false;
 
-    bool needs_present = context->pending_present_frame.has_value() || context->pending_present_frame_scheduled;
-    for (auto& child : context->child_contexts_by_surface_id) {
-        if (present_subtree_for_screenshot(child.value))
+    bool needs_present = context->needs_synchronous_present_for_screenshot();
+    for (auto& child : context->child_contexts()) {
+        if (present_subtree_for_screenshot(child.child_context_id))
             needs_present = true;
     }
 
-    if (!needs_present || !context->presentation_mode.has<Web::Compositor::PublishToCompositorSurface>())
+    if (!needs_present || !context->publishes_to_parent_surface())
         return false;
 
     present_context_synchronously(*context);
@@ -585,34 +369,9 @@ bool CompositorState::present_subtree_for_screenshot(Web::Compositor::Compositor
 
 void CompositorState::present_context_synchronously(ContextState& context)
 {
-    auto* publish_mode = context.presentation_mode.get_pointer<Web::Compositor::PublishToCompositorSurface>();
-    if (!publish_mode)
-        return;
-    if (!context.display_list || !context.visual_context_tree.has_value() || !context.backing_store_manager.is_valid())
-        return;
-    // Don't race an async present already in flight for this context; its own completion will publish.
-    if (context.gpu_present_bitmap_id_awaiting_completion.has_value() || context.presented_bitmap_id_awaiting_ack.has_value())
-        return;
-
-    auto viewport_rect = context.pending_present_frame;
-    if (!viewport_rect.has_value())
-        viewport_rect = context.presented_frame;
-    if (!viewport_rect.has_value())
-        return;
-
-    auto& back_store = context.backing_store_manager.back_store();
-    {
-        Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
-        painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
-    }
-    m_display_list_player->execute(*context.display_list, context.visual_context_tree.value(), context.display_list_resource_storage, context.scroll_state_snapshot, back_store);
-    context.viewport_scrollbar_controller.paint(back_store, *m_display_list_player, context.scroll_state_snapshot);
-    m_display_list_player->flush(back_store);
-    context.backing_store_manager.swap();
-    context.presented_frame = viewport_rect;
-    context.pending_present_frame.clear();
-    context.pending_present_frame_scheduled = false;
-    publish_to_parent_surface(context, *publish_mode);
+    auto publish_mode = context.present_synchronously(*m_display_list_player);
+    if (publish_mode.has_value())
+        publish_to_parent_surface(context, *publish_mode);
 }
 
 bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId context_id, Gfx::ShareableBitmap& target_bitmap)
@@ -620,16 +379,11 @@ bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId co
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    if (!context->display_list || !context->visual_context_tree.has_value() || !target_bitmap.is_valid() || !target_bitmap.bitmap())
+    if (!context->can_paint_screenshot(target_bitmap))
         return false;
 
     flush_descendant_surfaces_for_screenshot(context_id);
-
-    auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
-    m_display_list_player->execute(*context->display_list, context->visual_context_tree.value(), context->display_list_resource_storage, context->scroll_state_snapshot, *target_surface);
-    context->viewport_scrollbar_controller.paint(*target_surface, *m_display_list_player, context->scroll_state_snapshot);
-    m_display_list_player->flush(*target_surface);
-    return true;
+    return context->paint_screenshot(*m_display_list_player, target_bitmap);
 }
 
 void CompositorState::presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id)
@@ -638,10 +392,9 @@ void CompositorState::presented_bitmap_ready_to_paint(Web::Compositor::Composito
     if (!context)
         return;
 
-    if (context->presented_bitmap_id_awaiting_ack != bitmap_id)
+    if (!context->acknowledge_presented_bitmap(bitmap_id))
         return;
 
-    context->presented_bitmap_id_awaiting_ack.clear();
     schedule_pending_present_frame_if_unblocked(context_id, *context);
 }
 
@@ -667,14 +420,12 @@ void CompositorState::did_finish_async_present(PendingAsyncPresent& pending_pres
 
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    VERIFY(context->gpu_present_bitmap_id_awaiting_completion == bitmap_id);
 
-    context->gpu_present_bitmap_id_awaiting_completion.clear();
-    context->presentation_mode.visit(
+    context->did_finish_gpu_present(bitmap_id);
+    context->presentation_mode().visit(
         [](Empty const&) {},
         [&](Web::Compositor::PresentToClient const&) {
             VERIFY(m_client);
-            VERIFY(context->presented_bitmap_id_awaiting_ack == bitmap_id);
             m_client->did_present_frame(context_id, viewport_rect, bitmap_id);
         },
         [&](Web::Compositor::PublishToCompositorSurface const& mode) {
@@ -721,7 +472,7 @@ void CompositorState::check_gpu_completions()
         m_gpu_completion_timer->stop();
 }
 
-CompositorState::ContextState* CompositorState::context_if_present(Web::Compositor::CompositorContextId context_id)
+ContextState* CompositorState::context_if_present(Web::Compositor::CompositorContextId context_id)
 {
     auto it = m_contexts.find(context_id);
     if (it == m_contexts.end())
@@ -729,7 +480,7 @@ CompositorState::ContextState* CompositorState::context_if_present(Web::Composit
     return it->value.ptr();
 }
 
-CompositorState::ContextState const* CompositorState::context_if_present(Web::Compositor::CompositorContextId context_id) const
+ContextState const* CompositorState::context_if_present(Web::Compositor::CompositorContextId context_id) const
 {
     auto it = m_contexts.find(context_id);
     if (it == m_contexts.end())
@@ -739,143 +490,33 @@ CompositorState::ContextState const* CompositorState::context_if_present(Web::Co
 
 void CompositorState::detach_from_parent_surface(Web::Compositor::CompositorContextId context_id, ContextState& context)
 {
-    if (!context.published_surface.has_value())
+    auto published_surface = context.take_published_surface();
+    if (!published_surface.has_value())
         return;
 
-    auto published_surface = context.published_surface.release_value();
-    auto* parent_context = context_if_present(published_surface.parent_context_id);
+    auto* parent_context = context_if_present(published_surface->parent_context_id);
     VERIFY(parent_context);
-    auto child_context_id = parent_context->child_contexts_by_surface_id.get(published_surface.surface_id);
-    VERIFY(child_context_id.has_value());
-    VERIFY(*child_context_id == context_id);
-    parent_context->child_contexts_by_surface_id.remove(published_surface.surface_id);
-    parent_context->display_list_resource_storage.clear_compositor_surface(published_surface.surface_id);
-    present_current_frame(published_surface.parent_context_id, *parent_context);
+    auto removed_child_context_id = parent_context->take_child_context_for_surface(published_surface->surface_id);
+    VERIFY(removed_child_context_id.has_value());
+    VERIFY(*removed_child_context_id == context_id);
+    parent_context->clear_compositor_surface(published_surface->surface_id);
+    present_current_frame(published_surface->parent_context_id, *parent_context);
 }
 
 void CompositorState::remove_child_surface(ContextState& context, Web::Compositor::CompositorContextId parent_context_id, Web::Painting::CompositorSurfaceId surface_id)
 {
-    auto child_context_id = context.child_contexts_by_surface_id.take(surface_id);
+    auto child_context_id = context.take_child_context_for_surface(surface_id);
     if (!child_context_id.has_value())
         return;
 
     auto* child_context = context_if_present(*child_context_id);
     VERIFY(child_context);
-    VERIFY(child_context->published_surface.has_value());
-    VERIFY(child_context->published_surface->parent_context_id == parent_context_id);
-    VERIFY(child_context->published_surface->surface_id == surface_id);
-    child_context->published_surface.clear();
-    child_context->presentation_mode = Empty {};
-}
-
-void CompositorState::install_display_list_update(ContextState& context, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
-{
-    VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree.version());
-    context.display_list = move(display_list);
-    context.visual_context_tree = move(visual_context_tree);
-    context.scroll_state_snapshot = move(scroll_state_snapshot);
-
-    if (!m_async_scrolling_enabled) {
-        context.async_scroll_tree.set_state({});
-        context.viewport_scrollbar_controller.clear();
-        context.pending_async_scroll_offsets.clear();
-        context.completed_async_scroll_operation_ids.clear();
-        context.wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState;
-        context.can_accept_async_wheel_events = false;
-        context.async_scrolling_viewport_rect = {};
-        context.has_async_scrolling_state = false;
-        return;
-    }
-
-    auto async_scrolling_state = Web::Compositor::async_scrolling_state_from_display_list(*context.display_list);
-    auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
-    auto wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
-    auto wheel_routing_admission = Web::Compositor::wheel_routing_admission_for(async_scrolling_state);
-    if (wheel_event_listener_state_generation < context.wheel_event_listener_state_generation)
-        wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::StaleWheelEventListeners;
-    else
-        context.wheel_event_listener_state_generation = wheel_event_listener_state_generation;
-
-    context.wheel_routing_admission = wheel_routing_admission;
-    context.can_accept_async_wheel_events = wheel_routing_admission == Web::Compositor::WheelRoutingAdmission::Accepted;
-
-    context.viewport_scrollbar_controller.set_scrollbars(async_scrolling_state.viewport_scrollbars);
-    context.async_scroll_tree.set_state(move(async_scrolling_state));
-    if (!context.pending_async_scroll_offsets.is_empty()) {
-        if (auto viewport_scroll_offset = reapply_pending_async_scroll_offsets(context, context.pending_async_scroll_offsets); viewport_scroll_offset.has_value())
-            async_scrolling_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
-    }
-    context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.display_list, context.visual_context_tree.has_value() ? &context.visual_context_tree.value() : nullptr, context.scroll_state_snapshot);
-    context.async_scrolling_viewport_rect = async_scrolling_viewport_rect;
-    context.has_async_scrolling_state = true;
-}
-
-Optional<Gfx::FloatPoint> CompositorState::viewport_scroll_offset_from(ContextState& context, Vector<Web::Compositor::AsyncScrollOffset> const& scroll_offsets) const
-{
-    Optional<Gfx::FloatPoint> viewport_scroll_offset;
-    for (auto const& scroll_offset : scroll_offsets) {
-        auto node_id = context.async_scroll_tree.scroll_node_id_for_stable_id(scroll_offset.stable_node_id);
-        if (node_id.has_value() && context.async_scroll_tree.scroll_node_is_viewport(*node_id))
-            viewport_scroll_offset = scroll_offset.compositor_scroll_offset;
-    }
-    return viewport_scroll_offset;
-}
-
-Optional<Gfx::FloatPoint> CompositorState::reapply_pending_async_scroll_offsets(ContextState& context, Vector<Web::Compositor::AsyncScrollOffset> const& pending_scroll_offsets)
-{
-    Optional<Gfx::FloatPoint> viewport_scroll_offset;
-    for (auto const& pending_scroll_offset : pending_scroll_offsets) {
-        auto node_id = context.async_scroll_tree.scroll_node_id_for_stable_id(pending_scroll_offset.stable_node_id);
-        if (!node_id.has_value())
-            continue;
-        auto reconciled_scroll_offset = context.async_scroll_tree.set_scroll_offset(*node_id, pending_scroll_offset.compositor_scroll_offset, context.scroll_state_snapshot);
-        if (reconciled_scroll_offset.has_value() && context.async_scroll_tree.scroll_node_is_viewport(*node_id))
-            viewport_scroll_offset = *reconciled_scroll_offset;
-    }
-    return viewport_scroll_offset;
-}
-
-void CompositorState::store_pending_async_scroll_offsets(ContextState& context, Vector<Web::Compositor::AsyncScrollOffset> const& scroll_offsets, Optional<Web::Compositor::AsyncScrollOperationID> operation_id)
-{
-    for (auto const& scroll_offset : scroll_offsets)
-        set_or_append_pending_scroll_offset(context.pending_async_scroll_offsets, scroll_offset);
-    if (operation_id.has_value())
-        context.completed_async_scroll_operation_ids.append(*operation_id);
-}
-
-bool CompositorState::apply_viewport_scrollbar_drag(Web::Compositor::CompositorContextId context_id, ContextState& context, ViewportScrollbarController::Drag const& drag)
-{
-    auto scroll_delta = context.viewport_scrollbar_controller.scroll_delta_for_drag(context.async_scroll_tree, context.scroll_state_snapshot, drag);
-    if (!scroll_delta.has_value())
-        return false;
-
-    auto scroll_offsets = context.async_scroll_tree.apply_scroll_delta(scroll_delta->scroll_node_id, scroll_delta->delta, context.scroll_state_snapshot);
-    if (scroll_offsets.is_empty())
-        return false;
-    context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.display_list, context.visual_context_tree.has_value() ? &context.visual_context_tree.value() : nullptr, context.scroll_state_snapshot);
-
-    auto viewport_scroll_offset = viewport_scroll_offset_from(context, scroll_offsets);
-    if (!viewport_scroll_offset.has_value())
-        return false;
-
-    store_pending_async_scroll_offsets(context, scroll_offsets);
-    auto async_scroll_viewport_rect = context.async_scrolling_viewport_rect;
-    async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
-    context.async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    schedule_present_frame(context_id, context, async_scroll_viewport_rect);
-    VERIFY(context.web_content_client);
-    context.web_content_client->request_rendering_update();
-    return true;
+    child_context->did_detach_from_parent_surface(parent_context_id, surface_id);
 }
 
 void CompositorState::resize_backing_stores_if_needed(Web::Compositor::CompositorContextId context_id, ContextState& context)
 {
-    auto allocation = context.backing_store_manager.resize_backing_stores_if_needed(context.viewport_size, context.window_resize_in_progress);
-    if (!allocation.has_value())
-        return;
-    if (auto publication = context.backing_store_manager.allocate_backing_stores(
-            *allocation, m_skia_backend_context, presentation_mode_presents_to_client(context.presentation_mode));
-        publication.has_value()) {
+    if (auto publication = context.resize_backing_stores_if_needed(m_skia_backend_context); publication.has_value()) {
         publish_backing_stores(context_id, context, publication.release_value());
         present_current_frame(context_id, context);
     }
@@ -883,12 +524,9 @@ void CompositorState::resize_backing_stores_if_needed(Web::Compositor::Composito
 
 void CompositorState::schedule_backing_store_shrink(Web::Compositor::CompositorContextId context_id, ContextState& context)
 {
-    if (!context.backing_store_shrink_timer) {
-        context.backing_store_shrink_timer = Core::Timer::create_single_shot(3000, [this, context_id] {
-            shrink_backing_stores_after_resize(context_id);
-        });
-    }
-    context.backing_store_shrink_timer->restart();
+    context.schedule_backing_store_shrink([this, context_id] {
+        shrink_backing_stores_after_resize(context_id);
+    });
 }
 
 void CompositorState::shrink_backing_stores_after_resize(Web::Compositor::CompositorContextId context_id)
@@ -897,7 +535,7 @@ void CompositorState::shrink_backing_stores_after_resize(Web::Compositor::Compos
     if (!context)
         return;
 
-    context->window_resize_in_progress = Web::Compositor::WindowResizingInProgress::No;
+    context->finish_window_resize();
     resize_backing_stores_if_needed(context_id, *context);
 }
 
@@ -905,11 +543,9 @@ void CompositorState::present_current_frame(Web::Compositor::CompositorContextId
 {
     // A queued frame already captures the newest viewport rect and will pick up
     // the updated resource when the outstanding bitmap is acknowledged.
-    if (context.pending_present_frame.has_value())
-        return;
-    if (!context.presented_frame.has_value())
-        return;
-    schedule_present_frame(context_id, context, *context.presented_frame);
+    auto frame_to_present = context.current_frame_rect_to_present();
+    if (frame_to_present.has_value())
+        schedule_present_frame(context_id, context, *frame_to_present);
 }
 
 void CompositorState::publish_to_parent_surface(ContextState& context, Web::Compositor::PublishToCompositorSurface const& mode)
@@ -917,16 +553,26 @@ void CompositorState::publish_to_parent_surface(ContextState& context, Web::Comp
     auto* parent_context = context_if_present(mode.target_context_id);
     VERIFY(parent_context);
 
-    parent_context->display_list_resource_storage.update_compositor_surface(
-        mode.surface_id,
-        context.backing_store_manager.front_store().snapshot_into_shared_image());
+    parent_context->update_compositor_surface(mode.surface_id, context.snapshot_front_store());
     present_current_frame(mode.target_context_id, *parent_context);
+}
+
+bool CompositorState::apply_context_update_result(
+    Web::Compositor::CompositorContextId context_id,
+    ContextState& context,
+    ContextState::ContextUpdateResult const& result)
+{
+    if (result.frame_to_present.has_value())
+        schedule_present_frame(context_id, context, *result.frame_to_present);
+    if (result.should_request_rendering_update)
+        context.request_rendering_update();
+    return result.accepted;
 }
 
 void CompositorState::publish_backing_stores(Web::Compositor::CompositorContextId context_id, ContextState& context, BackingStoreManager::Publication&& publication)
 {
     VERIFY(m_client);
-    if (!presentation_mode_presents_to_client(context.presentation_mode))
+    if (!context.presents_to_client())
         return;
 
     m_client->did_allocate_backing_stores(context_id, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image));

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -69,10 +69,9 @@ void CompositorState::create_context(Web::Compositor::CompositorContextId contex
     if (page_id.has_value())
         VERIFY(context_id == Web::Compositor::compositor_context_id_for_page(*page_id));
 
-    auto& context = *m_contexts.ensure(context_id, [] {
-        return make<ContextState>();
+    auto& context = *m_contexts.ensure(context_id, [&] {
+        return make<ContextState>(page_id, web_content_client);
     });
-    context.initialize(page_id, web_content_client);
     resize_backing_stores_if_needed(context_id, context);
 }
 

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -342,8 +342,7 @@ void CompositorState::flush_descendant_surfaces_for_screenshot(Web::Compositor::
     // list, whose embedded-content commands read those child surfaces. So, flush any descendant with a deferred
     // present synchronously (deepest-first) — to capture a complete frame instead of a stale/blank iframe.
     auto* context = context_if_present(context_id);
-    if (!context)
-        return;
+    VERIFY(context);
     for (auto& child : context->child_contexts())
         present_subtree_for_screenshot(child.child_context_id);
 }
@@ -351,8 +350,7 @@ void CompositorState::flush_descendant_surfaces_for_screenshot(Web::Compositor::
 bool CompositorState::present_subtree_for_screenshot(Web::Compositor::CompositorContextId context_id)
 {
     auto* context = context_if_present(context_id);
-    if (!context)
-        return false;
+    VERIFY(context);
 
     bool needs_present = context->needs_synchronous_present_for_screenshot();
     for (auto& child : context->child_contexts()) {
@@ -383,7 +381,8 @@ bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId co
         return false;
 
     flush_descendant_surfaces_for_screenshot(context_id);
-    return context->paint_screenshot(*m_display_list_player, target_bitmap);
+    context->paint_screenshot(*m_display_list_player, target_bitmap);
+    return true;
 }
 
 void CompositorState::presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id)
@@ -445,8 +444,9 @@ void CompositorState::cancel_pending_async_presents_for_context(Web::Compositor:
 
 void CompositorState::schedule_gpu_completion_check()
 {
-    if (!m_skia_backend_context || m_pending_async_presents.is_empty())
+    if (!m_skia_backend_context)
         return;
+    VERIFY(!m_pending_async_presents.is_empty());
 
     if (!m_gpu_completion_timer) {
         m_gpu_completion_timer = Core::Timer::create_repeating(gpu_completion_check_interval_ms, [this] {
@@ -572,8 +572,7 @@ bool CompositorState::apply_context_update_result(
 void CompositorState::publish_backing_stores(Web::Compositor::CompositorContextId context_id, ContextState& context, BackingStoreManager::Publication&& publication)
 {
     VERIFY(m_client);
-    if (!context.presents_to_client())
-        return;
+    VERIFY(context.presents_to_client());
 
     m_client->did_allocate_backing_stores(context_id, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image));
 }

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -12,12 +12,9 @@
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
-#include <AK/Vector.h>
-#include <Compositor/BackingStoreManager.h>
+#include <Compositor/ContextState.h>
 #include <Compositor/VSyncScheduler.h>
-#include <Compositor/ViewportScrollbarController.h>
 #include <LibCore/Forward.h>
-#include <LibGfx/PaintingSurface.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/ShareableBitmap.h>
@@ -25,14 +22,11 @@
 #include <LibGfx/Size.h>
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibMedia/Forward.h>
-#include <LibWeb/Compositor/AsyncScrollTree.h>
-#include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
-#include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/ScrollState.h>
 
 namespace Web {
@@ -101,54 +95,6 @@ public:
 private:
     CompositorState(RefPtr<Gfx::SkiaBackendContext>, bool async_scrolling_enabled);
 
-    struct ContextState {
-        ~ContextState();
-
-        struct PublishedSurface {
-            Web::Compositor::CompositorContextId parent_context_id;
-            Web::Painting::CompositorSurfaceId surface_id;
-        };
-
-        CompositorStateWebContentClient* web_content_client { nullptr };
-        Optional<u64> page_id;
-
-        Web::Compositor::PresentationMode presentation_mode { Empty {} };
-        Optional<PublishedSurface> published_surface;
-        HashMap<Web::Painting::CompositorSurfaceId, Web::Compositor::CompositorContextId> child_contexts_by_surface_id;
-
-        RefPtr<Web::Painting::DisplayList const> display_list;
-        Optional<Web::Painting::AccumulatedVisualContextTree> visual_context_tree;
-        Web::Painting::DisplayListResourceStorage display_list_resource_storage;
-        Web::Painting::ScrollStateSnapshot scroll_state_snapshot;
-        BackingStoreManager backing_store_manager;
-
-        Web::Compositor::AsyncScrollTree async_scroll_tree;
-        ViewportScrollbarController viewport_scrollbar_controller;
-
-        Vector<Web::Compositor::AsyncScrollOffset> pending_async_scroll_offsets;
-        Vector<Web::Compositor::AsyncScrollOperationID> completed_async_scroll_operation_ids;
-        Web::Compositor::AsyncScrollOperationID next_async_scroll_operation_id { 0 };
-        Gfx::IntRect async_scrolling_viewport_rect;
-        bool has_async_scrolling_state { false };
-        bool can_accept_async_wheel_events { false };
-        u64 wheel_event_listener_state_generation { 0 };
-        Web::Compositor::WheelRoutingAdmission wheel_routing_admission { Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState };
-
-        Gfx::IntSize viewport_size;
-        Web::Compositor::WindowResizingInProgress window_resize_in_progress { Web::Compositor::WindowResizingInProgress::No };
-        RefPtr<Core::Timer> backing_store_shrink_timer;
-        Optional<u64> display_id;
-        double display_refresh_rate { 60.0 };
-
-        Optional<Gfx::IntRect> pending_present_frame;
-        bool pending_present_frame_scheduled { false };
-        Optional<Gfx::IntRect> presented_frame;
-        Optional<i32> gpu_present_bitmap_id_awaiting_completion;
-        Optional<i32> presented_bitmap_id_awaiting_ack;
-
-        void stop_backing_store_shrink_timer();
-    };
-
     struct PendingAsyncPresent {
         PendingAsyncPresent(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, i32 bitmap_id)
             : context_id(context_id)
@@ -167,16 +113,15 @@ private:
     ContextState const* context_if_present(Web::Compositor::CompositorContextId) const;
     void detach_from_parent_surface(Web::Compositor::CompositorContextId, ContextState&);
     void remove_child_surface(ContextState&, Web::Compositor::CompositorContextId parent_context_id, Web::Painting::CompositorSurfaceId);
-    void install_display_list_update(ContextState&, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::AccumulatedVisualContextTree, Web::Painting::ScrollStateSnapshot&&);
-    Optional<Gfx::FloatPoint> viewport_scroll_offset_from(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&) const;
-    Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&);
-    void store_pending_async_scroll_offsets(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&, Optional<Web::Compositor::AsyncScrollOperationID> = {});
-    bool apply_viewport_scrollbar_drag(Web::Compositor::CompositorContextId, ContextState&, ViewportScrollbarController::Drag const&);
     void schedule_backing_store_shrink(Web::Compositor::CompositorContextId, ContextState&);
     void shrink_backing_stores_after_resize(Web::Compositor::CompositorContextId);
     void resize_backing_stores_if_needed(Web::Compositor::CompositorContextId, ContextState&);
     void present_current_frame(Web::Compositor::CompositorContextId, ContextState&);
     void publish_to_parent_surface(ContextState&, Web::Compositor::PublishToCompositorSurface const&);
+    bool apply_context_update_result(
+        Web::Compositor::CompositorContextId,
+        ContextState&,
+        ContextState::ContextUpdateResult const&);
     void present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect);
     void schedule_present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect);
     void schedule_pending_present_frame_on_vsync(Web::Compositor::CompositorContextId, ContextState&);

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -31,9 +31,10 @@ static void set_or_append_pending_scroll_offset(
     pending_scroll_offsets.append(scroll_offset);
 }
 
-ContextState::ContextState(Optional<u64> page_id, CompositorStateWebContentClient& web_content_client)
+ContextState::ContextState(Optional<u64> page_id, CompositorStateWebContentClient& web_content_client, bool async_scrolling_enabled)
     : m_web_content_client(web_content_client)
     , m_page_id(page_id)
+    , m_async_scrolling_enabled(async_scrolling_enabled)
 {
     if (page_id.has_value())
         m_presentation_mode = Web::Compositor::PresentToClient {};
@@ -128,18 +129,15 @@ void ContextState::apply_display_list_resource_transaction(Web::Painting::Displa
 void ContextState::install_display_list_update(
     NonnullRefPtr<Web::Painting::DisplayList> display_list,
     Web::Painting::AccumulatedVisualContextTree visual_context_tree,
-    Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot,
-    bool async_scrolling_enabled)
+    Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
     VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree.version());
     m_display_list = move(display_list);
     m_visual_context_tree = move(visual_context_tree);
     m_scroll_state_snapshot = move(scroll_state_snapshot);
 
-    if (!async_scrolling_enabled) {
-        clear_async_scrolling_state();
+    if (!m_async_scrolling_enabled)
         return;
-    }
 
     auto async_scrolling_state = Web::Compositor::async_scrolling_state_from_display_list(*m_display_list);
     auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
@@ -571,18 +569,6 @@ void ContextState::stop_backing_store_shrink_timer()
         return;
     m_backing_store_shrink_timer->on_timeout = {};
     m_backing_store_shrink_timer->stop();
-}
-
-void ContextState::clear_async_scrolling_state()
-{
-    m_async_scroll_tree.set_state({});
-    m_viewport_scrollbar_controller.clear();
-    m_pending_async_scroll_offsets.clear();
-    m_completed_async_scroll_operation_ids.clear();
-    m_wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState;
-    m_can_accept_async_wheel_events = false;
-    m_async_scrolling_viewport_rect = {};
-    m_has_async_scrolling_state = false;
 }
 
 Web::Painting::AccumulatedVisualContextTree const& ContextState::current_visual_context_tree() const

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -1,0 +1,689 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <AK/StdLibExtras.h>
+#include <Compositor/CompositorState.h>
+#include <Compositor/ContextState.h>
+#include <LibCore/Timer.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/PainterSkia.h>
+#include <LibGfx/PaintingSurface.h>
+#include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Painting/DisplayListPlayerSkia.h>
+
+namespace Compositor {
+
+static void set_or_append_pending_scroll_offset(
+    Vector<Web::Compositor::AsyncScrollOffset>& pending_scroll_offsets,
+    Web::Compositor::AsyncScrollOffset const& scroll_offset)
+{
+    for (auto& existing : pending_scroll_offsets) {
+        if (existing.stable_node_id == scroll_offset.stable_node_id) {
+            existing.compositor_scroll_offset = scroll_offset.compositor_scroll_offset;
+            existing.unadopted_scroll_delta.translate_by(scroll_offset.unadopted_scroll_delta);
+            return;
+        }
+    }
+    pending_scroll_offsets.append(scroll_offset);
+}
+
+ContextState::~ContextState()
+{
+    stop_backing_store_shrink_timer();
+}
+
+bool ContextState::presentation_mode_presents_to_client(Web::Compositor::PresentationMode const& presentation_mode)
+{
+    return presentation_mode.has<Web::Compositor::PresentToClient>();
+}
+
+void ContextState::initialize(Optional<u64> page_id, CompositorStateWebContentClient& web_content_client)
+{
+    m_web_content_client = &web_content_client;
+    m_page_id = page_id;
+    if (page_id.has_value())
+        m_presentation_mode = Web::Compositor::PresentToClient {};
+}
+
+bool ContextState::is_owned_by(CompositorStateWebContentClient const& web_content_client) const
+{
+    VERIFY(m_web_content_client);
+    return m_web_content_client == &web_content_client;
+}
+
+void ContextState::request_rendering_update()
+{
+    VERIFY(m_web_content_client);
+    m_web_content_client->request_rendering_update();
+}
+
+void ContextState::dispatch_mouse_event_to_web_content(Web::MouseEvent const& event)
+{
+    VERIFY(m_web_content_client);
+    VERIFY(m_page_id.has_value());
+    m_web_content_client->dispatch_mouse_event_to_web_content(*m_page_id, event);
+}
+
+void ContextState::set_presentation_mode(Web::Compositor::PresentationMode presentation_mode)
+{
+    if (presentation_mode_presents_to_client(presentation_mode))
+        VERIFY(m_page_id.has_value());
+    m_presentation_mode = move(presentation_mode);
+}
+
+void ContextState::did_stop_presenting_to_client_if_needed(bool was_presenting_to_client, bool will_present_to_client)
+{
+    if (was_presenting_to_client && !will_present_to_client
+        && m_gpu_present_bitmap_id_awaiting_completion.has_value()
+        && m_presented_bitmap_id_awaiting_ack == m_gpu_present_bitmap_id_awaiting_completion)
+        m_presented_bitmap_id_awaiting_ack.clear();
+}
+
+void ContextState::set_published_surface(PublishedSurface published_surface)
+{
+    m_published_surface = published_surface;
+}
+
+Optional<ContextState::PublishedSurface> ContextState::take_published_surface()
+{
+    if (!m_published_surface.has_value())
+        return {};
+    return m_published_surface.release_value();
+}
+
+void ContextState::did_detach_from_parent_surface(Web::Compositor::CompositorContextId parent_context_id, Web::Painting::CompositorSurfaceId surface_id)
+{
+    VERIFY(m_published_surface.has_value());
+    VERIFY(m_published_surface->parent_context_id == parent_context_id);
+    VERIFY(m_published_surface->surface_id == surface_id);
+    m_published_surface.clear();
+    m_presentation_mode = Empty {};
+}
+
+void ContextState::attach_child_surface(Web::Painting::CompositorSurfaceId surface_id, Web::Compositor::CompositorContextId child_context_id)
+{
+    m_child_contexts_by_surface_id.set(surface_id, child_context_id);
+}
+
+Optional<Web::Compositor::CompositorContextId> ContextState::take_child_context_for_surface(Web::Painting::CompositorSurfaceId surface_id)
+{
+    return m_child_contexts_by_surface_id.take(surface_id);
+}
+
+Vector<ContextState::ChildSurface> ContextState::child_contexts() const
+{
+    Vector<ChildSurface> child_contexts;
+    child_contexts.ensure_capacity(m_child_contexts_by_surface_id.size());
+    for (auto& child_context : m_child_contexts_by_surface_id)
+        child_contexts.unchecked_append({ child_context.key, child_context.value });
+    return child_contexts;
+}
+
+void ContextState::apply_display_list_resource_transaction(Web::Painting::DisplayListResourceTransaction&& resource_transaction)
+{
+    m_display_list_resource_storage.apply_transaction(move(resource_transaction));
+}
+
+void ContextState::install_display_list_update(
+    NonnullRefPtr<Web::Painting::DisplayList> display_list,
+    Web::Painting::AccumulatedVisualContextTree visual_context_tree,
+    Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot,
+    bool async_scrolling_enabled)
+{
+    VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree.version());
+    m_display_list = move(display_list);
+    m_visual_context_tree = move(visual_context_tree);
+    m_scroll_state_snapshot = move(scroll_state_snapshot);
+
+    if (!async_scrolling_enabled) {
+        clear_async_scrolling_state();
+        return;
+    }
+
+    auto async_scrolling_state = Web::Compositor::async_scrolling_state_from_display_list(*m_display_list);
+    auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
+    auto wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
+    auto wheel_routing_admission = Web::Compositor::wheel_routing_admission_for(async_scrolling_state);
+    if (wheel_event_listener_state_generation < m_wheel_event_listener_state_generation)
+        wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::StaleWheelEventListeners;
+    else
+        m_wheel_event_listener_state_generation = wheel_event_listener_state_generation;
+
+    m_wheel_routing_admission = wheel_routing_admission;
+    m_can_accept_async_wheel_events = wheel_routing_admission == Web::Compositor::WheelRoutingAdmission::Accepted;
+
+    m_viewport_scrollbar_controller.set_scrollbars(async_scrolling_state.viewport_scrollbars);
+    m_async_scroll_tree.set_state(move(async_scrolling_state));
+    if (!m_pending_async_scroll_offsets.is_empty()) {
+        if (auto viewport_scroll_offset = reapply_pending_async_scroll_offsets(m_pending_async_scroll_offsets); viewport_scroll_offset.has_value())
+            async_scrolling_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+    }
+    rebuild_wheel_hit_test_targets();
+    m_async_scrolling_viewport_rect = async_scrolling_viewport_rect;
+    m_has_async_scrolling_state = true;
+}
+
+void ContextState::update_scroll_state(Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    m_scroll_state_snapshot = move(scroll_state_snapshot);
+    if (!m_has_async_scrolling_state)
+        return;
+
+    auto reconciled_viewport_scroll_offset = reapply_pending_async_scroll_offsets(m_pending_async_scroll_offsets);
+    rebuild_wheel_hit_test_targets();
+    if (reconciled_viewport_scroll_offset.has_value()) {
+        auto reconciled_viewport_rect = m_async_scrolling_viewport_rect;
+        reconciled_viewport_rect.set_location(reconciled_viewport_scroll_offset->to_type<int>());
+        m_async_scrolling_viewport_rect = reconciled_viewport_rect;
+    }
+}
+
+void ContextState::update_video_frame(Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)
+{
+    m_display_list_resource_storage.update_video_frame(frame_id, move(frame));
+}
+
+void ContextState::clear_video_frame(Web::Painting::VideoFrameResourceId frame_id)
+{
+    m_display_list_resource_storage.clear_video_frame(frame_id);
+}
+
+void ContextState::update_compositor_surface(Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
+{
+    m_display_list_resource_storage.update_compositor_surface(surface_id, move(shared_image));
+}
+
+void ContextState::clear_compositor_surface(Web::Painting::CompositorSurfaceId surface_id)
+{
+    m_display_list_resource_storage.clear_compositor_surface(surface_id);
+}
+
+Gfx::SharedImage ContextState::snapshot_front_store()
+{
+    return m_backing_store_manager.front_store().snapshot_into_shared_image();
+}
+
+void ContextState::invalidate_wheel_event_listener_state(u64 generation)
+{
+    m_wheel_event_listener_state_generation = max(m_wheel_event_listener_state_generation, generation);
+    m_wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::StaleWheelEventListeners;
+    m_can_accept_async_wheel_events = false;
+}
+
+ContextState::ContextUpdateResult ContextState::handle_mouse_event(Web::MouseEvent const& event)
+{
+    if (!presents_to_client())
+        return {};
+
+    auto position = Gfx::FloatPoint {
+        static_cast<float>(event.position.x().value()),
+        static_cast<float>(event.position.y().value()),
+    };
+
+    switch (event.type) {
+    case Web::MouseEvent::Type::MouseDown: {
+        if (event.button != Web::UIEvents::MouseButton::Primary)
+            return {};
+
+        auto drag = m_viewport_scrollbar_controller.begin_drag(m_async_scroll_tree, m_scroll_state_snapshot, position);
+        if (!drag.has_value())
+            return {};
+
+        ContextUpdateResult result;
+        result.accepted = true;
+        if (!m_async_scrolling_viewport_rect.is_empty())
+            result.frame_to_present = m_async_scrolling_viewport_rect;
+        if (auto frame_to_present = apply_viewport_scrollbar_drag(*drag); frame_to_present.has_value()) {
+            result.frame_to_present = *frame_to_present;
+            result.should_request_rendering_update = true;
+        }
+        return result;
+    }
+    case Web::MouseEvent::Type::MouseMove: {
+        auto had_capture = m_viewport_scrollbar_controller.has_captured_scrollbar();
+        if (had_capture) {
+            auto drag = m_viewport_scrollbar_controller.captured_drag(position);
+            if (!drag.has_value())
+                return {};
+            auto frame_to_present = apply_viewport_scrollbar_drag(*drag);
+            return { .accepted = true, .frame_to_present = frame_to_present, .should_request_rendering_update = frame_to_present.has_value() };
+        }
+
+        auto hovered_scrollbar_index = m_viewport_scrollbar_controller.hit_test(m_async_scroll_tree, m_scroll_state_snapshot, position);
+        Optional<Gfx::IntRect> frame_to_present;
+        if (m_viewport_scrollbar_controller.set_hovered_scrollbar(hovered_scrollbar_index) && !m_async_scrolling_viewport_rect.is_empty())
+            frame_to_present = m_async_scrolling_viewport_rect;
+        return {
+            .accepted = hovered_scrollbar_index.has_value(),
+            .frame_to_present = frame_to_present,
+            .should_request_rendering_update = false,
+        };
+    }
+    case Web::MouseEvent::Type::MouseUp: {
+        auto drag = m_viewport_scrollbar_controller.release_captured_drag(position);
+        if (!drag.has_value())
+            return {};
+
+        ContextUpdateResult result;
+        result.accepted = true;
+        if (!m_async_scrolling_viewport_rect.is_empty())
+            result.frame_to_present = m_async_scrolling_viewport_rect;
+        if (auto frame_to_present = apply_viewport_scrollbar_drag(*drag); frame_to_present.has_value()) {
+            result.frame_to_present = *frame_to_present;
+            result.should_request_rendering_update = true;
+        }
+        return result;
+    }
+    case Web::MouseEvent::Type::MouseLeave: {
+        auto had_capture = m_viewport_scrollbar_controller.has_captured_scrollbar();
+        Optional<Gfx::IntRect> frame_to_present;
+        if (m_viewport_scrollbar_controller.set_hovered_scrollbar({}) && !m_async_scrolling_viewport_rect.is_empty())
+            frame_to_present = m_async_scrolling_viewport_rect;
+        return {
+            .accepted = had_capture,
+            .frame_to_present = frame_to_present,
+            .should_request_rendering_update = false,
+        };
+    }
+    case Web::MouseEvent::Type::MouseWheel:
+        return {};
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+ContextState::AsyncScrollResult ContextState::async_scroll_by(
+    Web::UniqueNodeID expected_document_id,
+    Gfx::FloatPoint position,
+    Gfx::FloatPoint delta,
+    Gfx::IntRect viewport_rect,
+    Web::Compositor::AsyncScrollOperationTracking operation_tracking)
+{
+    if (!m_can_accept_async_wheel_events)
+        return {};
+
+    auto scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
+    if (scroll_target.blocked_by_main_thread_region || scroll_target.blocked_by_wheel_event_region || !scroll_target.node_id.has_value())
+        return {};
+    if (scroll_target.node_id->document_id != expected_document_id)
+        return {};
+
+    Optional<Web::Compositor::AsyncScrollOperationID> operation_id;
+    if (operation_tracking == Web::Compositor::AsyncScrollOperationTracking::Yes)
+        operation_id = ++m_next_async_scroll_operation_id;
+
+    auto async_scroll_viewport_rect = viewport_rect;
+    auto scroll_offsets = m_async_scroll_tree.apply_scroll_delta(*scroll_target.node_id, delta, m_scroll_state_snapshot);
+    if (scroll_offsets.is_empty()) {
+        if (operation_id.has_value())
+            m_completed_async_scroll_operation_ids.append(*operation_id);
+        return {
+            .enqueue_result = { true, operation_id },
+            .frame_to_present = {},
+        };
+    }
+
+    rebuild_wheel_hit_test_targets();
+    if (auto viewport_scroll_offset = viewport_scroll_offset_from(scroll_offsets); viewport_scroll_offset.has_value())
+        async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+    store_pending_async_scroll_offsets(scroll_offsets, operation_id);
+    m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
+    return { .enqueue_result = { true, operation_id }, .frame_to_present = async_scroll_viewport_rect };
+}
+
+ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta)
+{
+    if (!presents_to_client())
+        return {};
+    VERIFY(m_web_content_client);
+    if (!m_can_accept_async_wheel_events)
+        return {};
+
+    auto scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
+    if (scroll_target.blocked_by_main_thread_region || scroll_target.blocked_by_wheel_event_region || !scroll_target.node_id.has_value())
+        return {};
+
+    auto async_scroll_viewport_rect = m_async_scrolling_viewport_rect;
+    auto scroll_offsets = m_async_scroll_tree.apply_scroll_delta(*scroll_target.node_id, delta, m_scroll_state_snapshot);
+    if (scroll_offsets.is_empty())
+        return {
+            .accepted = true,
+            .frame_to_present = {},
+            .should_request_rendering_update = false,
+        };
+
+    rebuild_wheel_hit_test_targets();
+    if (auto viewport_scroll_offset = viewport_scroll_offset_from(scroll_offsets); viewport_scroll_offset.has_value())
+        async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+    store_pending_async_scroll_offsets(scroll_offsets);
+    m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
+    return { .accepted = true, .frame_to_present = async_scroll_viewport_rect, .should_request_rendering_update = true };
+}
+
+bool ContextState::should_defer_main_thread_present_for_async_scroll() const
+{
+    if (m_pending_async_scroll_offsets.is_empty())
+        return false;
+    return m_pending_present_frame.has_value()
+        || m_gpu_present_bitmap_id_awaiting_completion.has_value()
+        || m_presented_bitmap_id_awaiting_ack.has_value();
+}
+
+Web::Compositor::PendingAsyncScrollUpdates ContextState::take_pending_async_scroll_updates()
+{
+    Web::Compositor::PendingAsyncScrollUpdates updates;
+    AK::swap(updates.scroll_offsets, m_pending_async_scroll_offsets);
+    AK::swap(updates.completed_operation_ids, m_completed_async_scroll_operation_ids);
+    return updates;
+}
+
+void ContextState::viewport_size_updated(Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+{
+    m_viewport_size = viewport_size;
+    auto is_page_presentation_context = m_page_id.has_value();
+    m_window_resize_in_progress = is_page_presentation_context
+        ? window_resize_in_progress
+        : Web::Compositor::WindowResizingInProgress::No;
+}
+
+bool ContextState::should_shrink_backing_stores_after_resize() const
+{
+    return m_window_resize_in_progress == Web::Compositor::WindowResizingInProgress::Yes;
+}
+
+void ContextState::schedule_backing_store_shrink(Function<void()> on_timeout)
+{
+    if (!m_backing_store_shrink_timer)
+        m_backing_store_shrink_timer = Core::Timer::create_single_shot(3000, move(on_timeout));
+    m_backing_store_shrink_timer->restart();
+}
+
+void ContextState::finish_window_resize()
+{
+    m_window_resize_in_progress = Web::Compositor::WindowResizingInProgress::No;
+}
+
+Optional<BackingStoreManager::Publication> ContextState::resize_backing_stores_if_needed(RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
+{
+    auto allocation = m_backing_store_manager.resize_backing_stores_if_needed(m_viewport_size, m_window_resize_in_progress);
+    if (!allocation.has_value())
+        return {};
+    return m_backing_store_manager.allocate_backing_stores(*allocation, skia_backend_context, presents_to_client());
+}
+
+bool ContextState::set_display_metadata(Optional<u64> display_id, double refresh_rate)
+{
+    m_display_id = display_id;
+    m_display_refresh_rate = refresh_rate;
+    return m_pending_present_frame_scheduled;
+}
+
+void ContextState::queue_present_frame(Gfx::IntRect viewport_rect)
+{
+    m_pending_present_frame = viewport_rect;
+}
+
+void ContextState::mark_pending_present_frame_scheduled()
+{
+    m_pending_present_frame_scheduled = true;
+}
+
+bool ContextState::has_pending_present_frame_scheduled_on(Optional<u64> display_id) const
+{
+    return m_pending_present_frame_scheduled && m_display_id == display_id;
+}
+
+bool ContextState::can_schedule_pending_present_frame_if_unblocked() const
+{
+    if (is_present_blocked())
+        return false;
+    if (!m_pending_present_frame.has_value())
+        return false;
+    if (m_pending_present_frame_scheduled)
+        return false;
+    return true;
+}
+
+Optional<Gfx::IntRect> ContextState::take_pending_present_frame_if_unblocked()
+{
+    m_pending_present_frame_scheduled = false;
+    if (is_present_blocked())
+        return {};
+    if (!m_pending_present_frame.has_value())
+        return {};
+    return m_pending_present_frame.release_value();
+}
+
+bool ContextState::needs_synchronous_present_for_screenshot() const
+{
+    return m_pending_present_frame.has_value() || m_pending_present_frame_scheduled;
+}
+
+Optional<Gfx::IntRect> ContextState::current_frame_rect_to_present() const
+{
+    if (m_pending_present_frame.has_value())
+        return {};
+    if (!m_presented_frame.has_value())
+        return {};
+    return m_presented_frame;
+}
+
+Optional<ContextState::PreparedFrame> ContextState::prepare_frame(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::IntRect viewport_rect)
+{
+    if (is_present_blocked()) {
+        m_pending_present_frame = viewport_rect;
+        return {};
+    }
+
+    if (!can_render_frame()) {
+        m_presented_frame = viewport_rect;
+        return {};
+    }
+
+    auto& back_store = m_backing_store_manager.back_store();
+    m_presentation_mode.visit(
+        [](Empty const&) {},
+        [](Web::Compositor::PresentToClient const&) {},
+        [&](Web::Compositor::PublishToCompositorSurface const&) {
+            Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
+            painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
+        });
+    paint_current_display_list(display_list_player, back_store);
+
+    auto rendered_bitmap_id = m_backing_store_manager.back_bitmap_id();
+    m_gpu_present_bitmap_id_awaiting_completion = rendered_bitmap_id;
+    if (presents_to_client())
+        m_presented_bitmap_id_awaiting_ack = rendered_bitmap_id;
+    return PreparedFrame {
+        .rendered_surface = &back_store,
+        .bitmap_id = rendered_bitmap_id,
+    };
+}
+
+void ContextState::did_submit_prepared_frame(Gfx::IntRect viewport_rect)
+{
+    m_backing_store_manager.swap();
+    m_presented_frame = viewport_rect;
+}
+
+Optional<Web::Compositor::PublishToCompositorSurface> ContextState::present_synchronously(Web::Painting::DisplayListPlayerSkia& display_list_player)
+{
+    auto* publish_mode = m_presentation_mode.get_pointer<Web::Compositor::PublishToCompositorSurface>();
+    if (!publish_mode)
+        return {};
+    if (!can_render_frame())
+        return {};
+    // Don't race an async present already in flight for this context; its own completion will publish.
+    if (is_present_blocked())
+        return {};
+
+    auto viewport_rect = m_pending_present_frame;
+    if (!viewport_rect.has_value())
+        viewport_rect = m_presented_frame;
+    if (!viewport_rect.has_value())
+        return {};
+
+    auto& back_store = m_backing_store_manager.back_store();
+    {
+        Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
+        painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
+    }
+    paint_current_display_list(display_list_player, back_store);
+    display_list_player.flush(back_store);
+    m_backing_store_manager.swap();
+    m_presented_frame = viewport_rect;
+    m_pending_present_frame.clear();
+    m_pending_present_frame_scheduled = false;
+    return *publish_mode;
+}
+
+bool ContextState::can_paint_screenshot(Gfx::ShareableBitmap& target_bitmap) const
+{
+    return m_display_list && target_bitmap.is_valid() && target_bitmap.bitmap();
+}
+
+bool ContextState::paint_screenshot(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::ShareableBitmap& target_bitmap)
+{
+    if (!can_paint_screenshot(target_bitmap))
+        return false;
+
+    auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
+    paint_current_display_list(display_list_player, *target_surface);
+    display_list_player.flush(*target_surface);
+    return true;
+}
+
+bool ContextState::acknowledge_presented_bitmap(i32 bitmap_id)
+{
+    if (m_presented_bitmap_id_awaiting_ack != bitmap_id)
+        return false;
+
+    m_presented_bitmap_id_awaiting_ack.clear();
+    return true;
+}
+
+void ContextState::did_finish_gpu_present(i32 bitmap_id)
+{
+    VERIFY(m_gpu_present_bitmap_id_awaiting_completion == bitmap_id);
+    m_gpu_present_bitmap_id_awaiting_completion.clear();
+}
+
+void ContextState::stop_backing_store_shrink_timer()
+{
+    if (!m_backing_store_shrink_timer)
+        return;
+    m_backing_store_shrink_timer->on_timeout = {};
+    m_backing_store_shrink_timer->stop();
+}
+
+void ContextState::clear_async_scrolling_state()
+{
+    m_async_scroll_tree.set_state({});
+    m_viewport_scrollbar_controller.clear();
+    m_pending_async_scroll_offsets.clear();
+    m_completed_async_scroll_operation_ids.clear();
+    m_wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState;
+    m_can_accept_async_wheel_events = false;
+    m_async_scrolling_viewport_rect = {};
+    m_has_async_scrolling_state = false;
+}
+
+Web::Painting::AccumulatedVisualContextTree const& ContextState::current_visual_context_tree() const
+{
+    VERIFY(m_display_list);
+    VERIFY(m_visual_context_tree.has_value());
+    return m_visual_context_tree.value();
+}
+
+Optional<Gfx::FloatPoint> ContextState::viewport_scroll_offset_from(Vector<Web::Compositor::AsyncScrollOffset> const& scroll_offsets) const
+{
+    Optional<Gfx::FloatPoint> viewport_scroll_offset;
+    for (auto const& scroll_offset : scroll_offsets) {
+        auto node_id = m_async_scroll_tree.scroll_node_id_for_stable_id(scroll_offset.stable_node_id);
+        if (node_id.has_value() && m_async_scroll_tree.scroll_node_is_viewport(*node_id))
+            viewport_scroll_offset = scroll_offset.compositor_scroll_offset;
+    }
+    return viewport_scroll_offset;
+}
+
+Optional<Gfx::FloatPoint> ContextState::reapply_pending_async_scroll_offsets(Vector<Web::Compositor::AsyncScrollOffset> const& pending_scroll_offsets)
+{
+    Optional<Gfx::FloatPoint> viewport_scroll_offset;
+    for (auto const& pending_scroll_offset : pending_scroll_offsets) {
+        auto node_id = m_async_scroll_tree.scroll_node_id_for_stable_id(pending_scroll_offset.stable_node_id);
+        if (!node_id.has_value())
+            continue;
+        auto reconciled_scroll_offset = m_async_scroll_tree.set_scroll_offset(
+            *node_id,
+            pending_scroll_offset.compositor_scroll_offset,
+            m_scroll_state_snapshot);
+        if (reconciled_scroll_offset.has_value() && m_async_scroll_tree.scroll_node_is_viewport(*node_id))
+            viewport_scroll_offset = *reconciled_scroll_offset;
+    }
+    return viewport_scroll_offset;
+}
+
+void ContextState::store_pending_async_scroll_offsets(
+    Vector<Web::Compositor::AsyncScrollOffset> const& scroll_offsets,
+    Optional<Web::Compositor::AsyncScrollOperationID> operation_id)
+{
+    for (auto const& scroll_offset : scroll_offsets)
+        set_or_append_pending_scroll_offset(m_pending_async_scroll_offsets, scroll_offset);
+    if (operation_id.has_value())
+        m_completed_async_scroll_operation_ids.append(*operation_id);
+}
+
+Optional<Gfx::IntRect> ContextState::apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const& drag)
+{
+    auto scroll_delta = m_viewport_scrollbar_controller.scroll_delta_for_drag(m_async_scroll_tree, m_scroll_state_snapshot, drag);
+    if (!scroll_delta.has_value())
+        return {};
+
+    auto scroll_offsets = m_async_scroll_tree.apply_scroll_delta(scroll_delta->scroll_node_id, scroll_delta->delta, m_scroll_state_snapshot);
+    if (scroll_offsets.is_empty())
+        return {};
+    rebuild_wheel_hit_test_targets();
+
+    auto viewport_scroll_offset = viewport_scroll_offset_from(scroll_offsets);
+    if (!viewport_scroll_offset.has_value())
+        return {};
+
+    store_pending_async_scroll_offsets(scroll_offsets);
+    auto async_scroll_viewport_rect = m_async_scrolling_viewport_rect;
+    async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+    m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
+    return async_scroll_viewport_rect;
+}
+
+void ContextState::rebuild_wheel_hit_test_targets()
+{
+    VERIFY(m_display_list);
+    m_async_scroll_tree.rebuild_wheel_hit_test_targets(
+        m_display_list,
+        &current_visual_context_tree(),
+        m_scroll_state_snapshot);
+}
+
+bool ContextState::is_present_blocked() const
+{
+    return m_gpu_present_bitmap_id_awaiting_completion.has_value()
+        || m_presented_bitmap_id_awaiting_ack.has_value();
+}
+
+bool ContextState::can_render_frame() const
+{
+    return m_display_list && m_backing_store_manager.is_valid();
+}
+
+void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::PaintingSurface& surface)
+{
+    VERIFY(m_display_list);
+    display_list_player.execute(*m_display_list, current_visual_context_tree(), m_display_list_resource_storage, m_scroll_state_snapshot, surface);
+    m_viewport_scrollbar_controller.paint(surface, display_list_player, m_scroll_state_snapshot);
+}
+
+}

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -513,8 +513,7 @@ void ContextState::did_submit_prepared_frame(Gfx::IntRect viewport_rect)
 Optional<Web::Compositor::PublishToCompositorSurface> ContextState::present_synchronously(Web::Painting::DisplayListPlayerSkia& display_list_player)
 {
     auto* publish_mode = m_presentation_mode.get_pointer<Web::Compositor::PublishToCompositorSurface>();
-    if (!publish_mode)
-        return {};
+    VERIFY(publish_mode);
     if (!can_render_frame())
         return {};
     // Don't race an async present already in flight for this context; its own completion will publish.
@@ -546,15 +545,13 @@ bool ContextState::can_paint_screenshot(Gfx::ShareableBitmap& target_bitmap) con
     return m_display_list && target_bitmap.is_valid() && target_bitmap.bitmap();
 }
 
-bool ContextState::paint_screenshot(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::ShareableBitmap& target_bitmap)
+void ContextState::paint_screenshot(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::ShareableBitmap& target_bitmap)
 {
-    if (!can_paint_screenshot(target_bitmap))
-        return false;
+    VERIFY(can_paint_screenshot(target_bitmap));
 
     auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
     paint_current_display_list(display_list_player, *target_surface);
     display_list_player.flush(*target_surface);
-    return true;
 }
 
 bool ContextState::acknowledge_presented_bitmap(i32 bitmap_id)

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -31,6 +31,14 @@ static void set_or_append_pending_scroll_offset(
     pending_scroll_offsets.append(scroll_offset);
 }
 
+ContextState::ContextState(Optional<u64> page_id, CompositorStateWebContentClient& web_content_client)
+    : m_web_content_client(web_content_client)
+    , m_page_id(page_id)
+{
+    if (page_id.has_value())
+        m_presentation_mode = Web::Compositor::PresentToClient {};
+}
+
 ContextState::~ContextState()
 {
     stop_backing_store_shrink_timer();
@@ -41,31 +49,20 @@ bool ContextState::presentation_mode_presents_to_client(Web::Compositor::Present
     return presentation_mode.has<Web::Compositor::PresentToClient>();
 }
 
-void ContextState::initialize(Optional<u64> page_id, CompositorStateWebContentClient& web_content_client)
-{
-    m_web_content_client = &web_content_client;
-    m_page_id = page_id;
-    if (page_id.has_value())
-        m_presentation_mode = Web::Compositor::PresentToClient {};
-}
-
 bool ContextState::is_owned_by(CompositorStateWebContentClient const& web_content_client) const
 {
-    VERIFY(m_web_content_client);
-    return m_web_content_client == &web_content_client;
+    return &m_web_content_client == &web_content_client;
 }
 
 void ContextState::request_rendering_update()
 {
-    VERIFY(m_web_content_client);
-    m_web_content_client->request_rendering_update();
+    m_web_content_client.request_rendering_update();
 }
 
 void ContextState::dispatch_mouse_event_to_web_content(Web::MouseEvent const& event)
 {
-    VERIFY(m_web_content_client);
     VERIFY(m_page_id.has_value());
-    m_web_content_client->dispatch_mouse_event_to_web_content(*m_page_id, event);
+    m_web_content_client.dispatch_mouse_event_to_web_content(*m_page_id, event);
 }
 
 void ContextState::set_presentation_mode(Web::Compositor::PresentationMode presentation_mode)
@@ -339,7 +336,6 @@ ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint 
 {
     if (!presents_to_client())
         return {};
-    VERIFY(m_web_content_client);
     if (!m_can_accept_async_wheel_events)
         return {};
 

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/HashMap.h>
+#include <AK/Noncopyable.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
+#include <AK/RefPtr.h>
+#include <AK/Vector.h>
+#include <Compositor/BackingStoreManager.h>
+#include <Compositor/ViewportScrollbarController.h>
+#include <LibCore/Forward.h>
+#include <LibGfx/PaintingSurface.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <LibGfx/SharedImage.h>
+#include <LibGfx/Size.h>
+#include <LibWeb/Compositor/AsyncScrollTree.h>
+#include <LibWeb/Compositor/AsyncScrollingState.h>
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ScrollState.h>
+
+namespace Gfx {
+
+class SkiaBackendContext;
+
+}
+
+namespace Web {
+
+struct MouseEvent;
+
+}
+
+namespace Web::Painting {
+
+class DisplayListPlayerSkia;
+
+}
+
+namespace Compositor {
+
+class CompositorStateWebContentClient;
+
+class ContextState {
+    AK_MAKE_NONCOPYABLE(ContextState);
+    AK_MAKE_NONMOVABLE(ContextState);
+
+public:
+    struct PublishedSurface {
+        Web::Compositor::CompositorContextId parent_context_id;
+        Web::Painting::CompositorSurfaceId surface_id;
+    };
+
+    struct ChildSurface {
+        Web::Painting::CompositorSurfaceId surface_id;
+        Web::Compositor::CompositorContextId child_context_id;
+    };
+
+    struct AsyncScrollResult {
+        Web::Compositor::AsyncScrollEnqueueResult enqueue_result;
+        Optional<Gfx::IntRect> frame_to_present;
+    };
+
+    struct ContextUpdateResult {
+        bool accepted { false };
+        Optional<Gfx::IntRect> frame_to_present;
+        bool should_request_rendering_update { false };
+    };
+
+    struct PreparedFrame {
+        Gfx::PaintingSurface* rendered_surface { nullptr };
+        i32 bitmap_id { 0 };
+    };
+
+    ContextState() = default;
+    ~ContextState();
+
+    static bool presentation_mode_presents_to_client(Web::Compositor::PresentationMode const&);
+
+    void initialize(Optional<u64> page_id, CompositorStateWebContentClient&);
+    bool is_owned_by(CompositorStateWebContentClient const&) const;
+    void request_rendering_update();
+    void dispatch_mouse_event_to_web_content(Web::MouseEvent const&);
+
+    bool presents_to_client() const { return presentation_mode_presents_to_client(m_presentation_mode); }
+    bool publishes_to_parent_surface() const { return m_presentation_mode.has<Web::Compositor::PublishToCompositorSurface>(); }
+    Web::Compositor::PresentationMode const& presentation_mode() const { return m_presentation_mode; }
+    void set_presentation_mode(Web::Compositor::PresentationMode);
+    void did_stop_presenting_to_client_if_needed(bool was_presenting_to_client, bool will_present_to_client);
+
+    void set_published_surface(PublishedSurface);
+    Optional<PublishedSurface> take_published_surface();
+    void did_detach_from_parent_surface(Web::Compositor::CompositorContextId parent_context_id, Web::Painting::CompositorSurfaceId);
+    void attach_child_surface(Web::Painting::CompositorSurfaceId, Web::Compositor::CompositorContextId child_context_id);
+    Optional<Web::Compositor::CompositorContextId> take_child_context_for_surface(Web::Painting::CompositorSurfaceId);
+    Vector<ChildSurface> child_contexts() const;
+
+    void apply_display_list_resource_transaction(Web::Painting::DisplayListResourceTransaction&&);
+    void install_display_list_update(
+        NonnullRefPtr<Web::Painting::DisplayList>,
+        Web::Painting::AccumulatedVisualContextTree,
+        Web::Painting::ScrollStateSnapshot&&,
+        bool async_scrolling_enabled);
+    void update_scroll_state(Web::Painting::ScrollStateSnapshot&&);
+    void update_video_frame(Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
+    void clear_video_frame(Web::Painting::VideoFrameResourceId);
+    void update_compositor_surface(Web::Painting::CompositorSurfaceId, Gfx::SharedImage&&);
+    void clear_compositor_surface(Web::Painting::CompositorSurfaceId);
+    Gfx::SharedImage snapshot_front_store();
+
+    void invalidate_wheel_event_listener_state(u64 generation);
+    ContextUpdateResult handle_mouse_event(Web::MouseEvent const&);
+    AsyncScrollResult async_scroll_by(
+        Web::UniqueNodeID document_id,
+        Gfx::FloatPoint position,
+        Gfx::FloatPoint delta,
+        Gfx::IntRect viewport_rect,
+        Web::Compositor::AsyncScrollOperationTracking);
+    ContextUpdateResult async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta);
+    bool should_defer_main_thread_present_for_async_scroll() const;
+    Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates();
+
+    void viewport_size_updated(Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
+    bool should_shrink_backing_stores_after_resize() const;
+    void schedule_backing_store_shrink(Function<void()>);
+    void finish_window_resize();
+    Optional<BackingStoreManager::Publication> resize_backing_stores_if_needed(RefPtr<Gfx::SkiaBackendContext> const&);
+
+    bool set_display_metadata(Optional<u64> display_id, double refresh_rate);
+    Optional<u64> display_id() const { return m_display_id; }
+    double display_refresh_rate() const { return m_display_refresh_rate; }
+
+    void queue_present_frame(Gfx::IntRect);
+    void mark_pending_present_frame_scheduled();
+    bool has_pending_present_frame_scheduled_on(Optional<u64> display_id) const;
+    bool can_schedule_pending_present_frame_if_unblocked() const;
+    Optional<Gfx::IntRect> take_pending_present_frame_if_unblocked();
+    bool needs_synchronous_present_for_screenshot() const;
+    Optional<Gfx::IntRect> current_frame_rect_to_present() const;
+    Optional<PreparedFrame> prepare_frame(Web::Painting::DisplayListPlayerSkia&, Gfx::IntRect);
+    void did_submit_prepared_frame(Gfx::IntRect);
+    Optional<Web::Compositor::PublishToCompositorSurface> present_synchronously(Web::Painting::DisplayListPlayerSkia&);
+    bool can_paint_screenshot(Gfx::ShareableBitmap&) const;
+    bool paint_screenshot(Web::Painting::DisplayListPlayerSkia&, Gfx::ShareableBitmap&);
+    bool acknowledge_presented_bitmap(i32 bitmap_id);
+    void did_finish_gpu_present(i32 bitmap_id);
+
+private:
+    void stop_backing_store_shrink_timer();
+    void clear_async_scrolling_state();
+    Web::Painting::AccumulatedVisualContextTree const& current_visual_context_tree() const;
+    Optional<Gfx::FloatPoint> viewport_scroll_offset_from(Vector<Web::Compositor::AsyncScrollOffset> const&) const;
+    Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(Vector<Web::Compositor::AsyncScrollOffset> const&);
+    void store_pending_async_scroll_offsets(Vector<Web::Compositor::AsyncScrollOffset> const&, Optional<Web::Compositor::AsyncScrollOperationID> = {});
+    Optional<Gfx::IntRect> apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const&);
+    void rebuild_wheel_hit_test_targets();
+    bool is_present_blocked() const;
+    bool can_render_frame() const;
+    void paint_current_display_list(Web::Painting::DisplayListPlayerSkia&, Gfx::PaintingSurface&);
+
+    CompositorStateWebContentClient* m_web_content_client { nullptr };
+    Optional<u64> m_page_id;
+
+    Web::Compositor::PresentationMode m_presentation_mode { Empty {} };
+    Optional<PublishedSurface> m_published_surface;
+    HashMap<Web::Painting::CompositorSurfaceId, Web::Compositor::CompositorContextId> m_child_contexts_by_surface_id;
+
+    RefPtr<Web::Painting::DisplayList const> m_display_list;
+    Optional<Web::Painting::AccumulatedVisualContextTree> m_visual_context_tree;
+    Web::Painting::DisplayListResourceStorage m_display_list_resource_storage;
+    Web::Painting::ScrollStateSnapshot m_scroll_state_snapshot;
+    BackingStoreManager m_backing_store_manager;
+
+    Web::Compositor::AsyncScrollTree m_async_scroll_tree;
+    ViewportScrollbarController m_viewport_scrollbar_controller;
+
+    Vector<Web::Compositor::AsyncScrollOffset> m_pending_async_scroll_offsets;
+    Vector<Web::Compositor::AsyncScrollOperationID> m_completed_async_scroll_operation_ids;
+    Web::Compositor::AsyncScrollOperationID m_next_async_scroll_operation_id { 0 };
+    Gfx::IntRect m_async_scrolling_viewport_rect;
+    bool m_has_async_scrolling_state { false };
+    bool m_can_accept_async_wheel_events { false };
+    u64 m_wheel_event_listener_state_generation { 0 };
+    Web::Compositor::WheelRoutingAdmission m_wheel_routing_admission { Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState };
+
+    Gfx::IntSize m_viewport_size;
+    Web::Compositor::WindowResizingInProgress m_window_resize_in_progress { Web::Compositor::WindowResizingInProgress::No };
+    RefPtr<Core::Timer> m_backing_store_shrink_timer;
+    Optional<u64> m_display_id;
+    double m_display_refresh_rate { 60.0 };
+
+    Optional<Gfx::IntRect> m_pending_present_frame;
+    bool m_pending_present_frame_scheduled { false };
+    Optional<Gfx::IntRect> m_presented_frame;
+    Optional<i32> m_gpu_present_bitmap_id_awaiting_completion;
+    Optional<i32> m_presented_bitmap_id_awaiting_ack;
+};
+
+}

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -84,7 +84,7 @@ public:
         i32 bitmap_id { 0 };
     };
 
-    ContextState(Optional<u64> page_id, CompositorStateWebContentClient&);
+    ContextState(Optional<u64> page_id, CompositorStateWebContentClient&, bool async_scrolling_enabled);
     ~ContextState();
 
     static bool presentation_mode_presents_to_client(Web::Compositor::PresentationMode const&);
@@ -110,8 +110,7 @@ public:
     void install_display_list_update(
         NonnullRefPtr<Web::Painting::DisplayList>,
         Web::Painting::AccumulatedVisualContextTree,
-        Web::Painting::ScrollStateSnapshot&&,
-        bool async_scrolling_enabled);
+        Web::Painting::ScrollStateSnapshot&&);
     void update_scroll_state(Web::Painting::ScrollStateSnapshot&&);
     void update_video_frame(Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
     void clear_video_frame(Web::Painting::VideoFrameResourceId);
@@ -158,7 +157,6 @@ public:
 
 private:
     void stop_backing_store_shrink_timer();
-    void clear_async_scrolling_state();
     Web::Painting::AccumulatedVisualContextTree const& current_visual_context_tree() const;
     Optional<Gfx::FloatPoint> viewport_scroll_offset_from(Vector<Web::Compositor::AsyncScrollOffset> const&) const;
     Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(Vector<Web::Compositor::AsyncScrollOffset> const&);
@@ -171,6 +169,7 @@ private:
 
     CompositorStateWebContentClient& m_web_content_client;
     Optional<u64> m_page_id;
+    bool const m_async_scrolling_enabled { true };
 
     Web::Compositor::PresentationMode m_presentation_mode { Empty {} };
     Optional<PublishedSurface> m_published_surface;

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -153,7 +153,7 @@ public:
     void did_submit_prepared_frame(Gfx::IntRect);
     Optional<Web::Compositor::PublishToCompositorSurface> present_synchronously(Web::Painting::DisplayListPlayerSkia&);
     bool can_paint_screenshot(Gfx::ShareableBitmap&) const;
-    bool paint_screenshot(Web::Painting::DisplayListPlayerSkia&, Gfx::ShareableBitmap&);
+    void paint_screenshot(Web::Painting::DisplayListPlayerSkia&, Gfx::ShareableBitmap&);
     bool acknowledge_presented_bitmap(i32 bitmap_id);
     void did_finish_gpu_present(i32 bitmap_id);
 

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -84,12 +84,11 @@ public:
         i32 bitmap_id { 0 };
     };
 
-    ContextState() = default;
+    ContextState(Optional<u64> page_id, CompositorStateWebContentClient&);
     ~ContextState();
 
     static bool presentation_mode_presents_to_client(Web::Compositor::PresentationMode const&);
 
-    void initialize(Optional<u64> page_id, CompositorStateWebContentClient&);
     bool is_owned_by(CompositorStateWebContentClient const&) const;
     void request_rendering_update();
     void dispatch_mouse_event_to_web_content(Web::MouseEvent const&);
@@ -170,7 +169,7 @@ private:
     bool can_render_frame() const;
     void paint_current_display_list(Web::Painting::DisplayListPlayerSkia&, Gfx::PaintingSurface&);
 
-    CompositorStateWebContentClient* m_web_content_client { nullptr };
+    CompositorStateWebContentClient& m_web_content_client;
     Optional<u64> m_page_id;
 
     Web::Compositor::PresentationMode m_presentation_mode { Empty {} };

--- a/Services/Compositor/ViewportScrollbarController.cpp
+++ b/Services/Compositor/ViewportScrollbarController.cpp
@@ -29,7 +29,7 @@ static ViewportScrollbarIdentity viewport_scrollbar_identity(Web::Compositor::Vi
 
 static Optional<ViewportScrollbarIdentity> viewport_scrollbar_identity_at(ReadonlySpan<Web::Compositor::ViewportScrollbar> scrollbars, Optional<size_t> scrollbar_index)
 {
-    if (!scrollbar_index.has_value() || *scrollbar_index >= scrollbars.size())
+    if (!scrollbar_index.has_value())
         return {};
     return viewport_scrollbar_identity(scrollbars[*scrollbar_index]);
 }
@@ -159,10 +159,6 @@ Optional<ViewportScrollbarController::Drag> ViewportScrollbarController::capture
     if (!m_captured_scrollbar_index.has_value())
         return {};
     auto scrollbar_index = *m_captured_scrollbar_index;
-    if (scrollbar_index >= m_scrollbars.size()) {
-        m_captured_scrollbar_index.clear();
-        return {};
-    }
     auto const& scrollbar = m_scrollbars[scrollbar_index];
     auto primary_position = position.primary_offset_for_orientation(orientation_for_scrollbar(scrollbar));
     return Drag { scrollbar_index, primary_position, m_thumb_grab_position };
@@ -174,10 +170,6 @@ Optional<ViewportScrollbarController::Drag> ViewportScrollbarController::release
         return {};
     auto scrollbar_index = *m_captured_scrollbar_index;
     auto thumb_grab_position = m_thumb_grab_position;
-    if (scrollbar_index >= m_scrollbars.size()) {
-        m_captured_scrollbar_index.clear();
-        return {};
-    }
     auto const& scrollbar = m_scrollbars[scrollbar_index];
     auto primary_position = position.primary_offset_for_orientation(orientation_for_scrollbar(scrollbar));
     m_captured_scrollbar_index.clear();
@@ -196,9 +188,6 @@ bool ViewportScrollbarController::set_hovered_scrollbar(Optional<size_t> scrollb
 
 Optional<ViewportScrollbarController::ScrollDelta> ViewportScrollbarController::scroll_delta_for_drag(Web::Compositor::AsyncScrollTree const& async_scroll_tree, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot, Drag const& drag) const
 {
-    if (drag.scrollbar_index >= m_scrollbars.size())
-        return {};
-
     auto const& scrollbar = m_scrollbars[drag.scrollbar_index];
     auto expanded = is_expanded(drag.scrollbar_index);
     auto scroll_size = scrollbar_scroll_size(scrollbar, expanded);


### PR DESCRIPTION
CompositorState mixed service-level orchestration with the mutable state transitions for each compositor context. That made parent context lookup, vsync scheduling, backing-store lifetime, async scrolling, and presentation bookkeeping harder to reason about because most helpers reached directly into ContextState fields.

Move ContextState into its own service file and give it methods for per-context updates: display-list resource installation, async scroll state, scrollbar interaction, backing-store resize state, screenshot painting, and present/ack bookkeeping. CompositorState keeps the cross-context work: lookup, parent/child surface wiring, vsync scheduling, async present completion, and client publication.