### PR TITLE
LibJS: Add ordinary-object fast path to `CopyDataProperties`

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1522,8 +1522,11 @@ static bool shape_has_enumerable_string_property(Shape const& shape)
 {
     bool has_enumerable_string_property = false;
     shape.for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
-        if (property_key.is_string() && metadata.attributes.is_enumerable())
+        if (property_key.is_string() && metadata.attributes.is_enumerable()) {
             has_enumerable_string_property = true;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
     });
     return has_enumerable_string_property;
 }

--- a/Libraries/LibJS/Runtime/DescriptorArray.cpp
+++ b/Libraries/LibJS/Runtime/DescriptorArray.cpp
@@ -88,17 +88,6 @@ void DescriptorArray::remove(PropertyKey const& property_key, u32 descriptor_cou
     }
 }
 
-void DescriptorArray::for_each_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const& callback, u32 descriptor_count) const
-{
-    VERIFY(descriptor_count <= m_entry_indices_by_enum_index.size());
-    for (u32 enum_index = 0; enum_index < descriptor_count; ++enum_index) {
-        auto const& entry = m_entries[m_entry_indices_by_enum_index[enum_index]];
-        VERIFY(entry.enum_index == enum_index);
-        auto metadata = entry.metadata();
-        callback(entry.property_key, metadata);
-    }
-}
-
 void DescriptorArray::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Libraries/LibJS/Runtime/DescriptorArray.h
+++ b/Libraries/LibJS/Runtime/DescriptorArray.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Function.h>
+#include <AK/IterationDecision.h>
 #include <AK/NumericLimits.h>
 #include <AK/Vector.h>
 #include <LibJS/Export.h>
@@ -51,7 +51,22 @@ public:
     void set_attributes(PropertyKey const&, PropertyAttributes, u32 descriptor_count);
     void remove(PropertyKey const&, u32 descriptor_count);
 
-    void for_each_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const&, u32 descriptor_count) const;
+    template<typename Callback>
+    void for_each_in_insertion_order(Callback&& callback, u32 descriptor_count) const
+    {
+        VERIFY(descriptor_count <= m_entry_indices_by_enum_index.size());
+        for (u32 enum_index = 0; enum_index < descriptor_count; ++enum_index) {
+            auto const& entry = m_entries[m_entry_indices_by_enum_index[enum_index]];
+            VERIFY(entry.enum_index == enum_index);
+            auto metadata = entry.metadata();
+            if constexpr (IsSame<IterationDecision, decltype(callback(entry.property_key, metadata))>) {
+                if (callback(entry.property_key, metadata) == IterationDecision::Break)
+                    return;
+            } else {
+                callback(entry.property_key, metadata);
+            }
+        }
+    }
 
 private:
     virtual void visit_edges(Visitor&) override;

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -550,6 +550,42 @@ ThrowCompletionOr<void> Object::copy_data_properties(VM& vm, Value source, HashT
     // 2. Let from be ! ToObject(source).
     auto from = MUST(source.to_object(vm));
 
+    // OPTIMIZATION: For ordinary objects we can iterate the shape directly and read values by storage
+    //               offset, avoiding repeated property lookups through DescriptorArray::find.
+    if (from->eligible_for_own_property_enumeration_fast_path()
+        && !from->has_intrinsic_accessors()
+        && !from->may_interfere_with_indexed_property_access()
+        && excluded_values.is_empty()
+        && from->indexed_storage_kind() <= IndexedStorageKind::Packed) {
+
+        bool has_accessors = false;
+        from->shape().for_each_property_in_insertion_order([&](auto const&, auto const& metadata) {
+            if (metadata.attributes.is_enumerable() && from->get_direct(metadata.offset).is_accessor()) {
+                has_accessors = true;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+
+        if (!has_accessors) {
+            for (u32 i = 0; i < from->indexed_array_like_size(); ++i) {
+                if (!excluded_keys.is_empty() && excluded_keys.contains(PropertyKey(i)))
+                    continue;
+                MUST(create_data_property_or_throw(PropertyKey(i), from->m_indexed_elements[i]));
+            }
+
+            from->shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
+                if (!metadata.attributes.is_enumerable())
+                    return;
+                if (!excluded_keys.is_empty() && excluded_keys.contains(property_key))
+                    return;
+                MUST(create_data_property_or_throw(property_key, from->get_direct(metadata.offset)));
+            });
+
+            return {};
+        }
+    }
+
     // 3. Let keys be ? from.[[OwnPropertyKeys]]().
     auto keys = TRY(from->internal_own_property_keys());
 

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -358,18 +358,6 @@ Optional<PropertyMetadata> Shape::lookup(PropertyKey const& property_key) const
     return descriptors()->lookup(property_key, m_property_count);
 }
 
-void Shape::for_each_property_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const& callback) const
-{
-    if (m_dictionary) {
-        for (auto const& [property_key, metadata] : property_table())
-            callback(property_key, metadata);
-        return;
-    }
-    if (!descriptors())
-        return;
-    descriptors()->for_each_in_insertion_order(callback, m_property_count);
-}
-
 void Shape::ensure_descriptor_array()
 {
     VERIFY(!m_dictionary);

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/IterationDecision.h>
 #include <AK/OwnPtr.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
@@ -91,7 +92,24 @@ public:
     Object const* prototype() const { return m_prototype; }
 
     Optional<PropertyMetadata> lookup(PropertyKey const&) const;
-    void for_each_property_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const&) const;
+    template<typename Callback>
+    void for_each_property_in_insertion_order(Callback&& callback) const
+    {
+        if (m_dictionary) {
+            for (auto const& [property_key, metadata] : property_table()) {
+                if constexpr (IsSame<IterationDecision, decltype(callback(property_key, metadata))>) {
+                    if (callback(property_key, metadata) == IterationDecision::Break)
+                        return;
+                } else {
+                    callback(property_key, metadata);
+                }
+            }
+            return;
+        }
+        if (!descriptors())
+            return;
+        descriptors()->for_each_in_insertion_order(forward<Callback>(callback), m_property_count);
+    }
     u32 property_count() const { return m_property_count; }
 
     void set_prototype_without_transition(Object* new_prototype);


### PR DESCRIPTION
The `CopyDataProperties` AO is used to implement object spread syntax. The generic path calls `[[OwnPropertyKeys]]` to materialize a key list and then performs a separate lookup through ``DescriptorArray::find()` for every key.

For ordinary objects we now instead walk the shape in insertion order and read each value directly by its storage offset, avoiding both the key-list allocation and the per-key descriptor lookups. The fast path is guarded to ordinary objects with no intrinsic accessors, no exotic indexed access, packed-or-simpler indexed storage, and no excluded values, falling back to the generic algorithm otherwise.

This is roughly 2x faster on a tight object spread microbenchmark.

Gives a noticeable speedup on https://wheelofnames.com/randomness-audit, where profiling showed this to be a particularly hot operation.

No appreciable difference in benchmark results except the object spread microbenchmark that I added in https://github.com/LadybirdBrowser/js-benchmarks/pull/24.

```
Suite       Test                                      Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  --------------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                                 1.004  0.673 ± 0.652 … 0.693              0.670 ± 0.658 … 0.682
Kraken      audio-beat-detection.js                     1.004  0.514 ± 0.510 … 0.518              0.512 ± 0.506 … 0.519
Kraken      audio-dft.js                                1.012  0.356 ± 0.340 … 0.372              0.352 ± 0.345 … 0.359
Kraken      audio-fft.js                                1.009  0.442 ± 0.438 … 0.446              0.438 ± 0.424 … 0.453
Kraken      audio-oscillator.js                         1.01   0.375 ± 0.374 … 0.376              0.371 ± 0.370 … 0.372
Kraken      imaging-darkroom.js                         0.993  0.537 ± 0.534 … 0.541              0.541 ± 0.540 … 0.542
Kraken      imaging-desaturate.js                       1.063  0.629 ± 0.622 … 0.636              0.591 ± 0.573 … 0.610
Kraken      imaging-gaussian-blur.js                    0.972  2.588 ± 2.573 … 2.603              2.662 ± 2.608 … 2.716
Kraken      json-parse-financial.js                     1.029  0.051 ± 0.050 … 0.052              0.049 ± 0.049 … 0.050
Kraken      json-stringify-tinderbox.js                 0.983  0.049 ± 0.047 … 0.050              0.049 ± 0.049 … 0.050
Kraken      stanford-crypto-aes.js                      0.993  0.221 ± 0.218 … 0.225              0.223 ± 0.219 … 0.227
Kraken      stanford-crypto-ccm.js                      0.993  0.165 ± 0.164 … 0.165              0.166 ± 0.162 … 0.170
Kraken      stanford-crypto-pbkdf2.js                   1.022  0.390 ± 0.384 … 0.396              0.382 ± 0.381 … 0.382
Kraken      stanford-crypto-sha256-iterative.js         1.008  0.137 ± 0.136 … 0.138              0.136 ± 0.136 … 0.136
Octane      box2d.js                                    0.983  7643.500 ± 7606.000 … 7681.000     7512.500 ± 7479.000 … 7546.000
Octane      code-load.js                                1.031  24052.000 ± 23761.000 … 24343.000  24792.500 ± 24753.000 … 24832.000
Octane      crypto.js                                   0.991  2838.500 ± 2837.000 … 2840.000     2814.000 ± 2776.000 … 2852.000
Octane      deltablue.js                                0.999  2150.000 ± 2109.000 … 2191.000     2147.000 ± 2125.000 … 2169.000
Octane      earley-boyer.js                             0.948  4885.500 ± 4863.000 … 4908.000     4633.000 ± 4446.000 … 4820.000
Octane      gbemu.js                                    1.021  15624.000 ± 15343.000 … 15905.000  15953.500 ± 15919.000 … 15988.000
Octane      mandreel.js                                 0.995  16987.500 ± 16785.000 … 17190.000  16899.500 ± 16785.000 … 17014.000
Octane      navier-stokes.js                            0.98   5262.500 ± 5184.000 … 5341.000     5157.000 ± 5097.000 … 5217.000
Octane      pdfjs.js                                    0.98   7883.000 ± 7864.000 … 7902.000     7721.500 ± 7714.000 … 7729.000
Octane      raytrace.js                                 0.959  3325.000 ± 3310.000 … 3340.000     3188.500 ± 3169.000 … 3208.000
Octane      regexp.js                                   0.981  2019.500 ± 2017.000 … 2022.000     1982.000 ± 1980.000 … 1984.000
Octane      richards.js                                 1.02   2325.500 ± 2302.000 … 2349.000     2373.000 ± 2362.000 … 2384.000
Octane      splay.js                                    0.994  8304.500 ± 8173.000 … 8436.000     8257.500 ± 8224.000 … 8291.000
Octane      typescript.js                               0.982  21469.500 ± 21444.000 … 21495.000  21073.500 ± 21002.000 … 21145.000
Octane      zlib.js                                     1.005  5548.000 ± 5493.000 … 5603.000     5574.500 ± 5557.000 … 5592.000
JetStream   bigfib.cpp.js                               0.987  4.831 ± 4.745 … 4.916              4.893 ± 4.816 … 4.970
JetStream   cdjs.js                                     0.974  2.119 ± 2.117 … 2.121              2.176 ± 2.155 … 2.198
JetStream   container.cpp.js                            0.994  24.144 ± 24.042 … 24.247           24.295 ± 24.189 … 24.402
JetStream   dry.c.js                                    0.906  11.013 ± 10.960 … 11.065           12.149 ± 11.397 … 12.902
JetStream   float-mm.c.js                               0.98   12.412 ± 12.398 … 12.425           12.668 ± 12.374 … 12.961
JetStream   gcc-loops.cpp.js                            1.022  65.025 ± 63.672 … 66.377           63.643 ± 61.775 … 65.511
JetStream   hash-map.js                                 0.992  1.025 ± 1.020 … 1.029              1.033 ± 1.026 … 1.040
JetStream   n-body.c.js                                 1      17.065 ± 16.953 … 17.177           17.072 ± 16.934 … 17.210
JetStream   quicksort.c.js                              0.967  2.918 ± 2.879 … 2.957              3.019 ± 2.991 … 3.047
JetStream   towers.c.js                                 1.038  7.179 ± 7.019 … 7.339              6.916 ± 6.910 … 6.923
JetStream3  js-tokens.js                                1.03   0.257 ± 0.253 … 0.261              0.249 ± 0.244 … 0.255
JetStream3  lazy-collections.js                         1.031  0.838 ± 0.831 … 0.844              0.813 ± 0.802 … 0.823
JetStream3  raytrace-private-class-fields.js            0.998  3.573 ± 3.570 … 3.576              3.580 ± 3.529 … 3.630
JetStream3  raytrace-public-class-fields.js             0.996  2.384 ± 2.374 … 2.395              2.395 ± 2.364 … 2.426
JetStream3  sync-file-system.js                         1.008  1.836 ± 1.828 … 1.843              1.821 ± 1.821 … 1.821
MicroBench  array-destructuring-assignment-rest.js      1      0.322 ± 0.320 … 0.324              0.322 ± 0.319 … 0.325
MicroBench  array-destructuring-assignment.js           0.985  2.712 ± 2.702 … 2.721              2.752 ± 2.729 … 2.775
MicroBench  array-prototype-map.js                      0.996  1.199 ± 1.193 … 1.205              1.203 ± 1.199 … 1.207
MicroBench  array-prototype-shift.js                    1.057  0.007 ± 0.007 … 0.008              0.007 ± 0.007 … 0.007
MicroBench  bound-call-00-args.js                       1.098  1.546 ± 1.424 … 1.669              1.408 ± 1.405 … 1.412
MicroBench  bound-call-04-args.js                       1.013  1.543 ± 1.529 … 1.557              1.524 ± 1.522 … 1.526
MicroBench  bound-call-16-args.js                       1.071  1.825 ± 1.709 … 1.942              1.704 ± 1.701 … 1.707
MicroBench  call-00-args.js                             0.997  0.444 ± 0.444 … 0.445              0.446 ± 0.445 … 0.447
MicroBench  call-01-args.js                             1.027  0.460 ± 0.453 … 0.467              0.448 ± 0.448 … 0.449
MicroBench  call-02-args.js                             1.006  0.470 ± 0.470 … 0.471              0.467 ± 0.466 … 0.469
MicroBench  call-03-args.js                             1.006  0.484 ± 0.482 … 0.487              0.481 ± 0.479 … 0.483
MicroBench  call-04-args.js                             1.004  0.499 ± 0.498 … 0.501              0.497 ± 0.494 … 0.501
MicroBench  call-16-args.js                             1      0.712 ± 0.712 … 0.712              0.712 ± 0.709 … 0.716
MicroBench  call-32-args.js                             1.016  0.955 ± 0.955 … 0.956              0.941 ± 0.940 … 0.941
MicroBench  for-in-indexed-properties.js                0.978  0.172 ± 0.169 … 0.175              0.176 ± 0.172 … 0.179
MicroBench  for-in-named-properties.js                  0.978  0.165 ± 0.164 … 0.165              0.168 ± 0.166 … 0.171
MicroBench  for-of.js                                   1.022  0.526 ± 0.514 … 0.537              0.514 ± 0.497 … 0.531
MicroBench  object-keys.js                              1.002  1.345 ± 1.342 … 1.349              1.343 ± 1.339 … 1.347
MicroBench  object-set-with-rope-strings.js             1.011  0.466 ± 0.465 … 0.467              0.461 ± 0.460 … 0.462
MicroBench  object-spread.js                            2.137  3.252 ± 3.245 … 3.258              1.522 ± 1.521 … 1.523
MicroBench  pic-add-own.js                              1.019  0.450 ± 0.446 … 0.455              0.442 ± 0.438 … 0.446
MicroBench  pic-get-own.js                              1.005  0.514 ± 0.510 … 0.517              0.511 ± 0.509 … 0.513
MicroBench  pic-get-pchain.js                           1.045  0.549 ± 0.534 … 0.564              0.525 ± 0.525 … 0.526
MicroBench  pic-put-own.js                              1.017  0.538 ± 0.530 … 0.545              0.529 ± 0.526 … 0.532
MicroBench  pic-put-pchain.js                           1.031  1.983 ± 1.923 … 2.042              1.923 ± 1.921 … 1.924
MicroBench  setter-in-prototype-chain.js                0.934  1.934 ± 1.928 … 1.940              2.071 ± 1.924 … 2.217
MicroBench  strictly-equals-object.js                   0.96   0.820 ± 0.813 … 0.827              0.854 ± 0.826 … 0.881
Kraken      Total                                       0.998  7.127                              7.144
Octane      Total                                       0.998  130318.500                         130079.500
JetStream   Total                                       0.999  147.730                            147.865
JetStream3  Total                                       1.003  8.887                              8.857
MicroBench  Total                                       1.081  25.893                             23.952
All Suites  Total                                       1.007  254.373                            252.609
```

