### PR TITLE
LibWeb: Route content blocker Rust allocations through mimalloc

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1256,7 +1256,12 @@ ladybird_lib(LibWeb web EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibWeb PRIVATE LibCore LibCompress LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibMedia LibWasm LibXML LibIDL LibURL LibTLS LibRequests LibGC LibSync LibThreading skia ${ANGLE_TARGETS} SDL3::SDL3 LibXml2::LibXml2)
 
 import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libweb_rust FFI_HEADER RustFFI.h)
-import_rust_crate(MANIFEST_PATH ContentBlocker/Rust/Cargo.toml CRATE_NAME libweb_content_blocker_rust FFI_HEADER ContentBlockerRustFFI.h)
+
+set(content_blocker_rust_features "")
+if (NOT BUILD_SHARED_LIBS)
+    set(content_blocker_rust_features FEATURES allocator)
+endif()
+import_rust_crate(MANIFEST_PATH ContentBlocker/Rust/Cargo.toml CRATE_NAME libweb_content_blocker_rust ${content_blocker_rust_features} FFI_HEADER ContentBlockerRustFFI.h)
 target_link_libraries(LibWeb PRIVATE libweb_rust libweb_content_blocker_rust)
 get_target_property(_libweb_rust_lib libweb_rust IMPORTED_LOCATION)
 get_target_property(_libweb_content_blocker_rust_lib libweb_content_blocker_rust IMPORTED_LOCATION)

--- a/Libraries/LibWeb/ContentBlocker/Rust/Cargo.toml
+++ b/Libraries/LibWeb/ContentBlocker/Rust/Cargo.toml
@@ -12,6 +12,10 @@ crate-type = ["staticlib"]
 adblock = "0.12.5"
 serde_json = "1.0"
 
+[features]
+default = []
+allocator = []
+
 [build-dependencies]
 cbindgen = "0.29"
 

--- a/Libraries/LibWeb/ContentBlocker/Rust/src/lib.rs
+++ b/Libraries/LibWeb/ContentBlocker/Rust/src/lib.rs
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#[cfg(feature = "allocator")]
+#[path = "../../../../RustAllocator.rs"]
+mod rust_allocator;
+
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::c_void;


### PR DESCRIPTION
This matches the pattern used by existing Rust components.

This fixes a crash when launching the Ladybird binary with the Distribution preset. 

Tested with: `BUILD_PRESET=Distribution ./Meta/ladybird.py run ladybird --headless=text example.com`