### PR TITLE
LibDNS: Fix crash on a resource record with trailing rdata bytes

### DIFF
--- a/Libraries/LibDNS/Message.cpp
+++ b/Libraries/LibDNS/Message.cpp
@@ -831,14 +831,15 @@ ErrorOr<ResourceRecord> ResourceRecord::from_raw(ParseContext& ctx)
     ParseContext rdata_ctx { rdata_stream, move(ctx.pointers) };
     ScopeGuard guard([&] { ctx.pointers = move(rdata_ctx.pointers); });
 
-#define PARSE_AS_RR(TYPE)                                                                                                                                   \
-    do {                                                                                                                                                    \
-        auto rr = TRY(Records::TYPE::from_raw(rdata_ctx));                                                                                                  \
-        if (!rdata_stream.is_eof()) {                                                                                                                       \
-            dbgln("Extra data ({}) left in stream: {:hex-dump}", rdata.size() - rdata_stream.read_bytes(), rdata.bytes().slice(rdata_stream.read_bytes())); \
-            return Error::from_string_literal("Extra data in " #TYPE " record content");                                                                    \
-        }                                                                                                                                                   \
-        return ResourceRecord { move(name), type, class_, ttl, rr, move(rr_raw_data) };                                                                     \
+#define PARSE_AS_RR(TYPE)                                                                                                 \
+    do {                                                                                                                  \
+        auto rr = TRY(Records::TYPE::from_raw(rdata_ctx));                                                                \
+        if (!rdata_stream.is_eof()) {                                                                                     \
+            auto consumed = rdata_stream.read_bytes() - original_offset;                                                  \
+            dbgln("Extra data ({}) left in stream: {:hex-dump}", rdata.size() - consumed, rdata.bytes().slice(consumed)); \
+            return Error::from_string_literal("Extra data in " #TYPE " record content");                                  \
+        }                                                                                                                 \
+        return ResourceRecord { move(name), type, class_, ttl, rr, move(rr_raw_data) };                                   \
     } while (0)
 
     switch (type) {

--- a/Tests/LibDNS/TestDNSMessage.cpp
+++ b/Tests/LibDNS/TestDNSMessage.cpp
@@ -41,3 +41,29 @@ TEST_CASE(parsing_a_reserved_label_length_fails)
     auto result = DNS::Messages::Message::from_raw(stream);
     EXPECT(result.is_error());
 }
+
+// A resource record whose RDLENGTH is larger than the type-specific parser
+// consumes used to abort the process: the "extra data" diagnostic computed an
+// rdata offset relative to the whole packet instead of relative to the rdata
+// buffer, slicing out of bounds. Parsing must fail gracefully instead.
+TEST_CASE(rdata_with_trailing_bytes_does_not_crash)
+{
+    Array<u8, 28> const message {
+        0x00, 0x00,                   // ID
+        0x00, 0x00,                   // Flags
+        0x00, 0x00,                   // QDCOUNT
+        0x00, 0x01,                   // ANCOUNT
+        0x00, 0x00,                   // NSCOUNT
+        0x00, 0x00,                   // ARCOUNT
+        0x00,                         // NAME: root
+        0x00, 0x01,                   // TYPE: A
+        0x00, 0x01,                   // CLASS: IN
+        0x00, 0x00, 0x00, 0x00,       // TTL
+        0x00, 0x05,                   // RDLENGTH: 5 (one byte more than an A record needs)
+        0x01, 0x02, 0x03, 0x04, 0xff, // RDATA
+    };
+
+    FixedMemoryStream stream { ReadonlyBytes { message } };
+    auto result = DNS::Messages::Message::from_raw(stream);
+    EXPECT(result.is_error());
+}


### PR DESCRIPTION
A DNS response answer record whose `RDLENGTH` is larger than the type-specific parser consumes crashes the process.

## Root cause

`ResourceRecord::from_raw()` parses each record's `RDATA` through a `CountingStream` seeded with the record's absolute offset in the packet, so that any compression pointers inside the rdata resolve against the whole message. As a result `rdata_stream.read_bytes()` returns a *packet-relative* offset.

When the type-specific parser leaves bytes unconsumed, the `PARSE_AS_RR` macro logs a diagnostic that uses that packet-relative offset to index into the *rdata-only* buffer:

```cpp
dbgln("Extra data ({}) left in stream: {:hex-dump}",
    rdata.size() - rdata_stream.read_bytes(),          // size_t underflow
    rdata.bytes().slice(rdata_stream.read_bytes()));   // slice start > size()
```

`read_bytes()` is almost always larger than `rdata.size()`, so the subtraction underflows and `Span::slice()` is called with `start > size()`, tripping a `VERIFY` and aborting the process. (On a build without assertions the same path is an out-of-bounds read.)

`RequestServer` parses DNS responses coming from the upstream resolver, so a hostile or on-path resolver can crash it — for example with an `A` record carrying `RDLENGTH=5` (the parser only reads 4 bytes for the address). That takes down networking for the rest of the session.

## Fix

Subtract the record's starting offset to obtain the rdata-relative number of consumed bytes before indexing into the buffer.

## Reproducer

Added `Tests/LibDNS/TestDNSMessage.cpp`, which feeds a 28-byte response containing an `A` record with `RDLENGTH=5` to `Message::from_raw()`. Before this change the test aborts; after it, parsing fails gracefully with an error.