### PR TITLE
LibWeb: Ensure that shadow roots have hosts before appending children

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1463,6 +1463,10 @@ void Element::set_shadow_root(GC::Ptr<ShadowRoot> shadow_root)
     }
     m_shadow_root = move(shadow_root);
     if (m_shadow_root) {
+        // NB: Children shouldn't be set on shadow roots until the shadow root is attached to a host so that they
+        //     correctly inherit connectedness.
+        VERIFY(!m_shadow_root->has_children());
+
         m_shadow_root->set_host(this);
         m_shadow_root->set_is_connected(is_connected());
     }

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -235,6 +235,7 @@ WebIDL::ExceptionOr<void> HTMLDetailsElement::create_shadow_tree_if_needed()
     auto shadow_root = realm.create<DOM::ShadowRoot>(document(), *this, Bindings::ShadowRootMode::Closed);
     shadow_root->set_user_agent_internal(true);
     shadow_root->set_slot_assignment(Bindings::SlotAssignmentMode::Manual);
+    set_shadow_root(shadow_root);
 
     // The first child element is a slot that is expected to take the details element's first summary element child, if any.
     auto summary_slot = TRY(DOM::create_element(document(), HTML::TagNames::slot, Namespace::HTML));
@@ -262,7 +263,6 @@ WebIDL::ExceptionOr<void> HTMLDetailsElement::create_shadow_tree_if_needed()
 
     m_summary_slot = static_cast<HTML::HTMLSlotElement&>(*summary_slot);
     m_descendants_slot = static_cast<HTML::HTMLSlotElement&>(*descendants_slot);
-    set_shadow_root(shadow_root);
 
     return {};
 }

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1256,6 +1256,7 @@ void HTMLInputElement::create_color_input_shadow_tree()
 {
     auto shadow_root = realm().create<DOM::ShadowRoot>(document(), *this, Bindings::ShadowRootMode::Closed);
     shadow_root->set_user_agent_internal(true);
+    set_shadow_root(shadow_root);
 
     auto color = value_sanitization_algorithm(m_value);
 
@@ -1279,7 +1280,6 @@ void HTMLInputElement::create_color_input_shadow_tree()
 
     MUST(border->append_child(*m_color_well_element));
     MUST(shadow_root->append_child(border));
-    set_shadow_root(shadow_root);
 }
 
 void HTMLInputElement::update_color_well_element()
@@ -1296,6 +1296,7 @@ void HTMLInputElement::create_file_input_shadow_tree()
 
     auto shadow_root = realm.create<DOM::ShadowRoot>(document(), *this, Bindings::ShadowRootMode::Closed);
     shadow_root->set_user_agent_internal(true);
+    set_shadow_root(shadow_root);
 
     m_file_button = DOM::create_element(document(), HTML::TagNames::button, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(shadow_root->append_child(*m_file_button));
@@ -1316,8 +1317,6 @@ void HTMLInputElement::create_file_input_shadow_tree()
     update_file_input_shadow_tree();
 
     MUST(shadow_root->append_child(*m_file_label));
-
-    set_shadow_root(shadow_root);
 }
 
 void HTMLInputElement::update_file_input_shadow_tree()

--- a/Tests/LibWeb/Text/expected/DOM/disconnected-input-shadow-tree-elements.txt
+++ b/Tests/LibWeb/Text/expected/DOM/disconnected-input-shadow-tree-elements.txt
@@ -1,0 +1,2 @@
+true
+true

--- a/Tests/LibWeb/Text/input/DOM/disconnected-input-shadow-tree-elements.html
+++ b/Tests/LibWeb/Text/input/DOM/disconnected-input-shadow-tree-elements.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+    <input id="fileInput" />
+    <input id="colorInput" />
+    <script src="../include.js"></script>
+    <script>
+        promiseTest(async () => {
+            await animationFrame();
+            await animationFrame();
+
+            // Rebuild the shadow tree so
+            fileInput.setAttribute("type", "file");
+
+            println(internals.getShadowRoot(fileInput).firstChild.isConnected);
+
+            colorInput.setAttribute("type", "color");
+            println(internals.getShadowRoot(colorInput).firstChild.isConnected);
+        });
+    </script>
+</html>


### PR DESCRIPTION
DOM nodes inherit their parent's connectedness at time of insertion so we need to make sure the shadow root has a host before we start appending children.

Before this change the shadow tree elements would be marked as disconnected despite being in the DOM tree, causing issues such as relevant layout invalidations not taking place.

Fixes a crash when submitting a prompt on https://www.chatgpt.com