### PR TITLE
LibWeb: Account for shadow contexts in the cascade

### DIFF
--- a/Libraries/LibWeb/CSS/CascadedProperties.cpp
+++ b/Libraries/LibWeb/CSS/CascadedProperties.cpp
@@ -51,7 +51,7 @@ void CascadedProperties::revert_property(PropertyID property_id, Important impor
     }
 }
 
-void CascadedProperties::revert_layer_property(PropertyID property_id, Important important, Optional<FlyString> layer_name)
+void CascadedProperties::revert_layer_property(PropertyID property_id, Important important, CascadeOrigin cascade_origin, Optional<FlyString> layer_name, GC::Ptr<DOM::ShadowRoot const> source_shadow_root)
 {
     auto it = m_properties.find(property_id);
     if (it == m_properties.end())
@@ -60,6 +60,8 @@ void CascadedProperties::revert_layer_property(PropertyID property_id, Important
     entries.remove_all_matching([&](auto& entry) {
         return entry.property.property_id == property_id
             && entry.property.important == important
+            && entry.origin == cascade_origin
+            && entry.source_shadow_root == source_shadow_root
             && layer_name == entry.layer_name;
     });
     if (entries.is_empty()) {
@@ -75,7 +77,7 @@ void CascadedProperties::set_property(PropertyID property_id, NonnullRefPtr<Styl
     auto& entries = m_properties.ensure(property_id);
 
     for (auto& entry : entries.in_reverse()) {
-        if (entry.origin == origin && entry.layer_name == layer_name) {
+        if (entry.origin == origin && entry.layer_name == layer_name && entry.source_shadow_root == source_shadow_root) {
             if (entry.property.important == Important::Yes && important == Important::No)
                 return;
             entry.property = StyleProperty {

--- a/Libraries/LibWeb/CSS/CascadedProperties.h
+++ b/Libraries/LibWeb/CSS/CascadedProperties.h
@@ -34,7 +34,7 @@ public:
     void set_property(PropertyID, NonnullRefPtr<StyleValue const>, Important, CascadeOrigin, Optional<FlyString> layer_name, GC::Ptr<CSS::CSSStyleDeclaration const> source, GC::Ptr<DOM::ShadowRoot const> source_shadow_root);
 
     void revert_property(PropertyID, Important, CascadeOrigin);
-    void revert_layer_property(PropertyID, Important, Optional<FlyString> layer_name);
+    void revert_layer_property(PropertyID, Important, CascadeOrigin, Optional<FlyString> layer_name, GC::Ptr<DOM::ShadowRoot const> source_shadow_root);
 
 private:
     CascadedProperties();

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -361,7 +361,7 @@ static Optional<ResolvedScope> resolve_scope(DOM::AbstractElement abstract_eleme
     return resolve_scope_chain(abstract_element, rule, shadow_host, rule_root, *rule.scope_rule);
 }
 
-Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules(DOM::AbstractElement abstract_element, CascadeOrigin cascade_origin, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name) const
+Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules_from_context(DOM::AbstractElement abstract_element, CascadeOrigin cascade_origin, GC::Ptr<DOM::ShadowRoot const> context_shadow_root, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name) const
 {
     auto const& root_node = abstract_element.element().root();
     auto shadow_root = as_if<DOM::ShadowRoot>(root_node);
@@ -449,18 +449,8 @@ Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules(
         });
     };
 
-    if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, nullptr))
-        add_rules_from_cache(*rule_cache, nullptr);
-
-    if (shadow_root) {
-        if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, shadow_root))
-            add_rules_from_cache(*rule_cache, shadow_root);
-    }
-
-    if (element_shadow_root) {
-        if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, element_shadow_root))
-            add_rules_from_cache(*rule_cache, element_shadow_root);
-    }
+    if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, context_shadow_root))
+        add_rules_from_cache(*rule_cache, context_shadow_root);
 
     // Per "find flattened slotables" (https://dom.spec.whatwg.org/#find-flattened-slotables),
     // a <slot> element whose root is a shadow root recurses into its own slottables instead of
@@ -475,6 +465,8 @@ Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules(
     if (!subject_is_reslotted_slot) {
         for (GC::Ptr<HTML::HTMLSlotElement const> slot = abstract_element.element().assigned_slot_internal(); slot; slot = slot->assigned_slot_internal()) {
             if (auto const* slot_shadow_root = as_if<DOM::ShadowRoot>(slot->root())) {
+                if (slot_shadow_root != context_shadow_root)
+                    continue;
                 if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, slot_shadow_root)) {
                     add_rules_to_run(rule_cache->slotted_rules, slot_shadow_root);
                 }
@@ -486,19 +478,22 @@ Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules(
     // Rules from any ancestor style scope can apply, including from the element's own shadow root
     // (for :host::part() within the shadow DOM's own stylesheet).
     if (shadow_root && (abstract_element.pseudo_element().has_value() || !abstract_element.element().part_names().is_empty())) {
-        if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, shadow_root)) {
-            add_rules_to_run(rule_cache->part_rules, shadow_root);
+        if (context_shadow_root == shadow_root) {
+            if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, shadow_root))
+                add_rules_to_run(rule_cache->part_rules, shadow_root);
         }
         for (auto* part_shadow_root = abstract_element.element().first_flat_tree_ancestor_of_type<DOM::ShadowRoot>();
             part_shadow_root;
             part_shadow_root = part_shadow_root->first_flat_tree_ancestor_of_type<DOM::ShadowRoot>()) {
 
-            if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, part_shadow_root)) {
+            if (context_shadow_root != part_shadow_root)
+                continue;
+            if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, part_shadow_root))
                 add_rules_to_run(rule_cache->part_rules, part_shadow_root);
-            }
         }
-        if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, nullptr)) {
-            add_rules_to_run(rule_cache->part_rules, nullptr);
+        if (!context_shadow_root) {
+            if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, nullptr))
+                add_rules_to_run(rule_cache->part_rules, nullptr);
         }
     }
 
@@ -677,7 +672,7 @@ void StyleComputer::apply_property_list_to_cascade(
             if (longhand_value.is_revert()) {
                 cascaded_properties.revert_property(longhand_id, important, cascade_origin);
             } else if (longhand_value.is_revert_layer()) {
-                cascaded_properties.revert_layer_property(longhand_id, important, layer_name);
+                cascaded_properties.revert_layer_property(longhand_id, important, cascade_origin, layer_name, source_shadow_root);
             } else {
                 // Track the exact shadow-root scope that supplied this winning declaration. A constructable
                 // stylesheet can be adopted into multiple scopes at once, so the declaration object alone is
@@ -694,55 +689,51 @@ void StyleComputer::cascade_declarations(
     Vector<ScopedMatchingRule> const& matching_rules,
     CascadeOrigin cascade_origin,
     Important important,
-    Optional<FlyString> layer_name) const
+    Optional<FlyString> layer_name,
+    bool include_inline_style) const
 {
     for (auto const& match : matching_rules) {
         auto const& declaration = match.rule->declaration();
         apply_property_list_to_cascade(cascaded_properties, abstract_element, declaration.properties(), cascade_origin, important, layer_name, &declaration, match.shadow_root, BypassPseudoElementPropertyWhitelist::No);
     }
 
-    if (cascade_origin == CascadeOrigin::Author) {
+    if (include_inline_style && cascade_origin == CascadeOrigin::Author) {
         if (auto const inline_style = abstract_element.inline_style())
             apply_property_list_to_cascade(cascaded_properties, abstract_element, inline_style->properties(), cascade_origin, important, layer_name, inline_style, nullptr, BypassPseudoElementPropertyWhitelist::Yes);
     }
 }
 
-static void cascade_custom_properties(DOM::AbstractElement abstract_element, Vector<StyleComputer::ScopedMatchingRule> const& matching_rules, OrderedHashMap<FlyString, StyleProperty>& custom_properties)
+static void cascade_custom_properties(DOM::AbstractElement abstract_element, Vector<StyleComputer::ScopedMatchingRule> const& matching_rules, OrderedHashMap<FlyString, StyleProperty>& custom_properties, Important important, bool include_inline_style)
 {
     size_t needed_capacity = 0;
     for (auto const& matching_rule : matching_rules)
         needed_capacity += matching_rule.rule->declaration().custom_properties().size();
 
     auto const inline_style = abstract_element.inline_style();
-    if (inline_style)
+    if (include_inline_style && inline_style)
         needed_capacity += inline_style->custom_properties().size();
 
     custom_properties.ensure_capacity(custom_properties.size() + needed_capacity);
 
-    OrderedHashMap<FlyString, StyleProperty> important_custom_properties;
     for (auto const& matching_rule : matching_rules) {
         for (auto const& it : matching_rule.rule->declaration().custom_properties()) {
+            if (it.value.important != important)
+                continue;
             auto style_value = it.value.value;
             if (style_value->is_revert_layer())
                 continue;
 
-            if (it.value.important == Important::Yes) {
-                important_custom_properties.set(it.key, it.value);
-            }
             custom_properties.set(it.key, it.value);
         }
     }
 
-    if (inline_style) {
+    if (include_inline_style && inline_style) {
         for (auto const& it : inline_style->custom_properties()) {
-            if (it.value.important == Important::Yes) {
-                important_custom_properties.set(it.key, it.value);
-            }
+            if (it.value.important != important)
+                continue;
             custom_properties.set(it.key, it.value);
         }
     }
-
-    custom_properties.update(important_custom_properties);
 }
 
 static RefPtr<CustomPropertyData const> inheritable_custom_property_data(DOM::AbstractElement abstract_element)
@@ -1407,30 +1398,87 @@ void StyleComputer::start_needed_transitions(ComputedProperties const& previous_
     }
 }
 
-StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::AbstractElement abstract_element, PseudoClassBitmap& attempted_pseudo_class_matches, bool& did_match_any_pseudo_element_rules, ComputeStyleMode mode, StyleScope const& style_scope) const
+StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::AbstractElement abstract_element, PseudoClassBitmap& attempted_pseudo_class_matches, bool& did_match_any_pseudo_element_rules, ComputeStyleMode mode) const
 {
+    auto collect_author_contexts = [&] {
+        Vector<GC::Ptr<DOM::ShadowRoot const>, 4> context_shadow_roots;
+        auto append_context = [&](GC::Ptr<DOM::ShadowRoot const> shadow_root) {
+            if (context_shadow_roots.contains_slow(shadow_root))
+                return;
+            context_shadow_roots.append(shadow_root);
+        };
+
+        append_context(nullptr);
+
+        // https://drafts.csswg.org/css-cascade-5/#cascade-context
+        // Keep contexts in outer-to-inner order so the cascade can apply them in the spec order without re-sorting
+        // individual declarations. Most elements only have the document context, and the small vector avoids heap
+        // storage for the common shadow-depth cases.
+        if (auto const* shadow_root = as_if<DOM::ShadowRoot>(abstract_element.element().root())) {
+            Vector<GC::Ref<DOM::ShadowRoot const>, 4> ancestor_shadow_roots;
+            for (auto const* current_shadow_root = shadow_root; current_shadow_root;) {
+                ancestor_shadow_roots.append(*current_shadow_root);
+                auto const* host = current_shadow_root->host();
+                if (!host)
+                    break;
+                current_shadow_root = as_if<DOM::ShadowRoot>(host->root());
+            }
+            for (auto& ancestor_shadow_root : ancestor_shadow_roots.in_reverse())
+                append_context(ancestor_shadow_root);
+        }
+
+        if (!is<HTML::HTMLSlotElement>(abstract_element.element()) || !abstract_element.element().root().is_shadow_root()) {
+            for (GC::Ptr<HTML::HTMLSlotElement const> slot = abstract_element.element().assigned_slot_internal(); slot; slot = slot->assigned_slot_internal()) {
+                if (auto const* slot_shadow_root = as_if<DOM::ShadowRoot>(slot->root()))
+                    append_context(slot_shadow_root);
+            }
+        }
+
+        if (auto element_shadow_root = abstract_element.element().shadow_root())
+            append_context(element_shadow_root);
+
+        Vector<ContextMatchingRules> author_contexts;
+        author_contexts.ensure_capacity(context_shadow_roots.size());
+
+        for (auto shadow_root : context_shadow_roots) {
+            auto& context_style_scope = shadow_root ? shadow_root->style_scope() : document().style_scope();
+            context_style_scope.build_rule_cache_if_needed();
+
+            ContextMatchingRules context {
+                .shadow_root = shadow_root,
+                .author_rules = {},
+            };
+
+            for (auto const& layer_name : context_style_scope.m_rule_cache->qualified_layer_names_in_order) {
+                auto layer_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::Author, shadow_root, attempted_pseudo_class_matches, layer_name);
+                sort_matching_rules(layer_rules);
+                context.author_rules.append({ layer_name, layer_rules });
+            }
+
+            auto unlayered_author_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::Author, shadow_root, attempted_pseudo_class_matches);
+            sort_matching_rules(unlayered_author_rules);
+            context.author_rules.append({ {}, unlayered_author_rules });
+
+            author_contexts.append(move(context));
+        }
+
+        return author_contexts;
+    };
+
     // First, we collect all the CSS rules whose selectors match `element`:
     MatchingRuleSet matching_rule_set;
-    matching_rule_set.user_agent_rules = collect_matching_rules(abstract_element, CascadeOrigin::UserAgent, attempted_pseudo_class_matches);
+    matching_rule_set.user_agent_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::UserAgent, nullptr, attempted_pseudo_class_matches);
     sort_matching_rules(matching_rule_set.user_agent_rules);
-    matching_rule_set.user_rules = collect_matching_rules(abstract_element, CascadeOrigin::User, attempted_pseudo_class_matches);
+    matching_rule_set.user_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::User, nullptr, attempted_pseudo_class_matches);
     sort_matching_rules(matching_rule_set.user_rules);
-
-    // @layer-ed author rules
-    for (auto const& layer_name : style_scope.m_rule_cache->qualified_layer_names_in_order) {
-        auto layer_rules = collect_matching_rules(abstract_element, CascadeOrigin::Author, attempted_pseudo_class_matches, layer_name);
-        sort_matching_rules(layer_rules);
-        matching_rule_set.author_rules.append({ layer_name, layer_rules });
-    }
-    // Un-@layer-ed author rules
-    auto unlayered_author_rules = collect_matching_rules(abstract_element, CascadeOrigin::Author, attempted_pseudo_class_matches);
-    sort_matching_rules(unlayered_author_rules);
-    matching_rule_set.author_rules.append({ {}, unlayered_author_rules });
+    matching_rule_set.author_contexts = collect_author_contexts();
 
     if (mode == ComputeStyleMode::CreatePseudoElementStyleIfNeeded) {
         VERIFY(abstract_element.pseudo_element().has_value());
-        auto author_rules_has_any_rules = any_of(matching_rule_set.author_rules, [](auto const& layer) {
-            return !layer.rules.is_empty();
+        auto author_rules_has_any_rules = any_of(matching_rule_set.author_contexts, [](auto const& context) {
+            return any_of(context.author_rules, [](auto const& layer) {
+                return !layer.rules.is_empty();
+            });
         });
         did_match_any_pseudo_element_rules = author_rules_has_any_rules
             || !matching_rule_set.user_rules.is_empty()
@@ -1450,10 +1498,10 @@ GC::Ref<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Abstract
     }
 
     // Normal user agent declarations
-    cascade_declarations(*cascaded_properties, abstract_element, matching_rule_set.user_agent_rules, CascadeOrigin::UserAgent, Important::No, {});
+    cascade_declarations(*cascaded_properties, abstract_element, matching_rule_set.user_agent_rules, CascadeOrigin::UserAgent, Important::No, {}, false);
 
     // Normal user declarations
-    cascade_declarations(*cascaded_properties, abstract_element, matching_rule_set.user_rules, CascadeOrigin::User, Important::No, {});
+    cascade_declarations(*cascaded_properties, abstract_element, matching_rule_set.user_rules, CascadeOrigin::User, Important::No, {}, false);
 
     // Author presentational hints
     // The spec calls this a special "Author presentational hint origin":
@@ -1478,21 +1526,32 @@ GC::Ref<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Abstract
         }
     }
 
-    // Normal author declarations, ordered by @layer, with un-@layer-ed rules last
-    for (auto const& layer : matching_rule_set.author_rules) {
-        cascade_declarations(cascaded_properties, abstract_element, layer.rules, CascadeOrigin::Author, Important::No, layer.qualified_layer_name);
+    auto element_context_shadow_root = as_if<DOM::ShadowRoot>(abstract_element.element().root());
+    auto cascade_inline_style = [&](Important important) {
+        cascade_declarations(cascaded_properties, abstract_element, {}, CascadeOrigin::Author, important, {}, true);
+    };
+
+    // Normal author declarations, with inner contexts first so outer contexts win.
+    for (auto const& context : matching_rule_set.author_contexts.in_reverse()) {
+        for (auto const& layer : context.author_rules)
+            cascade_declarations(cascaded_properties, abstract_element, layer.rules, CascadeOrigin::Author, Important::No, layer.qualified_layer_name, false);
+        if (context.shadow_root == element_context_shadow_root)
+            cascade_inline_style(Important::No);
     }
 
-    // Important author declarations, with un-@layer-ed rules first, followed by each @layer in reverse order.
-    for (auto const& layer : matching_rule_set.author_rules.in_reverse()) {
-        cascade_declarations(cascaded_properties, abstract_element, layer.rules, CascadeOrigin::Author, Important::Yes, {});
+    // Important author declarations, with outer contexts first so inner contexts win.
+    for (auto const& context : matching_rule_set.author_contexts) {
+        for (auto const& layer : context.author_rules.in_reverse())
+            cascade_declarations(cascaded_properties, abstract_element, layer.rules, CascadeOrigin::Author, Important::Yes, {}, false);
+        if (context.shadow_root == element_context_shadow_root)
+            cascade_inline_style(Important::Yes);
     }
 
     // Important user declarations
-    cascade_declarations(cascaded_properties, abstract_element, matching_rule_set.user_rules, CascadeOrigin::User, Important::Yes, {});
+    cascade_declarations(cascaded_properties, abstract_element, matching_rule_set.user_rules, CascadeOrigin::User, Important::Yes, {}, false);
 
     // Important user agent declarations
-    cascade_declarations(cascaded_properties, abstract_element, matching_rule_set.user_agent_rules, CascadeOrigin::UserAgent, Important::Yes, {});
+    cascade_declarations(cascaded_properties, abstract_element, matching_rule_set.user_agent_rules, CascadeOrigin::UserAgent, Important::Yes, {}, false);
 
     // Transition declarations [css-transitions-1]
     // Note that we have to do these after finishing computing the style,
@@ -2017,7 +2076,7 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
     // 1. Perform the cascade. This produces the "specified style"
     bool did_match_any_pseudo_element_rules = false;
     PseudoClassBitmap attempted_pseudo_class_matches;
-    auto matching_rule_set = build_matching_rule_set(abstract_element, attempted_pseudo_class_matches, did_match_any_pseudo_element_rules, mode, style_scope);
+    auto matching_rule_set = build_matching_rule_set(abstract_element, attempted_pseudo_class_matches, did_match_any_pseudo_element_rules, mode);
 
     if (mode == ComputeStyleMode::CreatePseudoElementStyleIfNeeded) {
         // NOTE: If we're computing style for a pseudo-element, we look for a number of reasons to bail early.
@@ -2043,8 +2102,24 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
     // Resolve all the CSS custom properties ("variables") for this element:
     if (!abstract_element.pseudo_element().has_value() || pseudo_element_supports_property(*abstract_element.pseudo_element(), PropertyID::Custom)) {
         OrderedHashMap<FlyString, StyleProperty> cascaded_all;
-        for (auto& layer : matching_rule_set.author_rules) {
-            cascade_custom_properties(abstract_element, layer.rules, cascaded_all);
+
+        auto element_context_shadow_root = as_if<DOM::ShadowRoot>(abstract_element.element().root());
+        auto cascade_inline_style = [&](Important important) {
+            cascade_custom_properties(abstract_element, {}, cascaded_all, important, true);
+        };
+
+        for (auto const& context : matching_rule_set.author_contexts.in_reverse()) {
+            for (auto const& layer : context.author_rules)
+                cascade_custom_properties(abstract_element, layer.rules, cascaded_all, Important::No, false);
+            if (context.shadow_root == element_context_shadow_root)
+                cascade_inline_style(Important::No);
+        }
+
+        for (auto const& context : matching_rule_set.author_contexts) {
+            for (auto const& layer : context.author_rules.in_reverse())
+                cascade_custom_properties(abstract_element, layer.rules, cascaded_all, Important::Yes, false);
+            if (context.shadow_root == element_context_shadow_root)
+                cascade_inline_style(Important::Yes);
         }
 
         RefPtr<CustomPropertyData const> parent_data;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -115,8 +115,6 @@ public:
         void visit_edges(GC::Cell::Visitor& visitor);
     };
 
-    [[nodiscard]] Vector<ScopedMatchingRule> collect_matching_rules(DOM::AbstractElement, CascadeOrigin, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name = {}) const;
-
     NonnullRefPtr<InvalidationPlan> invalidation_plan_for_properties(Vector<InvalidationSet::Property> const&, StyleScope const&) const;
     Vector<HasInvalidationMetadata> const* has_invalidation_metadata_for_property(InvalidationSet::Property const&, StyleScope const&) const;
 
@@ -169,13 +167,18 @@ private:
         Vector<ScopedMatchingRule> rules;
     };
 
-    struct MatchingRuleSet {
-        Vector<ScopedMatchingRule> user_agent_rules;
-        Vector<ScopedMatchingRule> user_rules;
+    struct ContextMatchingRules {
+        GC::Ptr<DOM::ShadowRoot const> shadow_root;
         Vector<LayerMatchingRules> author_rules;
     };
 
-    [[nodiscard]] MatchingRuleSet build_matching_rule_set(DOM::AbstractElement, PseudoClassBitmap& attempted_pseudo_class_matches, bool& did_match_any_pseudo_element_rules, ComputeStyleMode, StyleScope const&) const;
+    struct MatchingRuleSet {
+        Vector<ScopedMatchingRule> user_agent_rules;
+        Vector<ScopedMatchingRule> user_rules;
+        Vector<ContextMatchingRules> author_contexts;
+    };
+
+    [[nodiscard]] MatchingRuleSet build_matching_rule_set(DOM::AbstractElement, PseudoClassBitmap& attempted_pseudo_class_matches, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
 
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_style_impl(DOM::AbstractElement, ComputeStyleMode, Optional<bool&> did_change_custom_properties, StyleScope const&) const;
     [[nodiscard]] GC::Ref<CascadedProperties> compute_cascaded_values(DOM::AbstractElement, bool did_match_any_pseudo_element_rules, ComputeStyleMode, MatchingRuleSet const&) const;
@@ -188,13 +191,16 @@ private:
 
     [[nodiscard]] Length::FontMetrics calculate_root_element_font_metrics(ComputedProperties const&) const;
 
+    [[nodiscard]] Vector<ScopedMatchingRule> collect_matching_rules_from_context(DOM::AbstractElement, CascadeOrigin, GC::Ptr<DOM::ShadowRoot const>, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name = {}) const;
+
     void cascade_declarations(
         CascadedProperties&,
         DOM::AbstractElement,
         Vector<ScopedMatchingRule> const&,
         CascadeOrigin,
         Important,
-        Optional<FlyString> layer_name) const;
+        Optional<FlyString> layer_name,
+        bool include_inline_style) const;
 
     void apply_property_list_to_cascade(
         CascadedProperties&,

--- a/Tests/LibWeb/Text/expected/css/shadow-host-cascade-context.txt
+++ b/Tests/LibWeb/Text/expected/css/shadow-host-cascade-context.txt
@@ -1,0 +1,12 @@
+normal margin-top: 0px
+normal margin-right: 0px
+important padding-left: 13px
+normal custom property color: rgb(0, 128, 0)
+normal slotted vs host: 1px
+important slotted vs host: 2px
+normal nested slotted vs host: 1px
+important nested slotted vs host: 3px
+normal inline vs host: 1px
+important inline vs host: 2px
+revert-layer preserves shadow host context: rgb(255, 0, 0)
+revert-layer preserves slotted host context: 7px

--- a/Tests/LibWeb/Text/input/css/shadow-host-cascade-context.html
+++ b/Tests/LibWeb/Text/input/css/shadow-host-cascade-context.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .outer {
+        margin: 0;
+        padding-left: 0 !important;
+        --normal-color: green;
+        color: var(--normal-color);
+    }
+
+    .revert-layer-outer {
+        color: revert-layer;
+    }
+</style>
+<script>
+    test(() => {
+        class ShadowHostCascadeContextElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                const style = document.createElement("style");
+                style.textContent = `
+                    :host(.outer) {
+                        margin: 4px 16px;
+                    }
+
+                    :host {
+                        padding-left: 13px !important;
+                        --normal-color: red;
+                    }
+                `;
+                shadowRoot.appendChild(style);
+            }
+        }
+        customElements.define("shadow-host-cascade-context", ShadowHostCascadeContextElement);
+
+        const outerElement = document.createElement("shadow-host-cascade-context");
+        outerElement.className = "outer";
+        document.body.appendChild(outerElement);
+
+        const outerStyle = getComputedStyle(outerElement);
+        println(`normal margin-top: ${outerStyle.marginTop}`);
+        println(`normal margin-right: ${outerStyle.marginRight}`);
+        println(`important padding-left: ${outerStyle.paddingLeft}`);
+        println(`normal custom property color: ${outerStyle.color}`);
+
+        class ShadowCascadeSlotElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                shadowRoot.innerHTML = `
+                    <style>
+                        ::slotted(shadow-cascade-host) {
+                            margin-left: 1px;
+                            margin-right: 1px !important;
+                        }
+                    </style>
+                    <slot></slot>
+                `;
+            }
+        }
+        customElements.define("shadow-cascade-slot", ShadowCascadeSlotElement);
+
+        class ShadowCascadeHostElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                const style = document.createElement("style");
+                style.textContent = `
+                    :host {
+                        margin-left: 2px;
+                        margin-right: 2px !important;
+                    }
+                `;
+                shadowRoot.appendChild(style);
+            }
+        }
+        customElements.define("shadow-cascade-host", ShadowCascadeHostElement);
+
+        const slotHost = document.createElement("shadow-cascade-slot");
+        const slottedElement = document.createElement("shadow-cascade-host");
+        slotHost.appendChild(slottedElement);
+        document.body.appendChild(slotHost);
+
+        const slottedStyle = getComputedStyle(slottedElement);
+        println(`normal slotted vs host: ${slottedStyle.marginLeft}`);
+        println(`important slotted vs host: ${slottedStyle.marginRight}`);
+
+        class ShadowCascadeNestedSlotElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                shadowRoot.innerHTML = `
+                    <style>
+                        ::slotted(shadow-cascade-nested-host) {
+                            margin-left: 1px;
+                            margin-right: 1px !important;
+                        }
+                    </style>
+                    <div><slot></slot></div>
+                `;
+
+                const inner = shadowRoot.querySelector("div");
+                const innerShadowRoot = inner.attachShadow({ mode: "open" });
+                innerShadowRoot.innerHTML = `
+                    <style>
+                        ::slotted(shadow-cascade-nested-host) {
+                            margin-left: 2px;
+                            margin-right: 2px !important;
+                        }
+                    </style>
+                    <slot></slot>
+                `;
+            }
+        }
+        customElements.define("shadow-cascade-nested-slot", ShadowCascadeNestedSlotElement);
+
+        class ShadowCascadeNestedHostElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                const style = document.createElement("style");
+                style.textContent = `
+                    :host {
+                        margin-left: 3px;
+                        margin-right: 3px !important;
+                    }
+                `;
+                shadowRoot.appendChild(style);
+            }
+        }
+        customElements.define("shadow-cascade-nested-host", ShadowCascadeNestedHostElement);
+
+        const nestedSlotHost = document.createElement("shadow-cascade-nested-slot");
+        const nestedSlottedElement = document.createElement("shadow-cascade-nested-host");
+        nestedSlotHost.appendChild(nestedSlottedElement);
+        document.body.appendChild(nestedSlotHost);
+
+        const nestedSlottedStyle = getComputedStyle(nestedSlottedElement);
+        println(`normal nested slotted vs host: ${nestedSlottedStyle.marginLeft}`);
+        println(`important nested slotted vs host: ${nestedSlottedStyle.marginRight}`);
+
+        class ShadowInlineCascadeContextElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                const style = document.createElement("style");
+                style.textContent = `
+                    :host {
+                        margin-top: 2px;
+                        margin-bottom: 2px !important;
+                    }
+                `;
+                shadowRoot.appendChild(style);
+            }
+        }
+        customElements.define("shadow-inline-cascade-context", ShadowInlineCascadeContextElement);
+
+        const inlineElement = document.createElement("shadow-inline-cascade-context");
+        inlineElement.setAttribute("style", "margin-top: 1px; margin-bottom: 1px !important;");
+        document.body.appendChild(inlineElement);
+
+        const inlineStyle = getComputedStyle(inlineElement);
+        println(`normal inline vs host: ${inlineStyle.marginTop}`);
+        println(`important inline vs host: ${inlineStyle.marginBottom}`);
+
+        class ShadowRevertLayerHostElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                shadowRoot.innerHTML = `
+                    <style>
+                        :host {
+                            color: red;
+                        }
+                    </style>
+                `;
+            }
+        }
+        customElements.define("shadow-revert-layer-host", ShadowRevertLayerHostElement);
+
+        const revertLayerHost = document.createElement("shadow-revert-layer-host");
+        revertLayerHost.className = "revert-layer-outer";
+        document.body.appendChild(revertLayerHost);
+
+        const revertLayerHostStyle = getComputedStyle(revertLayerHost);
+        println(`revert-layer preserves shadow host context: ${revertLayerHostStyle.color}`);
+
+        class ShadowRevertLayerSlotElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                shadowRoot.innerHTML = `
+                    <style>
+                        ::slotted(shadow-revert-layer-slotted) {
+                            margin-left: revert-layer;
+                        }
+                    </style>
+                    <slot></slot>
+                `;
+            }
+        }
+        customElements.define("shadow-revert-layer-slot", ShadowRevertLayerSlotElement);
+
+        class ShadowRevertLayerSlottedElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                shadowRoot.innerHTML = `
+                    <style>
+                        :host {
+                            margin-left: 7px;
+                        }
+                    </style>
+                `;
+            }
+        }
+        customElements.define("shadow-revert-layer-slotted", ShadowRevertLayerSlottedElement);
+
+        const revertLayerSlotHost = document.createElement("shadow-revert-layer-slot");
+        const revertLayerSlottedElement = document.createElement("shadow-revert-layer-slotted");
+        revertLayerSlotHost.appendChild(revertLayerSlottedElement);
+        document.body.appendChild(revertLayerSlotHost);
+
+        const revertLayerSlottedStyle = getComputedStyle(revertLayerSlottedElement);
+        println(`revert-layer preserves slotted host context: ${revertLayerSlottedStyle.marginLeft}`);
+    });
+</script>


### PR DESCRIPTION
Apply author declarations in encapsulation-context order before layer, specificity, scope proximity, and source-order tie breaking. Normal author rules now cascade from inner shadow contexts outward. This lets outer contexts override component defaults. Important author rules cascade the other way so inner contexts can enforce requirements.

Keep the ordering context-bucketed. The common document-only path still collects and sorts one author context. Custom properties follow the same context order. var() substitution now observes the same winners as longhand properties.

Make revert-layer remove declarations only from the matching cascade origin, context, and layer. This keeps presentational hints and values from other shadow contexts available when one context rolls back its own layer.

Add coverage for document and shadow-host competition, slotted rules, nested slot contexts, inline styles, important declarations, custom properties, and revert-layer across shadow contexts.