### PR TITLE
LibGfx+LibWeb: Don't rasterize an oversized SVG pattern tile

### DIFF
--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -60,7 +60,7 @@ size_t Bitmap::minimum_pitch(size_t width, BitmapFormat format)
     return width * element_size;
 }
 
-static bool size_would_overflow(BitmapFormat format, IntSize size)
+bool Bitmap::size_would_overflow(BitmapFormat format, IntSize size)
 {
     if (size.width() < 0 || size.height() < 0)
         return true;

--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -95,6 +95,7 @@ public:
     [[nodiscard]] size_t pitch() const { return m_pitch; }
 
     [[nodiscard]] static size_t minimum_pitch(size_t width, BitmapFormat);
+    [[nodiscard]] static bool size_would_overflow(BitmapFormat, IntSize);
 
     [[nodiscard]] bool has_alpha_channel() const { return m_format == BitmapFormat::BGRA8888 || m_format == BitmapFormat::RGBA8888; }
     [[nodiscard]] BitmapFormat format() const { return m_format; }

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -623,6 +623,10 @@ SkPaint DisplayListPlayerSkia::paint_style_to_skia_paint(DisplayListPaintStyle c
         if (tile_size.is_empty())
             return {};
 
+        // Don't try to rasterize a tile the bitmap backend can't represent; PaintingSurface would abort.
+        if (Gfx::Bitmap::size_would_overflow(Gfx::BitmapFormat::BGRA8888, tile_size))
+            return {};
+
         auto tile_surface = Gfx::PaintingSurface::create_with_size(tile_size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_skia_backend_context);
 
         auto const& tile_display_list = resource_storage().display_list_resource(paint_style.pattern_tile_display_list_id);

--- a/Tests/LibWeb/Crash/SVG/pattern-with-huge-tile-size.html
+++ b/Tests/LibWeb/Crash/SVG/pattern-with-huge-tile-size.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<script>
+    // Rasterising a pattern with an enormous tile used to create an over-sized
+    // bitmap-backed surface and abort. Force rasterisation via drawImage.
+    const svg = "<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>"
+        + "<defs><pattern id='p' patternUnits='userSpaceOnUse' width='100000' height='100000'>"
+        + "<rect width='100' height='100' fill='red'/></pattern></defs>"
+        + "<rect width='200' height='200' fill='url(%23p)'/></svg>";
+    const img = new Image();
+    const done = () => document.documentElement.classList.remove("test-wait");
+    img.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 200;
+        canvas.height = 200;
+        canvas.getContext("2d").drawImage(img, 0, 0);
+        done();
+    };
+    img.onerror = done;
+    img.src = "data:image/svg+xml," + svg;
+</script>
+</html>


### PR DESCRIPTION
A web page can abort the WebContent process with an SVG `<pattern>` whose tile is too large to rasterize.

## Root cause

`SVGPatternElement::to_gfx_paint_style()` only rejects non-positive tile sizes. A pattern with a very large `width`/`height` — e.g. a `patternUnits="userSpaceOnUse"` pattern of `100000x100000` — produces a tile rect whose device-pixel size exceeds what `Gfx::Bitmap` can represent (`size_would_overflow`: each dimension must be ≤ 65535 and `pitch * height` must fit in an `i32`).

The pattern is rasterized into a bitmap-backed `PaintingSurface`, and `PaintingSurface::create_with_size()` unwraps `Bitmap::create(...)` with `.value()`:

```cpp
auto bitmap = Bitmap::create(color_type, alpha_type, size).value();  // aborts on error
```

So when the pattern is painted, the oversized tile makes `Bitmap::create` return an error and the `.value()` aborts the process.

## Fix

Reject tile sizes the bitmap backend cannot represent in `to_gfx_paint_style()`, matching `Gfx::Bitmap`'s own limits, so the pattern is simply not painted instead of crashing.

## Reproducer

`Tests/LibWeb/Crash/SVG/pattern-with-huge-tile-size.html` draws a `100000x100000` `userSpaceOnUse` pattern into a canvas via `drawImage()` to force rasterization. Before this change it aborts WebContent when the pattern is painted; after it, the page renders without the pattern and stays up.

(Rasterization has to be forced — for example via `drawImage` — because the crash happens during painting, not layout.)