### PR TITLE
LibWeb: Immediately clear `PlaybackManager` on remote resource failure

### DIFF
--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -100,8 +100,6 @@ public:
     void add_media_source(NonnullRefPtr<MediaStream> const&);
     void add_media_source(NonnullRefPtr<Demuxer> const&);
 
-    WeakPlaybackManager weak();
-
 private:
     struct VideoTrackData {
         Track track;
@@ -118,6 +116,8 @@ private:
     using AudioTrackDatas = Vector<AudioTrackData, EXPECTED_AUDIO_TRACK_COUNT>;
 
     PlaybackManager();
+
+    WeakPlaybackManager weak();
 
     void set_time_provider(NonnullRefPtr<MediaTimeProvider> const&);
     void disable_audio();

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1806,12 +1806,16 @@ void HTMLMediaElement::set_up_playback_manager_for_remote()
 
     // -> If the media data can be fetched but is found by inspection to be in an unsupported format, or can otherwise not be rendered at all
     m_playback_manager->on_unsupported_format_error = GC::weak_callback(*this, [](auto& self, Media::DecoderError&& error) mutable {
+        auto const* playback_manager_ptr = self.m_playback_manager.ptr();
+
         // NB: Queue a task for this so that we don't destroy the PlaybackManager within one of its callbacks when we
         //     call forget_media_resource_specific_tracks().
-        self.queue_a_media_element_task([self = GC::Weak(self), error = move(error)] {
+        self.queue_a_media_element_task([self = GC::Weak(self), error = move(error), playback_manager_ptr = move(playback_manager_ptr)] {
             if (!self)
                 return;
             if (self->m_error)
+                return;
+            if (playback_manager_ptr != self->m_playback_manager.ptr())
                 return;
 
             // 1. The user agent should cancel the fetching process.
@@ -1826,8 +1830,14 @@ void HTMLMediaElement::set_up_playback_manager_for_remote()
 
     // -> If the media data is corrupted
     m_playback_manager->on_error = GC::weak_callback(*this, [](auto& self, Media::DecoderError&& error) {
-        self.queue_a_media_element_task([self = GC::Weak(self), error = move(error)] {
+        auto const* playback_manager_ptr = self.m_playback_manager.ptr();
+
+        self.queue_a_media_element_task([self = GC::Weak(self), error = move(error), playback_manager_ptr = move(playback_manager_ptr)] {
             if (!self)
+                return;
+            if (self->m_error)
+                return;
+            if (playback_manager_ptr != self->m_playback_manager.ptr())
                 return;
             self->set_decoder_error(MUST(String::from_utf8(error.description())));
         });

--- a/Tests/LibWeb/Crash/HTML/media-multiple-network-errors.html
+++ b/Tests/LibWeb/Crash/HTML/media-multiple-network-errors.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<video id="foo">
+    <source src="https://foobardoesntexist.com/" />
+    <source src="https://foobardoesntexist.com/" />
+</video>


### PR DESCRIPTION
Previously this was done as part of a queued media element task in `failure_callback` but that could cause issues as the background thread creating a demuxer from the associated stream could also raise a failure in the interim, by clearing the `PlaybackManager` immediately we suppress the additional failure.
    
Fixes a crash on https://chatgpt.com

CC @Zaggy1024 - I believe this is the same issue as was raised in #9815