### PR TITLE
LibWeb: Apply clip-path and CSS clip to abspos and fixed descendants

### DIFF
--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -231,6 +231,13 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         return effects;
     };
 
+    auto make_css_clip_data = [&](PaintableBox const& box) -> Optional<ClipData> {
+        auto css_clip = box.get_clip_rect();
+        if (!css_clip.has_value())
+            return {};
+        return ClipData { converter.rounded_device_rect(effective_css_clip_rect(*css_clip)), {} };
+    };
+
     // FIXME: Support other geometry boxes. See: https://drafts.fxtf.org/css-masking/#typedef-geometry-box
     auto make_clip_path_data = [&](PaintableBox const& box) -> Optional<ClipPathData> {
         auto const& computed_values = box.computed_values();
@@ -277,21 +284,27 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
         VisualContextIndex inherited_state;
 
-        if (paintable_box.is_fixed_position()) {
-            inherited_state = visual_viewport_context_index;
-
-            Vector<VisualContextData, 4> intermediate_constraints;
-            for (RefPtr<Paintable> paintable = visual_parent; paintable; paintable = paintable->parent()) {
+        auto collect_intermediate_constraints = [&](RefPtr<Paintable> const& from, RefPtr<Paintable> const& to) {
+            Vector<VisualContextData, 4> constraints;
+            for (RefPtr<Paintable> paintable = from; paintable && paintable != to; paintable = paintable->parent()) {
                 auto* ancestor_box = as_if<PaintableBox>(paintable.ptr());
                 if (!ancestor_box)
                     continue;
                 if (auto effects = make_effects_data(*ancestor_box); effects.has_value())
-                    intermediate_constraints.append(effects.release_value());
+                    constraints.append(effects.release_value());
+                if (auto css_clip_data = make_css_clip_data(*ancestor_box); css_clip_data.has_value())
+                    constraints.append(css_clip_data.release_value());
                 if (auto clip_path_data = make_clip_path_data(*ancestor_box); clip_path_data.has_value())
-                    intermediate_constraints.append(clip_path_data.release_value());
+                    constraints.append(clip_path_data.release_value());
             }
+            return constraints;
+        };
 
-            for (auto& constraint : intermediate_constraints.in_reverse())
+        if (paintable_box.is_fixed_position()) {
+            inherited_state = visual_viewport_context_index;
+
+            auto constraints = collect_intermediate_constraints(visual_parent, nullptr);
+            for (auto& constraint : constraints.in_reverse())
                 inherited_state = append_node(inherited_state, move(constraint));
         } else if (paintable_box.is_absolutely_positioned()) {
             // For position: absolute, use containing block's state to correctly escape scroll containers.
@@ -304,18 +317,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             // block and collect these intermediate effects.
             // NOTE: transforms/perspectives/filters establish containing blocks for abspos,
             //       so they cannot appear as intermediates.
-            Vector<VisualContextData, 4> intermediate_constraints;
-            RefPtr<Paintable> containing_paintable = containing;
-            for (RefPtr<Paintable> paintable = visual_parent; paintable && paintable != containing_paintable; paintable = paintable->parent()) {
-                auto* ancestor_box = as_if<PaintableBox>(paintable.ptr());
-                if (!ancestor_box)
-                    continue;
-                if (auto effects = make_effects_data(*ancestor_box); effects.has_value())
-                    intermediate_constraints.append(effects.release_value());
-                if (auto clip_path_data = make_clip_path_data(*ancestor_box); clip_path_data.has_value())
-                    intermediate_constraints.append(clip_path_data.release_value());
-            }
-            for (auto& constraint : intermediate_constraints.in_reverse())
+            auto constraints = collect_intermediate_constraints(visual_parent, containing);
+            for (auto& constraint : constraints.in_reverse())
                 inherited_state = append_node(inherited_state, move(constraint));
         } else {
             // For position: relative/static, use visual parent's state directly.
@@ -346,10 +349,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             paintable_box.set_has_non_invertible_css_transform(false);
         }
 
-        if (auto css_clip = paintable_box.get_clip_rect(); css_clip.has_value()) {
-            auto effective_rect = effective_css_clip_rect(*css_clip);
-            own_state = append_node(own_state, ClipData { converter.rounded_device_rect(effective_rect), {} });
-        }
+        if (auto css_clip_data = make_css_clip_data(paintable_box); css_clip_data.has_value())
+            own_state = append_node(own_state, css_clip_data.release_value());
 
         if (auto clip_path_data = make_clip_path_data(paintable_box); clip_path_data.has_value())
             own_state = append_node(own_state, clip_path_data.release_value());

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -231,6 +231,29 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         return effects;
     };
 
+    // FIXME: Support other geometry boxes. See: https://drafts.fxtf.org/css-masking/#typedef-geometry-box
+    auto make_clip_path_data = [&](PaintableBox const& box) -> Optional<ClipPathData> {
+        auto const& computed_values = box.computed_values();
+        auto const& clip_path = computed_values.clip_path();
+
+        if (!clip_path.has_value() || !clip_path->is_basic_shape())
+            return {};
+
+        auto masking_area = box.absolute_border_box_rect();
+        auto reference_box = CSSPixelRect { {}, masking_area.size() };
+        auto const& basic_shape = clip_path->basic_shape();
+        auto path = basic_shape.to_path(reference_box, box.layout_node());
+        path.offset(masking_area.top_left().template to_type<float>());
+        auto fill_rule = basic_shape.basic_shape().visit(
+            [](CSS::Polygon const& polygon) { return polygon.fill_rule; },
+            [](CSS::Path const& path) { return path.fill_rule; },
+            [](auto const&) { return Gfx::WindingRule::Nonzero; });
+        auto device_path = path.copy_transformed(Gfx::AffineTransform {}.set_scale(scale, scale));
+        auto device_bounding_rect = converter.rounded_device_rect(masking_area);
+
+        return ClipPathData { move(device_path), device_bounding_rect, fill_rule };
+    };
+
     auto visual_viewport_context_index = VISUAL_VIEWPORT_NODE_INDEX;
 
     VisualContextIndex viewport_state_for_descendants = visual_viewport_context_index;
@@ -256,6 +279,20 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
         if (paintable_box.is_fixed_position()) {
             inherited_state = visual_viewport_context_index;
+
+            Vector<VisualContextData, 4> intermediate_constraints;
+            for (RefPtr<Paintable> paintable = visual_parent; paintable; paintable = paintable->parent()) {
+                auto* ancestor_box = as_if<PaintableBox>(paintable.ptr());
+                if (!ancestor_box)
+                    continue;
+                if (auto effects = make_effects_data(*ancestor_box); effects.has_value())
+                    intermediate_constraints.append(effects.release_value());
+                if (auto clip_path_data = make_clip_path_data(*ancestor_box); clip_path_data.has_value())
+                    intermediate_constraints.append(clip_path_data.release_value());
+            }
+
+            for (auto& constraint : intermediate_constraints.in_reverse())
+                inherited_state = append_node(inherited_state, move(constraint));
         } else if (paintable_box.is_absolutely_positioned()) {
             // For position: absolute, use containing block's state to correctly escape scroll containers.
             auto containing = paintable_box.containing_block();
@@ -267,17 +304,19 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             // block and collect these intermediate effects.
             // NOTE: transforms/perspectives/filters establish containing blocks for abspos,
             //       so they cannot appear as intermediates.
-            Vector<VisualContextData, 4> intermediate_effects;
+            Vector<VisualContextData, 4> intermediate_constraints;
             RefPtr<Paintable> containing_paintable = containing;
             for (RefPtr<Paintable> paintable = visual_parent; paintable && paintable != containing_paintable; paintable = paintable->parent()) {
                 auto* ancestor_box = as_if<PaintableBox>(paintable.ptr());
                 if (!ancestor_box)
                     continue;
                 if (auto effects = make_effects_data(*ancestor_box); effects.has_value())
-                    intermediate_effects.append(effects.release_value());
+                    intermediate_constraints.append(effects.release_value());
+                if (auto clip_path_data = make_clip_path_data(*ancestor_box); clip_path_data.has_value())
+                    intermediate_constraints.append(clip_path_data.release_value());
             }
-            for (auto& effects : intermediate_effects.in_reverse())
-                inherited_state = append_node(inherited_state, move(effects));
+            for (auto& constraint : intermediate_constraints.in_reverse())
+                inherited_state = append_node(inherited_state, move(constraint));
         } else {
             // For position: relative/static, use visual parent's state directly.
             // This avoids duplicate transform/perspective allocations that would occur with
@@ -312,21 +351,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             own_state = append_node(own_state, ClipData { converter.rounded_device_rect(effective_rect), {} });
         }
 
-        // FIXME: Support other geometry boxes. See: https://drafts.fxtf.org/css-masking/#typedef-geometry-box
-        if (auto const& clip_path = computed_values.clip_path(); clip_path.has_value() && clip_path->is_basic_shape()) {
-            auto masking_area = paintable_box.absolute_border_box_rect();
-            auto reference_box = CSSPixelRect { {}, masking_area.size() };
-            auto const& basic_shape = clip_path->basic_shape();
-            auto path = basic_shape.to_path(reference_box, paintable_box.layout_node());
-            path.offset(masking_area.top_left().template to_type<float>());
-            auto fill_rule = basic_shape.basic_shape().visit(
-                [](CSS::Polygon const& polygon) { return polygon.fill_rule; },
-                [](CSS::Path const& path) { return path.fill_rule; },
-                [](auto const&) { return Gfx::WindingRule::Nonzero; });
-            auto device_path = path.copy_transformed(Gfx::AffineTransform {}.set_scale(scale, scale));
-            auto device_bounding_rect = converter.rounded_device_rect(masking_area);
-            own_state = append_node(own_state, ClipPathData { move(device_path), device_bounding_rect, fill_rule });
-        }
+        if (auto clip_path_data = make_clip_path_data(paintable_box); clip_path_data.has_value())
+            own_state = append_node(own_state, clip_path_data.release_value());
 
         paintable_box.set_accumulated_visual_context(own_state);
 

--- a/Tests/LibWeb/Ref/expected/clip-path-inset-abspos-child.html
+++ b/Tests/LibWeb/Ref/expected/clip-path-inset-abspos-child.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+        transform: translate(50%, 50%);
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/clip-path-inset-fixed-child.html
+++ b/Tests/LibWeb/Ref/expected/clip-path-inset-fixed-child.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+        transform: translate(50%, 50%);
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/css-clip-abspos-fixed-child.html
+++ b/Tests/LibWeb/Ref/expected/css-clip-abspos-fixed-child.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/clip-path-inset-abspos-child.html
+++ b/Tests/LibWeb/Ref/input/clip-path-inset-abspos-child.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/clip-path-inset-abspos-child.html" />
+<style>
+    .clipped {
+        clip-path: inset(50px);
+        height: 200px;
+        width: 200px;
+    }
+
+    .clipped::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-color: red;
+    }
+</style>
+<div class="clipped"></div>

--- a/Tests/LibWeb/Ref/input/clip-path-inset-fixed-child.html
+++ b/Tests/LibWeb/Ref/input/clip-path-inset-fixed-child.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/clip-path-inset-fixed-child.html" />
+<style>
+    .clipped {
+        clip-path: inset(50px);
+        height: 200px;
+        width: 200px;
+    }
+
+    .clipped::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        background-color: red;
+    }
+</style>
+<div class="clipped"></div>

--- a/Tests/LibWeb/Ref/input/css-clip-abspos-fixed-child.html
+++ b/Tests/LibWeb/Ref/input/css-clip-abspos-fixed-child.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/css-clip-abspos-fixed-child.html" />
+<style>
+    .a {
+        position: relative;
+        z-index: 1;
+    }
+
+    .b {
+        position: absolute;
+        inset: 0;
+        clip: rect(0px, 100px, 100px, 0px);
+    }
+
+    .b div {
+        position: fixed;
+        inset: 0;
+        background-color: red;
+    }
+</style>
+<div class="a">
+    <div class="b">
+        <div></div>
+    </div>
+</div>


### PR DESCRIPTION
Absolutely and fixed positioned elements were not inheriting `clip-path/clip` property from intermediate ancestors, causing them to paint outside clipping regions they should be contained within.

The intermediate ancestor walk already existed for collecting stacking context effects using `make_effects_data`, so I just followed the same pattern and added `make_clip_path_data` and `make_css_clip_data` alongside it.

First commit fixes main visual on https://magicalmirai.com/2026/:

<img width="600" alt="before_after_1" src="https://github.com/user-attachments/assets/ba41622b-b139-49d7-8409-a1e343f63834" />


Second commit on https://magicalmirai.com/2025/: 

<img width="600" alt="before_after_2" src="https://github.com/user-attachments/assets/a841b776-5f10-4216-a6e8-ae2a05432ed5" />
