### PR TITLE
LibWeb: Cache async scrolling metadata commands

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -41,9 +41,6 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
             context.display_list_recorder().set_accumulated_visual_context(paintable_box->accumulated_visual_context_index());
     }
 
-    if (paintable_box && phase == PaintPhase::Background)
-        paintable_box->record_async_scrolling_metadata(context);
-
     if (paintable_box)
         paintable_box->record_hit_test_items(context, phase);
 
@@ -52,9 +49,13 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
         context.display_list_recorder().replay_cached_commands(paintable_box->cached_commands(phase));
     } else if (!skip_cache) {
         auto capture = context.display_list_recorder().begin_command_capture();
+        if (phase == PaintPhase::Background)
+            paintable_box->record_async_scrolling_metadata(context);
         paintable.paint(context, phase);
         paintable_box->set_cached_commands(phase, capture.take());
     } else {
+        if (paintable_box && phase == PaintPhase::Background)
+            paintable_box->record_async_scrolling_metadata(context);
         paintable.paint(context, phase);
     }
 


### PR DESCRIPTION
Async scrolling metadata was emitted before the display list cache branch in StackingContext, so cached background display lists did not own the compositor metadata commands. Cache hits replayed ordinary paint commands, while only cache misses regenerated wheel hit-test targets, scroll nodes, viewport scrollbar state, and sticky areas.

Record the metadata while capturing uncached background commands so the cached sequence owns the same async scrolling compositor commands as the original paint. The cache-disabled path still records metadata directly before painting.