### PR TITLE
LibWeb: Fix SVG use masks with filtered contents

### DIFF
--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/SVGClipBox.h>
 #include <LibWeb/Layout/SVGMaskBox.h>
+#include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/Blending.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/ResolvedCSSFilter.h>
 #include <LibWeb/Painting/SVGClipPaintable.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/Painting/SVGPaintable.h>
@@ -68,6 +72,43 @@ static Gfx::MaskKind mask_type_to_gfx_mask_kind(CSS::MaskType mask_type)
     }
 }
 
+static void build_nested_svg_visual_context_tree_for_subtree(AccumulatedVisualContextTree& visual_context_tree, PaintableBox& paintable_box, VisualContextIndex inherited_state, float pixel_ratio)
+{
+    auto const& computed_values = paintable_box.computed_values();
+    if (computed_values.filter().has_filters())
+        paintable_box.set_filter(resolve_css_filter(computed_values.filter(), paintable_box));
+    else
+        paintable_box.set_filter({});
+
+    auto gfx_filter = to_gfx_filter(paintable_box.filter(), pixel_ratio);
+    EffectsData effects {
+        computed_values.opacity(),
+        mix_blend_mode_to_compositing_and_blending_operator(computed_values.mix_blend_mode()),
+        move(gfx_filter)
+    };
+
+    auto own_state = inherited_state;
+    if (effects.needs_layer())
+        own_state = visual_context_tree.append(move(effects), inherited_state);
+
+    paintable_box.set_accumulated_visual_context(own_state);
+    paintable_box.set_accumulated_visual_context_for_descendants(own_state);
+
+    paintable_box.for_each_child_of_type<PaintableBox>([&](PaintableBox& child) {
+        build_nested_svg_visual_context_tree_for_subtree(visual_context_tree, child, own_state, pixel_ratio);
+        return IterationDecision::Continue;
+    });
+}
+
+static AccumulatedVisualContextTree build_nested_svg_visual_context_tree(PaintableBox& root_paintable)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto pixel_ratio = root_paintable.document().page().client().device_pixels_per_css_pixel();
+    build_nested_svg_visual_context_tree_for_subtree(visual_context_tree, root_paintable, {}, pixel_ratio);
+
+    return visual_context_tree;
+}
+
 Optional<Gfx::MaskKind> SVGMaskable::get_svg_mask_type() const
 {
     auto const& graphics_element = as<SVG::SVGGraphicsElement const>(*dom_node_of_svg());
@@ -84,7 +125,7 @@ static Optional<DisplayListResource> paint_mask_or_clip_to_display_list(
     bool is_clip_path)
 {
     auto mask_rect = context.enclosing_device_rect(area);
-    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto visual_context_tree = build_nested_svg_visual_context_tree(const_cast<PaintableBox&>(paintable));
     auto display_list = DisplayList::create(visual_context_tree);
     DisplayListRecorder display_list_recorder(*display_list, visual_context_tree, context.display_list_recorder().resource_storage());
     display_list_recorder.translate(-mask_rect.location().to_type<int>());

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -239,16 +239,16 @@ void SVGElement::update_use_elements_that_reference_this()
         || !id().has_value()
         // An unconnected node cannot have valid references.
         // This also prevents searches for elements that are in the process of being constructed - as clones.
-        || !this->is_connected()
-        // Each use element already listens for the completely_loaded event and then clones its reference,
-        // we do not have to also clone it in the process of initial DOM building.
-        || !document().is_completely_loaded()) {
+        || !this->is_connected()) {
 
         return;
     }
 
     document().for_each_in_subtree_of_type<SVGUseElement>([this](SVGUseElement& use_element) {
-        use_element.svg_element_changed(*this);
+        if (document().is_completely_loaded())
+            use_element.svg_element_changed(*this);
+        else
+            use_element.svg_element_changed_before_document_complete(*this);
         return TraversalDecision::Continue;
     });
 }

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -49,6 +49,11 @@ void SVGUseElement::initialize(JS::Realm& realm)
 
     m_document_observer = realm.create<DOM::DocumentObserver>(realm, document());
     m_document_observer->set_document_completely_loaded([this]() {
+        // The href processing path already populated the shadow tree for resolved references,
+        // unless the referenced subtree changed while the document was still loading.
+        if (instance_root() && !m_needs_document_complete_reclone)
+            return;
+        m_needs_document_complete_reclone = false;
         clone_element_tree_as_our_shadow_tree(referenced_element());
     });
 }
@@ -118,6 +123,17 @@ void SVGUseElement::svg_element_changed(SVGElement& svg_element)
     if (to_clone == &svg_element || to_clone->is_ancestor_of(svg_element)) {
         clone_element_tree_as_our_shadow_tree(to_clone);
     }
+}
+
+void SVGUseElement::svg_element_changed_before_document_complete(SVGElement& svg_element)
+{
+    auto to_clone = referenced_element();
+    if (!to_clone)
+        return;
+
+    // NOTE: We need to check the ancestor because attribute_changed of a child doesn't call children_changed on the parent(s)
+    if (to_clone == &svg_element || to_clone->is_ancestor_of(svg_element))
+        m_needs_document_complete_reclone = true;
 }
 
 void SVGUseElement::svg_element_removed(SVGElement& svg_element)

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -27,6 +27,7 @@ public:
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     void svg_element_changed(SVGElement&);
+    void svg_element_changed_before_document_complete(SVGElement&);
     void svg_element_removed(SVGElement&);
 
     GC::Ref<SVGAnimatedLength> x() const;
@@ -65,6 +66,7 @@ private:
 
     Optional<float> m_x;
     Optional<float> m_y;
+    bool m_needs_document_complete_reclone { false };
 
     Optional<URL::URL> m_href;
 

--- a/Tests/LibWeb/Ref/expected/svg/mask-filter-alpha-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/mask-filter-alpha-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <rect width="100" height="100" fill="rgb(88, 101, 242)"></rect>
+    <rect x="25" y="25" width="50" height="50" fill="white"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/expected/svg/mask-filter-alpha-use-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/mask-filter-alpha-use-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <rect width="100" height="100" fill="rgb(88, 101, 242)"></rect>
+    <rect x="25" y="25" width="50" height="50" fill="white"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/expected/svg/use-in-mask-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/use-in-mask-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+</style>
+<svg width="100" height="100" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="rgb(88, 101, 242)"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/mask-filter-alpha-use.html
+++ b/Tests/LibWeb/Ref/input/svg/mask-filter-alpha-use.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/mask-filter-alpha-use-ref.html" />
+<style>
+    body {
+        margin: 0;
+    }
+</style>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100">
+    <defs>
+        <clippath id="clip">
+            <rect width="100" height="100"></rect>
+        </clippath>
+        <g id="cutout" clip-path="url(#clip)">
+            <rect x="25" y="25" width="50" height="50" fill="white"></rect>
+        </g>
+        <filter id="invert-alpha">
+            <feComponentTransfer>
+                <feFuncA type="table" tableValues="1 0"></feFuncA>
+            </feComponentTransfer>
+        </filter>
+        <mask id="mask" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+            <g filter="url(#invert-alpha)">
+                <rect width="100" height="100" fill="white" opacity="0"></rect>
+                <use xlink:href="#cutout"></use>
+            </g>
+        </mask>
+    </defs>
+    <rect width="100" height="100" fill="rgb(88, 101, 242)" mask="url(#mask)"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/mask-filter-alpha.html
+++ b/Tests/LibWeb/Ref/input/svg/mask-filter-alpha.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/mask-filter-alpha-ref.html" />
+<style>
+    body {
+        margin: 0;
+    }
+</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <defs>
+        <filter id="invert-alpha">
+            <feComponentTransfer>
+                <feFuncA type="table" tableValues="1 0"></feFuncA>
+            </feComponentTransfer>
+        </filter>
+        <mask id="mask" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+            <g filter="url(#invert-alpha)">
+                <rect width="100" height="100" fill="white" opacity="0"></rect>
+                <rect x="25" y="25" width="50" height="50" fill="white"></rect>
+            </g>
+        </mask>
+    </defs>
+    <rect width="100" height="100" fill="rgb(88, 101, 242)" mask="url(#mask)"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/use-in-mask.html
+++ b/Tests/LibWeb/Ref/input/svg/use-in-mask.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/use-in-mask-ref.html" />
+<style>
+    body {
+        margin: 0;
+    }
+</style>
+<svg width="100" height="100" viewBox="0 0 100 100">
+    <defs>
+        <rect id="source" width="100" height="100" fill="white"></rect>
+    </defs>
+    <mask id="mask" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+        <use href="#source"></use>
+    </mask>
+    <rect width="100" height="100" fill="rgb(88, 101, 242)" mask="url(#mask)"></rect>
+</svg>

--- a/Tests/LibWeb/Text/expected/SVG/use-element-does-not-reclone-on-load.txt
+++ b/Tests/LibWeb/Text/expected/SVG/use-element-does-not-reclone-on-load.txt
@@ -1,0 +1,4 @@
+Had resolved instance root before load: true
+Had forward instance root before load: false
+Kept resolved instance root after load: true
+Has forward instance root after load: true

--- a/Tests/LibWeb/Text/input/SVG/use-element-does-not-reclone-on-load.html
+++ b/Tests/LibWeb/Text/input/SVG/use-element-does-not-reclone-on-load.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg>
+    <defs>
+        <rect id="source" width="100" height="100" fill="white"></rect>
+    </defs>
+    <mask id="mask">
+        <use id="resolvedUse" href="#source"></use>
+        <use id="forwardUse" href="#lateSource"></use>
+    </mask>
+    <rect id="lateSource" width="100" height="100" fill="white"></rect>
+</svg>
+<script>
+    const resolvedUseElement = document.getElementById("resolvedUse");
+    const forwardUseElement = document.getElementById("forwardUse");
+    const initialResolvedInstanceRoot = resolvedUseElement.instanceRoot;
+    const initialForwardInstanceRoot = forwardUseElement.instanceRoot;
+
+    asyncTest((done) => {
+        window.addEventListener("load", () => {
+            setTimeout(() => {
+                println(`Had resolved instance root before load: ${!!initialResolvedInstanceRoot}`);
+                println(`Had forward instance root before load: ${!!initialForwardInstanceRoot}`);
+                println(`Kept resolved instance root after load: ${resolvedUseElement.instanceRoot === initialResolvedInstanceRoot}`);
+                println(`Has forward instance root after load: ${!!forwardUseElement.instanceRoot}`);
+                done();
+            }, 0);
+        }, { once: true });
+    });
+</script>


### PR DESCRIPTION
This fixes a flaky SVG rendering issue where a `use` inside an SVG mask could briefly render correctly, then disappear or render with the wrong mask polarity.

The fix avoids redundantly recloning unchanged SVG `use` shadow trees at document-complete time, while still recloning forward references and referenced subtrees that changed before load. It also records SVG mask and clip subtrees with an accumulated visual context tree, so filters inside mask contents are applied when the nested display list is painted.

Added coverage for:

- SVG `use` elements inside masks
- preserving unchanged `use` instance roots across load
- pre-load referenced subtree mutations
- alpha-inverting filters inside SVG masks, including through `use`

This makes the GIF button appear in the Discord message editor.

Before:
<img width="402" height="84" alt="Screenshot from 2026-05-31 13-23-49" src="https://github.com/user-attachments/assets/6a9c523c-1c52-4140-846f-1e1a7a40e575" />

After:
<img width="402" height="84" alt="Screenshot from 2026-05-31 13-11-30" src="https://github.com/user-attachments/assets/13784046-e3e6-4364-858f-864fdae61b9c" />
