### PR TITLE
LibWeb: Avoid starting transitions on inactive timelines

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1199,8 +1199,11 @@ void StyleComputer::start_needed_transitions(ComputedProperties const& previous_
 
     // For each element and property, the implementation must act as follows:
     // NB: We know that a DocumentTimeline's current time is always in milliseconds
-    VERIFY(m_document->timeline()->current_time()->type == Animations::TimeValue::Type::Milliseconds);
-    auto style_change_event_time = m_document->timeline()->current_time()->value;
+    auto current_time = m_document->timeline()->current_time();
+    if (!current_time.has_value())
+        return;
+    VERIFY(current_time->type == Animations::TimeValue::Type::Milliseconds);
+    auto style_change_event_time = current_time->value;
 
     // FIXME: Add some transition helpers to AbstractElement.
     auto& element = abstract_element.element();

--- a/Tests/LibWeb/Crash/CSS/focus-starts-transition-before-timeline-time.html
+++ b/Tests/LibWeb/Crash/CSS/focus-starts-transition-before-timeline-time.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+    button {
+        opacity: 0;
+        transition: opacity 1s;
+    }
+
+    button:focus {
+        opacity: 1;
+    }
+</style>
+<button>content</button>
+<script>
+    asyncTest(done => {
+        requestAnimationFrame(() => {
+            document.querySelector("button").focus();
+            done();
+        });
+    });
+</script>


### PR DESCRIPTION
Skip starting CSS transitions when the document timeline has no current time yet. Focus can force a style update from a requestAnimationFrame callback before the rendering step updates animation timelines, leaving the DocumentTimeline current time unresolved.

Add crash coverage for a focus-triggered transition from a frame callback.