### PR TITLE
LibJS: Speed up warm bytecode cache loads

### DIFF
--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -736,6 +736,11 @@ impl DecodedCacheBlob {
             && self.program.indices_are_valid()
     }
 
+    pub(crate) fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
+        self.metadata.validate_cached_bytecode()?;
+        self.program.validate_cached_bytecode()
+    }
+
     pub(crate) unsafe fn materialize_script(
         self,
         vm_ptr: *mut c_void,
@@ -1344,10 +1349,6 @@ unsafe fn materialize_function(
     shared_function_data_owner: crate::bytecode::ffi::SharedFunctionDataOwner,
 ) -> *mut c_void {
     unsafe {
-        if function.precompiled.validate_cached_bytecode().is_err() {
-            return std::ptr::null_mut();
-        }
-
         let (_parameter_name_storage, parameter_names): (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) = function
             .parameter_names
             .as_ref()
@@ -1469,10 +1470,6 @@ unsafe fn prepare_function_install(
         }
 
         if crate::bytecode::ffi::rust_sfd_executable(existing_sfd_ptr).is_null() {
-            if function.precompiled.validate_cached_bytecode().is_err() {
-                return std::ptr::null_mut();
-            }
-
             pending_function_installs.push(PendingFunctionInstall {
                 existing_sfd_ptr,
                 replacement: PendingFunctionInstallReplacement::CachedBytecode(function.precompiled),
@@ -1484,9 +1481,6 @@ unsafe fn prepare_function_install(
         let Some(executable) = function.precompiled.decode_executable() else {
             return std::ptr::null_mut();
         };
-        if executable.validate_cached_bytecode().is_err() {
-            return std::ptr::null_mut();
-        }
         let executable_ptr = materialize_executable_for_install(
             executable,
             Some(existing_shared_function_data),
@@ -1523,9 +1517,6 @@ pub(crate) unsafe fn materialize_cached_function(
         let Some(executable) = cached_executable.decode_executable() else {
             return std::ptr::null_mut();
         };
-        if executable.validate_cached_bytecode().is_err() {
-            return std::ptr::null_mut();
-        }
         let shared_function_data_owner = if shared_function_data_list_ptr.is_null() {
             crate::bytecode::ffi::SharedFunctionDataOwner::None
         } else {
@@ -1832,6 +1823,22 @@ impl DecodedDeclarationMetadata {
                             || usize::try_from(binding.function_index)
                                 .is_ok_and(|index| index < declaration_functions.len())
                     })
+            }
+        }
+    }
+
+    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
+        match self {
+            Self::Script {
+                declaration_functions, ..
+            }
+            | Self::Module {
+                declaration_functions, ..
+            } => {
+                for function in declaration_functions {
+                    function.precompiled.validate_cached_bytecode()?;
+                }
+                Ok(())
             }
         }
     }
@@ -2709,6 +2716,10 @@ impl DecodedProgramRecord {
 
     fn indices_are_valid(&self) -> bool {
         self.executable.indices_are_valid()
+    }
+
+    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
+        self.executable.validate_cached_bytecode()
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -42,7 +42,7 @@ use crate::bytecode::validator::validate_bytecode;
 use crate::u32_from_usize;
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
-const FORMAT_VERSION: u32 = 12;
+const FORMAT_VERSION: u32 = 13;
 const SOURCE_HASH_SIZE: usize = 32;
 const BYTECODE_ALIGNMENT: usize = 8;
 const COMPLETION_TYPE_VARIANT_COUNT: u32 = 6;
@@ -668,7 +668,7 @@ impl Encode for Utf16<'_> {
 struct CacheBlob<'a> {
     compiled: &'a CompiledProgram,
     program_type: ast::ProgramType,
-    // Fingerprint of the decoded source text the blob was generated from. Cache writes happen asynchronously after the
+    // Fingerprint of the encoded source bytes the blob was generated from. Cache writes happen asynchronously after the
     // HTTP response has been served, so the entry on disk may have been replaced for the same (URL, vary key) by the
     // time we go to attach the sidecar. Embedding the source hash makes a stale write harmless: a later read whose
     // source no longer matches will reject the blob and fall through to source compilation.
@@ -681,6 +681,7 @@ impl Encode for CacheBlob<'_> {
         FORMAT_VERSION.encode(encoder);
         self.program_type.encode(encoder);
         encoder.bytes(self.source_hash);
+        u32_from_usize(self.compiled.source_len).encode(encoder);
         self.compiled.parsed.has_top_level_await.encode(encoder);
         self.compiled.parsed.is_strict_mode.encode(encoder);
         DeclarationMetadataRecord {
@@ -703,8 +704,10 @@ impl CacheBlob<'_> {
         let program_type = ast::ProgramType::decode(decoder)?;
         (program_type == expected_program_type).then_some(())?;
         (decoder.bytes(SOURCE_HASH_SIZE)? == expected_source_hash).then_some(())?;
+        let source_len = u32::decode(decoder)? as usize;
         Some(DecodedCacheBlob {
             program_type,
+            source_len,
             has_top_level_await: bool::decode(decoder)?,
             is_strict_mode: bool::decode(decoder)?,
             metadata: DeclarationMetadataRecord::decode(decoder)?,
@@ -715,6 +718,7 @@ impl CacheBlob<'_> {
 
 pub(crate) struct DecodedCacheBlob {
     program_type: ast::ProgramType,
+    source_len: usize,
     has_top_level_await: bool,
     is_strict_mode: bool,
     metadata: DecodedDeclarationMetadata,
@@ -724,9 +728,14 @@ pub(crate) struct DecodedCacheBlob {
 impl DecodedCacheBlob {
     fn validate(&self) {
         let _ = self.program_type as u8;
+        let _ = self.source_len;
         let _ = self.has_top_level_await || self.is_strict_mode;
         self.metadata.validate();
         self.program.validate();
+    }
+
+    pub(crate) fn source_len(&self) -> usize {
+        self.source_len
     }
 
     pub(crate) fn source_ranges_are_valid(&self, source_len: usize) -> bool {

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -943,6 +943,9 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_script(
             if !blob._blob.source_ranges_are_valid(source_len) {
                 return std::ptr::null_mut();
             }
+            if blob._blob.validate_cached_bytecode().is_err() {
+                return std::ptr::null_mut();
+            }
             blob._blob
                 .materialize_script(vm_ptr, source_code_ptr, shared_function_data_list_ptr, gdi_context)
         })
@@ -975,6 +978,9 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_module(
             }
             let blob = Box::from_raw(blob);
             if !blob._blob.source_ranges_are_valid(source_len) {
+                return std::ptr::null_mut();
+            }
+            if blob._blob.validate_cached_bytecode().is_err() {
                 return std::ptr::null_mut();
             }
             blob._blob.materialize_module(
@@ -1027,6 +1033,9 @@ pub unsafe extern "C" fn rust_install_bytecode_cache_script(
             if !blob._blob.source_ranges_are_valid(source_len) {
                 return std::ptr::null_mut();
             }
+            if blob._blob.validate_cached_bytecode().is_err() {
+                return std::ptr::null_mut();
+            }
             blob._blob.install_script(
                 vm_ptr,
                 source_code_ptr,
@@ -1076,6 +1085,9 @@ pub unsafe extern "C" fn rust_install_bytecode_cache_module(
                 std::slice::from_raw_parts(existing_declaration_function_ptrs, existing_declaration_function_count)
             };
             if !blob._blob.source_ranges_are_valid(source_len) {
+                return std::ptr::null_mut();
+            }
+            if blob._blob.validate_cached_bytecode().is_err() {
                 return std::ptr::null_mut();
             }
             blob._blob.install_module(

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -137,6 +137,7 @@ pub struct CompiledProgram {
     parsed: ParsedProgram,
     bytecode: CompiledProgramBytecode,
     declaration_functions: Vec<PendingSharedFunctionData>,
+    source_len: usize,
 }
 
 pub struct CompiledFunction {
@@ -745,6 +746,7 @@ fn compile_parsed_program_off_thread_impl(
                 parsed: *parsed,
                 bytecode,
                 declaration_functions,
+                source_len,
             }))
         })
     }
@@ -915,6 +917,20 @@ pub unsafe extern "C" fn rust_decode_bytecode_cache_blob_with_owner(
 pub unsafe extern "C" fn rust_free_decoded_bytecode_cache_blob(blob: *mut DecodedBytecodeCacheBlob) {
     unsafe {
         drop(Box::from_raw(blob));
+    }
+}
+
+/// Return the decoded source length carried by a decoded bytecode cache blob.
+///
+/// # Safety
+/// `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob_with_owner()`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_decoded_bytecode_cache_source_len(blob: *const DecodedBytecodeCacheBlob) -> usize {
+    unsafe {
+        if blob.is_null() {
+            return 0;
+        }
+        (*blob)._blob.source_len()
     }
 }
 

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -445,6 +445,11 @@ DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes bytes,
     return rust_decode_bytecode_cache_blob_with_owner(owner->bytes().data(), owner->bytes().size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size(), owner, clone_bytecode_cache_blob_owner, free_bytecode_cache_blob_owner);
 }
 
+size_t decoded_bytecode_cache_source_length(DecodedBytecodeCacheBlob const* blob)
+{
+    return rust_decoded_bytecode_cache_source_len(blob);
+}
+
 void free_decoded_bytecode_cache_blob(DecodedBytecodeCacheBlob* blob)
 {
     rust_free_decoded_bytecode_cache_blob(blob);

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -118,6 +118,9 @@ JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledPro
 // Decode an ImmutableBytes-backed bytecode cache blob into a parser-free cache handle.
 JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes, ProgramType, ReadonlyBytes source_hash);
 
+// Return the decoded source length carried by a bytecode cache blob.
+JS_API size_t decoded_bytecode_cache_source_length(FFI::DecodedBytecodeCacheBlob const*);
+
 // Free a decoded bytecode cache blob.
 JS_API void free_decoded_bytecode_cache_blob(FFI::DecodedBytecodeCacheBlob*);
 

--- a/Libraries/LibTextCodec/Decoder.cpp
+++ b/Libraries/LibTextCodec/Decoder.cpp
@@ -325,6 +325,19 @@ ErrorOr<String> convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte
     return output;
 }
 
+ErrorOr<size_t> convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(Decoder& fallback_decoder, StringView input)
+{
+    Decoder* actual_decoder = &fallback_decoder;
+
+    if (auto unicode_decoder = bom_sniff_to_decoder(input); unicode_decoder.has_value()) {
+        actual_decoder = &unicode_decoder.value();
+        input = input.substring_view(&unicode_decoder.value() == &s_utf8_decoder ? 3 : 2);
+    }
+
+    VERIFY(actual_decoder);
+    return actual_decoder->length_in_utf16_code_units(input);
+}
+
 // https://encoding.spec.whatwg.org/#get-an-output-encoding
 StringView get_output_encoding(StringView encoding)
 {
@@ -352,6 +365,16 @@ ErrorOr<String> Decoder::to_utf8(StringView input)
     StringBuilder builder(input.length());
     TRY(process(input, [&builder](u32 c) { return builder.try_append_code_point(c); }));
     return builder.to_string_without_validation();
+}
+
+ErrorOr<size_t> Decoder::length_in_utf16_code_units(StringView input)
+{
+    size_t length = 0;
+    TRY(process(input, [&](u32 code_point) -> ErrorOr<void> {
+        length += code_point <= 0xffff ? 1 : 2;
+        return {};
+    }));
+    return length;
 }
 
 ErrorOr<void> Decoder::process_code_points(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
@@ -794,6 +817,83 @@ static ErrorOr<void> process_utf8_with_replacement_character(StringView input, F
     return {};
 }
 
+static size_t utf8_length_in_utf16_code_units_with_replacement_character(StringView input)
+{
+    auto bytes = input.bytes();
+    size_t length = 0;
+
+    for (size_t i = 0; i < bytes.size();) {
+        auto byte = bytes[i];
+        if (byte <= 0x7f) {
+            ++length;
+            ++i;
+            continue;
+        }
+
+        size_t sequence_length = 0;
+        u32 code_point = 0;
+        u32 minimum_code_point = 0;
+
+        if (byte >= 0xc2 && byte <= 0xdf) {
+            sequence_length = 2;
+            code_point = byte & 0x1f;
+            minimum_code_point = 0x80;
+        } else if (byte >= 0xe0 && byte <= 0xef) {
+            sequence_length = 3;
+            code_point = byte & 0x0f;
+            minimum_code_point = 0x800;
+        } else if (byte >= 0xf0 && byte <= 0xf4) {
+            sequence_length = 4;
+            code_point = byte & 0x07;
+            minimum_code_point = 0x10000;
+        } else {
+            ++length;
+            ++i;
+            continue;
+        }
+
+        if (i + 1 < bytes.size() && !is_utf8_second_byte_in_range(byte, bytes[i + 1])) {
+            ++length;
+            ++i;
+            continue;
+        }
+
+        if (i + sequence_length > bytes.size()) {
+            ++length;
+            i = bytes.size();
+            continue;
+        }
+
+        Optional<size_t> invalid_continuation_offset;
+        for (size_t offset = 1; offset < sequence_length; ++offset) {
+            auto continuation_byte = bytes[i + offset];
+            if (!is_utf8_continuation_byte(continuation_byte)) {
+                invalid_continuation_offset = offset;
+                break;
+            }
+            code_point <<= 6;
+            code_point |= continuation_byte & 0x3f;
+        }
+
+        if (invalid_continuation_offset.has_value()) {
+            ++length;
+            i += *invalid_continuation_offset;
+            continue;
+        }
+
+        if (code_point < minimum_code_point || code_point > 0x10ffff || is_unicode_surrogate(code_point)) {
+            ++length;
+            ++i;
+            continue;
+        }
+
+        length += code_point <= 0xffff ? 1 : 2;
+        i += sequence_length;
+    }
+
+    return length;
+}
+
 ErrorOr<void> UTF8Decoder::process(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
 {
     return process_utf8_with_replacement_character(input, move(on_code_point));
@@ -816,11 +916,31 @@ ErrorOr<String> UTF8Decoder::to_utf8(StringView input)
     return builder.to_string_without_validation();
 }
 
+ErrorOr<size_t> UTF8Decoder::length_in_utf16_code_units(StringView input)
+{
+    if (auto bytes = input.bytes(); bytes.starts_with({ { 0xEF, 0xBB, 0xBF } }))
+        input = input.substring_view(3);
+
+    return utf8_length_in_utf16_code_units_with_replacement_character(input);
+}
+
 bool UTF16BEDecoder::validate(StringView input)
 {
     if (input.bytes().size() % 2 != 0)
         return false;
     return AK::validate_utf16_be(input.bytes());
+}
+
+static size_t utf16_length_in_utf16_code_units(StringView input, bool big_endian)
+{
+    auto bytes = input.bytes();
+    if (bytes.size() >= 2) {
+        if ((big_endian && bytes[0] == 0xFE && bytes[1] == 0xFF)
+            || (!big_endian && bytes[0] == 0xFF && bytes[1] == 0xFE))
+            bytes = bytes.slice(2);
+    }
+
+    return (bytes.size() + 1) / 2;
 }
 
 static ErrorOr<void> process_utf16(StringView input, bool big_endian, Function<ErrorOr<void>(u32)> on_code_point)
@@ -877,6 +997,11 @@ ErrorOr<String> UTF16BEDecoder::to_utf8(StringView input)
     return Decoder::to_utf8(input);
 }
 
+ErrorOr<size_t> UTF16BEDecoder::length_in_utf16_code_units(StringView input)
+{
+    return utf16_length_in_utf16_code_units(input, true);
+}
+
 bool UTF16LEDecoder::validate(StringView input)
 {
     if (input.bytes().size() % 2 != 0)
@@ -894,6 +1019,11 @@ ErrorOr<String> UTF16LEDecoder::to_utf8(StringView input)
     return Decoder::to_utf8(input);
 }
 
+ErrorOr<size_t> UTF16LEDecoder::length_in_utf16_code_units(StringView input)
+{
+    return utf16_length_in_utf16_code_units(input, false);
+}
+
 ErrorOr<void> Latin1Decoder::process(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
 {
     for (u8 ch : input) {
@@ -902,6 +1032,11 @@ ErrorOr<void> Latin1Decoder::process(StringView input, Function<ErrorOr<void>(u3
     }
 
     return {};
+}
+
+ErrorOr<size_t> Latin1Decoder::length_in_utf16_code_units(StringView input)
+{
+    return input.length();
 }
 
 ErrorOr<void> PDFDocEncodingDecoder::process(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
@@ -951,6 +1086,11 @@ ErrorOr<void> PDFDocEncodingDecoder::process(StringView input, Function<ErrorOr<
     return {};
 }
 
+ErrorOr<size_t> PDFDocEncodingDecoder::length_in_utf16_code_units(StringView input)
+{
+    return input.length();
+}
+
 // https://encoding.spec.whatwg.org/#x-user-defined-decoder
 ErrorOr<void> XUserDefinedDecoder::process(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
 {
@@ -975,6 +1115,11 @@ ErrorOr<void> XUserDefinedDecoder::process(StringView input, Function<ErrorOr<vo
     return {};
 }
 
+ErrorOr<size_t> XUserDefinedDecoder::length_in_utf16_code_units(StringView input)
+{
+    return input.length();
+}
+
 // https://encoding.spec.whatwg.org/#single-byte-decoder
 template<Integral ArrayType>
 ErrorOr<void> SingleByteDecoder<ArrayType>::process(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
@@ -996,6 +1141,12 @@ ErrorOr<void> SingleByteDecoder<ArrayType>::process(StringView input, Function<E
     }
     // 1. If byte is end-of-queue, return finished.
     return {};
+}
+
+template<Integral ArrayType>
+ErrorOr<size_t> SingleByteDecoder<ArrayType>::length_in_utf16_code_units(StringView input)
+{
+    return input.length();
 }
 
 // https://encoding.spec.whatwg.org/#index-gb18030-ranges-code-point
@@ -1750,6 +1901,11 @@ ErrorOr<void> ReplacementDecoder::process(StringView input, Function<ErrorOr<voi
     if (!input.is_empty())
         return on_code_point(replacement_code_point);
     return {};
+}
+
+ErrorOr<size_t> ReplacementDecoder::length_in_utf16_code_units(StringView input)
+{
+    return input.is_empty() ? 0 : 1;
 }
 
 // https://infra.spec.whatwg.org/#isomorphic-decode

--- a/Libraries/LibTextCodec/Decoder.h
+++ b/Libraries/LibTextCodec/Decoder.h
@@ -22,6 +22,7 @@ class TEXTCODEC_API Decoder {
 public:
     virtual bool validate(StringView);
     virtual ErrorOr<String> to_utf8(StringView);
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView);
     ErrorOr<void> process_code_points(StringView, Function<ErrorOr<void>(u32)>);
 
     // Returns the number of trailing bytes that form an incomplete sequence and must be buffered
@@ -38,6 +39,7 @@ public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
     virtual bool validate(StringView) override;
     virtual ErrorOr<String> to_utf8(StringView) override;
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView) override;
     virtual size_t incomplete_tail_length(ReadonlyBytes) const override;
 };
 
@@ -45,6 +47,7 @@ class TEXTCODEC_API UTF16BEDecoder final : public Decoder {
 public:
     virtual bool validate(StringView) override;
     virtual ErrorOr<String> to_utf8(StringView) override;
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView) override;
     virtual size_t incomplete_tail_length(ReadonlyBytes) const override;
 
 private:
@@ -55,6 +58,7 @@ class TEXTCODEC_API UTF16LEDecoder final : public Decoder {
 public:
     virtual bool validate(StringView) override;
     virtual ErrorOr<String> to_utf8(StringView) override;
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView) override;
     virtual size_t incomplete_tail_length(ReadonlyBytes) const override;
 
 private:
@@ -70,6 +74,7 @@ public:
     }
 
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView) override;
 
 private:
     Array<ArrayType, 128> m_translation_table;
@@ -79,18 +84,21 @@ class TEXTCODEC_API Latin1Decoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
     virtual bool validate(StringView) override { return true; }
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView) override;
 };
 
 class TEXTCODEC_API PDFDocEncodingDecoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
     virtual bool validate(StringView) override { return true; }
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView) override;
 };
 
 class TEXTCODEC_API XUserDefinedDecoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
     virtual bool validate(StringView) override { return true; }
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView) override;
 };
 
 class TEXTCODEC_API GB18030Decoder final : public Decoder {
@@ -133,6 +141,7 @@ class TEXTCODEC_API ReplacementDecoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
     virtual bool validate(StringView input) override { return input.is_empty(); }
+    virtual ErrorOr<size_t> length_in_utf16_code_units(StringView) override;
 };
 
 // Preserves incomplete trailing decoder tokens when callers provide input in chunks.
@@ -164,6 +173,7 @@ TEXTCODEC_API Optional<Decoder&> bom_sniff_to_decoder(StringView);
 // NOTE: This has an obnoxious name to discourage usage. Only use this if you absolutely must! For example, XHR in LibWeb uses this.
 // This will use the given decoder unless there is a byte order mark in the input, in which we will instead use the appropriate Unicode decoder.
 TEXTCODEC_API ErrorOr<String> convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(Decoder&, StringView);
+TEXTCODEC_API ErrorOr<size_t> convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(Decoder&, StringView);
 
 TEXTCODEC_API StringView get_output_encoding(StringView encoding);
 

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -9,7 +9,6 @@
 #include <AK/Array.h>
 #include <AK/NumericLimits.h>
 #include <AK/StringBuilder.h>
-#include <AK/UnicodeUtils.h>
 #include <AK/Utf16String.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/ImmutableBytes.h>
@@ -105,32 +104,23 @@ struct BytecodeCacheInstallTarget {
     }
 };
 
-static ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> bytecode_cache_source_hash(JS::SourceCode const& source_code)
+static ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> bytecode_cache_source_hash(ReadonlyBytes source_bytes, StringView source_encoding)
 {
-    if (source_code.code_view().has_ascii_storage()) {
-        auto hasher = ::Crypto::Hash::SHA256::create();
-        auto ascii = source_code.code_view().ascii_span();
+    auto hasher = ::Crypto::Hash::SHA256::create();
+    hasher->update(source_bytes);
 
-        constexpr size_t chunk_size = 4096;
-        Array<u16, chunk_size> utf16_data;
-        for (size_t offset = 0; offset < ascii.size(); offset += chunk_size) {
-            auto current_chunk_size = min(chunk_size, ascii.size() - offset);
-            for (size_t i = 0; i < current_chunk_size; ++i)
-                utf16_data[i] = static_cast<u16>(ascii[offset + i]);
-
-            hasher->update(reinterpret_cast<u8 const*>(utf16_data.data()), current_chunk_size * sizeof(u16));
-        }
-
-        return hasher->digest();
-    }
-
-    return ::Crypto::Hash::SHA256::hash(reinterpret_cast<u8 const*>(source_code.utf16_data()), source_code.length_in_code_units() * sizeof(u16));
+    auto standardized_encoding = TextCodec::get_standardized_encoding(source_encoding).value_or(source_encoding);
+    auto encoding_length = static_cast<u32>(standardized_encoding.length());
+    Array<u8, sizeof(u32)> encoded_length {
+        static_cast<u8>(encoding_length),
+        static_cast<u8>(encoding_length >> 8),
+        static_cast<u8>(encoding_length >> 16),
+        static_cast<u8>(encoding_length >> 24),
+    };
+    hasher->update(encoded_length.span());
+    hasher->update(standardized_encoding);
+    return hasher->digest();
 }
-
-struct DecodedSourceTextInfo {
-    ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> hash;
-    size_t length_in_code_units { 0 };
-};
 
 static ErrorOr<String> decode_source_text(TextCodec::Decoder& fallback_decoder, StringView input)
 {
@@ -147,71 +137,9 @@ static ReadonlyBytes body_bytes_view(Fetch::Infrastructure::FetchAlgorithms::Bod
     return body_bytes.get<Core::ImmutableBytes>().bytes();
 }
 
-static Core::ImmutableBytes take_body_bytes(Fetch::Infrastructure::FetchAlgorithms::BodyBytes& body_bytes)
-{
-    return move(body_bytes.get<Core::ImmutableBytes>());
-}
-
 static ByteBuffer take_body_bytes_as_byte_buffer(Fetch::Infrastructure::FetchAlgorithms::BodyBytes& body_bytes)
 {
     return body_bytes.get<Core::ImmutableBytes>().copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
-}
-
-static ErrorOr<DecodedSourceTextInfo> decoded_source_text_info(TextCodec::Decoder& fallback_decoder, ReadonlyBytes bytes)
-{
-    StringView input { bytes };
-    TextCodec::Decoder* actual_decoder = &fallback_decoder;
-
-    auto unicode_decoder = TextCodec::bom_sniff_to_decoder(input);
-    if (unicode_decoder.has_value()) {
-        auto input_bytes = input.bytes();
-        auto byte_order_mark_size = input_bytes.size() >= 3 && input_bytes[0] == 0xEF && input_bytes[1] == 0xBB && input_bytes[2] == 0xBF ? 3 : 2;
-        actual_decoder = &unicode_decoder.value();
-        input = input.substring_view(byte_order_mark_size);
-    }
-
-    auto hasher = ::Crypto::Hash::SHA256::create();
-
-    constexpr size_t chunk_size = 4096;
-    Array<u16, chunk_size> utf16_data;
-    size_t chunk_offset = 0;
-    auto flush_chunk = [&] {
-        if (chunk_offset == 0)
-            return;
-        hasher->update(reinterpret_cast<u8 const*>(utf16_data.data()), chunk_offset * sizeof(u16));
-        chunk_offset = 0;
-    };
-
-    size_t length_in_code_units = 0;
-    TRY(actual_decoder->process_code_points(input, [&](auto code_point) -> ErrorOr<void> {
-        if (code_point <= 0xffff) {
-            ++length_in_code_units;
-            utf16_data[chunk_offset++] = static_cast<u16>(code_point);
-            if (chunk_offset == chunk_size)
-                flush_chunk();
-            return {};
-        }
-
-        Array<char16_t, 2> code_units;
-        size_t code_point_length_in_code_units = 0;
-        (void)AK::UnicodeUtils::code_point_to_utf16(code_point, [&](auto code_unit) {
-            code_units[code_point_length_in_code_units++] = code_unit;
-        });
-
-        length_in_code_units += code_point_length_in_code_units;
-        for (size_t i = 0; i < code_point_length_in_code_units; ++i) {
-            utf16_data[chunk_offset++] = code_units[i];
-            if (chunk_offset == chunk_size)
-                flush_chunk();
-        }
-        return {};
-    }));
-
-    flush_chunk();
-    return DecodedSourceTextInfo {
-        .hash = hasher->digest(),
-        .length_in_code_units = length_in_code_units,
-    };
 }
 
 static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::Infrastructure::Request const& request, Fetch::Infrastructure::Response const& response, URL::URL const& response_url)
@@ -240,7 +168,7 @@ static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::
 // Reparsing here is intentional: the execution-path compile only eagerly generates top-level bytecode plus direct
 // IIFEs, while the cache wants every nested function compiled so that warm loads avoid lazy compile work entirely. Once
 // the blob is back on the main thread, try to install that same blob into the live script/module before storing it.
-static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode const> original_source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, BytecodeCacheContext cache_context, BytecodeCacheInstallTarget install_target)
+static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode const> original_source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, BytecodeCacheContext cache_context, BytecodeCacheInstallTarget install_target, ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> source_hash)
 {
     auto filename = original_source_code->filename();
     auto source_code = original_source_code->code();
@@ -260,9 +188,8 @@ static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode cons
             (void)ResourceLoader::the().request_client()->store_cache_associated_data(cache_context.url, cache_context.method, *cache_context.request_headers, cache_context.vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, immutable_blob.bytes());
         });
 
-    Threading::ThreadPool::the().submit([filename = move(filename), source_code = move(source_code), type, line_number_offset, callback, event_loop_weak = move(event_loop_weak)]() mutable {
+    Threading::ThreadPool::the().submit([filename = move(filename), source_code = move(source_code), type, line_number_offset, callback, event_loop_weak = move(event_loop_weak), source_hash]() mutable {
         auto source = JS::SourceCode::create(move(filename), move(source_code));
-        auto source_hash = bytecode_cache_source_hash(*source);
         ByteBuffer blob;
 
         auto* parsed = JS::RustIntegration::parse_program(source->utf16_data(), source->length_in_code_units(), type, line_number_offset);
@@ -772,40 +699,47 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
             auto response_url_string = response_url.to_byte_string();
             auto source_bytes = body_bytes_view(body_bytes);
             auto const& bytecode = response->javascript_bytecode_cache();
-            Optional<DecodedSourceTextInfo> source_text_info;
-            if (bytecode.has_value())
-                source_text_info = decoded_source_text_info(*fallback_decoder, source_bytes).release_value_but_fixme_should_propagate_errors();
-            auto source_code_filename = String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors();
-            auto source_code = [&] {
-                if (source_text_info.has_value()) {
-                    return JS::SourceCode::create(
-                        move(source_code_filename),
-                        source_text_info->length_in_code_units,
-                        String::from_utf8(extracted_character_encoding).release_value_but_fixme_should_propagate_errors(),
-                        take_body_bytes(body_bytes));
-                }
-                return JS::SourceCode::create(move(source_code_filename), Utf16String::from_utf8(decode_source_text(*fallback_decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
-            }();
+            Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
             auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *response, response_url);
+            Optional<decltype(bytecode_cache_source_hash(source_bytes, extracted_character_encoding))> source_hash;
+            if (bytecode.has_value() || bytecode_cache_context.has_value())
+                source_hash = bytecode_cache_source_hash(source_bytes, extracted_character_encoding);
             // Warm-cache fast path: a sidecar arrived with the response, decode it, and try to materialize a script
             // straight from the cached bytecode without parsing or compiling. Pass non-moved source_code / response_url
-            // so the fallback compile path below can reuse them if decode or materialization is rejected.
+            // so the fallback compile path below can reuse them if materialization is rejected.
             if (bytecode.has_value()) {
-                VERIFY(source_text_info.has_value());
-                if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Script, source_text_info->hash.bytes())) {
-                    auto script = ClassicScript::create_from_bytecode_cache(response_url_string, source_code, settings_object, response_url, bytecode_cache, muted_errors);
-                    // Bytecode validation runs during materialization and may reject a structurally valid blob whose
-                    // bytecode is corrupt. Treat that as a cache miss and fall through to off-thread source compile.
-                    if (script->parse_error().is_null()) {
-                        on_complete->function()(script);
-                        return;
+                if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Script, source_hash->bytes())) {
+                    auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*fallback_decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
+                    if (JS::RustIntegration::decoded_bytecode_cache_source_length(bytecode_cache) != source_length) {
+                        JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
+                    } else {
+                        source_code = JS::SourceCode::create(
+                            String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                            source_length,
+                            String::from_utf8(extracted_character_encoding).release_value_but_fixme_should_propagate_errors(),
+                            body_bytes.template get<Core::ImmutableBytes>());
+                        auto script = ClassicScript::create_from_bytecode_cache(response_url_string, *source_code, settings_object, response_url, bytecode_cache, muted_errors);
+                        // Bytecode validation runs during materialization and may reject a structurally valid blob whose
+                        // bytecode is corrupt. Treat that as a cache miss and fall through to off-thread source compile.
+                        if (script->parse_error().is_null()) {
+                            on_complete->function()(script);
+                            return;
+                        }
+                        source_code = {};
                     }
                 }
             }
 
-            compile_off_thread(move(source_code), JS::RustIntegration::ProgramType::Script, 1,
+            if (!source_code.has_value()) {
+                source_code = JS::SourceCode::create(
+                    String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                    Utf16String::from_utf8(decode_source_text(*fallback_decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
+            }
+
+            compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Script, 1,
                 [response_url = move(response_url), response_url_string = move(response_url_string),
                     bytecode_cache_context = move(bytecode_cache_context),
+                    source_hash = move(source_hash),
                     muted_errors, on_complete_root = move(on_complete_root),
                     settings_root = move(settings_root)](auto result, auto source_code) mutable {
                     auto source_code_for_cache = source_code;
@@ -824,7 +758,8 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                     on_complete_root->function()(script);
                     if (should_generate_bytecode_cache) {
                         install_target.begin_generation();
-                        schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value(), move(install_target));
+                        VERIFY(source_hash.has_value());
+                        schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
                     }
                 });
         } else {
@@ -1178,37 +1113,44 @@ void fetch_single_module_script(JS::Realm& realm,
                     auto module_type_string = module_type.to_byte_string();
                     auto source_bytes = body_bytes_view(body_bytes);
                     auto const& bytecode = internal_response->javascript_bytecode_cache();
-                    Optional<DecodedSourceTextInfo> source_text_info;
-                    if (bytecode.has_value())
-                        source_text_info = decoded_source_text_info(*decoder, source_bytes).release_value_but_fixme_should_propagate_errors();
-                    auto source_code_filename = String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors();
-                    auto source_code = [&] {
-                        if (source_text_info.has_value()) {
-                            return JS::SourceCode::create(
-                                move(source_code_filename),
-                                source_text_info->length_in_code_units,
-                                "UTF-8"_string,
-                                take_body_bytes(body_bytes));
-                        }
-                        return JS::SourceCode::create(move(source_code_filename), Utf16String::from_utf8(decode_source_text(*decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
-                    }();
+                    Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
                     auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *internal_response, response_url);
+                    Optional<decltype(bytecode_cache_source_hash(source_bytes, "UTF-8"sv))> source_hash;
+                    if (bytecode.has_value() || bytecode_cache_context.has_value())
+                        source_hash = bytecode_cache_source_hash(source_bytes, "UTF-8"sv);
                     if (bytecode.has_value()) {
-                        VERIFY(source_text_info.has_value());
-                        if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Module, source_text_info->hash.bytes())) {
-                            auto module_script = ModuleScript::create_from_bytecode_cache(url_string, source_code, settings_object, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
-                            if (module_script && module_script->parse_error().is_null()) {
-                                settings_object.module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
-                                on_complete->function()(module_script);
-                                return;
+                        if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Module, source_hash->bytes())) {
+                            auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
+                            if (JS::RustIntegration::decoded_bytecode_cache_source_length(bytecode_cache) != source_length) {
+                                JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
+                            } else {
+                                source_code = JS::SourceCode::create(
+                                    String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                                    source_length,
+                                    "UTF-8"_string,
+                                    body_bytes.template get<Core::ImmutableBytes>());
+                                auto module_script = ModuleScript::create_from_bytecode_cache(url_string, *source_code, settings_object, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
+                                if (module_script && module_script->parse_error().is_null()) {
+                                    settings_object.module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
+                                    on_complete->function()(module_script);
+                                    return;
+                                }
+                                source_code = {};
                             }
                         }
                     }
 
-                    compile_off_thread(move(source_code), JS::RustIntegration::ProgramType::Module, 0,
+                    if (!source_code.has_value()) {
+                        source_code = JS::SourceCode::create(
+                            String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                            Utf16String::from_utf8(decode_source_text(*decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
+                    }
+
+                    compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Module, 0,
                         [url = move(url), url_string = move(url_string), response_url = move(response_url),
                             module_type_string = move(module_type_string),
                             bytecode_cache_context = move(bytecode_cache_context),
+                            source_hash = move(source_hash),
                             on_complete_root = move(on_complete_root),
                             settings_root = move(settings_root)](auto result, auto source_code) mutable {
                             auto source_code_for_cache = source_code;
@@ -1230,7 +1172,8 @@ void fetch_single_module_script(JS::Realm& realm,
                             on_complete_root->function()(module_script);
                             if (should_generate_bytecode_cache) {
                                 install_target.begin_generation();
-                                schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value(), move(install_target));
+                                VERIFY(source_hash.has_value());
+                                schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
                             }
                         });
                     return;

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/File.h>
 #include <LibCore/ImmutableBytes.h>
@@ -27,6 +28,23 @@ struct BytecodeCacheTestData {
     Core::ImmutableBytes blob;
     Crypto::Hash::SHA256::DigestType source_hash;
 };
+
+static Crypto::Hash::SHA256::DigestType bytecode_cache_source_hash(StringView source, StringView source_encoding)
+{
+    auto hasher = Crypto::Hash::SHA256::create();
+    hasher->update(source.bytes());
+
+    auto encoding_length = static_cast<u32>(source_encoding.length());
+    Array<u8, sizeof(u32)> encoded_length {
+        static_cast<u8>(encoding_length),
+        static_cast<u8>(encoding_length >> 8),
+        static_cast<u8>(encoding_length >> 16),
+        static_cast<u8>(encoding_length >> 24),
+    };
+    hasher->update(encoded_length.span());
+    hasher->update(source_encoding);
+    return hasher->digest();
+}
 
 TEST_CASE(lazy_source_code_decoding_replaces_utf8_surrogates)
 {
@@ -222,6 +240,7 @@ static size_t top_level_bytecode_payload_offset(ReadonlyBytes blob)
     reader.skip(sizeof(u32)); // Format version.
     reader.skip(1);           // Program type.
     reader.skip(32);          // Source hash.
+    reader.skip(sizeof(u32)); // Source length in code units.
     reader.skip(1);           // Has top-level await.
     reader.skip(1);           // Is strict mode.
 
@@ -251,7 +270,7 @@ static void enter_declaration_function_table(BytecodeCacheBlobReader& reader, bo
 static BytecodeCacheTestData create_bytecode_cache_blob(StringView source)
 {
     auto source_code = JS::SourceCode::create("test.js"_string, Utf16String::from_utf8(source));
-    auto source_hash = Crypto::Hash::SHA256::hash(reinterpret_cast<u8 const*>(source_code->utf16_data()), source_code->length_in_code_units() * sizeof(u16));
+    auto source_hash = bytecode_cache_source_hash(source, "UTF-8"sv);
 
     auto* parsed = JS::RustIntegration::parse_program(source_code->utf16_data(), source_code->length_in_code_units(), JS::RustIntegration::ProgramType::Script);
     VERIFY(parsed);
@@ -280,7 +299,7 @@ static BytecodeCacheTestData create_bytecode_cache_blob(StringView source)
 static BytecodeCacheTestData create_module_bytecode_cache_blob(StringView source)
 {
     auto source_code = JS::SourceCode::create("test.mjs"_string, Utf16String::from_utf8(source));
-    auto source_hash = Crypto::Hash::SHA256::hash(reinterpret_cast<u8 const*>(source_code->utf16_data()), source_code->length_in_code_units() * sizeof(u16));
+    auto source_hash = bytecode_cache_source_hash(source, "UTF-8"sv);
 
     auto* parsed = JS::RustIntegration::parse_program(source_code->utf16_data(), source_code->length_in_code_units(), JS::RustIntegration::ProgramType::Module);
     VERIFY(parsed);
@@ -353,6 +372,7 @@ static size_t first_declaration_function_bytecode_payload_offset(ReadonlyBytes b
     reader.skip(sizeof(u32)); // Format version.
     reader.skip(1);           // Program type.
     reader.skip(32);          // Source hash.
+    reader.skip(sizeof(u32)); // Source length in code units.
     reader.skip(1);           // Has top-level await.
     reader.skip(1);           // Is strict mode.
 
@@ -398,6 +418,7 @@ static size_t first_declaration_function_source_text_start_offset(ReadonlyBytes 
     reader.skip(sizeof(u32)); // Format version.
     reader.skip(1);           // Program type.
     reader.skip(32);          // Source hash.
+    reader.skip(sizeof(u32)); // Source length in code units.
     reader.skip(1);           // Has top-level await.
     reader.skip(1);           // Is strict mode.
 


### PR DESCRIPTION
This PR reduces main-thread work on JavaScript bytecode cache hits.

Bytecode cache blobs now hash the original encoded response bytes plus the effective source encoding, instead of hashing decoded UTF-16 source text. The blob also stores the decoded source length, letting warm script and module loads create lazy SourceCode objects without decoding the full source before accepting a valid cache sidecar.

It also moves cached bytecode validation to the decoded blob boundary, so script, module, and install paths validate the cache payload once before materialization instead of repeating validation during later lazy executable construction.