### PR TITLE
UI/Qt: Focus the location bar when the browser first opens with no URLs

### DIFF
--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -143,9 +143,9 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Win
 {
     auto* window = new BrowserWindow(initial_urls, is_popup_window, parent_tab, move(page_index));
     set_active_window(*window);
-    if (initial_urls.is_empty()) {
-        auto* tab = window->current_tab();
-        if (tab) {
+
+    if (initial_urls.size() == 1 && initial_urls.first() == URL::about_newtab()) {
+        if (auto* tab = window->current_tab()) {
             tab->set_url_is_hidden(true);
             tab->focus_location_editor();
         }


### PR DESCRIPTION
When no URLs are provided on the command line, LibWebView actually adds `about:newtab` to the initial URL list. The only time this list is empty is when we open a popup window.