### PR TITLE
Tests: Merge tests into single binary per lib

### DIFF
--- a/Meta/CMake/targets.cmake
+++ b/Meta/CMake/targets.cmake
@@ -177,6 +177,29 @@ function(ladybird_utility name)
     ladybird_generate_dsym(${name})
 endfunction()
 
+function(ladybird_test_suite name sub_dir)
+    cmake_parse_arguments(PARSE_ARGV 2 LADYBIRD_TEST_SUITE "" "" "SOURCES;LIBS")
+
+    add_executable(${name} ${LADYBIRD_TEST_SUITE_SOURCES})
+    target_link_libraries(${name} PRIVATE AK LibCore LibFileSystem LibTest $<TARGET_OBJECTS:LibTestMain> ${LADYBIRD_TEST_SUITE_LIBS})
+    ladybird_windows_bin(${name} CONSOLE)
+    ladybird_generate_dsym(${name})
+
+    if (WIN32)
+        target_include_directories(${name} PRIVATE ${PTHREAD_INCLUDE_DIR})
+        target_link_libraries(${name} PRIVATE ${PTHREAD_LIBRARY})
+
+        target_include_directories(${name} PRIVATE ${MMAN_INCLUDE_DIR})
+        target_link_libraries(${name} PRIVATE ${MMAN_LIBRARY})
+    endif()
+
+    add_test(
+            NAME ${name}
+            COMMAND ${name}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endfunction()
+
 if (NOT TARGET ladybird_codegen_accumulator)
     # Meta target to run all code-gen steps in the build.
     add_custom_target(ladybird_codegen_accumulator)

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -89,14 +89,13 @@ else()
     list(APPEND AK_TEST_SOURCES TestDelayLoadWindows.cpp)
 endif()
 
-foreach(source IN LISTS AK_TEST_SOURCES)
-    ladybird_test("${source}" AK)
-endforeach()
+ladybird_test_suite(TestAK AK SOURCES ${AK_TEST_SOURCES} LIBS LibUnicode)
 
 if (WIN32)
     # FIXME: Windows on ARM
-    target_link_libraries(TestUFixedBigInt PRIVATE clang_rt.builtins-x86_64.lib)
+    target_link_libraries(TestAK PRIVATE clang_rt.builtins-x86_64.lib)
 endif()
+
 
 if (APPLE)
     ladybird_test(TestFunctionObjC.mm AK NAME TestFunctionObjC)
@@ -104,6 +103,3 @@ if (APPLE)
     ladybird_test(TestFunctionObjC.mm AK NAME TestFunctionObjCArc)
     target_compile_options(TestFunctionObjCArc PRIVATE -fobjc-arc)
 endif()
-
-target_link_libraries(TestString PRIVATE LibUnicode)
-target_link_libraries(TestUtf16String PRIVATE LibUnicode)

--- a/Tests/LibCompress/CMakeLists.txt
+++ b/Tests/LibCompress/CMakeLists.txt
@@ -6,6 +6,4 @@ set(TEST_SOURCES
     TestZlib.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibCompress LIBS LibCompress)
-endforeach()
+ladybird_test_suite(TestCompress LibCompress SOURCES ${TEST_SOURCES} LIBS LibCompress)

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -6,7 +6,6 @@ set(TEST_SOURCES
     TestLibCoreMappedFile.cpp
     TestLibCoreMimeType.cpp
     TestLibCorePromise.cpp
-    TestLibCoreStream.cpp
 )
 
 # FIXME: Change these tests to use a portable tempfile directory
@@ -16,16 +15,12 @@ if (LINUX)
     )
 endif()
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibCore)
-endforeach()
+ladybird_test_suite(TestLibCore LibCore SOURCES ${TEST_SOURCES} LIBS LibSync LibThreading)
 
-target_link_libraries(TestLibCorePromise PRIVATE LibSync LibThreading)
+ladybird_test(TestLibCoreStream.cpp LibCore)
 target_link_libraries(TestLibCoreStream PRIVATE LibSync LibThreading)
 
 if(NOT WIN32)
     # These tests use the .txt files in the current directory
-    set_tests_properties(TestLibCoreMappedFile TestLibCoreStream PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+    set_tests_properties(TestLibCoreStream PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
-
-target_link_libraries(TestLibCoreEventLoop PRIVATE LibSync LibThreading)

--- a/Tests/LibCrypto/CMakeLists.txt
+++ b/Tests/LibCrypto/CMakeLists.txt
@@ -17,6 +17,4 @@ set(TEST_SOURCES
     TestRSA.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibCrypto LIBS LibCrypto)
-endforeach()
+ladybird_test_suite(TestCrypto LibCrypto SOURCES ${TEST_SOURCES} LIBS LibCrypto)

--- a/Tests/LibGC/CMakeLists.txt
+++ b/Tests/LibGC/CMakeLists.txt
@@ -4,6 +4,4 @@ set(TEST_SOURCES
     TestGCVisitor.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibGC LIBS LibGC)
-endforeach()
+ladybird_test_suite(TestGC LibGC SOURCES ${TEST_SOURCES} LIBS LibGC)

--- a/Tests/LibGC/TestGCContainers.cpp
+++ b/Tests/LibGC/TestGCContainers.cpp
@@ -20,6 +20,8 @@
 #include <LibGC/WeakHashMap.h>
 #include <LibTest/TestCase.h>
 
+namespace {
+
 class TestCell : public GC::Cell {
     GC_CELL(TestCell, GC::Cell);
     GC_DECLARE_ALLOCATOR(TestCell);
@@ -29,6 +31,8 @@ class TestCell : public GC::Cell {
 };
 
 GC_DEFINE_ALLOCATOR(TestCell);
+
+}
 
 static GC::Heap& test_heap()
 {
@@ -41,6 +45,8 @@ TEST_SETUP
     GC::Heap::set_default_heap_for_testing(test_heap());
 }
 
+namespace {
+
 class TestVisitor : public GC::Cell::Visitor {
     virtual void visit_impl(GC::Cell& cell) override { visited_cells.set(&cell); }
     virtual void visit_impl(ReadonlySpan<GC::NanBoxedValue>) override { }
@@ -49,6 +55,8 @@ class TestVisitor : public GC::Cell::Visitor {
 public:
     HashTable<GC::Cell*> visited_cells;
 };
+
+}
 
 static bool possible_values_contain(GC::ConservativeVectorBase const& container, GC::Cell* cell)
 {

--- a/Tests/LibGC/TestGCVisitor.cpp
+++ b/Tests/LibGC/TestGCVisitor.cpp
@@ -18,6 +18,8 @@
 #include <LibGC/Ptr.h>
 #include <LibTest/TestCase.h>
 
+namespace {
+
 class TestCell : public GC::Cell {
     GC_CELL(TestCell, GC::Cell);
     GC_DECLARE_ALLOCATOR(TestCell);
@@ -26,6 +28,8 @@ class TestCell : public GC::Cell {
 };
 
 GC_DEFINE_ALLOCATOR(TestCell);
+
+}
 
 static GC::Heap& test_heap()
 {
@@ -38,6 +42,8 @@ TEST_SETUP
     GC::Heap::set_default_heap_for_testing(test_heap());
 }
 
+namespace {
+
 class TestVisitor : public GC::Cell::Visitor {
     virtual void visit_impl(GC::Cell& cell) override { visited_cells.set(&cell); }
     virtual void visit_impl(ReadonlySpan<GC::NanBoxedValue> span) override { last_nan_span_size = span.size(); }
@@ -47,6 +53,8 @@ public:
     HashTable<GC::Cell*> visited_cells;
     Optional<size_t> last_nan_span_size;
 };
+
+}
 
 class TestNanBox : public GC::NanBoxedValue {
 public:

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -10,8 +10,4 @@ set(TEST_SOURCES
     TestWOFF2.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibGfx LIBS LibGfx)
-endforeach()
-
-ladybird_test(TestYUVData.cpp LibGfx LIBS LibGfx skia)
+ladybird_test_suite(TestGfx LibGfx SOURCES ${TEST_SOURCES} TestYUVData.cpp LIBS LibGfx skia)

--- a/Tests/LibHTTP/CMakeLists.txt
+++ b/Tests/LibHTTP/CMakeLists.txt
@@ -5,9 +5,4 @@ set(TEST_SOURCES
     TestHTTPUtils.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibWeb LIBS LibHTTP)
-endforeach()
-
-ladybird_test("TestCacheIndex.cpp" LibWeb LIBS LibHTTP LibDatabase)
-ladybird_test("TestDiskCache.cpp" LibWeb LIBS LibHTTP LibURL)
+ladybird_test_suite(TestHTTP LibHTTP SOURCES ${TEST_SOURCES} TestCacheIndex.cpp TestDiskCache.cpp LIBS LibHTTP LibDatabase LibURL)

--- a/Tests/LibIPC/CMakeLists.txt
+++ b/Tests/LibIPC/CMakeLists.txt
@@ -1,4 +1,3 @@
 if (UNIX AND NOT APPLE)
-    ladybird_test("TestTransportSocket.cpp" LibIPC LIBS LibIPC)
-    ladybird_test("TestConnection.cpp" LibIPC LIBS LibIPC)
+    ladybird_test_suite(TestIPC LibIPC SOURCES TestTransportSocket.cpp TestConnection.cpp LIBS LibIPC)
 endif()

--- a/Tests/LibMedia/CMakeLists.txt
+++ b/Tests/LibMedia/CMakeLists.txt
@@ -18,14 +18,9 @@ set(TEST_SOURCES
     TestWav.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibMedia LIBS LibMedia LibFileSystem LibSync)
-endforeach()
-
-target_link_libraries(TestFFmpegDemuxer PRIVATE LibThreading)
-target_link_libraries(TestIncrementallyPopulatedStream PRIVATE LibThreading)
+ladybird_test_suite(TestMedia LibMedia SOURCES ${TEST_SOURCES} LIBS LibMedia LibFileSystem LibSync LibThreading)
 
 if (LADYBIRD_AUDIO_BACKEND STREQUAL "PULSE")
-    target_compile_definitions(TestPlaybackStream PRIVATE HAVE_PULSEAUDIO=1)
-    target_link_libraries(TestPlaybackStream PRIVATE PkgConfig::PULSEAUDIO)
+    target_compile_definitions(TestMedia PRIVATE HAVE_PULSEAUDIO=1)
+    target_link_libraries(TestMedia PRIVATE PkgConfig::PULSEAUDIO)
 endif()

--- a/Tests/LibTLS/CMakeLists.txt
+++ b/Tests/LibTLS/CMakeLists.txt
@@ -3,6 +3,4 @@ set(TEST_SOURCES
     TestTLSHandshake.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibTLS LIBS LibTLS LibCrypto)
-endforeach()
+ladybird_test_suite(TestTLS LibTLS SOURCES ${TEST_SOURCES} LIBS LibTLS LibCrypto)

--- a/Tests/LibTest/CMakeLists.txt
+++ b/Tests/LibTest/CMakeLists.txt
@@ -3,6 +3,4 @@ set(TEST_SOURCES
     TestGenerator.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" Test)
-endforeach()
+ladybird_test_suite(TestLibTest Test SOURCES ${TEST_SOURCES})

--- a/Tests/LibTextCodec/CMakeLists.txt
+++ b/Tests/LibTextCodec/CMakeLists.txt
@@ -3,6 +3,4 @@ set(TEST_SOURCES
     TestTextEncoders.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibTextCodec LIBS LibTextCodec)
-endforeach()
+ladybird_test_suite(TestTextCodec LibTextCodec SOURCES ${TEST_SOURCES} LIBS LibTextCodec)

--- a/Tests/LibThreading/CMakeLists.txt
+++ b/Tests/LibThreading/CMakeLists.txt
@@ -3,8 +3,4 @@ set(TEST_SOURCES
     TestThread.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibThreading LIBS LibThreading)
-endforeach()
-
-target_link_libraries(TestBackgroundAction PRIVATE LibSync)
+ladybird_test_suite(TestThreading LibThreading SOURCES ${TEST_SOURCES} LIBS LibThreading LibSync)

--- a/Tests/LibURL/CMakeLists.txt
+++ b/Tests/LibURL/CMakeLists.txt
@@ -4,6 +4,4 @@ set(URL_TEST_SOURCES
     TestPublicSuffix.cpp
 )
 
-foreach(source IN LISTS URL_TEST_SOURCES)
-    ladybird_test("${source}" LibURL LIBS LibURL LibRegex)
-endforeach()
+ladybird_test_suite(TestURL LibURL SOURCES ${URL_TEST_SOURCES} LIBS LibURL LibRegex)

--- a/Tests/LibUnicode/CMakeLists.txt
+++ b/Tests/LibUnicode/CMakeLists.txt
@@ -8,6 +8,4 @@ set(TEST_SOURCES
     TestUnicodeNormalization.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibUnicode LIBS LibUnicode)
-endforeach()
+ladybird_test_suite(TestUnicode LibUnicode SOURCES ${TEST_SOURCES} LIBS LibUnicode)

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -19,17 +19,9 @@ set(TEST_SOURCES
     TestStrings.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibWeb LIBS LibWeb)
-endforeach()
+ladybird_test_suite(TestWeb LibWeb SOURCES ${TEST_SOURCES} LIBS LibWeb LibURL LibSync LibWebView)
 
 ladybird_utility(css-tokenizer SOURCES css-tokenizer.cpp LIBS LibFileSystem LibMain LibWeb)
-
-target_link_libraries(TestContentBlocker PRIVATE LibURL)
-target_link_libraries(TestControlMessageQueue PRIVATE LibSync)
-target_link_libraries(TestFetchURL PRIVATE LibURL)
-target_link_libraries(TestSecureContexts PRIVATE LibURL)
-target_link_libraries(TestSourceHighlighter PRIVATE LibURL LibWebView)
 
 if (NOT WIN32)
     add_custom_target(test-css-tokenizer ALL DEPENDS css-tokenizer "${CMAKE_BINARY_DIR}/bin/test-css-tokenizer")

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -4,6 +4,4 @@ set(TEST_SOURCES
     TestWebViewURL.cpp
 )
 
-foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibWebView LIBS LibDatabase LibWebView LibURL)
-endforeach()
+ladybird_test_suite(TestWebView LibWebView SOURCES ${TEST_SOURCES} LIBS LibDatabase LibWebView LibURL)


### PR DESCRIPTION
This merges all tests in libraries with more than one tests source into a single file. The exception to this are test runners like test-js, test-wasm, and test-web. TestLibCoreStream is also left out temporarily until flakiness with it on Windows is resolved. This significantly reduces the time needed to build tests without impacting organization. As all the test functions are static anyway, there are no conflicts. This would need modifying the ladybird_test_suite function for #9741. Along with PCH files some preliminary benchmarks show a reduction in the time needed to build all tests (going from ninja ladybird to ninja) from 1m 20s to 42s. 