### PR TITLE
LibWebView+UI: Save and restore open windows and tabs across sessions

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -381,6 +381,21 @@
                 </div>
             </div>
 
+            <h3 class="card-title">Startup</h3>
+            <div class="card">
+                <div class="card-body">
+                    <div class="card-group inline-container">
+                        <label for="restore-session-on-startup">
+                            Open previous windows and tabs on startup
+                            <p class="description">
+                                Restore all windows and tabs from your last session when Ladybird starts.
+                            </p>
+                        </label>
+                        <input id="restore-session-on-startup" type="checkbox" switch />
+                    </div>
+                </div>
+            </div>
+
             <h3 class="card-title">Tabs</h3>
             <div class="card">
                 <div class="card-body">
@@ -715,6 +730,7 @@
 
         <script src="resource://ladybird/about-pages/settings/advanced.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/browsing-behavior.js" type="module"></script>
+        <script src="resource://ladybird/about-pages/settings/startup.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/default-zoom-level.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/languages.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/network.js" type="module"></script>

--- a/Base/res/ladybird/about-pages/settings/startup.js
+++ b/Base/res/ladybird/about-pages/settings/startup.js
@@ -1,0 +1,19 @@
+const restoreSessionOnStartup = document.querySelector("#restore-session-on-startup");
+
+let STARTUP_BEHAVIOR = {};
+
+const loadSettings = settings => {
+    STARTUP_BEHAVIOR.restoreSessionOnStartup = settings.restoreSessionOnStartup ?? true;
+    restoreSessionOnStartup.checked = STARTUP_BEHAVIOR.restoreSessionOnStartup;
+};
+
+restoreSessionOnStartup.addEventListener("change", () => {
+    STARTUP_BEHAVIOR.restoreSessionOnStartup = restoreSessionOnStartup.checked;
+    ladybird.sendMessage("setStartupBehavior", STARTUP_BEHAVIOR);
+});
+
+document.addEventListener("WebUIMessage", event => {
+    if (event.detail.name === "loadSettings") {
+        loadSettings(event.detail.data);
+    }
+});

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -34,6 +34,7 @@
 #include <LibWebView/HistoryStore.h>
 #include <LibWebView/Menu.h>
 #include <LibWebView/ProcessType.h>
+#include <LibWebView/SessionStore.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/UserAgent.h>
 #include <LibWebView/Utilities.h>
@@ -732,12 +733,15 @@ ErrorOr<void> Application::launch_services()
 
         m_database = TRY(Database::Database::create(database_path, "Ladybird"sv));
         m_history_database = TRY(Database::Database::create(database_path, "History"sv));
+        auto enable_fk = TRY(m_history_database->prepare_statement("PRAGMA foreign_keys = ON;"sv));
+        m_history_database->execute_statement(enable_fk, {});
 
         if (auto history_database_path = m_history_database->database_path(); history_database_path.has_value())
             dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] SQL history is enabled, using {}", history_database_path->string());
 
         m_cookie_jar = TRY(CookieJar::create(*m_database));
         m_history_store = TRY(HistoryStore::create(*m_history_database));
+        m_session_store = TRY(SessionStore::create(*m_history_database));
         m_hsts_store = TRY(HSTSStore::create(*m_database));
         m_storage_jar = TRY(StorageJar::create(*m_database));
     } else {
@@ -1224,6 +1228,8 @@ void Application::clear_browsing_data(ClearBrowsingDataOptions const& options)
 
     if (options.delete_history == ClearBrowsingDataOptions::Delete::Yes) {
         m_history_store->remove_entries_accessed_since(options.since);
+        if (m_session_store.has_value())
+            m_session_store.value()->clear();
         did_change_history = true;
     }
 
@@ -1242,6 +1248,8 @@ void Application::clear_history()
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Clearing browsing history");
 
     m_history_store->clear();
+    if (m_session_store.has_value())
+        m_session_store.value()->clear();
     on_recently_closed_entries_changed();
 }
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -35,6 +35,7 @@
 #include <LibWebView/Options.h>
 #include <LibWebView/Process.h>
 #include <LibWebView/ProcessManager.h>
+#include <LibWebView/SessionStore.h>
 #include <LibWebView/Settings.h>
 #include <LibWebView/StorageJar.h>
 
@@ -78,6 +79,12 @@ public:
 
     static BookmarkStore& bookmark_store() { return the().m_bookmark_store; }
     static HistoryStore& history_store() { return *the().m_history_store; }
+    static Optional<SessionStore&> session_store()
+    {
+        if (the().m_session_store.has_value())
+            return **the().m_session_store;
+        return {};
+    }
     void update_bookmark_action_for_current_web_view();
     void bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>);
     void show_bookmarks_bar_changed(Badge<ApplicationSettingsObserver>);
@@ -322,6 +329,7 @@ private:
     BookmarkStore m_bookmark_store;
     OwnPtr<ApplicationBookmarkStoreObserver> m_bookmark_store_observer;
     OwnPtr<HistoryStore> m_history_store;
+    Optional<OwnPtr<SessionStore>> m_session_store;
 
     Main::Arguments m_arguments;
     BrowserOptions m_browser_options;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     ProcessManager.cpp
     ProcessMonitor.cpp
     SearchEngine.cpp
+    SessionStore.cpp
     Settings.cpp
     SiteIsolation.cpp
     SourceHighlighter.cpp

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -23,6 +23,7 @@ class HSTSStore;
 class Menu;
 class OutOfProcessWebView;
 class ProcessManager;
+class SessionStore;
 class Settings;
 class ViewImplementation;
 class WebContentClient;

--- a/Libraries/LibWebView/SessionStore.cpp
+++ b/Libraries/LibWebView/SessionStore.cpp
@@ -16,7 +16,6 @@ ErrorOr<NonnullOwnPtr<SessionStore>> SessionStore::create(Database::Database& da
     auto create_windows_table = TRY(database.prepare_statement(R"#(
         CREATE TABLE IF NOT EXISTS SessionWindows (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            window_index INTEGER NOT NULL,
             active_tab_index INTEGER NOT NULL DEFAULT 0,
             x INTEGER,
             y INTEGER,
@@ -40,8 +39,8 @@ ErrorOr<NonnullOwnPtr<SessionStore>> SessionStore::create(Database::Database& da
     statements.clear_windows = TRY(database.prepare_statement("DELETE FROM SessionWindows;"sv));
     statements.clear_tabs = TRY(database.prepare_statement("DELETE FROM SessionTabs;"sv));
     statements.insert_window = TRY(database.prepare_statement(R"#(
-        INSERT INTO SessionWindows (window_index, active_tab_index, x, y, width, height, maximized)
-        VALUES (?, ?, ?, ?, ?, ?, ?);
+        INSERT INTO SessionWindows (active_tab_index, x, y, width, height, maximized)
+        VALUES (?, ?, ?, ?, ?, ?);
     )#"sv));
     statements.update_window = TRY(database.prepare_statement(R"#(
         UPDATE SessionWindows
@@ -68,9 +67,9 @@ ErrorOr<NonnullOwnPtr<SessionStore>> SessionStore::create(Database::Database& da
         UPDATE SessionWindows SET active_tab_index = ? WHERE id = ?;
     )#"sv));
     statements.get_windows = TRY(database.prepare_statement(R"#(
-        SELECT id, window_index, active_tab_index, x, y, width, height, maximized
+        SELECT id, active_tab_index, x, y, width, height, maximized
         FROM SessionWindows
-        ORDER BY window_index ASC;
+        ORDER BY id ASC;
     )#"sv));
     statements.get_tabs_for_window = TRY(database.prepare_statement(R"#(
         SELECT url
@@ -79,7 +78,6 @@ ErrorOr<NonnullOwnPtr<SessionStore>> SessionStore::create(Database::Database& da
         ORDER BY tab_index ASC;
     )#"sv));
     statements.last_insert_rowid = TRY(database.prepare_statement("SELECT last_insert_rowid();"sv));
-    statements.count_windows = TRY(database.prepare_statement("SELECT COUNT(*) FROM SessionWindows;"sv));
 
     return adopt_own(*new SessionStore { database, move(statements) });
 }
@@ -99,13 +97,13 @@ Vector<SessionWindow> SessionStore::load_session()
     m_database.execute_statement(m_statements.get_windows, [&](Database::StatementID) {
         SessionWindow window;
         window.id = m_database.result_column<i64>(m_statements.get_windows, 0);
-        window.active_tab_index = static_cast<size_t>(m_database.result_column<i64>(m_statements.get_windows, 2));
+        window.active_tab_index = static_cast<size_t>(m_database.result_column<i64>(m_statements.get_windows, 1));
 
-        auto x = m_database.result_column<i64>(m_statements.get_windows, 3);
-        auto y = m_database.result_column<i64>(m_statements.get_windows, 4);
-        auto w = m_database.result_column<i64>(m_statements.get_windows, 5);
-        auto h = m_database.result_column<i64>(m_statements.get_windows, 6);
-        auto maximized = m_database.result_column<i64>(m_statements.get_windows, 7);
+        auto x = m_database.result_column<i64>(m_statements.get_windows, 2);
+        auto y = m_database.result_column<i64>(m_statements.get_windows, 3);
+        auto w = m_database.result_column<i64>(m_statements.get_windows, 4);
+        auto h = m_database.result_column<i64>(m_statements.get_windows, 5);
+        auto maximized = m_database.result_column<i64>(m_statements.get_windows, 6);
 
         if (x >= 0)
             window.x = static_cast<int>(x);
@@ -117,15 +115,13 @@ Vector<SessionWindow> SessionStore::load_session()
             window.height = static_cast<int>(h);
         window.maximized = (maximized != 0);
 
-        auto window_id = m_database.result_column<i64>(m_statements.get_windows, 0);
-
         m_database.execute_statement(
             m_statements.get_tabs_for_window,
             [&](Database::StatementID) {
                 auto url = m_database.result_column<String>(m_statements.get_tabs_for_window, 0);
                 window.tabs.append(SessionTab { AK::move(url) });
             },
-            window_id);
+            window.id);
 
         windows.append(AK::move(window));
     });
@@ -141,21 +137,12 @@ i64 SessionStore::insert_window(SessionWindow const& window)
     int height = window.height.has_value() ? *window.height : -1;
     int maximized = window.maximized ? 1 : 0;
 
-    // Count existing windows to determine the next window_index
-    i64 next_index = 0;
-    m_database.execute_statement(
-        m_statements.count_windows,
-        [&](Database::StatementID) {
-            next_index = m_database.result_column<i64>(m_statements.count_windows, 0);
-        });
-    i64 new_id = -1;
-
     m_database.execute_statement(
         m_statements.insert_window,
-        [&](Database::StatementID) { },
-        next_index,
+        {},
         static_cast<i64>(window.active_tab_index),
         x, y, width, height, maximized);
+    i64 new_id = -1;
 
     m_database.execute_statement(
         m_statements.last_insert_rowid,

--- a/Libraries/LibWebView/SessionStore.cpp
+++ b/Libraries/LibWebView/SessionStore.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibDatabase/Database.h>
+#include <LibWebView/SessionStore.h>
+
+namespace WebView {
+
+ErrorOr<NonnullOwnPtr<SessionStore>> SessionStore::create(Database::Database& database)
+{
+    Statements statements {};
+
+    auto create_windows_table = TRY(database.prepare_statement(R"#(
+        CREATE TABLE IF NOT EXISTS SessionWindows (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            window_index INTEGER NOT NULL,
+            active_tab_index INTEGER NOT NULL DEFAULT 0,
+            x INTEGER,
+            y INTEGER,
+            width INTEGER,
+            height INTEGER,
+            maximized INTEGER NOT NULL DEFAULT 0
+        );
+    )#"sv));
+    database.execute_statement(create_windows_table, {});
+
+    auto create_tabs_table = TRY(database.prepare_statement(R"#(
+        CREATE TABLE IF NOT EXISTS SessionTabs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            window_id INTEGER NOT NULL REFERENCES SessionWindows(id) ON DELETE CASCADE,
+            tab_index INTEGER NOT NULL,
+            url TEXT NOT NULL
+        );
+    )#"sv));
+    database.execute_statement(create_tabs_table, {});
+
+    statements.clear_windows = TRY(database.prepare_statement("DELETE FROM SessionWindows;"sv));
+    statements.clear_tabs = TRY(database.prepare_statement("DELETE FROM SessionTabs;"sv));
+    statements.insert_window = TRY(database.prepare_statement(R"#(
+        INSERT INTO SessionWindows (window_index, active_tab_index, x, y, width, height, maximized)
+        VALUES (?, ?, ?, ?, ?, ?, ?);
+    )#"sv));
+    statements.update_window = TRY(database.prepare_statement(R"#(
+        UPDATE SessionWindows
+        SET x = ?, y = ?, width = ?, height = ?, maximized = ?
+        WHERE id = ?;
+    )#"sv));
+    statements.delete_window = TRY(database.prepare_statement("DELETE FROM SessionWindows WHERE id = ?;"sv));
+    statements.insert_tab = TRY(database.prepare_statement(R"#(
+        INSERT INTO SessionTabs (window_id, tab_index, url)
+        VALUES (?, ?, ?);
+    )#"sv));
+    statements.update_tab_url = TRY(database.prepare_statement(R"#(
+        UPDATE SessionTabs SET url = ? WHERE window_id = ? AND tab_index = ?;
+    )#"sv));
+    statements.delete_tab = TRY(database.prepare_statement(R"#(
+        DELETE FROM SessionTabs WHERE window_id = ? AND tab_index = ?;
+    )#"sv));
+    statements.move_tabs_down = TRY(database.prepare_statement(R"#(
+        UPDATE SessionTabs
+        SET tab_index = tab_index - 1
+        WHERE window_id = ? AND tab_index > ?;
+    )#"sv));
+    statements.set_active_tab = TRY(database.prepare_statement(R"#(
+        UPDATE SessionWindows SET active_tab_index = ? WHERE id = ?;
+    )#"sv));
+    statements.get_windows = TRY(database.prepare_statement(R"#(
+        SELECT id, window_index, active_tab_index, x, y, width, height, maximized
+        FROM SessionWindows
+        ORDER BY window_index ASC;
+    )#"sv));
+    statements.get_tabs_for_window = TRY(database.prepare_statement(R"#(
+        SELECT url
+        FROM SessionTabs
+        WHERE window_id = ?
+        ORDER BY tab_index ASC;
+    )#"sv));
+    statements.last_insert_rowid = TRY(database.prepare_statement("SELECT last_insert_rowid();"sv));
+    statements.count_windows = TRY(database.prepare_statement("SELECT COUNT(*) FROM SessionWindows;"sv));
+
+    return adopt_own(*new SessionStore { database, move(statements) });
+}
+
+SessionStore::SessionStore(Database::Database& database, Statements&& statements)
+    : m_database(database)
+    , m_statements(move(statements))
+{
+}
+
+SessionStore::~SessionStore() = default;
+
+Vector<SessionWindow> SessionStore::load_session()
+{
+    Vector<SessionWindow> windows;
+
+    m_database.execute_statement(m_statements.get_windows, [&](Database::StatementID) {
+        SessionWindow window;
+        window.id = m_database.result_column<i64>(m_statements.get_windows, 0);
+        window.active_tab_index = static_cast<size_t>(m_database.result_column<i64>(m_statements.get_windows, 2));
+
+        auto x = m_database.result_column<i64>(m_statements.get_windows, 3);
+        auto y = m_database.result_column<i64>(m_statements.get_windows, 4);
+        auto w = m_database.result_column<i64>(m_statements.get_windows, 5);
+        auto h = m_database.result_column<i64>(m_statements.get_windows, 6);
+        auto maximized = m_database.result_column<i64>(m_statements.get_windows, 7);
+
+        if (x >= 0)
+            window.x = static_cast<int>(x);
+        if (y >= 0)
+            window.y = static_cast<int>(y);
+        if (w >= 0)
+            window.width = static_cast<int>(w);
+        if (h >= 0)
+            window.height = static_cast<int>(h);
+        window.maximized = (maximized != 0);
+
+        auto window_id = m_database.result_column<i64>(m_statements.get_windows, 0);
+
+        m_database.execute_statement(
+            m_statements.get_tabs_for_window,
+            [&](Database::StatementID) {
+                auto url = m_database.result_column<String>(m_statements.get_tabs_for_window, 0);
+                window.tabs.append(SessionTab { AK::move(url) });
+            },
+            window_id);
+
+        windows.append(AK::move(window));
+    });
+
+    return windows;
+}
+
+i64 SessionStore::insert_window(SessionWindow const& window)
+{
+    int x = window.x.has_value() ? *window.x : -1;
+    int y = window.y.has_value() ? *window.y : -1;
+    int width = window.width.has_value() ? *window.width : -1;
+    int height = window.height.has_value() ? *window.height : -1;
+    int maximized = window.maximized ? 1 : 0;
+
+    // Count existing windows to determine the next window_index
+    i64 next_index = 0;
+    m_database.execute_statement(
+        m_statements.count_windows,
+        [&](Database::StatementID) {
+            next_index = m_database.result_column<i64>(m_statements.count_windows, 0);
+        });
+    i64 new_id = -1;
+
+    m_database.execute_statement(
+        m_statements.insert_window,
+        [&](Database::StatementID) { },
+        next_index,
+        static_cast<i64>(window.active_tab_index),
+        x, y, width, height, maximized);
+
+    m_database.execute_statement(
+        m_statements.last_insert_rowid,
+        [&](Database::StatementID) {
+            new_id = m_database.result_column<i64>(m_statements.last_insert_rowid, 0);
+        });
+
+    for (size_t tab_idx = 0; tab_idx < window.tabs.size(); ++tab_idx) {
+        m_database.execute_statement(
+            m_statements.insert_tab,
+            {},
+            new_id,
+            static_cast<i64>(tab_idx),
+            window.tabs[tab_idx].url);
+    }
+
+    return new_id;
+}
+
+void SessionStore::update_window(i64 window_id, SessionWindow const& window)
+{
+    int x = window.x.has_value() ? *window.x : -1;
+    int y = window.y.has_value() ? *window.y : -1;
+    int width = window.width.has_value() ? *window.width : -1;
+    int height = window.height.has_value() ? *window.height : -1;
+    int maximized = window.maximized ? 1 : 0;
+
+    m_database.execute_statement(m_statements.update_window, {}, x, y, width, height, maximized, window_id);
+}
+
+void SessionStore::delete_window(i64 window_id)
+{
+    m_database.execute_statement(m_statements.delete_window, {}, window_id);
+}
+
+void SessionStore::insert_tab(i64 window_id, size_t tab_index, String const& url)
+{
+    m_database.execute_statement(m_statements.insert_tab, {}, window_id, static_cast<i64>(tab_index), url);
+}
+
+void SessionStore::update_tab_url(i64 window_id, size_t tab_index, String const& url)
+{
+    m_database.execute_statement(m_statements.update_tab_url, {}, url, window_id, static_cast<i64>(tab_index));
+}
+
+void SessionStore::delete_tab(i64 window_id, size_t tab_index)
+{
+    m_database.execute_statement(m_statements.delete_tab, {}, window_id, static_cast<i64>(tab_index));
+    // Shift remaining tabs down
+    m_database.execute_statement(m_statements.move_tabs_down, {}, window_id, static_cast<i64>(tab_index));
+}
+
+void SessionStore::set_active_tab(i64 window_id, size_t active_tab_index)
+{
+    m_database.execute_statement(m_statements.set_active_tab, {}, static_cast<i64>(active_tab_index), window_id);
+}
+
+void SessionStore::clear()
+{
+    m_database.execute_statement(m_statements.clear_tabs, {});
+    m_database.execute_statement(m_statements.clear_windows, {});
+}
+
+}

--- a/Libraries/LibWebView/SessionStore.cpp
+++ b/Libraries/LibWebView/SessionStore.cpp
@@ -58,6 +58,11 @@ ErrorOr<NonnullOwnPtr<SessionStore>> SessionStore::create(Database::Database& da
     statements.delete_tab = TRY(database.prepare_statement(R"#(
         DELETE FROM SessionTabs WHERE window_id = ? AND tab_index = ?;
     )#"sv));
+    statements.move_tabs_up = TRY(database.prepare_statement(R"#(
+        UPDATE SessionTabs
+        SET tab_index = tab_index + 1
+        WHERE window_id = ? AND tab_index >= ?;
+    )#"sv));
     statements.move_tabs_down = TRY(database.prepare_statement(R"#(
         UPDATE SessionTabs
         SET tab_index = tab_index - 1
@@ -180,6 +185,8 @@ void SessionStore::delete_window(i64 window_id)
 
 void SessionStore::insert_tab(i64 window_id, size_t tab_index, String const& url)
 {
+    // Shift existing tabs at or after the insertion point up to make room
+    m_database.execute_statement(m_statements.move_tabs_up, {}, window_id, static_cast<i64>(tab_index));
     m_database.execute_statement(m_statements.insert_tab, {}, window_id, static_cast<i64>(tab_index), url);
 }
 

--- a/Libraries/LibWebView/SessionStore.h
+++ b/Libraries/LibWebView/SessionStore.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibDatabase/Forward.h>
+#include <LibWebView/Export.h>
+
+namespace WebView {
+
+struct WEBVIEW_API SessionTab {
+    String url;
+};
+
+struct WEBVIEW_API SessionWindow {
+    i64 id { -1 };
+    Vector<SessionTab> tabs;
+    size_t active_tab_index { 0 };
+    Optional<int> x;
+    Optional<int> y;
+    Optional<int> width;
+    Optional<int> height;
+    bool maximized { false };
+};
+
+/*
+ * Session Restore Behavior
+ * ===========================================================================================
+ * Context \ Action   | Click Window 'X' (One by One) | Cmd + Q / Menu Quit | Crash / SIGKILL
+ * -------------------+-------------------------------+---------------------+-----------------
+ * Single Window      | Save as "Last Extinct Window" | Save current window | Trigger crash
+ * (Only 1 remaining) | Restore that single window.   | Restore it on next  | recovery flow
+ *                    |                               | boot.               | on next boot.
+ * -------------------+-------------------------------+---------------------+-----------------
+ * Multiple Windows   | Move closed window to         | Save ALL active     | Trigger crash
+ * (e.g. A, B, C)     | RecentlyClosed queue. Next    | windows. Next boot  | recovery flow
+ *                    | boot ONLY restores C.         | restores A, B, and C| restores ALL.
+ * ===========================================================================================
+ */
+class WEBVIEW_API SessionStore {
+    AK_MAKE_NONCOPYABLE(SessionStore);
+    AK_MAKE_NONMOVABLE(SessionStore);
+
+public:
+    static ErrorOr<NonnullOwnPtr<SessionStore>> create(Database::Database&);
+
+    ~SessionStore();
+
+    // On start up
+    Vector<SessionWindow> load_session();
+
+    i64 insert_window(SessionWindow const&);
+    void update_window(i64 window_id, SessionWindow const&);
+    void delete_window(i64 window_id);
+
+    void insert_tab(i64 window_id, size_t tab_index, String const& url);
+    void update_tab_url(i64 window_id, size_t tab_index, String const& url);
+    void delete_tab(i64 window_id, size_t tab_index);
+    void set_active_tab(i64 window_id, size_t active_tab_index);
+
+    void clear();
+
+    // FIXME: Maybe we should move "Recently Closed" tracking from HistoryStore into SessionStore
+private:
+    struct Statements {
+        Database::StatementID clear_windows { 0 };
+        Database::StatementID clear_tabs { 0 };
+        Database::StatementID insert_window { 0 };
+        Database::StatementID update_window { 0 };
+        Database::StatementID delete_window { 0 };
+        Database::StatementID insert_tab { 0 };
+        Database::StatementID update_tab_url { 0 };
+        Database::StatementID delete_tab { 0 };
+        Database::StatementID move_tabs_down { 0 };
+        Database::StatementID set_active_tab { 0 };
+        Database::StatementID get_windows { 0 };
+        Database::StatementID get_tabs_for_window { 0 };
+        Database::StatementID count_windows { 0 };
+        Database::StatementID last_insert_rowid { 0 };
+    };
+
+    SessionStore(Database::Database&, Statements&&);
+
+    Database::Database& m_database;
+    Statements m_statements;
+};
+
+}

--- a/Libraries/LibWebView/SessionStore.h
+++ b/Libraries/LibWebView/SessionStore.h
@@ -83,7 +83,6 @@ private:
         Database::StatementID set_active_tab { 0 };
         Database::StatementID get_windows { 0 };
         Database::StatementID get_tabs_for_window { 0 };
-        Database::StatementID count_windows { 0 };
         Database::StatementID last_insert_rowid { 0 };
     };
 

--- a/Libraries/LibWebView/SessionStore.h
+++ b/Libraries/LibWebView/SessionStore.h
@@ -79,6 +79,7 @@ private:
         Database::StatementID insert_tab { 0 };
         Database::StatementID update_tab_url { 0 };
         Database::StatementID delete_tab { 0 };
+        Database::StatementID move_tabs_up { 0 };
         Database::StatementID move_tabs_down { 0 };
         Database::StatementID set_active_tab { 0 };
         Database::StatementID get_windows { 0 };

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -32,6 +32,7 @@ static constexpr auto SHOW_MENU_BAR_KEY = "showMenuBar"sv;
 static constexpr auto DEFAULT_SHOW_MENU_BAR = false;
 
 static constexpr auto SHOW_BOOKMARKS_BAR_KEY = "showBookmarksBar"sv;
+static constexpr auto RESTORE_SESSION_ON_STARTUP_KEY = "restoreSessionOnStartup"sv;
 static constexpr auto DEFAULT_SHOW_BOOKMARKS_BAR = true;
 
 static constexpr auto DEFAULT_ZOOM_LEVEL_FACTOR_KEY = "defaultZoomLevelFactor"sv;
@@ -203,6 +204,9 @@ Settings Settings::create(Badge<Application>)
     if (auto show_bookmarks_bar = settings_json.value().get_bool(SHOW_BOOKMARKS_BAR_KEY); show_bookmarks_bar.has_value())
         settings.m_show_bookmarks_bar = *show_bookmarks_bar;
 
+    if (auto restore_session_on_startup = settings_json.value().get_bool(RESTORE_SESSION_ON_STARTUP_KEY); restore_session_on_startup.has_value())
+        settings.m_restore_session_on_startup = *restore_session_on_startup;
+
     if (auto factor = settings_json.value().get_double_with_precision_loss(DEFAULT_ZOOM_LEVEL_FACTOR_KEY); factor.has_value())
         settings.m_default_zoom_level_factor = factor.release_value();
 
@@ -310,6 +314,7 @@ JsonValue Settings::serialize_json() const
 
     settings.set(SHOW_MENU_BAR_KEY, m_show_menu_bar);
     settings.set(SHOW_BOOKMARKS_BAR_KEY, m_show_bookmarks_bar);
+    settings.set(RESTORE_SESSION_ON_STARTUP_KEY, m_restore_session_on_startup);
     settings.set(DEFAULT_ZOOM_LEVEL_FACTOR_KEY, m_default_zoom_level_factor);
 
     if (!m_zoom_per_host.is_empty()) {
@@ -469,6 +474,15 @@ void Settings::set_show_bookmarks_bar(bool show_bookmarks_bar)
 
     for (auto& observer : m_observers)
         observer.show_bookmarks_bar_changed();
+}
+
+void Settings::set_restore_session_on_startup(bool restore_session_on_startup)
+{
+    m_restore_session_on_startup = restore_session_on_startup;
+    persist_settings();
+
+    for (auto& observer : m_observers)
+        observer.restore_session_on_startup_changed();
 }
 
 void Settings::set_default_zoom_level_factor(double zoom_level)

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -81,6 +81,7 @@ public:
     virtual void tab_settings_changed() { }
     virtual void show_menu_bar_changed() { }
     virtual void show_bookmarks_bar_changed() { }
+    virtual void restore_session_on_startup_changed() { }
     virtual void default_zoom_level_factor_changed() { }
     virtual void zoom_per_host_changed(StringView host) { (void)host; }
     virtual void languages_changed() { }
@@ -112,6 +113,9 @@ public:
 
     bool show_bookmarks_bar() const { return m_show_bookmarks_bar; }
     void set_show_bookmarks_bar(bool);
+
+    bool restore_session_on_startup() const { return m_restore_session_on_startup; }
+    void set_restore_session_on_startup(bool);
 
     double default_zoom_level_factor() const { return m_default_zoom_level_factor; }
     void set_default_zoom_level_factor(double);
@@ -176,6 +180,7 @@ private:
     TabSettings m_tab_settings;
     bool m_show_menu_bar { false };
     bool m_show_bookmarks_bar { true };
+    bool m_restore_session_on_startup { true };
     double m_default_zoom_level_factor { 0 };
     HashMap<String, double> m_zoom_per_host;
     Vector<String> m_languages;

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -69,6 +69,9 @@ void SettingsUI::register_interfaces()
     register_interface("setBrowsingBehavior"sv, [this](auto const& data) {
         set_browsing_behavior(data);
     });
+    register_interface("setStartupBehavior"sv, [this](auto const& data) {
+        set_startup_behavior(data);
+    });
     register_interface("setConfigVariable"sv, [this](auto const& data) {
         set_config_variable(data);
     });
@@ -207,6 +210,17 @@ void SettingsUI::set_browsing_behavior(JsonValue const& browsing_behavior)
 {
     auto parsed_browsing_behavior = Settings::parse_browsing_behavior(browsing_behavior);
     WebView::Application::settings().set_browsing_behavior(parsed_browsing_behavior);
+
+    load_current_settings();
+}
+
+void SettingsUI::set_startup_behavior(JsonValue const& startup_behavior)
+{
+    if (!startup_behavior.is_object())
+        return;
+
+    if (auto restore_session = startup_behavior.as_object().get_bool("restoreSessionOnStartup"sv); restore_session.has_value())
+        WebView::Application::settings().set_restore_session_on_startup(*restore_session);
 
     load_current_settings();
 }

--- a/Libraries/LibWebView/WebUI/SettingsUI.h
+++ b/Libraries/LibWebView/WebUI/SettingsUI.h
@@ -25,6 +25,7 @@ private:
     void set_default_zoom_level_factor(JsonValue const&);
     void set_languages(JsonValue const&);
     void set_browsing_behavior(JsonValue const&);
+    void set_startup_behavior(JsonValue const&);
     void set_config_variable(JsonValue const&);
 
     void load_available_engines();

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -141,7 +141,7 @@ NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
 
 BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& configuration, BrowserWindow::IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
 {
-    auto* window = new BrowserWindow(initial_urls, is_popup_window, parent_tab, move(page_index));
+    auto* window = new BrowserWindow(initial_urls, is_popup_window, parent_tab, move(page_index), configuration.session_window_id);
     set_active_window(*window);
 
     if (initial_urls.size() == 1 && initial_urls.first() == URL::about_newtab()) {

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -21,6 +21,7 @@ struct WindowConfiguration {
     Optional<Web::DevicePixels> width {};
     Optional<Web::DevicePixels> height {};
     Optional<bool> maximized {};
+    Optional<i64> session_window_id {};
 };
 
 class Application final : public WebView::Application {

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -449,6 +449,12 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
                 tab->view().setFocus();
         }
         fullscreen_mode().exit(FullscreenMode::ExitInitiatedBy::UI);
+
+        if (m_session_window_id.has_value() && !m_is_restoring_session) {
+            auto store = Application::session_store();
+            if (store.has_value())
+                store->set_active_tab(m_session_window_id.value(), static_cast<size_t>(index));
+        }
     });
     QObject::connect(m_tabs_container, &TabWidget::tab_close_requested, this, &BrowserWindow::request_to_close_tab);
     QObject::connect(m_tabs_container, &TabWidget::tab_reordered, this, [this](int from, int to) {

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -451,6 +451,16 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         fullscreen_mode().exit(FullscreenMode::ExitInitiatedBy::UI);
     });
     QObject::connect(m_tabs_container, &TabWidget::tab_close_requested, this, &BrowserWindow::request_to_close_tab);
+    QObject::connect(m_tabs_container, &TabWidget::tab_reordered, this, [this](int from, int to) {
+        if (m_session_window_id.has_value() && !m_is_restoring_session) {
+            auto store = Application::session_store();
+            if (store.has_value()) {
+                auto url = m_tabs_container->tab(to)->view().url().serialize();
+                store->delete_tab(m_session_window_id.value(), static_cast<size_t>(from));
+                store->insert_tab(m_session_window_id.value(), static_cast<size_t>(to), url);
+            }
+        }
+    });
     QObject::connect(close_current_tab_action, &QAction::triggered, this, &BrowserWindow::request_to_close_current_tab);
 
     for (int i = 0; i <= 7; ++i) {

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -16,6 +16,7 @@
 #include <AK/TypeCasts.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/HistoryStore.h>
+#include <LibWebView/SessionStore.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/ChromeLayout.h>
@@ -230,9 +231,11 @@ static QIcon const& app_icon()
     return icon;
 }
 
-BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
+BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index, Optional<i64> session_window_id)
     : m_tabs_container(new TabWidget(this))
     , m_is_popup_window(is_popup_window)
+    , m_session_window_id(session_window_id)
+    , m_is_restoring_session(session_window_id.has_value())
 {
     auto& application = WebView::Application::the();
     auto const& browser_options = WebView::Application::browser_options();
@@ -242,6 +245,12 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     setWindowIcon(app_icon());
     qApp->installEventFilter(this);
     update_window_corners();
+
+    m_geometry_save_timer = new QTimer(this);
+    m_geometry_save_timer->setSingleShot(true);
+    QObject::connect(m_geometry_save_timer, &QTimer::timeout, this, [this] {
+        session_did_update_window();
+    });
 
     update_tabs_display();
 
@@ -468,6 +477,8 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         }
     }
 
+    m_is_restoring_session = false;
+
     m_tabs_container->set_new_tab_action(m_new_tab_action);
 
     auto* main_widget = new QWidget(this);
@@ -536,6 +547,7 @@ Tab& BrowserWindow::new_tab_from_url(URL::URL const& url, Web::HTML::ActivateTab
 {
     auto& tab = create_new_tab(activate_tab);
     tab.navigate(url);
+    session_did_open_tab(url);
     return tab;
 }
 
@@ -621,6 +633,21 @@ void BrowserWindow::initialize_tab(Tab* tab)
     };
 
     initialize_tab_buttons(tab);
+
+    // Wrap view's on_load_start to track navigation in the session.
+    auto original_on_load_start = AK::move(tab->view().on_load_start);
+    tab->view().on_load_start = [this, tab, original = AK::move(original_on_load_start)](auto const& url, bool is_redirect) {
+        if (original)
+            original(url, is_redirect);
+        if (m_session_window_id.has_value() && !m_is_restoring_session) {
+            auto idx = tab_index(tab);
+            if (idx >= 0) {
+                auto store = Application::session_store();
+                if (store.has_value())
+                    store->update_tab_url(m_session_window_id.value(), static_cast<size_t>(idx), url.serialize());
+            }
+        }
+    };
 }
 
 void BrowserWindow::uninitialize_tab(Tab* tab)
@@ -716,6 +743,7 @@ void BrowserWindow::definitely_close_tab(int index)
     m_tabs_container->remove_tab(index);
     Application::history_store().record_closed_tab(url);
     Application::the().update_reopen_recently_closed_actions();
+    session_did_close_tab(static_cast<size_t>(index));
     tab->deleteLater();
 
     if (m_tabs_container->count() == 0) {
@@ -1102,6 +1130,7 @@ void BrowserWindow::set_window_rect(Optional<Web::DevicePixels> x, Optional<Web:
         height = 600;
 
     setGeometry(x.value().value(), y.value().value(), width.value().value(), height.value().value());
+    session_did_update_window();
 }
 
 void BrowserWindow::enter_fullscreen()
@@ -1160,6 +1189,9 @@ bool BrowserWindow::event(QEvent* event)
 
 bool BrowserWindow::eventFilter(QObject* object, QEvent* event)
 {
+    if (object == qApp && event->type() == QEvent::Quit)
+        m_is_application_quitting = true;
+
     auto* widget = as_if<QWidget>(object);
     if (!widget || widget->window() != this)
         return QMainWindow::eventFilter(object, event);
@@ -1301,6 +1333,8 @@ void BrowserWindow::resizeEvent(QResizeEvent* event)
     for_each_tab([&](auto& tab) {
         tab.view().set_window_size({ width(), height() });
     });
+
+    session_schedule_update_window();
 }
 
 void BrowserWindow::changeEvent(QEvent* event)
@@ -1360,6 +1394,8 @@ void BrowserWindow::moveEvent(QMoveEvent* event)
     for_each_tab([&](auto& tab) {
         tab.view().set_window_position({ x(), y() });
     });
+
+    session_schedule_update_window();
 }
 
 void BrowserWindow::wheelEvent(QWheelEvent* event)
@@ -1378,6 +1414,7 @@ void BrowserWindow::wheelEvent(QWheelEvent* event)
 void BrowserWindow::closeEvent(QCloseEvent* event)
 {
     clear_resize_cursor();
+    m_geometry_save_timer->stop();
 
     Optional<Vector<URL::URL>> recently_closed_window_urls;
     size_t recently_closed_window_active_tab_index { 0 };
@@ -1399,6 +1436,80 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
     if (event->isAccepted() && recently_closed_window_urls.has_value()) {
         Application::history_store().record_closed_window(recently_closed_window_urls.release_value(), recently_closed_window_active_tab_index);
         Application::the().update_reopen_recently_closed_actions();
+    }
+
+    if (event->isAccepted() && m_session_window_id.has_value()) {
+        auto store = Application::session_store();
+        if (store.has_value()) {
+            WebView::SessionWindow sw;
+            sw.x = x();
+            sw.y = y();
+            sw.width = width();
+            sw.height = height();
+            sw.maximized = isMaximized();
+
+            bool is_last_window = true;
+            auto const top_level_widgets = QApplication::topLevelWidgets();
+            for (auto* widget : top_level_widgets) {
+                if (widget != this && qobject_cast<BrowserWindow*>(widget)) {
+                    is_last_window = false;
+                    break;
+                }
+            }
+
+            if (m_is_application_quitting || is_last_window)
+                store->update_window(m_session_window_id.value(), sw);
+            else
+                store->delete_window(m_session_window_id.value());
+        }
+    }
+}
+
+void BrowserWindow::session_did_open_tab(URL::URL const& url)
+{
+    if (m_is_restoring_session || m_is_popup_window == IsPopupWindow::Yes)
+        return;
+
+    auto store = Application::session_store();
+    if (!store.has_value())
+        return;
+
+    if (!m_session_window_id.has_value())
+        m_session_window_id = store->insert_window({});
+
+    store->insert_tab(m_session_window_id.value(), static_cast<size_t>(m_tabs_container->count() - 1), url.serialize());
+}
+
+void BrowserWindow::session_schedule_update_window()
+{
+    // Avoid updating session store too frequently while resizing/moving the window.
+    if (!m_geometry_save_timer->isActive())
+        m_geometry_save_timer->start(500);
+}
+
+void BrowserWindow::session_did_close_tab(size_t tab_index)
+{
+    if (!m_session_window_id.has_value() || m_is_restoring_session)
+        return;
+
+    auto store = Application::session_store();
+    if (store.has_value())
+        store->delete_tab(m_session_window_id.value(), tab_index);
+}
+
+void BrowserWindow::session_did_update_window()
+{
+    if (m_session_window_id.has_value()) {
+        auto store = Application::session_store();
+        if (store.has_value()) {
+            WebView::SessionWindow sw;
+            sw.x = x();
+            sw.y = y();
+            sw.width = width();
+            sw.height = height();
+            sw.maximized = isMaximized();
+            store->update_window(m_session_window_id.value(), sw);
+        }
     }
 }
 

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -21,6 +21,7 @@
 #include <QTabBar>
 
 class QPropertyAnimation;
+class QTimer;
 class QWindow;
 class QToolButton;
 class QWidget;
@@ -93,7 +94,7 @@ public:
         Yes,
     };
 
-    BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window = IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window = IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {}, Optional<i64> session_window_id = {});
     virtual ~BrowserWindow() override;
 
     WebContentView& view() const { return m_current_tab->view(); }
@@ -193,6 +194,10 @@ private:
     void disconnect_screen_signals(QScreen*);
     void screen_changed(QScreen*);
     void display_metadata_changed(Optional<u64> display_id, qreal refresh_rate);
+    void session_did_open_tab(URL::URL const&);
+    void session_did_close_tab(size_t tab_index);
+    void session_did_update_window();
+    void session_schedule_update_window();
 
     QIcon icon_for_page_mute_state(Tab&) const;
     QString tool_tip_for_page_mute_state(Tab&) const;
@@ -220,6 +225,12 @@ private:
     QAction* m_find_in_page_action { nullptr };
 
     IsPopupWindow m_is_popup_window { IsPopupWindow::No };
+    Optional<i64> m_session_window_id;
+    // Will set to true when it's restoring tabs from last close.
+    // So, if this is true, we will skip recording tab operations
+    bool m_is_restoring_session { false };
+    bool m_is_application_quitting { false };
+    QTimer* m_geometry_save_timer { nullptr };
 
     ExitFullscreenButton* m_exit_button { nullptr };
     FullscreenMode* m_fullscreen_mode { nullptr };

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1231,6 +1231,8 @@ TabWidget::TabWidget(QWidget* parent)
             m_toolbar_container->insertWidget(to, toolbar);
         }
         m_stacked_widget->setCurrentIndex(m_tab_bar->currentIndex());
+
+        emit tab_reordered(from, to);
     });
 
     connect(m_minimize_window_button, &QToolButton::clicked, this, [this] {

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -156,6 +156,7 @@ public:
 signals:
     void current_tab_changed(int index);
     void tab_close_requested(int index);
+    void tab_reordered(int from, int to);
 
 protected:
     virtual void dragEnterEvent(QDragEnterEvent*) override;

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -106,9 +106,11 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         }
 
         Vector<WebView::SessionWindow> session_windows;
-        auto store = WebView::Application::session_store();
-        if (store.has_value())
-            session_windows = store->load_session();
+        if (WebView::Application::settings().restore_session_on_startup()) {
+            auto store = WebView::Application::session_store();
+            if (store.has_value())
+                session_windows = store->load_session();
+        }
 
         if (session_windows.is_empty()) {
             auto& window = app->new_window(browser_options.urls, configuration);

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -5,8 +5,10 @@
  */
 
 #include <LibMain/Main.h>
+#include <LibURL/Parser.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/BrowserProcess.h>
+#include <LibWebView/SessionStore.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/Utilities.h>
 #include <UI/Qt/Application.h>
@@ -102,8 +104,45 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
             configuration.x = last_position->x();
             configuration.y = last_position->y();
         }
-        auto& window = app->new_window(browser_options.urls, configuration);
-        window.setWindowTitle("Ladybird");
+
+        Vector<WebView::SessionWindow> session_windows;
+        auto store = WebView::Application::session_store();
+        if (store.has_value())
+            session_windows = store->load_session();
+
+        if (session_windows.is_empty()) {
+            auto& window = app->new_window(browser_options.urls, configuration);
+            window.setWindowTitle("Ladybird");
+        } else {
+            bool any_window_created = false;
+            for (auto& session_window : session_windows) {
+                Vector<URL::URL> urls;
+                for (auto& tab : session_window.tabs) {
+                    if (auto url = URL::Parser::basic_parse(tab.url); url.has_value())
+                        urls.append(url.release_value());
+                }
+                if (urls.is_empty())
+                    continue;
+
+                Ladybird::WindowConfiguration window_config {
+                    .x = session_window.x.has_value() ? Optional<Web::DevicePixels>(*session_window.x) : Optional<Web::DevicePixels>(),
+                    .y = session_window.y.has_value() ? Optional<Web::DevicePixels>(*session_window.y) : Optional<Web::DevicePixels>(),
+                    .width = session_window.width.has_value() ? Optional<Web::DevicePixels>(*session_window.width) : configuration.width,
+                    .height = session_window.height.has_value() ? Optional<Web::DevicePixels>(*session_window.height) : configuration.height,
+                    .maximized = session_window.maximized,
+                    .session_window_id = session_window.id,
+                };
+                auto& window = app->new_window(urls, window_config);
+                window.activate_tab(static_cast<int>(session_window.active_tab_index));
+                window.setWindowTitle("Ladybird");
+                any_window_created = true;
+            }
+
+            if (!any_window_created) {
+                auto& window = app->new_window(browser_options.urls, configuration);
+                window.setWindowTitle("Ladybird");
+            }
+        }
     }
 
     return app->execute();


### PR DESCRIPTION
Fixes #5440

This PR implements session persistence: open windows and tabs are saved to a SQLite database and restored when Ladybird restarts.

- Added SessionStore (`LibWebView/SessionStore`): tracks open windows and tabs in `History.db`, including:
  - SessionWindows: window geometry (`x`, `y`, `width`, `height`), maximized state, and active tab index.
  - SessionTabs: per-window tab URLs with ordering via `tab_index`, foreign-keyed to `SessionWindows`.

- Updated `main.cpp` to make it reads all windows and tabs from the store and recreates them with their saved geometry on starts up.
- Updated `about:settings` UI: `General > Startup > Open previous windows and tabs on startup` controls whether the session is restored on launch and is set to true in default. Session data is always saved to disk regardless of this setting, so you can toggle it on at any time.
- Supported this feature in `UI/Qt`.

<img width="1376" height="945" alt="Screenshot 2026-06-04 at 20 03 35" src="https://github.com/user-attachments/assets/a53ac808-5d18-4965-b9fa-8034911245f5" />

*Note: I didn't implements the AppKit supports, as the tabs' life circle is not very clear and I'm not very familiar with it. :(*