### PR TITLE
UI/Qt: Improve macOS chrome and content presentation

### DIFF
--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -89,6 +89,14 @@ static Array<ConfigVariableDefinition, static_cast<size_t>(ConfigVariableID::Cou
         .default_value = JsonArray {},
         .array_element_type = JsonValue::Type::String,
     },
+    {
+        .id = ConfigVariableID::UseRoundedWindowCorners,
+        .name = "ui.window.use_rounded_corners"sv,
+        .title = "Use rounded window corners"sv,
+        .description = "Clip browser windows to rounded corners."sv,
+        .default_value = true,
+        .array_element_type = {},
+    },
 } };
 
 ReadonlySpan<ConfigVariableDefinition const> config_variable_definitions()

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -52,6 +52,7 @@ enum class ConfigVariableID : u8 {
     ShowWebContentProcessIDInTabTitle,
     ShowAdvancedDebugMenu,
     ContentBlockerListPaths,
+    UseRoundedWindowCorners,
 
     Count,
 };

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -278,8 +278,13 @@ void ViewImplementation::reset_zoom()
 
 void ViewImplementation::enqueue_input_event(Web::InputEvent event)
 {
-    if (auto* mouse_event = event.get_pointer<Web::MouseEvent>();
-        Application::web_content_options().enable_async_scrolling == EnableAsyncScrolling::Yes
+    auto* mouse_event = event.get_pointer<Web::MouseEvent>();
+    if (mouse_event && mouse_event->type == Web::MouseEvent::Type::MouseWheel) {
+        mouse_event->wheel_delta_x /= zoom_level();
+        mouse_event->wheel_delta_y /= zoom_level();
+    }
+
+    if (Application::web_content_options().enable_async_scrolling == EnableAsyncScrolling::Yes
         && m_client_state.has_usable_bitmap
         && mouse_event) {
         if (mouse_event->type == Web::MouseEvent::Type::MouseWheel) {

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/JsonArray.h>
+#include <AK/Platform.h>
 #include <LibURL/Parser.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/SearchEngine.h>
@@ -30,6 +31,16 @@ static StringView config_variable_type_to_string(JsonValue::Type type)
     }
 
     VERIFY_NOT_REACHED();
+}
+
+static bool should_show_config_variable([[maybe_unused]] ConfigVariableID id)
+{
+#if !defined(AK_OS_MACOS)
+    if (id == ConfigVariableID::UseRoundedWindowCorners)
+        return false;
+#endif
+
+    return true;
 }
 
 void SettingsUI::register_interfaces()
@@ -127,6 +138,9 @@ void SettingsUI::load_current_settings()
 
     JsonArray config_variables;
     for (auto const& variable : config_variable_definitions()) {
+        if (!should_show_config_variable(variable.id))
+            continue;
+
         JsonObject variable_object;
         variable_object.set("name"sv, variable.name);
         variable_object.set("title"sv, variable.title);

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <AK/HashMap.h>
+#include <AK/Platform.h>
 #include <AK/RefPtr.h>
 #include <AK/StdLibExtras.h>
 #include <AK/TypeCasts.h>
@@ -19,6 +20,9 @@
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
+#if defined(AK_OS_MACOS)
+#    include <UI/Qt/MacWindow.h>
+#endif
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/Settings.h>
 #include <UI/Qt/StringUtils.h>
@@ -55,6 +59,9 @@ namespace Ladybird {
 static constexpr auto AUDIO_STATE_BUTTON_POSITION = QTabBar::LeftSide;
 static constexpr auto TAB_CLOSE_BUTTON_POSITION = QTabBar::RightSide;
 static constexpr auto WINDOW_DRAG_REGION_PROPERTY = "LadybirdWindowDragRegion";
+#if defined(AK_OS_MACOS)
+static constexpr qreal WINDOW_CORNER_RADIUS = 12.0;
+#endif
 
 static bool should_use_screen_signal_for_dpi_changes()
 {
@@ -227,6 +234,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     setAttribute(Qt::WA_OpaquePaintEvent);
     setWindowIcon(app_icon());
     qApp->installEventFilter(this);
+    update_window_corners();
 
     update_tabs_display();
 
@@ -1229,6 +1237,7 @@ void BrowserWindow::clear_resize_cursor()
 void BrowserWindow::resizeEvent(QResizeEvent* event)
 {
     QWidget::resizeEvent(event);
+    update_window_corners();
 
     for_each_tab([&](auto& tab) {
         tab.view().set_window_size({ width(), height() });
@@ -1244,6 +1253,7 @@ void BrowserWindow::changeEvent(QEvent* event)
     } else if (event->type() == QEvent::WindowStateChange) {
         update_menu_bar_window_control_icons();
         m_tabs_container->update_window_button_icons();
+        update_window_corners();
 
         QWindowStateChangeEvent* stateChangeEvent = static_cast<QWindowStateChangeEvent*>(event);
         bool was_fullscreen = stateChangeEvent->oldState() & Qt::WindowFullScreen;
@@ -1258,6 +1268,26 @@ void BrowserWindow::changeEvent(QEvent* event)
         }
     }
     QWidget::changeEvent(event);
+}
+
+void BrowserWindow::config_variable_changed(WebView::ConfigVariableID variable)
+{
+    if (variable == WebView::ConfigVariableID::UseRoundedWindowCorners)
+        update_window_corners();
+}
+
+void BrowserWindow::update_window_corners()
+{
+    auto should_use_rounded_corners = WebView::Application::settings().config_variable_as_bool(WebView::ConfigVariableID::UseRoundedWindowCorners);
+    auto should_round_window = should_use_rounded_corners && !isMaximized() && !isFullScreen();
+
+#if defined(AK_OS_MACOS)
+    clearMask();
+    set_rounded_window_corners(*this, should_round_window, WINDOW_CORNER_RADIUS);
+#else
+    clearMask();
+    (void)should_round_window;
+#endif
 }
 
 void BrowserWindow::moveEvent(QMoveEvent* event)

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/Settings.h>
 #include <UI/Qt/Tab.h>
 #include <UI/Qt/TabBar.h>
 
@@ -80,7 +81,9 @@ private:
     bool m_debounce { false };
 };
 
-class BrowserWindow : public QMainWindow {
+class BrowserWindow
+    : public QMainWindow
+    , public WebView::SettingsObserver {
     Q_OBJECT
 
 public:
@@ -151,6 +154,7 @@ private:
     virtual void moveEvent(QMoveEvent*) override;
     virtual void wheelEvent(QWheelEvent*) override;
     virtual void closeEvent(QCloseEvent*) override;
+    virtual void config_variable_changed(WebView::ConfigVariableID) override;
 
     Tab& create_new_tab(Web::HTML::ActivateTab, Tab& parent, Optional<u64> page_index);
     void initialize_tab(Tab*);
@@ -161,6 +165,7 @@ private:
     Optional<Qt::CursorShape> resize_cursor_for_edges(Qt::Edges) const;
     void update_resize_cursor(QPoint const&);
     void clear_resize_cursor();
+    void update_window_corners();
 
     template<typename Callback>
     void for_each_tab(Callback&& callback)

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -3,6 +3,13 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
 
+if (APPLE)
+    # The macOS QRhiWidget presentation path uses QRhi's private Metal native
+    # handle types to import IOSurfaces without CPU readback.
+    set(QT_NO_PRIVATE_MODULE_WARNING ON)
+    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+endif()
+
 qt_add_executable(ladybird main.cpp)
 target_sources(ladybird PRIVATE
     Application.cpp
@@ -27,8 +34,11 @@ target_sources(ladybird PRIVATE
 target_link_libraries(ladybird PRIVATE Qt::Core Qt::Gui Qt::Widgets)
 
 if (APPLE)
-    target_sources(ladybird PRIVATE MacWindow.mm)
-    target_link_libraries(ladybird PRIVATE "-framework Cocoa" "-framework QuartzCore")
+    target_sources(ladybird PRIVATE
+        MacWindow.mm
+        WebContentViewMac.mm
+    )
+    target_link_libraries(ladybird PRIVATE Qt::GuiPrivate "-framework Cocoa" "-framework IOSurface" "-framework Metal" "-framework QuartzCore")
 endif()
 
 create_ladybird_bundle(ladybird)

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -25,6 +25,12 @@ target_sources(ladybird PRIVATE
     ladybird.qrc
 )
 target_link_libraries(ladybird PRIVATE Qt::Core Qt::Gui Qt::Widgets)
+
+if (APPLE)
+    target_sources(ladybird PRIVATE MacWindow.mm)
+    target_link_libraries(ladybird PRIVATE "-framework Cocoa" "-framework QuartzCore")
+endif()
+
 create_ladybird_bundle(ladybird)
 
 if (WIN32)

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -737,7 +737,6 @@ void LocationEdit::show_full_url_preserving_display_selection()
 
     auto selection_start = selectionStart();
     auto selection_length = selectedText().length();
-    auto cursor_position = cursorPosition();
 
     setText(serialized_url());
 
@@ -746,7 +745,7 @@ void LocationEdit::show_full_url_preserving_display_selection()
         auto serialized_selection_end = serialized_url_position_for_display_position(selection_start + selection_length);
         setSelection(serialized_selection_start, serialized_selection_end - serialized_selection_start);
     } else {
-        setCursorPosition(serialized_url_position_for_display_position(cursor_position));
+        selectAll();
     }
 
     highlight_location();

--- a/UI/Qt/MacWindow.h
+++ b/UI/Qt/MacWindow.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+class QWidget;
+
+namespace Ladybird {
+
+void set_rounded_window_corners(QWidget&, bool enabled, double radius);
+
+}

--- a/UI/Qt/MacWindow.mm
+++ b/UI/Qt/MacWindow.mm
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <UI/Qt/MacWindow.h>
+
+#include <QWidget>
+
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
+
+namespace Ladybird {
+
+void set_rounded_window_corners(QWidget& widget, bool enabled, double radius)
+{
+    auto* view = reinterpret_cast<NSView*>(widget.winId());
+    if (!view)
+        return;
+
+    auto* window = view.window;
+    if (!window)
+        return;
+
+    auto* content_view = window.contentView;
+    if (!content_view)
+        return;
+
+    content_view.wantsLayer = YES;
+    content_view.layer.cornerRadius = enabled ? radius : 0.0;
+    content_view.layer.masksToBounds = enabled ? YES : NO;
+}
+
+}

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -171,6 +171,7 @@ TabBar::TabBar(TabWidget* tab_widget)
     setFocusPolicy(Qt::NoFocus);
     setIconSize({ 16, 16 });
     setMinimumHeight(39);
+    recreate_icons();
 
     m_hover_animation = new QVariantAnimation(this);
     m_hover_animation->setDuration(120);
@@ -226,6 +227,12 @@ void TabBar::refresh_tab_layout()
     set_vertical_scroll_offset(m_vertical_scroll_offset);
     updateGeometry();
     update_tab_button_geometry();
+    update();
+}
+
+void TabBar::recreate_icons()
+{
+    m_fallback_tab_icon = create_chrome_icon(ChromeIcon::Globe, palette());
     update();
 }
 
@@ -359,7 +366,7 @@ void TabBar::paintEvent(QPaintEvent*)
 
         auto icon = tabIcon(index);
         if (icon.isNull())
-            icon = create_chrome_icon(ChromeIcon::Globe, palette());
+            icon = m_fallback_tab_icon;
 
         if (is_collapsed_vertical) {
             QRect icon_rect {
@@ -1413,6 +1420,7 @@ void TabWidget::update_tab_chrome_visibility()
 
 void TabWidget::recreate_icons()
 {
+    m_tab_bar->recreate_icons();
     m_new_tab_button->setIcon(create_chrome_icon(ChromeIcon::NewTab, palette()));
     update_vertical_tabs_action_labels();
     update_window_button_icons();

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -55,6 +55,7 @@ public:
     TabLayout tab_layout() const { return m_tab_layout; }
     void set_tab_layout(TabLayout);
     void refresh_tab_layout();
+    void recreate_icons();
 
 private:
     virtual QSize sizeHint() const override;
@@ -105,6 +106,7 @@ private:
     qreal m_hover_progress { 0.0 };
     int m_drop_indicator_index { -1 };
     QVariantAnimation* m_hover_animation { nullptr };
+    QIcon m_fallback_tab_icon;
     QPointer<Tab> m_pressed_tab;
     QPoint m_position_in_selected_tab_while_dragging;
     QPoint m_drag_start_position;

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -37,6 +37,7 @@
 #include <QKeySequence>
 #include <QMimeData>
 #include <QMouseEvent>
+#include <QNativeGestureEvent>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPalette>
@@ -945,6 +946,18 @@ bool WebContentView::event(QEvent* event)
     if (event->type() == QEvent::KeyRelease) {
         keyReleaseEvent(static_cast<QKeyEvent*>(event));
         return true;
+    }
+    if (event->type() == QEvent::NativeGesture) {
+        auto const& native_gesture_event = *static_cast<QNativeGestureEvent const*>(event);
+        if (native_gesture_event.gestureType() == Qt::ZoomNativeGesture) {
+            Web::PinchEvent pinch_event;
+            auto const local_position = mapFromGlobal(native_gesture_event.globalPosition());
+            pinch_event.position = { local_position.x() * m_device_pixel_ratio, local_position.y() * m_device_pixel_ratio };
+            pinch_event.modifiers = get_modifiers_from_qt_keyboard_modifiers(native_gesture_event.modifiers());
+            pinch_event.scale_delta = native_gesture_event.value();
+            enqueue_input_event(AK::move(pinch_event));
+            return true;
+        }
     }
 
     if (event->type() == QEvent::PaletteChange || event->type() == QEvent::ApplicationPaletteChange || event->type() == QEvent::ThemeChange) {

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -53,8 +53,12 @@ namespace Ladybird {
 bool is_using_dark_system_theme(QWidget&);
 
 WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index, WebContentViewInitialState initial_state)
-    : QWidget(window)
+    : WebContentViewBase(window)
 {
+#ifdef AK_OS_MACOS
+    setApi(QRhiWidget::Api::Metal);
+#endif
+
     m_client_state.client = parent_client;
     m_client_state.page_index = page_index;
 
@@ -186,7 +190,12 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     };
 }
 
-WebContentView::~WebContentView() = default;
+WebContentView::~WebContentView()
+{
+#ifdef AK_OS_MACOS
+    release_metal_resources();
+#endif
+}
 
 void WebContentView::select_dropdown_action()
 {
@@ -463,14 +472,14 @@ void WebContentView::leaveEvent(QEvent* event)
 {
     if (is_node_picker_active()) {
         clear_node_picker();
-        QWidget::leaveEvent(event);
+        WebContentViewBase::leaveEvent(event);
         return;
     }
 
     static QMouseEvent mouse_event { QEvent::Type::Leave, {}, {}, Qt::MouseButton::NoButton, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier };
     enqueue_native_event(Web::MouseEvent::Type::MouseLeave, mouse_event);
 
-    QWidget::leaveEvent(event);
+    WebContentViewBase::leaveEvent(event);
 }
 
 void WebContentView::mouseMoveEvent(QMouseEvent* event)
@@ -488,7 +497,7 @@ void WebContentView::mouseMoveEvent(QMouseEvent* event)
     }
 
     enqueue_native_event(Web::MouseEvent::Type::MouseMove, *event);
-    QWidget::mouseMoveEvent(event);
+    WebContentViewBase::mouseMoveEvent(event);
 }
 
 void WebContentView::mousePressEvent(QMouseEvent* event)
@@ -616,21 +625,37 @@ void WebContentView::focusOutEvent(QFocusEvent*)
     client().async_set_has_focus(m_client_state.page_index, false);
 }
 
+Optional<WebContentView::Paintable> WebContentView::current_paintable() const
+{
+    Gfx::SharedImageBuffer const* shared_image_buffer = nullptr;
+    Gfx::IntSize bitmap_size;
+
+    if (m_client_state.has_usable_bitmap) {
+        VERIFY(m_client_state.front_bitmap.shared_image_buffer);
+        shared_image_buffer = m_client_state.front_bitmap.shared_image_buffer.ptr();
+        bitmap_size = m_client_state.front_bitmap.last_painted_size.to_type<int>();
+    } else if (m_backup_shared_image_buffer) {
+        shared_image_buffer = m_backup_shared_image_buffer.ptr();
+        bitmap_size = m_backup_bitmap_size.to_type<int>();
+    }
+
+    if (!shared_image_buffer)
+        return {};
+    return Paintable { shared_image_buffer, bitmap_size };
+}
+
+#ifndef AK_OS_MACOS
 void WebContentView::paintEvent(QPaintEvent*)
 {
     QPainter painter(this);
     painter.scale(1 / m_device_pixel_ratio, 1 / m_device_pixel_ratio);
 
+    auto paintable = current_paintable();
     Gfx::Bitmap const* bitmap = nullptr;
     Gfx::IntSize bitmap_size;
-
-    if (m_client_state.has_usable_bitmap) {
-        VERIFY(m_client_state.front_bitmap.shared_image_buffer);
-        bitmap = m_client_state.front_bitmap.shared_image_buffer->bitmap().ptr();
-        bitmap_size = m_client_state.front_bitmap.last_painted_size.to_type<int>();
-    } else if (m_backup_shared_image_buffer) {
-        bitmap = m_backup_shared_image_buffer->bitmap().ptr();
-        bitmap_size = m_backup_bitmap_size.to_type<int>();
+    if (paintable.has_value()) {
+        bitmap = paintable->shared_image_buffer->bitmap().ptr();
+        bitmap_size = paintable->bitmap_size;
     }
 
     if (bitmap) {
@@ -652,10 +677,11 @@ void WebContentView::paintEvent(QPaintEvent*)
     auto background_color = page_background_color();
     painter.fillRect(QRect(0, 0, m_viewport_size.width(), m_viewport_size.height()), QColor(background_color.red(), background_color.green(), background_color.blue()));
 }
+#endif
 
 void WebContentView::resizeEvent(QResizeEvent* event)
 {
-    QWidget::resizeEvent(event);
+    WebContentViewBase::resizeEvent(event);
     update_viewport_size();
     handle_resize();
 }
@@ -719,13 +745,13 @@ void WebContentView::update_zoom()
 
 void WebContentView::showEvent(QShowEvent* event)
 {
-    QWidget::showEvent(event);
+    WebContentViewBase::showEvent(event);
     set_system_visibility_state(Web::HTML::VisibilityState::Visible);
 }
 
 void WebContentView::hideEvent(QHideEvent* event)
 {
-    QWidget::hideEvent(event);
+    WebContentViewBase::hideEvent(event);
     set_system_visibility_state(Web::HTML::VisibilityState::Hidden);
 }
 
@@ -926,7 +952,7 @@ bool WebContentView::event(QEvent* event)
             update_palette();
             update();
         });
-        return QWidget::event(event);
+        return WebContentViewBase::event(event);
     }
 
     if (event->type() == QEvent::ShortcutOverride) {
@@ -940,7 +966,7 @@ bool WebContentView::event(QEvent* event)
         return true;
     }
 
-    return QWidget::event(event);
+    return WebContentViewBase::event(event);
 }
 
 void WebContentView::enqueue_native_event(Web::MouseEvent::Type type, QSinglePointEvent const& event)
@@ -1075,10 +1101,10 @@ void WebContentView::finish_handling_key_event(Web::KeyEvent const& key_event)
 
     switch (key_event.type) {
     case Web::KeyEvent::Type::KeyDown:
-        QWidget::keyPressEvent(&event);
+        WebContentViewBase::keyPressEvent(&event);
         break;
     case Web::KeyEvent::Type::KeyUp:
-        QWidget::keyReleaseEvent(&event);
+        WebContentViewBase::keyReleaseEvent(&event);
         break;
     }
 

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -1012,8 +1012,8 @@ void WebContentView::enqueue_native_event(Web::MouseEvent::Type type, QSinglePoi
             double delta_y = static_cast<double>(angle_delta.y()) / 120.0;
 
             static constexpr double scroll_step_size = 40;
-            auto step_x = delta_x * static_cast<double>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
-            auto step_y = delta_y * static_cast<double>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
+            auto step_x = delta_x * static_cast<double>(QApplication::wheelScrollLines());
+            auto step_y = delta_y * static_cast<double>(QApplication::wheelScrollLines());
 
             wheel_delta_x = step_x * scroll_step_size;
             wheel_delta_y = step_y * scroll_step_size;

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -240,24 +240,25 @@ static Web::UIEvents::KeyModifier get_modifiers_from_qt_keyboard_modifiers(Qt::K
     auto result = Web::UIEvents::KeyModifier::Mod_None;
     if (modifiers.testFlag(Qt::AltModifier))
         result |= Web::UIEvents::KeyModifier::Mod_Alt;
-    if (modifiers.testFlag(Qt::ControlModifier))
-        result |= Web::UIEvents::KeyModifier::Mod_Ctrl;
     if (modifiers.testFlag(Qt::ShiftModifier))
         result |= Web::UIEvents::KeyModifier::Mod_Shift;
+#if defined(AK_OS_MACOS)
+    if (modifiers.testFlag(Qt::ControlModifier))
+        result |= Web::UIEvents::KeyModifier::Mod_Super;
+    if (modifiers.testFlag(Qt::MetaModifier))
+        result |= Web::UIEvents::KeyModifier::Mod_Ctrl;
+#else
+    if (modifiers.testFlag(Qt::ControlModifier))
+        result |= Web::UIEvents::KeyModifier::Mod_Ctrl;
+    if (modifiers.testFlag(Qt::MetaModifier))
+        result |= Web::UIEvents::KeyModifier::Mod_Super;
+#endif
     return result;
 }
 
 static Web::UIEvents::KeyModifier get_modifiers_from_qt_key_event(QKeyEvent const& event)
 {
-    auto modifiers = Web::UIEvents::KeyModifier::Mod_None;
-    if (event.modifiers().testFlag(Qt::AltModifier))
-        modifiers |= Web::UIEvents::KeyModifier::Mod_Alt;
-    if (event.modifiers().testFlag(Qt::ControlModifier))
-        modifiers |= Web::UIEvents::KeyModifier::Mod_Ctrl;
-    if (event.modifiers().testFlag(Qt::MetaModifier))
-        modifiers |= Web::UIEvents::KeyModifier::Mod_Super;
-    if (event.modifiers().testFlag(Qt::ShiftModifier))
-        modifiers |= Web::UIEvents::KeyModifier::Mod_Shift;
+    auto modifiers = get_modifiers_from_qt_keyboard_modifiers(event.modifiers());
     if (event.modifiers().testFlag(Qt::KeypadModifier))
         modifiers |= Web::UIEvents::KeyModifier::Mod_Keypad;
     return modifiers;

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -21,12 +21,23 @@
 #include <QMenu>
 #include <QTimer>
 #include <QUrl>
-#include <QWidget>
+
+#ifdef AK_OS_MACOS
+#    include <QRhiWidget>
+#else
+#    include <QWidget>
+#endif
 
 class QKeyEvent;
 class QSinglePointEvent;
 
 namespace Ladybird {
+
+#ifdef AK_OS_MACOS
+using WebContentViewBase = QRhiWidget;
+#else
+using WebContentViewBase = QWidget;
+#endif
 
 struct WebContentViewInitialState {
     double maximum_frames_per_second { 60.0 };
@@ -34,14 +45,16 @@ struct WebContentViewInitialState {
 };
 
 class WebContentView final
-    : public QWidget
+    : public WebContentViewBase
     , public WebView::ViewImplementation {
     Q_OBJECT
 public:
     WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0, WebContentViewInitialState initial_state = {});
     virtual ~WebContentView() override;
 
+#ifndef AK_OS_MACOS
     virtual void paintEvent(QPaintEvent*) override;
+#endif
     virtual void resizeEvent(QResizeEvent*) override;
     virtual void leaveEvent(QEvent* event) override;
     virtual void mouseMoveEvent(QMouseEvent*) override;
@@ -93,6 +106,20 @@ private:
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const override;
 
+#ifdef AK_OS_MACOS
+    // ^QRhiWidget
+    virtual void initialize(QRhiCommandBuffer*) override;
+    virtual void render(QRhiCommandBuffer*) override;
+    virtual void releaseResources() override;
+#endif
+
+    struct Paintable {
+        Gfx::SharedImageBuffer const* shared_image_buffer { nullptr };
+        Gfx::IntSize bitmap_size;
+    };
+
+    Optional<Paintable> current_paintable() const;
+
     void update_viewport_size();
     void update_cursor(Gfx::Cursor cursor);
     void update_compositor_display_metadata();
@@ -120,6 +147,21 @@ private:
     int m_click_count { 0 };
 
     QMenu* m_select_dropdown { nullptr };
+
+#ifdef AK_OS_MACOS
+    bool prepare_metal_renderer(unsigned long render_target_pixel_format);
+    bool update_imported_iosurface_texture(Gfx::SharedImageBuffer const&);
+    void release_metal_resources();
+    void release_imported_iosurface_texture();
+
+    void* m_metal_device { nullptr };
+    void* m_metal_library { nullptr };
+    void* m_metal_pipeline_state { nullptr };
+    void* m_metal_sampler_state { nullptr };
+    void* m_imported_iosurface_texture { nullptr };
+    Gfx::SharedImageBuffer const* m_imported_shared_image_buffer { nullptr };
+    unsigned long m_render_target_pixel_format { 0 };
+#endif
 };
 
 }

--- a/UI/Qt/WebContentViewMac.mm
+++ b/UI/Qt/WebContentViewMac.mm
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Debug.h>
+#include <AK/Math.h>
+#include <LibGfx/SharedImageBuffer.h>
+#include <UI/Qt/WebContentView.h>
+
+#include <QColor>
+#include <rhi/qrhi.h>
+#include <rhi/qrhi_platform.h>
+
+#import <IOSurface/IOSurface.h>
+#import <Metal/Metal.h>
+
+namespace Ladybird {
+
+static void release_metal_object(void*& object)
+{
+    if (!object)
+        return;
+
+    [(id)object release];
+    object = nullptr;
+}
+
+void WebContentView::release_imported_iosurface_texture()
+{
+    release_metal_object(m_imported_iosurface_texture);
+    m_imported_shared_image_buffer = nullptr;
+}
+
+void WebContentView::release_metal_resources()
+{
+    release_imported_iosurface_texture();
+    release_metal_object(m_metal_sampler_state);
+    release_metal_object(m_metal_pipeline_state);
+    release_metal_object(m_metal_library);
+    m_metal_device = nullptr;
+    m_render_target_pixel_format = 0;
+}
+
+bool WebContentView::prepare_metal_renderer(unsigned long render_target_pixel_format)
+{
+    auto const* rhi_native_handles = static_cast<QRhiMetalNativeHandles const*>(rhi()->nativeHandles());
+    if (!rhi_native_handles || !rhi_native_handles->dev)
+        return false;
+
+    auto* device = (id<MTLDevice>)rhi_native_handles->dev;
+    if (m_metal_device != device || m_render_target_pixel_format != render_target_pixel_format) {
+        release_metal_resources();
+        m_metal_device = device;
+        m_render_target_pixel_format = render_target_pixel_format;
+    }
+
+    if (m_metal_pipeline_state && m_metal_sampler_state)
+        return true;
+
+    // NB: QRhiWidget gives us a Metal render target for the widget, but QRhi does
+    // not expose a way to wrap the IOSurface-backed texture from WebContent as a
+    // QRhiTexture. Importing the IOSurface with Metal and drawing a textured quad
+    // lets us present it without doing a CPU readback through QImage/QPainter.
+    //
+    // The shader deliberately keeps the geometry tiny: it maps the painted content
+    // rectangle into the QRhiWidget render target and samples the corresponding
+    // sub-rectangle from the IOSurface. The IOSurface is imported as BGRA below;
+    // Metal texture sampling exposes those pixels to the shader as logical RGBA
+    // components, so the fragment shader does not need an explicit swizzle.
+    auto const* shader_source = R"(
+#include <metal_stdlib>
+using namespace metal;
+
+struct Uniforms {
+    float2 target_size;
+    float2 content_size;
+    float2 source_size;
+};
+
+struct VertexOut {
+    float4 position [[position]];
+    float2 texture_coordinate;
+};
+
+vertex VertexOut vertex_main(uint vertex_id [[vertex_id]], constant Uniforms& uniforms [[buffer(0)]])
+{
+    float2 unit_positions[4] = {
+        float2(0.0, 0.0),
+        float2(1.0, 0.0),
+        float2(0.0, 1.0),
+        float2(1.0, 1.0),
+    };
+
+    float2 unit_position = unit_positions[vertex_id];
+    float2 pixel_position = unit_position * uniforms.content_size;
+
+    VertexOut out;
+    out.position = float4(
+        pixel_position.x / uniforms.target_size.x * 2.0 - 1.0,
+        1.0 - pixel_position.y / uniforms.target_size.y * 2.0,
+        0.0,
+        1.0);
+    out.texture_coordinate = pixel_position / uniforms.source_size;
+    return out;
+}
+
+fragment half4 fragment_main(VertexOut in [[stage_in]], texture2d<half> texture [[texture(0)]], sampler texture_sampler [[sampler(0)]])
+{
+    return texture.sample(texture_sampler, in.texture_coordinate);
+}
+)";
+
+    NSError* error = nil;
+    auto* library = [device newLibraryWithSource:[NSString stringWithUTF8String:shader_source] options:nil error:&error];
+    if (!library) {
+        dbgln("Failed to create Metal shader library for Qt WebContentView");
+        return false;
+    }
+    m_metal_library = library;
+
+    auto* vertex_function = [library newFunctionWithName:@"vertex_main"];
+    auto* fragment_function = [library newFunctionWithName:@"fragment_main"];
+    if (!vertex_function || !fragment_function) {
+        [vertex_function release];
+        [fragment_function release];
+        dbgln("Failed to create Metal shader functions for Qt WebContentView");
+        return false;
+    }
+
+    auto* pipeline_descriptor = [[MTLRenderPipelineDescriptor alloc] init];
+    pipeline_descriptor.vertexFunction = vertex_function;
+    pipeline_descriptor.fragmentFunction = fragment_function;
+    pipeline_descriptor.colorAttachments[0].pixelFormat = static_cast<MTLPixelFormat>(render_target_pixel_format);
+
+    auto* pipeline_state = [device newRenderPipelineStateWithDescriptor:pipeline_descriptor error:&error];
+    [pipeline_descriptor release];
+    [vertex_function release];
+    [fragment_function release];
+
+    if (!pipeline_state) {
+        dbgln("Failed to create Metal render pipeline for Qt WebContentView");
+        return false;
+    }
+    m_metal_pipeline_state = pipeline_state;
+
+    auto* sampler_descriptor = [[MTLSamplerDescriptor alloc] init];
+    sampler_descriptor.minFilter = MTLSamplerMinMagFilterNearest;
+    sampler_descriptor.magFilter = MTLSamplerMinMagFilterNearest;
+    sampler_descriptor.sAddressMode = MTLSamplerAddressModeClampToEdge;
+    sampler_descriptor.tAddressMode = MTLSamplerAddressModeClampToEdge;
+    m_metal_sampler_state = [device newSamplerStateWithDescriptor:sampler_descriptor];
+    [sampler_descriptor release];
+
+    if (!m_metal_sampler_state) {
+        dbgln("Failed to create Metal sampler for Qt WebContentView");
+        return false;
+    }
+
+    return true;
+}
+
+bool WebContentView::update_imported_iosurface_texture(Gfx::SharedImageBuffer const& shared_image_buffer)
+{
+    if (m_imported_shared_image_buffer == &shared_image_buffer && m_imported_iosurface_texture)
+        return true;
+
+    release_imported_iosurface_texture();
+
+    auto* device = (id<MTLDevice>)m_metal_device;
+    if (!device)
+        return false;
+
+    auto const& iosurface_handle = shared_image_buffer.iosurface_handle();
+    // LibGfx IOSurfaces are BGRA in memory. Match that storage format when
+    // importing the IOSurface so Metal can do the channel mapping while sampling.
+    auto* descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                                                          width:iosurface_handle.width()
+                                                                         height:iosurface_handle.height()
+                                                                      mipmapped:NO];
+    descriptor.storageMode = MTLStorageModeShared;
+    descriptor.usage = MTLTextureUsageShaderRead;
+
+    m_imported_iosurface_texture = [device newTextureWithDescriptor:descriptor
+                                                          iosurface:(IOSurfaceRef)iosurface_handle.core_foundation_pointer()
+                                                              plane:0];
+    if (!m_imported_iosurface_texture)
+        return false;
+
+    m_imported_shared_image_buffer = &shared_image_buffer;
+    return true;
+}
+
+void WebContentView::initialize(QRhiCommandBuffer*)
+{
+    release_metal_resources();
+}
+
+void WebContentView::releaseResources()
+{
+    release_metal_resources();
+}
+
+void WebContentView::render(QRhiCommandBuffer* command_buffer)
+{
+    auto background_color = page_background_color();
+    auto clear_color = QColor(background_color.red(), background_color.green(), background_color.blue());
+
+    command_buffer->beginPass(renderTarget(), clear_color, { 1.0f, 0 }, nullptr, QRhiCommandBuffer::ExternalContent);
+
+    auto paintable = current_paintable();
+    if (!paintable.has_value() || paintable->bitmap_size.is_empty() || !rhi() || rhi()->backend() != QRhi::Metal) {
+        command_buffer->endPass();
+        return;
+    }
+
+    auto native_color_texture = colorTexture()->nativeTexture();
+    auto* render_target_texture = (id<MTLTexture>)native_color_texture.object;
+    if (!render_target_texture || !prepare_metal_renderer(render_target_texture.pixelFormat) || !update_imported_iosurface_texture(*paintable->shared_image_buffer)) {
+        command_buffer->endPass();
+        return;
+    }
+
+    auto target_size = colorTexture()->pixelSize();
+    auto content_width = min(paintable->bitmap_size.width(), target_size.width());
+    auto content_height = min(paintable->bitmap_size.height(), target_size.height());
+    if (content_width <= 0 || content_height <= 0) {
+        command_buffer->endPass();
+        return;
+    }
+
+    struct Uniforms {
+        float target_size[2];
+        float content_size[2];
+        float source_size[2];
+    } uniforms {
+        { static_cast<float>(target_size.width()), static_cast<float>(target_size.height()) },
+        { static_cast<float>(content_width), static_cast<float>(content_height) },
+        { static_cast<float>(paintable->shared_image_buffer->iosurface_handle().width()), static_cast<float>(paintable->shared_image_buffer->iosurface_handle().height()) },
+    };
+
+    // The pass was opened with ExternalContent so we can encode the Metal draw
+    // directly into Qt's command buffer.
+    command_buffer->beginExternal();
+    auto const* command_buffer_native_handles = static_cast<QRhiMetalCommandBufferNativeHandles const*>(command_buffer->nativeHandles());
+    if (command_buffer_native_handles && command_buffer_native_handles->encoder) {
+        auto* encoder = command_buffer_native_handles->encoder;
+        [encoder setRenderPipelineState:(id<MTLRenderPipelineState>)m_metal_pipeline_state];
+        [encoder setVertexBytes:&uniforms length:sizeof(uniforms) atIndex:0];
+        [encoder setFragmentTexture:(id<MTLTexture>)m_imported_iosurface_texture atIndex:0];
+        [encoder setFragmentSamplerState:(id<MTLSamplerState>)m_metal_sampler_state atIndex:0];
+        [encoder drawPrimitives:MTLPrimitiveTypeTriangleStrip vertexStart:0 vertexCount:4];
+    }
+    command_buffer->endExternal();
+
+    command_buffer->endPass();
+}
+
+}

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -13,6 +13,8 @@
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/Settings.h>
 
+#include <QtGlobal>
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 #    include <QStyleHints>
 #endif
@@ -42,6 +44,13 @@ bool is_using_dark_system_theme(QWidget& widget)
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
     AK::set_rich_debug_enabled(true);
+
+#ifdef AK_OS_MACOS
+    if (!qEnvironmentVariableIsSet("QT_WIDGETS_RHI"))
+        qputenv("QT_WIDGETS_RHI", "1");
+    if (!qEnvironmentVariableIsSet("QT_WIDGETS_RHI_BACKEND"))
+        qputenv("QT_WIDGETS_RHI_BACKEND", "metal");
+#endif
 
     auto app = TRY(Ladybird::Application::create(arguments));
     WebView::BrowserProcess browser_process;


### PR DESCRIPTION
This improves a few Qt UI behaviors around macOS browser windows and web content presentation.

Browser windows on macOS can now use rounded corners while custom chrome is active, with the setting hidden on other platforms. The web content view now uses `QRhiWidget` with Metal on macOS so IOSurface-backed frames can be presented through the GPU path instead of wrapping them in a `QImage`.

This also adds native pinch gesture handling for Qt, caches the fallback tab icon used by tabs without favicons, and makes a plain omnibox click select the serialized URL after mouse release.