### PR TITLE
LibWeb: Throw from SourceBuffer::buffered() after removing SourceBuffer

### DIFF
--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
@@ -215,12 +215,15 @@ bool SourceBuffer::updating() const
 }
 
 // https://w3c.github.io/media-source/#dom-sourcebuffer-buffered
-GC::Ref<HTML::TimeRanges> SourceBuffer::buffered()
+WebIDL::ExceptionOr<GC::Ref<HTML::TimeRanges>> SourceBuffer::buffered()
 {
-    auto time_ranges = realm().create<HTML::TimeRanges>(realm());
+    // 1. If this object has been removed from the sourceBuffers attribute of the parent media source then throw
+    //    an InvalidStateError exception and abort these steps.
 
-    // FIXME: 1. If this object has been removed from the sourceBuffers attribute of the parent media source then throw
-    //           an InvalidStateError exception and abort these steps.
+    if (!m_media_source->source_buffers()->contains(*this))
+        return WebIDL::InvalidStateError::create(realm(), "SourceBuffer has been removed"_utf16);
+
+    auto time_ranges = realm().create<HTML::TimeRanges>(realm());
 
     // NB: Further steps to intersect the buffered ranges of the track buffers are implemented within
     //     SourceBufferProcessor::buffered_ranges() below, since it has access to the track buffers.

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
@@ -46,7 +46,7 @@ public:
     bool updating() const;
 
     // https://w3c.github.io/media-source/#dom-sourcebuffer-buffered
-    GC::Ref<HTML::TimeRanges> buffered();
+    WebIDL::ExceptionOr<GC::Ref<HTML::TimeRanges>> buffered();
 
     void set_content_type(String const& type);
 


### PR DESCRIPTION
Adds the missing InvalidStateError check for SourceBuffer::buffered().

Also change the return type for SourceBuffer::buffered() to WebIDL::ExceptionOr in order to return the error.