### PR TITLE
LibWeb: Avoid NaN values when reversing zero-duration transitions

### DIFF
--- a/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -167,11 +167,11 @@ void CSSTransition::visit_edges(Cell::Visitor& visitor)
 
 double CSSTransition::timing_function_output_at_time(double t) const
 {
-    auto progress = (t - transition_start_time()) / (transition_end_time() - transition_start_time());
     // AD-HOC: If the transition has an empty duration then we get NaN here,
     // setting progress to 1 because an instant transition may be considered "finished".
+    double progress = 1;
     if (transition_start_time() < transition_end_time())
-        progress = 1;
+        progress = (t - transition_start_time()) / (transition_end_time() - transition_start_time());
 
     // FIXME: Is this before_flag value correct?
     bool before_flag = t < transition_start_time();

--- a/Tests/LibWeb/Crash/CSS/zero-duration-transition-reversal.html
+++ b/Tests/LibWeb/Crash/CSS/zero-duration-transition-reversal.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+    #target {
+        transition: opacity 0s 1ms linear(1, 1);
+    }
+</style>
+<div id="target"></div>
+<script>
+    getComputedStyle(target).opacity;
+
+    target.style.opacity = 0;
+    const transition = target.getAnimations()[0];
+
+    transition.effect.updateTiming({ duration: 2 });
+    transition.currentTime = 1;
+
+    target.style.transition = "opacity 150ms";
+    target.style.opacity = 1;
+
+    getComputedStyle(target).opacity;
+</script>


### PR DESCRIPTION
A transition with zero duration and a positive delay can still start, but its start and end times are equal. If it is reversed while running, sampling the old transition's timing function performed a division by zero and propagated NaN into the new transition timing. This caused a crash under UBSan. We now treat zero duration transitions as if they are finished for this calculation, avoiding the division by zero.

NB: On `master` the included crash test only crashes with UBSan enabled.

Fixes: #9717