### PR TITLE
Meta: Rebuild Rust crates when the toolchain changes, not just sources

### DIFF
--- a/Meta/CMake/rust_crate.cmake
+++ b/Meta/CMake/rust_crate.cmake
@@ -54,6 +54,7 @@ function(import_rust_crate)
                 -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/sync_rust_ffi_header.cmake"
         DEPENDS "${manifest_path}"
             "${workspace_dir}/Cargo.lock" "${workspace_dir}/Cargo.toml"
+            "${RUST_RUSTC}" "${CMAKE_SOURCE_DIR}/rust-toolchain.toml"
         DEPFILE "${depfile}"
         COMMENT "Building Rust crate ${ARG_CRATE_NAME}"
         USES_TERMINAL
@@ -108,6 +109,7 @@ function(build_rust_binary)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "${cargo_binary}" "${output_binary}"
         DEPENDS "${manifest_path}"
             "${workspace_dir}/Cargo.lock" "${workspace_dir}/Cargo.toml"
+            "${RUST_RUSTC}" "${CMAKE_SOURCE_DIR}/rust-toolchain.toml"
         DEPFILE "${depfile}"
         COMMENT "Building Rust binary ${ARG_BINARY_NAME}"
         USES_TERMINAL


### PR DESCRIPTION
**Problem:** After a `git pull` of master, builds fail with an error message about multiple/duplicate `rust_eh_personality` definitions/symbols.

**Cause:** LibWeb links two Rust staticlibs: `libweb_content_blocker_rust` and `libweb_rust`. Both bundle Rust’s standard library (`std`). When we re-pin `rust-toolchain.toml`, a `git pull` moves a rustup user’s compiler — but we were only rebuilding the crate whose `.rs` also changed. So that left one crate on the old `std`, and the other crate on the new `std`.

**Fix:** Make the cargo custom commands also depend on `rust-toolchain.toml` and `rustc` — so a toolchain change re-triggers every Rust crate. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9854. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9643.
