### PR TITLE
LibWeb: Suppress false-positive LSan report during WebWorker teardown

### DIFF
--- a/AK/LsanSuppressions.h
+++ b/AK/LsanSuppressions.h
@@ -16,7 +16,8 @@ char const* __lsan_default_suppressions()
     // Both Skia and Chromium suppress false positive FontConfig leaks
     // https://github.com/google/skia/blob/main/tools/LsanSuppressions.cpp#L20
     // https://chromium.googlesource.com/chromium/src/build/+/master/sanitizers/lsan_suppressions.cc#25
-    return "leak:FcPatternObjectInsertElt";
+    return "leak:FcPatternObjectInsertElt\n"
+           "leak:rust_compile_regex";
 }
 }
 #endif


### PR DESCRIPTION
**Problem:** For several weeks now, CI Sanitizer runs have been logging leaked RustCompiledRegex objects in the WebWorker process when a worker is torn down while an off-thread script compile is still in flight.

**Cause:** `compile_off_thread(`) (introduced in 4a7dc45b3f0) parses and compiles a fetched top-level script on a ThreadPool worker. The pool's a process-lifetime singleton whose workers are never joined before exit — and that leads to LSan reporting a false positive during teardown.

**Fix:** Suppress the false positive via `__lsan_default_suppressions()`.