### PR TITLE
UI/Qt: Keep location bar selection when right-click context menu opens

### DIFF
--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -374,6 +374,10 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
 void LocationEdit::focusOutEvent(QFocusEvent* event)
 {
     QLineEdit::focusOutEvent(event);
+
+    if (event->reason() == Qt::PopupFocusReason)
+        return;
+
     animate_focus_glow(0);
 
     reset_autocomplete_state();


### PR DESCRIPTION
Previously, selecting all or part of the URL in the location bar, then right clicking it would cause the URL to become deselected.