### PR TITLE
UI/Qt: Add a location zoom indicator

### DIFF
--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -480,6 +480,11 @@ QString location_edit_style_sheet(QPalette const& palette)
     auto not_secure_hover = style_sheet_color(dark ? mix(surface_color, QColor(104, 55, 51), 0.34) : QColor(242, 226, 223));
     auto not_secure_pressed = style_sheet_color(dark ? mix(surface_color, QColor(112, 60, 55), 0.40) : QColor(236, 215, 211));
     auto not_secure_border = style_sheet_color(dark ? mix(QColor(92, 48, 45), chrome_border(palette), 0.52) : QColor(224, 203, 199));
+    auto zoom_text = style_sheet_color(chrome_muted_text(palette));
+    auto zoom_background = style_sheet_color(dark ? mix(surface_color, chrome_surface_recessed(palette), 0.28) : mix(surface_color, chrome_surface_recessed(palette), 0.14));
+    auto zoom_hover = style_sheet_color(dark ? mix(surface_color, chrome_surface_recessed(palette), 0.36) : mix(surface_color, chrome_surface_recessed(palette), 0.20));
+    auto zoom_pressed = style_sheet_color(dark ? mix(surface_color, chrome_surface_recessed(palette), 0.44) : mix(surface_color, chrome_surface_recessed(palette), 0.28));
+    auto zoom_border = style_sheet_color(dark ? mix(chrome_border(palette), surface_color, 0.38) : mix(chrome_border(palette), surface_color, 0.54));
 
     return qformatted(R"(
 QLineEdit#LadybirdLocationEdit {{
@@ -531,6 +536,23 @@ QToolButton#LadybirdLocationIcon[notSecure="true"]:pressed {{
     background: {14};
 }}
 
+QToolButton#LadybirdLocationZoomIndicator {{
+    color: {16};
+    background: {17};
+    border: 1px solid {20};
+    border-radius: 10px;
+    padding: 0 7px;
+    font-weight: 500;
+}}
+
+QToolButton#LadybirdLocationZoomIndicator:hover {{
+    background: {18};
+}}
+
+QToolButton#LadybirdLocationZoomIndicator:pressed {{
+    background: {19};
+}}
+
 QToolButton#LadybirdLocationAction {{
     background: transparent;
     border: 0;
@@ -547,7 +569,7 @@ QToolButton#LadybirdLocationAction:pressed {{
 }}
 )",
         surface, hover, border, focus_border, text, placeholder, selection, selection_text, control_hover, control_pressed, hover_border,
-        not_secure_text, not_secure_background, not_secure_hover, not_secure_pressed, not_secure_border);
+        not_secure_text, not_secure_background, not_secure_hover, not_secure_pressed, not_secure_border, zoom_text, zoom_background, zoom_hover, zoom_pressed, zoom_border);
 }
 
 QString bookmarks_bar_style_sheet(QPalette const& palette)

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -149,13 +149,19 @@ static bool should_suppress_inline_autocomplete_for_key(QKeyEvent const* event)
     return key == Qt::Key_Backspace || key == Qt::Key_Delete;
 }
 
+static constexpr int LOCATION_TRAILING_EDGE_MARGIN = 12;
+static constexpr int LOCATION_TRAILING_TEXT_GAP = 4;
+static constexpr int LOCATION_TRAILING_ITEM_GAP = 6;
+static constexpr int LOCATION_TRAILING_ACTION_SIZE = 24;
+static constexpr int LOCATION_PILL_HEIGHT = 22;
+static constexpr int LOCATION_PILL_HORIZONTAL_PADDING = 18;
+
 LocationEdit::LocationEdit(QWidget* parent)
     : QLineEdit(parent)
     , m_autocomplete(new Autocomplete(this))
 {
     setObjectName("LadybirdLocationEdit");
     setMinimumHeight(32);
-    setTextMargins(0, 0, 40, 0);
     update_chrome_style();
 
     m_focus_glow_effect = new QGraphicsDropShadowEffect(this);
@@ -182,6 +188,7 @@ LocationEdit::LocationEdit(QWidget* parent)
 
     m_trailing_action_button = new QToolButton(this);
     m_trailing_action_button->setObjectName("LadybirdLocationAction");
+    m_trailing_action_button->setToolButtonStyle(Qt::ToolButtonIconOnly);
     m_trailing_action_button->setIconSize({ 18, 18 });
     m_trailing_action_button->setFixedSize(24, 24);
     m_trailing_action_button->setAutoRaise(true);
@@ -189,6 +196,20 @@ LocationEdit::LocationEdit(QWidget* parent)
     m_trailing_action_button->setCursor(Qt::ArrowCursor);
     m_trailing_action_button->hide();
 
+    m_zoom_indicator_button = new QToolButton(this);
+    m_zoom_indicator_button->setObjectName("LadybirdLocationZoomIndicator");
+    m_zoom_indicator_button->setToolButtonStyle(Qt::ToolButtonTextOnly);
+    m_zoom_indicator_button->setFixedHeight(LOCATION_PILL_HEIGHT);
+    m_zoom_indicator_button->setAutoRaise(true);
+    m_zoom_indicator_button->setFocusPolicy(Qt::NoFocus);
+    m_zoom_indicator_button->setCursor(Qt::ArrowCursor);
+    m_zoom_indicator_button->hide();
+    connect(m_zoom_indicator_button, &QToolButton::clicked, this, [this] {
+        if (m_zoom_action)
+            m_zoom_action->trigger();
+    });
+
+    update_text_margins();
     update_placeholder();
     update_location_icon();
 
@@ -285,11 +306,29 @@ void LocationEdit::set_trailing_action(QAction* action)
 {
     m_trailing_action_button->setDefaultAction(action);
     m_trailing_action_button->setVisible(action != nullptr);
+    update_text_margins();
+    update_trailing_item_positions();
 }
 
 QAction* LocationEdit::trailing_action() const
 {
     return m_trailing_action_button->defaultAction();
+}
+
+void LocationEdit::set_zoom_action(QAction* action)
+{
+    if (m_zoom_action == action)
+        return;
+
+    if (m_zoom_action)
+        QObject::disconnect(m_zoom_action, nullptr, this, nullptr);
+
+    m_zoom_action = action;
+
+    if (m_zoom_action)
+        connect(m_zoom_action, &QAction::changed, this, &LocationEdit::update_zoom_indicator);
+
+    update_zoom_indicator();
 }
 
 void LocationEdit::set_url_is_hidden(bool url_is_hidden)
@@ -424,19 +463,46 @@ void LocationEdit::resizeEvent(QResizeEvent* event)
 {
     QLineEdit::resizeEvent(event);
 
+    update_trailing_item_positions();
+}
+
+void LocationEdit::update_trailing_item_positions()
+{
     auto button_size = m_leading_icon_button->size();
     auto y = (height() - button_size.height()) / 2 + (m_leading_icon_button->property("notSecure").toBool() ? 0 : 1);
     m_leading_icon_button->move(12, y);
 
-    auto trailing_button_size = m_trailing_action_button->sizeHint();
+    auto trailing_button_size = m_trailing_action_button->size();
+    auto trailing_x = width() - trailing_button_size.width() - LOCATION_TRAILING_EDGE_MARGIN;
     auto trailing_y = (height() - trailing_button_size.height()) / 2 + 1;
-    m_trailing_action_button->move(width() - trailing_button_size.width() - 12, trailing_y);
+    m_trailing_action_button->move(trailing_x, trailing_y);
+
+    auto zoom_button_size = m_zoom_indicator_button->size();
+    auto zoom_y = (height() - zoom_button_size.height()) / 2;
+    m_zoom_indicator_button->move(trailing_x - LOCATION_TRAILING_ITEM_GAP - zoom_button_size.width(), zoom_y);
+    m_zoom_indicator_button->raise();
+    m_trailing_action_button->raise();
 }
 
 void LocationEdit::search_engine_changed()
 {
     update_placeholder();
     update_location_icon();
+}
+
+void LocationEdit::update_text_margins()
+{
+    setTextMargins(m_text_leading_margin, 0, trailing_text_margin(), 0);
+}
+
+int LocationEdit::trailing_text_margin() const
+{
+    auto margin = LOCATION_TRAILING_EDGE_MARGIN + LOCATION_TRAILING_ACTION_SIZE + LOCATION_TRAILING_TEXT_GAP;
+
+    if (m_zoom_indicator_button && !m_zoom_indicator_button->isHidden())
+        margin += m_zoom_indicator_button->width() + LOCATION_TRAILING_ITEM_GAP;
+
+    return margin;
 }
 
 void LocationEdit::update_chrome_style()
@@ -447,6 +513,7 @@ void LocationEdit::update_chrome_style()
     m_is_updating_chrome_style = true;
     setStyleSheet(ChromeStyle::location_edit_style_sheet(palette()));
     m_is_updating_chrome_style = false;
+    update_zoom_indicator();
 }
 
 void LocationEdit::schedule_chrome_style_update()
@@ -460,6 +527,7 @@ void LocationEdit::schedule_chrome_style_update()
         m_autocomplete->schedule_chrome_style_update();
         update_focus_glow(m_focus_glow_alpha);
         update_location_icon();
+        update_zoom_indicator();
         highlight_location();
         update();
         m_has_pending_chrome_style_update = false;
@@ -502,7 +570,8 @@ void LocationEdit::update_location_icon()
         m_leading_icon_button->setText({});
         m_leading_icon_button->setIcon({});
         m_leading_icon_button->setToolTip({});
-        setTextMargins(0, 0, 40, 0);
+        m_text_leading_margin = 0;
+        update_text_margins();
     };
 
     auto show_icon = [&](ChromeIcon icon, QString const& tooltip) {
@@ -515,7 +584,8 @@ void LocationEdit::update_location_icon()
         m_leading_icon_button->setToolTip(tooltip);
         m_leading_icon_button->show();
         position_indicator(1);
-        setTextMargins(22, 0, 40, 0);
+        m_text_leading_margin = 22;
+        update_text_margins();
     };
 
     auto show_not_secure_indicator = [&] {
@@ -529,7 +599,8 @@ void LocationEdit::update_location_icon()
         m_leading_icon_button->setToolTip("Not secure");
         m_leading_icon_button->show();
         position_indicator(0);
-        setTextMargins(width, 0, 40, 0);
+        m_text_leading_margin = width;
+        update_text_margins();
     };
 
     if (text_matches_current_url()) {
@@ -552,6 +623,30 @@ void LocationEdit::update_location_icon()
     } else {
         hide_indicator();
     }
+}
+
+void LocationEdit::update_zoom_indicator()
+{
+    if (!m_zoom_indicator_button)
+        return;
+
+    auto visible = m_zoom_action && m_zoom_action->isVisible() && !m_zoom_action->text().isEmpty();
+    if (!visible) {
+        m_zoom_indicator_button->hide();
+        update_text_margins();
+        update_trailing_item_positions();
+        return;
+    }
+
+    m_zoom_indicator_button->setText(m_zoom_action->text());
+    m_zoom_indicator_button->setToolTip(m_zoom_action->toolTip());
+
+    auto width = m_zoom_indicator_button->fontMetrics().horizontalAdvance(m_zoom_indicator_button->text()) + LOCATION_PILL_HORIZONTAL_PADDING;
+    m_zoom_indicator_button->setFixedSize(width, LOCATION_PILL_HEIGHT);
+    m_zoom_indicator_button->show();
+
+    update_text_margins();
+    update_trailing_item_positions();
 }
 
 void LocationEdit::highlight_location()

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -37,6 +37,7 @@ public:
 
     void set_trailing_action(QAction*);
     QAction* trailing_action() const;
+    void set_zoom_action(QAction*);
 
     Optional<URL::URL const&> url() const { return m_url; }
     void set_url(Optional<URL::URL>);
@@ -55,9 +56,13 @@ private:
 
     void show_full_url_preserving_display_selection();
     int serialized_url_position_for_display_position(int) const;
+    void update_text_margins();
+    int trailing_text_margin() const;
+    void update_trailing_item_positions();
     void update_placeholder();
     void update_chrome_style();
     void update_location_icon();
+    void update_zoom_indicator();
     void update_focus_glow(int alpha);
     void schedule_chrome_style_update();
     void animate_focus_glow(int target_alpha);
@@ -76,8 +81,10 @@ private:
     Autocomplete* m_autocomplete { nullptr };
     QToolButton* m_leading_icon_button { nullptr };
     QToolButton* m_trailing_action_button { nullptr };
+    QToolButton* m_zoom_indicator_button { nullptr };
     QVariantAnimation* m_focus_glow_animation { nullptr };
     QGraphicsDropShadowEffect* m_focus_glow_effect { nullptr };
+    QAction* m_zoom_action { nullptr };
 
     Optional<URL::URL> m_url;
     bool m_url_is_hidden { false };
@@ -85,6 +92,7 @@ private:
     bool m_is_updating_chrome_style { false };
     bool m_has_pending_chrome_style_update { false };
     bool m_should_show_full_url_on_mouse_release { false };
+    int m_text_leading_margin { 0 };
     int m_focus_glow_alpha { 0 };
 
     bool m_is_applying_inline_autocomplete { false };

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -175,6 +175,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     toolbar_layout->addWidget(navigation_button_cluster, 0, Qt::AlignTop);
     m_location_edit->set_trailing_action(create_application_action(*m_location_edit, view().toggle_bookmark_action()));
+    m_location_edit->set_zoom_action(create_application_action(*m_location_edit, view().reset_zoom_action(), IncludeActionIcon::No));
     toolbar_layout->addWidget(m_location_edit, 1);
     toolbar_layout->addWidget(m_hamburger_button, 0, Qt::AlignTop);
 


### PR DESCRIPTION
Show active page zoom as a muted pill inside the right side of the location edit whenever zoom differs from 100%. Keep it next to the bookmark action and reserve text margin space so the URL cannot render under the controls.

Clicking the pill activates the existing reset zoom action, returning the page to 100% and hiding the indicator again.