### PR TITLE
DevTools: Support navigation

### DIFF
--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -7,6 +7,7 @@
 #include <AK/Enumerate.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
+#include <LibCore/EventLoop.h>
 #include <LibDevTools/Actors/AccessibilityActor.h>
 #include <LibDevTools/Actors/CSSPropertiesActor.h>
 #include <LibDevTools/Actors/ConsoleActor.h>
@@ -16,20 +17,22 @@
 #include <LibDevTools/Actors/StyleSheetsActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/ThreadActor.h>
+#include <LibDevTools/Actors/WatcherActor.h>
 #include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/DevToolsServer.h>
 #include <LibWebView/ConsoleOutput.h>
 
 namespace DevTools {
 
-NonnullRefPtr<FrameActor> FrameActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<ConsoleActor> console, WeakPtr<InspectorActor> inspector, WeakPtr<StyleSheetsActor> style_sheets, WeakPtr<ThreadActor> thread, WeakPtr<AccessibilityActor> accessibility)
+NonnullRefPtr<FrameActor> FrameActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<WatcherActor> watcher, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<ConsoleActor> console, WeakPtr<InspectorActor> inspector, WeakPtr<StyleSheetsActor> style_sheets, WeakPtr<ThreadActor> thread, WeakPtr<AccessibilityActor> accessibility)
 {
-    return adopt_ref(*new FrameActor(devtools, move(name), move(tab), move(css_properties), move(console), move(inspector), move(style_sheets), move(thread), move(accessibility)));
+    return adopt_ref(*new FrameActor(devtools, move(name), move(tab), move(watcher), move(css_properties), move(console), move(inspector), move(style_sheets), move(thread), move(accessibility)));
 }
 
-FrameActor::FrameActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<ConsoleActor> console, WeakPtr<InspectorActor> inspector, WeakPtr<StyleSheetsActor> style_sheets, WeakPtr<ThreadActor> thread, WeakPtr<AccessibilityActor> accessibility)
+FrameActor::FrameActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<WatcherActor> watcher, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<ConsoleActor> console, WeakPtr<InspectorActor> inspector, WeakPtr<StyleSheetsActor> style_sheets, WeakPtr<ThreadActor> thread, WeakPtr<AccessibilityActor> accessibility)
     : Actor(devtools, move(name))
     , m_tab(move(tab))
+    , m_watcher(move(watcher))
     , m_css_properties(move(css_properties))
     , m_console(move(console))
     , m_inspector(move(inspector))
@@ -38,11 +41,6 @@ FrameActor::FrameActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> 
     , m_accessibility(move(accessibility))
 {
     if (auto tab = m_tab.strong_ref()) {
-        // NB: We must notify WebContent that DevTools is connected before setting up listeners,
-        //     so that WebContent knows to start sending network response bodies over IPC.
-        //     IPC messages are processed in order, so this is guaranteed to arrive first.
-        devtools.delegate().did_connect_devtools_client(tab->description());
-
         devtools.delegate().listen_for_console_messages(
             tab->description(),
             weak_callback(*this, [](auto& self, WebView::ConsoleOutput console_output) {
@@ -50,10 +48,14 @@ FrameActor::FrameActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> 
             }));
 
         // FIXME: We should adopt WebContent to inform us when style sheets are available or removed.
-        devtools.delegate().retrieve_style_sheets(tab->description(),
-            async_handler<FrameActor>({}, [](auto& self, auto style_sheets, auto& response) {
-                self.style_sheets_available(response, move(style_sheets));
-            }));
+        Core::deferred_invoke([weak_self = make_weak_ptr<FrameActor>(), tab] {
+            if (auto self = weak_self.strong_ref()) {
+                self->devtools().delegate().retrieve_style_sheets(tab->description(),
+                    self->async_handler<FrameActor>({}, [](auto& self, auto style_sheets, auto& response) {
+                        self.style_sheets_available(response, move(style_sheets));
+                    }));
+            }
+        });
 
         devtools.delegate().listen_for_network_events(
             tab->description(),
@@ -78,17 +80,28 @@ FrameActor::FrameActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> 
             weak_callback(*this, [](auto& self, String url, String title) {
                 self.on_navigation_finished(move(url), move(title));
             }));
+
+        m_is_listening = true;
     }
 }
 
 FrameActor::~FrameActor()
 {
+    stop_listening();
+}
+
+void FrameActor::stop_listening()
+{
+    if (!m_is_listening)
+        return;
+
     if (auto tab = m_tab.strong_ref()) {
         devtools().delegate().stop_listening_for_console_messages(tab->description());
         devtools().delegate().stop_listening_for_network_events(tab->description());
         devtools().delegate().stop_listening_for_navigation_events(tab->description());
-        devtools().delegate().did_disconnect_devtools_client(tab->description());
     }
+
+    m_is_listening = false;
 }
 
 void FrameActor::handle_message(Message const& message)
@@ -110,6 +123,7 @@ void FrameActor::handle_message(Message const& message)
 
     if (message.type == "listFrames"sv) {
         send_response(message, move(response));
+        send_pending_navigation_document_events_after_target_switch();
         return;
     }
 
@@ -134,6 +148,25 @@ void FrameActor::send_frame_update_message()
     send_message(move(message));
 }
 
+void FrameActor::set_pending_navigation_document_events_after_target_switch(String const& url, String const& title)
+{
+    m_pending_navigation_document_events_after_target_switch = PendingNavigationDocumentEvents {
+        .url = url,
+        .title = title,
+    };
+}
+
+void FrameActor::send_pending_navigation_document_events_after_target_switch()
+{
+    if (!m_pending_navigation_document_events_after_target_switch.has_value())
+        return;
+
+    auto pending_events = m_pending_navigation_document_events_after_target_switch.release_value();
+    send_document_event("dom-loading"sv, pending_events.url);
+    send_document_event("dom-interactive"sv, pending_events.url, pending_events.title);
+    send_document_event("dom-complete"sv, pending_events.url);
+}
+
 JsonObject FrameActor::serialize_target() const
 {
     JsonObject traits;
@@ -152,7 +185,13 @@ JsonObject FrameActor::serialize_target() const
         target.set("title"sv, tab_actor->description().title);
         target.set("url"sv, tab_actor->description().url);
         target.set("browsingContextID"sv, tab_actor->description().id);
+        target.set("followWindowGlobalLifeCycle"sv, true);
+        target.set("innerWindowId"sv, tab_actor->inner_window_id());
+        target.set("isPopup"sv, false);
+        target.set("isPrivate"sv, false);
         target.set("outerWindowID"sv, tab_actor->description().id);
+        target.set("processID"sv, 1);
+        target.set("topInnerWindowId"sv, tab_actor->inner_window_id());
         target.set("isTopLevelTarget"sv, true);
     }
 
@@ -506,21 +545,20 @@ void FrameActor::on_network_request_finished(DevToolsDelegate::NetworkRequestCom
     send_message(move(message));
 }
 
-void FrameActor::on_navigation_started(String url)
+void FrameActor::send_document_event(StringView name, String const& url, Optional<StringView> title)
 {
-    if (auto inspector = m_inspector.strong_ref())
-        inspector->on_navigation_started();
-
-    // Clear our internal tracking of network events
-    m_network_events.clear();
-
-    // Send will-navigate document event to trigger network panel clear
     JsonObject document_event;
     document_event.set("resourceType"sv, "document-event"sv);
-    document_event.set("name"sv, "will-navigate"sv);
+    document_event.set("name"sv, name);
     document_event.set("time"sv, UnixDateTime::now().milliseconds_since_epoch());
-    document_event.set("newURI"sv, url);
     document_event.set("isFrameSwitching"sv, false);
+
+    if (name == "will-navigate"sv)
+        document_event.set("newURI"sv, url);
+    if (name == "dom-loading"sv || name == "dom-interactive"sv)
+        document_event.set("url"sv, url);
+    if (title.has_value())
+        document_event.set("title"sv, title.value());
 
     JsonArray events;
     events.must_append(move(document_event));
@@ -536,34 +574,37 @@ void FrameActor::on_navigation_started(String url)
     resources_message.set("type"sv, "resources-available-array"sv);
     resources_message.set("array"sv, move(array));
     send_message(move(resources_message));
+}
 
-    // Also send tabNavigated for backwards compatibility
-    JsonObject message;
-    message.set("type"sv, "tabNavigated"sv);
-    message.set("url"sv, move(url));
-    message.set("state"sv, "start"sv);
-    message.set("isFrameSwitching"sv, false);
-    send_message(move(message));
+void FrameActor::on_navigation_started(String url)
+{
+    if (auto inspector = m_inspector.strong_ref())
+        inspector->on_navigation_started();
+
+    // Clear our internal tracking of network events
+    m_network_events.clear();
+
+    send_document_event("will-navigate"sv, url);
 }
 
 void FrameActor::on_navigation_finished(String url, String title)
 {
     // Update the tab description with the new URL and title
-    if (auto tab = m_tab.strong_ref()) {
-        tab->set_url(url);
-        tab->set_title(title);
-    }
+    if (auto tab = m_tab.strong_ref())
+        tab->navigate_to(url, title);
 
-    JsonObject message;
-    message.set("type"sv, "tabNavigated"sv);
-    message.set("url"sv, move(url));
-    message.set("title"sv, move(title));
-    message.set("state"sv, "stop"sv);
-    message.set("isFrameSwitching"sv, false);
-    send_message(move(message));
+    if (auto inspector = m_inspector.strong_ref())
+        inspector->on_navigation_finished();
 
-    // Also send a frameUpdate message to update the frame info
-    send_frame_update_message();
+    auto finished_url = url;
+    auto finished_title = title;
+
+    Core::deferred_invoke([watcher = m_watcher, target = make_weak_ptr<FrameActor>(), url = move(finished_url), title = move(finished_title)] {
+        auto strong_watcher = watcher.strong_ref();
+        auto strong_target = target.strong_ref();
+        if (strong_watcher && strong_target)
+            strong_watcher->switch_frame_target(*strong_target, url, title);
+    });
 }
 
 }

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -133,6 +133,22 @@ void FrameActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "goBack"sv) {
+        if (auto tab = m_tab.strong_ref())
+            devtools().delegate().traverse_the_history_by_delta(tab->description(), -1);
+
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "goForward"sv) {
+        if (auto tab = m_tab.strong_ref())
+            devtools().delegate().traverse_the_history_by_delta(tab->description(), 1);
+
+        send_response(message, move(response));
+        return;
+    }
+
     if (message.type == "listFrames"sv) {
         send_response(message, move(response));
         send_pending_navigation_document_events_after_target_switch();

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -508,6 +508,9 @@ void FrameActor::on_network_request_finished(DevToolsDelegate::NetworkRequestCom
 
 void FrameActor::on_navigation_started(String url)
 {
+    if (auto inspector = m_inspector.strong_ref())
+        inspector->on_navigation_started();
+
     // Clear our internal tracking of network events
     m_network_events.clear();
 

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -121,6 +121,18 @@ void FrameActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "reload"sv) {
+        bool bypass_cache = false;
+        if (auto options = message.data.get_object("options"sv); options.has_value())
+            bypass_cache = options->get_bool("force"sv).value_or(false);
+
+        if (auto tab = m_tab.strong_ref())
+            devtools().delegate().reload_tab(tab->description(), bypass_cache);
+
+        send_response(message, move(response));
+        return;
+    }
+
     if (message.type == "listFrames"sv) {
         send_response(message, move(response));
         send_pending_navigation_document_events_after_target_switch();

--- a/Libraries/LibDevTools/Actors/FrameActor.h
+++ b/Libraries/LibDevTools/Actors/FrameActor.h
@@ -22,15 +22,17 @@ class DEVTOOLS_API FrameActor final : public Actor {
 public:
     static constexpr auto base_name = "frame"sv;
 
-    static NonnullRefPtr<FrameActor> create(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<ConsoleActor>, WeakPtr<InspectorActor>, WeakPtr<StyleSheetsActor>, WeakPtr<ThreadActor>, WeakPtr<AccessibilityActor>);
+    static NonnullRefPtr<FrameActor> create(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<WatcherActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<ConsoleActor>, WeakPtr<InspectorActor>, WeakPtr<StyleSheetsActor>, WeakPtr<ThreadActor>, WeakPtr<AccessibilityActor>);
     virtual ~FrameActor() override;
 
     void send_frame_update_message();
+    void set_pending_navigation_document_events_after_target_switch(String const& url, String const& title);
+    void stop_listening();
 
     JsonObject serialize_target() const;
 
 private:
-    FrameActor(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<ConsoleActor>, WeakPtr<InspectorActor>, WeakPtr<StyleSheetsActor>, WeakPtr<ThreadActor>, WeakPtr<AccessibilityActor>);
+    FrameActor(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<WatcherActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<ConsoleActor>, WeakPtr<InspectorActor>, WeakPtr<StyleSheetsActor>, WeakPtr<ThreadActor>, WeakPtr<AccessibilityActor>);
 
     void style_sheets_available(JsonObject& response, Vector<Web::CSS::StyleSheetIdentifier> style_sheets);
 
@@ -45,8 +47,16 @@ private:
 
     void on_navigation_started(String url);
     void on_navigation_finished(String url, String title);
+    void send_document_event(StringView name, String const& url, Optional<StringView> title = {});
+    void send_pending_navigation_document_events_after_target_switch();
+
+    struct PendingNavigationDocumentEvents {
+        String url;
+        String title;
+    };
 
     WeakPtr<TabActor> m_tab;
+    WeakPtr<WatcherActor> m_watcher;
 
     WeakPtr<CSSPropertiesActor> m_css_properties;
     WeakPtr<ConsoleActor> m_console;
@@ -55,7 +65,9 @@ private:
     WeakPtr<ThreadActor> m_thread;
     WeakPtr<AccessibilityActor> m_accessibility;
 
+    Optional<PendingNavigationDocumentEvents> m_pending_navigation_document_events_after_target_switch;
     HashMap<u64, NonnullRefPtr<NetworkEventActor>> m_network_events;
+    bool m_is_listening { false };
 };
 
 }

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -99,6 +99,30 @@ void InspectorActor::on_navigation_started()
         tab->reset_selected_node();
 }
 
+void InspectorActor::on_navigation_finished()
+{
+    auto walker = m_walker.strong_ref();
+    auto tab = m_tab.strong_ref();
+    if (!walker || !tab)
+        return;
+
+    devtools().delegate().inspect_tab(tab->description(),
+        weak_callback(*this, [walker](auto&, auto dom_tree) {
+            if (dom_tree.is_error()) {
+                dbgln_if(DEVTOOLS_DEBUG, "Error inspecting tab after navigation: {}", dom_tree.error());
+                return;
+            }
+
+            auto value = dom_tree.release_value();
+            if (!WalkerActor::is_suitable_for_dom_inspection(value)) {
+                dbgln_if(DEVTOOLS_DEBUG, "Did not receive a suitable DOM tree: {}", value);
+                return;
+            }
+
+            walker->replace_dom_tree(move(value.as_object()));
+        }));
+}
+
 RefPtr<TabActor> InspectorActor::tab_for(WeakPtr<InspectorActor> const& weak_inspector)
 {
     if (auto inspector = weak_inspector.strong_ref())

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -91,6 +91,14 @@ void InspectorActor::received_dom_tree(JsonObject& response, JsonObject dom_tree
     response.set("walker"sv, move(walker));
 }
 
+void InspectorActor::on_navigation_started()
+{
+    if (auto walker = m_walker.strong_ref())
+        walker->document_unloaded();
+    if (auto tab = m_tab.strong_ref())
+        tab->reset_selected_node();
+}
+
 RefPtr<TabActor> InspectorActor::tab_for(WeakPtr<InspectorActor> const& weak_inspector)
 {
     if (auto inspector = weak_inspector.strong_ref())

--- a/Libraries/LibDevTools/Actors/InspectorActor.h
+++ b/Libraries/LibDevTools/Actors/InspectorActor.h
@@ -22,6 +22,8 @@ public:
     static RefPtr<TabActor> tab_for(WeakPtr<InspectorActor> const&);
     static RefPtr<WalkerActor> walker_for(WeakPtr<InspectorActor> const&);
 
+    void on_navigation_started();
+
 private:
     InspectorActor(DevToolsServer&, String name, WeakPtr<TabActor>);
 

--- a/Libraries/LibDevTools/Actors/InspectorActor.h
+++ b/Libraries/LibDevTools/Actors/InspectorActor.h
@@ -23,6 +23,7 @@ public:
     static RefPtr<WalkerActor> walker_for(WeakPtr<InspectorActor> const&);
 
     void on_navigation_started();
+    void on_navigation_finished();
 
 private:
     InspectorActor(DevToolsServer&, String name, WeakPtr<TabActor>);

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -78,4 +78,11 @@ void TabActor::reset_selected_node()
     devtools().delegate().clear_inspected_dom_node(description());
 }
 
+void TabActor::navigate_to(String url, String title)
+{
+    m_description.url = move(url);
+    m_description.title = move(title);
+    ++m_inner_window_id;
+}
+
 }

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -50,6 +50,13 @@ void TabActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "reloadDescriptor"sv) {
+        auto bypass_cache = message.data.get_bool("bypassCache"sv).value_or(false);
+        devtools().delegate().reload_tab(m_description, bypass_cache);
+        send_response(message, move(response));
+        return;
+    }
+
     send_unrecognized_packet_type_error(message);
 }
 

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -57,6 +57,18 @@ void TabActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "goBack"sv) {
+        devtools().delegate().traverse_the_history_by_delta(m_description, -1);
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "goForward"sv) {
+        devtools().delegate().traverse_the_history_by_delta(m_description, 1);
+        send_response(message, move(response));
+        return;
+    }
+
     send_unrecognized_packet_type_error(message);
 }
 
@@ -65,6 +77,7 @@ JsonObject TabActor::serialize_description() const
     JsonObject traits;
     traits.set("watcher"sv, true);
     traits.set("supportsReloadDescriptor"sv, true);
+    traits.set("supportsNavigation"sv, true);
 
     // FIXME: We are using the tab's ID multiple times here. This is likely not correct, as both Firefox and Servo
     //        provide different IDs for browserId, browsingContextID, and outerWindowID.

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -57,6 +57,16 @@ void TabActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "navigateTo"sv) {
+        auto url = get_required_parameter<String>(message, "url"sv);
+        if (!url.has_value())
+            return;
+
+        devtools().delegate().navigate_tab(m_description, *url);
+        send_response(message, move(response));
+        return;
+    }
+
     if (message.type == "goBack"sv) {
         devtools().delegate().traverse_the_history_by_delta(m_description, -1);
         send_response(message, move(response));

--- a/Libraries/LibDevTools/Actors/TabActor.h
+++ b/Libraries/LibDevTools/Actors/TabActor.h
@@ -28,9 +28,9 @@ public:
 
     TabDescription const& description() const { return m_description; }
     JsonObject serialize_description() const;
+    u64 inner_window_id() const { return m_inner_window_id; }
 
-    void set_url(String url) { m_description.url = move(url); }
-    void set_title(String title) { m_description.title = move(title); }
+    void navigate_to(String url, String title);
 
     void reset_selected_node();
 
@@ -40,6 +40,7 @@ private:
     virtual void handle_message(Message const&) override;
 
     TabDescription m_description;
+    u64 m_inner_window_id { 1 };
     WeakPtr<WatcherActor> m_watcher;
 };
 

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -542,6 +542,9 @@ bool WalkerActor::is_suitable_for_dom_inspection(JsonValue const& node)
 
 JsonValue WalkerActor::serialize_root() const
 {
+    if (!m_has_live_dom_tree)
+        return {};
+
     return serialize_node(m_dom_tree);
 }
 
@@ -671,6 +674,9 @@ Optional<Node> WalkerActor::dom_node_for(WeakPtr<WalkerActor> const& weak_walker
 
 Optional<Node> WalkerActor::dom_node(StringView actor)
 {
+    if (!m_has_live_dom_tree)
+        return {};
+
     auto tab = m_tab.strong_ref();
     if (!tab)
         return {};
@@ -687,6 +693,9 @@ Optional<Node> WalkerActor::dom_node(StringView actor)
 
 Optional<String> WalkerActor::node_actor_name_for(Web::UniqueNodeID node_id) const
 {
+    if (!m_has_live_dom_tree)
+        return {};
+
     return m_dom_node_id_to_actor_map.get(node_id).copy();
 }
 
@@ -913,6 +922,9 @@ Optional<JsonObject const&> WalkerActor::remove_node(JsonObject const& node)
 
 void WalkerActor::new_dom_node_mutation(WebView::Mutation mutation)
 {
+    if (!m_has_live_dom_tree)
+        return;
+
     auto serialized_target = JsonValue::from_string(mutation.serialized_target);
     if (serialized_target.is_error() || !serialized_target.value().is_object()) {
         dbgln_if(DEVTOOLS_DEBUG, "Unable to parse serialized target as JSON object: {}", serialized_target.error());
@@ -1003,11 +1015,44 @@ bool WalkerActor::replace_node_in_tree(JsonObject replacement)
 
 void WalkerActor::populate_dom_tree_cache()
 {
+    clear_dom_tree_cache();
+
+    if (!m_has_live_dom_tree)
+        return;
+
+    populate_dom_tree_cache(m_dom_tree, nullptr);
+}
+
+void WalkerActor::document_unloaded()
+{
+    if (!m_has_live_dom_tree)
+        return;
+
+    auto root = serialize_root();
+
+    stop_node_picker();
+    clear_dom_tree_state();
+    m_has_live_dom_tree = false;
+
+    JsonObject message;
+    message.set("type"sv, "root-destroyed"sv);
+    message.set("node"sv, move(root));
+    send_message(move(message));
+}
+
+void WalkerActor::clear_dom_tree_state()
+{
+    m_dom_node_mutations.clear();
+    m_has_new_mutations_since_last_mutations_request = false;
+    clear_dom_tree_cache();
+    m_node_actors.clear();
+}
+
+void WalkerActor::clear_dom_tree_cache()
+{
     m_dom_node_to_parent_map.clear();
     m_actor_to_dom_node_map.clear();
     m_dom_node_id_to_actor_map.clear();
-
-    populate_dom_tree_cache(m_dom_tree, nullptr);
 }
 
 void WalkerActor::populate_dom_tree_cache(JsonObject& node, JsonObject const* parent)

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -1040,6 +1040,21 @@ void WalkerActor::document_unloaded()
     send_message(move(message));
 }
 
+void WalkerActor::replace_dom_tree(JsonObject dom_tree)
+{
+    stop_node_picker();
+    clear_dom_tree_state();
+
+    m_dom_tree = move(dom_tree);
+    m_has_live_dom_tree = true;
+    populate_dom_tree_cache();
+
+    JsonObject message;
+    message.set("type"sv, "root-available"sv);
+    message.set("node"sv, serialize_root());
+    send_message(move(message));
+}
+
 void WalkerActor::clear_dom_tree_state()
 {
     m_dom_node_mutations.clear();

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -34,6 +34,7 @@ public:
     Optional<Node> dom_node(StringView actor);
     Optional<String> node_actor_name_for(Web::UniqueNodeID) const;
     void document_unloaded();
+    void replace_dom_tree(JsonObject);
 
 private:
     WalkerActor(DevToolsServer&, String name, WeakPtr<TabActor>, JsonObject dom_tree);

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -33,6 +33,7 @@ public:
     static Optional<Node> dom_node_for(WeakPtr<WalkerActor> const&, StringView actor);
     Optional<Node> dom_node(StringView actor);
     Optional<String> node_actor_name_for(Web::UniqueNodeID) const;
+    void document_unloaded();
 
 private:
     WalkerActor(DevToolsServer&, String name, WeakPtr<TabActor>, JsonObject dom_tree);
@@ -52,6 +53,8 @@ private:
 
     bool replace_node_in_tree(JsonObject replacement);
 
+    void clear_dom_tree_cache();
+    void clear_dom_tree_state();
     void populate_dom_tree_cache();
     void populate_dom_tree_cache(JsonObject& node, JsonObject const* parent);
 
@@ -65,6 +68,7 @@ private:
     WeakPtr<LayoutInspectorActor> m_layout_inspector;
 
     JsonObject m_dom_tree;
+    bool m_has_live_dom_tree { true };
 
     Vector<WebView::Mutation> m_dom_node_mutations;
     bool m_has_new_mutations_since_last_mutations_request { false };

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -19,6 +19,7 @@
 #include <LibDevTools/Actors/ThreadActor.h>
 #include <LibDevTools/Actors/ThreadConfigurationActor.h>
 #include <LibDevTools/Actors/WatcherActor.h>
+#include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/DevToolsServer.h>
 
 namespace DevTools {
@@ -34,7 +35,14 @@ WatcherActor::WatcherActor(DevToolsServer& devtools, String name, WeakPtr<TabAct
 {
 }
 
-WatcherActor::~WatcherActor() = default;
+WatcherActor::~WatcherActor()
+{
+    if (!m_is_watching_frame_targets)
+        return;
+
+    if (auto tab = m_tab.strong_ref())
+        devtools().delegate().did_disconnect_devtools_client(tab->description());
+}
 
 void WatcherActor::handle_message(Message const& message)
 {
@@ -100,23 +108,18 @@ void WatcherActor::handle_message(Message const& message)
             return;
 
         if (target_type == "frame"sv) {
-            auto& css_properties = devtools().register_actor<CSSPropertiesActor>();
-            auto& console = devtools().register_actor<ConsoleActor>(m_tab);
-            auto& inspector = devtools().register_actor<InspectorActor>(m_tab);
-            auto& style_sheets = devtools().register_actor<StyleSheetsActor>(m_tab);
-            auto& thread = devtools().register_actor<ThreadActor>();
-            auto& accessibility = devtools().register_actor<AccessibilityActor>(m_tab);
+            if (!m_is_watching_frame_targets) {
+                if (auto tab = m_tab.strong_ref())
+                    devtools().delegate().did_connect_devtools_client(tab->description());
+                m_is_watching_frame_targets = true;
+            }
 
-            auto& target = devtools().register_actor<FrameActor>(m_tab, css_properties, console, inspector, style_sheets, thread, accessibility);
-            m_target = target;
+            auto& target = create_frame_target();
 
-            response.set("type"sv, "target-available-form"sv);
-            response.set("target"sv, target.serialize_target());
             send_response(message, move(response));
 
+            send_frame_target_available_message(target);
             target.send_frame_update_message();
-
-            send_message({});
             return;
         }
     }
@@ -161,6 +164,63 @@ JsonObject WatcherActor::serialize_description() const
     description.set("resources"sv, move(resources));
 
     return description;
+}
+
+FrameActor& WatcherActor::create_frame_target()
+{
+    auto& css_properties = devtools().register_actor<CSSPropertiesActor>();
+    auto& console = devtools().register_actor<ConsoleActor>(m_tab);
+    auto& inspector = devtools().register_actor<InspectorActor>(m_tab);
+    auto& style_sheets = devtools().register_actor<StyleSheetsActor>(m_tab);
+    auto& thread = devtools().register_actor<ThreadActor>();
+    auto& accessibility = devtools().register_actor<AccessibilityActor>(m_tab);
+
+    auto& target = devtools().register_actor<FrameActor>(m_tab, make_weak_ptr<WatcherActor>(), css_properties, console, inspector, style_sheets, thread, accessibility);
+    m_target = target;
+    return target;
+}
+
+void WatcherActor::send_frame_target_available_message()
+{
+    auto& target = create_frame_target();
+    send_frame_target_available_message(target);
+}
+
+void WatcherActor::switch_frame_target(FrameActor& previous_target, String const& url, String const& title)
+{
+    auto previous_target_ref = m_target.strong_ref();
+    if (!previous_target_ref || previous_target_ref.ptr() != &previous_target)
+        return;
+
+    send_frame_target_destroyed_message(*previous_target_ref);
+    previous_target_ref->stop_listening();
+    devtools().unregister_actor(previous_target_ref->name());
+
+    auto& target = create_frame_target();
+    send_frame_target_available_message(target);
+    target.send_frame_update_message();
+    target.set_pending_navigation_document_events_after_target_switch(url, title);
+}
+
+void WatcherActor::send_frame_target_available_message(FrameActor& target)
+{
+    JsonObject message;
+    message.set("type"sv, "target-available-form"sv);
+    message.set("target"sv, target.serialize_target());
+    send_message(move(message));
+}
+
+void WatcherActor::send_frame_target_destroyed_message(FrameActor& target)
+{
+    JsonObject options;
+    options.set("isTargetSwitching"sv, true);
+    options.set("shouldDestroyTargetFront"sv, true);
+
+    JsonObject message;
+    message.set("type"sv, "target-destroyed-form"sv);
+    message.set("target"sv, target.serialize_target());
+    message.set("options"sv, move(options));
+    send_message(move(message));
 }
 
 }

--- a/Libraries/LibDevTools/Actors/WatcherActor.h
+++ b/Libraries/LibDevTools/Actors/WatcherActor.h
@@ -20,17 +20,24 @@ public:
     virtual ~WatcherActor() override;
 
     JsonObject serialize_description() const;
+    void send_frame_target_available_message();
+    void switch_frame_target(FrameActor&, String const& url, String const& title);
 
 private:
     WatcherActor(DevToolsServer&, String name, WeakPtr<TabActor>);
 
     virtual void handle_message(Message const&) override;
 
+    FrameActor& create_frame_target();
+    void send_frame_target_available_message(FrameActor&);
+    void send_frame_target_destroyed_message(FrameActor&);
+
     WeakPtr<TabActor> m_tab;
-    WeakPtr<Actor> m_target;
+    WeakPtr<FrameActor> m_target;
     WeakPtr<TargetConfigurationActor> m_target_configuration;
     WeakPtr<ThreadConfigurationActor> m_thread_configuration;
     WeakPtr<NetworkParentActor> m_network_parent;
+    bool m_is_watching_frame_targets { false };
 };
 
 }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -34,6 +34,7 @@ public:
 
     virtual Vector<TabDescription> tab_list() const { return {}; }
     virtual Vector<CSSProperty> css_property_list() const { return {}; }
+    virtual void reload_tab(TabDescription const&, bool bypass_cache) const { (void)bypass_cache; }
 
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -35,6 +35,7 @@ public:
     virtual Vector<TabDescription> tab_list() const { return {}; }
     virtual Vector<CSSProperty> css_property_list() const { return {}; }
     virtual void reload_tab(TabDescription const&, bool bypass_cache) const { (void)bypass_cache; }
+    virtual void traverse_the_history_by_delta(TabDescription const&, int) const { }
 
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -34,6 +34,7 @@ public:
 
     virtual Vector<TabDescription> tab_list() const { return {}; }
     virtual Vector<CSSProperty> css_property_list() const { return {}; }
+    virtual void navigate_tab(TabDescription const&, String const&) const { }
     virtual void reload_tab(TabDescription const&, bool bypass_cache) const { (void)bypass_cache; }
     virtual void traverse_the_history_by_delta(TabDescription const&, int) const { }
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1797,6 +1797,12 @@ Vector<DevTools::CSSProperty> Application::css_property_list() const
     return property_list;
 }
 
+void Application::reload_tab(DevTools::TabDescription const& description, bool) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->reload();
+}
+
 void Application::inspect_tab(DevTools::TabDescription const& description, OnTabInspectionComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1803,6 +1803,12 @@ void Application::reload_tab(DevTools::TabDescription const& description, bool) 
         view->reload();
 }
 
+void Application::traverse_the_history_by_delta(DevTools::TabDescription const& description, int delta) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->traverse_the_history_by_delta(delta);
+}
+
 void Application::inspect_tab(DevTools::TabDescription const& description, OnTabInspectionComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1803,6 +1803,19 @@ void Application::reload_tab(DevTools::TabDescription const& description, bool) 
         view->reload();
 }
 
+void Application::navigate_tab(DevTools::TabDescription const& description, String const& url) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    auto parsed_url = sanitize_url(url, Application::settings().search_engine());
+    if (!parsed_url.has_value())
+        return;
+
+    view->load(*parsed_url);
+}
+
 void Application::traverse_the_history_by_delta(DevTools::TabDescription const& description, int delta) const
 {
     if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -266,6 +266,7 @@ private:
 
     virtual Vector<DevTools::TabDescription> tab_list() const override;
     virtual Vector<DevTools::CSSProperty> css_property_list() const override;
+    virtual void reload_tab(DevTools::TabDescription const&, bool) const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;
     virtual void inspect_accessibility_tree(DevTools::TabDescription const&, OnAccessibilityTreeInspectionComplete) const override;
     virtual void listen_for_dom_properties(DevTools::TabDescription const&, OnDOMNodePropertiesReceived) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -267,6 +267,7 @@ private:
     virtual Vector<DevTools::TabDescription> tab_list() const override;
     virtual Vector<DevTools::CSSProperty> css_property_list() const override;
     virtual void reload_tab(DevTools::TabDescription const&, bool) const override;
+    virtual void traverse_the_history_by_delta(DevTools::TabDescription const&, int) const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;
     virtual void inspect_accessibility_tree(DevTools::TabDescription const&, OnAccessibilityTreeInspectionComplete) const override;
     virtual void listen_for_dom_properties(DevTools::TabDescription const&, OnDOMNodePropertiesReceived) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -266,6 +266,7 @@ private:
 
     virtual Vector<DevTools::TabDescription> tab_list() const override;
     virtual Vector<DevTools::CSSProperty> css_property_list() const override;
+    virtual void navigate_tab(DevTools::TabDescription const&, String const&) const override;
     virtual void reload_tab(DevTools::TabDescription const&, bool) const override;
     virtual void traverse_the_history_by_delta(DevTools::TabDescription const&, int) const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1002,10 +1002,19 @@ void ConnectionFromClient::highlight_dom_node(u64 page_id, Web::UniqueNodeID nod
     }
 
     auto* node = Web::DOM::Node::from_unique_id(node_id);
-    if (!node || !node->layout_node())
+    if (!node || !node->is_connected())
         return;
 
-    node->document().set_highlighted_node(node, pseudo_element);
+    auto& document = node->document();
+    auto navigable = document.navigable();
+    if (!navigable || navigable->active_document() != &document)
+        return;
+
+    document.update_layout(Web::DOM::UpdateLayoutReason::Debugging);
+    if (!node->layout_node())
+        return;
+
+    document.set_highlighted_node(node, pseudo_element);
 }
 
 static Web::Painting::FlexboxInspectorOverlayOptions flexbox_inspector_overlay_options_from_json(JsonValue const& options)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1243,6 +1243,43 @@ TEST_CASE(walker_node_picker)
     EXPECT_EQ(client.request(move(children)).get_array("nodes"sv)->size(), 1u);
 }
 
+TEST_CASE(inspector_walker_navigation_unloads_root)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto target = get_frame_target(client, actor_from(get_tab(client), "actor"sv));
+    auto inspector_actor = actor_from(target, "inspectorActor"sv);
+    auto walker = get_walker(client, inspector_actor);
+    auto walker_actor = actor_from(walker, "actor"sv);
+    auto root_node = walker.get_object("root"sv).release_value();
+    auto root_node_actor = actor_from(root_node, "actor"sv);
+
+    auto div_actor = query_selector(client, walker_actor, root_node_actor, "div"sv);
+
+    JsonObject watch_root;
+    watch_root.set("to"sv, walker_actor);
+    watch_root.set("type"sv, "watchRootNode"sv);
+    EXPECT_EQ(client.request(move(watch_root)).get_string("type"sv).value(), "root-available"sv);
+
+    session->delegate.emit_navigation_start();
+
+    auto root_destroyed = read_packet_with_type(client, "root-destroyed"sv);
+    auto destroyed_node = root_destroyed.get_object("node"sv).release_value();
+    EXPECT_EQ(destroyed_node.get_string("actor"sv).value(), root_node_actor);
+    EXPECT(destroyed_node.get_bool("isTopLevelDocument"sv).value());
+
+    JsonObject is_in_dom_tree;
+    is_in_dom_tree.set("to"sv, walker_actor);
+    is_in_dom_tree.set("type"sv, "isInDOMTree"sv);
+    is_in_dom_tree.set("node"sv, div_actor);
+    EXPECT(!client.request(move(is_in_dom_tree)).get_bool("attached"sv).value());
+
+    EXPECT_EQ(session->delegate.clear_highlighted_dom_node_call_count, 1u);
+    EXPECT_EQ(session->delegate.clear_inspected_dom_node_call_count, 1u);
+}
+
 TEST_CASE(inspector_walker_highlighter_layout_and_editing)
 {
     auto session = create_session();

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -644,11 +644,15 @@ public:
     virtual void listen_for_navigation_events(DevTools::TabDescription const&, OnNavigationStarted on_started, OnNavigationFinished on_finished) const override
     {
         ++listen_for_navigation_events_call_count;
-        on_navigation_started = move(on_started);
-        on_navigation_finished = move(on_finished);
+        navigation_listeners.append({ move(on_started), move(on_finished) });
     }
 
-    virtual void stop_listening_for_navigation_events(DevTools::TabDescription const&) const override { ++stop_listening_for_navigation_events_call_count; }
+    virtual void stop_listening_for_navigation_events(DevTools::TabDescription const&) const override
+    {
+        ++stop_listening_for_navigation_events_call_count;
+        if (!navigation_listeners.is_empty())
+            navigation_listeners.take_first();
+    }
     virtual void did_connect_devtools_client(DevTools::TabDescription const&) const override { ++did_connect_devtools_client_call_count; }
     virtual void did_disconnect_devtools_client(DevTools::TabDescription const&) const override { ++did_disconnect_devtools_client_call_count; }
 
@@ -731,14 +735,23 @@ public:
 
     void emit_navigation_start() const
     {
-        VERIFY(on_navigation_started);
-        on_navigation_started("https://example.test/next"_string);
+        VERIFY(!navigation_listeners.is_empty());
+        auto listener_count = navigation_listeners.size();
+        for (size_t i = 0; i < listener_count; ++i)
+            navigation_listeners[i].on_navigation_started("https://example.test/next"_string);
     }
 
     void emit_navigation_finish() const
     {
-        VERIFY(on_navigation_finished);
-        on_navigation_finished("https://example.test/next"_string, "Next page"_string);
+        VERIFY(!navigation_listeners.is_empty());
+        auto listener_count = navigation_listeners.size();
+        for (size_t i = 0; i < listener_count; ++i)
+            navigation_listeners[i].on_navigation_finished("https://example.test/next"_string, "Next page"_string);
+    }
+
+    size_t navigation_listener_count() const
+    {
+        return navigation_listeners.size();
     }
 
     void switch_to_navigation_dom_tree() const
@@ -760,9 +773,13 @@ public:
     mutable Function<void(DevToolsDelegate::NetworkResponseData)> on_network_response_headers_received;
     mutable Function<void(u64, ByteBuffer)> on_network_response_body_received;
     mutable Function<void(DevToolsDelegate::NetworkRequestCompleteData)> on_network_request_finished;
-    mutable Function<void(String)> on_navigation_started;
-    mutable Function<void(String, String)> on_navigation_finished;
     mutable Function<void(DevToolsDelegate::NodePickerEvent)> on_node_picker_event;
+
+    struct NavigationListener {
+        Function<void(String)> on_navigation_started;
+        Function<void(String, String)> on_navigation_finished;
+    };
+    mutable Vector<NavigationListener> navigation_listeners;
 
     mutable bool use_navigation_dom_tree { false };
 
@@ -901,7 +918,9 @@ private:
             || *type == "pickerNodeHovered"sv
             || *type == "pickerNodePicked"sv
             || *type == "pickerNodePreviewed"sv
-            || *type == "tabListChanged"sv;
+            || *type == "tabListChanged"sv
+            || *type == "target-available-form"sv
+            || *type == "target-destroyed-form"sv;
     }
 
     JsonObject request(JsonObject message, StringView response_actor)
@@ -995,9 +1014,13 @@ static JsonObject get_frame_target(ProtocolClient& client, StringView tab_actor)
     request.set("type"sv, "watchTargets"sv);
     request.set("targetType"sv, "frame"sv);
 
-    auto response = client.request(move(request));
-    VERIFY(response.get_string("type"sv).value() == "target-available-form"sv);
-    return response.get_object("target"sv).release_value();
+    EXPECT_EQ(client.request(move(request)).get_string("from"sv).value(), watcher_actor);
+
+    while (true) {
+        auto message = client.read_message();
+        if (message.get_string("type"sv).value_or({}) == "target-available-form"sv)
+            return message.get_object("target"sv).release_value();
+    }
 }
 
 static JsonObject get_walker(ProtocolClient& client, StringView inspector_actor)
@@ -1243,7 +1266,7 @@ TEST_CASE(walker_node_picker)
     EXPECT_EQ(client.request(move(children)).get_array("nodes"sv)->size(), 1u);
 }
 
-TEST_CASE(inspector_walker_navigation_unloads_root)
+TEST_CASE(inspector_walker_navigation_reloads_root)
 {
     auto session = create_session();
     auto& client = *session->client;
@@ -1255,6 +1278,7 @@ TEST_CASE(inspector_walker_navigation_unloads_root)
     auto walker_actor = actor_from(walker, "actor"sv);
     auto root_node = walker.get_object("root"sv).release_value();
     auto root_node_actor = actor_from(root_node, "actor"sv);
+    EXPECT_EQ(session->delegate.navigation_listener_count(), 1u);
 
     auto div_actor = query_selector(client, walker_actor, root_node_actor, "div"sv);
 
@@ -1278,6 +1302,93 @@ TEST_CASE(inspector_walker_navigation_unloads_root)
 
     EXPECT_EQ(session->delegate.clear_highlighted_dom_node_call_count, 1u);
     EXPECT_EQ(session->delegate.clear_inspected_dom_node_call_count, 1u);
+
+    auto will_navigate = read_resource(client, "document-event"sv);
+    EXPECT_EQ(will_navigate.get_string("name"sv).value(), "will-navigate"sv);
+    EXPECT_EQ(will_navigate.get_string("newURI"sv).value(), "https://example.test/next"sv);
+    EXPECT(!will_navigate.has_string("url"sv));
+
+    session->delegate.switch_to_navigation_dom_tree();
+    session->delegate.emit_navigation_finish();
+
+    auto root_available = read_packet_with_type(client, "root-available"sv);
+    auto new_root_node = root_available.get_object("node"sv).release_value();
+    auto new_root_node_actor = actor_from(new_root_node, "actor"sv);
+    auto main_actor = query_selector(client, walker_actor, new_root_node_actor, "main"sv);
+
+    JsonObject main_is_in_dom_tree;
+    main_is_in_dom_tree.set("to"sv, walker_actor);
+    main_is_in_dom_tree.set("type"sv, "isInDOMTree"sv);
+    main_is_in_dom_tree.set("node"sv, main_actor);
+    EXPECT(client.request(move(main_is_in_dom_tree)).get_bool("attached"sv).value());
+
+    EXPECT_EQ(session->delegate.inspect_tab_call_count, 2u);
+
+    auto target_destroyed = read_packet_with_type(client, "target-destroyed-form"sv);
+    auto destroyed_target = target_destroyed.get_object("target"sv).release_value();
+    EXPECT_EQ(actor_from(destroyed_target, "actor"sv), actor_from(target, "actor"sv));
+    auto options = target_destroyed.get_object("options"sv).release_value();
+    EXPECT(options.get_bool("isTargetSwitching"sv).value());
+    EXPECT(options.get_bool("shouldDestroyTargetFront"sv).value());
+
+    auto new_target_available = read_packet_with_type(client, "target-available-form"sv);
+    auto new_target = new_target_available.get_object("target"sv).release_value();
+    EXPECT_NE(actor_from(new_target, "actor"sv), actor_from(target, "actor"sv));
+    EXPECT_EQ(new_target.get_string("url"sv).value(), "https://example.test/next"sv);
+    EXPECT_NE(
+        new_target.get_integer<u64>("innerWindowId"sv).value(),
+        target.get_integer<u64>("innerWindowId"sv).value());
+
+    EXPECT_EQ(client.request(actor_from(new_target, "actor"sv), "listFrames"sv).get_string("from"sv).value(), actor_from(new_target, "actor"sv));
+
+    auto dom_loading = read_resource(client, "document-event"sv);
+    EXPECT_EQ(dom_loading.get_string("name"sv).value(), "dom-loading"sv);
+    EXPECT_EQ(dom_loading.get_string("url"sv).value(), "https://example.test/next"sv);
+    EXPECT(!dom_loading.has_string("title"sv));
+
+    auto dom_interactive = read_resource(client, "document-event"sv);
+    EXPECT_EQ(dom_interactive.get_string("name"sv).value(), "dom-interactive"sv);
+    EXPECT_EQ(dom_interactive.get_string("url"sv).value(), "https://example.test/next"sv);
+    EXPECT_EQ(dom_interactive.get_string("title"sv).value(), "Next page"sv);
+
+    auto dom_complete = read_resource(client, "document-event"sv);
+    EXPECT_EQ(dom_complete.get_string("name"sv).value(), "dom-complete"sv);
+    EXPECT(!dom_complete.has_string("url"sv));
+    EXPECT(!dom_complete.has_string("title"sv));
+
+    EXPECT_EQ(session->delegate.navigation_listener_count(), 1u);
+    EXPECT_EQ(session->delegate.listen_for_navigation_events_call_count, 2u);
+    EXPECT_EQ(session->delegate.stop_listening_for_navigation_events_call_count, 1u);
+    EXPECT_EQ(session->delegate.did_connect_devtools_client_call_count, 1u);
+    EXPECT_EQ(session->delegate.did_disconnect_devtools_client_call_count, 0u);
+
+    auto new_walker = get_walker(client, actor_from(new_target, "inspectorActor"sv));
+    auto new_walker_root = new_walker.get_object("root"sv).release_value();
+    auto new_walker_root_actor = actor_from(new_walker_root, "actor"sv);
+    auto heading_actor = query_selector(client, actor_from(new_walker, "actor"sv), new_walker_root_actor, "h1"sv);
+    EXPECT(!heading_actor.is_empty());
+
+    session->delegate.emit_navigation_start();
+    (void)read_packet_with_type(client, "root-destroyed"sv);
+
+    session->delegate.emit_navigation_finish();
+    (void)read_packet_with_type(client, "root-available"sv);
+
+    auto refreshed_target_destroyed = read_packet_with_type(client, "target-destroyed-form"sv);
+    auto refreshed_destroyed_target = refreshed_target_destroyed.get_object("target"sv).release_value();
+    EXPECT_EQ(actor_from(refreshed_destroyed_target, "actor"sv), actor_from(new_target, "actor"sv));
+
+    auto refreshed_target_available = read_packet_with_type(client, "target-available-form"sv);
+    auto refreshed_target = refreshed_target_available.get_object("target"sv).release_value();
+    EXPECT_NE(actor_from(refreshed_target, "actor"sv), actor_from(new_target, "actor"sv));
+    EXPECT_NE(
+        refreshed_target.get_integer<u64>("innerWindowId"sv).value(),
+        new_target.get_integer<u64>("innerWindowId"sv).value());
+    EXPECT_EQ(session->delegate.navigation_listener_count(), 1u);
+    EXPECT_EQ(session->delegate.listen_for_navigation_events_call_count, 3u);
+    EXPECT_EQ(session->delegate.stop_listening_for_navigation_events_call_count, 2u);
+    EXPECT_EQ(session->delegate.did_connect_devtools_client_call_count, 1u);
+    EXPECT_EQ(session->delegate.did_disconnect_devtools_client_call_count, 0u);
 }
 
 TEST_CASE(inspector_walker_highlighter_layout_and_editing)
@@ -1757,11 +1868,17 @@ TEST_CASE(console_network_navigation_and_accessibility)
 
     session->delegate.emit_navigation();
     EXPECT_EQ(read_resource(client, "document-event"sv).get_string("name"sv).value(), "will-navigate"sv);
-    while (true) {
-        auto packet = client.read_message();
-        if (packet.get_string("type"sv).value_or({}) == "tabNavigated"sv && packet.get_string("state"sv).value_or({}) == "stop"sv)
-            break;
-    }
+
+    (void)read_packet_with_type(client, "target-destroyed-form"sv);
+    auto new_target_available = read_packet_with_type(client, "target-available-form"sv);
+    target = new_target_available.get_object("target"sv).release_value();
+    accessibility_actor = actor_from(target, "accessibilityActor"sv);
+
+    EXPECT_EQ(client.request(actor_from(target, "actor"sv), "listFrames"sv).get_string("from"sv).value(), actor_from(target, "actor"sv));
+
+    EXPECT_EQ(read_resource(client, "document-event"sv).get_string("name"sv).value(), "dom-loading"sv);
+    EXPECT_EQ(read_resource(client, "document-event"sv).get_string("name"sv).value(), "dom-interactive"sv);
+    EXPECT_EQ(read_resource(client, "document-event"sv).get_string("name"sv).value(), "dom-complete"sv);
 
     EXPECT(client.request(accessibility_actor, "bootstrap"sv).has_object("state"sv));
     EXPECT(client.request(accessibility_actor, "getTraits"sv).get_object("traits"sv)->get_bool("tabbingOrder"sv).value());

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -382,6 +382,12 @@ public:
         last_reload_bypass_cache = bypass_cache;
     }
 
+    virtual void traverse_the_history_by_delta(DevTools::TabDescription const&, int delta) const override
+    {
+        ++traverse_the_history_by_delta_call_count;
+        last_history_delta = delta;
+    }
+
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete callback) const override
     {
         ++inspect_tab_call_count;
@@ -833,6 +839,7 @@ public:
     mutable size_t did_connect_devtools_client_call_count { 0 };
     mutable size_t did_disconnect_devtools_client_call_count { 0 };
     mutable size_t reload_tab_call_count { 0 };
+    mutable size_t traverse_the_history_by_delta_call_count { 0 };
 
     mutable Optional<Web::UniqueNodeID> last_highlighted_dom_node;
     mutable Optional<Web::CSS::PseudoElement> last_highlighted_pseudo_element;
@@ -857,6 +864,7 @@ public:
     mutable Optional<String> last_attribute;
     mutable size_t last_attribute_count { 0 };
     mutable Optional<bool> last_reload_bypass_cache;
+    mutable Optional<int> last_history_delta;
 };
 
 class ProtocolClient {
@@ -1105,6 +1113,9 @@ TEST_CASE(root_actor_and_connection_errors)
     auto tab_actor = actor_from(tab, "actor"sv);
     EXPECT_EQ(tab.get_string("title"sv).value(), "Fixture page"sv);
     EXPECT_EQ(tab.get_integer<u64>("browserId"sv).value(), 1u);
+    auto tab_traits = tab.get_object("traits"sv).release_value();
+    EXPECT(tab_traits.get_bool("supportsReloadDescriptor"sv).value());
+    EXPECT(tab_traits.get_bool("supportsNavigation"sv).value());
 
     JsonObject get_tab_request;
     get_tab_request.set("to"sv, "root"sv);
@@ -1144,6 +1155,34 @@ TEST_CASE(root_actor_and_connection_errors)
     client.send(move(second));
     EXPECT(client.read_message().has_array("workers"sv));
     EXPECT(client.read_message().has_array("addons"sv));
+}
+
+TEST_CASE(history_navigation_requests)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto tab_actor = actor_from(get_tab(client), "actor"sv);
+
+    EXPECT_EQ(client.request(tab_actor, "goBack"sv).get_string("from"sv).value(), tab_actor);
+    EXPECT_EQ(session->delegate.traverse_the_history_by_delta_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_history_delta.value(), -1);
+
+    EXPECT_EQ(client.request(tab_actor, "goForward"sv).get_string("from"sv).value(), tab_actor);
+    EXPECT_EQ(session->delegate.traverse_the_history_by_delta_call_count, 2u);
+    EXPECT_EQ(session->delegate.last_history_delta.value(), 1);
+
+    auto target = get_frame_target(client, tab_actor);
+    auto target_actor = actor_from(target, "actor"sv);
+
+    EXPECT_EQ(client.request(target_actor, "goBack"sv).get_string("from"sv).value(), target_actor);
+    EXPECT_EQ(session->delegate.traverse_the_history_by_delta_call_count, 3u);
+    EXPECT_EQ(session->delegate.last_history_delta.value(), -1);
+
+    EXPECT_EQ(client.request(target_actor, "goForward"sv).get_string("from"sv).value(), target_actor);
+    EXPECT_EQ(session->delegate.traverse_the_history_by_delta_call_count, 4u);
+    EXPECT_EQ(session->delegate.last_history_delta.value(), 1);
 }
 
 TEST_CASE(target_bootstrap_and_lifetime)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -131,6 +131,40 @@ static JsonObject make_dom_tree()
     return document;
 }
 
+static JsonObject make_navigation_dom_tree()
+{
+    JsonObject heading = make_node(105, "element"sv, "H1"sv);
+    heading.set("visible"sv, true);
+
+    JsonObject main = make_node(104, "element"sv, "MAIN"sv);
+    main.set("visible"sv, true);
+
+    JsonArray main_children;
+    main_children.must_append(move(heading));
+    main.set("children"sv, move(main_children));
+
+    JsonArray body_children;
+    body_children.must_append(move(main));
+
+    JsonObject body = make_node(103, "element"sv, "BODY"sv);
+    body.set("visible"sv, true);
+    body.set("children"sv, move(body_children));
+
+    JsonArray html_children;
+    html_children.must_append(move(body));
+
+    JsonObject html = make_node(102, "element"sv, "HTML"sv);
+    html.set("visible"sv, true);
+    html.set("children"sv, move(html_children));
+
+    JsonArray document_children;
+    document_children.must_append(move(html));
+
+    JsonObject document = make_node(101, "document"sv, "#document"sv);
+    document.set("children"sv, move(document_children));
+    return document;
+}
+
 static JsonObject make_accessibility_tree()
 {
     JsonObject button = make_node(4, "element"sv, "Target button"sv);
@@ -345,7 +379,7 @@ public:
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete callback) const override
     {
         ++inspect_tab_call_count;
-        callback(make_dom_tree());
+        callback(use_navigation_dom_tree ? make_navigation_dom_tree() : make_dom_tree());
     }
 
     virtual void inspect_accessibility_tree(DevTools::TabDescription const&, OnAccessibilityTreeInspectionComplete callback) const override
@@ -691,10 +725,25 @@ public:
 
     void emit_navigation() const
     {
+        emit_navigation_start();
+        emit_navigation_finish();
+    }
+
+    void emit_navigation_start() const
+    {
         VERIFY(on_navigation_started);
-        VERIFY(on_navigation_finished);
         on_navigation_started("https://example.test/next"_string);
+    }
+
+    void emit_navigation_finish() const
+    {
+        VERIFY(on_navigation_finished);
         on_navigation_finished("https://example.test/next"_string, "Next page"_string);
+    }
+
+    void switch_to_navigation_dom_tree() const
+    {
+        use_navigation_dom_tree = true;
     }
 
     void emit_node_picker_event(DevToolsDelegate::NodePickerEvent event) const
@@ -714,6 +763,8 @@ public:
     mutable Function<void(String)> on_navigation_started;
     mutable Function<void(String, String)> on_navigation_finished;
     mutable Function<void(DevToolsDelegate::NodePickerEvent)> on_node_picker_event;
+
+    mutable bool use_navigation_dom_tree { false };
 
     mutable size_t inspect_tab_call_count { 0 };
     mutable size_t inspect_accessibility_tree_call_count { 0 };

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -382,6 +382,12 @@ public:
         last_reload_bypass_cache = bypass_cache;
     }
 
+    virtual void navigate_tab(DevTools::TabDescription const&, String const& url) const override
+    {
+        ++navigate_tab_call_count;
+        last_navigated_url = url;
+    }
+
     virtual void traverse_the_history_by_delta(DevTools::TabDescription const&, int delta) const override
     {
         ++traverse_the_history_by_delta_call_count;
@@ -838,6 +844,7 @@ public:
     mutable size_t stop_listening_for_navigation_events_call_count { 0 };
     mutable size_t did_connect_devtools_client_call_count { 0 };
     mutable size_t did_disconnect_devtools_client_call_count { 0 };
+    mutable size_t navigate_tab_call_count { 0 };
     mutable size_t reload_tab_call_count { 0 };
     mutable size_t traverse_the_history_by_delta_call_count { 0 };
 
@@ -863,6 +870,7 @@ public:
     mutable Optional<String> last_tag;
     mutable Optional<String> last_attribute;
     mutable size_t last_attribute_count { 0 };
+    mutable Optional<String> last_navigated_url;
     mutable Optional<bool> last_reload_bypass_cache;
     mutable Optional<int> last_history_delta;
 };
@@ -1164,6 +1172,15 @@ TEST_CASE(history_navigation_requests)
     (void)client.read_message();
 
     auto tab_actor = actor_from(get_tab(client), "actor"sv);
+
+    JsonObject navigate_to;
+    navigate_to.set("to"sv, tab_actor);
+    navigate_to.set("type"sv, "navigateTo"sv);
+    navigate_to.set("url"sv, "https://example.test/from-devtools"sv);
+    navigate_to.set("waitForLoad"sv, false);
+    EXPECT_EQ(client.request(move(navigate_to)).get_string("from"sv).value(), tab_actor);
+    EXPECT_EQ(session->delegate.navigate_tab_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_navigated_url.value(), "https://example.test/from-devtools"sv);
 
     EXPECT_EQ(client.request(tab_actor, "goBack"sv).get_string("from"sv).value(), tab_actor);
     EXPECT_EQ(session->delegate.traverse_the_history_by_delta_call_count, 1u);

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -376,6 +376,12 @@ public:
         return properties;
     }
 
+    virtual void reload_tab(DevTools::TabDescription const&, bool bypass_cache) const override
+    {
+        ++reload_tab_call_count;
+        last_reload_bypass_cache = bypass_cache;
+    }
+
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete callback) const override
     {
         ++inspect_tab_call_count;
@@ -826,6 +832,7 @@ public:
     mutable size_t stop_listening_for_navigation_events_call_count { 0 };
     mutable size_t did_connect_devtools_client_call_count { 0 };
     mutable size_t did_disconnect_devtools_client_call_count { 0 };
+    mutable size_t reload_tab_call_count { 0 };
 
     mutable Optional<Web::UniqueNodeID> last_highlighted_dom_node;
     mutable Optional<Web::CSS::PseudoElement> last_highlighted_pseudo_element;
@@ -849,6 +856,7 @@ public:
     mutable Optional<String> last_tag;
     mutable Optional<String> last_attribute;
     mutable size_t last_attribute_count { 0 };
+    mutable Optional<bool> last_reload_bypass_cache;
 };
 
 class ProtocolClient {
@@ -1272,7 +1280,9 @@ TEST_CASE(inspector_walker_navigation_reloads_root)
     auto& client = *session->client;
     (void)client.read_message();
 
-    auto target = get_frame_target(client, actor_from(get_tab(client), "actor"sv));
+    auto tab = get_tab(client);
+    auto tab_actor = actor_from(tab, "actor"sv);
+    auto target = get_frame_target(client, tab_actor);
     auto inspector_actor = actor_from(target, "inspectorActor"sv);
     auto walker = get_walker(client, inspector_actor);
     auto walker_actor = actor_from(walker, "actor"sv);
@@ -1367,6 +1377,14 @@ TEST_CASE(inspector_walker_navigation_reloads_root)
     auto new_walker_root_actor = actor_from(new_walker_root, "actor"sv);
     auto heading_actor = query_selector(client, actor_from(new_walker, "actor"sv), new_walker_root_actor, "h1"sv);
     EXPECT(!heading_actor.is_empty());
+
+    JsonObject reload_descriptor;
+    reload_descriptor.set("to"sv, tab_actor);
+    reload_descriptor.set("type"sv, "reloadDescriptor"sv);
+    reload_descriptor.set("bypassCache"sv, true);
+    EXPECT_EQ(client.request(move(reload_descriptor)).get_string("from"sv).value(), tab_actor);
+    EXPECT_EQ(session->delegate.reload_tab_call_count, 1u);
+    EXPECT(session->delegate.last_reload_bypass_cache.value());
 
     session->delegate.emit_navigation_start();
     (void)read_packet_with_type(client, "root-destroyed"sv);


### PR DESCRIPTION
The main part of this is wiring up DevTools so that when we navigate the inspected page, the inspector loads the new DOM and continues to work. Previously, it would discard the previous page's data and then be unusable.

I've also wired up the navigation tools of the inspector itself: The back, forward and reload buttons, and the URL box.