### PR TITLE
Base: Add a favicon to all internal about: pages

### DIFF
--- a/Base/res/ladybird/about-pages/about.html
+++ b/Base/res/ladybird/about-pages/about.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="color-scheme" content="light dark" />
         <title>About URLs</title>
+        <link rel="icon" type="image/png" href="resource://icons/48x48/app-browser.png" />
     </head>
     <body>
         <h1>List of About URLs</h1>

--- a/Base/res/ladybird/about-pages/bookmarks.html
+++ b/Base/res/ladybird/about-pages/bookmarks.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>Bookmark Manager</title>
+        <link rel="icon" type="image/png" href="resource://icons/48x48/app-browser.png" />
         <link rel="stylesheet" type="text/css" href="resource://ladybird/ladybird.css" />
         <link rel="stylesheet" type="text/css" href="resource://ladybird/about-pages/webui.css" />
         <style>

--- a/Base/res/ladybird/about-pages/newtab.html
+++ b/Base/res/ladybird/about-pages/newtab.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <title>New Tab</title>
+        <link rel="icon" type="image/png" href="resource://icons/48x48/app-browser.png" />
         <style>
             html {
                 color-scheme: light dark;

--- a/Base/res/ladybird/about-pages/processes.html
+++ b/Base/res/ladybird/about-pages/processes.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>Task Manager</title>
+        <link rel="icon" type="image/png" href="resource://icons/48x48/app-browser.png" />
         <style>
             @media (prefers-color-scheme: dark) {
                 :root {

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>Settings</title>
+        <link rel="icon" type="image/png" href="resource://icons/48x48/app-browser.png" />
         <link rel="stylesheet" type="text/css" href="resource://ladybird/ladybird.css" />
         <link rel="stylesheet" type="text/css" href="resource://ladybird/about-pages/webui.css" />
         <style>

--- a/Base/res/ladybird/about-pages/version.html
+++ b/Base/res/ladybird/about-pages/version.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="color-scheme" content="light dark" />
+        <link rel="icon" type="image/png" href="resource://icons/48x48/app-browser.png" />
         <link rel="stylesheet" type="text/css" href="resource://ladybird/ladybird.css" />
         <link rel="stylesheet" type="text/css" href="resource://ladybird/about-pages/webui.css" />
         <style>


### PR DESCRIPTION
The UI no longer uses the Ladybird icon as a fallback for pages with a missing favicon. That included our own internal pages, where it makes sense to use the icon. So let's specify it explicitly.