### PR TITLE
LibWeb: Consolidate PaintableBox paint cache storage

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -29,8 +29,6 @@ static void set_command_sequence_visual_context(Bytes command_bytes, VisualConte
     }
 }
 
-DisplayListCommandSequence::DisplayListCommandSequence() = default;
-
 DisplayList::DisplayList(u64 compatible_visual_context_tree_version)
     : m_compatible_visual_context_tree_version(compatible_visual_context_tree_version)
     , m_id(s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
@@ -57,12 +55,12 @@ bool DisplayList::append_bytes(
     VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
     if (context_index.value() && visual_context_tree.has_empty_effective_clip(context_index))
         return false;
-    VERIFY(m_command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
+    VERIFY(m_command_bytes.size() % DisplayList::command_alignment == 0);
     VERIFY(payload.size() <= NumericLimits<u32>::max());
     VERIFY(inline_data.size() <= NumericLimits<u32>::max() - payload.size());
     auto payload_size = payload.size() + inline_data.size();
     auto record_size = sizeof(DisplayListCommandHeader) + payload_size;
-    constexpr auto command_alignment = DisplayListCommandSequence::command_alignment;
+    constexpr auto command_alignment = DisplayList::command_alignment;
     auto trailing_padding = align_up_to(record_size, command_alignment) - record_size;
     VERIFY(trailing_padding <= NumericLimits<u32>::max() - payload_size);
     DisplayListCommandHeader header {
@@ -92,21 +90,19 @@ void DisplayList::append_command_sequence(
     auto command_bytes = MUST(ByteBuffer::copy(command_sequence));
 
     set_command_sequence_visual_context(command_bytes.span(), context_index);
-    VERIFY(m_command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
-    VERIFY(command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
+    VERIFY(m_command_bytes.size() % DisplayList::command_alignment == 0);
+    VERIFY(command_bytes.size() % DisplayList::command_alignment == 0);
 
     if (!command_bytes.is_empty())
         m_command_bytes.append(command_bytes.data(), command_bytes.size());
 }
 
-DisplayListCommandSequence DisplayList::copy_command_sequence_from(size_t command_start_offset) const
+ByteBuffer DisplayList::copy_command_bytes_from(size_t command_start_offset) const
 {
     VERIFY(command_start_offset <= m_command_bytes.size());
-    DisplayListCommandSequence sequence;
-    sequence.m_command_bytes = MUST(m_command_bytes.slice(
+    return MUST(m_command_bytes.slice(
         command_start_offset,
         m_command_bytes.size() - command_start_offset));
-    return sequence;
 }
 
 void DisplayListPlayer::execute(

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -83,13 +83,13 @@ bool DisplayList::append_bytes(
 }
 
 void DisplayList::append_command_sequence(
-    DisplayListCommandSequence const& sequence,
+    ReadonlyBytes command_sequence,
     AccumulatedVisualContextTree const& visual_context_tree,
     VisualContextIndex context_index)
 {
     VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
 
-    auto command_bytes = MUST(ByteBuffer::copy(sequence.m_command_bytes.span()));
+    auto command_bytes = MUST(ByteBuffer::copy(command_sequence));
 
     set_command_sequence_visual_context(command_bytes.span(), context_index);
     VERIFY(m_command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -187,7 +187,7 @@ public:
         DisplayListCommandSequence::for_each_command_header(command_bytes(), move(callback));
     }
 
-    void append_command_sequence(DisplayListCommandSequence const&, AccumulatedVisualContextTree const&, VisualContextIndex);
+    void append_command_sequence(ReadonlyBytes, AccumulatedVisualContextTree const&, VisualContextIndex);
     DisplayListCommandSequence copy_command_sequence_from(size_t command_start_offset) const;
     size_t command_byte_size() const { return m_command_bytes.size(); }
 

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -29,40 +29,6 @@
 
 namespace Web::Painting {
 
-class DisplayListCommandSequence {
-public:
-    static constexpr size_t command_alignment = 16;
-
-    ReadonlyBytes command_bytes() const { return m_command_bytes.span(); }
-
-    template<typename SpanType, typename Callback>
-    static void for_each_command_header(SpanType command_bytes, Callback callback)
-    {
-        static_assert(IsSame<SpanType, Bytes> || IsSame<SpanType, ReadonlyBytes>);
-        for (size_t offset = 0; offset < command_bytes.size();) {
-            VERIFY(offset + sizeof(DisplayListCommandHeader) <= command_bytes.size());
-            auto header = read_display_list_object<DisplayListCommandHeader>(command_bytes.slice(offset));
-            offset += sizeof(header);
-            VERIFY(offset + header.payload_size <= command_bytes.size());
-            auto payload = SpanType { command_bytes.data() + offset, header.payload_size };
-            offset += header.payload_size;
-            callback(header, payload);
-        }
-    }
-
-    template<typename Callback>
-    void for_each_command_header(Callback callback) const
-    {
-        for_each_command_header(command_bytes(), move(callback));
-    }
-
-private:
-    friend class DisplayList;
-    DisplayListCommandSequence();
-
-    ByteBuffer m_command_bytes;
-};
-
 class WEB_API DisplayListPlayer {
 public:
     virtual ~DisplayListPlayer() = default;
@@ -175,20 +141,31 @@ public:
     void set_async_scrolling_metadata(AsyncScrollingMetadata metadata) { m_async_scrolling_metadata = metadata; }
     Optional<AsyncScrollingMetadata> const& async_scrolling_metadata() const { return m_async_scrolling_metadata; }
 
-    template<typename Callback>
-    static void for_each_command_header(ReadonlyBytes command_bytes, Callback callback)
+    static constexpr size_t command_alignment = 16;
+
+    template<typename SpanType, typename Callback>
+    static void for_each_command_header(SpanType command_bytes, Callback callback)
     {
-        DisplayListCommandSequence::for_each_command_header(command_bytes, move(callback));
+        static_assert(IsSame<SpanType, Bytes> || IsSame<SpanType, ReadonlyBytes>);
+        for (size_t offset = 0; offset < command_bytes.size();) {
+            VERIFY(offset + sizeof(DisplayListCommandHeader) <= command_bytes.size());
+            auto header = read_display_list_object<DisplayListCommandHeader>(command_bytes.slice(offset));
+            offset += sizeof(header);
+            VERIFY(offset + header.payload_size <= command_bytes.size());
+            auto payload = SpanType { command_bytes.data() + offset, header.payload_size };
+            offset += header.payload_size;
+            callback(header, payload);
+        }
     }
 
     template<typename Callback>
     void for_each_command_header(Callback callback) const
     {
-        DisplayListCommandSequence::for_each_command_header(command_bytes(), move(callback));
+        for_each_command_header(command_bytes(), move(callback));
     }
 
     void append_command_sequence(ReadonlyBytes, AccumulatedVisualContextTree const&, VisualContextIndex);
-    DisplayListCommandSequence copy_command_sequence_from(size_t command_start_offset) const;
+    ByteBuffer copy_command_bytes_from(size_t command_start_offset) const;
     size_t command_byte_size() const { return m_command_bytes.size(); }
 
 private:

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -275,12 +275,12 @@ static DisplayListDataSpan append_filter_data(
     return payload_builder.append_data(filter_data, alignof(u32));
 }
 
-void DisplayListRecorder::replay_cached_commands(DisplayListCommandSequence const& commands)
+void DisplayListRecorder::replay_cached_commands(ReadonlyBytes command_bytes)
 {
-    commands.for_each_command_header([&](DisplayListCommandHeader const& header, ReadonlyBytes) {
+    DisplayListCommandSequence::for_each_command_header(command_bytes, [&](DisplayListCommandHeader const& header, ReadonlyBytes) {
         m_save_nesting_level += display_list_command_nesting_level_change(header.type);
     });
-    m_display_list.append_command_sequence(commands, m_visual_context_tree, m_accumulated_visual_context_index);
+    m_display_list.append_command_sequence(command_bytes, m_visual_context_tree, m_accumulated_visual_context_index);
 }
 
 void DisplayListRecorder::paint_nested_display_list(DisplayListResource const& display_list, Gfx::IntRect rect)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -32,10 +32,10 @@ DisplayListRecorder::CommandCapture::~CommandCapture()
         m_recorder->end_capture();
 }
 
-DisplayListCommandSequence DisplayListRecorder::CommandCapture::take()
+ByteBuffer DisplayListRecorder::CommandCapture::take()
 {
     VERIFY(m_recorder);
-    auto commands = m_recorder->m_display_list.copy_command_sequence_from(
+    auto commands = m_recorder->m_display_list.copy_command_bytes_from(
         m_recorder->m_capture_start_command_offset);
     m_recorder->m_is_capturing = false;
     m_recorder = nullptr;
@@ -62,7 +62,7 @@ public:
         : m_payload_start_offset(display_list.command_byte_size() + sizeof(DisplayListCommandHeader))
         , m_payload_size(sizeof(Command))
     {
-        VERIFY(display_list.command_byte_size() % DisplayListCommandSequence::command_alignment == 0);
+        VERIFY(display_list.command_byte_size() % DisplayList::command_alignment == 0);
     }
 
     DisplayListDataSpan append_data(ReadonlyBytes bytes, size_t alignment)
@@ -277,7 +277,7 @@ static DisplayListDataSpan append_filter_data(
 
 void DisplayListRecorder::replay_cached_commands(ReadonlyBytes command_bytes)
 {
-    DisplayListCommandSequence::for_each_command_header(command_bytes, [&](DisplayListCommandHeader const& header, ReadonlyBytes) {
+    DisplayList::for_each_command_header(command_bytes, [&](DisplayListCommandHeader const& header, ReadonlyBytes) {
         m_save_nesting_level += display_list_command_nesting_level_change(header.type);
     });
     m_display_list.append_command_sequence(command_bytes, m_visual_context_tree, m_accumulated_visual_context_index);

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -103,7 +103,7 @@ public:
         {
         }
         ~CommandCapture();
-        DisplayListCommandSequence take();
+        ByteBuffer take();
 
     private:
         friend class DisplayListRecorder;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -92,7 +92,7 @@ public:
     void set_accumulated_visual_context(VisualContextIndex index) { m_accumulated_visual_context_index = index; }
     VisualContextIndex accumulated_visual_context() const { return m_accumulated_visual_context_index; }
 
-    void replay_cached_commands(DisplayListCommandSequence const& commands);
+    void replay_cached_commands(ReadonlyBytes commands);
 
     class CommandCapture {
         AK_MAKE_NONCOPYABLE(CommandCapture);

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -499,7 +499,7 @@ void PaintableBox::invalidate_paint_cache() const
     m_cached_paint_data = nullptr;
 }
 
-void PaintableBox::set_cached_commands(PaintPhase phase, DisplayListCommandSequence commands) const
+void PaintableBox::set_cached_commands(PaintPhase phase, ByteBuffer const& commands) const
 {
     if (!m_cached_paint_data)
         m_cached_paint_data = make<CachedPaintData>();
@@ -507,7 +507,7 @@ void PaintableBox::set_cached_commands(PaintPhase phase, DisplayListCommandSeque
     if (m_cached_paint_data->has(phase))
         release_cache_references_for_cached_commands(m_cached_paint_data->bytes_for(phase));
 
-    auto command_bytes = commands.command_bytes();
+    auto command_bytes = commands.span();
     acquire_cache_references_for_cached_commands(command_bytes);
     m_cached_paint_data->set(phase, command_bytes);
 }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/GenericShorthands.h>
 #include <AK/StdLibExtras.h>
 #include <LibGfx/Font/Font.h>
@@ -49,6 +50,76 @@
 namespace Web::Painting {
 
 static bool g_paint_viewport_scrollbars = true;
+
+struct PaintableBox::CachedPaintData {
+    bool has(PaintPhase phase) const
+    {
+        return m_present_phases[to_underlying(phase)];
+    }
+
+    ReadonlyBytes bytes_for(PaintPhase phase) const
+    {
+        auto const& span = m_phase_spans[to_underlying(phase)];
+        return m_command_bytes.span().slice(span.offset, span.size);
+    }
+
+    void set(PaintPhase phase, ReadonlyBytes command_bytes)
+    {
+        auto const phase_index = to_underlying(phase);
+        if (m_present_phases[phase_index]) {
+            replace(phase, command_bytes);
+            return;
+        }
+
+        m_phase_spans[phase_index] = append_to(m_command_bytes, command_bytes);
+        m_present_phases[phase_index] = true;
+    }
+
+    template<typename Callback>
+    void for_each_present_phase(Callback callback) const
+    {
+        for (size_t phase_index = 0; phase_index < paint_phase_count; ++phase_index) {
+            if (!m_present_phases[phase_index])
+                continue;
+            auto phase = static_cast<PaintPhase>(phase_index);
+            callback(phase, bytes_for(phase));
+        }
+    }
+
+private:
+    struct Span {
+        u32 offset { 0 };
+        u32 size { 0 };
+    };
+
+    static Span append_to(ByteBuffer& command_buffer, ReadonlyBytes command_bytes)
+    {
+        auto const offset = command_buffer.size();
+        command_buffer.append(command_bytes);
+        return { static_cast<u32>(offset), static_cast<u32>(command_bytes.size()) };
+    }
+
+    void replace(PaintPhase phase, ReadonlyBytes replacement_bytes)
+    {
+        ByteBuffer command_buffer;
+        Array<Span, paint_phase_count> phase_spans {};
+
+        for (size_t phase_index = 0; phase_index < paint_phase_count; ++phase_index) {
+            if (!m_present_phases[phase_index])
+                continue;
+            auto present_phase = static_cast<PaintPhase>(phase_index);
+            auto command_bytes = present_phase == phase ? replacement_bytes : bytes_for(present_phase);
+            phase_spans[phase_index] = append_to(command_buffer, command_bytes);
+        }
+
+        m_command_bytes = move(command_buffer);
+        m_phase_spans = phase_spans;
+    }
+
+    ByteBuffer m_command_bytes;
+    Array<bool, paint_phase_count> m_present_phases {};
+    Array<Span, paint_phase_count> m_phase_spans {};
+};
 
 static bool content_size_change_affects_container_queries(PaintableBox const& paintable_box, CSSPixelSize old_size, CSSPixelSize new_size)
 {
@@ -389,40 +460,56 @@ PaintableBox::~PaintableBox()
         invalidate_paint_cache();
 }
 
-void PaintableBox::acquire_cache_references_for_cached_commands(DisplayListCommandSequence const& commands) const
+void PaintableBox::acquire_cache_references_for_cached_commands(ReadonlyBytes command_bytes) const
 {
     auto& resource_storage = navigable()->display_list_resource_storage();
-    auto referenced_resources = resource_storage.collect_referenced_resources(commands.command_bytes());
+    auto referenced_resources = resource_storage.collect_referenced_resources(command_bytes);
     if (referenced_resources.is_empty())
         return;
     resource_storage.acquire_cache_references(referenced_resources);
 }
 
-void PaintableBox::release_cache_references_for_cached_commands(DisplayListCommandSequence const& commands) const
+void PaintableBox::release_cache_references_for_cached_commands(ReadonlyBytes command_bytes) const
 {
     auto& resource_storage = navigable()->display_list_resource_storage();
-    auto referenced_resources = resource_storage.collect_referenced_resources(commands.command_bytes());
+    auto referenced_resources = resource_storage.collect_referenced_resources(command_bytes);
     if (referenced_resources.is_empty())
         return;
     resource_storage.release_cache_references(referenced_resources);
 }
 
+bool PaintableBox::has_cached_commands(PaintPhase phase) const
+{
+    return m_cached_paint_data && m_cached_paint_data->has(phase);
+}
+
+ReadonlyBytes PaintableBox::cached_commands(PaintPhase phase) const
+{
+    return m_cached_paint_data->bytes_for(phase);
+}
+
 void PaintableBox::invalidate_paint_cache() const
 {
-    for (auto const& commands : m_cached_phase_commands) {
-        if (commands.has_value())
-            release_cache_references_for_cached_commands(commands.value());
-    }
-    m_cached_phase_commands = {};
+    if (!m_cached_paint_data)
+        return;
+
+    m_cached_paint_data->for_each_present_phase([&](PaintPhase, ReadonlyBytes command_bytes) {
+        release_cache_references_for_cached_commands(command_bytes);
+    });
+    m_cached_paint_data = nullptr;
 }
 
 void PaintableBox::set_cached_commands(PaintPhase phase, DisplayListCommandSequence commands) const
 {
-    auto& cached_commands = m_cached_phase_commands[to_underlying(phase)];
-    if (cached_commands.has_value())
-        release_cache_references_for_cached_commands(cached_commands.value());
-    acquire_cache_references_for_cached_commands(commands);
-    cached_commands = move(commands);
+    if (!m_cached_paint_data)
+        m_cached_paint_data = make<CachedPaintData>();
+
+    if (m_cached_paint_data->has(phase))
+        release_cache_references_for_cached_commands(m_cached_paint_data->bytes_for(phase));
+
+    auto command_bytes = commands.command_bytes();
+    acquire_cache_references_for_cached_commands(command_bytes);
+    m_cached_paint_data->set(phase, command_bytes);
 }
 
 void PaintableBox::reset_for_relayout()

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -307,7 +307,7 @@ public:
 
     bool has_cached_commands(PaintPhase) const;
     ReadonlyBytes cached_commands(PaintPhase) const;
-    void set_cached_commands(PaintPhase phase, DisplayListCommandSequence commands) const;
+    void set_cached_commands(PaintPhase phase, ByteBuffer const& commands) const;
 
     void set_fixed_background_visual_context(VisualContextIndex index) { m_fixed_background_visual_context = index; }
     [[nodiscard]] Optional<VisualContextIndex> fixed_background_visual_context() const { return m_fixed_background_visual_context; }

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
@@ -306,16 +305,8 @@ public:
 
     void invalidate_paint_cache() const;
 
-    bool has_cached_commands(PaintPhase phase) const
-    {
-        return m_cached_phase_commands[to_underlying(phase)].has_value();
-    }
-
-    DisplayListCommandSequence const& cached_commands(PaintPhase phase) const
-    {
-        return m_cached_phase_commands[to_underlying(phase)].value();
-    }
-
+    bool has_cached_commands(PaintPhase) const;
+    ReadonlyBytes cached_commands(PaintPhase) const;
     void set_cached_commands(PaintPhase phase, DisplayListCommandSequence commands) const;
 
     void set_fixed_background_visual_context(VisualContextIndex index) { m_fixed_background_visual_context = index; }
@@ -342,11 +333,13 @@ protected:
     Optional<CSSPixelRect> absolute_resizer_rect(ChromeMetrics const& chrome_metrics) const;
 
 private:
+    struct CachedPaintData;
+
     [[nodiscard]] virtual bool is_paintable_box() const final { return true; }
 
     void paint_middle_button_scroll_indicator(DisplayListRecordingContext&) const;
-    void acquire_cache_references_for_cached_commands(DisplayListCommandSequence const&) const;
-    void release_cache_references_for_cached_commands(DisplayListCommandSequence const&) const;
+    void acquire_cache_references_for_cached_commands(ReadonlyBytes) const;
+    void release_cache_references_for_cached_commands(ReadonlyBytes) const;
 
     RefPtr<StackingContext> m_stacking_context;
 
@@ -391,7 +384,7 @@ private:
     bool m_fragment_right_edge_away { false };
     bool m_fragment_bottom_edge_away { false };
 
-    mutable Array<Optional<DisplayListCommandSequence>, paint_phase_count> m_cached_phase_commands;
+    mutable OwnPtr<CachedPaintData> m_cached_paint_data;
 };
 
 }


### PR DESCRIPTION
PaintableBox kept an inline array of six optional command-sequence slots
for per-phase paint caching. That made every box pay 336 bytes even when
it never cached paint commands. Cached boxes could allocate a separate
ByteBuffer for each populated phase.

Move storage behind a lazy CachedPaintData holder. The holder records
explicit phase presence and offset/size spans into a single ByteBuffer.
Empty cached phases stay distinct from absent phases. Replay copies
command bytes into the frame display list, and cache references now use
the cached bytes view instead of a retained command object.

On the release arm64 build, sizeof(PaintableBox) drops from 944 to 616
bytes. The old inline holder was 336 bytes; the new inline field is one
8-byte pointer, so uncached boxes are 328 bytes smaller. Cached boxes
now use one consolidated byte buffer for all cached phases.