### PR TITLE
LibWeb: Enforce autoplay permission on HTMLMediaElement.play()    Closes #9723

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -511,11 +511,16 @@ void HTMLMediaElement::set_duration(double duration)
     set_needs_repaint();
 }
 
+// https://html.spec.whatwg.org/multipage/media.html#dom-media-play
 GC::Ref<WebIDL::Promise> HTMLMediaElement::play()
 {
     auto& realm = this->realm();
 
-    // FIXME: 1. If the media element is not allowed to play, then return a promise rejected with a "NotAllowedError" DOMException.
+    // 1. If the media element is not allowed to play, then return a promise rejected with a "NotAllowedError" DOMException.
+    if (!is_allowed_to_play()) {
+        auto exception = WebIDL::NotAllowedError::create(realm, "play() failed because the user didn't interact with the document first."_utf16);
+        return WebIDL::create_rejected_promise_from_exception(realm, exception);
+    }
 
     // 2. If the media element's error attribute is not null and its code is MEDIA_ERR_SRC_NOT_SUPPORTED, then return a promise
     //    rejected with a "NotSupportedError" DOMException.
@@ -596,7 +601,9 @@ void HTMLMediaElement::volume_or_muted_attribute_changed()
         dispatch_event(DOM::Event::create(realm(), HTML::EventNames::volumechange));
     });
 
-    // FIXME: Then, if the media element is not allowed to play, the user agent must run the internal pause steps for the media element.
+    // Then, if the media element is not allowed to play, the user agent must run the internal pause steps for the media element.
+    if (!is_allowed_to_play())
+        pause_element();
 
     update_volume();
 }
@@ -2642,6 +2649,31 @@ bool HTMLMediaElement::potentially_playing() const
     // playback, playback has not stopped due to errors, and the element is not a blocked media element.
     // FIXME: Implement "stopped due to errors".
     return !paused() && !ended() && !blocked();
+}
+
+// https://html.spec.whatwg.org/multipage/media.html#allowed-to-play
+bool HTMLMediaElement::is_allowed_to_play() const
+{
+    // A media element is said to be allowed to play if the user agent and the system allow
+    // media playback in the current context.
+    //
+    // For example, a user agent could allow playback only when the media element's Window object
+    // has transient activation, but an exception could be made to allow playback while muted.
+
+    auto const& global_object = HTML::relevant_global_object(document());
+    if (auto* window = as_if<HTML::Window>(global_object)) {
+        // NB: Allow playback when the relevant window has transient activation (spec example above).
+        if (window->has_transient_activation())
+            return true;
+    }
+
+    // NB: Allow inaudible playback without interaction; matches muted-autoplay behavior in
+    // Chrome/Firefox and the spec's "exception ... while muted" example.
+    if (effective_media_volume() == 0.0)
+        return true;
+
+    // NB: Otherwise use the autoplay permissions allowlist (PolicyControlledFeature::Autoplay).
+    return document().is_allowed_to_use_feature(DOM::PolicyControlledFeature::Autoplay);
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#eligible-for-autoplay

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -253,6 +253,7 @@ private:
     void clear_compositor_video_frame();
     void update_current_video_frame();
 
+    bool is_allowed_to_play() const;
     bool is_eligible_for_autoplay() const;
 
     enum class PlaybackDirection : u8 {

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-play-without-user-activation.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-play-without-user-activation.txt
@@ -1,0 +1,2 @@
+PASS: unmuted play() rejected with NotAllowedError
+PASS: muted play() allowed without user activation

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-play-without-user-activation.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-play-without-user-activation.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<video id="unmuted-video" src="../../../Assets/test-webm.webm"></video>
+<video id="muted-video" src="../../../Assets/test-webm.webm" muted></video>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        unmuted_video.play().then(
+            () => {
+                println("FAIL: unmuted play() succeeded without user activation");
+                done();
+            },
+            error => {
+                if (error.name === "NotAllowedError")
+                    println("PASS: unmuted play() rejected with NotAllowedError");
+                else
+                    println("FAIL: unmuted play() rejected with " + error.name);
+                done();
+            },
+        );
+    });
+
+    asyncTest(done => {
+        muted_video.play().then(
+            () => {
+                println("PASS: muted play() allowed without user activation");
+                done();
+            },
+            error => {
+                println("FAIL: muted play() rejected with " + error.name);
+                done();
+            },
+        );
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-resize-event-during-playback.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-resize-event-during-playback.html
@@ -18,6 +18,7 @@
         await new Promise(resolve => video.addEventListener("loadedmetadata", resolve, { once: true }));
 
         println("--- play ---");
+        video.muted = true;
         await video.play();
         await new Promise(resolve => video.addEventListener("ended", resolve, { once: true }));
 

--- a/Tests/LibWeb/Text/input/HTML/media-source-setup.html
+++ b/Tests/LibWeb/Text/input/HTML/media-source-setup.html
@@ -99,7 +99,8 @@
                     step("endOfStream succeeded");
                     printBuffered("endOfStream");
 
-                    // Step 9: Play
+                    // Step 9: Play (muted so play() is allowed without user activation on non-allowlisted origins)
+                    video.muted = true;
                     video.addEventListener("error", () => {
                         fail("playback", video.error?.message ?? "unknown error");
                     });


### PR DESCRIPTION
## Summary
- Implement \`is_allowed_to_play()\` and use it in \`HTMLMediaElement::play()\` so programmatic playback respects user activation, muted/inaudible media rules, and the autoplay permissions allowlist.
- Pause playback when volume/mute changes make the element no longer allowed to play.
- Add a LibWeb text test for unmuted vs muted \`play()\` without user activation.

Closes #9723

## Test plan
- [ ] CI: \`test-web -f HTMLMediaElement-play-without-user-activation\`
- [ ] CI: \`test-web -f autoplay-of-file-video-from-file-document\`
- [ ] Manual: open a YouTube watch URL with autoplay restricted to allowlisted sites only; confirm no audible playback until user interaction"