### PR TITLE
LibWebView+UI: Some settings cleanup

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1391,6 +1391,11 @@ void Application::initialize_actions()
     });
     update_vertical_tabs_action();
 
+    m_toggle_menu_bar_action = Action::create_checkable("Show Menubar"sv, ActionID::ToggleMenuBar, [this]() {
+        m_settings.set_show_menu_bar(!m_settings.show_menu_bar());
+    });
+    m_toggle_menu_bar_action->set_checked(m_settings.show_menu_bar());
+
     m_bookmarks_menu = Menu::create("Bookmarks"sv);
     m_bookmarks_menu->add_action(Action::create("Manage Bookmarks"sv, ActionID::ManageBookmarks, [this]() {
         open_url_in_new_tab(URL::about_bookmarks(), Web::HTML::ActivateTab::Yes);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -68,11 +68,6 @@ struct ApplicationSettingsObserver final : public SettingsObserver {
         Application::the().tab_settings_changed({});
     }
 
-    virtual void show_bookmarks_bar_changed() override
-    {
-        Application::the().show_bookmarks_bar_changed({});
-    }
-
     virtual void browsing_data_settings_changed() override
     {
         auto const& browsing_data_settings = Application::settings().browsing_data_settings();
@@ -1415,11 +1410,11 @@ void Application::initialize_actions()
     m_bookmarks_menu->add_action(*m_toggle_bookmark_action);
     update_bookmark_action_for_current_web_view();
 
-    m_toggle_bookmark_bar_action = Action::create("Toggle Bookmarks Bar"sv, ActionID::ToggleBookmarksBar, [this]() {
+    m_toggle_bookmark_bar_action = Action::create_checkable("Show Bookmarks Bar"sv, ActionID::ToggleBookmarksBar, [this]() {
         m_settings.set_show_bookmarks_bar(!m_settings.show_bookmarks_bar());
     });
+    m_toggle_bookmark_bar_action->set_checked(m_settings.show_bookmarks_bar());
     m_bookmarks_menu->add_action(*m_toggle_bookmark_bar_action);
-    update_bookmarks_bar_action();
 
     m_bookmarks_menu->add_separator();
     m_bookmarks_menu_static_size = m_bookmarks_menu->size();
@@ -1651,17 +1646,6 @@ void Application::bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>)
     m_bookmarks_menu->shrink(m_bookmarks_menu_static_size);
     create_bookmark_menu_items();
     rebuild_bookmarks_menu();
-}
-
-void Application::update_bookmarks_bar_action()
-{
-    m_toggle_bookmark_bar_action->set_text(m_settings.show_bookmarks_bar() ? "Hide Bookmark Bar"sv : "Show Bookmark Bar"sv);
-}
-
-void Application::show_bookmarks_bar_changed(Badge<ApplicationSettingsObserver>)
-{
-    update_bookmarks_bar_action();
-    update_bookmarks_bar_display(m_settings.show_bookmarks_bar());
 }
 
 void Application::create_bookmark_menu_items(Optional<MenuData> data)

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -220,7 +220,6 @@ protected:
     virtual void update_tabs_display() const { }
 
     virtual void rebuild_bookmarks_menu() const { }
-    virtual void update_bookmarks_bar_display([[maybe_unused]] bool show_bookmarks_bar) const { }
     virtual void on_recently_closed_entries_changed() const { }
 
     struct BookmarkID {
@@ -256,9 +255,7 @@ private:
     ErrorOr<void> load_content_blocker_lists();
 
     void initialize_actions();
-
     void update_vertical_tabs_action();
-    void update_bookmarks_bar_action();
 
     struct MenuData {
         Menu& menu;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -183,6 +183,8 @@ public:
 
     Action& toggle_vertical_tabs_expanded_action() { return *m_toggle_vertical_tabs_expanded_action; }
 
+    Action& toggle_menu_bar_action() { return *m_toggle_menu_bar_action; }
+
     Menu& bookmarks_menu() { return *m_bookmarks_menu; }
     Menu& bookmarks_bar_context_menu() { return *m_bookmarks_bar_context_menu; }
     Menu& bookmark_context_menu() { return *m_bookmark_context_menu; }
@@ -378,6 +380,8 @@ private:
     Web::CSS::PreferredMotion m_motion { Web::CSS::PreferredMotion::Auto };
 
     RefPtr<Action> m_toggle_vertical_tabs_expanded_action;
+
+    RefPtr<Action> m_toggle_menu_bar_action;
 
     RefPtr<Menu> m_bookmarks_menu;
     RefPtr<Action> m_toggle_bookmark_action;

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -40,6 +40,8 @@ enum class ActionID {
 
     ToggleVerticalTabsExpanded,
 
+    ToggleMenuBar,
+
     ManageBookmarks,
     ToggleBookmark,
     ToggleBookmarkViaToolbar,

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -26,6 +26,7 @@ static constexpr auto TAB_SETTINGS_KEY = "tabs"sv;
 static constexpr auto VERTICAL_TABS_ENABLED_KEY = "verticalTabsEnabled"sv;
 static constexpr auto VERTICAL_TABS_EXPANDED_KEY = "verticalTabsExpanded"sv;
 static constexpr auto VERTICAL_TABS_EXPAND_ON_HOVER_KEY = "verticalTabsExpandOnHover"sv;
+static constexpr auto VERTICAL_TABS_EXPANDED_WIDTH_KEY = "verticalTabsExpandedWidth"sv;
 
 static constexpr auto SHOW_BOOKMARKS_BAR_KEY = "showBookmarksBar"sv;
 static constexpr auto DEFAULT_SHOW_BOOKMARKS_BAR = true;
@@ -296,6 +297,8 @@ JsonValue Settings::serialize_json() const
     tab_settings.set(VERTICAL_TABS_ENABLED_KEY, m_tab_settings.vertical_tabs_enabled);
     tab_settings.set(VERTICAL_TABS_EXPANDED_KEY, m_tab_settings.vertical_tabs_expanded);
     tab_settings.set(VERTICAL_TABS_EXPAND_ON_HOVER_KEY, m_tab_settings.vertical_tabs_expand_on_hover);
+    if (m_tab_settings.vertical_tabs_expanded_width.has_value())
+        tab_settings.set(VERTICAL_TABS_EXPANDED_WIDTH_KEY, *m_tab_settings.vertical_tabs_expanded_width);
     settings.set(TAB_SETTINGS_KEY, move(tab_settings));
 
     settings.set(SHOW_BOOKMARKS_BAR_KEY, m_show_bookmarks_bar);
@@ -427,6 +430,8 @@ TabSettings Settings::parse_tab_settings(JsonValue const& settings)
         tab_settings.vertical_tabs_expanded = *vertical_tabs_expanded;
     if (auto vertical_tabs_expand_on_hover = settings.as_object().get_bool(VERTICAL_TABS_EXPAND_ON_HOVER_KEY); vertical_tabs_expand_on_hover.has_value())
         tab_settings.vertical_tabs_expand_on_hover = *vertical_tabs_expand_on_hover;
+    if (auto vertical_tabs_expanded_width = settings.as_object().get_integer<u16>(VERTICAL_TABS_EXPANDED_WIDTH_KEY); vertical_tabs_expanded_width.has_value())
+        tab_settings.vertical_tabs_expanded_width = *vertical_tabs_expanded_width;
 
     return tab_settings;
 }

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -28,6 +28,9 @@ static constexpr auto VERTICAL_TABS_EXPANDED_KEY = "verticalTabsExpanded"sv;
 static constexpr auto VERTICAL_TABS_EXPAND_ON_HOVER_KEY = "verticalTabsExpandOnHover"sv;
 static constexpr auto VERTICAL_TABS_EXPANDED_WIDTH_KEY = "verticalTabsExpandedWidth"sv;
 
+static constexpr auto SHOW_MENU_BAR_KEY = "showMenuBar"sv;
+static constexpr auto DEFAULT_SHOW_MENU_BAR = false;
+
 static constexpr auto SHOW_BOOKMARKS_BAR_KEY = "showBookmarksBar"sv;
 static constexpr auto DEFAULT_SHOW_BOOKMARKS_BAR = true;
 
@@ -194,6 +197,9 @@ Settings Settings::create(Badge<Application>)
     if (auto tab_settings = settings_json.value().get(TAB_SETTINGS_KEY); tab_settings.has_value())
         settings.m_tab_settings = parse_tab_settings(*tab_settings);
 
+    if (auto show_menu_bar = settings_json.value().get_bool(SHOW_MENU_BAR_KEY); show_menu_bar.has_value())
+        settings.m_show_menu_bar = *show_menu_bar;
+
     if (auto show_bookmarks_bar = settings_json.value().get_bool(SHOW_BOOKMARKS_BAR_KEY); show_bookmarks_bar.has_value())
         settings.m_show_bookmarks_bar = *show_bookmarks_bar;
 
@@ -279,6 +285,7 @@ Settings Settings::create(Badge<Application>)
 Settings::Settings(ByteString settings_path)
     : m_settings_path(move(settings_path))
     , m_new_tab_page_url(URL::about_newtab())
+    , m_show_menu_bar(DEFAULT_SHOW_MENU_BAR)
     , m_show_bookmarks_bar(DEFAULT_SHOW_BOOKMARKS_BAR)
     , m_default_zoom_level_factor(INITIAL_ZOOM_LEVEL_FACTOR)
     , m_languages({ DEFAULT_LANGUAGE })
@@ -301,6 +308,7 @@ JsonValue Settings::serialize_json() const
         tab_settings.set(VERTICAL_TABS_EXPANDED_WIDTH_KEY, *m_tab_settings.vertical_tabs_expanded_width);
     settings.set(TAB_SETTINGS_KEY, move(tab_settings));
 
+    settings.set(SHOW_MENU_BAR_KEY, m_show_menu_bar);
     settings.set(SHOW_BOOKMARKS_BAR_KEY, m_show_bookmarks_bar);
     settings.set(DEFAULT_ZOOM_LEVEL_FACTOR_KEY, m_default_zoom_level_factor);
 
@@ -443,6 +451,15 @@ void Settings::set_tab_settings(TabSettings tab_settings)
 
     for (auto& observer : m_observers)
         observer.tab_settings_changed();
+}
+
+void Settings::set_show_menu_bar(bool show_menu_bar)
+{
+    m_show_menu_bar = show_menu_bar;
+    persist_settings();
+
+    for (auto& observer : m_observers)
+        observer.show_menu_bar_changed();
 }
 
 void Settings::set_show_bookmarks_bar(bool show_bookmarks_bar)

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -26,6 +26,7 @@ struct TabSettings {
     bool vertical_tabs_enabled { false };
     bool vertical_tabs_expanded { true };
     bool vertical_tabs_expand_on_hover { false };
+    Optional<u16> vertical_tabs_expanded_width;
 };
 
 struct BrowsingBehavior {

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -79,6 +79,7 @@ public:
 
     virtual void new_tab_page_url_changed() { }
     virtual void tab_settings_changed() { }
+    virtual void show_menu_bar_changed() { }
     virtual void show_bookmarks_bar_changed() { }
     virtual void default_zoom_level_factor_changed() { }
     virtual void zoom_per_host_changed(StringView host) { (void)host; }
@@ -105,6 +106,9 @@ public:
     static TabSettings parse_tab_settings(JsonValue const&);
     TabSettings const& tab_settings() const { return m_tab_settings; }
     void set_tab_settings(TabSettings);
+
+    bool show_menu_bar() const { return m_show_menu_bar; }
+    void set_show_menu_bar(bool);
 
     bool show_bookmarks_bar() const { return m_show_bookmarks_bar; }
     void set_show_bookmarks_bar(bool);
@@ -170,6 +174,7 @@ private:
 
     URL::URL m_new_tab_page_url;
     TabSettings m_tab_settings;
+    bool m_show_menu_bar { false };
     bool m_show_bookmarks_bar { true };
     double m_default_zoom_level_factor { 0 };
     HashMap<String, double> m_zoom_per_host;

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -176,9 +176,11 @@ void SettingsUI::set_tab_settings(JsonValue const& tab_settings)
 {
     auto& settings = WebView::Application::settings();
     auto parsed_tab_settings = Settings::parse_tab_settings(tab_settings);
+    auto const& current_tab_settings = settings.tab_settings();
 
-    // Collapsed/expanded vertical tabs are not controlled by the settings UI. Don't overwrite it.
-    parsed_tab_settings.vertical_tabs_expanded = settings.tab_settings().vertical_tabs_expanded;
+    // Collapsed/expanded vertical tabs and their width are not controlled by the settings UI. Don't overwrite them.
+    parsed_tab_settings.vertical_tabs_expanded = current_tab_settings.vertical_tabs_expanded;
+    parsed_tab_settings.vertical_tabs_expanded_width = current_tab_settings.vertical_tabs_expanded_width;
 
     settings.set_tab_settings(parsed_tab_settings);
     load_current_settings();

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -33,7 +33,6 @@ private:
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
 
     virtual void rebuild_bookmarks_menu() const override;
-    virtual void update_bookmarks_bar_display(bool) const override;
     virtual void show_bookmark_context_menu(Gfx::IntPoint, Optional<WebView::BookmarkItem const&>, Optional<String const&> target_folder_id) override;
     virtual Optional<BookmarkID> bookmark_item_id_for_context_menu() const override;
     virtual NonnullRefPtr<BookmarkPromise> display_add_bookmark_dialog() const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -170,12 +170,6 @@ void Application::rebuild_bookmarks_menu() const
     [delegate rebuildBookmarksMenu];
 }
 
-void Application::update_bookmarks_bar_display(bool show_bookmarks_bar) const
-{
-    ApplicationDelegate* delegate = [NSApp delegate];
-    [delegate updateBookmarksBarDisplay:show_bookmarks_bar];
-}
-
 void Application::show_bookmark_context_menu(Gfx::IntPoint content_position, Optional<WebView::BookmarkItem const&> item, Optional<String const&> target_folder_id)
 {
     ApplicationDelegate* delegate = [NSApp delegate];

--- a/UI/AppKit/Application/ApplicationDelegate.h
+++ b/UI/AppKit/Application/ApplicationDelegate.h
@@ -38,7 +38,6 @@
 - (void)removeTab:(nonnull TabController*)controller;
 
 - (void)rebuildBookmarksMenu;
-- (void)updateBookmarksBarDisplay:(bool)show_bookmarks_bar;
 
 - (void)onDevtoolsEnabled;
 - (void)onDevtoolsDisabled;

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -146,15 +146,6 @@
     }
 }
 
-- (void)updateBookmarksBarDisplay:(bool)show_bookmarks_bar
-{
-    for (TabController* controller in self.managed_tabs) {
-        if (auto* tab = (Tab*)[controller window]; ([tab styleMask] & NSWindowStyleMaskFullScreen) == 0) {
-            [tab updateBookmarksBarDisplay:show_bookmarks_bar];
-        }
-    }
-}
-
 - (void)onDevtoolsEnabled
 {
     if (!self.info_bar) {

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -33,18 +33,17 @@ static constexpr NSUInteger const TAB_LOADING_SPINNER_SEGMENT_COUNT = 12;
 
 class TabSettingsObserver final : public WebView::SettingsObserver {
 public:
-    explicit TabSettingsObserver(Function<void(WebView::ConfigVariableID)> callback)
-        : m_callback(move(callback))
+    explicit TabSettingsObserver(Tab* tab)
+        : m_tab(tab)
     {
-    }
-
-    virtual void config_variable_changed(WebView::ConfigVariableID variable) override
-    {
-        m_callback(variable);
     }
 
 private:
-    Function<void(WebView::ConfigVariableID)> m_callback;
+    // These are forward-declared so that they may access non-public Tab methods.
+    virtual void show_bookmarks_bar_changed() override;
+    virtual void config_variable_changed(WebView::ConfigVariableID variable) override;
+
+    __weak Tab* m_tab { nil };
 };
 
 static NSImage* tab_loading_spinner_icon(NSUInteger frame)
@@ -141,19 +140,12 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
 
         self.favicon = [Tab defaultFavicon];
         self.title = @"New Tab";
-        __weak Tab* weak_self = self;
-        m_settings_observer = make<TabSettingsObserver>([weak_self](WebView::ConfigVariableID variable) {
-            if (variable != WebView::ConfigVariableID::ShowWebContentProcessIDInTabTitle)
-                return;
-            Tab* strong_self = weak_self;
-            if (strong_self == nil)
-                return;
-            [strong_self updateTabTitleAndFavicon];
-        });
         [self updateTabTitleAndFavicon];
 
         [self setTitleVisibility:NSWindowTitleHidden];
         [self setIsVisible:YES];
+
+        m_settings_observer = make<TabSettingsObserver>(self);
 
         auto* bookmarks_bar = [[BookmarksBar alloc] init];
         self.bookmarks_bar_controller = [[NSTitlebarAccessoryViewController alloc] init];
@@ -477,3 +469,14 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
 }
 
 @end
+
+void TabSettingsObserver::show_bookmarks_bar_changed()
+{
+    [m_tab updateBookmarksBarDisplay:WebView::Application::settings().show_bookmarks_bar()];
+}
+
+void TabSettingsObserver::config_variable_changed(WebView::ConfigVariableID variable)
+{
+    if (variable == WebView::ConfigVariableID::ShowWebContentProcessIDInTabTitle)
+        [m_tab updateTabTitleAndFavicon];
+}

--- a/UI/Gtk/Application.cpp
+++ b/UI/Gtk/Application.cpp
@@ -287,10 +287,6 @@ void Application::rebuild_bookmarks_menu() const
 {
 }
 
-void Application::update_bookmarks_bar_display(bool) const
-{
-}
-
 void Application::on_devtools_enabled() const
 {
     WebView::Application::on_devtools_enabled();

--- a/UI/Gtk/Application.h
+++ b/UI/Gtk/Application.h
@@ -60,7 +60,6 @@ private:
     virtual bool should_capture_web_content_output() const override { return false; }
 
     virtual void rebuild_bookmarks_menu() const override;
-    virtual void update_bookmarks_bar_display(bool) const override;
 
     virtual void on_devtools_enabled() const override;
     virtual void on_devtools_disabled() const override;

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -319,14 +319,6 @@ void Application::rebuild_bookmarks_menu() const
     }
 }
 
-void Application::update_bookmarks_bar_display(bool show_bookmarks_bar) const
-{
-    for (auto* widget : QApplication::topLevelWidgets()) {
-        if (auto* window = as_if<BrowserWindow>(widget))
-            window->update_bookmarks_bar_display(show_bookmarks_bar);
-    }
-}
-
 void Application::update_reopen_recently_closed_actions() const
 {
     for (auto* widget : QApplication::topLevelWidgets()) {

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -64,7 +64,6 @@ private:
     virtual void update_tabs_display() const override;
 
     virtual void rebuild_bookmarks_menu() const override;
-    virtual void update_bookmarks_bar_display(bool) const override;
     virtual void show_bookmark_context_menu(Gfx::IntPoint, Optional<WebView::BookmarkItem const&>, Optional<String const&> target_folder_id) override;
     virtual Optional<BookmarkID> bookmark_item_id_for_context_menu() const override;
     virtual NonnullRefPtr<BookmarkPromise> display_add_bookmark_dialog() const override;

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -264,11 +264,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     menuBar()->setObjectName("LadybirdMenuBar");
     create_menu_bar_window_controls();
     update_menu_bar_style();
-    update_menu_bar_visibility(Settings::the()->show_menubar());
-
-    QObject::connect(Settings::the(), &Settings::show_menubar_changed, this, [this](bool show_menubar) {
-        update_menu_bar_visibility(show_menubar);
-    });
+    update_menu_bar_visibility();
 
     auto* file_menu = menuBar()->addMenu("&File");
 
@@ -369,15 +365,8 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     view_menu->addMenu(create_application_menu(*view_menu, application.motion_menu()));
     view_menu->addSeparator();
 
-    if (show_menubar_option_available()) {
-        auto* show_menubar = new QAction("Show &Menubar", this);
-        show_menubar->setCheckable(true);
-        show_menubar->setChecked(Settings::the()->show_menubar());
-        view_menu->addAction(show_menubar);
-        QObject::connect(show_menubar, &QAction::triggered, this, [](bool checked) {
-            Settings::the()->set_show_menubar(checked);
-        });
-    }
+    if (show_menubar_option_available())
+        view_menu->addAction(create_application_action(*view_menu, application.toggle_menu_bar_action(), IncludeActionIcon::No));
 
     m_bookmarks_menu = create_application_menu(*this, application.bookmarks_menu());
     m_hamburger_menu->addMenu(m_bookmarks_menu);
@@ -938,12 +927,14 @@ void BrowserWindow::update_menu_bar_style()
     menuBar()->setStyleSheet(ChromeStyle::menu_bar_style_sheet(palette()));
 }
 
-void BrowserWindow::update_menu_bar_visibility(bool show_menubar)
+void BrowserWindow::update_menu_bar_visibility()
 {
-    menuBar()->setVisible(show_menubar);
+    auto show_menu_bar = show_menubar_option_available() && WebView::Application::settings().show_menu_bar();
+    menuBar()->setVisible(show_menu_bar);
+
     if (m_menu_bar_window_controls)
-        m_menu_bar_window_controls->setVisible(show_menubar && uses_client_side_decorations());
-    m_tabs_container->set_window_controls_visible(!show_menubar && uses_client_side_decorations());
+        m_menu_bar_window_controls->setVisible(show_menu_bar && uses_client_side_decorations());
+    m_tabs_container->set_window_controls_visible(!show_menu_bar && uses_client_side_decorations());
 }
 
 void BrowserWindow::update_menu_bar_window_control_icons()
@@ -982,7 +973,7 @@ void BrowserWindow::update_window_decoration_state()
         }
     }
 
-    update_menu_bar_visibility(Settings::the()->show_menubar());
+    update_menu_bar_visibility();
 }
 
 void BrowserWindow::toggle_window_maximized()
@@ -1335,6 +1326,11 @@ void BrowserWindow::changeEvent(QEvent* event)
         }
     }
     QWidget::changeEvent(event);
+}
+
+void BrowserWindow::show_menu_bar_changed()
+{
+    update_menu_bar_visibility();
 }
 
 void BrowserWindow::config_variable_changed(WebView::ConfigVariableID variable)

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -234,6 +234,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     : m_tabs_container(new TabWidget(this))
     , m_is_popup_window(is_popup_window)
 {
+    auto& application = WebView::Application::the();
     auto const& browser_options = WebView::Application::browser_options();
 
     setWindowFlag(Qt::FramelessWindowHint, uses_client_side_decorations());
@@ -302,10 +303,10 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     auto* edit_menu = m_hamburger_menu->addMenu("&Edit");
     menuBar()->addMenu(edit_menu);
 
-    edit_menu->addAction(create_application_action(*this, Application::the().cut_selection_action(), IncludeActionIcon::No));
-    edit_menu->addAction(create_application_action(*this, Application::the().copy_selection_action(), IncludeActionIcon::No));
-    edit_menu->addAction(create_application_action(*this, Application::the().paste_action(), IncludeActionIcon::No));
-    edit_menu->addAction(create_application_action(*this, Application::the().select_all_action(), IncludeActionIcon::No));
+    edit_menu->addAction(create_application_action(*this, application.cut_selection_action(), IncludeActionIcon::No));
+    edit_menu->addAction(create_application_action(*this, application.copy_selection_action(), IncludeActionIcon::No));
+    edit_menu->addAction(create_application_action(*this, application.paste_action(), IncludeActionIcon::No));
+    edit_menu->addAction(create_application_action(*this, application.select_all_action(), IncludeActionIcon::No));
     edit_menu->addSeparator();
 
     m_find_in_page_action = new QAction("&Find in Page...", this);
@@ -329,7 +330,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     QObject::connect(m_find_in_page_action, &QAction::triggered, this, &BrowserWindow::show_find_in_page);
 
     edit_menu->addSeparator();
-    edit_menu->addAction(create_application_action(*edit_menu, Application::the().open_settings_page_action(), IncludeActionIcon::No));
+    edit_menu->addAction(create_application_action(*edit_menu, application.open_settings_page_action(), IncludeActionIcon::No));
 
     auto* view_menu = m_hamburger_menu->addMenu("&View");
     menuBar()->addMenu(view_menu);
@@ -360,12 +361,12 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
 
     view_menu->addSeparator();
 
-    view_menu->addMenu(create_application_menu(*view_menu, Application::the().zoom_menu()));
+    view_menu->addMenu(create_application_menu(*view_menu, application.zoom_menu()));
     view_menu->addSeparator();
 
-    view_menu->addMenu(create_application_menu(*view_menu, Application::the().color_scheme_menu()));
-    view_menu->addMenu(create_application_menu(*view_menu, Application::the().contrast_menu()));
-    view_menu->addMenu(create_application_menu(*view_menu, Application::the().motion_menu()));
+    view_menu->addMenu(create_application_menu(*view_menu, application.color_scheme_menu()));
+    view_menu->addMenu(create_application_menu(*view_menu, application.contrast_menu()));
+    view_menu->addMenu(create_application_menu(*view_menu, application.motion_menu()));
     view_menu->addSeparator();
 
     if (show_menubar_option_available()) {
@@ -378,22 +379,22 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         });
     }
 
-    m_bookmarks_menu = create_application_menu(*this, Application::the().bookmarks_menu());
+    m_bookmarks_menu = create_application_menu(*this, application.bookmarks_menu());
     m_hamburger_menu->addMenu(m_bookmarks_menu);
     menuBar()->addMenu(m_bookmarks_menu);
 
-    auto* inspect_menu = create_application_menu(*m_hamburger_menu, Application::the().inspect_menu());
+    auto* inspect_menu = create_application_menu(*m_hamburger_menu, application.inspect_menu());
     m_hamburger_menu->addMenu(inspect_menu);
     menuBar()->addMenu(inspect_menu);
 
-    auto* debug_menu = create_application_menu(*m_hamburger_menu, Application::the().debug_menu());
+    auto* debug_menu = create_application_menu(*m_hamburger_menu, application.debug_menu());
     m_hamburger_menu->addMenu(debug_menu);
     menuBar()->addMenu(debug_menu);
 
     auto* help_menu = m_hamburger_menu->addMenu("&Help");
     menuBar()->addMenu(help_menu);
 
-    help_menu->addAction(create_application_action(*help_menu, Application::the().open_about_page_action(), IncludeActionIcon::No));
+    help_menu->addAction(create_application_action(*help_menu, application.open_about_page_action(), IncludeActionIcon::No));
 
     m_hamburger_menu->addSeparator();
     file_menu->addSeparator();

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -512,11 +512,12 @@ void BrowserWindow::rebuild_bookmarks_menu()
     });
 }
 
-void BrowserWindow::update_bookmarks_bar_display(bool show_bookmarks_bar)
+void BrowserWindow::show_bookmarks_bar_changed()
 {
+    auto show_bookmarks_bar = WebView::Application::settings().show_bookmarks_bar();
+
     for_each_tab([&](Tab& tab) {
-        if (tab.view().is_fullscreen() == Web::ViewportIsFullscreen::No)
-            tab.bookmarks_bar().setVisible(show_bookmarks_bar);
+        tab.bookmarks_bar().setVisible(show_bookmarks_bar);
     });
 }
 

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -156,6 +156,8 @@ private:
     virtual void moveEvent(QMoveEvent*) override;
     virtual void wheelEvent(QWheelEvent*) override;
     virtual void closeEvent(QCloseEvent*) override;
+
+    virtual void show_menu_bar_changed() override;
     virtual void config_variable_changed(WebView::ConfigVariableID) override;
 
     Tab& create_new_tab(Web::HTML::ActivateTab, Tab& parent, Optional<u64> page_index);
@@ -180,7 +182,7 @@ private:
     void create_menu_bar_window_controls();
     void update_tab_button_icons();
     void update_menu_bar_style();
-    void update_menu_bar_visibility(bool);
+    void update_menu_bar_visibility();
     void update_menu_bar_window_control_icons();
     void update_window_decoration_state();
     void toggle_window_maximized();

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -114,7 +114,6 @@ public:
     void update_tabs_display();
 
     void rebuild_bookmarks_menu();
-    void update_bookmarks_bar_display(bool show_bookmarks_bar);
     void update_reopen_recently_closed_action();
     void detach_tab_to_new_window(int index, QPoint global_position);
     void move_tab_to_window(int index, BrowserWindow& target_window, int target_index);
@@ -158,6 +157,7 @@ private:
     virtual void closeEvent(QCloseEvent*) override;
 
     virtual void show_menu_bar_changed() override;
+    virtual void show_bookmarks_bar_changed() override;
     virtual void config_variable_changed(WebView::ConfigVariableID) override;
 
     Tab& create_new_tab(Web::HTML::ActivateTab, Tab& parent, Optional<u64> page_index);

--- a/UI/Qt/Settings.cpp
+++ b/UI/Qt/Settings.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AK/LexicalPath.h>
-#include <UI/Qt/ChromeLayout.h>
 #include <UI/Qt/Settings.h>
 #include <UI/Qt/StringUtils.h>
 
@@ -53,24 +52,6 @@ bool Settings::is_maximized()
 void Settings::set_is_maximized(bool is_maximized)
 {
     m_qsettings->setValue("is_maximized", is_maximized);
-}
-
-bool Settings::show_menubar()
-{
-    if (!show_menubar_option_available())
-        return false;
-
-    return m_qsettings->value("show_menubar", false).toBool();
-}
-
-void Settings::set_show_menubar(bool show_menubar)
-{
-    if (!show_menubar_option_available())
-        show_menubar = false;
-    else
-        m_qsettings->setValue("show_menubar", show_menubar);
-
-    emit show_menubar_changed(show_menubar);
 }
 
 }

--- a/UI/Qt/Settings.cpp
+++ b/UI/Qt/Settings.cpp
@@ -73,16 +73,4 @@ void Settings::set_show_menubar(bool show_menubar)
     emit show_menubar_changed(show_menubar);
 }
 
-Optional<int> Settings::vertical_tabs_expanded_width()
-{
-    if (m_qsettings->contains("vertical_tabs_expanded_width"))
-        return m_qsettings->value("vertical_tabs_expanded_width").toInt();
-    return {};
-}
-
-void Settings::set_vertical_tabs_expanded_width(int width)
-{
-    m_qsettings->setValue("vertical_tabs_expanded_width", width);
-}
-
 }

--- a/UI/Qt/Settings.h
+++ b/UI/Qt/Settings.h
@@ -45,9 +45,6 @@ public:
     bool show_menubar();
     void set_show_menubar(bool show_menubar);
 
-    Optional<int> vertical_tabs_expanded_width();
-    void set_vertical_tabs_expanded_width(int);
-
 signals:
     void show_menubar_changed(bool show_menubar);
 

--- a/UI/Qt/Settings.h
+++ b/UI/Qt/Settings.h
@@ -42,12 +42,6 @@ public:
     bool is_maximized();
     void set_is_maximized(bool is_maximized);
 
-    bool show_menubar();
-    void set_show_menubar(bool show_menubar);
-
-signals:
-    void show_menubar_changed(bool show_menubar);
-
 protected:
     Settings();
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -17,7 +17,6 @@
 #include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
-#include <UI/Qt/Settings.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/WindowControlButton.h>
 
@@ -242,12 +241,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     update_chrome_style();
     set_toolbar_window_controls_visible(false);
-
-    m_hamburger_button->setVisible(!Settings::the()->show_menubar());
-
-    QObject::connect(Settings::the(), &Settings::show_menubar_changed, this, [this](bool show_menubar) {
-        m_hamburger_button->setVisible(!show_menubar);
-    });
 
     view().on_activate_tab = [this] {
         m_window->activate_tab(tab_index());
@@ -582,7 +575,6 @@ void Tab::set_window(BrowserWindow& window)
     m_window = &window;
     m_hamburger_button->setMenu(&m_window->hamburger_menu());
     connect_hamburger_menu();
-    m_hamburger_button->setVisible(!Settings::the()->show_menubar());
     recreate_toolbar_icons();
 }
 
@@ -644,6 +636,14 @@ void Tab::connect_hamburger_menu()
     QObject::connect(&m_window->hamburger_menu(), &QMenu::aboutToHide, m_hamburger_button, [this]() {
         m_hamburger_button->setDown(false);
     });
+
+    update_hamburger_menu();
+}
+
+void Tab::update_hamburger_menu()
+{
+    auto show_menu_bar = show_menubar_option_available() && WebView::Application::settings().show_menu_bar();
+    m_hamburger_button->setVisible(!show_menu_bar);
 }
 
 void Tab::navigate(URL::URL const& url)
@@ -688,6 +688,11 @@ QString Tab::title() const
 void Tab::update_tab_title()
 {
     emit title_changed(tab_index(), title());
+}
+
+void Tab::show_menu_bar_changed()
+{
+    update_hamburger_menu();
 }
 
 void Tab::config_variable_changed(WebView::ConfigVariableID variable)

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -103,10 +103,13 @@ signals:
 private:
     virtual void resizeEvent(QResizeEvent*) override;
     virtual bool event(QEvent*) override;
+
+    virtual void show_menu_bar_changed() override;
     virtual void config_variable_changed(WebView::ConfigVariableID) override;
 
     void recreate_toolbar_icons();
     void connect_hamburger_menu();
+    void update_hamburger_menu();
     void update_chrome_style();
     void update_tab_title();
     void set_loading(bool);

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -16,7 +16,6 @@
 #    include <UI/Qt/MacWindow.h>
 #endif
 #include <UI/Qt/Menu.h>
-#include <UI/Qt/Settings.h>
 #include <UI/Qt/Tab.h>
 #include <UI/Qt/TabBar.h>
 #include <UI/Qt/WindowControlButton.h>
@@ -1116,7 +1115,7 @@ TabWidget::TabWidget(QWidget* parent)
     if (auto* top_level_window = window(); top_level_window != this)
         top_level_window->installEventFilter(this);
 
-    m_vertical_tabs_expanded_width = Settings::the()->vertical_tabs_expanded_width().value_or(VERTICAL_TABS_DEFAULT_EXPANDED_WIDTH);
+    m_vertical_tabs_expanded_width = Application::settings().tab_settings().vertical_tabs_expanded_width.value_or(VERTICAL_TABS_DEFAULT_EXPANDED_WIDTH);
     m_vertical_tabs_expanded_width = clamp_vertical_tabs_expanded_width(m_vertical_tabs_expanded_width);
 
     m_tab_bar = new TabBar(this);
@@ -1717,7 +1716,12 @@ void TabWidget::apply_vertical_tabs_expanded_width(int width)
 
 void TabWidget::persist_vertical_tabs_expanded_width()
 {
-    Settings::the()->set_vertical_tabs_expanded_width(m_vertical_tabs_expanded_width);
+    auto tab_settings = Application::settings().tab_settings();
+
+    using ValueType = decltype(tab_settings.vertical_tabs_expanded_width)::ValueType;
+    tab_settings.vertical_tabs_expanded_width = clamp(m_vertical_tabs_expanded_width, 0, NumericLimits<ValueType>::max());
+
+    Application::settings().set_tab_settings(tab_settings);
 }
 
 void TabWidget::set_resize_handle_property(char const* property, bool enabled)


### PR DESCRIPTION
* Use Qt's settings less for things we can store in LibWebView's settings.
    * We now only store the window geometry; we could store the geometry in LibWebView as well, but it would only be used by Qt because AppKit goes through `frameAutosaveName` instead.
* Remove boilerplate to update the bookmarks bar display.