### PR TITLE
LibDNS: Reject domain name labels longer than 63 octets

### DIFF
--- a/Libraries/LibDNS/Message.cpp
+++ b/Libraries/LibDNS/Message.cpp
@@ -678,6 +678,11 @@ ErrorOr<DomainName> DomainName::from_raw(ParseContext& ctx)
             return Error::from_string_literal("Invalid domain name pointer in label");
         }
 
+        // A normal label is at most 63 octets. Lengths whose top two bits are 0b01 or 0b10 are reserved (RFC 1035,
+        // 4.1.4) and would produce a label that can no longer be re-encoded, so reject them here.
+        if (length > 63)
+            return Error::from_string_literal("Domain name label exceeds 63 octets");
+
         ByteBuffer content;
         TRY(ctx.stream.read_until_filled(TRY(content.get_bytes_for_writing(length))));
         name.labels.append(ByteString::copy(content));
@@ -691,7 +696,8 @@ ErrorOr<DomainName> DomainName::from_raw(ParseContext& ctx)
 ErrorOr<void> DomainName::to_raw(ByteBuffer& out) const
 {
     for (auto& label : labels) {
-        VERIFY(label.length() <= 63);
+        if (label.length() > 63)
+            return Error::from_string_literal("Domain name label exceeds 63 octets");
         auto size_bytes = TRY(out.get_bytes_for_writing(1));
         u8 size = static_cast<u8>(label.length());
         memcpy(size_bytes.data(), &size, 1);

--- a/Libraries/LibDNS/Resolver.h
+++ b/Libraries/LibDNS/Resolver.h
@@ -666,7 +666,10 @@ public:
         });
 
         ByteBuffer query_bytes;
-        MUST(query.to_raw(query_bytes));
+        if (auto result = query.to_raw(query_bytes); result.is_error()) {
+            promise->reject(result.release_error());
+            return promise;
+        }
 
         if (m_mode == ConnectionMode::TCP) {
             auto original_query_bytes = query_bytes;

--- a/Tests/LibDNS/CMakeLists.txt
+++ b/Tests/LibDNS/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestDNSMessage.cpp
     TestDNSResolver.cpp
 )
 

--- a/Tests/LibDNS/TestDNSMessage.cpp
+++ b/Tests/LibDNS/TestDNSMessage.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteString.h>
+#include <AK/MemoryStream.h>
+#include <AK/Vector.h>
+#include <LibDNS/Message.h>
+#include <LibTest/TestCase.h>
+
+// A label longer than 63 octets cannot be represented in the wire format, whose length field is a 6-bit value.
+// Encoding such a label used to abort the process via a VERIFY in DomainName::to_raw(); it must now fail
+// gracefully. Reachable from a query for a host name that contains an over-long label.
+TEST_CASE(encoding_a_domain_name_with_an_overlong_label_does_not_crash)
+{
+    auto domain_name = DNS::Messages::DomainName::from_string(ByteString::repeated('a', 64));
+
+    ByteBuffer out;
+    auto result = domain_name.to_raw(out);
+    EXPECT(result.is_error());
+}
+
+// A label length octet whose top two bits are 0b01 or 0b10 is reserved (RFC 1035, 4.1.4); the parser used to
+// accept it as an ordinary label of up to 191 octets, producing a name that could no longer be re-encoded.
+// Parsing such a message must fail instead.
+TEST_CASE(parsing_a_reserved_label_length_fails)
+{
+    // Header with QDCOUNT = 1 and all other counts 0, then a question whose name starts with a label length octet
+    // of 0x40 (reserved top bits, 64 octets).
+    Vector<u8> message;
+    message.extend({ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 });
+    message.append(0x40);
+    for (size_t i = 0; i < 64; ++i)
+        message.append('a');
+    message.append(0x00);
+    message.extend({ 0, 1, 0, 1 }); // QTYPE = A, QCLASS = IN
+
+    FixedMemoryStream stream { message.span() };
+    auto result = DNS::Messages::Message::from_raw(stream);
+    EXPECT(result.is_error());
+}


### PR DESCRIPTION
A DNS label length octet is a 6-bit value, so a label can hold at most 63 octets. Several code paths violated this and could abort the process.

## Root cause

- `DomainName::from_raw()` treats any length octet that is not a compression pointer (top two bits `0b11`) as an ordinary label. The reserved `0b01`/`0b10` encodings (RFC 1035 §4.1.4) were accepted as labels of up to 191 octets.
- `DomainName::to_raw()` then `VERIFY`-aborts on any label longer than 63 octets when encoding it back to the wire.
- `Resolver::lookup()` encodes the outgoing query with `MUST(query.to_raw(...))`, so even once `to_raw()` returns an error the `MUST` would still abort.

Together these crash `RequestServer`, which drives DNS for the whole browser:

- **Outgoing (web-reachable):** when a custom resolver is configured, a page that references a host whose name contains a label longer than 63 characters aborts RequestServer while the query is being encoded.
- **Incoming:** a response carrying a reserved-length label is accepted by the parser and then aborts when the name is re-encoded (e.g. during DNSSEC validation).

## Fix

Reject over-long labels while parsing, return an error instead of aborting while encoding, and reject the lookup promise instead of `MUST`-aborting at the query call site.

## Reproducers

**Browser** — with a custom resolver configured, loading a host with an over-long label aborts RequestServer before this change:

```
Ladybird --headless=text --dns-server 127.0.0.1 \
    http://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com/
```

Before: `VERIFICATION FAILED: label.length() <= 63 at Libraries/LibDNS/Message.cpp:694`, reached via `RequestServer::Request::fetch → Message::to_raw`. After: the lookup fails gracefully ("Domain name label exceeds 63 octets") and RequestServer stays up.

**Unit tests** — `Tests/LibDNS/TestDNSMessage.cpp` covers both directions: encoding a name built from a 64-octet label (the outgoing path, which aborted before the fix), and parsing a message whose question name begins with a reserved `0x40` length octet (the incoming path, silently accepted before the fix).

> Note: this PR adds `Tests/LibDNS/TestDNSMessage.cpp`, the same new file added by #9809. Whichever merges second needs a trivial rebase to keep both test cases.