### PR TITLE
Tests: Fix intermittent SharedWorker-reuse timeout flake

### DIFF
--- a/Tests/LibWeb/Text/input/Worker/SharedWorker-reuse.html
+++ b/Tests/LibWeb/Text/input/Worker/SharedWorker-reuse.html
@@ -18,13 +18,13 @@
 
         const workerURL = URL.createObjectURL(new Blob([workerScript], { type: "text/javascript" }));
 
-        // Print the next message from 'worker', and resolve. Uses addEventListener to make messages arriving before the
-        // next call get queued (rather than lost); important when worker2 connects before we get around to awaiting it.
-        function nextMessage(worker, label) {
+        // Resolve with the next message from 'worker'. The one-shot listener must be registered before the message can
+        // arrive: a 'message' event dispatched with no listener is dropped, not queued for a listener added later — so
+        // a late listener would miss the message and hang.
+        function nextMessage(worker) {
             return new Promise(resolve => {
                 worker.port.addEventListener("message", function handler(event) {
                     worker.port.removeEventListener("message", handler);
-                    println(`${label}: ${event.data}`);
                     resolve(event.data);
                 });
             });
@@ -32,19 +32,24 @@
 
         const worker1 = new SharedWorker(workerURL, "shared-worker-reuse");
         const worker2 = new SharedWorker(workerURL, "shared-worker-reuse");
+
+        // The two connections are independent message ports with no ordering guarantee between them — so worker2's
+        // "connect" can be dispatched before worker1's. Register both listeners before starting either port — so
+        // whichever arrives first still has a listener, and neither message is lost.
+        const connect1 = nextMessage(worker1);
+        const connect2 = nextMessage(worker2);
         worker1.port.start();
         worker2.port.start();
 
-        // Sequence each message explicitly — so the printed order is deterministic, even though the underlying messages
-        // race against each other.
-        await nextMessage(worker1, "worker1"); // "connect 1"
-        await nextMessage(worker2, "worker2"); // "connect 2"
+        // Await in a fixed order — so the printed output is deterministic, regardless of arrival order.
+        println(`worker1: ${await connect1}`); // "connect 1"
+        println(`worker2: ${await connect2}`); // "connect 2"
 
         worker1.port.postMessage("one");
-        await nextMessage(worker1, "worker1"); // "echo 1: one"
+        println(`worker1: ${await nextMessage(worker1)}`); // "echo 1: one"
 
         worker2.port.postMessage("two");
-        await nextMessage(worker2, "worker2"); // "echo 2: two"
+        println(`worker2: ${await nextMessage(worker2)}`); // "echo 2: two"
 
         done();
     });


### PR DESCRIPTION
**Problem:** The `SharedWorker-reuse.html` test was hanging intermittently under CI (on the order of 1 in 40 runs).

**Cause:** The test awaits the connect message for one worker and only then registers a listener for a second one. Their two `SharedWorker` connections are independent message ports — with no ordering guarantee between them. So, the connect message for the second can be dispatched during that first await — before its listener exists. A message event fired with no listener is dropped — it’s not queued for a listener added later. So, the second await never resolves — and the test hangs.

**Fix:** Register both connect listeners before starting either port — and await them in fixed order — so no connect message can be lost, regardless of arrival order.
