### PR TITLE
Generate accumulated visual context property metadata

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -460,6 +460,7 @@
     "multiplicity": "coordinating-list"
   },
   "background-attachment": {
+    "affects-accumulated-visual-contexts": true,
     "affects-layout": false,
     "animation-type": "discrete",
     "inherited": false,
@@ -1349,6 +1350,7 @@
     ]
   },
   "clip": {
+    "affects-accumulated-visual-contexts": true,
     "affects-layout": false,
     "animation-type": "by-computed-value",
     "inherited": false,
@@ -1365,6 +1367,7 @@
     ]
   },
   "clip-path": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "by-computed-value",
     "affects-layout": false,
     "affects-stacking-context": true,
@@ -1893,6 +1896,7 @@
     ]
   },
   "filter": {
+    "affects-accumulated-visual-contexts": true,
     "affects-layout": false,
     "affects-stacking-context": true,
     "animation-type": "custom",
@@ -3170,6 +3174,7 @@
     ]
   },
   "mix-blend-mode": {
+    "affects-accumulated-visual-contexts": true,
     "affects-layout": false,
     "animation-type": "discrete",
     "inherited": false,
@@ -3202,6 +3207,7 @@
     "percentages-resolve-to": "length"
   },
   "opacity": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "by-computed-value",
     "affects-layout": false,
     "affects-stacking-context": true,
@@ -3583,6 +3589,7 @@
     ]
   },
   "perspective": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "none",
@@ -3595,6 +3602,7 @@
     ]
   },
   "perspective-origin": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "by-computed-value",
     "affects-layout": false,
     "inherited": false,
@@ -3768,6 +3776,7 @@
     "needs-layout-for-getcomputedstyle": true
   },
   "rotate": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "custom",
     "inherited": false,
     "initial": "none",
@@ -3826,6 +3835,7 @@
     ]
   },
   "scale": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "custom",
     "inherited": false,
     "initial": "none",
@@ -4510,6 +4520,7 @@
     ]
   },
   "transform": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "custom",
     "inherited": false,
     "initial": "none",
@@ -4536,6 +4547,7 @@
     ]
   },
   "transform-origin": {
+    "affects-accumulated-visual-contexts": true,
     "affects-layout": false,
     "animation-type": "by-computed-value",
     "inherited": false,
@@ -4637,6 +4649,7 @@
     ]
   },
   "translate": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "custom",
     "inherited": false,
     "initial": "none",

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -135,23 +135,8 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     }
     invalidation.repaint = true;
 
-    // Transform, perspective, clip, clip-path, effects, and background-attachment properties require rebuilding AccumulatedVisualContext tree.
-    if (AK::first_is_one_of(property_id,
-            CSS::PropertyID::Transform,
-            CSS::PropertyID::Rotate,
-            CSS::PropertyID::Scale,
-            CSS::PropertyID::Translate,
-            CSS::PropertyID::Perspective,
-            CSS::PropertyID::TransformOrigin,
-            CSS::PropertyID::PerspectiveOrigin,
-            CSS::PropertyID::Clip,
-            CSS::PropertyID::ClipPath,
-            CSS::PropertyID::Opacity,
-            CSS::PropertyID::MixBlendMode,
-            CSS::PropertyID::Filter,
-            CSS::PropertyID::BackgroundAttachment)) {
+    if (CSS::property_affects_accumulated_visual_contexts(property_id))
         invalidation.rebuild_accumulated_visual_contexts = true;
-    }
 
     return invalidation;
 }

--- a/Meta/Generators/generate_libweb_css_property_id.py
+++ b/Meta/Generators/generate_libweb_css_property_id.py
@@ -291,6 +291,7 @@ size_t property_maximum_value_count(PropertyID);
 
 bool property_affects_layout(PropertyID);
 bool property_affects_stacking_context(PropertyID);
+bool property_affects_accumulated_visual_contexts(PropertyID);
 bool property_needs_layout_for_getcomputedstyle(PropertyID);
 bool property_needs_layout_node_for_resolved_value(PropertyID);
 
@@ -540,6 +541,23 @@ bool property_affects_stacking_context(PropertyID property_id)
         if is_legacy_alias(value):
             continue
         if value.get("affects-stacking-context", False):
+            out.write(f"    case PropertyID::{title_casify(name)}:\n")
+    out.write("""
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool property_affects_accumulated_visual_contexts(PropertyID property_id)
+{
+    switch (property_id) {
+""")
+
+    for name, value in properties.items():
+        if is_legacy_alias(value):
+            continue
+        if value.get("affects-accumulated-visual-contexts", False):
             out.write(f"    case PropertyID::{title_casify(name)}:\n")
     out.write("""
         return true;


### PR DESCRIPTION
Style invalidation kept the list of properties that require rebuilding the accumulated visual context tree in StyleInvalidation.cpp. That made the classification separate from the existing property metadata used for layout and stacking-context invalidation.

Move that classification into Properties.json and teach the PropertyID generator to emit property_affects_accumulated_visual_contexts(). Style invalidation now uses the generated predicate, preserving the existing property set and behavior while making future classification changes data-driven.