### PR TITLE
LibWeb: Store cached display list commands without resources

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8478,6 +8478,8 @@ Painting::HitTestDisplayList const* Document::ensure_hit_test_display_list()
         if (auto navigable = this->navigable()) {
             if (navigable->record_display_list_and_scroll_state(paint_config))
                 return;
+            (void)record_display_list(paint_config, navigable->display_list_resource_storage());
+            return;
         }
         Painting::DisplayListResourceStorage resource_storage;
         (void)record_display_list(paint_config, resource_storage);
@@ -8888,7 +8890,7 @@ String Document::dump_display_list()
     if (!viewport_paintable)
         return "No paintable"_string;
 
-    Painting::DisplayListResourceStorage resource_storage;
+    auto& resource_storage = navigable()->display_list_resource_storage();
     auto display_list = record_display_list(HTML::PaintConfig {}, resource_storage);
     if (!display_list)
         return "No display list"_string;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3489,6 +3489,7 @@ bool Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
         VERIFY(recorded_document_paintable);
         visual_context_tree = recorded_document_paintable->visual_context_tree();
         display_list_resources = m_display_list_resource_storage.collect_referenced_resources(*display_list);
+        display_list_resources.include(m_display_list_resource_storage.cache_referenced_resources());
         resource_transaction = m_display_list_resource_storage.create_transaction(
             m_compositor_display_list_resources,
             display_list_resources);

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -235,6 +235,8 @@ public:
     bool record_display_list_and_scroll_state(PaintConfig);
     void paint_next_frame();
     void render_screenshot(Gfx::PaintingSurface&, PaintConfig, Function<void()>&& callback);
+    Painting::DisplayListResourceStorage& display_list_resource_storage() { return m_display_list_resource_storage; }
+    Painting::DisplayListResourceStorage const& display_list_resource_storage() const { return m_display_list_resource_storage; }
 
     bool needs_repaint() const { return m_needs_repaint; }
     void set_needs_repaint() { m_needs_repaint = true; }

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -792,8 +792,7 @@ static Optional<AsyncScrollingStateSnapshot> capture_async_scrolling_state(DOM::
     auto document_paintable = document.paintable();
     if (!navigable || !document_paintable)
         return {};
-    Painting::DisplayListResourceStorage resource_storage;
-    auto display_list = document.record_display_list(HTML::PaintConfig {}, resource_storage);
+    auto display_list = document.record_display_list(HTML::PaintConfig {}, navigable->display_list_resource_storage());
     if (!display_list)
         return {};
     return AsyncScrollingStateSnapshot {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -57,8 +57,17 @@ Node::Node(DOM::Document& document, DOM::Node* node, AttachToDOMNode attach_to_d
 
 Node::~Node() = default;
 
+static void invalidate_paint_caches(Node& node)
+{
+    for (auto& paintable : node.paintables()) {
+        if (auto* paintable_box = as_if<Painting::PaintableBox>(*paintable))
+            paintable_box->invalidate_paint_cache();
+    }
+}
+
 void Node::prepare_for_detach_from_layout_tree()
 {
+    invalidate_paint_caches(*this);
     if (auto* node_with_style = as_if<NodeWithStyle>(*this))
         node_with_style->clear_image_observers();
     if (auto* image_box = as_if<ImageBox>(*this))
@@ -1327,6 +1336,7 @@ void Node::add_paintable(RefPtr<Painting::Paintable> paintable)
 
 void Node::clear_paintables()
 {
+    invalidate_paint_caches(*this);
     for (auto& paintable : m_paintable) {
         if (paintable->parent())
             paintable->remove();

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -85,15 +85,13 @@ bool DisplayList::append_bytes(
 void DisplayList::append_command_sequence(
     DisplayListCommandSequence const& sequence,
     AccumulatedVisualContextTree const& visual_context_tree,
-    VisualContextIndex context_index,
-    DisplayListResourceStorage& resource_storage)
+    VisualContextIndex context_index)
 {
     VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
 
     auto command_bytes = MUST(ByteBuffer::copy(sequence.m_command_bytes.span()));
 
     set_command_sequence_visual_context(command_bytes.span(), context_index);
-    resource_storage.append_referenced_resources_from(sequence.m_resource_storage, command_bytes.span());
     VERIFY(m_command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
     VERIFY(command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
 
@@ -101,14 +99,13 @@ void DisplayList::append_command_sequence(
         m_command_bytes.append(command_bytes.data(), command_bytes.size());
 }
 
-DisplayListCommandSequence DisplayList::copy_command_sequence_from(
-    size_t command_start_offset,
-    DisplayListResourceStorage const& resource_storage) const
+DisplayListCommandSequence DisplayList::copy_command_sequence_from(size_t command_start_offset) const
 {
     VERIFY(command_start_offset <= m_command_bytes.size());
     DisplayListCommandSequence sequence;
-    sequence.m_command_bytes = MUST(m_command_bytes.slice(command_start_offset, m_command_bytes.size() - command_start_offset));
-    sequence.m_resource_storage.append_referenced_resources_from(resource_storage, sequence.m_command_bytes.span());
+    sequence.m_command_bytes = MUST(m_command_bytes.slice(
+        command_start_offset,
+        m_command_bytes.size() - command_start_offset));
     return sequence;
 }
 

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -60,7 +60,6 @@ private:
     friend class DisplayList;
     DisplayListCommandSequence();
 
-    DisplayListResourceStorage m_resource_storage;
     ByteBuffer m_command_bytes;
 };
 
@@ -188,8 +187,8 @@ public:
         DisplayListCommandSequence::for_each_command_header(command_bytes(), move(callback));
     }
 
-    void append_command_sequence(DisplayListCommandSequence const&, AccumulatedVisualContextTree const&, VisualContextIndex, DisplayListResourceStorage&);
-    DisplayListCommandSequence copy_command_sequence_from(size_t command_start_offset, DisplayListResourceStorage const&) const;
+    void append_command_sequence(DisplayListCommandSequence const&, AccumulatedVisualContextTree const&, VisualContextIndex);
+    DisplayListCommandSequence copy_command_sequence_from(size_t command_start_offset) const;
     size_t command_byte_size() const { return m_command_bytes.size(); }
 
 private:

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -36,8 +36,7 @@ DisplayListCommandSequence DisplayListRecorder::CommandCapture::take()
 {
     VERIFY(m_recorder);
     auto commands = m_recorder->m_display_list.copy_command_sequence_from(
-        m_recorder->m_capture_start_command_offset,
-        m_recorder->m_resource_storage);
+        m_recorder->m_capture_start_command_offset);
     m_recorder->m_is_capturing = false;
     m_recorder = nullptr;
     return commands;
@@ -281,7 +280,7 @@ void DisplayListRecorder::replay_cached_commands(DisplayListCommandSequence cons
     commands.for_each_command_header([&](DisplayListCommandHeader const& header, ReadonlyBytes) {
         m_save_nesting_level += display_list_command_nesting_level_change(header.type);
     });
-    m_display_list.append_command_sequence(commands, m_visual_context_tree, m_accumulated_visual_context_index, m_resource_storage);
+    m_display_list.append_command_sequence(commands, m_visual_context_tree, m_accumulated_visual_context_index);
 }
 
 void DisplayListRecorder::paint_nested_display_list(DisplayListResource const& display_list, Gfx::IntRect rect)

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -13,6 +13,26 @@
 
 namespace Web::Painting {
 
+bool DisplayListResourceSet::is_empty() const
+{
+    return fonts.is_empty()
+        && image_frames.is_empty()
+        && video_frames.is_empty()
+        && display_lists.is_empty();
+}
+
+void DisplayListResourceSet::include(DisplayListResourceSet const& other)
+{
+    for (auto id : other.fonts)
+        fonts.set(id, AK::HashSetExistingEntryBehavior::Keep);
+    for (auto id : other.image_frames)
+        image_frames.set(id, AK::HashSetExistingEntryBehavior::Keep);
+    for (auto id : other.video_frames)
+        video_frames.set(id, AK::HashSetExistingEntryBehavior::Keep);
+    for (auto id : other.display_lists)
+        display_lists.set(id, AK::HashSetExistingEntryBehavior::Keep);
+}
+
 DisplayListResource::DisplayListResource(NonnullRefPtr<DisplayList> display_list, AccumulatedVisualContextTree visual_context_tree)
     : display_list(move(display_list))
     , visual_context_tree(move(visual_context_tree))
@@ -85,23 +105,6 @@ static ReadonlyBytes inline_data(ReadonlyBytes payload, DisplayListDataSpan span
     return payload.slice(span.offset, span.size);
 }
 
-void DisplayListResourceStorage::append_referenced_resources_from(
-    DisplayListResourceStorage const& source,
-    ReadonlyBytes command_bytes)
-{
-    auto referenced_resources = source.collect_referenced_resources(command_bytes);
-    for (auto id : referenced_resources.fonts)
-        add_font(source.font(id));
-    for (auto id : referenced_resources.image_frames)
-        add_image_frame(source.image_frame(id));
-    for (auto id : referenced_resources.video_frames)
-        add_video_frame(id, source.video_frame(id));
-    for (auto id : referenced_resources.display_lists) {
-        auto const& display_list_resource = source.display_list_resource(id);
-        add_display_list(display_list_resource.display_list, display_list_resource.visual_context_tree);
-    }
-}
-
 void DisplayListResourceStorage::collect_referenced_resources(
     ReadonlyBytes command_bytes,
     DisplayListResourceSet& referenced_resources) const
@@ -162,6 +165,58 @@ DisplayListResourceSet DisplayListResourceStorage::collect_referenced_resources(
 DisplayListResourceSet DisplayListResourceStorage::collect_referenced_resources(DisplayList const& display_list) const
 {
     return collect_referenced_resources(display_list.command_bytes());
+}
+
+template<typename ResourceId>
+static void increment_cache_reference_counts(HashMap<u64, size_t>& counts, HashTable<ResourceId> const& ids)
+{
+    for (auto id : ids) {
+        auto& count = counts.ensure(id.value(), [] { return 0; });
+        ++count;
+    }
+}
+
+template<typename ResourceId>
+static void decrement_cache_reference_counts(HashMap<u64, size_t>& counts, HashTable<ResourceId> const& ids)
+{
+    for (auto id : ids) {
+        auto it = counts.find(id.value());
+        VERIFY(it != counts.end());
+        VERIFY(it->value > 0);
+        --it->value;
+        if (it->value == 0)
+            counts.remove(it);
+    }
+}
+
+void DisplayListResourceStorage::acquire_cache_references(DisplayListResourceSet const& resource_set)
+{
+    increment_cache_reference_counts(m_font_cache_reference_counts, resource_set.fonts);
+    increment_cache_reference_counts(m_image_frame_cache_reference_counts, resource_set.image_frames);
+    increment_cache_reference_counts(m_video_frame_cache_reference_counts, resource_set.video_frames);
+    increment_cache_reference_counts(m_display_list_cache_reference_counts, resource_set.display_lists);
+}
+
+void DisplayListResourceStorage::release_cache_references(DisplayListResourceSet const& resource_set)
+{
+    decrement_cache_reference_counts(m_font_cache_reference_counts, resource_set.fonts);
+    decrement_cache_reference_counts(m_image_frame_cache_reference_counts, resource_set.image_frames);
+    decrement_cache_reference_counts(m_video_frame_cache_reference_counts, resource_set.video_frames);
+    decrement_cache_reference_counts(m_display_list_cache_reference_counts, resource_set.display_lists);
+}
+
+DisplayListResourceSet DisplayListResourceStorage::cache_referenced_resources() const
+{
+    DisplayListResourceSet resource_set;
+    for (auto id : m_font_cache_reference_counts.keys())
+        resource_set.fonts.set(FontResourceId { id });
+    for (auto id : m_image_frame_cache_reference_counts.keys())
+        resource_set.image_frames.set(ImageFrameResourceId { id });
+    for (auto id : m_video_frame_cache_reference_counts.keys())
+        resource_set.video_frames.set(VideoFrameResourceId { id });
+    for (auto id : m_display_list_cache_reference_counts.keys())
+        resource_set.display_lists.set(DisplayListResourceId { id });
+    return resource_set;
 }
 
 DisplayListResourceTransaction DisplayListResourceStorage::create_transaction(
@@ -229,10 +284,22 @@ void DisplayListResourceStorage::apply_transaction(DisplayListResourceTransactio
 
 void DisplayListResourceStorage::retain_only(DisplayListResourceSet const& resource_set)
 {
-    m_fonts.remove_all_matching([&](auto id, auto const&) { return !resource_set.fonts.contains(FontResourceId { id }); });
-    m_image_frames.remove_all_matching([&](auto id, auto const&) { return !resource_set.image_frames.contains(ImageFrameResourceId { id }); });
-    m_video_frames.remove_all_matching([&](auto id, auto const&) { return !resource_set.video_frames.contains(VideoFrameResourceId { id }); });
-    m_display_lists.remove_all_matching([&](auto id, auto const&) { return !resource_set.display_lists.contains(DisplayListResourceId { id }); });
+    m_fonts.remove_all_matching([&](auto id, auto const&) {
+        return !resource_set.fonts.contains(FontResourceId { id })
+            && !m_font_cache_reference_counts.contains(id);
+    });
+    m_image_frames.remove_all_matching([&](auto id, auto const&) {
+        return !resource_set.image_frames.contains(ImageFrameResourceId { id })
+            && !m_image_frame_cache_reference_counts.contains(id);
+    });
+    m_video_frames.remove_all_matching([&](auto id, auto const&) {
+        return !resource_set.video_frames.contains(VideoFrameResourceId { id })
+            && !m_video_frame_cache_reference_counts.contains(id);
+    });
+    m_display_lists.remove_all_matching([&](auto id, auto const&) {
+        return !resource_set.display_lists.contains(DisplayListResourceId { id })
+            && !m_display_list_cache_reference_counts.contains(id);
+    });
 }
 
 void DisplayListResourceStorage::update_video_frame(VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -27,6 +27,9 @@
 namespace Web::Painting {
 
 struct DisplayListResourceSet {
+    bool is_empty() const;
+    void include(DisplayListResourceSet const&);
+
     HashTable<FontResourceId> fonts;
     HashTable<ImageFrameResourceId> image_frames;
     HashTable<VideoFrameResourceId> video_frames;
@@ -84,11 +87,13 @@ public:
     DisplayListResourceId add_display_list(DisplayListResource&&);
     void set_font(FontResourceId, NonnullRefPtr<Gfx::Font const>);
     void set_image_frame(ImageFrameResourceId, Gfx::DecodedImageFrame);
-    void append_referenced_resources_from(DisplayListResourceStorage const& source, ReadonlyBytes command_bytes);
     void apply_transaction(DisplayListResourceTransaction&&);
     DisplayListResourceTransaction create_transaction(DisplayListResourceSet const& previous, DisplayListResourceSet const& current) const;
     DisplayListResourceSet collect_referenced_resources(DisplayList const&) const;
     DisplayListResourceSet collect_referenced_resources(ReadonlyBytes command_bytes) const;
+    void acquire_cache_references(DisplayListResourceSet const&);
+    void release_cache_references(DisplayListResourceSet const&);
+    DisplayListResourceSet cache_referenced_resources() const;
     void retain_only(DisplayListResourceSet const&);
     void update_video_frame(VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
     void clear_video_frame(VideoFrameResourceId);
@@ -111,6 +116,11 @@ private:
     HashMap<u64, RefPtr<Media::VideoFrame const>> m_video_frames;
     HashMap<u64, DisplayListResource> m_display_lists;
     HashMap<u64, Gfx::DecodedImageFrame> m_compositor_surfaces;
+
+    HashMap<u64, size_t> m_font_cache_reference_counts;
+    HashMap<u64, size_t> m_image_frame_cache_reference_counts;
+    HashMap<u64, size_t> m_video_frame_cache_reference_counts;
+    HashMap<u64, size_t> m_display_list_cache_reference_counts;
 };
 
 }

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -43,8 +43,6 @@ public:
 
     virtual StringView class_name() const { return "Paintable"sv; }
 
-    void detach_from_layout_node();
-
     [[nodiscard]] bool is_visible() const
     {
         auto const& cv = computed_values();
@@ -147,6 +145,7 @@ protected:
     explicit Paintable(Layout::Node const&);
 
     void paint_with_inspector_overlay_context(DisplayListRecordingContext&, Function<void()> const&) const;
+    bool has_layout_node() const { return m_layout_node; }
 
     virtual void paint_inspector_overlay_internal(DisplayListRecordingContext&) const { }
     Optional<WeakPtr<PaintableBox>> mutable m_containing_block;

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -385,6 +385,44 @@ PaintableBox::PaintableBox(Layout::InlineNode const& layout_box)
 
 PaintableBox::~PaintableBox()
 {
+    if (has_layout_node())
+        invalidate_paint_cache();
+}
+
+void PaintableBox::acquire_cache_references_for_cached_commands(DisplayListCommandSequence const& commands) const
+{
+    auto& resource_storage = navigable()->display_list_resource_storage();
+    auto referenced_resources = resource_storage.collect_referenced_resources(commands.command_bytes());
+    if (referenced_resources.is_empty())
+        return;
+    resource_storage.acquire_cache_references(referenced_resources);
+}
+
+void PaintableBox::release_cache_references_for_cached_commands(DisplayListCommandSequence const& commands) const
+{
+    auto& resource_storage = navigable()->display_list_resource_storage();
+    auto referenced_resources = resource_storage.collect_referenced_resources(commands.command_bytes());
+    if (referenced_resources.is_empty())
+        return;
+    resource_storage.release_cache_references(referenced_resources);
+}
+
+void PaintableBox::invalidate_paint_cache() const
+{
+    for (auto const& commands : m_cached_phase_commands) {
+        if (commands.has_value())
+            release_cache_references_for_cached_commands(commands.value());
+    }
+    m_cached_phase_commands = {};
+}
+
+void PaintableBox::set_cached_commands(PaintPhase phase, DisplayListCommandSequence commands) const
+{
+    auto& cached_commands = m_cached_phase_commands[to_underlying(phase)];
+    if (cached_commands.has_value())
+        release_cache_references_for_cached_commands(cached_commands.value());
+    acquire_cache_references_for_cached_commands(commands);
+    cached_commands = move(commands);
 }
 
 void PaintableBox::reset_for_relayout()
@@ -420,7 +458,7 @@ void PaintableBox::reset_for_relayout()
     m_grid_layout_data = nullptr;
     m_flex_layout_data = nullptr;
 
-    m_cached_phase_commands = {};
+    invalidate_paint_cache();
 
     invalidate_stacking_context();
 }

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -304,7 +304,7 @@ public:
 
     static constexpr size_t paint_phase_count = to_underlying(PaintPhase::Overlay) + 1;
 
-    void invalidate_paint_cache() const { m_cached_phase_commands = {}; }
+    void invalidate_paint_cache() const;
 
     bool has_cached_commands(PaintPhase phase) const
     {
@@ -316,10 +316,7 @@ public:
         return m_cached_phase_commands[to_underlying(phase)].value();
     }
 
-    void set_cached_commands(PaintPhase phase, DisplayListCommandSequence commands) const
-    {
-        m_cached_phase_commands[to_underlying(phase)] = move(commands);
-    }
+    void set_cached_commands(PaintPhase phase, DisplayListCommandSequence commands) const;
 
     void set_fixed_background_visual_context(VisualContextIndex index) { m_fixed_background_visual_context = index; }
     [[nodiscard]] Optional<VisualContextIndex> fixed_background_visual_context() const { return m_fixed_background_visual_context; }
@@ -348,6 +345,8 @@ private:
     [[nodiscard]] virtual bool is_paintable_box() const final { return true; }
 
     void paint_middle_button_scroll_indicator(DisplayListRecordingContext&) const;
+    void acquire_cache_references_for_cached_commands(DisplayListCommandSequence const&) const;
+    void release_cache_references_for_cached_commands(DisplayListCommandSequence const&) const;
 
     RefPtr<StackingContext> m_stacking_context;
 

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/DocumentState.h>
+#include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
@@ -136,30 +137,57 @@ size_t SVGDecodedImageData::external_memory_size() const
     return size;
 }
 
-Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list(Gfx::IntSize size, Painting::DisplayListResourceStorage& resource_storage) const
+static void copy_referenced_resources_to(
+    Painting::DisplayListResourceStorage& destination,
+    Painting::DisplayListResourceStorage const& source,
+    Painting::DisplayListResourceSet const& referenced_resources)
 {
+    Painting::DisplayListResourceSet empty_resource_set;
+    destination.apply_transaction(source.create_transaction(empty_resource_set, referenced_resources));
+}
+
+void SVGDecodedImageData::prune_cached_display_list_resources() const
+{
+    auto& resource_storage = m_document->navigable()->display_list_resource_storage();
+
+    Painting::DisplayListResourceSet retained_resources;
+    for (auto const& cached_display_list : m_cached_display_lists) {
+        retained_resources.include(
+            resource_storage.collect_referenced_resources(*cached_display_list.value.display_list));
+    }
+    resource_storage.retain_only(retained_resources);
+}
+
+Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list(Gfx::IntSize size, Painting::DisplayListResourceStorage& destination_resource_storage) const
+{
+    auto& resource_storage = m_document->navigable()->display_list_resource_storage();
+
     if (auto it = m_cached_display_lists.find(size); it != m_cached_display_lists.end()) {
-        resource_storage.append_referenced_resources_from(it->value.resource_storage, it->value.display_list->command_bytes());
+        auto referenced_resources = resource_storage.collect_referenced_resources(*it->value.display_list);
+        copy_referenced_resources_to(destination_resource_storage, resource_storage, referenced_resources);
         return Painting::DisplayListResource { *it->value.display_list, it->value.visual_context_tree };
     }
 
     // FIXME: Evict least used entries.
-    if (m_cached_display_lists.size() > 10)
+    if (m_cached_display_lists.size() > 10) {
         m_cached_display_lists.remove(m_cached_display_lists.begin());
+        prune_cached_display_list_resources();
+    }
 
-    Painting::DisplayListResourceStorage local_storage;
     m_document->navigable()->set_viewport_size(size.to_type<CSSPixels>());
     m_document->update_layout(DOM::UpdateLayoutReason::SVGDecodedImageDataRender);
-    auto display_list = m_document->record_display_list({}, local_storage);
+    auto display_list = m_document->record_display_list({}, resource_storage);
     if (!display_list)
         return {};
 
-    resource_storage.append_referenced_resources_from(local_storage, display_list->command_bytes());
+    auto referenced_resources = resource_storage.collect_referenced_resources(*display_list);
+    copy_referenced_resources_to(destination_resource_storage, resource_storage, referenced_resources);
     auto document_paintable = m_document->paintable();
     VERIFY(document_paintable);
     auto visual_context_tree = document_paintable->visual_context_tree();
     auto display_list_resource = Painting::DisplayListResource { *display_list, visual_context_tree };
-    m_cached_display_lists.set(size, CachedDisplayList { NonnullRefPtr<Painting::DisplayList> { *display_list }, move(visual_context_tree), move(local_storage) });
+    m_cached_display_lists.set(size, CachedDisplayList { NonnullRefPtr<Painting::DisplayList> { *display_list }, move(visual_context_tree) });
+    prune_cached_display_list_resources();
     return display_list_resource;
 }
 

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -50,6 +50,7 @@ private:
     RefPtr<Gfx::PaintingSurface> surface(size_t frame_index, Gfx::IntSize) const;
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
     Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
+    void prune_cached_display_list_resources() const;
 
     // FIXME: Remove this once everything is using surfaces instead.
     mutable HashMap<Gfx::IntSize, Gfx::DecodedImageFrame> m_cached_rendered_frames;
@@ -59,7 +60,6 @@ private:
     struct CachedDisplayList {
         NonnullRefPtr<Painting::DisplayList> display_list;
         Painting::AccumulatedVisualContextTree visual_context_tree;
-        Painting::DisplayListResourceStorage resource_storage;
     };
     mutable HashMap<Gfx::IntSize, CachedDisplayList> m_cached_display_lists;
 


### PR DESCRIPTION
Cached display list command sequences used to carry their own DisplayListResourceStorage. That kept resource ID sets and referenced fonts, images, video frames, and nested display lists alive on every cached phase, even though the command bytes already contain enough information to discover those references when they are needed.

This makes cached command sequences store only command bytes. Resource references are collected transiently from those bytes when a cache entry is installed or invalidated. The navigable's central display list resource storage now keeps cache reference counts, so compositor pruning retains resources used by live cached commands without duplicating storage in each sequence.