### PR TITLE
LibWeb: Bail earlier from `getClientRects()` for a boxless element

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1613,6 +1613,9 @@ Vector<CSSPixelRect> Element::get_client_rects() const
     // NOTE: Ensure that layout is up-to-date before looking at metrics.
     const_cast<Document&>(document()).update_layout_if_needed_for_node(*this, UpdateLayoutReason::ElementGetClientRects);
 
+    if (!layout_node())
+        return {};
+
     // NOTE: Make sure CSS transforms are resolved before they are used to calculate the rect position.
     const_cast<Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 

--- a/Tests/LibWeb/Crash/Layout/scroll-frame-stale-paintable-on-removed-element.html
+++ b/Tests/LibWeb/Crash/Layout/scroll-frame-stale-paintable-on-removed-element.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<style>
+    x-scroller {
+        display: block;
+        overflow: scroll;
+        width: 100px;
+        height: 100px;
+    }
+    x-scroller .content {
+        height: 1000px;
+    }
+</style>
+<div id="outer"></div>
+<script>
+    class XScroller extends HTMLElement {
+        disconnectedCallback() {
+            internals.gc();
+            this.getBoundingClientRect();
+        }
+    }
+    customElements.define("x-scroller", XScroller);
+
+    const scroller = document.createElement("x-scroller");
+    scroller.innerHTML = `<div class="content"></div>`;
+    document.getElementById("outer").appendChild(scroller);
+
+    scroller.getBoundingClientRect();
+
+    scroller.scrollTop = 50;
+
+    scroller.remove();
+</script>


### PR DESCRIPTION
Previously, calling `getClientRects()` on a disconnected node would cause a crash. The algorithm's first step returns an empty list when the element has no associated layout box, but we only ran that check after refreshing the document's paint state. Layout is not updated for a disconnected node, so that refresh operated on a stale layout: a removed scroll container's paintable had already been destroyed while the viewport's scroll state still referenced it, tripping an assertion.

We now perform the layout box check before the paint state refresh, so a boxless  element returns before any of that work runs.

This fixes a crash I came across when navigating between posts on https://reddit.com.