### PR TITLE
LibWeb: Ignore vertical-align on flex and grid items in box_baseline

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2555,7 +2555,7 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
 
     // https://drafts.csswg.org/css2/#propdef-vertical-align
     auto const& vertical_align = box.computed_values().vertical_align();
-    if (vertical_align.has<CSS::VerticalAlign>()) {
+    if (box.vertical_align_applies() && vertical_align.has<CSS::VerticalAlign>()) {
         switch (vertical_align.get<CSS::VerticalAlign>()) {
         case CSS::VerticalAlign::Top:
             // Top: Align the top of the aligned subtree with the top of the line box.

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -161,6 +161,21 @@ public:
     bool is_grid_item() const { return m_is_grid_item; }
     void set_grid_item(bool b) { m_is_grid_item = b; }
 
+    bool vertical_align_applies() const
+    {
+        // https://drafts.csswg.org/css-flexbox/#flex-containers
+        // "vertical-align has no effect on a flex item"
+        if (is_flex_item())
+            return false;
+        // https://drafts.csswg.org/css-grid-1/#grid-container
+        // "vertical-align has no effect on a grid item"
+        if (is_grid_item())
+            return false;
+        // FIXME: Per-spec, vertical-align only applies to inline-level boxes and table cells; this should be narrowed
+        //        to that — rather than only excluding flex and grid items.
+        return true;
+    }
+
     [[nodiscard]] GC::Ptr<Box const> containing_block() const { return m_containing_block; }
     [[nodiscard]] GC::Ptr<Box> containing_block() { return m_containing_block; }
 

--- a/Tests/LibWeb/Layout/expected/flex-item-baseline-ignores-vertical-align.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-baseline-ignores-vertical-align.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 34 0+0+8] children: not-inline
+      BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 34 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [8,10 15.765625x30] baseline: 22.796875
+            "x"
+        frag 1 from Box start: 0, length: 0, rect: [28.765625,10 14.78125x30] baseline: 24.796875
+        frag 2 from TextNode start: 0, length: 1, rect: [48.546875,10 11.65625x30] baseline: 22.796875
+            "y"
+        TextNode <#text> (not painted)
+        Box <button> at [28.765625,10] flex-container(row) [0+1+4 14.78125 4+1+0] [0+1+1 30 1+1+0] [FFC] children: not-inline
+          Box <span> at [28.765625,10] flex-container(row) flex-item [0+0+0 14.78125 0+0+0] [0+0+0 30 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> at [28.765625,10] flex-item [0+0+0 14.78125 0+0+0] [0+0+0 30 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [28.765625,10 14.78125x30] baseline: 22.796875
+                  "3"
+              TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,42] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x50]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x34]
+        TextPaintable (TextNode<#text>)
+        PaintableBox (Box<BUTTON>) [23.765625,8 24.78125x34]
+          PaintableBox (Box<SPAN>) [28.765625,10 14.78125x30]
+            PaintableWithLines (BlockContainer(anonymous)) [28.765625,10 14.78125x30]
+              TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x50] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex-item-baseline-ignores-vertical-align.html
+++ b/Tests/LibWeb/Layout/input/flex-item-baseline-ignores-vertical-align.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><div style="font-size: 26px">x<button style="display: inline-flex"><span style="display: inline-flex; vertical-align: top">3</span></button>y</div>


### PR DESCRIPTION
**Problem:** Borked layout on (flex-styled) “D&D Beyond” site.

**Cause:** `FormattingContext::box_baseline()` was applying the box’s `vertical-align` unconditionally. But `vertical-align` shouldn’t be consulted for flex items or grid items.

**Fix:** Skip `vertical-align` handling in `box_baseline()` when the box is a flex or grid item.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/9840
