### PR TITLE
LibWeb: Queue parent load recheck after child ready state

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4889,13 +4889,19 @@ void Document::set_ready_for_post_load_tasks(bool ready)
     m_ready_for_post_load_tasks = ready;
     if (ready) {
         if (auto navigable = this->navigable()) {
-            // AD-HOC: Clear the navigation load event guard now that the document is ready.
-            //         This guard was set in finalize_a_cross_document_navigation to prevent the parent's
-            //         load event from firing while the about:blank was still the active document.
-            navigable->clear_navigation_load_event_guard();
-
             if (auto container = navigable->container()) {
-                container->document().schedule_html_parser_end_check();
+                // AD-HOC: The "ready for post-load tasks" step can run immediately after queueing this document's
+                //         load event task. Queue the parent wake-up behind that already-queued task so the parent's
+                //         parser end check observes the same task order as the spec event loop.
+                container->queue_an_element_task(HTML::Task::Source::DOMManipulation, [navigable, container] {
+                    // AD-HOC: Clear the navigation load event guard now that the document is ready.
+                    //         This guard was set in finalize_a_cross_document_navigation to prevent the parent's
+                    //         load event from firing while the about:blank was still the active document.
+                    navigable->clear_navigation_load_event_guard();
+                    container->document().schedule_html_parser_end_check();
+                });
+            } else {
+                navigable->clear_navigation_load_event_guard();
             }
         }
     }

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Verify that the frame reloads with empty body after we remove srcdoc.

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset.html
@@ -1,0 +1,33 @@
+<title>Verify that clearing srcdoc resets the iframe's content.</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#process-the-iframe-attributes">
+<link rel="author" title="James MacLean" href="mailto:wjmaclean@chromium.org">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<iframe id=myframe srcdoc='srcdoc_text'></iframe>
+<script>
+  'use strict';
+
+  async_test(function(t) {
+    window.onload = () => {
+      // Verify that the srcdoc content is loaded before we start.
+      t.step(() => {
+        assert_true(typeof myframe.contentDocument !== 'undefined',
+            'iframe has contentDocument');
+        assert_equals(myframe.contentDocument.body.innerText, 'srcdoc_text',
+            'iframe contains srcdoc content');
+      });
+
+      myframe.onload = t.step_func_done(function() {
+        assert_true(typeof myframe.contentDocument !== 'undefined',
+            'iframe has contentDocument');
+        assert_equals(myframe.contentDocument.body.innerText, '',
+            'iframe content is empty');
+      });
+
+      // Don't remove srcdoc until the initial load has completed, and the
+      // frame's onload handler is in place.
+      myframe.removeAttribute('srcdoc');
+    };
+  }, 'Verify that the frame reloads with empty body after we remove srcdoc.');
+</script>


### PR DESCRIPTION
Before async parser-end, load event delay/ordering was effectively:

1. Enter the parent's parser-end load-delay phase.
2. Block until child iframes stopped delaying load.
3. Queue the parent document load task.

That blocking wait let queued child iframe work run first. The child document load task could run and call completely_finish_loading(), which queued the iframe element load.

The async version kept the same readiness checks, but woke the parent synchronously when a child document became ready for post-load tasks. The parent could then observe the child as ready before the child document load task had run.

Queue the parent wake-up as an element task on the iframe container instead. This keeps the spec step order while matching the old queue behavior: the child document load task runs before the parent re-checks whether it can queue load.

This fixes srcdoc-attribute-reset.html, where the parent load handler could install a new iframe.onload handler that was then invoked by the stale srcdoc iframe load event.