### PR TITLE
LibWeb/SVG: Fix crash parsing a coordinate sequence that ends mid-token

### DIFF
--- a/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -349,6 +349,7 @@ ErrorOr<Vector<float>> AttributeParser::parse_coordinate_sequence()
         if (coordinate_or_error.is_error()) {
             if (is_first)
                 return Error::from_string_literal("Expected coordinate sequence");
+            break;
         }
         is_first = false;
         sequence.append(coordinate_or_error.release_value());

--- a/Tests/LibWeb/Crash/SVG/path-coordinate-sequence-trailing-comma.svg
+++ b/Tests/LibWeb/Crash/SVG/path-coordinate-sequence-trailing-comma.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"><path d="H1,,"/></svg>


### PR DESCRIPTION
When parsing the path data `H1,,`, `AttributeParser::parse_coordinate_sequence()` crashes the WebContent process.

## Root cause

`parse_coordinate_sequence()` is missing the `break` that its sibling `parse_coordinate_pair_sequence()` has in the non-first-iteration error branch:

```cpp
auto coordinate_or_error = parse_coordinate();
if (coordinate_or_error.is_error()) {
    if (is_first)
        return Error::from_string_literal("Expected coordinate sequence");
    // <-- falls through instead of breaking
}
is_first = false;
sequence.append(coordinate_or_error.release_value());
```

After the first coordinate in `H1,,`, `match_comma_whitespace()` is still true, so the loop runs again, the next `parse_coordinate()` fails on the second comma, and the function falls through to `coordinate_or_error.release_value()`. Releasing the value of an errored `ErrorOr` trips a `VERIFY` and aborts the process.

This is reachable from any web page via `<path d>`, `new Path2D(...)`, or the CSS `path()` function.

## Fix

Break out of the loop on a non-first error, exactly as `parse_coordinate_pair_sequence()` already does.

## Reproducer

Added a crash test at `Tests/LibWeb/Crash/SVG/path-coordinate-sequence-trailing-comma.svg`:

```xml
<svg xmlns="http://www.w3.org/2000/svg"><path d="H1,,"/></svg>
```

Before this change the test aborts WebContent; after it, the page loads cleanly.