### PR TITLE
LibWeb: Suppress assigned slot fallback layout

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1005,8 +1005,14 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         });
     }
 
+    auto should_layout_dom_children = [&]() {
+        if (auto const* slot_element = as_if<HTML::HTMLSlotElement>(dom_node))
+            return slot_element->assigned_nodes_internal().is_empty() && dom_node.has_children();
+        return dom_node.has_children();
+    }();
+
     if (should_create_layout_node || dom_node.child_needs_layout_tree_update()) {
-        if ((dom_node.has_children() || shadow_root) && layout_node->can_have_children() && !element_has_content_visibility_hidden) {
+        if ((should_layout_dom_children || shadow_root) && layout_node->can_have_children() && !element_has_content_visibility_hidden) {
             push_parent(as<NodeWithStyle>(*layout_node));
             if (shadow_root) {
                 // For replaced elements with shadow DOM children, wrap the children in an
@@ -1025,7 +1031,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
                     pop_parent();
                 shadow_root->set_child_needs_layout_tree_update(false);
                 shadow_root->set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
-            } else {
+            } else if (should_layout_dom_children) {
                 // This is the same as as<DOM::ParentNode>(dom_node).for_each_child
                 for (auto* node = as<DOM::ParentNode>(dom_node).first_child(); node; node = node->next_sibling())
                     update_layout_tree(*node, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);

--- a/Tests/LibWeb/Text/expected/css/slotted-flex-item-negative-margin.txt
+++ b/Tests/LibWeb/Text/expected/css/slotted-flex-item-negative-margin.txt
@@ -1,0 +1,3 @@
+wrapper width: 16
+slotted offset: -12
+field offset: 24

--- a/Tests/LibWeb/Text/input/css/slotted-flex-item-negative-margin.html
+++ b/Tests/LibWeb/Text/input/css/slotted-flex-item-negative-margin.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="host">
+    <svg id="slotted" slot="icon" width="28" height="28" viewBox="0 0 10 10"></svg>
+</div>
+<script>
+    test(() => {
+        const shadowRoot = host.attachShadow({ mode: "open" });
+        shadowRoot.innerHTML = `
+            <style>
+                .container {
+                    display: flex;
+                    width: 200px;
+                }
+                .icon-wrapper {
+                    display: flex;
+                    margin-right: 8px;
+                }
+                .field {
+                    flex: 1;
+                    height: 28px;
+                }
+                slot {
+                    display: contents;
+                }
+                ::slotted([slot=icon]) {
+                    display: inline-flex;
+                    align-items: center;
+                    margin-left: -12px;
+                }
+            </style>
+            <div class="container">
+                <span id="icon-wrapper" class="icon-wrapper">
+                    <slot name="icon"><svg width="16" height="10" viewBox="0 0 10 10"></svg></slot>
+                </span>
+                <span id="field" class="field"></span>
+            </div>
+        `;
+
+        const wrapper = shadowRoot.getElementById("icon-wrapper");
+        const field = shadowRoot.getElementById("field");
+        const wrapperRect = wrapper.getBoundingClientRect();
+        const slottedRect = slotted.getBoundingClientRect();
+        const fieldRect = field.getBoundingClientRect();
+
+        println(`wrapper width: ${wrapperRect.width}`);
+        println(`slotted offset: ${slottedRect.left - wrapperRect.left}`);
+        println(`field offset: ${fieldRect.left - wrapperRect.left}`);
+    });
+</script>


### PR DESCRIPTION
Skip layout tree construction for a slot's DOM children while it has assigned nodes. These children are fallback content, and should only produce boxes while assignment is empty.