### PR TITLE
UI: Reserve browser-owned shortcuts before WebContent

### DIFF
--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -51,6 +51,24 @@ static Optional<u64> display_id_for_screen(NSScreen* screen)
     return static_cast<u64>([screen_number unsignedLongLongValue]);
 }
 
+static bool is_browser_reserved_key_equivalent(NSEvent* event)
+{
+    auto modifiers = event.modifierFlags & (NSEventModifierFlagCommand | NSEventModifierFlagControl | NSEventModifierFlagOption | NSEventModifierFlagShift);
+    if (modifiers != NSEventModifierFlagCommand)
+        return false;
+
+    auto* characters = [[event charactersIgnoringModifiers] lowercaseString];
+    if ([characters length] != 1)
+        return false;
+
+    unichar character = [characters characterAtIndex:0];
+    return character == 'l'
+        || character == 'n'
+        || character == 'q'
+        || character == 't'
+        || character == 'w';
+}
+
 static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge const& web_view_bridge, Web::DevicePixelPoint widget_position)
 {
     return {
@@ -1280,6 +1298,9 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         return NO;
     }
     if (self.event_being_redispatched == event) {
+        return NO;
+    }
+    if (is_browser_reserved_key_equivalent(event)) {
         return NO;
     }
 

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -392,7 +392,7 @@ static Web::UIEvents::KeyCode get_keycode_from_qt_key_event(QKeyEvent const& eve
 
 static bool is_browser_reserved_shortcut(QKeyEvent const& event)
 {
-    // Browser chrome shortcuts that manage tabs or windows should not wait for
+    // Browser chrome shortcuts that manage tabs, windows, or focus should not wait for
     // WebContent to decide whether the page wants to suppress them.
     if (event.matches(QKeySequence::StandardKey::AddTab)
         || event.matches(QKeySequence::StandardKey::Close)
@@ -406,7 +406,7 @@ static bool is_browser_reserved_shortcut(QKeyEvent const& event)
     if (modifiers == (Qt::ControlModifier | Qt::ShiftModifier) && key == Qt::Key_T)
         return true;
 
-    if (modifiers == Qt::ControlModifier && (key == Qt::Key_Tab || key == Qt::Key_PageDown))
+    if (modifiers == Qt::ControlModifier && (key == Qt::Key_L || key == Qt::Key_Tab || key == Qt::Key_PageDown))
         return true;
 
     if (modifiers == (Qt::ControlModifier | Qt::ShiftModifier) && (key == Qt::Key_Tab || key == Qt::Key_Backtab))


### PR DESCRIPTION
This keeps browser chrome shortcuts from being delivered to WebContent before the UI has a chance to handle them.

AppKit now lets Cmd+L, Cmd+N, Cmd+Q, Cmd+T, and Cmd+W go through normal menu dispatch when the web view is focused. Qt now also reserves Ctrl+L in the same shortcut override path as its existing tab and window shortcuts, so focusing the location editor cannot be intercepted by page content.

This matches the behavior of other browsers IIUC, and makes us feel much more responsive when you use the keyboard under WebContent load.