### PR TITLE
UI/Qt: Tweak the color used for the collapsed tab close button

### DIFF
--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -754,6 +754,7 @@ QString tab_widget_style_sheet(QPalette const& palette)
     auto sidebar_separator = style_sheet_color(mix(chrome_background_color, chrome_border(palette), dark ? 0.44 : 0.58));
     auto sidebar_separator_hover = style_sheet_color(mix(chrome_background_color, chrome_border(palette), dark ? 0.64 : 0.76));
     auto vertical_tab_button_background_color = style_sheet_color(chrome_active_tab_surface_top(palette));
+
     return qformatted(R"(
 QWidget#LadybirdTabStrip {{
     color: {4};
@@ -823,7 +824,7 @@ QPushButton#LadybirdTabButton[collapsedVerticalTabButton="true"] {{
     max-width: 16px;
     max-height: 16px;
     background: {10};
-    border-color: {4};
+    border-color: {1};
     border-radius: 8px;
 }}
 


### PR DESCRIPTION
The previous color was a bit jarringly bright.

Before:
<img width="50" height="49" alt="before" src="https://github.com/user-attachments/assets/06ea11e4-222a-4b34-9bc4-4cdb06d37e11" />

After:
<img width="50" height="49" alt="after" src="https://github.com/user-attachments/assets/0a02fba4-709a-4f0c-9908-c071d08254d2" />

And the look when the close button is hovered (same before/after):
<img width="50" height="49" alt="hover" src="https://github.com/user-attachments/assets/83e6f199-f309-432f-8547-b6c0a414669e" />
