### PR TITLE
LibWeb: Make DevTools layout state collection only run when needed

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -1063,17 +1063,13 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         // https://www.w3.org/TR/css-grid-2/#resolved-track-list-standalone
         if (property_id == PropertyID::GridTemplateColumns) {
             if (auto first_paintable = layout_node.first_paintable(); auto const* paintable_box = as_if<Painting::PaintableBox>(first_paintable.ptr())) {
-                if (auto const* grid_layout_data = paintable_box->grid_layout_data()) {
-                    if (auto const& resolved_grid_template_columns = grid_layout_data->resolved_grid_template_columns)
-                        return resolved_grid_template_columns;
-                }
+                if (auto used_values_for_grid_template_columns = paintable_box->used_values_for_grid_template_columns())
+                    return used_values_for_grid_template_columns;
             }
         } else if (property_id == PropertyID::GridTemplateRows) {
             if (auto first_paintable = layout_node.first_paintable(); auto const* paintable_box = as_if<Painting::PaintableBox>(first_paintable.ptr())) {
-                if (auto const* grid_layout_data = paintable_box->grid_layout_data()) {
-                    if (auto const& resolved_grid_template_rows = grid_layout_data->resolved_grid_template_rows)
-                        return resolved_grid_template_rows;
-                }
+                if (auto used_values_for_grid_template_rows = paintable_box->used_values_for_grid_template_rows())
+                    return used_values_for_grid_template_rows;
             }
         }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1779,7 +1779,11 @@ void Document::update_layout(UpdateLayoutReason reason)
     for (size_t layout_pass = 0; layout_pass < max_container_query_layout_passes; ++layout_pass) {
         update_style();
 
-        if (layout_is_up_to_date())
+        auto const should_collect_devtools_layout_data = page().client().has_active_devtools_client();
+        auto const force_devtools_layout_data_collection = should_collect_devtools_layout_data
+            && reason == UpdateLayoutReason::InspectDevToolsLayoutData;
+
+        if (layout_is_up_to_date() && !force_devtools_layout_data_collection)
             return;
 
         auto svg_roots_to_relayout = move(m_svg_roots_needing_relayout);
@@ -1866,6 +1870,7 @@ void Document::update_layout(UpdateLayoutReason reason)
 
         Layout::LayoutState layout_state;
         layout_state.ensure_capacity(layout_index_counter);
+        layout_state.set_should_collect_devtools_layout_data(should_collect_devtools_layout_data);
 
         {
             auto& viewport = static_cast<Layout::Viewport&>(*m_layout_root);
@@ -1961,6 +1966,22 @@ void Document::update_layout(UpdateLayoutReason reason)
     }
 
     VERIFY(layout_is_up_to_date());
+}
+
+void Document::clear_devtools_layout_inspection_data()
+{
+    clear_grid_highlighted_node(nullptr);
+    clear_flexbox_highlighted_node(nullptr);
+
+    auto paintable = this->paintable();
+    if (!paintable)
+        return;
+
+    paintable->for_each_in_subtree_of_type<Painting::PaintableBox>([](auto& paintable_box) {
+        paintable_box.set_grid_layout_data(nullptr);
+        paintable_box.set_flex_layout_data(nullptr);
+        return TraversalDecision::Continue;
+    });
 }
 
 bool Document::layout_is_up_to_date() const

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -126,8 +126,7 @@ enum class InvalidateLayoutTreeReason {
     X(HostedDocumentBeforePaint)             \
     X(InspectAccessibilityTree)              \
     X(InspectDOMTree)                        \
-    X(InspectFlexboxLayout)                  \
-    X(InspectGridLayout)                     \
+    X(InspectDevToolsLayoutData)             \
     X(InternalsHitTest)                      \
     X(MediaQueryListMatches)                 \
     X(NavigableSelectedText)                 \
@@ -400,6 +399,7 @@ public:
     void update_layout(UpdateLayoutReason);
     void update_layout_if_needed_for_node(Node const&, UpdateLayoutReason);
     [[nodiscard]] bool layout_is_up_to_date() const;
+    void clear_devtools_layout_inspection_data();
     void update_paint_and_hit_testing_properties_if_needed();
     void update_animated_style_if_needed();
 

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -247,7 +247,8 @@ void FlexFormattingContext::run(AvailableSpace const& available_space)
         resolve_baseline_aligned_items();
     }
 
-    save_flex_layout_data();
+    if (m_state.should_collect_devtools_layout_data())
+        save_flex_layout_data();
 }
 
 void FlexFormattingContext::parent_context_did_dimension_child_root_box()

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2418,14 +2418,12 @@ void GridFormattingContext::resolve_track_spacing(GridDimension dimension)
     }
 }
 
-void GridFormattingContext::save_grid_layout_data(CSS::GridTrackSizeList&& columns, CSS::GridTrackSizeList&& rows)
+void GridFormattingContext::save_grid_layout_data()
 {
     auto data = make<GridLayoutData>();
     data->direction = grid_container().computed_values().direction();
     data->is_subgrid = is_subgridded_axis(GridDimension::Column) || is_subgridded_axis(GridDimension::Row);
     data->writing_mode = grid_container().computed_values().writing_mode();
-    data->resolved_grid_template_columns = CSS::GridTrackSizeListStyleValue::create(move(columns));
-    data->resolved_grid_template_rows = CSS::GridTrackSizeListStyleValue::create(move(rows));
 
     auto track_type_for_index = [](size_t index, size_t explicit_start_line_index, size_t explicit_line_count) {
         if (explicit_line_count == 0)
@@ -2911,7 +2909,9 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
 
     // getComputedStyle() needs to return the resolved values of grid-template-columns and grid-template-rows
     // so they need to be saved in the state, and then assigned to paintables in LayoutState::commit()
-    save_grid_layout_data(move(grid_track_columns), move(grid_track_rows));
+    m_grid_container_used_values.set_grid_template_columns(CSS::GridTrackSizeListStyleValue::create(move(grid_track_columns)));
+    m_grid_container_used_values.set_grid_template_rows(CSS::GridTrackSizeListStyleValue::create(move(grid_track_rows)));
+    save_grid_layout_data();
 }
 
 // https://www.w3.org/TR/css-grid-2/#abspos-items

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2420,6 +2420,9 @@ void GridFormattingContext::resolve_track_spacing(GridDimension dimension)
 
 void GridFormattingContext::save_grid_layout_data()
 {
+    if (!m_state.should_collect_devtools_layout_data())
+        return;
+
     auto data = make<GridLayoutData>();
     data->direction = grid_container().computed_values().direction();
     data->is_subgrid = is_subgridded_axis(GridDimension::Column) || is_subgridded_axis(GridDimension::Row);

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -322,7 +322,7 @@ private:
     void resolve_grid_item_sizes(GridDimension dimension);
 
     void resolve_track_spacing(GridDimension dimension);
-    void save_grid_layout_data(CSS::GridTrackSizeList&& columns, CSS::GridTrackSizeList&& rows);
+    void save_grid_layout_data();
     CSSPixels grid_container_size_for_track_alignment(GridDimension dimension) const;
 
     AvailableSize get_free_space(AvailableSpace const&, GridDimension) const;

--- a/Libraries/LibWeb/Layout/GridLayoutData.h
+++ b/Libraries/LibWeb/Layout/GridLayoutData.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/Enums.h>
@@ -66,8 +65,6 @@ struct GridLayoutData {
     CSS::Direction direction { CSS::Direction::Ltr };
     CSS::WritingMode writing_mode { CSS::WritingMode::HorizontalTb };
     bool is_subgrid { false };
-    RefPtr<CSS::GridTrackSizeListStyleValue const> resolved_grid_template_columns;
-    RefPtr<CSS::GridTrackSizeListStyleValue const> resolved_grid_template_rows;
     Vector<GridLayoutFragment> fragments;
 };
 

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -591,6 +591,8 @@ void LayoutState::commit(Box& root)
             }
 
             if (node.display().is_grid_inside()) {
+                paintable_box->set_used_values_for_grid_template_columns(used_values.grid_template_columns());
+                paintable_box->set_used_values_for_grid_template_rows(used_values.grid_template_rows());
                 paintable_box->set_grid_layout_data(used_values.take_grid_layout_data());
             }
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -392,6 +392,9 @@ struct LayoutState {
 
     void ensure_capacity(u32 node_count);
 
+    void set_should_collect_devtools_layout_data(bool should_collect) { m_should_collect_devtools_layout_data = should_collect; }
+    bool should_collect_devtools_layout_data() const { return m_should_collect_devtools_layout_data; }
+
     UsedValues& get_mutable(NodeWithStyle const&);
     UsedValues const& get(NodeWithStyle const&) const;
 
@@ -408,6 +411,7 @@ private:
 
     PagedStore<UsedValues> m_used_values_store;
     GC::Ptr<Layout::NodeWithStyle const> m_subtree_root;
+    bool m_should_collect_devtools_layout_data { false };
 };
 
 inline CSSPixels clamp_to_max_dimension_value(CSSPixels value)

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -276,6 +276,20 @@ struct LayoutState {
             return move(m_rare->grid_layout_data);
         }
 
+        void set_grid_template_columns(RefPtr<CSS::GridTrackSizeListStyleValue const> used_values_for_grid_template_columns) { ensure_rare_data().grid_template_columns = move(used_values_for_grid_template_columns); }
+        RefPtr<CSS::GridTrackSizeListStyleValue const> const& grid_template_columns() const
+        {
+            static RefPtr<CSS::GridTrackSizeListStyleValue const> const empty;
+            return m_rare ? m_rare->grid_template_columns : empty;
+        }
+
+        void set_grid_template_rows(RefPtr<CSS::GridTrackSizeListStyleValue const> used_values_for_grid_template_rows) { ensure_rare_data().grid_template_rows = move(used_values_for_grid_template_rows); }
+        RefPtr<CSS::GridTrackSizeListStyleValue const> const& grid_template_rows() const
+        {
+            static RefPtr<CSS::GridTrackSizeListStyleValue const> const empty;
+            return m_rare ? m_rare->grid_template_rows : empty;
+        }
+
         void set_flex_layout_data(OwnPtr<FlexLayoutData> flex_layout_data) { ensure_rare_data().flex_layout_data = move(flex_layout_data); }
         FlexLayoutData const* flex_layout_data() const
         {
@@ -322,6 +336,8 @@ struct LayoutState {
                 : floating_descendants(other.floating_descendants)
                 , table_cell_coordinates(other.table_cell_coordinates)
                 , computed_svg_path(other.computed_svg_path)
+                , grid_template_columns(other.grid_template_columns)
+                , grid_template_rows(other.grid_template_rows)
                 , grid_area_size(other.grid_area_size)
                 , override_borders_data(other.override_borders_data)
                 , computed_svg_transforms(other.computed_svg_transforms)
@@ -338,6 +354,8 @@ struct LayoutState {
             Optional<Gfx::Path> computed_svg_path;
             OwnPtr<GridLayoutData> grid_layout_data;
             OwnPtr<FlexLayoutData> flex_layout_data;
+            RefPtr<CSS::GridTrackSizeListStyleValue const> grid_template_columns;
+            RefPtr<CSS::GridTrackSizeListStyleValue const> grid_template_rows;
             Optional<CSSPixelSize> grid_area_size;
             Optional<Painting::PaintableBox::BordersDataWithElementKind> override_borders_data;
             Optional<Painting::SVGGraphicsPaintable::ComputedTransforms> computed_svg_transforms;

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -414,6 +414,7 @@ public:
     virtual Page& page() = 0;
     virtual Page const& page() const = 0;
     virtual bool is_connection_open() const = 0;
+    virtual bool has_active_devtools_client() const { return false; }
     virtual bool is_url_suitable_for_same_process_navigation([[maybe_unused]] URL::URL const& current_url, [[maybe_unused]] URL::URL const& target_url) const { return true; }
     virtual void request_new_process_for_navigation(URL::URL const&) { }
     virtual Gfx::Palette palette() const = 0;

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -551,6 +551,8 @@ void PaintableBox::reset_for_relayout()
     m_accumulated_visual_context_for_descendants_index = {};
     m_fixed_background_visual_context = {};
 
+    m_used_values_for_grid_template_columns = nullptr;
+    m_used_values_for_grid_template_rows = nullptr;
     m_grid_layout_data = nullptr;
     m_flex_layout_data = nullptr;
 

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -281,6 +281,12 @@ public:
     [[nodiscard]] bool could_be_scrolled_by_wheel_event() const;
     [[nodiscard]] bool could_be_scrolled_by_wheel_event(ScrollDirection direction) const;
 
+    void set_used_values_for_grid_template_columns(RefPtr<CSS::GridTrackSizeListStyleValue const> style_value) { m_used_values_for_grid_template_columns = move(style_value); }
+    RefPtr<CSS::GridTrackSizeListStyleValue const> const& used_values_for_grid_template_columns() const { return m_used_values_for_grid_template_columns; }
+
+    void set_used_values_for_grid_template_rows(RefPtr<CSS::GridTrackSizeListStyleValue const> style_value) { m_used_values_for_grid_template_rows = move(style_value); }
+    RefPtr<CSS::GridTrackSizeListStyleValue const> const& used_values_for_grid_template_rows() const { return m_used_values_for_grid_template_rows; }
+
     void set_grid_layout_data(OwnPtr<Layout::GridLayoutData> grid_layout_data) { m_grid_layout_data = move(grid_layout_data); }
     Layout::GridLayoutData const* grid_layout_data() const { return m_grid_layout_data.ptr(); }
     void set_flex_layout_data(OwnPtr<Layout::FlexLayoutData> flex_layout_data) { m_flex_layout_data = move(flex_layout_data); }
@@ -371,6 +377,8 @@ private:
 
     OwnPtr<StickyInsets> m_sticky_insets;
 
+    RefPtr<CSS::GridTrackSizeListStyleValue const> m_used_values_for_grid_template_columns;
+    RefPtr<CSS::GridTrackSizeListStyleValue const> m_used_values_for_grid_template_rows;
     OwnPtr<Layout::GridLayoutData> m_grid_layout_data;
     OwnPtr<Layout::FlexLayoutData> m_flex_layout_data;
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -902,7 +902,7 @@ static void append_grid_layouts_for_node_and_frame_descendants(Web::DOM::Node& r
         if (!content_document->origin().is_same_origin_domain(navigable_container->document().origin()))
             return Web::TraversalDecision::Continue;
 
-        content_document->update_layout(Web::DOM::UpdateLayoutReason::InspectGridLayout);
+        content_document->update_layout(Web::DOM::UpdateLayoutReason::Debugging);
         append_grid_layouts_for_node_and_frame_descendants(*content_document, grid_layouts);
         return Web::TraversalDecision::Continue;
     });
@@ -920,7 +920,7 @@ void ConnectionFromClient::inspect_grid_layouts(u64 page_id, Web::UniqueNodeID r
         return;
     }
 
-    root_node->document().update_layout(Web::DOM::UpdateLayoutReason::InspectGridLayout);
+    root_node->document().update_layout(Web::DOM::UpdateLayoutReason::Debugging);
 
     JsonArray grid_layouts;
     append_grid_layouts_for_node_and_frame_descendants(*root_node, grid_layouts);
@@ -940,7 +940,7 @@ void ConnectionFromClient::inspect_current_grid(u64 page_id, Web::UniqueNodeID n
         return;
     }
 
-    node->document().update_layout(Web::DOM::UpdateLayoutReason::InspectGridLayout);
+    node->document().update_layout(Web::DOM::UpdateLayoutReason::Debugging);
 
     for (auto const* current = node; current; current = current->parent_or_shadow_host_node()) {
         if (auto grid_layout = grid_layout_for_node(*current); grid_layout.has_value()) {
@@ -964,7 +964,7 @@ void ConnectionFromClient::inspect_current_flexbox(u64 page_id, Web::UniqueNodeI
         return;
     }
 
-    node->document().update_layout(Web::DOM::UpdateLayoutReason::InspectFlexboxLayout);
+    node->document().update_layout(Web::DOM::UpdateLayoutReason::Debugging);
 
     for (auto const* current = only_look_at_parents ? node->parent_or_shadow_host_node() : node; current; current = current->parent_or_shadow_host_node()) {
         if (auto flex_layout = flex_layout_for_node(*current); flex_layout.has_value()) {
@@ -1053,10 +1053,15 @@ void ConnectionFromClient::highlight_flexbox(u64 page_id, Web::UniqueNodeID node
         return;
 
     auto* node = Web::DOM::Node::from_unique_id(node_id);
-    if (!node || !node->layout_node())
+    if (!node)
         return;
 
-    node->document().set_flexbox_highlighted_node(node, flexbox_inspector_overlay_options_from_json(options));
+    auto& document = node->document();
+    document.update_layout(Web::DOM::UpdateLayoutReason::Debugging);
+    if (!node->layout_node())
+        return;
+
+    document.set_flexbox_highlighted_node(node, flexbox_inspector_overlay_options_from_json(options));
 }
 
 void ConnectionFromClient::clear_flexbox_highlight(u64 page_id, Web::UniqueNodeID node_id)
@@ -1085,10 +1090,15 @@ void ConnectionFromClient::highlight_grid(u64 page_id, Web::UniqueNodeID node_id
         return;
 
     auto* node = Web::DOM::Node::from_unique_id(node_id);
-    if (!node || !node->layout_node())
+    if (!node)
         return;
 
-    node->document().set_grid_highlighted_node(node, grid_inspector_overlay_options_from_json(options));
+    auto& document = node->document();
+    document.update_layout(Web::DOM::UpdateLayoutReason::Debugging);
+    if (!node->layout_node())
+        return;
+
+    document.set_grid_highlighted_node(node, grid_inspector_overlay_options_from_json(options));
 }
 
 void ConnectionFromClient::clear_grid_highlight(u64 page_id, Web::UniqueNodeID node_id)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -28,6 +28,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLLinkElement.h>
+#include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
@@ -935,13 +936,34 @@ void PageClient::page_did_receive_network_response_body(u64 request_id, Readonly
 
 void PageClient::did_connect_devtools_client()
 {
+    auto was_first_devtools_client = !has_devtools_client();
     ++m_devtools_client_count;
+
+    if (!was_first_devtools_client)
+        return;
+
+    for (auto& navigable : Web::HTML::all_navigables()) {
+        if (&navigable->page() != &page())
+            continue;
+        if (auto active_document = navigable->active_document())
+            active_document->update_layout(Web::DOM::UpdateLayoutReason::InspectDevToolsLayoutData);
+    }
 }
 
 void PageClient::did_disconnect_devtools_client()
 {
     VERIFY(m_devtools_client_count > 0);
     --m_devtools_client_count;
+
+    if (has_devtools_client())
+        return;
+
+    for (auto& navigable : Web::HTML::all_navigables()) {
+        if (&navigable->page() != &page())
+            continue;
+        if (auto active_document = navigable->active_document())
+            active_document->clear_devtools_layout_inspection_data();
+    }
 }
 
 void PageClient::page_did_finish_network_request(u64 request_id, u64 body_size, Requests::RequestTimingInfo const& timing_info, Optional<Requests::NetworkError> const& network_error)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -87,6 +87,7 @@ public:
     void did_connect_devtools_client();
     void did_disconnect_devtools_client();
     bool has_devtools_client() const { return m_devtools_client_count > 0; }
+    virtual bool has_active_devtools_client() const override { return has_devtools_client(); }
 
     void initialize_js_console(Web::DOM::Document& document);
     void js_console_input(StringView js_source);


### PR DESCRIPTION
If DevTools isn't connected, don't waste time and memory collecting grid and flexbox layout data. Instead, when DevTools connects, we force an extra layout pass to populate that data, and then regular layout updates keep it correct from then on. When the last DevTools client disconnects, we discard the data again as it's no longer needed.