### PR TITLE
Reuse display lists for visual viewport updates

### DIFF
--- a/Libraries/LibWeb/CSS/VisualViewport.cpp
+++ b/Libraries/LibWeb/CSS/VisualViewport.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/DOM/EventDispatcher.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 
 namespace Web::CSS {
 
@@ -146,6 +147,15 @@ WebIDL::CallbackType* VisualViewport::onscrollend()
     return event_handler_attribute(HTML::EventNames::scrollend);
 }
 
+void VisualViewport::scroll_by(CSSPixelPoint delta)
+{
+    if (delta.is_zero())
+        return;
+    m_offset += delta;
+    update_accumulated_visual_context();
+    m_document->set_needs_repaint(Badge<CSS::VisualViewport> {}, InvalidateDisplayList::No);
+}
+
 Gfx::AffineTransform VisualViewport::transform() const
 {
     Gfx::AffineTransform transform;
@@ -174,8 +184,8 @@ void VisualViewport::zoom(CSSPixelPoint position, double scale_delta)
 
     m_scale = new_scale;
     m_offset = (new_offset / m_scale).to_type<CSSPixels>();
-    m_document->set_needs_accumulated_visual_contexts_update(true);
-    m_document->set_needs_repaint(Badge<CSS::VisualViewport> {}, InvalidateDisplayList::Yes);
+    update_accumulated_visual_context();
+    m_document->set_needs_repaint(Badge<CSS::VisualViewport> {}, InvalidateDisplayList::No);
 }
 
 CSSPixelPoint VisualViewport::map_to_layout_viewport(CSSPixelPoint position) const
@@ -188,8 +198,18 @@ void VisualViewport::reset()
 {
     m_scale = 1.0;
     m_offset = { 0, 0 };
+    update_accumulated_visual_context();
+    m_document->set_needs_repaint(Badge<CSS::VisualViewport> {}, InvalidateDisplayList::No);
+}
+
+void VisualViewport::update_accumulated_visual_context()
+{
+    if (auto paintable = m_document->unsafe_paintable(); paintable && paintable->has_visual_context_tree()) {
+        paintable->update_visual_viewport_accumulated_visual_context();
+        return;
+    }
+
     m_document->set_needs_accumulated_visual_contexts_update(true);
-    m_document->set_needs_repaint(Badge<CSS::VisualViewport> {}, InvalidateDisplayList::Yes);
 }
 
 }

--- a/Libraries/LibWeb/CSS/VisualViewport.h
+++ b/Libraries/LibWeb/CSS/VisualViewport.h
@@ -43,7 +43,7 @@ public:
     void set_onscrollend(WebIDL::CallbackType*);
     WebIDL::CallbackType* onscrollend();
 
-    void scroll_by(CSSPixelPoint delta) { m_offset += delta; }
+    void scroll_by(CSSPixelPoint delta);
 
     [[nodiscard]] Gfx::AffineTransform transform() const;
     void zoom(CSSPixelPoint position, double scale_delta);
@@ -55,6 +55,8 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+
+    void update_accumulated_visual_context();
 
     GC::Ref<DOM::Document> m_document;
     CSSPixelPoint m_offset;

--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -31,6 +31,11 @@ void CompositorContextHandle::update_display_list(NonnullRefPtr<Painting::Displa
     m_host.update_display_list(m_context_id, move(display_list), move(visual_context_tree), move(resource_transaction), move(scroll_state_snapshot));
 }
 
+void CompositorContextHandle::update_visual_context_tree(Painting::AccumulatedVisualContextTree visual_context_tree)
+{
+    m_host.update_visual_context_tree(m_context_id, move(visual_context_tree));
+}
+
 void CompositorContextHandle::update_video_frame(Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)
 {
     m_host.update_video_frame(m_context_id, frame_id, move(frame));

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -36,6 +36,7 @@ public:
     void set_presentation_mode(PresentationMode);
 
     void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::AccumulatedVisualContextTree, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
+    void update_visual_context_tree(Painting::AccumulatedVisualContextTree);
     void update_video_frame(Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
     void clear_video_frame(Painting::VideoFrameResourceId);
     void update_compositor_surface(Painting::CompositorSurfaceId, Gfx::SharedImage&&);
@@ -72,6 +73,7 @@ public:
     virtual void set_presentation_mode(CompositorContextId, PresentationMode) = 0;
 
     virtual void update_display_list(CompositorContextId, NonnullRefPtr<Painting::DisplayList>, Painting::AccumulatedVisualContextTree, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&) = 0;
+    virtual void update_visual_context_tree(CompositorContextId, Painting::AccumulatedVisualContextTree) = 0;
     virtual void update_video_frame(CompositorContextId, Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>) = 0;
     virtual void clear_video_frame(CompositorContextId, Painting::VideoFrameResourceId) = 0;
     virtual void update_compositor_surface(CompositorContextId, Painting::CompositorSurfaceId, Gfx::SharedImage&&) = 0;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8487,6 +8487,8 @@ void Document::set_caret_hit_test_debug_rect(Optional<CSSPixelRect> rect)
 
 Painting::HitTestDisplayList const* Document::ensure_hit_test_display_list()
 {
+    update_paint_and_hit_testing_properties_if_needed();
+
     auto viewport_paintable = paintable();
     if (!viewport_paintable)
         return nullptr;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2822,7 +2822,7 @@ static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting
 {
     auto inverse_transform_point = [](Painting::PaintableBox const& paintable_box, CSSPixelPoint position) -> Optional<CSSPixelPoint> {
         auto viewport_paintable = paintable_box.document().unsafe_paintable();
-        if (!viewport_paintable)
+        if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
             return {};
         auto pixel_ratio = static_cast<float>(paintable_box.document().page().client().device_pixels_per_css_pixel());
         auto const& visual_context_tree = viewport_paintable->visual_context_tree();
@@ -2833,15 +2833,11 @@ static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting
 
     CSSPixelPoint offset_position = position;
     if (auto const* paintable_box = as_if<Painting::PaintableBox>(paintable)) {
-        if (paintable_box->accumulated_visual_context_index().value()) {
-            if (auto transformed_position = inverse_transform_point(*paintable_box, position); transformed_position.has_value())
-                offset_position = *transformed_position;
-        }
+        if (auto transformed_position = inverse_transform_point(*paintable_box, position); transformed_position.has_value())
+            offset_position = *transformed_position;
     } else if (auto containing_block = paintable.containing_block()) {
-        if (containing_block->accumulated_visual_context_index().value()) {
-            if (auto transformed_position = inverse_transform_point(*containing_block, position); transformed_position.has_value())
-                offset_position = *transformed_position;
-        }
+        if (auto transformed_position = inverse_transform_point(*containing_block, position); transformed_position.has_value())
+            offset_position = *transformed_position;
     }
 
     auto const top_left_of_layout_node = paintable.box_type_agnostic_position();
@@ -8921,8 +8917,7 @@ String Document::dump_display_list()
     HashMap<size_t, RefPtr<Painting::PaintableBox const>> context_id_to_paintable;
     viewport_paintable->for_each_in_inclusive_subtree_of_type<Painting::PaintableBox>([&](auto const& paintable_box) {
         auto visual_context_index = paintable_box.accumulated_visual_context_index();
-        if (visual_context_index.value())
-            (void)context_id_to_paintable.try_set(visual_context_index.value(), paintable_box);
+        (void)context_id_to_paintable.try_set(visual_context_index.value(), paintable_box);
         return TraversalDecision::Continue;
     });
 
@@ -8935,15 +8930,15 @@ String Document::dump_display_list()
     Vector<size_t> root_contexts;
 
     display_list->for_each_command_header([&](Painting::DisplayListCommandHeader const& header, ReadonlyBytes) {
-        if (!header.context_index.value())
-            return;
-        for (size_t node_index = header.context_index.value(); node_index && !visited.contains(node_index);) {
+        for (size_t node_index = header.context_index.value(); !visited.contains(node_index);) {
             visited.set(node_index);
+            if (node_index == Painting::VISUAL_VIEWPORT_NODE_INDEX.value()) {
+                if (!root_contexts.contains_slow(node_index))
+                    root_contexts.append(node_index);
+                break;
+            }
             auto parent = visual_context_tree.node_at(Painting::VisualContextIndex(node_index)).parent_index.value();
-            if (parent)
-                children.ensure(parent).append(node_index);
-            else if (!root_contexts.contains_slow(node_index))
-                root_contexts.append(node_index);
+            children.ensure(parent).append(node_index);
             node_index = parent;
         }
     });

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3471,6 +3471,7 @@ bool Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
         return false;
 
     adopt_pending_async_scroll_offsets();
+    document->update_paint_and_hit_testing_properties_if_needed();
 
     auto should_record_display_list = m_needs_to_record_display_list
         || !m_compositor_display_list_paint_config.has_value()
@@ -3496,16 +3497,22 @@ bool Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
 
     auto document_paintable = document->paintable();
     VERIFY(document_paintable);
+    auto visual_context_tree_needs_compositor_update = document_paintable->visual_context_tree_needs_compositor_update();
     document_paintable->refresh_scroll_state();
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
     if (should_record_display_list) {
         compositor_context().update_display_list(*display_list, visual_context_tree.release_value(), move(resource_transaction), move(scroll_state_snapshot));
+        document_paintable->did_update_visual_context_tree_in_compositor();
         m_display_list_resource_storage.retain_only(display_list_resources);
         m_compositor_display_list_resources = move(display_list_resources);
         m_needs_to_record_display_list = false;
         m_compositor_display_list_paint_config = paint_config;
     } else {
+        if (visual_context_tree_needs_compositor_update) {
+            compositor_context().update_visual_context_tree(document_paintable->visual_context_tree());
+            document_paintable->did_update_visual_context_tree_in_compositor();
+        }
         compositor_context().update_scroll_state(move(scroll_state_snapshot));
     }
     return true;
@@ -3645,12 +3652,8 @@ GC::Ref<WebIDL::Promise> Navigable::perform_a_scroll_of_the_viewport(CSSPixelPoi
     //     from this step.
     // FIXME: Get a Promise from this.
     vv->scroll_by({ visual_dx, visual_dy });
-    if (visual_dx != 0.0 || visual_dy != 0.0) {
-        doc->set_needs_accumulated_visual_contexts_update(true);
-        doc->set_needs_repaint(Badge<HTML::Navigable> {}, InvalidateDisplayList::Yes);
-    } else {
+    if (visual_dx == 0.0 && visual_dy == 0.0)
         doc->set_needs_repaint(Badge<HTML::Navigable> {}, InvalidateDisplayList::No);
-    }
 
     // 16. Let scrollPromise be a new Promise.
     auto scroll_promise = WebIDL::create_promise(doc->realm());

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2912,8 +2912,7 @@ CSSPixelPoint Navigable::to_top_level_position(CSSPixelPoint a_position)
         if (!paintable)
             return {};
 
-        if (auto const* paintable_box = as_if<Painting::PaintableBox>(*paintable);
-            paintable_box && paintable_box->accumulated_visual_context_index().value()) {
+        if (auto const* paintable_box = as_if<Painting::PaintableBox>(*paintable)) {
             auto point = paintable_box->absolute_position();
             point.translate_by(position);
             position = paintable_box->transform_rect_to_viewport({ point, { 0, 0 } }).location();

--- a/Libraries/LibWeb/Page/AutoScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/AutoScrollHandler.cpp
@@ -43,8 +43,6 @@ static Optional<CSSPixelRect> scrollport_rect_in_viewport(Painting::PaintableBox
     if (paintable_box.is_viewport_paintable())
         return scrollport;
 
-    if (!paintable_box.accumulated_visual_context_index().value())
-        return {};
     return paintable_box.transform_rect_to_viewport(scrollport);
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -38,11 +38,21 @@ bool ClipData::contains(DevicePixelPoint point) const
 
 static Atomic<u64> s_next_accumulated_visual_context_tree_version { 1 };
 
+static TransformData identity_visual_viewport_transform()
+{
+    return { Gfx::FloatMatrix4x4::identity(), { 0.f, 0.f } };
+}
+
 AccumulatedVisualContextTree AccumulatedVisualContextTree::create()
 {
+    return create(identity_visual_viewport_transform());
+}
+
+AccumulatedVisualContextTree AccumulatedVisualContextTree::create(TransformData visual_viewport_transform)
+{
     Vector<AccumulatedVisualContextNode> nodes;
-    // Sentinel at index 0 (null context). Data type doesn't matter; it's never accessed.
-    nodes.append({ ScrollData { {}, false }, {}, 0, false });
+    // Visual viewport transform root. This is identity for trees that are not attached to a document viewport.
+    nodes.append({ move(visual_viewport_transform), {}, 0, false });
     return AccumulatedVisualContextTree {
         s_next_accumulated_visual_context_tree_version.fetch_add(1, AK::MemoryOrder::memory_order_relaxed),
         move(nodes)
@@ -69,6 +79,13 @@ static FloatMatrix4x4 scale_matrix_for_device_pixels(FloatMatrix4x4 matrix, floa
     matrix[3, 1] /= scale;
     matrix[3, 2] /= scale;
     return matrix;
+}
+
+static TransformData visual_viewport_transform_data(DOM::Document& document)
+{
+    auto scale = static_cast<float>(document.page().client().device_pixels_per_css_pixel());
+    auto matrix = scale_matrix_for_device_pixels(document.visual_viewport()->transform().to_matrix(), scale);
+    return TransformData { matrix, { 0.f, 0.f } };
 }
 
 static Optional<TransformData> compute_transform(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, double pixel_ratio)
@@ -190,9 +207,8 @@ static Optional<ClipData> compute_clip_data(PaintableBox const& paintable_box, C
 
 AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable& viewport_paintable)
 {
-    auto visual_context_tree = AccumulatedVisualContextTree::create();
-
     auto& document = viewport_paintable.document();
+    auto visual_context_tree = AccumulatedVisualContextTree::create(visual_viewport_transform_data(document));
     auto pixel_ratio = document.page().client().device_pixels_per_css_pixel();
     DevicePixelConverter converter { pixel_ratio };
     auto scale = static_cast<float>(pixel_ratio);
@@ -214,18 +230,12 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         return effects;
     };
 
-    // Create visual viewport transform as root (if not identity)
-    VisualContextIndex visual_viewport_context_index {};
-    auto transform = document.visual_viewport()->transform();
-    if (!transform.is_identity()) {
-        auto matrix = scale_matrix_for_device_pixels(transform.to_matrix(), scale);
-        visual_viewport_context_index = append_node({}, TransformData { matrix, { 0.f, 0.f } });
-    }
+    auto visual_viewport_context_index = VISUAL_VIEWPORT_NODE_INDEX;
 
     VisualContextIndex viewport_state_for_descendants = visual_viewport_context_index;
     if (viewport_paintable.own_scroll_frame_index().value())
         viewport_state_for_descendants = append_node(visual_viewport_context_index, ScrollData { viewport_paintable.own_scroll_frame_index(), false });
-    viewport_paintable.set_accumulated_visual_context({});
+    viewport_paintable.set_accumulated_visual_context(VISUAL_VIEWPORT_NODE_INDEX);
     viewport_paintable.set_accumulated_visual_context_for_descendants(viewport_state_for_descendants);
 
     viewport_paintable.for_each_in_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
@@ -393,10 +403,11 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
 VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, VisualContextIndex parent_index)
 {
-    size_t depth = parent_index.value() ? m_nodes[parent_index.value()].depth + 1 : 1;
+    VERIFY(parent_index.value() < m_nodes.size());
+    size_t depth = m_nodes[parent_index.value()].depth + 1;
 
     bool empty_clip = false;
-    if (parent_index.value() && m_nodes[parent_index.value()].has_empty_effective_clip) {
+    if (m_nodes[parent_index.value()].has_empty_effective_clip) {
         empty_clip = true;
     } else if (data.has<ClipData>()) {
         empty_clip = data.get<ClipData>().rect.is_empty();
@@ -411,8 +422,8 @@ VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, 
 
 VisualContextIndex AccumulatedVisualContextTree::find_common_ancestor(VisualContextIndex a, VisualContextIndex b) const
 {
-    if (!a.value() || !b.value())
-        return {};
+    VERIFY(a.value() < m_nodes.size());
+    VERIFY(b.value() < m_nodes.size());
     size_t a_index = a.value();
     size_t b_index = b.value();
     while (m_nodes[a_index].depth > m_nodes[b_index].depth)
@@ -428,19 +439,20 @@ VisualContextIndex AccumulatedVisualContextTree::find_common_ancestor(VisualCont
 
 Vector<size_t, 8> AccumulatedVisualContextTree::build_ancestor_chain(VisualContextIndex index) const
 {
+    VERIFY(index.value() < m_nodes.size());
     auto const& node = m_nodes[index.value()];
     Vector<size_t, 8> chain;
-    chain.ensure_capacity(node.depth);
-    for (size_t i = index.value(); i; i = m_nodes[i].parent_index.value())
+    chain.ensure_capacity(node.depth + 1);
+    for (size_t i = index.value();; i = m_nodes[i].parent_index.value()) {
         chain.append(i);
+        if (i == VISUAL_VIEWPORT_NODE_INDEX.value())
+            break;
+    }
     return chain;
 }
 
 Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_test(VisualContextIndex index, Gfx::FloatPoint screen_point, ScrollStateSnapshot const& scroll_state) const
 {
-    if (!index.value())
-        return screen_point;
-
     auto chain = build_ancestor_chain(index);
 
     auto point = screen_point;
@@ -505,9 +517,6 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
 
 Gfx::FloatPoint AccumulatedVisualContextTree::inverse_transform_point(VisualContextIndex index, Gfx::FloatPoint screen_point) const
 {
-    if (!index.value())
-        return screen_point;
-
     auto chain = build_ancestor_chain(index);
 
     auto point = screen_point;
@@ -538,11 +547,8 @@ Gfx::FloatPoint AccumulatedVisualContextTree::inverse_transform_point(VisualCont
 
 Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualContextIndex index, Gfx::FloatRect const& source_rect, ScrollStateSnapshot const& scroll_state) const
 {
-    if (!index.value())
-        return source_rect;
-
     auto rect = source_rect;
-    for (size_t i = index.value(); i; i = m_nodes[i].parent_index.value()) {
+    for (size_t i = index.value();; i = m_nodes[i].parent_index.value()) {
         auto const& node = m_nodes[i];
         node.data.visit(
             [&](TransformData const& transform) {
@@ -565,6 +571,8 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
             [&](ClipData const&) { /* clips don't affect rect coordinates */ },
             [&](ClipPathData const&) { /* clip paths don't affect rect coordinates */ },
             [&](EffectsData const&) { /* effects don't affect rect coordinates */ });
+        if (i == VISUAL_VIEWPORT_NODE_INDEX.value())
+            break;
     }
 
     return rect;
@@ -572,9 +580,6 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
 
 void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder& builder) const
 {
-    if (!index.value())
-        return;
-
     auto const& node = m_nodes[index.value()];
     node.data.visit(
         [&](PerspectiveData const&) {
@@ -787,7 +792,9 @@ ErrorOr<Web::Painting::AccumulatedVisualContextTree> decode(Decoder& decoder)
     auto version = TRY(decoder.decode<u64>());
     auto nodes = TRY(decoder.decode<Vector<Web::Painting::AccumulatedVisualContextNode>>());
     if (nodes.is_empty())
-        return Error::from_string_literal("IPC decode: AccumulatedVisualContextTree missing sentinel node");
+        return Error::from_string_literal("IPC decode: AccumulatedVisualContextTree missing visual viewport node");
+    if (!nodes[Web::Painting::VISUAL_VIEWPORT_NODE_INDEX.value()].data.has<Web::Painting::TransformData>())
+        return Error::from_string_literal("IPC decode: AccumulatedVisualContextTree visual viewport node is not a transform");
     return Web::Painting::AccumulatedVisualContextTree { version, move(nodes) };
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -30,6 +30,7 @@
 namespace Web::Painting {
 
 AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable&);
+void update_visual_viewport_accumulated_visual_context(ViewportPaintable&);
 
 bool ClipData::contains(DevicePixelPoint point) const
 {
@@ -401,6 +402,11 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
     return visual_context_tree;
 }
 
+void update_visual_viewport_accumulated_visual_context(ViewportPaintable& viewport_paintable)
+{
+    viewport_paintable.visual_context_tree().set_visual_viewport_transform(visual_viewport_transform_data(viewport_paintable.document()));
+}
+
 VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, VisualContextIndex parent_index)
 {
     VERIFY(parent_index.value() < m_nodes.size());
@@ -418,6 +424,13 @@ VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, 
     auto index = VisualContextIndex(m_nodes.size());
     m_nodes.append({ move(data), parent_index, depth, empty_clip });
     return index;
+}
+
+void AccumulatedVisualContextTree::set_visual_viewport_transform(TransformData transform)
+{
+    VERIFY(!m_nodes.is_empty());
+    VERIFY(m_nodes[VISUAL_VIEWPORT_NODE_INDEX.value()].data.has<TransformData>());
+    m_nodes[VISUAL_VIEWPORT_NODE_INDEX.value()].data = move(transform);
 }
 
 VisualContextIndex AccumulatedVisualContextTree::find_common_ancestor(VisualContextIndex a, VisualContextIndex b) const

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -105,6 +105,7 @@ public:
     u64 version() const { return m_version; }
 
     VisualContextIndex append(VisualContextData data, VisualContextIndex parent_index);
+    void set_visual_viewport_transform(TransformData);
 
     AccumulatedVisualContextNode const& node_at(VisualContextIndex index) const { return m_nodes[index.value()]; }
     ReadonlySpan<AccumulatedVisualContextNode> nodes() const { return m_nodes.span(); }

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -28,6 +28,8 @@ class ScrollStateSnapshot;
 
 AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, VisualContextIndex);
 
+static constexpr VisualContextIndex VISUAL_VIEWPORT_NODE_INDEX { 0 };
+
 struct ScrollData {
     ScrollFrameIndex scroll_frame_index;
     bool is_sticky;
@@ -92,6 +94,7 @@ struct AccumulatedVisualContextNode {
 class AccumulatedVisualContextTree {
 public:
     static AccumulatedVisualContextTree create();
+    static AccumulatedVisualContextTree create(TransformData visual_viewport_transform);
 
     AccumulatedVisualContextTree(AccumulatedVisualContextTree const&) = default;
     AccumulatedVisualContextTree& operator=(AccumulatedVisualContextTree const&) = default;

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -53,7 +53,7 @@ bool DisplayList::append_bytes(
     bool is_clip)
 {
     VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
-    if (context_index.value() && visual_context_tree.has_empty_effective_clip(context_index))
+    if (visual_context_tree.has_empty_effective_clip(context_index))
         return false;
     VERIFY(m_command_bytes.size() % DisplayList::command_alignment == 0);
     VERIFY(payload.size() <= NumericLimits<u32>::max());
@@ -165,13 +165,14 @@ void DisplayListPlayer::execute_impl(
 
     auto for_each_node_from_common_ancestor_to_target =
         [&](this auto const& self,
-            VisualContextIndex common_ancestor_index,
+            Optional<VisualContextIndex> common_ancestor_index,
             VisualContextIndex target_index,
             auto&& callback) -> IterationDecision {
-        if (!target_index.value() || target_index == common_ancestor_index)
+        if (common_ancestor_index.has_value() && target_index == common_ancestor_index.value())
             return IterationDecision::Continue;
-        if (self(common_ancestor_index, visual_context_tree.node_at(target_index).parent_index, callback)
-            == IterationDecision::Break) {
+        if (target_index != VISUAL_VIEWPORT_NODE_INDEX
+            && self(common_ancestor_index, visual_context_tree.node_at(target_index).parent_index, callback)
+                == IterationDecision::Break) {
             return IterationDecision::Break;
         }
         return callback(target_index, visual_context_tree.node_at(target_index));
@@ -228,6 +229,7 @@ void DisplayListPlayer::execute_impl(
         };
 
     VisualContextIndex applied_context_index;
+    bool has_applied_context { false };
     size_t applied_depth = 0;
 
     // OPTIMIZATION: When walking down to apply effects (opacity, filters, blend modes), check culling before applying
@@ -238,20 +240,26 @@ void DisplayListPlayer::execute_impl(
         CulledByEffect,
     };
     auto switch_to_context = [&](VisualContextIndex target_index, Optional<Gfx::IntRect> bounding_rect = {}) -> SwitchResult {
-        if (applied_context_index == target_index)
+        if (has_applied_context && applied_context_index == target_index)
             return SwitchResult::Switched;
 
-        auto common_ancestor_index = visual_context_tree.find_common_ancestor(applied_context_index, target_index);
-        size_t const common_ancestor_depth = common_ancestor_index.value() ? visual_context_tree.node_at(common_ancestor_index).depth : 0;
+        Optional<VisualContextIndex> common_ancestor_index;
+        if (has_applied_context)
+            common_ancestor_index = visual_context_tree.find_common_ancestor(applied_context_index, target_index);
+        size_t const common_ancestor_depth = common_ancestor_index.has_value() ? visual_context_tree.node_at(common_ancestor_index.value()).depth + 1 : 0;
 
-        auto has_coordinate_changing_descendant = [&](VisualContextIndex ancestor_index) {
-            for (auto index = target_index; index != ancestor_index; index = visual_context_tree.node_at(index).parent_index) {
+        auto has_coordinate_changing_descendant = [&](Optional<VisualContextIndex> ancestor_index) {
+            for (auto index = target_index;; index = visual_context_tree.node_at(index).parent_index) {
+                if (ancestor_index.has_value() && index == ancestor_index.value())
+                    break;
                 auto const& node = visual_context_tree.node_at(index);
                 if (node.data.has<TransformData>()
                     || node.data.has<PerspectiveData>()
                     || node.data.has<ScrollData>()
                     || node.data.has<ScrollCompensation>())
                     return true;
+                if (index == VISUAL_VIEWPORT_NODE_INDEX)
+                    break;
             }
             return false;
         };
@@ -267,7 +275,7 @@ void DisplayListPlayer::execute_impl(
             target_index,
             [&](VisualContextIndex node_index, AccumulatedVisualContextNode const& node) {
                 if (bounding_rect.has_value() && node.data.has<EffectsData>()) {
-                    auto can_cull_before_effect = !has_coordinate_changing_descendant(node_index);
+                    auto can_cull_before_effect = !has_coordinate_changing_descendant(Optional<VisualContextIndex> { node_index });
                     if (bounding_rect->is_empty() || (can_cull_before_effect && would_be_fully_clipped_by_painter(*bounding_rect))) {
                         result = SwitchResult::CulledByEffect;
                         return IterationDecision::Break;
@@ -278,8 +286,10 @@ void DisplayListPlayer::execute_impl(
                 return IterationDecision::Continue;
             });
 
-        if (result == SwitchResult::Switched)
+        if (result == SwitchResult::Switched) {
             applied_context_index = target_index;
+            has_applied_context = true;
+        }
         return result;
     };
 

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -101,7 +101,7 @@ struct DisplayListGradientColorStops {
 struct DisplayListCommandHeader {
     DisplayListCommandType type;
     u32 payload_size { 0 };
-    VisualContextIndex context_index {};
+    VisualContextIndex context_index { VISUAL_VIEWPORT_NODE_INDEX };
     bool has_bounding_rect { false };
     bool is_clip { false };
     Gfx::IntRect bounding_rect {};

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -169,7 +169,7 @@ private:
         m_display_list.append(command, m_visual_context_tree, m_accumulated_visual_context_index, inline_data);
     }
 
-    VisualContextIndex m_accumulated_visual_context_index {};
+    VisualContextIndex m_accumulated_visual_context_index { VISUAL_VIEWPORT_NODE_INDEX };
     DisplayList& m_display_list;
     AccumulatedVisualContextTree const& m_visual_context_tree;
     DisplayListResourceStorage& m_resource_storage;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -379,9 +379,6 @@ void HitTestDisplayList::add_item_to_caret_items(size_t item_index)
 
 Optional<CSSPixelPoint> HitTestDisplayList::local_point_for_visual_context(VisualContextIndex visual_context_index, CSSPixelPoint point, ViewportPaintable const& viewport_paintable, double device_pixels_per_css_pixel) const
 {
-    if (!visual_context_index.value())
-        return point;
-
     auto pixel_ratio = static_cast<float>(device_pixels_per_css_pixel);
     auto const& visual_context_tree = viewport_paintable.visual_context_tree();
     auto result = visual_context_tree.transform_point_for_hit_test(visual_context_index, point.to_type<float>() * pixel_ratio, viewport_paintable.scroll_state_snapshot());
@@ -392,9 +389,6 @@ Optional<CSSPixelPoint> HitTestDisplayList::local_point_for_visual_context(Visua
 
 CSSPixelRect HitTestDisplayList::viewport_rect_for_item(Item const& item, CSSPixelRect const& rect, ViewportPaintable const& viewport_paintable, double device_pixels_per_css_pixel) const
 {
-    if (!item.visual_context_index.value())
-        return rect;
-
     auto pixel_ratio = static_cast<float>(device_pixels_per_css_pixel);
     auto const& visual_context_tree = viewport_paintable.visual_context_tree();
     auto result = visual_context_tree.transform_rect_to_viewport(item.visual_context_index, rect.to_type<float>() * pixel_ratio, viewport_paintable.scroll_state_snapshot());

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -184,9 +184,9 @@ void Paintable::paint_with_inspector_overlay_context(DisplayListRecordingContext
         auto& visual_context_tree = const_cast<ViewportPaintable&>(*viewport_paintable).visual_context_tree();
         auto visual_context_index = paintable_box->accumulated_visual_context_index();
 
-        if (visual_context_index.value()) {
+        if (visual_context_index != VISUAL_VIEWPORT_NODE_INDEX) {
             Vector<VisualContextIndex> relevant_indices;
-            for (auto i = visual_context_index; i.value(); i = visual_context_tree.node_at(i).parent_index) {
+            for (auto i = visual_context_index; i != VISUAL_VIEWPORT_NODE_INDEX; i = visual_context_tree.node_at(i).parent_index) {
                 auto should_keep = visual_context_tree.node_at(i).data.visit(
                     [](ScrollData const&) { return true; },
                     [](ClipData const&) { return false; },
@@ -199,11 +199,11 @@ void Paintable::paint_with_inspector_overlay_context(DisplayListRecordingContext
                     relevant_indices.append(i);
             }
 
-            VisualContextIndex overlay_visual_context_index {};
+            auto overlay_visual_context_index = VISUAL_VIEWPORT_NODE_INDEX;
             for (auto const& source_visual_context_index : relevant_indices.in_reverse())
                 overlay_visual_context_index = visual_context_tree.append(visual_context_tree.node_at(source_visual_context_index).data, overlay_visual_context_index);
 
-            if (overlay_visual_context_index.value())
+            if (overlay_visual_context_index != VISUAL_VIEWPORT_NODE_INDEX)
                 display_list_recorder.set_accumulated_visual_context(overlay_visual_context_index);
         }
     }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -547,8 +547,8 @@ void PaintableBox::reset_for_relayout()
 
     m_enclosing_scroll_frame_index = {};
     m_own_scroll_frame_index = {};
-    m_accumulated_visual_context_index = {};
-    m_accumulated_visual_context_for_descendants_index = {};
+    m_accumulated_visual_context_index = VISUAL_VIEWPORT_NODE_INDEX;
+    m_accumulated_visual_context_for_descendants_index = VISUAL_VIEWPORT_NODE_INDEX;
     m_fixed_background_visual_context = {};
 
     m_used_values_for_grid_template_columns = nullptr;
@@ -1736,11 +1736,12 @@ BorderRadiiData PaintableBox::normalized_border_radii_data(ShrinkRadiiForBorders
 
 Optional<CSSPixelPoint> PaintableBox::transform_point_to_local(CSSPixelPoint screen_position) const
 {
-    if (!m_accumulated_visual_context_index.value())
+    auto viewport_paintable = document().paintable();
+    if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
         return screen_position;
     auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
-    auto const& scroll_state = document().paintable()->scroll_state_snapshot();
-    auto const& visual_context_tree = document().paintable()->visual_context_tree();
+    auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
+    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
     auto result = visual_context_tree.transform_point_for_hit_test(m_accumulated_visual_context_index, screen_position.to_type<float>() * pixel_ratio, scroll_state);
     if (!result.has_value())
         return {};
@@ -1749,11 +1750,12 @@ Optional<CSSPixelPoint> PaintableBox::transform_point_to_local(CSSPixelPoint scr
 
 Optional<CSSPixelPoint> PaintableBox::transform_point_to_local_for_descendants(CSSPixelPoint screen_position) const
 {
-    if (!m_accumulated_visual_context_for_descendants_index.value())
+    auto viewport_paintable = document().paintable();
+    if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
         return screen_position;
     auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
-    auto const& scroll_state = document().paintable()->scroll_state_snapshot();
-    auto const& visual_context_tree = document().paintable()->visual_context_tree();
+    auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
+    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
     auto result = visual_context_tree.transform_point_for_hit_test(m_accumulated_visual_context_for_descendants_index, screen_position.to_type<float>() * pixel_ratio, scroll_state);
     if (!result.has_value())
         return {};
@@ -1762,21 +1764,23 @@ Optional<CSSPixelPoint> PaintableBox::transform_point_to_local_for_descendants(C
 
 CSSPixelRect PaintableBox::transform_rect_to_viewport(CSSPixelRect const& rect) const
 {
-    if (!m_accumulated_visual_context_index.value())
+    auto viewport_paintable = document().paintable();
+    if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
         return rect;
     auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
-    auto const& scroll_state = document().paintable()->scroll_state_snapshot();
-    auto const& visual_context_tree = document().paintable()->visual_context_tree();
+    auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
+    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
     auto result = visual_context_tree.transform_rect_to_viewport(m_accumulated_visual_context_index, rect.to_type<float>() * pixel_ratio, scroll_state);
     return (result * (1.f / pixel_ratio)).to_type<CSSPixels>();
 }
 
 CSSPixelPoint PaintableBox::inverse_transform_point(CSSPixelPoint screen_position) const
 {
-    if (!m_accumulated_visual_context_index.value())
+    auto viewport_paintable = document().paintable();
+    if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
         return screen_position;
     auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
-    auto const& visual_context_tree = document().paintable()->visual_context_tree();
+    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
     auto result = visual_context_tree.inverse_transform_point(m_accumulated_visual_context_index, screen_position.to_type<float>() * pixel_ratio);
     return (result / pixel_ratio).to_type<CSSPixels>();
 }

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -360,8 +360,8 @@ private:
 
     ScrollFrameIndex m_enclosing_scroll_frame_index {};
     ScrollFrameIndex m_own_scroll_frame_index {};
-    VisualContextIndex m_accumulated_visual_context_index {};
-    VisualContextIndex m_accumulated_visual_context_for_descendants_index {};
+    VisualContextIndex m_accumulated_visual_context_index { VISUAL_VIEWPORT_NODE_INDEX };
+    VisualContextIndex m_accumulated_visual_context_for_descendants_index { VISUAL_VIEWPORT_NODE_INDEX };
     Optional<VisualContextIndex> m_fixed_background_visual_context;
 
     Optional<BordersDataWithElementKind> m_override_borders_data;

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -59,7 +59,7 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
         paintable.paint(context, phase);
     }
 
-    context.display_list_recorder().set_accumulated_visual_context({});
+    context.display_list_recorder().set_accumulated_visual_context(VISUAL_VIEWPORT_NODE_INDEX);
 
     VERIFY(context.display_list_recorder().m_save_nesting_level == 0);
 }

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -26,6 +26,7 @@
 namespace Web::Painting {
 
 AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable&);
+void update_visual_viewport_accumulated_visual_context(ViewportPaintable&);
 
 NonnullRefPtr<ViewportPaintable> ViewportPaintable::create(Layout::Viewport const& layout_viewport)
 {
@@ -94,6 +95,7 @@ void ViewportPaintable::reset_for_relayout()
     m_needs_to_refresh_scroll_state = true;
     m_paintable_boxes_with_auto_content_visibility.clear();
     m_visual_context_tree.clear();
+    m_visual_context_tree_needs_compositor_update = false;
 }
 
 void ViewportPaintable::build_stacking_context_tree_if_needed()
@@ -214,6 +216,17 @@ void ViewportPaintable::assign_scroll_frames()
 void ViewportPaintable::assign_accumulated_visual_contexts()
 {
     m_visual_context_tree = build_accumulated_visual_context_tree(*this);
+    m_visual_context_tree_needs_compositor_update = true;
+}
+
+void ViewportPaintable::update_visual_viewport_accumulated_visual_context()
+{
+    if (!m_visual_context_tree.has_value()) {
+        assign_accumulated_visual_contexts();
+        return;
+    }
+    Painting::update_visual_viewport_accumulated_visual_context(*this);
+    m_visual_context_tree_needs_compositor_update = true;
 }
 
 void ViewportPaintable::refresh_scroll_state()

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -31,6 +31,7 @@ public:
     void refresh_scroll_state();
 
     void assign_accumulated_visual_contexts();
+    bool has_visual_context_tree() const { return m_visual_context_tree.has_value(); }
 
     GC::Ptr<Selection::Selection> selection() const;
     void recompute_selection_states(DOM::Range&);

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -31,6 +31,9 @@ public:
     void refresh_scroll_state();
 
     void assign_accumulated_visual_contexts();
+    void update_visual_viewport_accumulated_visual_context();
+    bool visual_context_tree_needs_compositor_update() const { return m_visual_context_tree_needs_compositor_update; }
+    void did_update_visual_context_tree_in_compositor() { m_visual_context_tree_needs_compositor_update = false; }
     bool has_visual_context_tree() const { return m_visual_context_tree.has_value(); }
 
     GC::Ptr<Selection::Selection> selection() const;
@@ -72,6 +75,7 @@ private:
     Vector<WeakPtr<PaintableBox>> m_paintable_boxes_with_auto_content_visibility;
 
     Optional<AccumulatedVisualContextTree> m_visual_context_tree;
+    bool m_visual_context_tree_needs_compositor_update { false };
 };
 
 template<>

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -125,6 +125,14 @@ void CompositorState::update_display_list(Web::Compositor::CompositorContextId c
     context->install_display_list_update(move(display_list), move(visual_context_tree), move(scroll_state_snapshot));
 }
 
+void CompositorState::update_visual_context_tree(Web::Compositor::CompositorContextId context_id, Web::Painting::AccumulatedVisualContextTree visual_context_tree)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    context->update_visual_context_tree(move(visual_context_tree));
+}
+
 void CompositorState::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
     auto* context = context_if_present(context_id);

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -74,6 +74,7 @@ public:
     void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode);
     void stop_presenting_to_client(Web::Compositor::CompositorContextId);
     void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::AccumulatedVisualContextTree, Web::Painting::DisplayListResourceTransaction&&, Web::Painting::ScrollStateSnapshot&&);
+    void update_visual_context_tree(Web::Compositor::CompositorContextId, Web::Painting::AccumulatedVisualContextTree);
     void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot&&);
     void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
     void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId);

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -17,6 +17,7 @@ endpoint CompositorWebContentServer
     destroy_context(Web::Compositor::CompositorContextId context_id) =|
 
     update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
+    update_visual_context_tree(Web::Compositor::CompositorContextId context_id, Web::Painting::AccumulatedVisualContextTree visual_context_tree) =|
     update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
 
     update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) =|

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -71,6 +71,12 @@ void ConnectionFromWebContent::update_display_list(Web::Compositor::CompositorCo
     m_compositor_state->update_display_list(context_id, move(display_list), move(visual_context_tree), move(resource_transaction), move(scroll_state_snapshot));
 }
 
+void ConnectionFromWebContent::update_visual_context_tree(Web::Compositor::CompositorContextId context_id, Web::Painting::AccumulatedVisualContextTree visual_context_tree)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->update_visual_context_tree(context_id, move(visual_context_tree));
+}
+
 void ConnectionFromWebContent::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot scroll_state_snapshot)
 {
     verify_context_is_owned_by_this_connection(context_id);

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -34,6 +34,7 @@ private:
     virtual void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode) override;
     virtual void destroy_context(Web::Compositor::CompositorContextId) override;
     virtual void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::AccumulatedVisualContextTree, Web::Painting::DisplayListResourceTransaction, Web::Painting::ScrollStateSnapshot) override;
+    virtual void update_visual_context_tree(Web::Compositor::CompositorContextId, Web::Painting::AccumulatedVisualContextTree) override;
     virtual void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot) override;
     virtual void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>) override;
     virtual void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId) override;

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -162,6 +162,16 @@ void ContextState::install_display_list_update(
     m_has_async_scrolling_state = true;
 }
 
+void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualContextTree visual_context_tree)
+{
+    VERIFY(m_display_list);
+    VERIFY(m_display_list->compatible_visual_context_tree_version() == visual_context_tree.version());
+    m_visual_context_tree = move(visual_context_tree);
+
+    if (m_has_async_scrolling_state)
+        rebuild_wheel_hit_test_targets();
+}
+
 void ContextState::update_scroll_state(Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
     m_scroll_state_snapshot = move(scroll_state_snapshot);

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -111,6 +111,7 @@ public:
         NonnullRefPtr<Web::Painting::DisplayList>,
         Web::Painting::AccumulatedVisualContextTree,
         Web::Painting::ScrollStateSnapshot&&);
+    void update_visual_context_tree(Web::Painting::AccumulatedVisualContextTree);
     void update_scroll_state(Web::Painting::ScrollStateSnapshot&&);
     void update_video_frame(Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
     void clear_video_frame(Web::Painting::VideoFrameResourceId);

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -48,6 +48,13 @@ void CompositorConnection::update_display_list(Web::Compositor::CompositorContex
         did_lose_compositor();
 }
 
+void CompositorConnection::update_visual_context_tree(Web::Compositor::CompositorContextId context_id, Web::Painting::AccumulatedVisualContextTree const& visual_context_tree)
+{
+    if (!can_send_message_to_compositor())
+        return;
+    async_update_visual_context_tree(context_id, visual_context_tree);
+}
+
 void CompositorConnection::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
     if (!can_send_message_to_compositor())

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -22,6 +22,7 @@
 #include <LibMedia/Forward.h>
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/ScrollState.h>
@@ -39,6 +40,7 @@ public:
     void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode const&);
     void destroy_context(Web::Compositor::CompositorContextId);
     void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList> const&, Web::Painting::AccumulatedVisualContextTree const&, Web::Painting::DisplayListResourceTransaction const&, Web::Painting::ScrollStateSnapshot const&);
+    void update_visual_context_tree(Web::Compositor::CompositorContextId, Web::Painting::AccumulatedVisualContextTree const&);
     void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot const&);
     void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const> const&);
     void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId);

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -41,6 +41,12 @@ private:
             connection->update_display_list(context_id, display_list, visual_context_tree, resource_transaction, scroll_state_snapshot);
     }
 
+    virtual void update_visual_context_tree(Web::Compositor::CompositorContextId context_id, Web::Painting::AccumulatedVisualContextTree visual_context_tree) override
+    {
+        if (auto* connection = compositor_connection())
+            connection->update_visual_context_tree(context_id, visual_context_tree);
+    }
+
     virtual void update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) override
     {
         if (auto* connection = compositor_connection())

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
@@ -5,10 +5,11 @@ clipped visible inside: true
 clipped overflow outside clip: false
 display list:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] transform=[1,0,0,1,100,0] origin=(20,20) (PaintableWithLines(BlockContainer<DIV>#transformed))
-    [3] clip=[20,160 100x100]
-      [4] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] transform=[1,0,0,1,100,0] origin=(20,20) (PaintableWithLines(BlockContainer<DIV>#transformed))
+      [3] clip=[20,160 100x100]
+        [4] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
@@ -24,9 +24,10 @@ removed window listener:
   blocking regions: 0
 display list after blocking element listener:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[0,0 200x200]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[0,0 200x200]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
@@ -3,7 +3,8 @@ listener generation increased: true
 after routing admission: blocking wheel event listeners
 display list:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
@@ -3,7 +3,8 @@ over iframe: blocked-by-main-thread-region
 outside iframe: accepted
 display list:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
@@ -2,9 +2,10 @@ scroller scrollTop: 100
 window scrollY: 0
 display list:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[0,0 100x100]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#spacer))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[0,0 100x100]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
@@ -4,10 +4,11 @@ dangling parent nodes: 0
 child parent is viewport: true
 display list:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
-      [3] clip=[0,0 100x100]
-        [4] scroll_frame_id=3 (PaintableWithLines(BlockContainer<DIV>#spacer))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
+        [3] clip=[0,0 100x100]
+          [4] scroll_frame_id=3 (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
@@ -7,9 +7,10 @@ child has same document as viewport: true
 child parent is viewport: true
 display list:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[0,0 100x100]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#spacer))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[0,0 100x100]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
@@ -8,9 +8,10 @@ outer has top inset only: true
 inner has top inset only: true
 display list:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
-      [3] scroll_frame_id=3 (sticky) (PaintableWithLines(BlockContainer<DIV>#inner))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
+        [3] scroll_frame_id=3 (sticky) (PaintableWithLines(BlockContainer<DIV>#inner))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
@@ -4,9 +4,10 @@ viewport wheel target: viewport
 scroller wheel target: non-viewport
 display list:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[0,0 100x100]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#scroller-spacer))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[0,0 100x100]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#scroller-spacer))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
@@ -11,9 +11,10 @@ blocking window listener: false
 stale blocking window regions: false
 display list after blocking element listener:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[0,0 200x200]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[0,0 200x200]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/css/text-underline-position.txt
+++ b/Tests/LibWeb/Text/expected/css/text-underline-position.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
@@ -1,8 +1,9 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
-      [5] effects=[opacity=0.5]
-        [6] effects=[opacity=0.3] (PaintableWithLines(BlockContainer<DIV>.abspos))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
+        [5] effects=[opacity=0.5]
+          [6] effects=[opacity=0.3] (PaintableWithLines(BlockContainer<DIV>.abspos))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
-      [4] effects=[opacity=0.5] (PaintableWithLines(BlockContainer<DIV>.abspos))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
+        [4] effects=[opacity=0.5] (PaintableWithLines(BlockContainer<DIV>.abspos))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
@@ -1,6 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] scroll_compensation(frame_id=1)
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] scroll_compensation(frame_id=1)
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
+++ b/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
@@ -1,7 +1,8 @@
 Before clip change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[8,13 100x100] (PaintableWithLines(BlockContainer<DIV>#box.box))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[8,13 100x100] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
 SaveLayer@0
@@ -14,8 +15,9 @@ Restore@0
 
 After clip change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[18,23 80x80] (PaintableWithLines(BlockContainer<DIV>#box.box))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[18,23 80x80] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
@@ -1,7 +1,8 @@
 Before clip-path change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (PaintableWithLines(BlockContainer<DIV>#box.box))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
 SaveLayer@0
@@ -15,8 +16,9 @@ Restore@0
 
 After clip-path change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip_path=[bounds: 8,8 100x100, path: M58 8L108 58L58 108L8 58L58 8Z] (PaintableWithLines(BlockContainer<DIV>#box.box))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip_path=[bounds: 8,8 100x100, path: M58 8L108 58L58 108L8 58L58 8Z] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
+++ b/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
@@ -1,6 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[28,23 80x70] (PaintableWithLines(BlockContainer<DIV>.clipped))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[28,23 80x70] (PaintableWithLines(BlockContainer<DIV>.clipped))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
+++ b/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
@@ -1,12 +1,13 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[10,10 400x200] (PaintableWithLines(BlockContainer<DIV>.branch))
-      [3] clip=[11,11 193x198] (PaintableWithLines(BlockContainer(anonymous)))
-        [4] transform=[0.9961947,-0.08715574,0.08715574,0.9961947,0,0] origin=(91,56) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-a))
-        [5] transform=[0.9,0,0,0.9,0,0] origin=(91,141) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-b))
-      [6] clip=[216,11 193x198] (PaintableWithLines(BlockContainer(anonymous)))
-        [7] transform=[1,0,0,1,10,0] origin=(296,56) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-c))
-        [8] transform=[1,0,0,1,0,10] origin=(296,141) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-d))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[10,10 400x200] (PaintableWithLines(BlockContainer<DIV>.branch))
+        [3] clip=[11,11 193x198] (PaintableWithLines(BlockContainer(anonymous)))
+          [4] transform=[0.9961947,-0.08715574,0.08715574,0.9961947,0,0] origin=(91,56) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-a))
+          [5] transform=[0.9,0,0,0.9,0,0] origin=(91,141) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-b))
+        [6] clip=[216,11 193x198] (PaintableWithLines(BlockContainer(anonymous)))
+          [7] transform=[1,0,0,1,10,0] origin=(296,56) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-c))
+          [8] transform=[1,0,0,1,0,10] origin=(296,141) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-d))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
@@ -1,6 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[8,8 200x100] (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (PaintableWithLines(BlockContainer<DIV>.fixed))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[8,8 200x100] (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
+++ b/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/iframe-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/iframe-compositor-surface.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/input-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-caret.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[9,9 100x20] (PaintableWithLines(BlockContainer<DIV>))
-      [3] clip=[11,10 96x18]
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[9,9 100x20] (PaintableWithLines(BlockContainer<DIV>))
+        [3] clip=[11,10 96x18]
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -1,9 +1,10 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[9,9 200x20] (PaintableWithLines(BlockContainer<DIV>))
-      [3] clip=[11,10 196x18]
-    [4] clip=[219,9 200x20] (PaintableWithLines(BlockContainer<DIV>))
-      [5] clip=[221,10 196x18]
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[9,9 200x20] (PaintableWithLines(BlockContainer<DIV>))
+        [3] clip=[11,10 196x18]
+      [4] clip=[219,9 200x20] (PaintableWithLines(BlockContainer<DIV>))
+        [5] clip=[221,10 196x18]
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
@@ -1,8 +1,9 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [3] clip=[119,9 100x100]
-      [4] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
-    [2] transform=[1,0,0,1,5,5] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.transformed))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [3] clip=[119,9 100x100]
+        [4] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+      [2] transform=[1,0,0,1,5,5] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.transformed))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
@@ -1,6 +1,7 @@
 Before:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
@@ -24,7 +25,8 @@ Restore@0
 
 After:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
@@ -1,12 +1,13 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[10,10 320x270] (PaintableWithLines(BlockContainer<DIV>.level2))
-      [3] clip=[21,21 143x248] (PaintableWithLines(BlockContainer(anonymous)))
-        [4] transform=[0.9986295,-0.05233596,0.05233596,0.9986295,0,0] origin=(92.5,46) (PaintableWithLines(BlockContainer<DIV>.level3.t1))
-        [5] transform=[0.9986295,0.05233596,-0.05233596,0.9986295,0,0] origin=(92.5,91) (PaintableWithLines(BlockContainer<DIV>.level3.t2))
-      [6] clip=[176,21 143x248] (PaintableWithLines(BlockContainer(anonymous)))
-        [7] transform=[0.95,0,0,0.95,0,0] origin=(247.5,46) (PaintableWithLines(BlockContainer<DIV>.level3.t3))
-        [8] transform=[1.05,0,0,1.05,0,0] origin=(247.5,91) (PaintableWithLines(BlockContainer<DIV>.level3.t4))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[10,10 320x270] (PaintableWithLines(BlockContainer<DIV>.level2))
+        [3] clip=[21,21 143x248] (PaintableWithLines(BlockContainer(anonymous)))
+          [4] transform=[0.9986295,-0.05233596,0.05233596,0.9986295,0,0] origin=(92.5,46) (PaintableWithLines(BlockContainer<DIV>.level3.t1))
+          [5] transform=[0.9986295,0.05233596,-0.05233596,0.9986295,0,0] origin=(92.5,91) (PaintableWithLines(BlockContainer<DIV>.level3.t2))
+        [6] clip=[176,21 143x248] (PaintableWithLines(BlockContainer(anonymous)))
+          [7] transform=[0.95,0,0,0.95,0,0] origin=(247.5,46) (PaintableWithLines(BlockContainer<DIV>.level3.t3))
+          [8] transform=[1.05,0,0,1.05,0,0] origin=(247.5,91) (PaintableWithLines(BlockContainer<DIV>.level3.t4))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
@@ -1,9 +1,10 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[10,10 200x150]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
-        [4] clip=[11,11 300x100]
-          [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[10,10 200x150]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+          [4] clip=[11,11 300x100]
+            [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] perspective (PaintableWithLines(BlockContainer(anonymous)))
-      [3] transform=[0.8660254,0,0,1,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.rotated))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] perspective (PaintableWithLines(BlockContainer(anonymous)))
+        [3] transform=[0.8660254,0,0,1,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.rotated))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
+++ b/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
@@ -1,6 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] transform=[1,0,0,1,10,10] origin=(108,108) (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] transform=[1,0,0,1,10,10] origin=(108,108) (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
+++ b/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] transform=[0.9848077,-0.17364818,0.17364818,0.9848077,0,0] origin=(58,58) (PaintableWithLines(InlineNode<SPAN>.inline-transformed))
-      [3] perspective (PaintableWithLines(BlockContainer<SPAN>.relative-child))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] transform=[0.9848077,-0.17364818,0.17364818,0.9848077,0,0] origin=(58,58) (PaintableWithLines(InlineNode<SPAN>.inline-transformed))
+        [3] perspective (PaintableWithLines(BlockContainer<SPAN>.relative-child))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-  [2] clip=[33,33 180x100]
-    [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (PaintableWithLines(BlockContainer(anonymous)))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[33,33 180x100]
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
@@ -1,9 +1,10 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[9,9 100x80]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
-    [4] clip=[131,9 100x80]
-      [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[9,9 100x80]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+      [4] clip=[131,9 100x80]
+        [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -1,11 +1,12 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-  [2] clip=[23,23 91x150]
-    [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
-  [4] clip=[126,23 92x150]
-    [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
-  [6] clip=[230,23 91x150]
-    [7] scroll_frame_id=4 (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (PaintableWithLines(BlockContainer<DIV>.scroll-container))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[23,23 91x150]
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+    [4] clip=[126,23 92x150]
+      [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
+    [6] clip=[230,23 91x150]
+      [7] scroll_frame_id=4 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] transform=[0.9848077,-0.17364818,0.17364818,0.9848077,0,0] origin=(48,48) (PaintableWithLines(BlockContainer<DIV>.box.left))
-    [3] transform=[0.8,0,0,0.8,0,0] origin=(138,48) (PaintableWithLines(BlockContainer<DIV>.box.right))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] transform=[0.9848077,-0.17364818,0.17364818,0.9848077,0,0] origin=(48,48) (PaintableWithLines(BlockContainer<DIV>.box.left))
+      [3] transform=[0.8,0,0,0.8,0,0] origin=(138,48) (PaintableWithLines(BlockContainer<DIV>.box.right))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[10,10 200x100]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>.inner-box))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[10,10 200x100]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>.inner-box))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
+++ b/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
@@ -1,6 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [6] clip=[8,108 100x100] (PaintableWithLines(BlockContainer<DIV>.child))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [6] clip=[8,108 100x100] (PaintableWithLines(BlockContainer<DIV>.child))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[8,8 100x100] (SVGForeignObjectPaintable(SVGForeignObjectBox<foreignObject>#fo))
-      [3] clip=[9,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[8,8 100x100] (SVGForeignObjectPaintable(SVGForeignObjectBox<foreignObject>#fo))
+        [3] clip=[9,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (ImagePaintable(ImageBox<IMG>))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (ImagePaintable(ImageBox<IMG>))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
@@ -1,6 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[0,0 200x200] (SVGPathPaintable(SVGGeometryBox<rect>))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[0,0 200x200] (SVGPathPaintable(SVGGeometryBox<rect>))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
@@ -1,8 +1,9 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[8,8 200x200]
-      [3] effects=[opacity=0.5]
-        [4] transform=[1,0,0,1,20,20] origin=(8,8) (SVGPathPaintable(SVGGeometryBox<rect>))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[8,8 200x200]
+        [3] effects=[opacity=0.5]
+          [4] transform=[1,0,0,1,20,20] origin=(8,8) (SVGPathPaintable(SVGGeometryBox<rect>))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
+++ b/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
@@ -1,5 +1,6 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
@@ -1,6 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[9,9 104x34] (PaintableWithLines(BlockContainer<DIV>))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[9,9 104x34] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
+++ b/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
@@ -1,8 +1,9 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] transform=[0.9659258,-0.25881904,0.25881904,0.9659258,0,0] origin=(38,38) (PaintableWithLines(BlockContainer<DIV>.box.a))
-    [3] transform=[1.1,0,0,1.1,0,0] origin=(103,38) (PaintableWithLines(BlockContainer<DIV>.box.b))
-    [4] transform=[1,0.17632698,0,1,0,0] origin=(168,38) (PaintableWithLines(BlockContainer<DIV>.box.c))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] transform=[0.9659258,-0.25881904,0.25881904,0.9659258,0,0] origin=(38,38) (PaintableWithLines(BlockContainer<DIV>.box.a))
+      [3] transform=[1.1,0,0,1.1,0,0] origin=(103,38) (PaintableWithLines(BlockContainer<DIV>.box.b))
+      [4] transform=[1,0.17632698,0,1,0,0] origin=(168,38) (PaintableWithLines(BlockContainer<DIV>.box.c))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
@@ -1,6 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] transform=[1,0,0,1,50,30] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.box))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] transform=[1,0,0,1,50,30] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.box))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
@@ -1,7 +1,8 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] transform=[0.70710677,-0.70710677,0.70710677,0.70710677,0,0] origin=(108,108) (PaintableWithLines(BlockContainer(anonymous)))
-      [3] transform=[0.5,0,0,0.5,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.inner))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] transform=[0.70710677,-0.70710677,0.70710677,0.70710677,0,0] origin=(108,108) (PaintableWithLines(BlockContainer(anonymous)))
+        [3] transform=[0.5,0,0,0.5,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.inner))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
@@ -1,8 +1,9 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-    [2] clip=[10,10 150x150]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
-        [4] transform=[1,0,0,1,20,20] origin=(110,110) (PaintableWithLines(BlockContainer<DIV>.transformed))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] clip=[10,10 150x150]
+        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+          [4] transform=[1,0,0,1,20,20] origin=(110,110) (PaintableWithLines(BlockContainer<DIV>.transformed))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
+++ b/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
@@ -1,6 +1,7 @@
 Before z-index change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
@@ -14,7 +15,8 @@ Restore@0
 
 After z-index change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0


### PR DESCRIPTION
- Reserve AVC node 0 as `VISUAL_VIEWPORT_NODE_INDEX`, so the visual viewport transform is always represented by the tree root.
- Add a Compositor IPC path for replacing the AVC tree associated with an existing display list.
- Patch the visual viewport AVC node directly for visual viewport scroll, reset, and pinch zoom updates, then send the updated tree to the Compositor without rerecording the display list.