### PR TITLE
LibWeb: Use first baseline for flex/grid items and containers

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2534,17 +2534,37 @@ Box const* FormattingContext::box_child_to_derive_baseline_from(Box const& box) 
 {
     if (!box.has_children() || box.children_are_inline())
         return nullptr;
-    // Find the last in-flow child that has a baseline (either directly via line boxes, or via its descendants).
-    for (auto const* child = box.last_child(); child; child = child->previous_sibling()) {
+
+    auto const& display = box.display();
+    bool is_flex_or_grid_container = display.is_flex_inside() || display.is_grid_inside();
+
+    auto check_child_for_baseline = [&](Node const* child) -> Box const* {
         auto const* child_box = as_if<Box>(*child);
         if (!child_box)
-            continue;
+            return nullptr;
         if (child_box->is_out_of_flow(*this))
-            continue;
+            return nullptr;
         if (!m_state.get(*child_box).line_boxes.is_empty())
             return child_box;
         if (box_child_to_derive_baseline_from(*child_box))
             return child_box;
+        return nullptr;
+    };
+
+    if (is_flex_or_grid_container) {
+        // https://drafts.csswg.org/css-flexbox-1/#flex-baselines
+        // https://drafts.csswg.org/css-grid-1/#grid-baselines
+        // For flex and grid containers, find the first in-flow child with a baseline.
+        for (auto const* child = box.first_child(); child; child = child->next_sibling()) {
+            if (auto const* result = check_child_for_baseline(child))
+                return result;
+        }
+    } else {
+        // Find the last in-flow child that has a baseline (CSS2.1 behavior for inline-block).
+        for (auto const* child = box.last_child(); child; child = child->previous_sibling()) {
+            if (auto const* result = check_child_for_baseline(child))
+                return result;
+        }
     }
     return nullptr;
 }
@@ -2592,9 +2612,13 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
     bool always_derive_from_content = is_flex_or_grid_container || has_visible_overflow;
 
     if (always_derive_from_content && !box_state.line_boxes.is_empty()) {
-        auto const& last_line_box = box_state.line_boxes.last();
-        auto last_line_box_top = last_line_box.bottom() - last_line_box.block_length();
-        return box_state.margin_box_top() + last_line_box_top + last_line_box.baseline();
+        // https://drafts.csswg.org/css-align-3/#baseline-values
+        // For flex and grid containers and flex/grid items, baseline alignment uses the first baseline set by default.
+        // For other containers with visible overflow (like inline-block), use last line (CSS2.1 behavior).
+        bool use_first_baseline = is_flex_or_grid_container || box.is_flex_item();
+        auto const& line_box = use_first_baseline ? box_state.line_boxes.first() : box_state.line_boxes.last();
+        auto line_box_top = line_box.bottom() - line_box.block_length();
+        return box_state.margin_box_top() + line_box_top + line_box.baseline();
     }
 
     // Derive baseline from block children if the box is flex/grid inside or has visible overflow.
@@ -2613,8 +2637,8 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
             // https://drafts.csswg.org/css-grid-1/#grid-baselines
             // Otherwise, the grid container's first (last) baseline set is generated from the alignment baseline of the
             // first (last) grid item in row-major grid order.
-            // FIXME: This does not yet select the spec-defined startmost/endmost flex item, or the first/last grid item
-            //        in row-major grid order.
+            // FIXME: This selects the first child for flex/grid containers, but does not yet handle writing modes
+            //        to determine the spec-defined startmost/endmost flex item, or row-major grid order.
             if (is_inline_flex_or_grid_container && !child_box_state.line_boxes.is_empty() && !child_box_state.line_boxes.first().is_empty()) {
                 auto const& first_line_box = child_box_state.line_boxes.first();
                 auto first_line_box_top = first_line_box.bottom() - first_line_box.block_length();

--- a/Tests/LibWeb/Layout/expected/flex-multiline-baseline-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/flex-multiline-baseline-alignment.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 46 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 30 0+0+8] children: inline
+      frag 0 from Box start: 0, length: 0, rect: [9,9 106.65625x28] baseline: 14.796875
+      Box <div.flex> at [9,9] flex-container(row) [0+1+0 106.65625 0+1+0] [0+1+0 28 0+1+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> at [9,9] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.single> at [9,9] flex-item [0+0+0 46.65625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 6, rect: [9,9 46.65625x18] baseline: 13.796875
+              "Single"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.multiline> at [55.65625,12.203125] flex-item [0+0+0 60 0+0+0] [0+0+0 28 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 10, rect: [55.65625,12.203125 57.953125x14] baseline: 10.59375
+              "First line"
+          frag 1 from TextNode start: 11, length: 5, rect: [55.65625,26.203125 36.140625x14] baseline: 10.59375
+              "wraps"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x46]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x30]
+      PaintableBox (Box<DIV>.flex) [8,8 108.65625x30]
+        PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]
+        PaintableWithLines (BlockContainer<DIV>.single) [9,9 46.65625x18]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.multiline) [55.65625,12.203125 60x28]
+          TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x46] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex-multiline-baseline-alignment.html
+++ b/Tests/LibWeb/Layout/input/flex-multiline-baseline-alignment.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+    .flex {
+        display: inline-flex;
+        align-items: baseline;
+        border: 1px solid black;
+    }
+    .single {
+        font-size: 16px;
+    }
+    .multiline {
+        font-size: 12px;
+        width: 60px;
+    }
+</style>
+<div class="flex">
+    <div class="single">Single</div>
+    <div class="multiline">First line wraps</div>
+</div>


### PR DESCRIPTION
_Disclaimer: this PR is made with a use of AI. I have no experience writing modern C++ code._

Flex and grid containers use the first baseline per [CSS specs](https://drafts.csswg.org/css-align-3/#baseline-values), while other containers use the last line baseline for CSS2.1 compatibility.

From [MDN: align-items CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/align-items) page:

| Before | After | Firefox |
|--------|--------|-------- |
| <img width="1505" height="627" alt="image" src="https://github.com/user-attachments/assets/bd8ad904-ab40-4ad0-ab52-52a234bbbb8f" /> | <img width="1506" height="633" alt="image" src="https://github.com/user-attachments/assets/7c3f1595-880e-4b3e-9bfe-1f61e62e3d53" /> |<img width="1503" height="625" alt="image" src="https://github.com/user-attachments/assets/18b08f3e-ea3d-4972-9c26-901071f80981" /> |
