### PR TITLE
Meta: Fix Optional & String printers & Add FlyString printer

### DIFF
--- a/Meta/Debuggers/gdb/AK.py
+++ b/Meta/Debuggers/gdb/AK.py
@@ -44,6 +44,8 @@ def handler_class_for_type(type, re=re.compile("^([^<]+)(<.*>)?$")):
         return AKSinglyLinkedList
     elif klass == "AK::String":
         return AKString
+    elif klass == "AK::FlyString":
+        return AKFlyString
     elif klass == "AK::ByteString":
         return AKByteString
     elif klass == "AK::StringView":
@@ -192,6 +194,20 @@ class AKString:
         return "AK::String"
 
 
+class AKFlyString:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        gdb.set_convenience_variable("_tmp", self.val.reference_value())
+        string_view = gdb.parse_and_eval("$_tmp.bytes_as_string_view()")
+        return AKStringView(string_view).to_string()
+
+    @classmethod
+    def prettyprint_type(cls, type):
+        return "AK::FlyString"
+
+
 class AKByteString:
     def __init__(self, val):
         self.val = val
@@ -319,17 +335,87 @@ class AKVariant:
 class AKOptional:
     def __init__(self, val):
         self.val = val
-        self.has_value = bool(self.val["m_has_value"])
         self.contained_type = self.val.type.strip_typedefs().template_argument(0)
 
+    def _direct_field(self, name):
+        for field in self.val.type.strip_typedefs().fields():
+            if field.name == name and not field.is_base_class:
+                return self.val[name]
+
+        for field in self.val.type.strip_typedefs().fields():
+            if not field.is_base_class:
+                continue
+
+            try:
+                base = self.val[field]
+            except gdb.error:
+                continue
+
+            for base_field in base.type.strip_typedefs().fields():
+                if base_field.name == name and not base_field.is_base_class:
+                    return base[name]
+
+        return None
+
+    def _storage_field(self):
+        for field in self.val.type.strip_typedefs().fields():
+            if field.is_base_class or field.name is not None:
+                continue
+
+            try:
+                anonymous_storage = self.val[field]
+                return anonymous_storage["m_storage"]
+            except gdb.error:
+                continue
+
+        return None
+
+    def _has_value(self):
+        m_has_value = self._direct_field("m_has_value")
+        if m_has_value is not None:
+            return bool(m_has_value)
+
+        m_pointer = self._direct_field("m_pointer")
+        if m_pointer is not None:
+            return int(m_pointer) != 0
+
+        m_value = self._direct_field("m_value")
+        if m_value is not None:
+            gdb.set_convenience_variable("_op", self.val.reference_value())
+            try:
+                return bool(gdb.parse_and_eval("$_op.has_value()"))
+            except gdb.error:
+                return None
+
+        return False
+
     def to_string(self):
-        return AKOptional.prettyprint_type(self.val.type)
+        has_value = self._has_value()
+
+        if has_value is None:
+            return "<eval failed>"
+
+        return "Some" if has_value else "None"
 
     def children(self):
-        if self.has_value:
-            data = self.val["m_storage"]
-            return [(self.contained_type.name, data)]
-        return [("OptionalNone", "{}")]
+        has_value = self._has_value()
+
+        if has_value is False:
+            return []
+
+        m_storage = self._storage_field()
+        if m_storage is not None:
+            return [("value", m_storage)]
+
+        m_pointer = self._direct_field("m_pointer")
+        if m_pointer is not None:
+            return [("value", m_pointer.dereference())]
+
+        m_value = self._direct_field("m_value")
+        if m_value is not None:
+            return [("value", m_value)]
+
+        return []
 
     @classmethod
     def prettyprint_type(cls, type):

--- a/Meta/Debuggers/lldb/AK.py
+++ b/Meta/Debuggers/lldb/AK.py
@@ -86,6 +86,21 @@ def ak_optional_summary(valobj, internal_dict):
     if m_pointer and m_pointer.IsValid():
         return "Some" if m_pointer.GetValueAsUnsigned() != 0 else "None"
 
+    m_value = valobj.GetChildMemberWithName("m_value")
+    if m_value and m_value.IsValid():
+        options = lldb.SBExpressionOptions()  # type: ignore
+        options.SetTimeoutInMicroSeconds(500_000)
+        result = valobj.EvaluateExpression("has_value()", options)
+
+        error = result.GetError()
+        if error.Fail():
+            print(f"Eval failed for {valobj.GetName()}: {error.GetCString()}")
+            return ""
+        if not result.IsValid():
+            return ""
+
+        return "Some" if result.GetValueAsUnsigned() != 0 else "None"
+
     return None
 
 
@@ -138,59 +153,41 @@ def ak_singlylinkedlist_summary(valobj, internal_dict):
     return f"size={size}"
 
 
-def ak_string_summary(valobj, internal_dict):
-    valobj = valobj.GetNonSyntheticValue()
-    process = valobj.GetProcess()
-    if not process.IsValid():
-        return None
-
-    impl = valobj.GetChildMemberWithName("m_impl")
-    short_string = impl.GetChildMemberWithName("short_string")
-    short_string_tag = short_string.GetChildMemberWithName("byte_count_and_short_string_flag").GetValueAsUnsigned()
-
-    if short_string_tag & 1:
-        length = short_string_tag >> 2
-        if length == 0:
-            return '""'
-
-        storage = short_string.GetChildMemberWithName("storage")
-        bytes_start = storage.GetLoadAddress()
-        raw_bytes = read_process_memory(process, bytes_start, length)
-        if raw_bytes is None:
-            return None
-        return '"' + raw_bytes.decode("utf-8", "replace") + '"'
-
-    data_ptr = impl.GetChildMemberWithName("data")
-    if data_ptr.GetValueAsUnsigned() == 0:
-        return '""'
-
-    string_data = data_ptr.Dereference()
-    if not string_data.IsValid():
-        return None
-
-    if string_data.GetChildMemberWithName("m_substring").GetValueAsUnsigned() != 0:
-        return None
-
-    length = string_data.GetChildMemberWithName("m_byte_count").GetValueAsUnsigned()
+def format_stringview(stringview_valobj):
+    length = stringview_valobj.GetChildMemberWithName("m_length").GetValueAsUnsigned()
     if length == 0:
         return '""'
+    characters = stringview_valobj.GetChildMemberWithName("m_characters")
+    arr = characters.GetPointeeData(0, length).uint8s
+    return '"' + bytes(arr).decode("utf-8", "replace") + '"'
 
-    bytes_start = string_data.GetChildMemberWithName("m_bytes_or_substring_data").GetLoadAddress()
-    raw_bytes = read_process_memory(process, bytes_start, length)
-    if raw_bytes is None:
+
+def eval_string_summary(valobj, internal_dict):
+    valobj = valobj.GetNonSyntheticValue()
+
+    options = lldb.SBExpressionOptions()  # type: ignore
+    options.SetTimeoutInMicroSeconds(500_000)
+    sv = valobj.EvaluateExpression("bytes_as_string_view()", options)
+
+    error = sv.GetError()
+    if error.Fail():
+        return None
+    if not sv or not sv.IsValid():
         return None
 
-    return '"' + raw_bytes.decode("utf-8", "replace") + '"'
+    return format_stringview(sv)
+
+
+def ak_string_summary(valobj, internal_dict):
+    return eval_string_summary(valobj, internal_dict)
+
+
+def ak_flystring_summary(valobj, internal_dict):
+    return eval_string_summary(valobj, internal_dict)
 
 
 def ak_stringview_summary(valobj, internal_dict):
-    length = valobj.GetChildMemberWithName("m_length").GetValueAsUnsigned()
-    if length == 0:
-        return '""'
-
-    characters = valobj.GetChildMemberWithName("m_characters")
-    arr = characters.GetPointeeData(0, length).uint8s
-    return '"' + bytes(arr).decode("utf-8", "replace") + '"'
+    return format_stringview(valobj)
 
 
 def ak_variant_summary(valobj, internal_dict):
@@ -548,6 +545,7 @@ def __lldb_init_module(debugger, internal_dict):
         'type summary add -x "^AK::RefPtr(<.*>)?$" -F AK.ak_refptr_summary',
         'type summary add -x "^AK::SinglyLinkedList(<.*>)?$" -F AK.ak_singlylinkedlist_summary',
         'type summary add -x "^AK::String(<.*>)?$" -F AK.ak_string_summary',
+        'type summary add -x "^AK::FlyString(<.*>)?$" -F AK.ak_flystring_summary',
         'type summary add -x "^AK::StringView(<.*>)?$" -F AK.ak_stringview_summary',
         'type summary add -x "^AK::Variant(<.*>)?$" -F AK.ak_variant_summary',
         'type summary add -x "^AK::Vector(<.*>)?$" -F AK.ak_vector_summary',


### PR DESCRIPTION
- Optional - Handle all 3 cases `m_storage | m_pointer | m_value`. `SentinelOptional.has_value()` fails on some occasion so it fallbacks to `null` instead of `Some | None`.
- String - Was failing to show heap allocated strings
