### PR TITLE
LibWeb: Cancel the async-scroll hover update when the document changes

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -295,8 +295,7 @@ Navigable::~Navigable() = default;
 
 void Navigable::set_has_been_destroyed()
 {
-    if (m_async_scroll_hover_update_timer)
-        m_async_scroll_hover_update_timer->stop();
+    cancel_hover_update_after_async_scroll();
     destroy_compositor_context();
     m_has_been_destroyed = true;
     resolve_all_pending_async_scroll_operations();
@@ -304,8 +303,7 @@ void Navigable::set_has_been_destroyed()
 
 void Navigable::remove_from_all_navigables()
 {
-    if (m_async_scroll_hover_update_timer)
-        m_async_scroll_hover_update_timer->stop();
+    cancel_hover_update_after_async_scroll();
     destroy_compositor_context();
     resolve_all_pending_async_scroll_operations();
 
@@ -316,8 +314,7 @@ void Navigable::remove_from_all_navigables()
 
 void Navigable::finalize()
 {
-    if (m_async_scroll_hover_update_timer)
-        m_async_scroll_hover_update_timer->stop();
+    cancel_hover_update_after_async_scroll();
     destroy_compositor_context();
     all_navigables().remove(*this);
     Base::finalize();
@@ -485,8 +482,11 @@ void Navigable::activate_history_entry(RefPtr<SessionHistoryEntry> entry, GC::Re
 
     // 4. Set navigable's active session history entry to entry.
     m_active_session_history_entry = entry;
-    if (m_active_document && m_active_document != new_document)
+    if (m_active_document && m_active_document != new_document) {
+        // The pending post-scroll hover refresh belongs to the outgoing document; drop it.
+        cancel_hover_update_after_async_scroll();
         m_active_document->set_navigable(nullptr);
+    }
     m_active_document = new_document;
     new_document->set_navigable(this);
     set_needs_to_record_display_list();
@@ -536,8 +536,11 @@ Optional<UniqueNodeID> Navigable::active_document_id() const
 
 void Navigable::set_active_document(GC::Ptr<DOM::Document> document)
 {
-    if (m_active_document && m_active_document != document)
+    if (m_active_document && m_active_document != document) {
+        // The pending post-scroll hover refresh belongs to the outgoing document; drop it.
+        cancel_hover_update_after_async_scroll();
         m_active_document->set_navigable(nullptr);
+    }
     m_active_document = document;
     if (document)
         document->set_navigable(this);
@@ -3176,6 +3179,12 @@ void Navigable::update_hover_after_async_scroll_stops()
     if (has_been_destroyed())
         return;
     event_handler().update_hover_after_scroll();
+}
+
+void Navigable::cancel_hover_update_after_async_scroll()
+{
+    if (m_async_scroll_hover_update_timer)
+        m_async_scroll_hover_update_timer->stop();
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -299,6 +299,7 @@ private:
     void resolve_all_pending_async_scroll_operations();
     void schedule_hover_update_after_async_scroll();
     void update_hover_after_async_scroll_stops();
+    void cancel_hover_update_after_async_scroll();
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-id
     String m_id;


### PR DESCRIPTION
**Problem:** A document loaded into a navigable just after a previous document in that navigable had been async-scrolling could receive hover and `mouseover`/`mouseout` boundary events which nothing in that document triggered. In our CI, that manifested as an intermittent flake/failure of the `async-scrolling/hover-updates-after-async-scroll.html` test — whose first `mouseover` count came up one short: a leftover refresh had moved hover onto the target before the test added its listeners.

**Cause:** A navigable tears down a document’s input state implicitly: its hover target and mousedown target are `GC::Weak` references that null themselves once the document is collected. The post-scroll hover refresh doesn’t get that automatic teardown — it runs off a `Core::Timer` that is stopped when the navigable is destroyed, but was *not* being stopped when the navigable swaps in a new active document. So a scroll in one document left a refresh that fired against the next.

**Fix:** Cancel the pending refresh when the navigable’s active document changes — the same boundary at which the weak references null. That gives the timer the same teardown the rest of the input state already has — with no per-document tracking state.
