### PR TITLE
LibWebView: Use named mutex for single-instance detection on Windows

### DIFF
--- a/Libraries/LibWebView/BrowserProcess.cpp
+++ b/Libraries/LibWebView/BrowserProcess.cpp
@@ -18,6 +18,10 @@
 #include <LibWebView/URL.h>
 #include <LibWebView/Utilities.h>
 
+#if defined(AK_OS_WINDOWS)
+#    include <AK/Windows.h>
+#endif
+
 namespace WebView {
 
 static HashMap<int, RefPtr<UIProcessConnectionFromClient>> s_connections;
@@ -36,24 +40,44 @@ ErrorOr<BrowserProcess::ProcessDisposition> BrowserProcess::connect(Vector<ByteS
 
     auto [socket_path, pid_path] = TRY(Process::paths_for_process(process_name));
 
-    if (auto pid = TRY(Process::get_process_pid(process_name, pid_path)); pid.has_value()) {
-#if defined(AK_OS_MACOS)
-        TRY(connect_as_client(*pid, raw_urls, new_window));
-#else
+#if defined(AK_OS_WINDOWS)
+    // On Windows, use a named mutex for single-instance detection instead of a PID file.
+    // The "Local\" prefix scopes the mutex to the current user session, so each logged-in
+    // user can independently run their own primary Ladybird instance.
+    static constexpr auto mutex_name = L"Local\\LadybirdBrowser";
+    m_instance_mutex = CreateMutexW(nullptr, FALSE, mutex_name);
+    if (m_instance_mutex == nullptr)
+        return Error::from_windows_error();
+
+    if (GetLastError() == ERROR_ALREADY_EXISTS) {
+        // Another instance already owns the mutex — connect to it as a client.
+        CloseHandle(m_instance_mutex);
+        m_instance_mutex = nullptr;
         TRY(connect_as_client(socket_path, raw_urls, new_window));
-#endif
         return ProcessDisposition::ExitProcess;
     }
 
-#if defined(AK_OS_MACOS)
-    TRY(connect_as_server());
-#else
     TRY(connect_as_server(socket_path));
-#endif
+#else
+    if (auto pid = TRY(Process::get_process_pid(process_name, pid_path)); pid.has_value()) {
+#    if defined(AK_OS_MACOS)
+        TRY(connect_as_client(*pid, raw_urls, new_window));
+#    else
+        TRY(connect_as_client(socket_path, raw_urls, new_window));
+#    endif
+        return ProcessDisposition::ExitProcess;
+    }
+
+#    if defined(AK_OS_MACOS)
+    TRY(connect_as_server());
+#    else
+    TRY(connect_as_server(socket_path));
+#    endif
 
     m_pid_path = pid_path;
     m_pid_file = TRY(Core::File::open(pid_path, Core::File::OpenMode::Write));
     TRY(m_pid_file->write_until_depleted(ByteString::number(Core::System::getpid())));
+#endif
 
     return ProcessDisposition::ContinueMainProcess;
 }
@@ -149,16 +173,17 @@ BrowserProcess::~BrowserProcess()
     Application::the().set_browser_process_transport_handler({});
 #endif
 
+#if defined(AK_OS_WINDOWS)
+    if (m_instance_mutex != nullptr) {
+        CloseHandle(m_instance_mutex);
+        m_instance_mutex = nullptr;
+    }
+#else
     if (m_pid_file) {
         MUST(m_pid_file->truncate(0));
-#if defined(AK_OS_WINDOWS)
-        // NOTE: On Windows, System::open() duplicates the underlying OS file handle,
-        // so we need to explicitly close said handle, otherwise the unlink() call fails due
-        // to permission errors and we crash on shutdown.
-        m_pid_file->close();
-#endif
         MUST(Core::System::unlink(m_pid_path));
     }
+#endif
 
     if (!m_socket_path.is_empty())
         MUST(Core::System::unlink(m_socket_path));

--- a/Libraries/LibWebView/BrowserProcess.h
+++ b/Libraries/LibWebView/BrowserProcess.h
@@ -69,10 +69,16 @@ private:
 #endif
 
     RefPtr<Core::LocalServer> m_local_server;
-    OwnPtr<Core::File> m_pid_file;
-    ByteString m_pid_path;
     ByteString m_socket_path;
     int m_next_client_id { 0 };
+
+#if defined(AK_OS_WINDOWS)
+    // HANDLE is typedef void* on Windows. We use void* here to avoid pulling Windows.h into this header.
+    void* m_instance_mutex { nullptr };
+#else
+    OwnPtr<Core::File> m_pid_file;
+    ByteString m_pid_path;
+#endif
 };
 
 }

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -20,7 +20,6 @@
 #endif
 
 #if defined(AK_OS_WINDOWS)
-#    include <AK/ScopeGuard.h>
 #    include <AK/Windows.h>
 #endif
 
@@ -111,6 +110,7 @@ ErrorOr<Process::ProcessAndIPCTransport> Process::spawn_and_connect_to_process(C
     return ProcessAndIPCTransport { move(process), move(transport), move(output_capture) };
 }
 
+#if !defined(AK_OS_WINDOWS)
 ErrorOr<Optional<pid_t>> Process::get_process_pid(StringView process_name, StringView pid_path)
 {
     if (Core::System::stat(pid_path).is_error())
@@ -139,26 +139,7 @@ ErrorOr<Optional<pid_t>> Process::get_process_pid(StringView process_name, Strin
         return OptionalNone {};
     }
 
-    bool const process_not_found = [&pid]() {
-#if defined(AK_OS_WINDOWS)
-        HANDLE process_handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, *pid);
-        if (process_handle == nullptr)
-            return true;
-
-        // FIXME: We should create an RAII wrapper around HANDLE objects.
-        ScopeGuard handle_guard = [&process_handle] { CloseHandle(process_handle); };
-        DWORD exit_code = 0;
-
-        if (GetExitCodeProcess(process_handle, &exit_code) == 0)
-            return true;
-
-        return exit_code != STILL_ACTIVE;
-#else
-        return kill(*pid, 0) < 0;
-#endif
-    }();
-
-    if (process_not_found) {
+    if (kill(*pid, 0) < 0) {
         warnln("{} PID file '{}' exists with PID {}, but process cannot be found", process_name, pid_path, *pid);
         TRY(Core::System::unlink(pid_path));
         return OptionalNone {};
@@ -166,6 +147,7 @@ ErrorOr<Optional<pid_t>> Process::get_process_pid(StringView process_name, Strin
 
     return pid;
 }
+#endif
 
 // This is heavily based on how SystemServer's Service creates its socket.
 ErrorOr<int> Process::create_ipc_socket(ByteString const& socket_path)

--- a/Libraries/LibWebView/Process.h
+++ b/Libraries/LibWebView/Process.h
@@ -59,7 +59,9 @@ public:
         ByteString pid_path;
     };
     static ErrorOr<ProcessPaths> paths_for_process(StringView process_name);
+#if !defined(AK_OS_WINDOWS)
     static ErrorOr<Optional<pid_t>> get_process_pid(StringView process_name, StringView pid_path);
+#endif
     static ErrorOr<int> create_ipc_socket(ByteString const& socket_path);
 
 private:


### PR DESCRIPTION
LibWebView: Use named mutex for single-instance detection on Windows
Replace the PID file approach for detecting an existing browser process
on Windows with a named mutex.

A named mutex is the "Windows way" of doing this. It is automatically
released by the OS when the process exits, even if it crashes,
making stale lock detection unnecessary.

`get_process_pid` and its associated PID file logic are now excluded
from Windows builds entirely.