### PR TITLE
LibWebView+UI/Qt: Some vertical tab fixes/cleanups

### DIFF
--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -172,9 +172,13 @@ void SettingsUI::set_new_tab_page_url(JsonValue const& new_tab_page_url)
 
 void SettingsUI::set_tab_settings(JsonValue const& tab_settings)
 {
+    auto& settings = WebView::Application::settings();
     auto parsed_tab_settings = Settings::parse_tab_settings(tab_settings);
-    WebView::Application::settings().set_tab_settings(parsed_tab_settings);
 
+    // Collapsed/expanded vertical tabs are not controlled by the settings UI. Don't overwrite it.
+    parsed_tab_settings.vertical_tabs_expanded = settings.tab_settings().vertical_tabs_expanded;
+
+    settings.set_tab_settings(parsed_tab_settings);
     load_current_settings();
 }
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -215,9 +215,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     auto* navigation_button_layout = new QHBoxLayout(navigation_button_cluster);
     navigation_button_layout->setSpacing(2);
     navigation_button_layout->setContentsMargins(0, 0, 0, 0);
-    m_toggle_vertical_tabs_expanded_button = create_toolbar_button(*navigation_button_cluster, *m_toggle_vertical_tabs_expanded_action);
-    m_toggle_vertical_tabs_expanded_button->setVisible(WebView::Application::settings().tab_settings().vertical_tabs_enabled);
-    navigation_button_layout->addWidget(m_toggle_vertical_tabs_expanded_button);
+    navigation_button_layout->addWidget(create_toolbar_button(*navigation_button_cluster, *m_toggle_vertical_tabs_expanded_action));
     navigation_button_layout->addWidget(create_toolbar_button(*navigation_button_cluster, *m_navigate_back_action));
     navigation_button_layout->addWidget(create_toolbar_button(*navigation_button_cluster, *m_navigate_forward_action));
     navigation_button_layout->addWidget(create_toolbar_button(*navigation_button_cluster, *m_reload_action));
@@ -232,8 +230,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     update_chrome_style();
     set_toolbar_window_controls_visible(!Settings::the()->show_menubar() && WebView::Application::settings().tab_settings().vertical_tabs_enabled);
-    set_vertical_tabs_enabled(WebView::Application::settings().tab_settings().vertical_tabs_enabled);
-    set_vertical_tabs_expanded(WebView::Application::settings().tab_settings().vertical_tabs_expanded);
 
     m_hamburger_button->setVisible(!Settings::the()->show_menubar());
 
@@ -582,14 +578,7 @@ void Tab::set_window(BrowserWindow& window)
 
 void Tab::set_vertical_tabs_enabled(bool enabled)
 {
-    m_toggle_vertical_tabs_expanded_button->setVisible(enabled);
-    recreate_toolbar_icons();
-    set_toolbar_window_drag_enabled(enabled);
-}
-
-void Tab::set_vertical_tabs_expanded(bool)
-{
-    recreate_toolbar_icons();
+    m_toolbar->setProperty(WINDOW_DRAG_REGION_PROPERTY, enabled);
 }
 
 void Tab::set_toolbar_window_controls_visible(bool visible)
@@ -597,11 +586,6 @@ void Tab::set_toolbar_window_controls_visible(bool visible)
     m_toolbar_window_controls_separator->setVisible(visible);
     m_toolbar_window_controls->setVisible(visible);
     m_toolbar->layout()->setContentsMargins(TOOLBAR_HORIZONTAL_MARGIN, TOOLBAR_VERTICAL_MARGIN, visible ? TOOLBAR_WINDOW_CONTROLS_RIGHT_MARGIN : TOOLBAR_HORIZONTAL_MARGIN, TOOLBAR_VERTICAL_MARGIN);
-}
-
-void Tab::set_toolbar_window_drag_enabled(bool enabled)
-{
-    m_toolbar->setProperty(WINDOW_DRAG_REGION_PROPERTY, enabled);
 }
 
 void Tab::update_window_control_icons()
@@ -763,16 +747,17 @@ void Tab::update_chrome_style()
 
 void Tab::recreate_toolbar_icons()
 {
-    m_navigate_back_action->setIcon(create_chrome_icon(ChromeIcon::Back, palette()));
-    m_navigate_forward_action->setIcon(create_chrome_icon(ChromeIcon::Forward, palette()));
-    m_reload_action->setIcon(create_chrome_icon(ChromeIcon::Reload, palette()));
     m_toggle_vertical_tabs_expanded_action->setIcon(create_chrome_icon(
         WebView::Application::settings().tab_settings().vertical_tabs_expanded
             ? ChromeIcon::VerticalTabBarCollapse
             : ChromeIcon::VerticalTabBarExpand,
         palette()));
+    m_navigate_back_action->setIcon(create_chrome_icon(ChromeIcon::Back, palette()));
+    m_navigate_forward_action->setIcon(create_chrome_icon(ChromeIcon::Forward, palette()));
+    m_reload_action->setIcon(create_chrome_icon(ChromeIcon::Reload, palette()));
     m_hamburger_button->setIcon(create_chrome_icon(ChromeIcon::Menu, palette()));
     update_window_control_icons();
+
     if (auto* action = m_location_edit->trailing_action()) {
         auto icon = view().toggle_bookmark_action().engaged() ? ChromeIcon::StarFilled : ChromeIcon::Star;
         action->setIcon(create_chrome_icon(icon, palette()));

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -81,10 +81,8 @@ public:
     QToolButton* hamburger_button() const { return m_hamburger_button; }
 
     void set_vertical_tabs_enabled(bool);
-    void set_vertical_tabs_expanded(bool);
     void set_window(BrowserWindow&);
     void set_toolbar_window_controls_visible(bool);
-    void set_toolbar_window_drag_enabled(bool);
     void update_window_control_icons();
     void update_hover_label();
 
@@ -121,7 +119,6 @@ private:
     WindowControlButton* m_maximize_window_button { nullptr };
     WindowControlButton* m_close_window_button { nullptr };
     BookmarksBar* m_bookmarks_bar { nullptr };
-    QToolButton* m_toggle_vertical_tabs_expanded_button { nullptr };
     QToolButton* m_hamburger_button { nullptr };
     LocationEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
@@ -142,10 +139,10 @@ private:
     QMenu* m_media_context_menu { nullptr };
     QMenu* m_select_dropdown { nullptr };
 
+    QAction* m_toggle_vertical_tabs_expanded_action { nullptr };
     QAction* m_navigate_back_action { nullptr };
     QAction* m_navigate_forward_action { nullptr };
     QAction* m_reload_action { nullptr };
-    QAction* m_toggle_vertical_tabs_expanded_action { nullptr };
 
     QPointer<QDialog> m_dialog;
 

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1297,8 +1297,6 @@ void TabWidget::rebuild_layout_for_horizontal_tabs()
 
     m_new_tab_button->setText({});
     m_new_tab_button->setProperty(VERTICAL_TABS_EXPANDED_PROPERTY, false);
-    m_new_tab_button->style()->unpolish(m_new_tab_button);
-    m_new_tab_button->style()->polish(m_new_tab_button);
     m_new_tab_button->setToolButtonStyle(Qt::ToolButtonIconOnly);
     m_new_tab_button->setFixedSize(32, 32);
     m_new_tab_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -1323,8 +1321,6 @@ void TabWidget::rebuild_layout_for_vertical_tabs()
     m_new_tab_button->setToolButtonStyle(m_vertical_tabs_expanded ? Qt::ToolButtonTextBesideIcon : Qt::ToolButtonIconOnly);
     update_vertical_tabs_action_labels();
     m_new_tab_button->setProperty(VERTICAL_TABS_EXPANDED_PROPERTY, m_vertical_tabs_expanded);
-    m_new_tab_button->style()->unpolish(m_new_tab_button);
-    m_new_tab_button->style()->polish(m_new_tab_button);
     m_vertical_tabs_new_tab_separator->setVisible(!m_vertical_tabs_expanded);
     if (m_vertical_tabs_expanded) {
         m_new_tab_button->setFixedHeight(VERTICAL_TAB_HEIGHT);

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1068,10 +1068,6 @@ void TabWidget::set_tab_bar_visible(bool visible)
 void TabWidget::set_window_controls_visible(bool visible)
 {
     m_window_controls_visible = visible;
-    auto show_tab_strip_window_controls = visible && m_tab_bar->tab_layout() == TabLayout::Horizontal;
-    m_minimize_window_button->setVisible(show_tab_strip_window_controls);
-    m_maximize_window_button->setVisible(show_tab_strip_window_controls);
-    m_close_window_button->setVisible(show_tab_strip_window_controls);
     for (int index = 0; index < m_stacked_widget->count(); ++index)
         tab(index)->set_toolbar_window_controls_visible(visible && m_vertical_tabs_enabled);
     update_tab_chrome_visibility();
@@ -1286,7 +1282,6 @@ void TabWidget::rebuild_layout()
         m_main_layout->addWidget(m_tab_bar_row);
         m_main_layout->addWidget(m_stacked_widget, 1);
         m_vertical_tabs_content->hide();
-        m_vertical_tab_bar_column->hide();
     }
 
     update_tab_button_visibility();

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1007,7 +1007,6 @@ void TabWidget::insert_tab(int index, Tab* widget, QString const& label)
 
     widget->set_toolbar_window_controls_visible(m_window_controls_visible && m_vertical_tabs_enabled);
     widget->set_vertical_tabs_enabled(m_vertical_tabs_enabled);
-    widget->set_vertical_tabs_expanded(m_vertical_tabs_expanded);
 
     update_tab_layout();
     update_tab_button_visibility();
@@ -1098,8 +1097,6 @@ void TabWidget::set_vertical_tabs_expanded(bool expanded)
         return;
 
     m_vertical_tabs_expanded = expanded;
-    for (int index = 0; index < m_stacked_widget->count(); ++index)
-        tab(index)->set_vertical_tabs_expanded(expanded);
     rebuild_layout();
 }
 

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1291,8 +1291,6 @@ void TabWidget::rebuild_layout()
 
 void TabWidget::rebuild_layout_for_horizontal_tabs()
 {
-    clear_layout(*m_tab_bar_row_layout);
-
     m_tab_bar_row->setMinimumHeight(HORIZONTAL_TAB_STRIP_HEIGHT);
     m_tab_bar_row_layout->setSpacing(4);
     m_tab_bar_row_layout->setContentsMargins(12, 2, 4, 1);
@@ -1315,9 +1313,6 @@ void TabWidget::rebuild_layout_for_horizontal_tabs()
 
 void TabWidget::rebuild_layout_for_vertical_tabs()
 {
-    clear_layout(*m_tab_bar_row_layout);
-    clear_layout(*m_vertical_tab_bar_column_layout);
-
     auto side_bar_width = current_vertical_tabs_width();
     m_vertical_tab_bar_column->setFixedWidth(side_bar_width);
 

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -49,6 +49,8 @@ namespace Ladybird {
 static constexpr auto LADYBIRD_TAB_MIME_TYPE = "application/x-ladybird-tab";
 static constexpr int HORIZONTAL_TAB_STRIP_HEIGHT = 43;
 static constexpr int HORIZONTAL_TAB_HEIGHT = 36;
+static constexpr int HORIZONTAL_TAB_MIN_WIDTH = 128;
+static constexpr int HORIZONTAL_TAB_MAX_WIDTH = 240;
 static constexpr int VERTICAL_TAB_HEIGHT = 38;
 static constexpr int VERTICAL_TABS_COLLAPSED_WIDTH = 52;
 static constexpr int VERTICAL_TABS_DEFAULT_EXPANDED_WIDTH = 232;
@@ -288,8 +290,8 @@ QSize TabBar::tabSizeHint(int index) const
 
     if (auto count = this->count(); count > 0) {
         auto width = (m_available_width > 0 ? m_available_width : this->width()) / count;
-        width = min(240, width);
-        width = max(128, width);
+        width = min(HORIZONTAL_TAB_MAX_WIDTH, width);
+        width = max(HORIZONTAL_TAB_MIN_WIDTH, width);
 
         hint.setWidth(width);
     }
@@ -1418,6 +1420,9 @@ void TabWidget::update_tab_layout()
     auto available_for_tabs = width() - controls_width - 36;
 
     m_tab_bar->set_available_width(available_for_tabs);
+
+    auto tab_bar_width = min(available_for_tabs, m_tab_bar->count() * HORIZONTAL_TAB_MAX_WIDTH);
+    m_tab_bar->setFixedWidth(max(0, tab_bar_width));
 }
 
 void TabWidget::update_tab_button_visibility()


### PR DESCRIPTION
* Fix `about:settings` incorrectly overriding the expanded vertical tab setting
* Fix horizontal tab layout when switching from vertical to horizontal tabs
* Remove redundant / unnecessary code