### PR TITLE
LibWeb: Apply body attribute link colors as presentational hints

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -282,16 +282,6 @@ public:
 
     static NonnullRefPtr<Gfx::Font const> font_fallback(bool monospace, bool bold, float point_size);
 
-    bool has_attempted_match_against_pseudo_class(PseudoClass pseudo_class) const
-    {
-        return m_attempted_pseudo_class_matches.get(pseudo_class);
-    }
-
-    void set_attempted_pseudo_class_matches(PseudoClassBitmap const& results)
-    {
-        m_attempted_pseudo_class_matches = results;
-    }
-
     HashMap<PropertyID, NonnullRefPtr<StyleValue const>> const& inheritance_dependent_specified_values() const { return m_inheritance_dependent_specified_values; }
     void add_inheritance_dependent_specified_value(PropertyID property_id, NonnullRefPtr<StyleValue const> value) { m_inheritance_dependent_specified_values.set(property_id, move(value)); }
 
@@ -328,8 +318,6 @@ private:
     }
 
     Optional<CSSPixels> m_line_height;
-
-    PseudoClassBitmap m_attempted_pseudo_class_matches;
 
     HashMap<PropertyID, NonnullRefPtr<StyleValue const>> m_inheritance_dependent_specified_values;
     RefPtr<StyleValue const> m_raw_cascaded_font_size;

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -663,7 +663,6 @@ static bool matches_optimal_value_pseudo_class(DOM::Element const& element, HTML
 
 static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoClassSelector const& pseudo_class, DOM::AbstractElement const& target, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, GC::Ptr<DOM::ParentNode const> scope, SelectorKind selector_kind)
 {
-    context.attempted_pseudo_class_matches.set(pseudo_class.type, true);
     auto note_structural_pseudo_class_match_attempt = [&] {
         if (&target.element() != context.subject)
             const_cast<DOM::Element&>(target.element()).set_affected_by_structural_pseudo_class_in_non_subject_position();

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -684,8 +684,9 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         return target.element().matches_local_link_pseudo_class();
     }
     case CSS::PseudoClass::Visited:
-        // FIXME: Maybe match this selector sometimes?
-        return false;
+        if (target.pseudo_element().has_value())
+            return false;
+        return target.element().matches_visited_pseudo_class();
     case CSS::PseudoClass::Active:
         // FIXME: Match pseudo-elements
         if (target.pseudo_element().has_value())

--- a/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -54,7 +54,6 @@ struct MatchContext {
     // later terminate once it leaves the scope. Transparent to callers; set
     // by matches_has_pseudo_class with a ScopeGuard.
     bool inside_has_argument_match { false };
-    CSS::PseudoClassBitmap attempted_pseudo_class_matches {};
     HasResultCache* has_result_cache { nullptr };
 };
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -362,7 +362,7 @@ static Optional<ResolvedScope> resolve_scope(DOM::AbstractElement abstract_eleme
     return resolve_scope_chain(abstract_element, rule, shadow_host, rule_root, *rule.scope_rule);
 }
 
-Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules_from_context(DOM::AbstractElement abstract_element, CascadeOrigin cascade_origin, GC::Ptr<DOM::ShadowRoot const> context_shadow_root, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name) const
+Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules_from_context(DOM::AbstractElement abstract_element, CascadeOrigin cascade_origin, GC::Ptr<DOM::ShadowRoot const> context_shadow_root, Optional<FlyString const> qualified_layer_name) const
 {
     auto const& root_node = abstract_element.element().root();
     auto shadow_root = as_if<DOM::ShadowRoot>(root_node);
@@ -525,9 +525,6 @@ Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules_
             .rule_shadow_root = rule_root,
             .collect_per_element_selector_involvement_metadata = true,
             .has_result_cache = m_has_result_cache.ptr(),
-        };
-        ScopeGuard guard = [&] {
-            attempted_pseudo_class_matches |= context.attempted_pseudo_class_matches;
         };
         if (!SelectorEngine::matches(selector, abstract_element, shadow_host_to_use, context, resolved_scope->root))
             continue;
@@ -1402,7 +1399,7 @@ void StyleComputer::start_needed_transitions(ComputedProperties const& previous_
     }
 }
 
-StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::AbstractElement abstract_element, PseudoClassBitmap& attempted_pseudo_class_matches, bool& did_match_any_pseudo_element_rules, ComputeStyleMode mode) const
+StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::AbstractElement abstract_element, bool& did_match_any_pseudo_element_rules, ComputeStyleMode mode) const
 {
     auto collect_author_contexts = [&] {
         Vector<GC::Ptr<DOM::ShadowRoot const>, 4> context_shadow_roots;
@@ -1454,12 +1451,12 @@ StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::Abstr
             };
 
             for (auto const& layer_name : context_style_scope.m_rule_cache->qualified_layer_names_in_order) {
-                auto layer_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::Author, shadow_root, attempted_pseudo_class_matches, layer_name);
+                auto layer_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::Author, shadow_root, layer_name);
                 sort_matching_rules(layer_rules);
                 context.author_rules.append({ layer_name, layer_rules });
             }
 
-            auto unlayered_author_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::Author, shadow_root, attempted_pseudo_class_matches);
+            auto unlayered_author_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::Author, shadow_root);
             sort_matching_rules(unlayered_author_rules);
             context.author_rules.append({ {}, unlayered_author_rules });
 
@@ -1471,9 +1468,9 @@ StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::Abstr
 
     // First, we collect all the CSS rules whose selectors match `element`:
     MatchingRuleSet matching_rule_set;
-    matching_rule_set.user_agent_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::UserAgent, nullptr, attempted_pseudo_class_matches);
+    matching_rule_set.user_agent_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::UserAgent, nullptr);
     sort_matching_rules(matching_rule_set.user_agent_rules);
-    matching_rule_set.user_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::User, nullptr, attempted_pseudo_class_matches);
+    matching_rule_set.user_rules = collect_matching_rules_from_context(abstract_element, CascadeOrigin::User, nullptr);
     sort_matching_rules(matching_rule_set.user_rules);
     matching_rule_set.author_contexts = collect_author_contexts();
 
@@ -2096,8 +2093,7 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
 
     // 1. Perform the cascade. This produces the "specified style"
     bool did_match_any_pseudo_element_rules = false;
-    PseudoClassBitmap attempted_pseudo_class_matches;
-    auto matching_rule_set = build_matching_rule_set(abstract_element, attempted_pseudo_class_matches, did_match_any_pseudo_element_rules, mode);
+    auto matching_rule_set = build_matching_rule_set(abstract_element, did_match_any_pseudo_element_rules, mode);
 
     if (mode == ComputeStyleMode::CreatePseudoElementStyleIfNeeded) {
         // NOTE: If we're computing style for a pseudo-element, we look for a number of reasons to bail early.
@@ -2197,7 +2193,6 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
     }
 
     auto computed_properties = compute_properties(abstract_element, cascaded_properties);
-    computed_properties->set_attempted_pseudo_class_matches(attempted_pseudo_class_matches);
 
     if (did_change_custom_properties.has_value()) {
         auto new_custom_property_data = abstract_element.custom_property_data();

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -178,7 +178,7 @@ private:
         Vector<ContextMatchingRules> author_contexts;
     };
 
-    [[nodiscard]] MatchingRuleSet build_matching_rule_set(DOM::AbstractElement, PseudoClassBitmap& attempted_pseudo_class_matches, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
+    [[nodiscard]] MatchingRuleSet build_matching_rule_set(DOM::AbstractElement, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
 
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_style_impl(DOM::AbstractElement, ComputeStyleMode, Optional<bool&> did_change_custom_properties, StyleScope const&) const;
     [[nodiscard]] GC::Ref<CascadedProperties> compute_cascaded_values(DOM::AbstractElement, bool did_match_any_pseudo_element_rules, ComputeStyleMode, MatchingRuleSet const&) const;
@@ -191,7 +191,7 @@ private:
 
     [[nodiscard]] Length::FontMetrics calculate_root_element_font_metrics(ComputedProperties const&) const;
 
-    [[nodiscard]] Vector<ScopedMatchingRule> collect_matching_rules_from_context(DOM::AbstractElement, CascadeOrigin, GC::Ptr<DOM::ShadowRoot const>, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name = {}) const;
+    [[nodiscard]] Vector<ScopedMatchingRule> collect_matching_rules_from_context(DOM::AbstractElement, CascadeOrigin, GC::Ptr<DOM::ShadowRoot const>, Optional<FlyString const> qualified_layer_name = {}) const;
 
     void cascade_declarations(
         CascadedProperties&,

--- a/Libraries/LibWeb/CSS/StyleValues/ColorMixStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ColorMixStyleValue.cpp
@@ -226,7 +226,6 @@ ValueComparingNonnullRefPtr<StyleValue const> ColorMixStyleValue::absolutized(Co
     ColorResolutionContext color_resolution_context {
         .color_scheme = context.color_scheme,
         .current_color = {},
-        .accent_color = {},
         .document = context.abstract_element.map([](auto& it) { return &it.document(); }).value_or(nullptr),
         .calculation_resolution_context = CalculationResolutionContext::from_computation_context(context),
     };

--- a/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
@@ -146,29 +146,17 @@ Optional<Color> KeywordStyleValue::to_color(ColorResolutionContext color_resolut
 
     PreferredColorScheme scheme = color_resolution_context.color_scheme.value_or(PreferredColorScheme::Light);
 
-    // Calculate accent_color_text based on contrast to accent_color
-    if (keyword() == Keyword::Accentcolortext) {
-        // min_contrast = 10.2 is a magic number which provides the best accessibility trade-off based on:
-        // 1. https://webaim.org/resources/contrastchecker/
-        // 2. Current implementation of luminosity() and contrast_ratio() methods for Color instances
-
-        // the baseline colors with the least contrast from black and white are #757575 and #767676
-        // which score over 4.5 ratio for #fff and #000 accent_color_text values correspondingly
-        auto constexpr min_contrast = 10.2;
-        auto system_accent_text = SystemColor::accent_color_text(scheme);
-
-        if (color_resolution_context.accent_color.value_or(SystemColor::accent_color(scheme)).contrast_ratio(system_accent_text) < min_contrast)
-            return system_accent_text.inverted();
-
-        return system_accent_text;
-    }
-
     // First, handle <system-color>s, since they don't strictly require a node.
     // https://www.w3.org/TR/css-color-4/#css-system-colors
     // https://www.w3.org/TR/css-color-4/#deprecated-system-colors
     switch (keyword()) {
+    // AD-HOC: The spec says that 'accentcolor' and 'accentcolortext' should be resolved based on the value of the
+    //         'accent-color' property, but this isn't implemented by any other browsers and isn't fully specified
+    //          (https://github.com/w3c/csswg-drafts/issues/10971).
     case Keyword::Accentcolor:
-        return color_resolution_context.accent_color.value_or(SystemColor::accent_color(scheme));
+        return SystemColor::accent_color(scheme);
+    case Keyword::Accentcolortext:
+        return SystemColor::accent_color_text(scheme);
     case Keyword::Buttonborder:
     case Keyword::Activeborder:
     case Keyword::Inactiveborder:

--- a/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
@@ -157,6 +157,8 @@ Optional<Color> KeywordStyleValue::to_color(ColorResolutionContext color_resolut
         return SystemColor::accent_color(scheme);
     case Keyword::Accentcolortext:
         return SystemColor::accent_color_text(scheme);
+    case Keyword::Activetext:
+        return SystemColor::active_text(scheme);
     case Keyword::Buttonborder:
     case Keyword::Activeborder:
     case Keyword::Inactiveborder:
@@ -212,6 +214,11 @@ Optional<Color> KeywordStyleValue::to_color(ColorResolutionContext color_resolut
         return SystemColor::button_face(scheme).with_alpha(128);
     case Keyword::LibwebButtonfacehover:
         return SystemColor::button_face(scheme).darkened(0.8f);
+    case Keyword::LibwebLink:
+    case Keyword::Linktext:
+        return SystemColor::link_text(scheme);
+    case Keyword::Visitedtext:
+        return SystemColor::visited_text(scheme);
     default:
         break;
     }
@@ -219,18 +226,6 @@ Optional<Color> KeywordStyleValue::to_color(ColorResolutionContext color_resolut
     if (!color_resolution_context.document) {
         // FIXME: Can't resolve palette colors without a document.
         return Color::Black;
-    }
-
-    switch (keyword()) {
-    case Keyword::LibwebLink:
-    case Keyword::Linktext:
-        return color_resolution_context.document->normal_link_color().value_or(SystemColor::link_text(scheme));
-    case Keyword::Visitedtext:
-        return color_resolution_context.document->visited_link_color().value_or(SystemColor::visited_text(scheme));
-    case Keyword::Activetext:
-        return color_resolution_context.document->active_link_color().value_or(SystemColor::active_text(scheme));
-    default:
-        break;
     }
 
     auto palette = color_resolution_context.document->page().palette();

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -86,7 +86,6 @@
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 #include <LibWeb/CSS/StyleValues/UnicodeRangeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/UnresolvedStyleValue.h>
-#include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/Layout/Node.h>
@@ -102,8 +101,7 @@ ColorResolutionContext ColorResolutionContext::for_element(DOM::AbstractElement 
 
     return {
         .color_scheme = color_scheme,
-        .current_color = element.computed_properties()->color(PropertyID::Color, { color_scheme, CSS::InitialValues::color(), CSS::SystemColor::accent_color(color_scheme), element.document(), calculation_resolution_context }),
-        .accent_color = element.computed_properties()->accent_color({ color_scheme, CSS::InitialValues::color(), CSS::SystemColor::accent_color(color_scheme), element.document(), calculation_resolution_context }),
+        .current_color = element.computed_properties()->color(PropertyID::Color, { color_scheme, CSS::InitialValues::color(), element.document(), calculation_resolution_context }),
         .document = element.document(),
         .calculation_resolution_context = calculation_resolution_context
     };
@@ -114,7 +112,6 @@ ColorResolutionContext ColorResolutionContext::for_layout_node_with_style(Layout
     return {
         .color_scheme = layout_node.computed_values().color_scheme(),
         .current_color = layout_node.computed_values().color(),
-        .accent_color = layout_node.computed_values().accent_color(),
         .document = layout_node.document(),
         .calculation_resolution_context = { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) },
     };

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -108,7 +108,6 @@ namespace Web::CSS {
 struct ColorResolutionContext {
     Optional<PreferredColorScheme> color_scheme;
     Optional<Color> current_color;
-    Optional<Color> accent_color;
     GC::Ptr<DOM::Document const> document;
     CalculationResolutionContext calculation_resolution_context;
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1837,22 +1837,6 @@ GC::Ptr<Layout::NodeWithStyle> Element::pseudo_element_unsafe_layout_node(CSS::P
     return nullptr;
 }
 
-bool Element::affected_by_pseudo_class(CSS::PseudoClass pseudo_class) const
-{
-    if (m_computed_properties && m_computed_properties->has_attempted_match_against_pseudo_class(pseudo_class)) {
-        return true;
-    }
-    if (m_pseudo_element_data) {
-        for (auto& pseudo_element : *m_pseudo_element_data) {
-            if (!pseudo_element.value->computed_properties())
-                continue;
-            if (pseudo_element.value->computed_properties()->has_attempted_match_against_pseudo_class(pseudo_class))
-                return true;
-        }
-    }
-    return false;
-}
-
 // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-enabled
 bool Element::matches_enabled_pseudo_class() const
 {

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1921,6 +1921,30 @@ bool Element::matches_link_pseudo_class() const
     return has_attribute(HTML::AttributeNames::href);
 }
 
+// https://drafts.csswg.org/selectors/#visited-pseudo
+bool Element::matches_visited_pseudo_class() const
+{
+    // The :visited pseudo-class comes with obvious privacy implications—​letting random websites know what other
+    // websites you’ve visited can be problematic for a number of reasons—​and so user agents must preserve user
+    // privacy in their implementation of :visited.
+
+    // NOTE: This specification intentionally does not specify exactly how to preserve user privacy in this regard, to
+    //       allow for user agents to innovate in this space. The following methods are suggested, however:
+    //       - Have :visited never match, so all links match :link instead.
+    //       - Carefully track what history entries could have been observed by a given origin on their own, and only
+    //         have links match :visited if that visit would have been observable from the site’s origin. A possible
+    //         specific approach for this is described in Appendix C: Example Privacy-Preserving :visited Restrictions.
+    //       - Allow links to match :visited on any origin, but carefully restrict what styles they can apply and what
+    //         information is returned by style-querying APIs like getComputedStyle(), to prevent sites from observing
+    //         whether a link is styled with :link or :visited. (This is documented at MDN, and was the historical
+    //         approach browsers took, but is not perfect; there are several ways for a hostile page to still extract
+    //         history information.)
+
+    // FIXME: For simplicity we currently take the first approach and have :visited never match. We may want to rethink
+    //        this in the future.
+    return false;
+}
+
 bool Element::matches_local_link_pseudo_class() const
 {
     // The :local-link pseudo-class allows authors to style hyperlinks based on the users current location

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -871,6 +871,37 @@ GC::Ptr<Layout::NodeWithStyle> Element::create_layout_node_for_display_type(DOM:
     return document.heap().allocate<Layout::InlineNode>(document, element, move(style));
 }
 
+void Element::apply_presentational_hints(Vector<CSS::StyleProperty>& properties) const
+{
+    // https://html.spec.whatwg.org/multipage/rendering.html#the-page
+    // When a body element has a link attribute, its value is expected to be parsed using the rules for parsing a legacy
+    // color value, and if that does not return failure, the user agent is expected to treat the attribute as a
+    // presentational hint setting the 'color' property of any element in the Document matching the :link pseudo-class
+    // to the resulting color.
+    if (matches_link_pseudo_class()) {
+        if (auto const& link_color = document().normal_link_color(); link_color.has_value())
+            properties.append({ .property_id = CSS::PropertyID::Color, .value = CSS::ColorStyleValue::create_from_color(*link_color, CSS::ColorSyntax::Legacy) });
+    }
+
+    // When a body element has a vlink attribute, its value is expected to be parsed using the rules for parsing a
+    // legacy color value, and if that does not return failure, the user agent is expected to treat the attribute as a
+    // presentational hint setting the 'color' property of any element in the Document matching the :visited
+    // pseudo-class to the resulting color.
+    if (matches_visited_pseudo_class()) {
+        if (auto const& visited_link_color = document().visited_link_color(); visited_link_color.has_value())
+            properties.append({ .property_id = CSS::PropertyID::Color, .value = CSS::ColorStyleValue::create_from_color(*visited_link_color, CSS::ColorSyntax::Legacy) });
+    }
+
+    // When a body element has an alink attribute, its value is expected to be parsed using the rules for parsing a
+    // legacy color value, and if that does not return failure, the user agent is expected to treat the attribute as a
+    // presentational hint setting the 'color' property of any element in the Document matching the :active pseudo-class
+    // and either the :link pseudo-class or the :visited pseudo-class to the resulting color.
+    if (is_being_activated() && (matches_link_pseudo_class() || matches_visited_pseudo_class())) {
+        if (auto const& active_link_color = document().active_link_color(); active_link_color.has_value())
+            properties.append({ .property_id = CSS::PropertyID::Color, .value = CSS::ColorStyleValue::create_from_color(*active_link_color, CSS::ColorSyntax::Legacy) });
+    }
+}
+
 void Element::run_attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     attribute_changed(local_name, old_value, value, namespace_);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -531,6 +531,7 @@ public:
     bool matches_unchecked_pseudo_class() const;
     bool matches_placeholder_shown_pseudo_class() const;
     bool matches_link_pseudo_class() const;
+    bool matches_visited_pseudo_class() const;
     bool matches_local_link_pseudo_class() const;
     bool matches_focus_within_pseudo_class() const;
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -192,7 +192,7 @@ public:
     virtual bool supports_dimension_attributes() const { return false; }
 
     virtual bool is_presentational_hint(FlyString const&) const { return false; }
-    virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const { }
+    virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const;
 
     void run_attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -371,7 +371,6 @@ public:
 
     static GC::Ptr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, GC::Ref<CSS::ComputedProperties>, Element*);
 
-    [[nodiscard]] bool affected_by_pseudo_class(CSS::PseudoClass) const;
     void clear_removed_attributes_for_style_invalidation() { m_removed_attributes_for_style_invalidation.clear(); }
     bool has_removed_attribute_for_style_invalidation(FlyString const& attribute_name) const
     {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -726,11 +726,12 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     // NOTE: color must be set after color-scheme to ensure currentColor can be resolved in other properties (e.g. background-color).
     // NOTE: color must be set after font_size as `CalculatedStyleValue`s can rely on it being set for resolving lengths.
     computed_values.set_color(computed_style.color(CSS::PropertyID::Color, CSS::ColorResolutionContext::for_layout_node_with_style(*this)));
-    // NOTE: Currently there are still discussions about `accentColor` and `currentColor` interactions, so the line below might need changing in the future
-    computed_values.set_accent_color(computed_style.accent_color(CSS::ColorResolutionContext::for_layout_node_with_style(*this)));
+
     // NOTE: This color resolution context must be created after we set color above so that currentColor resolves correctly
     // FIXME: We should resolve colors to their absolute forms at compute time (i.e. by implementing the relevant absolutized methods)
     auto color_resolution_context = CSS::ColorResolutionContext::for_layout_node_with_style(*this);
+
+    computed_values.set_accent_color(computed_style.accent_color(color_resolution_context));
 
     computed_values.set_vertical_align(computed_style.vertical_align());
 

--- a/Tests/LibWeb/Text/expected/body-link-attributes-and-system-colors.txt
+++ b/Tests/LibWeb/Text/expected/body-link-attributes-and-system-colors.txt
@@ -1,0 +1,5 @@
+link: rgb(255, 0, 0)
+active: rgb(0, 0, 255)
+link-text: rgb(0, 0, 238)
+visited-text: rgb(85, 26, 139)
+active-text: rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/input/body-link-attributes-and-system-colors.html
+++ b/Tests/LibWeb/Text/input/body-link-attributes-and-system-colors.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<body link="#ff0000" vlink="#00ff00" alink="#0000ff">
+    <a href="#active" id="link">link</a>
+    <a href="#active" id="active">active</a>
+    <!-- FIXME: Add a vlink case if/when matching :visited is supported. -->
+
+    <div id="link-text" style="color: linktext"></div>
+    <div id="visited-text" style="color: visitedtext"></div>
+    <div id="active-text" style="color: activetext"></div>
+    <script src="include.js"></script>
+    <script>
+        test(() => {
+            const rect = active.getBoundingClientRect();
+            internals.clickAndHold(rect.left + rect.width / 2, rect.top + rect.height / 2);
+
+            for (const id of ["link", "active", "link-text", "visited-text", "active-text"])
+                println(`${id}: ${getComputedStyle(document.getElementById(id)).color}`);
+        });
+    </script>
+</body>


### PR DESCRIPTION
Previously we overrode the resolved values of the `activetext`, `linktext` and `visitedtext` based on the values of the body's `alink`, `link` and `vlink` attributes respectively.

This was incorrect and the spec instead expects us to apply these to the relevant link elements as presentational hints while leaving those colors untouched for other users.

Also includes some unrelated dead code removal.