### PR TITLE
UI/Qt: Draw audio icons manually and draw the close tab / audio icons on collapsed tabs

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -47,7 +47,6 @@
 #include <QPushButton>
 #include <QScreen>
 #include <QShortcut>
-#include <QStyle>
 #include <QTabBar>
 #include <QTimer>
 #include <QVBoxLayout>
@@ -880,15 +879,18 @@ void BrowserWindow::initialize_tab_buttons(Tab* tab)
     m_tabs_container->update_tab_button_visibility();
 }
 
-void BrowserWindow::update_tab_close_button_icons()
+void BrowserWindow::update_tab_button_icons()
 {
     for (int index = 0; index < m_tabs_container->count(); ++index) {
-        auto* button = m_tabs_container->tab_bar()->tabButton(index, TAB_CLOSE_BUTTON_POSITION);
-        if (!button || button->objectName() != "LadybirdTabButton")
-            return;
+        if (auto* button = m_tabs_container->tab_bar()->tabButton(index, TAB_CLOSE_BUTTON_POSITION)) {
+            if (auto* tab_bar_button = qobject_cast<TabBarButton*>(button))
+                tab_bar_button->setIcon(create_chrome_icon(ChromeIcon::TabClose, palette()));
+        }
 
-        if (auto* tab_bar_button = qobject_cast<TabBarButton*>(button))
-            tab_bar_button->setIcon(create_chrome_icon(ChromeIcon::TabClose, palette()));
+        if (auto* button = m_tabs_container->tab_bar()->tabButton(index, AUDIO_STATE_BUTTON_POSITION)) {
+            if (auto* tab_bar_button = qobject_cast<TabBarButton*>(button))
+                tab_bar_button->setIcon(icon_for_page_mute_state(*m_tabs_container->tab(index)));
+        }
     }
 }
 
@@ -1010,9 +1012,9 @@ QIcon BrowserWindow::icon_for_page_mute_state(Tab& tab) const
 {
     switch (tab.view().page_mute_state()) {
     case Web::HTML::MuteState::Muted:
-        return style()->standardIcon(QStyle::SP_MediaVolumeMuted);
+        return create_chrome_icon(ChromeIcon::VolumeMuted, palette());
     case Web::HTML::MuteState::Unmuted:
-        return style()->standardIcon(QStyle::SP_MediaVolume);
+        return create_chrome_icon(ChromeIcon::Volume, palette());
     }
 
     VERIFY_NOT_REACHED();
@@ -1274,7 +1276,7 @@ void BrowserWindow::changeEvent(QEvent* event)
     if (event->type() == QEvent::PaletteChange) {
         update_menu_bar_style();
         update_menu_bar_window_control_icons();
-        update_tab_close_button_icons();
+        update_tab_button_icons();
     } else if (event->type() == QEvent::WindowStateChange) {
         update_menu_bar_window_control_icons();
         m_tabs_container->update_window_button_icons();

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -177,7 +177,7 @@ private:
 
     void initialize_tab_buttons(Tab*);
     void create_menu_bar_window_controls();
-    void update_tab_close_button_icons();
+    void update_tab_button_icons();
     void update_menu_bar_style();
     void update_menu_bar_visibility(bool);
     void update_menu_bar_window_control_icons();

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -762,6 +762,8 @@ QString tab_widget_style_sheet(QPalette const& palette)
     auto strip_separator = dark ? background_bottom : control_border;
     auto sidebar_separator = style_sheet_color(mix(tab_strip_bottom, chrome_border(palette), dark ? 0.44 : 0.58));
     auto sidebar_separator_hover = style_sheet_color(mix(tab_strip_bottom, chrome_border(palette), dark ? 0.64 : 0.76));
+    auto vertical_tab_button_background_color = style_sheet_color(chrome_active_tab_surface_top(palette));
+
     return qformatted(R"(
 QWidget#LadybirdTabStrip {{
     color: {5};
@@ -814,6 +816,24 @@ QPushButton#LadybirdTabButton {{
     min-height: 22px;
     max-width: 22px;
     max-height: 22px;
+}}
+
+QPushButton#LadybirdAudioState[collapsedVerticalTabButton="true"] {{
+    min-width: 18px;
+    min-height: 18px;
+    max-width: 18px;
+    max-height: 18px;
+    border-radius: 9px;
+}}
+
+QPushButton#LadybirdTabButton[collapsedVerticalTabButton="true"] {{
+    min-width: 16px;
+    min-height: 16px;
+    max-width: 16px;
+    max-height: 16px;
+    background: {12};
+    border-color: {4};
+    border-radius: 8px;
 }}
 
 QPushButton#LadybirdAudioState:hover,
@@ -870,7 +890,7 @@ QToolButton#LadybirdCloseWindowButton[pressedOutside="true"] {{
 }}
 )",
         background, background_bottom, hover, pressed, control_border, text, close_hover, close_text, strip_separator,
-        sidebar_separator, sidebar_separator_hover, sidebar_background);
+        sidebar_separator, sidebar_separator_hover, sidebar_background, vertical_tab_button_background_color);
 }
 
 QString autocomplete_popup_style_sheet(QPalette const& palette)

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -792,6 +792,7 @@ QWidget#LadybirdVerticalTabsSeparator {{
     max-height: 1px;
 }}
 
+QPushButton#LadybirdAudioState,
 QToolButton#LadybirdNewTabButton,
 QPushButton#LadybirdTabButton {{
     color: {5};
@@ -807,6 +808,7 @@ QToolButton#LadybirdNewTabButton {{
     border-radius: 16px;
 }}
 
+QPushButton#LadybirdAudioState,
 QPushButton#LadybirdTabButton {{
     min-width: 22px;
     min-height: 22px;
@@ -814,6 +816,7 @@ QPushButton#LadybirdTabButton {{
     max-height: 22px;
 }}
 
+QPushButton#LadybirdAudioState:hover,
 QToolButton#LadybirdNewTabButton:hover,
 QPushButton#LadybirdTabButton:hover {{
     color: {5};
@@ -821,6 +824,8 @@ QPushButton#LadybirdTabButton:hover {{
     border-color: {4};
 }}
 
+QPushButton#LadybirdAudioState:pressed,
+QPushButton#LadybirdAudioState:checked,
 QToolButton#LadybirdNewTabButton:pressed,
 QPushButton#LadybirdTabButton:pressed,
 QPushButton#LadybirdTabButton:checked {{

--- a/UI/Qt/Icon.cpp
+++ b/UI/Qt/Icon.cpp
@@ -146,6 +146,38 @@ static void draw_globe_icon(QPainter& painter, QColor const& color)
     draw_stroked_icon_path(painter, path, color, 1.55);
 }
 
+static void draw_volume_icon(QPainter& painter, QColor const& color, bool muted)
+{
+    QPainterPath speaker;
+    speaker.setFillRule(Qt::WindingFill);
+
+    speaker.moveTo(0, 13);
+    speaker.lineTo(4, 13);
+    speaker.lineTo(10, 18);
+    speaker.lineTo(10, 0);
+    speaker.lineTo(4, 5);
+    speaker.lineTo(0, 5);
+    speaker.closeSubpath();
+    painter.fillPath(speaker, color);
+
+    if (muted) {
+        painter.drawLine(QPoint { 0, 0 }, QPoint { 17, 18 });
+        return;
+    }
+
+    QPainterPath inner_wave;
+    inner_wave.moveTo(12, 5);
+    inner_wave.lineTo(12, 13);
+    inner_wave.cubicTo(13.6, 13, 14.9, 11.21, 14.9, 9);
+    inner_wave.cubicTo(14.9, 6.79, 13.6, 5, 12, 5);
+    inner_wave.closeSubpath();
+    painter.fillPath(inner_wave, color);
+
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(chrome_icon_pen(color, 1.6));
+    painter.drawArc(QRectF(7.3, 1.4, 10.8, 15.2), 90 * 16, -180 * 16);
+}
+
 static QPixmap create_transparent_icon_pixmap(QSize logical_size, qreal device_pixel_ratio)
 {
     QPixmap pixmap(physical_size_for_device_pixel_ratio(logical_size, device_pixel_ratio));
@@ -230,6 +262,12 @@ static QPixmap create_chrome_icon_pixmap(ChromeIcon icon, QColor color, qreal de
         painter.drawPath(path);
         break;
     }
+    case ChromeIcon::Volume:
+        draw_volume_icon(painter, color, false);
+        break;
+    case ChromeIcon::VolumeMuted:
+        draw_volume_icon(painter, color, true);
+        break;
     case ChromeIcon::ChevronUp:
         painter.setPen(chrome_icon_pen(color, 1.85));
         painter.drawLine(QPointF(5.0, 12.4), QPointF(10.0, 7.4));

--- a/UI/Qt/Icon.h
+++ b/UI/Qt/Icon.h
@@ -30,6 +30,8 @@ enum class ChromeIcon {
     Search,
     Globe,
     Folder,
+    Volume,
+    VolumeMuted,
     ChevronUp,
     ChevronDown,
     VerticalTabBarCollapse,

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -64,8 +64,12 @@ static constexpr int VERTICAL_TABS_NEW_TAB_SEPARATOR_SPACING = 4;
 static constexpr int VERTICAL_TAB_SHAPE_HORIZONTAL_INSET = 5;
 static constexpr int VERTICAL_TAB_CONTENT_HORIZONTAL_INSET = 8;
 static constexpr int VERTICAL_TABS_HOVER_COLLAPSE_POLL_INTERVAL_MS = 250;
+static constexpr int TAB_BUTTON_SIZE = 22;
 static constexpr int TAB_ICON_SIZE = 16;
+static constexpr int COLLAPSED_VERTICAL_TAB_BUTTON_SIZE = 16;
+static constexpr int COLLAPSED_VERTICAL_TAB_ICON_SIZE = 12;
 static constexpr auto VERTICAL_TABS_EXPANDED_PROPERTY = "verticalTabsExpanded";
+static constexpr auto COLLAPSED_VERTICAL_TAB_BUTTON_PROPERTY = "collapsedVerticalTabButton";
 static constexpr auto VERTICAL_TABS_RESIZE_HANDLE_HOVERED_PROPERTY = "hovered";
 static constexpr auto VERTICAL_TABS_RESIZE_HANDLE_ACTIVE_PROPERTY = "active";
 
@@ -125,6 +129,16 @@ static QRectF expanded_vertical_tab_shape_rect(QRectF const& rect)
 static QRect expanded_vertical_tab_shape_rect(QRect const& rect)
 {
     return rect.adjusted(VERTICAL_TAB_SHAPE_HORIZONTAL_INSET, 3, -VERTICAL_TAB_SHAPE_HORIZONTAL_INSET, -3);
+}
+
+static QRectF collapsed_vertical_tab_shape_rect(QRectF const& rect)
+{
+    return rect.adjusted(4.0, 3.0, -4.0, -3.0);
+}
+
+static QRect collapsed_vertical_tab_shape_rect(QRect const& rect)
+{
+    return rect.adjusted(4, 3, -4, -3);
 }
 
 class NewTabButton final : public QToolButton {
@@ -343,7 +357,7 @@ void TabBar::paintEvent(QPaintEvent*)
 
         QRectF shape_rect;
         if (is_collapsed_vertical)
-            shape_rect = QRectF(tab_rect).adjusted(4.0, 3.0, -4.0, -3.0);
+            shape_rect = collapsed_vertical_tab_shape_rect(QRectF(tab_rect));
         else if (is_vertical)
             shape_rect = expanded_vertical_tab_shape_rect(QRectF(tab_rect));
         else
@@ -518,6 +532,28 @@ void TabBar::dropEvent(QDropEvent* event)
     update();
     event->setDropAction(Qt::MoveAction);
     event->accept();
+}
+
+bool TabBar::eventFilter(QObject* watched, QEvent* event)
+{
+    auto hovered_tab_for_button = [this](QObject* button) {
+        for (int index = 0; index < count(); ++index) {
+            if (tabButton(index, QTabBar::LeftSide) == button || tabButton(index, QTabBar::RightSide) == button)
+                return index;
+        }
+        return -1;
+    };
+
+    if (auto hovered_tab = hovered_tab_for_button(watched); hovered_tab >= 0) {
+        if (event->type() == QEvent::Enter || event->type() == QEvent::MouseMove) {
+            set_hovered_tab_index(hovered_tab);
+        } else if (event->type() == QEvent::Leave) {
+            auto cursor_position = mapFromGlobal(QCursor::pos());
+            set_hovered_tab_index(tab_index_at(cursor_position));
+        }
+    }
+
+    return QTabBar::eventFilter(watched, event);
 }
 
 void TabBar::mousePressEvent(QMouseEvent* event)
@@ -839,16 +875,35 @@ void TabBar::set_hovered_tab_index(int index)
 
 void TabBar::update_tab_button_geometry()
 {
-    if (tab_layout() == TabLayout::Horizontal || tab_layout() == TabLayout::VerticalCollapsed)
+    auto set_button_collapsed_overlay = [](QWidget* button, bool enabled) {
+        if (auto* tab_bar_button = qobject_cast<TabBarButton*>(button))
+            tab_bar_button->set_collapsed_vertical_overlay(enabled);
+    };
+
+    auto prepare_button = [&](QWidget* button, bool collapsed_overlay) {
+        if (!button)
+            return;
+        button->installEventFilter(this);
+        set_button_collapsed_overlay(button, collapsed_overlay);
+    };
+
+    if (tab_layout() == TabLayout::Horizontal) {
+        for (int index = 0; index < count(); ++index) {
+            prepare_button(tabButton(index, QTabBar::LeftSide), false);
+            prepare_button(tabButton(index, QTabBar::RightSide), false);
+        }
         return;
+    }
 
     // Keep this out of paintEvent(): setVisible(), setGeometry(), and raise()
     // dirty child widgets, and doing that while painting can schedule another
     // tab bar repaint before the current one has finished flushing.
-    auto place_button = [&](int index, QTabBar::ButtonPosition position, QRect shape_rect) {
+    auto place_expanded_button = [&](int index, QTabBar::ButtonPosition position, QRect shape_rect) {
         auto* button = tabButton(index, position);
         if (!button)
             return;
+        prepare_button(button, false);
+
         auto should_be_visible = position != QTabBar::RightSide || index == currentIndex() || index == m_hovered_tab_index;
         bool did_update_button = false;
         if (button->isVisible() != should_be_visible) {
@@ -874,14 +929,61 @@ void TabBar::update_tab_button_geometry()
             button->raise();
     };
 
+    auto place_collapsed_button = [&](int index, QTabBar::ButtonPosition position, QRect tab_rect, QRect shape_rect) {
+        auto* button = tabButton(index, position);
+        if (!button)
+            return;
+        prepare_button(button, true);
+
+        auto should_be_visible = position == QTabBar::LeftSide || index == m_hovered_tab_index;
+        bool did_update_button = false;
+        if (button->isVisible() != should_be_visible) {
+            button->setVisible(should_be_visible);
+            did_update_button = true;
+        }
+
+        auto button_size = button->size();
+        if (button_size.isEmpty())
+            button_size = button->sizeHint();
+        if (button_size.isEmpty())
+            return;
+
+        QPoint button_position;
+        if (position == QTabBar::RightSide) {
+            button_position = {
+                max(tab_rect.left(), shape_rect.left() - 5),
+                max(tab_rect.top(), shape_rect.top() - 5),
+            };
+        } else {
+            auto x = min(tab_rect.right() - button_size.width() + 1, shape_rect.right() - button_size.width() + 5);
+            auto y = min(tab_rect.bottom() - button_size.height() + 1, shape_rect.bottom() - button_size.height() + 5);
+            button_position = { x, y };
+        }
+
+        QRect button_geometry { button_position, button_size };
+        if (button->geometry() != button_geometry) {
+            button->setGeometry(button_geometry);
+            did_update_button = true;
+        }
+
+        if (did_update_button)
+            button->raise();
+    };
+
     for (int index = 0; index < count(); ++index) {
         auto tab_rect = visual_tab_rect(index);
         if (!tab_rect.isValid())
             continue;
 
-        auto shape_rect = expanded_vertical_tab_shape_rect(tab_rect);
-        place_button(index, QTabBar::LeftSide, shape_rect);
-        place_button(index, QTabBar::RightSide, shape_rect);
+        if (tab_layout() == TabLayout::VerticalCollapsed) {
+            auto shape_rect = collapsed_vertical_tab_shape_rect(tab_rect);
+            place_collapsed_button(index, QTabBar::LeftSide, tab_rect, shape_rect);
+            place_collapsed_button(index, QTabBar::RightSide, tab_rect, shape_rect);
+        } else {
+            auto shape_rect = expanded_vertical_tab_shape_rect(tab_rect);
+            place_expanded_button(index, QTabBar::LeftSide, shape_rect);
+            place_expanded_button(index, QTabBar::RightSide, shape_rect);
+        }
     }
 }
 
@@ -1520,13 +1622,21 @@ void TabWidget::update_tab_layout()
 
 void TabWidget::update_tab_button_visibility()
 {
-    auto show_tab_buttons = m_tab_bar->tab_layout() != TabLayout::VerticalCollapsed;
+    if (m_tab_bar->tab_layout() == TabLayout::VerticalCollapsed) {
+        for (int index = 0; index < m_tab_bar->count(); ++index) {
+            if (auto* button = m_tab_bar->tabButton(index, QTabBar::RightSide))
+                button->hide();
+        }
+
+        m_tab_bar->refresh_tab_layout();
+        return;
+    }
 
     for (int index = 0; index < m_tab_bar->count(); ++index) {
         if (auto* button = m_tab_bar->tabButton(index, QTabBar::LeftSide))
-            button->setVisible(show_tab_buttons);
+            button->setVisible(true);
         if (auto* button = m_tab_bar->tabButton(index, QTabBar::RightSide))
-            button->setVisible(show_tab_buttons);
+            button->setVisible(true);
     }
 
     m_tab_bar->refresh_tab_layout();
@@ -1633,14 +1743,36 @@ bool TabWidget::start_window_move()
     return handle->startSystemMove();
 }
 
+void TabBarButton::set_collapsed_vertical_overlay(bool enabled)
+{
+    if (property(COLLAPSED_VERTICAL_TAB_BUTTON_PROPERTY).toBool() == enabled)
+        return;
+
+    setProperty(COLLAPSED_VERTICAL_TAB_BUTTON_PROPERTY, enabled);
+
+    QSize button_size { TAB_BUTTON_SIZE, TAB_BUTTON_SIZE };
+    QSize icon_size { TAB_ICON_SIZE, TAB_ICON_SIZE };
+    if (enabled) {
+        button_size = { COLLAPSED_VERTICAL_TAB_BUTTON_SIZE, COLLAPSED_VERTICAL_TAB_BUTTON_SIZE };
+        icon_size = { COLLAPSED_VERTICAL_TAB_ICON_SIZE, COLLAPSED_VERTICAL_TAB_ICON_SIZE };
+    }
+
+    setFixedSize(button_size);
+    setIconSize(icon_size);
+    style()->unpolish(this);
+    style()->polish(this);
+    update();
+}
+
 TabBarButton::TabBarButton(QIcon const& icon, QWidget* parent)
     : QPushButton(icon, {}, parent)
 {
     setObjectName("LadybirdTabButton");
-    setFixedSize({ 22, 22 });
-    setIconSize({ 16, 16 });
+    setFixedSize({ TAB_BUTTON_SIZE, TAB_BUTTON_SIZE });
+    setIconSize({ TAB_ICON_SIZE, TAB_ICON_SIZE });
     setFocusPolicy(Qt::NoFocus);
     setFlat(true);
+    hide();
 }
 
 bool TabBarButton::event(QEvent* event)

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -72,6 +72,7 @@ private:
     virtual void dragLeaveEvent(QDragLeaveEvent*) override;
     virtual void dragMoveEvent(QDragMoveEvent*) override;
     virtual void dropEvent(QDropEvent*) override;
+    virtual bool eventFilter(QObject*, QEvent*) override;
     virtual void leaveEvent(QEvent*) override;
     virtual void mouseDoubleClickEvent(QMouseEvent*) override;
     virtual void mousePressEvent(QMouseEvent*) override;
@@ -229,6 +230,7 @@ class TabBarButton final : public QPushButton {
 
 public:
     explicit TabBarButton(QIcon const& icon, QWidget* parent = nullptr);
+    void set_collapsed_vertical_overlay(bool);
 
 protected:
     virtual bool event(QEvent* event) override;


### PR DESCRIPTION
This PR first draws the audio icons using the chrome icon infra, as the audio icons Qt chooses on macOS look particularly out-of-place. Then it draws the icons on collapsed vertical tabs. I looked at a few vertical tab implementations and went with Firefox's approach to drawing these icons. (Brave only draws a close tab icon on the active tab (in place of the favicon), for example, which I don't like).

[icons.webm](https://github.com/user-attachments/assets/66be4f64-bf4a-4039-ade9-353da5beb965)
