### PR TITLE
LibWeb+LibJS: Don't crash when serializing deeply nested values

### DIFF
--- a/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -261,6 +261,9 @@ static void write_indent(StringBuilder& builder, StringView gap, size_t depth)
 // 25.5.2.4 SerializeJSONObject ( state, value ), https://tc39.es/ecma262/#sec-serializejsonobject
 ThrowCompletionOr<void> JSONObject::serialize_json_object(VM& vm, StringifyState& state, Object& object)
 {
+    if (vm.did_reach_stack_space_limit())
+        return vm.throw_completion<InternalError>(ErrorType::CallStackSizeExceeded);
+
     if (state.seen_objects.contains(&object))
         return vm.throw_completion<TypeError>(ErrorType::JsonCircular);
 
@@ -334,6 +337,9 @@ ThrowCompletionOr<void> JSONObject::serialize_json_object(VM& vm, StringifyState
 // 25.5.2.5 SerializeJSONArray ( state, value ), https://tc39.es/ecma262/#sec-serializejsonarray
 ThrowCompletionOr<void> JSONObject::serialize_json_array(VM& vm, StringifyState& state, Object& object)
 {
+    if (vm.did_reach_stack_space_limit())
+        return vm.throw_completion<InternalError>(ErrorType::CallStackSizeExceeded);
+
     if (state.seen_objects.contains(&object))
         return vm.throw_completion<TypeError>(ErrorType::JsonCircular);
 

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -270,6 +270,9 @@ public:
     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
     WebIDL::ExceptionOr<SerializationRecord> serialize(JS::Value value)
     {
+        if (m_vm.did_reach_stack_space_limit())
+            return m_vm.throw_completion<JS::InternalError>(JS::ErrorType::CallStackSizeExceeded);
+
         TransferDataEncoder serialized;
 
         // 2. If memory[value] exists, then return memory[value].
@@ -593,6 +596,9 @@ public:
     // https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize
     WebIDL::ExceptionOr<JS::Value> deserialize()
     {
+        if (m_vm.did_reach_stack_space_limit())
+            return m_vm.throw_completion<JS::InternalError>(JS::ErrorType::CallStackSizeExceeded);
+
         auto& realm = *m_vm.current_realm();
 
         auto tag = m_serialized.decode<ValueTag>();

--- a/Tests/LibJS/Runtime/builtins/JSON/JSON.stringify.js
+++ b/Tests/LibJS/Runtime/builtins/JSON/JSON.stringify.js
@@ -148,4 +148,28 @@ describe("errors", () => {
             }).toThrow(TypeError, "Cannot stringify circular object");
         });
     });
+
+    test("should not crash when serializing deeply nested structures", () => {
+        const deepArray = [];
+        let current = deepArray;
+        for (let i = 0; i < 100_000; i++) {
+            current[0] = [];
+            current = current[0];
+        }
+
+        expect(() => {
+            JSON.stringify(deepArray);
+        }).toThrow(InternalError, "Call stack size limit exceeded");
+
+        const deepObject = {};
+        current = deepObject;
+        for (let i = 0; i < 100_000; i++) {
+            current.x = {};
+            current = current.x;
+        }
+
+        expect(() => {
+            JSON.stringify(deepObject);
+        }).toThrow(InternalError, "Call stack size limit exceeded");
+    });
 });

--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-deep-nesting.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-deep-nesting.txt
@@ -1,0 +1,1 @@
+ERROR: InternalError: Call stack size limit exceeded

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-deep-nesting.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-deep-nesting.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const deep = [];
+        let current = deep;
+        for (let i = 0; i < 100_000; i++) {
+            current[0] = [];
+            current = current[0];
+        }
+
+        try {
+            structuredClone(deep);
+            println("FAILED");
+        } catch (e) {
+            println(`ERROR: ${e.name}: ${e.message}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Deeply nested structures passed to JSON.stringify or structuredClone would cause a lot of recursion, eventually causing a crash.

We now throw an InternalError instead, same as other browser engines.

Fixes #5049