### PR TITLE
UI/Qt: Let fullscreen content occupy the whole window

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -180,7 +180,7 @@ bool FullscreenMode::eventFilter(QObject* obj, QEvent* event)
     ASSERT(is_api_fullscreen());
     if (event->type() == QEvent::MouseMove) {
         QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
-        maybe_animate_show_exit_button(mouse_event->pos());
+        maybe_animate_show_exit_button(m_window->mapFromGlobal(mouse_event->globalPosition().toPoint()));
     }
 
     return QObject::eventFilter(obj, event);
@@ -189,10 +189,14 @@ bool FullscreenMode::eventFilter(QObject* obj, QEvent* event)
 ExitFullscreenButton::ExitFullscreenButton(QWidget* parent)
     : QPushButton("Exit fullscreen", parent)
 {
+#if defined(AK_OS_MACOS)
+    // The web content view is a native QRhiWidget on macOS, so this overlay must also be native to remain above it.
+    setAttribute(Qt::WA_NativeWindow);
+#endif
     setStyleSheet("background-color:rgb(55, 99, 129); color: white; padding: 10px; border-radius: 5px;");
     adjustSize();
     hide();
-    m_widget_animation = new QPropertyAnimation(this, "pos");
+    m_widget_animation = new QPropertyAnimation(this, "pos", this);
 }
 
 void ExitFullscreenButton::animate_show()
@@ -201,12 +205,13 @@ void ExitFullscreenButton::animate_show()
         return;
 
     show();
-    QScreen* current_screen = screen();
-    QRect screen_geometry = current_screen->geometry();
+    raise();
 
-    int const destination_x = (screen_geometry.width() - width()) / 2;
-    int const destination_y = static_cast<int>(static_cast<float>(screen_geometry.height()) * 0.05);
+    auto const container_size = screen() ? screen()->geometry().size() : (parentWidget() ? parentWidget()->size() : QSize {});
+    int const destination_x = (container_size.width() - width()) / 2;
+    int const destination_y = static_cast<int>(static_cast<float>(container_size.height()) * 0.05);
 
+    m_widget_animation->stop();
     m_widget_animation->setDuration(FullscreenMode::button_animation_time());
     m_widget_animation->setStartValue(QPoint(destination_x, -height()));
     m_widget_animation->setEndValue(QPoint(destination_x, destination_y));

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -494,13 +494,11 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     view().on_fullscreen_window = [this]() {
-        m_toolbar_container->hide();
         m_window->fullscreen_mode().enter(this);
     };
 
     view().on_exit_fullscreen_window = [this]() {
         m_window->fullscreen_mode().exit(FullscreenMode::ExitInitiatedBy::WebContent);
-        m_toolbar_container->show();
     };
 
     view().on_audio_play_state_changed = [this](auto play_state) {

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1319,6 +1319,7 @@ void TabWidget::set_tab_bar_visible(bool visible)
 
     m_tab_bar_visible = visible;
     update_tab_chrome_visibility();
+    update_tab_layout();
 }
 
 void TabWidget::set_window_controls_visible(bool visible)
@@ -1579,6 +1580,8 @@ bool TabWidget::cursor_is_over_vertical_tabs() const
 
 int TabWidget::vertical_tabs_layout_width() const
 {
+    if (!m_tab_bar_visible)
+        return 0;
     return m_vertical_tabs_expanded ? m_vertical_tabs_expanded_width : VERTICAL_TABS_COLLAPSED_WIDTH;
 }
 
@@ -1725,7 +1728,7 @@ void TabWidget::set_resize_handle_property(char const* property, bool enabled)
 void TabWidget::update_vertical_tabs_resize_handle()
 {
     auto is_vertical = m_tab_bar->tab_layout() != TabLayout::Horizontal;
-    auto show_resize_handle = is_vertical && m_vertical_tabs_expanded;
+    auto show_resize_handle = m_tab_bar_visible && is_vertical && m_vertical_tabs_expanded;
     m_vertical_tabs_resize_handle->setVisible(show_resize_handle);
     if (!show_resize_handle) {
         m_vertical_tabs_resize_handle->releaseMouse();
@@ -1873,6 +1876,7 @@ void TabWidget::update_tab_chrome_visibility()
     auto is_horizontal = tab_layout == TabLayout::Horizontal;
     auto show_top_row = m_tab_bar_visible && is_horizontal;
     m_tab_bar_row->setVisible(show_top_row);
+    m_toolbar_container->setVisible(m_tab_bar_visible);
     m_vertical_tab_bar_column->setVisible(m_tab_bar_visible && !is_horizontal);
     update_vertical_tabs_content_separator();
 
@@ -1906,7 +1910,7 @@ void TabWidget::update_chrome_style()
 
 void TabWidget::update_vertical_tabs_overlay_geometry()
 {
-    if (m_tab_bar->tab_layout() == TabLayout::Horizontal) {
+    if (!m_tab_bar_visible || m_tab_bar->tab_layout() == TabLayout::Horizontal) {
         m_vertical_tab_bar_column->hide();
         return;
     }


### PR DESCRIPTION
This PR fixes the fullscreen look after all the recent browser window changes. There were previously black bars around the fullscreen content, and if vertical tabs were enabled, they would not disappear. The "exit fullscreen" button was also quite broken.

Before:
<img width="2560" height="1440" alt="before" src="https://github.com/user-attachments/assets/1eab36ca-c014-4452-9bbe-abdd3313da32" />

After:
<img width="2560" height="1440" alt="after" src="https://github.com/user-attachments/assets/1fcbfb27-c167-4dcc-b042-a8d7379b78ad" />

