### PR TITLE
UI/Qt: Fix macOS tab chrome polish and repaint churn

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -329,12 +329,26 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     menuBar()->addMenu(view_menu);
 
     auto* open_next_tab_action = new QAction("Open &Next Tab", this);
-    open_next_tab_action->setShortcuts({ QKeySequence(Qt::CTRL | Qt::Key_PageDown), QKeySequence(Qt::CTRL | Qt::Key_Tab) });
+    open_next_tab_action->setShortcuts({
+        QKeySequence(Qt::CTRL | Qt::Key_PageDown),
+        QKeySequence(Qt::CTRL | Qt::Key_Tab),
+#if defined(AK_OS_MACOS)
+        QKeySequence(Qt::META | Qt::Key_Tab),
+        QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_BracketRight),
+#endif
+    });
     view_menu->addAction(open_next_tab_action);
     QObject::connect(open_next_tab_action, &QAction::triggered, this, &BrowserWindow::open_next_tab);
 
     auto* open_previous_tab_action = new QAction("Open &Previous Tab", this);
-    open_previous_tab_action->setShortcuts({ QKeySequence(Qt::CTRL | Qt::Key_PageUp), QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Tab) });
+    open_previous_tab_action->setShortcuts({
+        QKeySequence(Qt::CTRL | Qt::Key_PageUp),
+        QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Tab),
+#if defined(AK_OS_MACOS)
+        QKeySequence(Qt::META | Qt::SHIFT | Qt::Key_Tab),
+        QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_BracketLeft),
+#endif
+    });
     view_menu->addAction(open_previous_tab_action);
     QObject::connect(open_previous_tab_action, &QAction::triggered, this, &BrowserWindow::open_previous_tab);
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -1099,10 +1099,16 @@ bool BrowserWindow::event(QEvent* event)
         connect_window_screen_changed_signal();
     if (event->type() == QEvent::PlatformSurface) {
         auto* platform_surface_event = static_cast<QPlatformSurfaceEvent*>(event);
-        if (platform_surface_event->surfaceEventType() == QPlatformSurfaceEvent::SurfaceCreated)
+        if (platform_surface_event->surfaceEventType() == QPlatformSurfaceEvent::SurfaceCreated) {
             connect_window_screen_changed_signal();
-        else if (platform_surface_event->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed)
+#if defined(AK_OS_MACOS)
+            QTimer::singleShot(0, this, [this] {
+                update_window_corners();
+            });
+#endif
+        } else if (platform_surface_event->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed) {
             disconnect_window_screen_changed_signal();
+        }
     }
     if (event->type() == QEvent::ScreenChangeInternal)
         screen_changed(screen());

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -193,6 +193,7 @@ TabBar::TabBar(TabWidget* tab_widget)
     });
     connect(this, &QTabBar::currentChanged, this, [this](int index) {
         ensure_tab_visible(index);
+        update_tab_button_geometry();
     });
 }
 
@@ -296,8 +297,6 @@ void TabBar::tabLayoutChange()
 
 void TabBar::paintEvent(QPaintEvent*)
 {
-    update_tab_button_geometry();
-
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
@@ -530,11 +529,7 @@ void TabBar::mousePressEvent(QMouseEvent* event)
 
 void TabBar::mouseMoveEvent(QMouseEvent* event)
 {
-    if (auto hovered_tab = tab_index_at(event->pos()); hovered_tab != m_hovered_tab_index) {
-        m_hovered_tab_index = hovered_tab;
-        start_hover_animation(hovered_tab, hovered_tab >= 0 ? 1.0 : 0.0);
-        update();
-    }
+    set_hovered_tab_index(tab_index_at(event->pos()));
 
     if (count() == 0) {
         if (tab_layout() == TabLayout::Horizontal)
@@ -561,10 +556,7 @@ void TabBar::mouseMoveEvent(QMouseEvent* event)
 
 void TabBar::leaveEvent(QEvent* event)
 {
-    auto previous_hovered_tab = m_hovered_tab_index;
-    m_hovered_tab_index = -1;
-    start_hover_animation(previous_hovered_tab, 0.0);
-    update();
+    set_hovered_tab_index(-1);
     QTabBar::leaveEvent(event);
 }
 
@@ -812,16 +804,36 @@ void TabBar::ensure_tab_visible(int index)
         set_vertical_scroll_offset(tab_bottom - height());
 }
 
+void TabBar::set_hovered_tab_index(int index)
+{
+    if (m_hovered_tab_index == index)
+        return;
+
+    auto previous_hovered_tab = m_hovered_tab_index;
+    m_hovered_tab_index = index;
+    update_tab_button_geometry();
+    start_hover_animation(index >= 0 ? index : previous_hovered_tab, index >= 0 ? 1.0 : 0.0);
+    update();
+}
+
 void TabBar::update_tab_button_geometry()
 {
     if (tab_layout() == TabLayout::Horizontal || tab_layout() == TabLayout::VerticalCollapsed)
         return;
 
+    // Keep this out of paintEvent(): setVisible(), setGeometry(), and raise()
+    // dirty child widgets, and doing that while painting can schedule another
+    // tab bar repaint before the current one has finished flushing.
     auto place_button = [&](int index, QTabBar::ButtonPosition position, QRect shape_rect) {
         auto* button = tabButton(index, position);
         if (!button)
             return;
-        button->setVisible(position != QTabBar::RightSide || index == currentIndex() || index == m_hovered_tab_index);
+        auto should_be_visible = position != QTabBar::RightSide || index == currentIndex() || index == m_hovered_tab_index;
+        bool did_update_button = false;
+        if (button->isVisible() != should_be_visible) {
+            button->setVisible(should_be_visible);
+            did_update_button = true;
+        }
 
         auto button_size = button->size();
         if (button_size.isEmpty())
@@ -831,8 +843,14 @@ void TabBar::update_tab_button_geometry()
 
         auto x = position == QTabBar::RightSide ? shape_rect.right() - button_size.width() - 6 : shape_rect.left() + 6;
         auto y = shape_rect.top() + ((shape_rect.height() - button_size.height()) / 2);
-        button->setGeometry({ { x, y }, button_size });
-        button->raise();
+        QRect button_geometry { { x, y }, button_size };
+        if (button->geometry() != button_geometry) {
+            button->setGeometry(button_geometry);
+            did_update_button = true;
+        }
+
+        if (did_update_button)
+            button->raise();
     };
 
     for (int index = 0; index < count(); ++index) {

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -55,7 +55,10 @@ static constexpr int VERTICAL_TABS_DEFAULT_EXPANDED_WIDTH = 232;
 static constexpr int VERTICAL_TABS_MIN_EXPANDED_WIDTH = 190;
 static constexpr int VERTICAL_TABS_MAX_EXPANDED_WIDTH = 400;
 static constexpr int VERTICAL_TABS_RESIZE_HIT_AREA_WIDTH = 5;
-static constexpr int VERTICAL_TABS_SIDE_MARGIN = 6;
+static constexpr int VERTICAL_TABS_COLLAPSED_SIDE_MARGIN = 6;
+static constexpr int VERTICAL_TABS_EXPANDED_SIDE_MARGIN = 5;
+static constexpr int VERTICAL_TAB_SHAPE_HORIZONTAL_INSET = 5;
+static constexpr int VERTICAL_TAB_CONTENT_HORIZONTAL_INSET = 8;
 static constexpr int TAB_ICON_SIZE = 16;
 static constexpr auto VERTICAL_TABS_EXPANDED_PROPERTY = "verticalTabsExpanded";
 static constexpr auto VERTICAL_TABS_RESIZE_HANDLE_HOVERED_PROPERTY = "hovered";
@@ -91,17 +94,32 @@ static void clear_layout(QLayout& layout)
         delete item;
 }
 
+static constexpr int vertical_tabs_side_margin(bool expanded)
+{
+    return expanded ? VERTICAL_TABS_EXPANDED_SIDE_MARGIN : VERTICAL_TABS_COLLAPSED_SIDE_MARGIN;
+}
+
 static constexpr int vertical_tab_width(int available_width, TabLayout tab_layout)
 {
     if (available_width > 0)
         return available_width;
     auto width = tab_layout == TabLayout::VerticalCollapsed ? VERTICAL_TABS_COLLAPSED_WIDTH : VERTICAL_TABS_DEFAULT_EXPANDED_WIDTH;
-    return width - (VERTICAL_TABS_SIDE_MARGIN * 2);
+    return width - (vertical_tabs_side_margin(tab_layout != TabLayout::VerticalCollapsed) * 2);
 }
 
 static constexpr int clamp_vertical_tabs_expanded_width(int width)
 {
     return clamp(width, VERTICAL_TABS_MIN_EXPANDED_WIDTH, VERTICAL_TABS_MAX_EXPANDED_WIDTH);
+}
+
+static QRectF expanded_vertical_tab_shape_rect(QRectF const& rect)
+{
+    return rect.adjusted(VERTICAL_TAB_SHAPE_HORIZONTAL_INSET, 3.0, -VERTICAL_TAB_SHAPE_HORIZONTAL_INSET, -3.0);
+}
+
+static QRect expanded_vertical_tab_shape_rect(QRect const& rect)
+{
+    return rect.adjusted(VERTICAL_TAB_SHAPE_HORIZONTAL_INSET, 3, -VERTICAL_TAB_SHAPE_HORIZONTAL_INSET, -3);
 }
 
 class NewTabButton final : public QToolButton {
@@ -125,7 +143,7 @@ private:
 
         auto dark = ChromeStyle::is_dark(palette());
         auto surface = ChromeStyle::chrome_surface(palette());
-        auto shape_rect = QRectF(rect()).adjusted(7.0, 3.0, -7.0, -3.0);
+        auto shape_rect = expanded_vertical_tab_shape_rect(QRectF(rect()));
         auto tab_path = tab_shape_path(shape_rect, 9.0, 9.0);
 
         if (isDown()) {
@@ -140,7 +158,7 @@ private:
             painter.drawPath(tab_path);
         }
 
-        auto contents_rect = shape_rect.toAlignedRect().adjusted(12, 0, -12, 0);
+        auto contents_rect = shape_rect.toAlignedRect().adjusted(VERTICAL_TAB_CONTENT_HORIZONTAL_INSET, 0, -VERTICAL_TAB_CONTENT_HORIZONTAL_INSET, 0);
         QRect icon_rect {
             contents_rect.left(),
             contents_rect.top() + ((contents_rect.height() - TAB_ICON_SIZE) / 2),
@@ -324,7 +342,7 @@ void TabBar::paintEvent(QPaintEvent*)
         if (is_collapsed_vertical)
             shape_rect = QRectF(tab_rect).adjusted(4.0, 3.0, -4.0, -3.0);
         else if (is_vertical)
-            shape_rect = QRectF(tab_rect).adjusted(7.0, 3.0, -7.0, -3.0);
+            shape_rect = expanded_vertical_tab_shape_rect(QRectF(tab_rect));
         else
             shape_rect = QRectF(tab_rect).adjusted(3.0, 2.0, -3.0, 1.0);
         auto tab_path = tab_shape_path(shape_rect, 9.0, is_vertical ? 9.0 : 8.0);
@@ -385,7 +403,7 @@ void TabBar::paintEvent(QPaintEvent*)
             continue;
         }
 
-        auto contents_rect = shape_rect.toAlignedRect().adjusted(is_vertical ? 12 : 16, 0, is_vertical ? -12 : -14, 0);
+        auto contents_rect = shape_rect.toAlignedRect().adjusted(is_vertical ? VERTICAL_TAB_CONTENT_HORIZONTAL_INSET : 16, 0, is_vertical ? -VERTICAL_TAB_CONTENT_HORIZONTAL_INSET : -14, 0);
         if (auto* left_button = tabButton(index, QTabBar::LeftSide); left_button && left_button->isVisible())
             contents_rect.setLeft(max(contents_rect.left(), left_button->geometry().right() + 6));
         if (auto* right_button = tabButton(index, QTabBar::RightSide); right_button && right_button->isVisible())
@@ -858,7 +876,7 @@ void TabBar::update_tab_button_geometry()
         if (!tab_rect.isValid())
             continue;
 
-        auto shape_rect = tab_rect.adjusted(7, 3, -7, -3);
+        auto shape_rect = expanded_vertical_tab_shape_rect(tab_rect);
         place_button(index, QTabBar::LeftSide, shape_rect);
         place_button(index, QTabBar::RightSide, shape_rect);
     }
@@ -1312,7 +1330,8 @@ void TabWidget::rebuild_layout_for_vertical_tabs()
     m_vertical_tab_bar_column->setFixedWidth(side_bar_width);
 
     m_vertical_tab_bar_column_layout->setSpacing(m_vertical_tabs_expanded ? 0 : 4);
-    m_vertical_tab_bar_column_layout->setContentsMargins(VERTICAL_TABS_SIDE_MARGIN, 8, VERTICAL_TABS_SIDE_MARGIN, 8);
+    auto side_margin = vertical_tabs_side_margin(m_vertical_tabs_expanded);
+    m_vertical_tab_bar_column_layout->setContentsMargins(side_margin, 8, side_margin, 8);
 
     m_new_tab_button->setToolButtonStyle(m_vertical_tabs_expanded ? Qt::ToolButtonTextBesideIcon : Qt::ToolButtonIconOnly);
     update_vertical_tabs_action_labels();
@@ -1398,7 +1417,7 @@ void TabWidget::update_tab_layout()
     if (m_tab_bar->tab_layout() != TabLayout::Horizontal) {
         auto side_bar_width = current_vertical_tabs_width();
         m_vertical_tab_bar_column->setFixedWidth(side_bar_width);
-        m_tab_bar->set_available_width(side_bar_width - (VERTICAL_TABS_SIDE_MARGIN * 2));
+        m_tab_bar->set_available_width(side_bar_width - (vertical_tabs_side_margin(m_vertical_tabs_expanded) * 2));
         update_vertical_tabs_resize_handle();
         return;
     }

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -106,7 +106,11 @@ static constexpr int clamp_vertical_tabs_expanded_width(int width)
 
 class NewTabButton final : public QToolButton {
 public:
-    using QToolButton::QToolButton;
+    explicit NewTabButton(QTabBar& tab_bar, QWidget* parent)
+        : QToolButton(parent)
+        , m_tab_bar(tab_bar)
+    {
+    }
 
 private:
     virtual void paintEvent(QPaintEvent* event) override
@@ -153,13 +157,16 @@ private:
         if (underMouse() || isDown())
             text_color = ChromeStyle::chrome_button_text(palette());
         painter.setPen(text_color);
-        painter.setFont(font());
+        auto text_font = m_tab_bar.font();
+        painter.setFont(text_font);
 
-        QFontMetrics font_metrics(font());
+        QFontMetrics font_metrics(text_font);
         auto title = font_metrics.elidedText(text(), Qt::ElideRight, max(0, contents_rect.width()));
         contents_rect.translate(0, -1);
         painter.drawText(contents_rect, Qt::AlignLeft | Qt::AlignVCenter, title);
     }
+
+    QTabBar& m_tab_bar;
 };
 
 TabBar::TabBar(TabWidget* tab_widget)
@@ -875,7 +882,7 @@ TabWidget::TabWidget(QWidget* parent)
 
     m_stacked_widget = new QStackedWidget(this);
 
-    m_new_tab_button = new NewTabButton(this);
+    m_new_tab_button = new NewTabButton(*m_tab_bar, this);
     m_new_tab_button->setObjectName("LadybirdNewTabButton");
     m_new_tab_button->setIconSize(QSize(18, 18));
     m_new_tab_button->setFixedSize(32, 32);

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -93,6 +93,7 @@ private:
     int max_vertical_scroll_offset() const;
     void set_vertical_scroll_offset(int);
 
+    void set_hovered_tab_index(int);
     void ensure_tab_visible(int index);
     void update_tab_button_geometry();
 

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -423,6 +423,17 @@ static bool is_browser_reserved_shortcut(QKeyEvent const& event)
     if (modifiers == (Qt::ControlModifier | Qt::ShiftModifier) && (key == Qt::Key_Tab || key == Qt::Key_Backtab))
         return true;
 
+#if defined(AK_OS_MACOS)
+    if (modifiers == Qt::MetaModifier && key == Qt::Key_Tab)
+        return true;
+
+    if (modifiers == (Qt::MetaModifier | Qt::ShiftModifier) && (key == Qt::Key_Tab || key == Qt::Key_Backtab))
+        return true;
+
+    if (modifiers == (Qt::ControlModifier | Qt::ShiftModifier) && (key == Qt::Key_BracketLeft || key == Qt::Key_BracketRight))
+        return true;
+#endif
+
     if (modifiers == Qt::ControlModifier && key == Qt::Key_PageUp)
         return true;
 

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -53,10 +53,25 @@ namespace Ladybird {
 
 bool is_using_dark_system_theme(QWidget&);
 
-WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index, WebContentViewInitialState initial_state)
-    : WebContentViewBase(window)
+static QWidget* initial_web_content_view_parent([[maybe_unused]] QWidget* window)
 {
 #ifdef AK_OS_MACOS
+    return nullptr;
+#else
+    return window;
+#endif
+}
+
+WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index, WebContentViewInitialState initial_state)
+    : WebContentViewBase(initial_web_content_view_parent(window))
+{
+#ifdef AK_OS_MACOS
+    // Keep the QRhiWidget out of the top-level QWidget backing store. If it is
+    // parented before becoming native, Qt propagates its RHI config to the whole
+    // browser window and uploads the full backing store texture on chrome repaints.
+    setAttribute(Qt::WA_DontCreateNativeAncestors);
+    setAttribute(Qt::WA_NativeWindow);
+    setParent(window);
     setApi(QRhiWidget::Api::Metal);
 #endif
 

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -13,6 +13,7 @@
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/Settings.h>
 
+#include <QCoreApplication>
 #include <QtGlobal>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
@@ -46,10 +47,9 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     AK::set_rich_debug_enabled(true);
 
 #ifdef AK_OS_MACOS
-    if (!qEnvironmentVariableIsSet("QT_WIDGETS_RHI"))
-        qputenv("QT_WIDGETS_RHI", "1");
-    if (!qEnvironmentVariableIsSet("QT_WIDGETS_RHI_BACKEND"))
-        qputenv("QT_WIDGETS_RHI_BACKEND", "metal");
+    // The web content view is a native QRhiWidget child. Keep it from forcing
+    // every sibling in the tab UI to become native as well.
+    QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 #endif
 
     auto app = TRY(Ladybird::Application::create(arguments));


### PR DESCRIPTION
This fixes a handful of Qt UI issues found while testing the macOS chrome:

- Match the expanded vertical “New Tab” button font to the tab bar font.
- Add macOS tab-switching shortcuts for Command+Shift+[ / ] and the browser-reserved Control+Tab variants.
- Reapply rounded window corners after Qt creates the platform surface.
- Keep the top-level macOS chrome on the normal QWidget backing-store path while WebContentView uses Metal through QRhiWidget.
- Move vertical tab button geometry updates out of paintEvent() to avoid a self-sustaining repaint loop.