### PR TITLE
LibMedia: Don't synchronously resolve seeks within video sink updates

### DIFF
--- a/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
+++ b/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
@@ -153,7 +153,11 @@ DisplayingVideoSinkUpdateResult DisplayingVideoSink::update()
         result = DisplayingVideoSinkUpdateResult::NewFrameAvailable;
     }
 
-    dispatch_state_if_changed(last_status);
+    // Dispatch the new state with a deferred invoke to avoid reentrancy. This prevents a seek from resolving while
+    // an update is being processed.
+    Core::deferred_invoke([self = NonnullRefPtr(*this), last_status] {
+        self->dispatch_state_if_changed(last_status);
+    });
 
     return result;
 }


### PR DESCRIPTION
Fixes an extremely rare flake in the resize-event-during-playback.html test when seeks are resolved in DisplayingVideoSink::update(). When they are resolved there, the media element would queue the `seeked` event before the `resize` event, causing the event ordering in the test to be incorrect.