### PR TITLE
LibJS: Avoid redundant prototype shape work

### DIFF
--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -252,10 +252,10 @@ GC::Ref<Shape> Shape::create_configure_transition(PropertyKey const& property_ke
 
 GC::Ref<Shape> Shape::create_prototype_transition(Object* new_prototype)
 {
-    if (new_prototype)
-        new_prototype->convert_to_prototype_if_needed();
     if (auto existing_shape = get_or_prune_cached_prototype_transition(new_prototype))
         return *existing_shape;
+    if (new_prototype)
+        new_prototype->convert_to_prototype_if_needed();
     auto new_shape = heap().allocate<Shape>(*this, new_prototype);
     if (m_dictionary && m_property_count > DescriptorArray::max_descriptor_count) {
         new_shape->become_dictionary_shape();
@@ -472,8 +472,11 @@ GC::Ref<Shape> Shape::clone_for_prototype()
     if (m_dictionary && m_property_count > DescriptorArray::max_descriptor_count) {
         new_shape->become_dictionary_shape();
         copy_properties_to_dictionary_shape(*new_shape);
-    } else {
+    } else if (m_dictionary) {
         new_shape->set_descriptors(copy_descriptors());
+        new_shape->m_property_count = m_property_count;
+    } else {
+        new_shape->set_descriptors(descriptors());
         new_shape->m_property_count = m_property_count;
     }
     new_shape->m_prototype_chain_validity = heap().allocate<PrototypeChainValidity>();


### PR DESCRIPTION
Check the cached prototype transition before converting the target prototype shape. A cache hit means the target was already converted when the transition was created, so this skips a redundant call in the hot path.

When cloning a non-dictionary shape for prototype tracking, share the descriptor array instead of copying it. Normal shape transitions already use the same sharing model, with each shape keeping its own property count boundary for lookups.