### PR TITLE
LibWeb: Let style sheets actually block scripts

### DIFF
--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -141,13 +141,6 @@ void CSSImportRule::fetch()
 
     // AD-HOC: Track pending import rules to block rendering until they are done.
     m_document->add_pending_css_import_rule({}, *this);
-    // FIXME: This dedicated load-event delayer shouldn't be needed. The style-sheet critical-subresource mechanism
-    //        already delays the document load event via the owning element. However, it only does that delay when
-    //        contributes_a_script_blocking_style_sheet() is true. But HTMLStyleElement currently always returns false
-    //        for that. Once HTMLStyleElement actually has working contributes_a_script_blocking_style_sheet() behavior
-    //        implemented (as HTMLLinkElement element already does), the owning style element's delayer will cover the
-    //        @import fetch — and then at that time, this dedicated load-event delayer can go away.
-    m_load_event_delayer.emplace(*m_document);
     set_loading_state(CSSStyleSheet::LoadingState::Loading);
 
     // 3. Fetch a style resource from rule’s URL, with ruleOrDeclaration rule, destination "style", CORS mode "no-cors", and
@@ -163,7 +156,6 @@ void CSSImportRule::fetch()
             // AD-HOC: Stop delaying the load event.
             ScopeGuard guard = [strong_this, document] {
                 document->remove_pending_css_import_rule({}, strong_this);
-                strong_this->m_load_event_delayer.clear();
                 if (strong_this->loading_state() != CSSStyleSheet::LoadingState::Error) {
                     // If we have no critical subresources, or they're loaded already, we can report that immediately.
                     auto sheet_loading_state = strong_this->m_style_sheet->loading_state();

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -134,8 +134,10 @@ void CSSImportRule::fetch()
     auto& parent_style_sheet = *this->parent_style_sheet();
 
     // 2. If rule has a <supports-condition>, and that condition is not true, return.
-    if (m_supports && !m_supports->matches())
+    if (m_supports && !m_supports->matches()) {
+        set_loading_state(CSSStyleSheet::LoadingState::Loaded);
         return;
+    }
 
     // AD-HOC: Track pending import rules to block rendering until they are done.
     m_document->add_pending_css_import_rule({}, *this);

--- a/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -11,7 +11,6 @@
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/URL.h>
-#include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 
@@ -67,7 +66,6 @@ private:
     RefPtr<Supports> m_supports;
     GC::Ref<MediaList> m_media;
     GC::Ptr<CSSStyleSheet> m_style_sheet;
-    Optional<DOM::DocumentLoadEventDelayer> m_load_event_delayer;
 };
 
 template<>

--- a/Libraries/LibWeb/DOM/StyleElementBase.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementBase.cpp
@@ -20,8 +20,22 @@
 
 namespace Web::DOM {
 
+void StyleElementBase::set_parser_document(Badge<HTML::HTMLParser>, GC::Ref<Document> document)
+{
+    m_parser_document = document;
+    m_is_on_parser_stack_of_open_elements = true;
+}
+
+void StyleElementBase::did_pop_off_parser_stack_of_open_elements()
+{
+    m_is_on_parser_stack_of_open_elements = false;
+    update_a_style_block(UpdateSource::ParserPop);
+}
+
 void StyleElementBase::update_a_style_block_for_dynamic_change()
 {
+    if (m_is_on_parser_stack_of_open_elements)
+        return;
     update_a_style_block();
 }
 
@@ -36,7 +50,7 @@ void StyleElementBase::style_element_attribute_changed(FlyString const& name, Op
 }
 
 // The user agent must run the "update a style block" algorithm whenever one of the following conditions occur:
-// FIXME: The element is popped off the stack of open elements of an HTML parser or XML parser.
+// The element is popped off the stack of open elements of an HTML parser or XML parser.
 //
 // NOTE: This is basically done by children_changed() today:
 // The element's children changed steps run.
@@ -45,7 +59,7 @@ void StyleElementBase::style_element_attribute_changed(FlyString const& name, Op
 // The element is not on the stack of open elements of an HTML parser or XML parser, and it becomes connected or disconnected.
 //
 // https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block
-void StyleElementBase::update_a_style_block()
+void StyleElementBase::update_a_style_block(UpdateSource update_source)
 {
     auto& style_element = as_element();
 
@@ -56,7 +70,6 @@ void StyleElementBase::update_a_style_block()
 
     // 1. Let element be the style element.
     // 2. If element has an associated CSS style sheet, remove the CSS style sheet in question.
-
     if (m_associated_css_style_sheet) {
         m_style_sheet_list->remove_a_css_style_sheet(*m_associated_css_style_sheet);
         m_style_sheet_list = nullptr;
@@ -64,6 +77,13 @@ void StyleElementBase::update_a_style_block()
         // FIXME: This should probably be handled by StyleSheet::set_owner_node().
         m_associated_css_style_sheet = nullptr;
     }
+
+    // AD-HOC: The script-blocking style sheet set tracks elements, but a style element's associated sheet can be
+    //         replaced before that sheet's critical subresources finish loading. Keep that set and any queued
+    //         completions in sync with the sheet removed above.
+    ++m_style_sheet_update_generation;
+    remove_from_script_blocking_style_sheet_set_if_needed();
+    clear_associated_css_style_sheet_parser_blocking_state();
 
     // 3. If element is not connected, then return.
     if (!style_element.is_connected())
@@ -114,10 +134,18 @@ void StyleElementBase::update_a_style_block()
         nullptr,
         nullptr);
 
+    if (update_source == UpdateSource::ParserPop) {
+        m_associated_css_style_sheet_was_created_by_parser = true;
+        m_associated_css_style_sheet_was_enabled_when_created_by_parser = !m_associated_css_style_sheet->disabled();
+        m_associated_css_style_sheet_load_is_pending_for_script_blocking = m_associated_css_style_sheet_was_enabled_when_created_by_parser
+            && m_associated_css_style_sheet->loading_state() == CSS::CSSStyleSheet::LoadingState::Loading;
+    }
+
     // 7. If element contributes a script-blocking style sheet, append element to its node document's script-blocking style sheet set.
     if (style_element.contributes_a_script_blocking_style_sheet()) {
         m_document_load_event_delayer.emplace(style_element.document());
         style_element.document().script_blocking_style_sheet_set().set(style_element);
+        m_associated_css_style_sheet_is_blocking_scripts = true;
     }
 
     // FIXME: 8. If element's media attribute's value matches the environment and element is potentially render-blocking, then block rendering on element.
@@ -134,6 +162,7 @@ void StyleElementBase::finished_loading_critical_subresources(AnyFailed any_fail
 {
     // 1. Let element be the style element associated with the style sheet in question.
     auto& element = as_element();
+    auto const style_sheet_update_generation = m_style_sheet_update_generation;
 
     // 2. Let success be true.
     auto success = true;
@@ -146,7 +175,12 @@ void StyleElementBase::finished_loading_critical_subresources(AnyFailed any_fail
         success = false;
 
     // 4. Queue an element task on the networking task source given element and the following steps:
-    element.queue_an_element_task(HTML::Task::Source::UserInteraction, [&element, success] {
+    element.queue_an_element_task(HTML::Task::Source::UserInteraction, [&element, success, style_sheet_update_generation] {
+        // AD-HOC: If the associated stylesheet has been replaced or removed since this task was queued, ignore it.
+        auto* style_element_base = as_if<StyleElementBase>(element);
+        if (!style_element_base || style_element_base->m_style_sheet_update_generation != style_sheet_update_generation)
+            return;
+
         // 1. If success is true, fire an event named load at element.
         // AD-HOC: these should call fire an event this is not implemented anywhere so we dispatch it ourselves
         if (success)
@@ -158,12 +192,15 @@ void StyleElementBase::finished_loading_critical_subresources(AnyFailed any_fail
         if (element.contributes_a_script_blocking_style_sheet()) {
             // 1. Assert: element's node document's script-blocking style sheet set contains element.
             VERIFY(element.document().script_blocking_style_sheet_set().contains(element));
+            VERIFY(style_element_base->m_associated_css_style_sheet_is_blocking_scripts);
             // 2. Remove element from its node document's script-blocking style sheet set.
             element.document().script_blocking_style_sheet_set().remove(element);
             element.document().schedule_html_parser_end_check();
+            style_element_base->m_associated_css_style_sheet_is_blocking_scripts = false;
         }
         // 4. Unblock rendering on element.
         element.unblock_rendering();
+        style_element_base->m_associated_css_style_sheet_load_is_pending_for_script_blocking = false;
     });
     m_document_load_event_delayer.clear();
 }
@@ -171,24 +208,63 @@ void StyleElementBase::finished_loading_critical_subresources(AnyFailed any_fail
 // https://html.spec.whatwg.org/multipage/semantics.html#contributes-a-script-blocking-style-sheet
 bool StyleElementBase::style_element_contributes_a_script_blocking_style_sheet() const
 {
-    // An element el in the context of a Document of an HTML parser or XML parser
-    // contributes a script-blocking style sheet if all of the following are true:
+    // An element el in the context of a Document of an HTML parser or XML parser contributes a script-blocking style
+    // sheet if all of the following are true:
+    auto& element = as_element();
 
-    // FIXME: el was created by that Document's parser.
+    // el was created by that Document's parser.
+    if (m_parser_document != &element.document())
+        return false;
 
-    // el is either a style element or a link element that was an external resource link that contributes to the styling processing model when the el was created by the parser.
-    // NOTE: This is a style element, so all good!
+    if (!m_associated_css_style_sheet_was_created_by_parser)
+        return false;
+
+    // el is either a style element or a link element that was an external resource link that contributes to the
+    // styling processing model when the el was created by the parser.
+    // NB: This is a style element, so all good!
 
     // FIXME: el's media attribute's value matches the environment.
 
-    // FIXME: el's style sheet was enabled when the element was created by the parser.
+    // el's style sheet was enabled when the element was created by the parser.
+    if (!m_associated_css_style_sheet_was_enabled_when_created_by_parser)
+        return false;
 
     // FIXME: The last time the event loop reached step 1, el's root was that Document.
 
     // FIXME: The user agent hasn't given up on loading that particular style sheet yet.
     //        A user agent may give up on loading a style sheet at any time.
 
-    return false;
+    // AD-HOC: Once this parser-created stylesheet has finished loading or stopped blocking scripts, it no longer
+    //         contributes a script-blocking stylesheet even though it is still the current associated stylesheet.
+    // FIXME: May not be needed once the other clauses above are implemented.
+    if (!m_associated_css_style_sheet_load_is_pending_for_script_blocking)
+        return false;
+
+    return true;
+}
+
+void StyleElementBase::remove_from_script_blocking_style_sheet_set_if_needed()
+{
+    if (!m_associated_css_style_sheet_is_blocking_scripts)
+        return;
+
+    auto& element = as_element();
+    auto& script_blocking_style_sheet_set = element.document().script_blocking_style_sheet_set();
+    if (script_blocking_style_sheet_set.contains(element)) {
+        script_blocking_style_sheet_set.remove(element);
+        element.document().schedule_html_parser_end_check();
+    }
+
+    m_associated_css_style_sheet_is_blocking_scripts = false;
+    m_document_load_event_delayer.clear();
+}
+
+void StyleElementBase::clear_associated_css_style_sheet_parser_blocking_state()
+{
+    m_associated_css_style_sheet_was_created_by_parser = false;
+    m_associated_css_style_sheet_was_enabled_when_created_by_parser = false;
+    m_associated_css_style_sheet_load_is_pending_for_script_blocking = false;
+    m_associated_css_style_sheet_is_blocking_scripts = false;
 }
 
 // https://www.w3.org/TR/cssom/#dom-linkstyle-sheet

--- a/Libraries/LibWeb/DOM/StyleElementBase.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementBase.cpp
@@ -42,8 +42,10 @@ void StyleElementBase::update_a_style_block_for_dynamic_change()
 void StyleElementBase::style_element_attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     if (name == HTML::AttributeNames::media) {
-        if (auto* sheet = this->sheet())
+        if (auto* sheet = this->sheet()) {
             sheet->set_media(value.value_or({}));
+            associated_style_sheet_media_attribute_changed();
+        }
     } else if (name == HTML::AttributeNames::type) {
         update_a_style_block_for_dynamic_change();
     }
@@ -134,10 +136,12 @@ void StyleElementBase::update_a_style_block(UpdateSource update_source)
         nullptr,
         nullptr);
 
+    evaluate_associated_style_sheet_media_queries();
     if (update_source == UpdateSource::ParserPop) {
         m_associated_css_style_sheet_was_created_by_parser = true;
         m_associated_css_style_sheet_was_enabled_when_created_by_parser = !m_associated_css_style_sheet->disabled();
         m_associated_css_style_sheet_load_is_pending_for_script_blocking = m_associated_css_style_sheet_was_enabled_when_created_by_parser
+            && m_associated_css_style_sheet_media_matches_environment
             && m_associated_css_style_sheet->loading_state() == CSS::CSSStyleSheet::LoadingState::Loading;
     }
 
@@ -205,6 +209,15 @@ void StyleElementBase::finished_loading_critical_subresources(AnyFailed any_fail
     m_document_load_event_delayer.clear();
 }
 
+void StyleElementBase::associated_style_sheet_media_attribute_changed()
+{
+    evaluate_associated_style_sheet_media_queries();
+    if (!as_element().contributes_a_script_blocking_style_sheet()) {
+        remove_from_script_blocking_style_sheet_set_if_needed();
+        m_associated_css_style_sheet_load_is_pending_for_script_blocking = false;
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/semantics.html#contributes-a-script-blocking-style-sheet
 bool StyleElementBase::style_element_contributes_a_script_blocking_style_sheet() const
 {
@@ -223,7 +236,9 @@ bool StyleElementBase::style_element_contributes_a_script_blocking_style_sheet()
     // styling processing model when the el was created by the parser.
     // NB: This is a style element, so all good!
 
-    // FIXME: el's media attribute's value matches the environment.
+    // el's media attribute's value matches the environment.
+    if (!m_associated_css_style_sheet_media_matches_environment)
+        return false;
 
     // el's style sheet was enabled when the element was created by the parser.
     if (!m_associated_css_style_sheet_was_enabled_when_created_by_parser)
@@ -241,6 +256,17 @@ bool StyleElementBase::style_element_contributes_a_script_blocking_style_sheet()
         return false;
 
     return true;
+}
+
+void StyleElementBase::evaluate_associated_style_sheet_media_queries()
+{
+    if (!m_associated_css_style_sheet) {
+        m_associated_css_style_sheet_media_matches_environment = false;
+        return;
+    }
+
+    m_associated_css_style_sheet->evaluate_media_queries(as_element().document());
+    m_associated_css_style_sheet_media_matches_environment = m_associated_css_style_sheet->media()->matches();
 }
 
 void StyleElementBase::remove_from_script_blocking_style_sheet_set_if_needed()
@@ -263,6 +289,7 @@ void StyleElementBase::clear_associated_css_style_sheet_parser_blocking_state()
 {
     m_associated_css_style_sheet_was_created_by_parser = false;
     m_associated_css_style_sheet_was_enabled_when_created_by_parser = false;
+    m_associated_css_style_sheet_media_matches_environment = false;
     m_associated_css_style_sheet_load_is_pending_for_script_blocking = false;
     m_associated_css_style_sheet_is_blocking_scripts = false;
 }

--- a/Libraries/LibWeb/DOM/StyleElementBase.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementBase.cpp
@@ -14,10 +14,26 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/StyleElementBase.h>
+#include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/Infra/Strings.h>
 
 namespace Web::DOM {
+
+void StyleElementBase::update_a_style_block_for_dynamic_change()
+{
+    update_a_style_block();
+}
+
+void StyleElementBase::style_element_attribute_changed(FlyString const& name, Optional<String> const& value)
+{
+    if (name == HTML::AttributeNames::media) {
+        if (auto* sheet = this->sheet())
+            sheet->set_media(value.value_or({}));
+    } else if (name == HTML::AttributeNames::type) {
+        update_a_style_block_for_dynamic_change();
+    }
+}
 
 // The user agent must run the "update a style block" algorithm whenever one of the following conditions occur:
 // FIXME: The element is popped off the stack of open elements of an HTML parser or XML parser.
@@ -150,6 +166,29 @@ void StyleElementBase::finished_loading_critical_subresources(AnyFailed any_fail
         element.unblock_rendering();
     });
     m_document_load_event_delayer.clear();
+}
+
+// https://html.spec.whatwg.org/multipage/semantics.html#contributes-a-script-blocking-style-sheet
+bool StyleElementBase::style_element_contributes_a_script_blocking_style_sheet() const
+{
+    // An element el in the context of a Document of an HTML parser or XML parser
+    // contributes a script-blocking style sheet if all of the following are true:
+
+    // FIXME: el was created by that Document's parser.
+
+    // el is either a style element or a link element that was an external resource link that contributes to the styling processing model when the el was created by the parser.
+    // NOTE: This is a style element, so all good!
+
+    // FIXME: el's media attribute's value matches the environment.
+
+    // FIXME: el's style sheet was enabled when the element was created by the parser.
+
+    // FIXME: The last time the event loop reached step 1, el's root was that Document.
+
+    // FIXME: The user agent hasn't given up on loading that particular style sheet yet.
+    //        A user agent may give up on loading a style sheet at any time.
+
+    return false;
 }
 
 // https://www.w3.org/TR/cssom/#dom-linkstyle-sheet

--- a/Libraries/LibWeb/DOM/StyleElementBase.h
+++ b/Libraries/LibWeb/DOM/StyleElementBase.h
@@ -18,6 +18,8 @@ public:
     virtual ~StyleElementBase() = default;
 
     void update_a_style_block();
+    void update_a_style_block_for_dynamic_change();
+    void style_element_attribute_changed(FlyString const&, Optional<String> const& value);
 
     CSS::CSSStyleSheet* sheet();
     CSS::CSSStyleSheet const* sheet() const;
@@ -34,6 +36,10 @@ public:
     void visit_style_element_edges(JS::Cell::Visitor&);
 
     virtual Element& as_element() = 0;
+    virtual Element const& as_element() const = 0;
+
+protected:
+    bool style_element_contributes_a_script_blocking_style_sheet() const;
 
 private:
     // https://www.w3.org/TR/cssom/#associated-css-style-sheet

--- a/Libraries/LibWeb/DOM/StyleElementBase.h
+++ b/Libraries/LibWeb/DOM/StyleElementBase.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Forward.h>
@@ -17,8 +18,14 @@ class StyleElementBase {
 public:
     virtual ~StyleElementBase() = default;
 
-    void update_a_style_block();
+    enum class UpdateSource : u8 {
+        Dynamic,
+        ParserPop,
+    };
+    void update_a_style_block(UpdateSource = UpdateSource::Dynamic);
     void update_a_style_block_for_dynamic_change();
+    void set_parser_document(Badge<HTML::HTMLParser>, GC::Ref<Document>);
+    void did_pop_off_parser_stack_of_open_elements();
     void style_element_attribute_changed(FlyString const&, Optional<String> const& value);
 
     CSS::CSSStyleSheet* sheet();
@@ -42,12 +49,25 @@ protected:
     bool style_element_contributes_a_script_blocking_style_sheet() const;
 
 private:
+    void remove_from_script_blocking_style_sheet_set_if_needed();
+    void clear_associated_css_style_sheet_parser_blocking_state();
+
+    GC::Weak<Document> m_parser_document;
+
     // https://www.w3.org/TR/cssom/#associated-css-style-sheet
     GC::Ptr<CSS::CSSStyleSheet> m_associated_css_style_sheet;
 
     GC::Ptr<CSS::StyleSheetList> m_style_sheet_list;
 
     Optional<DocumentLoadEventDelayer> m_document_load_event_delayer;
+
+    u64 m_style_sheet_update_generation { 0 };
+
+    bool m_associated_css_style_sheet_was_created_by_parser : 1 { false };
+    bool m_associated_css_style_sheet_was_enabled_when_created_by_parser : 1 { false };
+    bool m_associated_css_style_sheet_load_is_pending_for_script_blocking : 1 { false };
+    bool m_associated_css_style_sheet_is_blocking_scripts : 1 { false };
+    bool m_is_on_parser_stack_of_open_elements : 1 { false };
 };
 
 }

--- a/Libraries/LibWeb/DOM/StyleElementBase.h
+++ b/Libraries/LibWeb/DOM/StyleElementBase.h
@@ -24,6 +24,7 @@ public:
     };
     void update_a_style_block(UpdateSource = UpdateSource::Dynamic);
     void update_a_style_block_for_dynamic_change();
+    void associated_style_sheet_media_attribute_changed();
     void set_parser_document(Badge<HTML::HTMLParser>, GC::Ref<Document>);
     void did_pop_off_parser_stack_of_open_elements();
     void style_element_attribute_changed(FlyString const&, Optional<String> const& value);
@@ -49,6 +50,7 @@ protected:
     bool style_element_contributes_a_script_blocking_style_sheet() const;
 
 private:
+    void evaluate_associated_style_sheet_media_queries();
     void remove_from_script_blocking_style_sheet_set_if_needed();
     void clear_associated_css_style_sheet_parser_blocking_state();
 
@@ -65,6 +67,7 @@ private:
 
     bool m_associated_css_style_sheet_was_created_by_parser : 1 { false };
     bool m_associated_css_style_sheet_was_enabled_when_created_by_parser : 1 { false };
+    bool m_associated_css_style_sheet_media_matches_environment : 1 { false };
     bool m_associated_css_style_sheet_load_is_pending_for_script_blocking : 1 { false };
     bool m_associated_css_style_sheet_is_blocking_scripts : 1 { false };
     bool m_is_on_parser_stack_of_open_elements : 1 { false };

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -7,8 +7,6 @@
  */
 
 #include <LibWeb/Bindings/HTMLStyleElement.h>
-#include <LibWeb/CSS/StyleComputer.h>
-#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLStyleElement.h>
 
 namespace Web::HTML {
@@ -37,31 +35,25 @@ void HTMLStyleElement::visit_edges(Cell::Visitor& visitor)
 void HTMLStyleElement::children_changed(ChildrenChangedMetadata const& metadata)
 {
     Base::children_changed(metadata);
-    update_a_style_block();
+    update_a_style_block_for_dynamic_change();
 }
 
 void HTMLStyleElement::inserted()
 {
     Base::inserted();
-    update_a_style_block();
+    update_a_style_block_for_dynamic_change();
 }
 
 void HTMLStyleElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
     Base::removed_from(is_subtree_root, old_ancestor, old_root);
-    update_a_style_block();
+    update_a_style_block_for_dynamic_change();
 }
 
 void HTMLStyleElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);
-
-    if (name == HTML::AttributeNames::media) {
-        if (auto* sheet = this->sheet())
-            sheet->set_media(value.value_or({}));
-    } else if (name == HTML::AttributeNames::type) {
-        update_a_style_block();
-    }
+    style_element_attribute_changed(name, value);
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-style-disabled
@@ -94,24 +86,7 @@ void HTMLStyleElement::set_disabled(bool disabled)
 // https://html.spec.whatwg.org/multipage/semantics.html#contributes-a-script-blocking-style-sheet
 bool HTMLStyleElement::contributes_a_script_blocking_style_sheet() const
 {
-    // An element el in the context of a Document of an HTML parser or XML parser
-    // contributes a script-blocking style sheet if all of the following are true:
-
-    // FIXME: el was created by that Document's parser.
-
-    // el is either a style element or a link element that was an external resource link that contributes to the styling processing model when the el was created by the parser.
-    // NOTE: This is a style element, so all good!
-
-    // FIXME: el's media attribute's value matches the environment.
-
-    // FIXME: el's style sheet was enabled when the element was created by the parser.
-
-    // FIXME: The last time the event loop reached step 1, el's root was that Document.
-
-    // FIXME: The user agent hasn't given up on loading that particular style sheet yet.
-    //        A user agent may give up on loading a style sheet at any time.
-
-    return false;
+    return style_element_contributes_a_script_blocking_style_sheet();
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -39,6 +39,7 @@ private:
 
     // ^DOM::StyleElementBase
     virtual Element& as_element() override { return *this; }
+    virtual Element const& as_element() const override { return *this; }
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -28,6 +28,7 @@
 #include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/DOM/QualifiedName.h>
 #include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/DOM/StyleElementBase.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/CustomElements/CustomElementDefinition.h>
 #include <LibWeb/HTML/CustomElements/CustomElementRegistry.h>
@@ -704,6 +705,11 @@ GC::Ref<DOM::Element> HTMLParser::create_element_for(HTMLToken const& token, Opt
         link_element.set_parser_document({}, document);
         link_element.set_was_enabled_when_created_by_parser({}, !token.has_attribute(HTML::AttributeNames::disabled));
     }
+
+    // AD-HOC: Let style elements know which document they were originally parsed for.
+    //         This is used for the render-blocking logic.
+    if (auto* style_element = as_if<DOM::StyleElementBase>(*element))
+        style_element->set_parser_document({}, document);
 
     // 11. Append each attribute in the given token to element.
     token.for_each_attribute([&](auto const& attribute) {
@@ -1936,6 +1942,12 @@ extern "C" void ladybird_html_parser_remove_node(size_t node)
 
 extern "C" void ladybird_html_parser_handle_element_popped(size_t element)
 {
+    // https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block
+    // When a style element is popped off the stack of open elements of an HTML parser or XML parser,
+    // the user agent must run the update a style block algorithm.
+    if (auto* style_element = as_if<DOM::StyleElementBase>(node_from_html_parser_ffi(element)))
+        style_element->did_pop_off_parser_stack_of_open_elements();
+
     // https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element
     // When an option element is popped off the stack of open elements of an HTML parser or XML parser,
     // the user agent must run maybe clone an option into selectedcontent given the option element.

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
@@ -2657,7 +2657,9 @@ impl TreeBuilder {
                     .eq_ignore_ascii_case(token.tag_name())
                 {
                     self.flush_character_insertions();
-                    self.stack_of_open_elements.truncate(index);
+                    while self.stack_of_open_elements.len() > index {
+                        self.pop_stack_node();
+                    }
                     return;
                 }
 

--- a/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -33,19 +33,30 @@ void SVGStyleElement::visit_edges(Cell::Visitor& visitor)
 void SVGStyleElement::children_changed(ChildrenChangedMetadata const& metadata)
 {
     Base::children_changed(metadata);
-    update_a_style_block();
+    update_a_style_block_for_dynamic_change();
 }
 
 void SVGStyleElement::inserted()
 {
     Base::inserted();
-    update_a_style_block();
+    update_a_style_block_for_dynamic_change();
 }
 
 void SVGStyleElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
     Base::removed_from(is_subtree_root, old_ancestor, old_root);
-    update_a_style_block();
+    update_a_style_block_for_dynamic_change();
+}
+
+void SVGStyleElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+{
+    Base::attribute_changed(name, old_value, value, namespace_);
+    style_element_attribute_changed(name, value);
+}
+
+bool SVGStyleElement::contributes_a_script_blocking_style_sheet() const
+{
+    return style_element_contributes_a_script_blocking_style_sheet();
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGStyleElement.h
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.h
@@ -23,6 +23,8 @@ public:
     virtual void children_changed(ChildrenChangedMetadata const&) override;
     virtual void inserted() override;
     virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+    virtual bool contributes_a_script_blocking_style_sheet() const final;
 
 private:
     SVGStyleElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGStyleElement.h
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.h
@@ -32,6 +32,7 @@ private:
 
     // ^DOM::StyleElementBase
     virtual Element& as_element() override { return *this; }
+    virtual Element const& as_element() const override { return *this; }
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Tests/LibWeb/Text/expected/HTML/parser-created-style-script-blocking.txt
+++ b/Tests/LibWeb/Text/expected/HTML/parser-created-style-script-blocking.txt
@@ -1,3 +1,5 @@
 Parser-created style import available to following script: rgb(1, 2, 3)
 Dynamic style update blocked following parser script: false
 Removed parser-created style blocked until import finished: false
+Non-matching media style blocked following parser script: false
+Media change blocked until import finished: false

--- a/Tests/LibWeb/Text/expected/HTML/parser-created-style-script-blocking.txt
+++ b/Tests/LibWeb/Text/expected/HTML/parser-created-style-script-blocking.txt
@@ -1,5 +1,10 @@
 Parser-created style import available to following script: rgb(1, 2, 3)
+Parser-created SVG style import blocked following parser script: true
 Dynamic style update blocked following parser script: false
+Dynamic SVG style update blocked following parser script: false
+Dynamic SVG style type change blocked following parser script: false
 Removed parser-created style blocked until import finished: false
 Non-matching media style blocked following parser script: false
+Non-matching SVG media style blocked following parser script: false
 Media change blocked until import finished: false
+SVG media change blocked until import finished: false

--- a/Tests/LibWeb/Text/expected/HTML/parser-created-style-script-blocking.txt
+++ b/Tests/LibWeb/Text/expected/HTML/parser-created-style-script-blocking.txt
@@ -1,0 +1,3 @@
+Parser-created style import available to following script: rgb(1, 2, 3)
+Dynamic style update blocked following parser script: false
+Removed parser-created style blocked until import finished: false

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/cssimportrule.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/cssimportrule.txt
@@ -2,14 +2,13 @@ Harness status: OK
 
 Found 11 tests
 
-10 Pass
-1 Fail
+11 Pass
 Pass	CSSRule and CSSImportRule types
 Pass	Type of CSSRule#type and constant values
 Pass	Existence and writability of CSSRule attributes
 Pass	Values of CSSRule attributes
 Pass	Existence and writability of CSSImportRule attributes
-Fail	Values of CSSImportRule attributes
+Pass	Values of CSSImportRule attributes
 Pass	CSSImportRule : MediaList mediaText attribute should be updated due to [PutForwards]
 Pass	CSSStyleDeclaration cssText attribute should be updated due to [PutForwards]
 Pass	StyleSheet : MediaList mediaText attribute should be updated due to [PutForwards]

--- a/Tests/LibWeb/Text/input/HTML/parser-created-style-script-blocking.html
+++ b/Tests/LibWeb/Text/input/HTML/parser-created-style-script-blocking.html
@@ -52,6 +52,19 @@
         `);
         println(`Parser-created style import available to following script: ${parserBlockingColor}`);
 
+        const svgParserBlockingStyle = await slowStyleSheet("/parser-created-svg-style-script-blocking.css");
+        const svgParserBlockingBlocked = await runFrame("/parser-created-svg-style-script-blocking-page", `
+            <!DOCTYPE html>
+            ${scriptStart}
+                window.svgParserBlockingStart = performance.now();
+            ${scriptEnd}
+            <svg><style>@import url("${svgParserBlockingStyle}");</style></svg>
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.svgParserBlockingStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`Parser-created SVG style import blocked following parser script: ${svgParserBlockingBlocked}`);
+
         const dynamicUpdateStyle = await slowStyleSheet("/dynamic-style-update-should-not-block.css");
         const dynamicUpdateBlocked = await runFrame("/dynamic-style-update-should-not-block-page", `
             <!DOCTYPE html>
@@ -65,6 +78,34 @@
             ${scriptEnd}
         `);
         println(`Dynamic style update blocked following parser script: ${dynamicUpdateBlocked}`);
+
+        const dynamicSvgUpdateStyle = await slowStyleSheet("/dynamic-svg-style-update-should-not-block.css");
+        const dynamicSvgUpdateBlocked = await runFrame("/dynamic-svg-style-update-should-not-block-page", `
+            <!DOCTYPE html>
+            <svg><style id="style"></style></svg>
+            ${scriptStart}
+                window.dynamicSvgUpdateStart = performance.now();
+                document.getElementById("style").textContent = '@import url("${dynamicSvgUpdateStyle}");';
+            ${scriptEnd}
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.dynamicSvgUpdateStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`Dynamic SVG style update blocked following parser script: ${dynamicSvgUpdateBlocked}`);
+
+        const dynamicSvgTypeStyle = await slowStyleSheet("/dynamic-svg-style-type-update-should-not-block.css");
+        const dynamicSvgTypeBlocked = await runFrame("/dynamic-svg-style-type-update-should-not-block-page", `
+            <!DOCTYPE html>
+            <svg><style id="style" type="text/plain">@import url("${dynamicSvgTypeStyle}");</style></svg>
+            ${scriptStart}
+                window.dynamicSvgTypeStart = performance.now();
+                document.getElementById("style").setAttribute("type", "text/css");
+            ${scriptEnd}
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.dynamicSvgTypeStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`Dynamic SVG style type change blocked following parser script: ${dynamicSvgTypeBlocked}`);
 
         const removedStyle = await slowStyleSheet("/removed-parser-created-style-should-unblock.css");
         const removedStyleBlocked = await runFrame("/removed-parser-created-style-should-unblock-page", `
@@ -93,6 +134,19 @@
         `);
         println(`Non-matching media style blocked following parser script: ${nonMatchingMediaBlocked}`);
 
+        const nonMatchingSvgMedia = await slowStyleSheet("/non-matching-svg-media-style-should-not-block.css");
+        const nonMatchingSvgMediaBlocked = await runFrame("/non-matching-svg-media-style-should-not-block-page", `
+            <!DOCTYPE html>
+            ${scriptStart}
+                window.svgMediaStart = performance.now();
+            ${scriptEnd}
+            <svg><style media="not all">@import url("${nonMatchingSvgMedia}");</style></svg>
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.svgMediaStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`Non-matching SVG media style blocked following parser script: ${nonMatchingSvgMediaBlocked}`);
+
         const changedMedia = await slowStyleSheet("/changed-media-style-should-unblock.css");
         const changedMediaBlocked = await runFrame("/changed-media-style-should-unblock-page", `
             <!DOCTYPE html>
@@ -106,6 +160,20 @@
             ${scriptEnd}
         `);
         println(`Media change blocked until import finished: ${changedMediaBlocked}`);
+
+        const changedSvgMedia = await slowStyleSheet("/changed-svg-media-style-should-unblock.css");
+        const changedSvgMediaBlocked = await runFrame("/changed-svg-media-style-should-unblock-page", `
+            <!DOCTYPE html>
+            ${scriptStart}
+                window.svgMediaChangeStart = performance.now();
+                setTimeout(() => document.getElementById("style").media = "not all", 0);
+            ${scriptEnd}
+            <svg><style id="style">@import url("${changedSvgMedia}");</style></svg>
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.svgMediaChangeStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`SVG media change blocked until import finished: ${changedSvgMediaBlocked}`);
 
         done();
     });

--- a/Tests/LibWeb/Text/input/HTML/parser-created-style-script-blocking.html
+++ b/Tests/LibWeb/Text/input/HTML/parser-created-style-script-blocking.html
@@ -80,6 +80,33 @@
         `);
         println(`Removed parser-created style blocked until import finished: ${removedStyleBlocked}`);
 
+        const nonMatchingMedia = await slowStyleSheet("/non-matching-media-style-should-not-block.css");
+        const nonMatchingMediaBlocked = await runFrame("/non-matching-media-style-should-not-block-page", `
+            <!DOCTYPE html>
+            ${scriptStart}
+                window.mediaStart = performance.now();
+            ${scriptEnd}
+            <style media="not all">@import url("${nonMatchingMedia}");</style>
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.mediaStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`Non-matching media style blocked following parser script: ${nonMatchingMediaBlocked}`);
+
+        const changedMedia = await slowStyleSheet("/changed-media-style-should-unblock.css");
+        const changedMediaBlocked = await runFrame("/changed-media-style-should-unblock-page", `
+            <!DOCTYPE html>
+            ${scriptStart}
+                window.mediaChangeStart = performance.now();
+                setTimeout(() => document.getElementById("style").media = "not all", 0);
+            ${scriptEnd}
+            <style id="style">@import url("${changedMedia}");</style>
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.mediaChangeStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`Media change blocked until import finished: ${changedMediaBlocked}`);
+
         done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/parser-created-style-script-blocking.html
+++ b/Tests/LibWeb/Text/input/HTML/parser-created-style-script-blocking.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        internals.setTestTimeout(10000);
+
+        const httpServer = httpTestServer();
+        const scriptStart = "<scr" + "ipt>";
+        const scriptEnd = "</scr" + "ipt>";
+
+        async function slowStyleSheet(path, body = "body { color: rgb(1, 2, 3); }") {
+            return await httpServer.createEcho("GET", path, {
+                status: 200,
+                headers: {
+                    "Cache-Control": "no-store",
+                    "Content-Type": "text/css",
+                },
+                body,
+                delay_ms: 800,
+            });
+        }
+
+        async function runFrame(path, body) {
+            const url = await httpServer.createEcho("GET", path, {
+                status: 200,
+                headers: {
+                    "Cache-Control": "no-store",
+                    "Content-Type": "text/html",
+                },
+                body,
+            });
+
+            return await new Promise(resolve => {
+                const frame = document.createElement("iframe");
+                window.addEventListener("message", event => {
+                    frame.remove();
+                    resolve(event.data);
+                }, { once: true });
+                frame.src = url;
+                document.body.appendChild(frame);
+            });
+        }
+
+        const parserBlockingStyle = await slowStyleSheet("/parser-created-style-script-blocking.css");
+        const parserBlockingColor = await runFrame("/parser-created-style-script-blocking-page", `
+            <!DOCTYPE html>
+            <style>@import url("${parserBlockingStyle}");</style>
+            <body>
+            ${scriptStart}
+                parent.postMessage(getComputedStyle(document.body).color, "*");
+            ${scriptEnd}
+        `);
+        println(`Parser-created style import available to following script: ${parserBlockingColor}`);
+
+        const dynamicUpdateStyle = await slowStyleSheet("/dynamic-style-update-should-not-block.css");
+        const dynamicUpdateBlocked = await runFrame("/dynamic-style-update-should-not-block-page", `
+            <!DOCTYPE html>
+            <style id="style"></style>
+            ${scriptStart}
+                window.dynamicUpdateStart = performance.now();
+                document.getElementById("style").textContent = '@import url("${dynamicUpdateStyle}");';
+            ${scriptEnd}
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.dynamicUpdateStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`Dynamic style update blocked following parser script: ${dynamicUpdateBlocked}`);
+
+        const removedStyle = await slowStyleSheet("/removed-parser-created-style-should-unblock.css");
+        const removedStyleBlocked = await runFrame("/removed-parser-created-style-should-unblock-page", `
+            <!DOCTYPE html>
+            ${scriptStart}
+                window.removeStart = performance.now();
+                setTimeout(() => document.getElementById("style").remove(), 0);
+            ${scriptEnd}
+            <style id="style">@import url("${removedStyle}");</style>
+            ${scriptStart}
+                parent.postMessage(performance.now() - window.removeStart >= 700, "*");
+            ${scriptEnd}
+        `);
+        println(`Removed parser-created style blocked until import finished: ${removedStyleBlocked}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
We had `HTMLStyleElement::contributes_a_script_blocking_style_sheet()` before, but it always returned false so scripts wouldn't wait for style sheets to be loaded. Oops.

This PR implements the majority of it, while also moving it into StyleElementBase so that SVGStyleElement also gets the same behaviour.

There's an additional small fix that any `@import supports(...)` that doesn't match is now treated as loaded instead of being stuck in the loading state forever.