### PR TITLE
UI: Prevent autocomplete highlight flicker while typing

### DIFF
--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -394,18 +394,13 @@ static NSImage* location_field_globe_icon()
             }
 
             auto selected_row = [self applyInlineAutocomplete:suggestions];
-            if (result_kind == WebView::AutocompleteResultKind::Intermediate && [self.autocomplete isVisible]) {
-                if (auto selected_suggestion = [self.autocomplete selectedSuggestion];
-                    selected_suggestion.has_value()) {
-                    for (auto const& suggestion : suggestions) {
-                        if (suggestion.text == *selected_suggestion)
-                            return;
-                    }
-                }
 
-                [self.autocomplete clearSelection];
+            // Do not update the popup while results are still changing.
+            // Intermediate updates are triggered on every keystroke and would
+            // cause visible flicker in the suggestion list.
+            // Only final results are used to refresh the UI.
+            if (result_kind == WebView::AutocompleteResultKind::Intermediate && [self.autocomplete isVisible])
                 return;
-            }
 
             [self.autocomplete showWithSuggestions:move(suggestions)
                                        selectedRow:selected_row];

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -216,16 +216,12 @@ LocationEdit::LocationEdit(QWidget* parent)
     m_autocomplete->on_query_complete = [this](auto suggestions, WebView::AutocompleteResultKind result_kind) {
         int selected_row = apply_inline_autocomplete(suggestions);
 
-        if (result_kind == WebView::AutocompleteResultKind::Intermediate && m_autocomplete->is_visible()) {
-            if (auto selected = m_autocomplete->selected_suggestion(); selected.has_value()) {
-                for (auto const& suggestion : suggestions) {
-                    if (suggestion.text == *selected)
-                        return;
-                }
-            }
-            m_autocomplete->clear_selection();
+        // Do not update the popup while results are still changing.
+        // Intermediate updates are triggered on every keystroke and would
+        // cause visible flicker in the suggestion list.
+        // Only final results are used to refresh the UI.
+        if (result_kind == WebView::AutocompleteResultKind::Intermediate && m_autocomplete->is_visible())
             return;
-        }
 
         m_autocomplete->show_with_suggestions(AK::move(suggestions), selected_row);
     };


### PR DESCRIPTION
Typing in the location bar caused the autocomplete highlight to flicker. Intermediate results were updating the popup on every keystroke, which led to repeated selection changes while typing.
Skip intermediate updates while the popup is visible and only apply final results, which update suggestions and selection together.

Fixed in AppKit and Qt.