### PR TITLE
DevTools: Implement CSS rule inspection

### DIFF
--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -254,7 +254,7 @@ void FrameActor::style_sheets_available(JsonObject& response, Vector<Web::CSS::S
         return;
 
     for (auto const& [i, style_sheet] : enumerate(style_sheets)) {
-        auto resource_id = MUST(String::formatted("{}-stylesheet:{}", style_sheets_actor->name(), i));
+        auto resource_id = StyleSheetsActor::resource_id_for_index(style_sheets_actor->name(), i);
 
         JsonValue href;
         JsonValue source_map_base_url;

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -9,6 +9,7 @@
 #include <LibDevTools/Actors/HighlighterActor.h>
 #include <LibDevTools/Actors/InspectorActor.h>
 #include <LibDevTools/Actors/PageStyleActor.h>
+#include <LibDevTools/Actors/StyleSheetsActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/WalkerActor.h>
 #include <LibDevTools/DevToolsDelegate.h>
@@ -16,14 +17,15 @@
 
 namespace DevTools {
 
-NonnullRefPtr<InspectorActor> InspectorActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
+NonnullRefPtr<InspectorActor> InspectorActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<StyleSheetsActor> style_sheets)
 {
-    return adopt_ref(*new InspectorActor(devtools, move(name), move(tab)));
+    return adopt_ref(*new InspectorActor(devtools, move(name), move(tab), move(style_sheets)));
 }
 
-InspectorActor::InspectorActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
+InspectorActor::InspectorActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<StyleSheetsActor> style_sheets)
     : Actor(devtools, move(name))
     , m_tab(move(tab))
+    , m_style_sheets(move(style_sheets))
 {
 }
 
@@ -134,6 +136,13 @@ RefPtr<WalkerActor> InspectorActor::walker_for(WeakPtr<InspectorActor> const& we
 {
     if (auto inspector = weak_inspector.strong_ref())
         return inspector->m_walker.strong_ref();
+    return {};
+}
+
+RefPtr<StyleSheetsActor> InspectorActor::style_sheets_for(WeakPtr<InspectorActor> const& weak_inspector)
+{
+    if (auto inspector = weak_inspector.strong_ref())
+        return inspector->m_style_sheets.strong_ref();
     return {};
 }
 

--- a/Libraries/LibDevTools/Actors/InspectorActor.h
+++ b/Libraries/LibDevTools/Actors/InspectorActor.h
@@ -16,23 +16,25 @@ class DEVTOOLS_API InspectorActor final : public Actor {
 public:
     static constexpr auto base_name = "inspector"sv;
 
-    static NonnullRefPtr<InspectorActor> create(DevToolsServer&, String name, WeakPtr<TabActor>);
+    static NonnullRefPtr<InspectorActor> create(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<StyleSheetsActor>);
     virtual ~InspectorActor() override;
 
     static RefPtr<TabActor> tab_for(WeakPtr<InspectorActor> const&);
     static RefPtr<WalkerActor> walker_for(WeakPtr<InspectorActor> const&);
+    static RefPtr<StyleSheetsActor> style_sheets_for(WeakPtr<InspectorActor> const&);
 
     void on_navigation_started();
     void on_navigation_finished();
 
 private:
-    InspectorActor(DevToolsServer&, String name, WeakPtr<TabActor>);
+    InspectorActor(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<StyleSheetsActor>);
 
     virtual void handle_message(Message const&) override;
 
     void received_dom_tree(JsonObject& response, JsonObject dom_tree);
 
     WeakPtr<TabActor> m_tab;
+    WeakPtr<StyleSheetsActor> m_style_sheets;
     WeakPtr<WalkerActor> m_walker;
     WeakPtr<PageStyleActor> m_page_style;
 };

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -7,13 +7,16 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
+#include <AK/ScopeGuard.h>
 #include <LibDevTools/Actors/InspectorActor.h>
 #include <LibDevTools/Actors/PageStyleActor.h>
 #include <LibDevTools/Actors/StyleRuleActor.h>
+#include <LibDevTools/Actors/StyleSheetsActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/WalkerActor.h>
 #include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/DevToolsServer.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 
 namespace DevTools {
 
@@ -112,6 +115,52 @@ static void received_fonts(JsonObject& response, JsonValue const& fonts)
     response.set("fontFaces"sv, move(font_faces));
 }
 
+static Optional<Web::CSS::StyleSheetIdentifier> style_sheet_identifier_from_json(JsonObject const& object)
+{
+    auto type_string = object.get_string("type"sv);
+    if (!type_string.has_value())
+        return {};
+
+    auto type = Web::CSS::style_sheet_identifier_type_from_string(*type_string);
+    if (!type.has_value())
+        return {};
+
+    auto dom_element_unique_id = object.get_integer<Web::UniqueNodeID::Type>("domElementUniqueId"sv);
+    auto rule_count = object.get_integer<size_t>("ruleCount"sv).value_or(0);
+    Optional<String> url;
+    if (auto url_value = object.get_string("url"sv); url_value.has_value())
+        url = *url_value;
+
+    return Web::CSS::StyleSheetIdentifier {
+        .type = *type,
+        .dom_element_unique_id = dom_element_unique_id.map([](auto value) -> Web::UniqueNodeID { return value; }),
+        .url = move(url),
+        .rule_count = rule_count,
+    };
+}
+
+static void link_rule_to_style_sheet_resource(WeakPtr<InspectorActor> const& inspector, JsonObject& rule)
+{
+    auto style_sheet = rule.get_object("styleSheet"sv);
+    if (!style_sheet.has_value())
+        return;
+
+    ScopeGuard remove_internal_style_sheet_data = [&] {
+        rule.remove("styleSheet"sv);
+    };
+
+    auto identifier = style_sheet_identifier_from_json(*style_sheet);
+    if (!identifier.has_value())
+        return;
+
+    auto style_sheets_actor = InspectorActor::style_sheets_for(inspector);
+    if (!style_sheets_actor)
+        return;
+
+    if (auto resource_id = style_sheets_actor->resource_id_for(*identifier); resource_id.has_value())
+        rule.set("parentStyleSheet"sv, resource_id.release_value());
+}
+
 void PageStyleActor::received_applied_style_rules(JsonObject& response, JsonValue const& applied_style_rules)
 {
     JsonArray entries;
@@ -126,6 +175,8 @@ void PageStyleActor::received_applied_style_rules(JsonObject& response, JsonValu
             auto rule = entry.get_object("rule"sv);
             if (!rule.has_value())
                 return;
+
+            link_rule_to_style_sheet_resource(m_inspector, *rule);
 
             auto& style_rule_actor = devtools().register_actor<StyleRuleActor>(*rule);
             m_style_rule_actors.append(style_rule_actor.name());

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -9,6 +9,7 @@
 #include <AK/JsonValue.h>
 #include <LibDevTools/Actors/InspectorActor.h>
 #include <LibDevTools/Actors/PageStyleActor.h>
+#include <LibDevTools/Actors/StyleRuleActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/WalkerActor.h>
 #include <LibDevTools/DevToolsDelegate.h>
@@ -111,6 +112,42 @@ static void received_fonts(JsonObject& response, JsonValue const& fonts)
     response.set("fontFaces"sv, move(font_faces));
 }
 
+void PageStyleActor::received_applied_style_rules(JsonObject& response, JsonValue const& applied_style_rules)
+{
+    JsonArray entries;
+    clear_style_rule_actors();
+
+    if (applied_style_rules.is_array()) {
+        applied_style_rules.as_array().for_each([&](JsonValue const& value) {
+            if (!value.is_object())
+                return;
+
+            auto entry = value.as_object();
+            auto rule = entry.get_object("rule"sv);
+            if (!rule.has_value())
+                return;
+
+            auto& style_rule_actor = devtools().register_actor<StyleRuleActor>(*rule);
+            m_style_rule_actors.append(style_rule_actor.name());
+            entry.set("rule"sv, style_rule_actor.serialize_rule());
+
+            if (auto inherited_node_id = entry.get_integer<Web::UniqueNodeID::Type>("inheritedNodeId"sv); inherited_node_id.has_value()) {
+                JsonValue inherited { JsonValue {} };
+                if (auto walker = InspectorActor::walker_for(m_inspector)) {
+                    if (auto inherited_node_actor = walker->node_actor_name_for(Web::UniqueNodeID { *inherited_node_id }); inherited_node_actor.has_value())
+                        inherited = *inherited_node_actor;
+                }
+                entry.set("inherited"sv, move(inherited));
+                entry.remove("inheritedNodeId"sv);
+            }
+
+            entries.must_append(move(entry));
+        });
+    }
+
+    response.set("entries"sv, move(entries));
+}
+
 NonnullRefPtr<PageStyleActor> PageStyleActor::create(DevToolsServer& devtools, String name, WeakPtr<InspectorActor> inspector)
 {
     return adopt_ref(*new PageStyleActor(devtools, move(name), move(inspector)));
@@ -130,8 +167,17 @@ PageStyleActor::PageStyleActor(DevToolsServer& devtools, String name, WeakPtr<In
 
 PageStyleActor::~PageStyleActor()
 {
+    clear_style_rule_actors();
+
     if (auto tab = InspectorActor::tab_for(m_inspector))
         devtools().delegate().stop_listening_for_dom_properties(tab->description());
+}
+
+void PageStyleActor::clear_style_rule_actors()
+{
+    for (auto const& actor : m_style_rule_actors)
+        devtools().unregister_actor(actor);
+    m_style_rule_actors.clear();
 }
 
 void PageStyleActor::handle_message(Message const& message)
@@ -145,10 +191,7 @@ void PageStyleActor::handle_message(Message const& message)
     }
 
     if (message.type == "getApplied"sv) {
-        // FIXME: This provides information to the "styles" pane in the inspector tab, which allows toggling and editing
-        //        styles live. We do not yet support figuring out the list of styles that apply to a specific node.
-        response.set("entries"sv, JsonArray {});
-        send_response(message, move(response));
+        inspect_dom_node(message, WebView::DOMNodeProperties::Type::AppliedStyleRules);
         return;
     }
 
@@ -202,7 +245,19 @@ void PageStyleActor::inspect_dom_node(Message const& message, WebView::DOMNodePr
         return;
     }
 
-    devtools().delegate().inspect_dom_node(dom_node->tab->description(), property_type, dom_node->identifier.id, dom_node->identifier.pseudo_element);
+    JsonObject options;
+    if (property_type == WebView::DOMNodeProperties::Type::AppliedStyleRules) {
+        if (auto inherited = message.data.get_bool("inherited"sv); inherited.has_value())
+            options.set("inherited"sv, *inherited);
+        if (auto matched_selectors = message.data.get_bool("matchedSelectors"sv); matched_selectors.has_value())
+            options.set("matchedSelectors"sv, *matched_selectors);
+        if (auto skip_pseudo = message.data.get_bool("skipPseudo"sv); skip_pseudo.has_value())
+            options.set("skipPseudo"sv, *skip_pseudo);
+        if (auto filter = message.data.get_string("filter"sv); filter.has_value())
+            options.set("filter"sv, *filter);
+    }
+
+    devtools().delegate().inspect_dom_node(dom_node->tab->description(), property_type, dom_node->identifier.id, dom_node->identifier.pseudo_element, move(options));
     m_pending_inspect_requests.append({ .id = message.id });
 }
 
@@ -214,6 +269,9 @@ void PageStyleActor::received_dom_node_properties(WebView::DOMNodeProperties con
     JsonObject response;
 
     switch (properties.type) {
+    case WebView::DOMNodeProperties::Type::AppliedStyleRules:
+        received_applied_style_rules(response, properties.properties);
+        break;
     case WebView::DOMNodeProperties::Type::ComputedStyle:
         received_computed_style(response, properties.properties);
         break;

--- a/Libraries/LibDevTools/Actors/PageStyleActor.h
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.h
@@ -28,11 +28,14 @@ private:
     virtual void handle_message(Message const&) override;
 
     void inspect_dom_node(Message const&, WebView::DOMNodeProperties::Type);
+    void clear_style_rule_actors();
+    void received_applied_style_rules(JsonObject&, JsonValue const&);
     void received_dom_node_properties(WebView::DOMNodeProperties const&);
 
     WeakPtr<InspectorActor> m_inspector;
 
     Vector<Message, 1> m_pending_inspect_requests;
+    Vector<String> m_style_rule_actors;
 };
 
 }

--- a/Libraries/LibDevTools/Actors/StyleRuleActor.cpp
+++ b/Libraries/LibDevTools/Actors/StyleRuleActor.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <LibDevTools/Actors/StyleRuleActor.h>
+
+namespace DevTools {
+
+NonnullRefPtr<StyleRuleActor> StyleRuleActor::create(DevToolsServer& devtools, String name, JsonObject rule)
+{
+    return adopt_ref(*new StyleRuleActor(devtools, move(name), move(rule)));
+}
+
+StyleRuleActor::StyleRuleActor(DevToolsServer& devtools, String name, JsonObject rule)
+    : Actor(devtools, move(name))
+    , m_rule(move(rule))
+{
+    m_rule.set("actor"sv, this->name());
+
+    JsonObject traits;
+    // FIXME: Support modifying style rules inside the inspector.
+    traits.set("canSetRuleText"sv, false);
+    m_rule.set("traits"sv, move(traits));
+    m_rule.set("ancestorData"sv, JsonArray {});
+}
+
+StyleRuleActor::~StyleRuleActor() = default;
+
+JsonObject StyleRuleActor::serialize_rule() const
+{
+    return m_rule;
+}
+
+void StyleRuleActor::handle_message(Message const& message)
+{
+    JsonObject response;
+
+    if (message.type == "getRuleText"sv) {
+        response.set("text"sv, m_rule.get_string("cssText"sv).value_or({}));
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "modifyProperties"sv || message.type == "setRuleText"sv || message.type == "modifySelector"sv) {
+        response.set("error"sv, "unsupported"sv);
+        response.set("message"sv, "Live CSS rule editing is not supported"sv);
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "getQueryContainerForNode"sv) {
+        response.set("container"sv, JsonValue {});
+        send_response(message, move(response));
+        return;
+    }
+
+    send_unrecognized_packet_type_error(message);
+}
+
+}

--- a/Libraries/LibDevTools/Actors/StyleRuleActor.h
+++ b/Libraries/LibDevTools/Actors/StyleRuleActor.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonObject.h>
+#include <AK/NonnullRefPtr.h>
+#include <LibDevTools/Actor.h>
+
+namespace DevTools {
+
+class DEVTOOLS_API StyleRuleActor final : public Actor {
+public:
+    static constexpr auto base_name = "style-rule"sv;
+
+    static NonnullRefPtr<StyleRuleActor> create(DevToolsServer&, String name, JsonObject rule);
+    virtual ~StyleRuleActor() override;
+
+    JsonObject serialize_rule() const;
+
+private:
+    StyleRuleActor(DevToolsServer&, String name, JsonObject rule);
+
+    virtual void handle_message(Message const&) override;
+
+    JsonObject m_rule;
+};
+
+}

--- a/Libraries/LibDevTools/Actors/StyleSheetsActor.cpp
+++ b/Libraries/LibDevTools/Actors/StyleSheetsActor.cpp
@@ -37,6 +37,11 @@ StyleSheetsActor::~StyleSheetsActor()
         devtools().delegate().stop_listening_for_style_sheet_sources(tab->description());
 }
 
+String StyleSheetsActor::resource_id_for_index(StringView actor_name, size_t index)
+{
+    return MUST(String::formatted("{}-stylesheet:{}", actor_name, index));
+}
+
 void StyleSheetsActor::handle_message(Message const& message)
 {
     if (message.type == "getText"sv) {
@@ -64,6 +69,14 @@ void StyleSheetsActor::handle_message(Message const& message)
 void StyleSheetsActor::set_style_sheets(Vector<Web::CSS::StyleSheetIdentifier> style_sheets)
 {
     m_style_sheets = move(style_sheets);
+}
+
+Optional<String> StyleSheetsActor::resource_id_for(Web::CSS::StyleSheetIdentifier const& style_sheet) const
+{
+    auto index = m_style_sheets.find_first_index(style_sheet);
+    if (!index.has_value())
+        return {};
+    return resource_id_for_index(name(), *index);
 }
 
 void StyleSheetsActor::style_sheet_source_received(Web::CSS::StyleSheetIdentifier const& style_sheet, String source)

--- a/Libraries/LibDevTools/Actors/StyleSheetsActor.h
+++ b/Libraries/LibDevTools/Actors/StyleSheetsActor.h
@@ -21,7 +21,10 @@ public:
     static NonnullRefPtr<StyleSheetsActor> create(DevToolsServer&, String name, WeakPtr<TabActor>);
     virtual ~StyleSheetsActor() override;
 
+    static String resource_id_for_index(StringView actor_name, size_t index);
+
     void set_style_sheets(Vector<Web::CSS::StyleSheetIdentifier>);
+    Optional<String> resource_id_for(Web::CSS::StyleSheetIdentifier const&) const;
 
 private:
     StyleSheetsActor(DevToolsServer&, String name, WeakPtr<TabActor>);

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -170,8 +170,8 @@ FrameActor& WatcherActor::create_frame_target()
 {
     auto& css_properties = devtools().register_actor<CSSPropertiesActor>();
     auto& console = devtools().register_actor<ConsoleActor>(m_tab);
-    auto& inspector = devtools().register_actor<InspectorActor>(m_tab);
     auto& style_sheets = devtools().register_actor<StyleSheetsActor>(m_tab);
+    auto& inspector = devtools().register_actor<InspectorActor>(m_tab, style_sheets);
     auto& thread = devtools().register_actor<ThreadActor>();
     auto& accessibility = devtools().register_actor<AccessibilityActor>(m_tab);
 

--- a/Libraries/LibDevTools/CMakeLists.txt
+++ b/Libraries/LibDevTools/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     Actors/PreferenceActor.cpp
     Actors/ProcessActor.cpp
     Actors/RootActor.cpp
+    Actors/StyleRuleActor.cpp
     Actors/StyleSheetsActor.cpp
     Actors/TabActor.cpp
     Actors/TargetConfigurationActor.cpp

--- a/Libraries/LibDevTools/Connection.cpp
+++ b/Libraries/LibDevTools/Connection.cpp
@@ -94,9 +94,13 @@ ErrorOr<void> Connection::on_ready_to_read()
         if (!message.is_object())
             continue;
 
-        Core::deferred_invoke([this, message = move(message)]() mutable {
-            if (on_message_received)
-                on_message_received(move(message.as_object()));
+        Core::deferred_invoke([weak_self = make_weak_ptr<Connection>(), message = move(message)]() mutable {
+            auto self = weak_self.strong_ref();
+            if (!self)
+                return;
+
+            if (self->on_message_received)
+                self->on_message_received(move(message.as_object()));
         });
     }
 

--- a/Libraries/LibDevTools/Connection.h
+++ b/Libraries/LibDevTools/Connection.h
@@ -11,12 +11,15 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
+#include <AK/Weakable.h>
 #include <LibCore/Socket.h>
 #include <LibDevTools/Forward.h>
 
 namespace DevTools {
 
-class DEVTOOLS_API Connection : public RefCounted<Connection> {
+class DEVTOOLS_API Connection
+    : public RefCounted<Connection>
+    , public Weakable<Connection> {
 public:
     static NonnullRefPtr<Connection> create(NonnullOwnPtr<Core::BufferedTCPSocket>);
     ~Connection();

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -47,7 +47,7 @@ public:
     using OnDOMNodePropertiesReceived = Function<void(WebView::DOMNodeProperties)>;
     virtual void listen_for_dom_properties(TabDescription const&, OnDOMNodePropertiesReceived) const { }
     virtual void stop_listening_for_dom_properties(TabDescription const&) const { }
-    virtual void inspect_dom_node(TabDescription const&, WebView::DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>) const { }
+    virtual void inspect_dom_node(TabDescription const&, WebView::DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>, JsonObject options = {}) const { (void)options; }
     virtual void clear_inspected_dom_node(TabDescription const&) const { }
 
     struct NodePickerEvent {

--- a/Libraries/LibDevTools/DevToolsServer.cpp
+++ b/Libraries/LibDevTools/DevToolsServer.cpp
@@ -37,13 +37,25 @@ DevToolsServer::DevToolsServer(DevToolsDelegate& delegate, NonnullRefPtr<Core::T
     , m_delegate(delegate)
     , m_server_id(s_server_count++)
 {
-    m_server->on_ready_to_accept = [this]() {
-        if (auto result = on_new_client(); result.is_error())
+    m_server->on_ready_to_accept = [weak_self = make_weak_ptr<DevToolsServer>()] {
+        if (!weak_self)
+            return;
+
+        if (auto result = weak_self->on_new_client(); result.is_error())
             warnln("Failed to accept DevTools client: {}", result.error());
     };
 }
 
-DevToolsServer::~DevToolsServer() = default;
+DevToolsServer::~DevToolsServer()
+{
+    m_is_shutting_down = true;
+    m_server->on_ready_to_accept = {};
+
+    if (m_connection) {
+        m_connection->on_connection_closed = {};
+        m_connection->on_message_received = {};
+    }
+}
 
 Optional<u16> DevToolsServer::local_port() const
 {
@@ -64,8 +76,12 @@ void DevToolsServer::refresh_tab_list()
 
 void DevToolsServer::unregister_actor(String const& name)
 {
-    Core::deferred_invoke([this, name] {
-        m_actor_registry.remove(name);
+    if (m_is_shutting_down)
+        return;
+
+    Core::deferred_invoke([weak_self = make_weak_ptr<DevToolsServer>(), name] {
+        if (weak_self)
+            weak_self->m_actor_registry.remove(name);
     });
 }
 
@@ -79,12 +95,14 @@ ErrorOr<void> DevToolsServer::on_new_client()
 
     m_connection = Connection::create(move(buffered_socket));
 
-    m_connection->on_connection_closed = [this]() {
-        close_connection();
+    m_connection->on_connection_closed = [weak_self = make_weak_ptr<DevToolsServer>()] {
+        if (weak_self)
+            weak_self->close_connection();
     };
 
-    m_connection->on_message_received = [this](auto message) {
-        on_message_received(move(message));
+    m_connection->on_message_received = [weak_self = make_weak_ptr<DevToolsServer>()](auto message) {
+        if (weak_self)
+            weak_self->on_message_received(move(message));
     };
 
     m_root_actor = register_actor<RootActor>();
@@ -124,10 +142,16 @@ void DevToolsServer::close_connection()
 {
     dbgln_if(DEVTOOLS_DEBUG, "Lost connection to the DevTools client");
 
-    Core::deferred_invoke([this]() {
-        m_connection = nullptr;
-        m_actor_registry.clear();
-        m_root_actor = nullptr;
+    if (m_is_shutting_down)
+        return;
+
+    Core::deferred_invoke([weak_self = make_weak_ptr<DevToolsServer>()] {
+        if (!weak_self)
+            return;
+
+        weak_self->m_connection = nullptr;
+        weak_self->m_actor_registry.clear();
+        weak_self->m_root_actor = nullptr;
     });
 }
 

--- a/Libraries/LibDevTools/DevToolsServer.h
+++ b/Libraries/LibDevTools/DevToolsServer.h
@@ -12,6 +12,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
+#include <AK/Weakable.h>
 #include <LibCore/Socket.h>
 #include <LibDevTools/Actors/RootActor.h>
 #include <LibDevTools/Forward.h>
@@ -20,7 +21,7 @@ namespace DevTools {
 
 using ActorRegistry = HashMap<String, NonnullRefPtr<Actor>>;
 
-class DEVTOOLS_API DevToolsServer {
+class DEVTOOLS_API DevToolsServer : public Weakable<DevToolsServer> {
 public:
     static ErrorOr<NonnullOwnPtr<DevToolsServer>> create(DevToolsDelegate&, u16 port);
     ~DevToolsServer();
@@ -69,6 +70,7 @@ private:
 
     u64 m_server_id { 0 };
     u64 m_actor_count { 0 };
+    bool m_is_shutting_down { false };
 };
 
 }

--- a/Libraries/LibDevTools/Forward.h
+++ b/Libraries/LibDevTools/Forward.h
@@ -32,6 +32,7 @@ class ParentAccessibilityActor;
 class PreferenceActor;
 class ProcessActor;
 class RootActor;
+class StyleRuleActor;
 class StyleSheetsActor;
 class TabActor;
 class TargetConfigurationActor;

--- a/Libraries/LibWeb/CSS/CSSNestedDeclarations.cpp
+++ b/Libraries/LibWeb/CSS/CSSNestedDeclarations.cpp
@@ -18,7 +18,10 @@ GC_DEFINE_ALLOCATOR(CSSNestedDeclarations);
 
 GC::Ref<CSSNestedDeclarations> CSSNestedDeclarations::create(JS::Realm& realm, Parser::Parser& parser, Vector<Parser::Declaration> const& declarations)
 {
-    return realm.create<CSSNestedDeclarations>(realm, parser.convert_to_style_declaration(declarations));
+    auto rule = realm.create<CSSNestedDeclarations>(realm, parser.convert_to_style_declaration(declarations));
+    if (!declarations.is_empty() && declarations.first().source_position.has_value())
+        rule->set_source_position(declarations.first().source_position);
+    return rule;
 }
 
 GC::Ref<CSSNestedDeclarations> CSSNestedDeclarations::create(JS::Realm& realm, CSSStyleProperties& declaration)

--- a/Libraries/LibWeb/CSS/CSSRule.h
+++ b/Libraries/LibWeb/CSS/CSSRule.h
@@ -61,6 +61,9 @@ public:
     CSSStyleSheet* parent_style_sheet() { return m_parent_style_sheet.ptr(); }
     MUST_UPCALL virtual void set_parent_style_sheet(CSSStyleSheet*);
 
+    Optional<SourcePosition> const& source_location() const { return m_source_position; }
+    void set_source_position(Optional<SourcePosition> source_location) { m_source_position = move(source_location); }
+
     template<typename T>
     bool fast_is() const = delete;
 
@@ -87,6 +90,7 @@ protected:
     GC::Ptr<CSSRule> m_parent_rule;
     GC::Ptr<CSSStyleSheet> m_parent_style_sheet;
 
+    Optional<SourcePosition> m_source_position;
     mutable Optional<FlyString> m_cached_layer_name;
 };
 

--- a/Libraries/LibWeb/CSS/CSSRule.h
+++ b/Libraries/LibWeb/CSS/CSSRule.h
@@ -59,6 +59,7 @@ public:
     void set_parent_rule(CSSRule*);
 
     CSSStyleSheet* parent_style_sheet() { return m_parent_style_sheet.ptr(); }
+    CSSStyleSheet const* parent_style_sheet() const { return m_parent_style_sheet.ptr(); }
     MUST_UPCALL virtual void set_parent_style_sheet(CSSStyleSheet*);
 
     Optional<SourcePosition> const& source_location() const { return m_source_position; }

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -634,16 +634,6 @@ void CSSStyleSheet::recalculate_rule_caches()
     }
 }
 
-void CSSStyleSheet::set_source_text(String source)
-{
-    m_source_text = move(source);
-}
-
-Optional<String> CSSStyleSheet::source_text(Badge<DOM::Document>) const
-{
-    return m_source_text;
-}
-
 void CSSStyleSheet::add_critical_subresource(Subresource& subresource)
 {
     m_critical_subresources.append(subresource);

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -122,8 +122,8 @@ public:
 
     bool disallow_modification() const { return m_disallow_modification; }
 
-    void set_source_text(String);
-    Optional<String> source_text(Badge<DOM::Document>) const;
+    void set_source_text(String source) { m_source_text = move(source); }
+    Optional<String> source_text() const { return m_source_text; }
 
     void add_critical_subresource(Subresource&);
     void remove_critical_subresource(Subresource&);

--- a/Libraries/LibWeb/CSS/Parser/ComponentValue.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ComponentValue.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2021-2026, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -83,6 +83,21 @@ String ComponentValue::to_debug_string() const
 String ComponentValue::original_source_text() const
 {
     return m_value.visit([](auto const& it) { return it.original_source_text(); });
+}
+
+Optional<SourcePosition> ComponentValue::start_position() const
+{
+    return m_value.visit(
+        [](Token const& token) -> Optional<SourcePosition> {
+            return token.start_position();
+        },
+        [](SimpleBlock const& block) -> Optional<SourcePosition> {
+            return block.token.start_position();
+        },
+        [](Function const& function) -> Optional<SourcePosition> {
+            return function.name_token.start_position();
+        },
+        [](auto const&) -> Optional<SourcePosition> { return {}; });
 }
 
 bool ComponentValue::contains_guaranteed_invalid_value() const

--- a/Libraries/LibWeb/CSS/Parser/ComponentValue.h
+++ b/Libraries/LibWeb/CSS/Parser/ComponentValue.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2021-2026, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2023, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -50,6 +50,8 @@ public:
     String to_string() const;
     String to_debug_string() const;
     String original_source_text() const;
+
+    Optional<SourcePosition> start_position() const;
 
     bool operator==(ComponentValue const&) const = default;
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1655,6 +1655,45 @@ Parser::PropertiesAndCustomProperties Parser::parse_as_property_declaration_bloc
     return parsed_declarations;
 }
 
+Vector<DevToolsStyleDeclaration> Parser::parse_as_devtools_property_declaration_block()
+{
+    auto declarations_and_at_rules = parse_a_blocks_contents(m_token_stream);
+
+    Vector<DevToolsStyleDeclaration> parsed_declarations;
+    for (auto const& rule_or_list : declarations_and_at_rules) {
+        if (auto* rule_declarations = rule_or_list.get_pointer<Vector<Declaration>>()) {
+            for (auto const& declaration : *rule_declarations) {
+                auto property = PropertyNameAndID::from_name(declaration.name);
+
+                StringBuilder value_builder;
+                for (auto const& value : declaration.value)
+                    value_builder.append(value.original_source_text());
+
+                parsed_declarations.append(DevToolsStyleDeclaration {
+                    .name = declaration.name,
+                    .value = value_builder.to_string_without_validation(),
+                    .important = declaration.important,
+                    .is_custom_property = property.has_value() && property->is_custom_property(),
+                    .is_name_valid = property.has_value(),
+                    .is_valid = property.has_value() && convert_to_style_property(declaration).has_value(),
+                });
+            }
+        }
+    }
+
+    return parsed_declarations;
+}
+
+Vector<DevToolsStyleDeclaration> parse_css_declaration_block_for_devtools(ParsingParams const& parsing_params, StringView declaration_block)
+{
+    auto devtools_parsing_params = parsing_params;
+    if (devtools_parsing_params.rule_context.is_empty())
+        devtools_parsing_params.rule_context.append(RuleContext::Style);
+
+    auto parser = Parser::create(devtools_parsing_params, declaration_block);
+    return parser.parse_as_devtools_property_declaration_block();
+}
+
 // https://drafts.csswg.org/cssom/#parse-a-css-declaration-block
 Vector<Descriptor> Parser::parse_as_descriptor_declaration_block(AtRuleID at_rule_id)
 {

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -755,6 +755,7 @@ Variant<Empty, QualifiedRule, Parser::InvalidRuleError> Parser::consume_a_qualif
         .prelude = {},
         .declarations = {},
         .child_rules = {},
+        .source_position = {},
     };
 
     // NOTE: Qualified rules inside @keyframes are a keyframe rule.
@@ -831,7 +832,10 @@ Variant<Empty, QualifiedRule, Parser::InvalidRuleError> Parser::consume_a_qualif
         // anything else
         {
             // Consume a component value from input and append the result to rule’s prelude.
-            rule.prelude.append(consume_a_component_value(input));
+            auto component_value = consume_a_component_value(input);
+            if (!rule.source_position.has_value() && !component_value.is(Token::Type::Whitespace))
+                rule.source_position = component_value.start_position();
+            rule.prelude.append(move(component_value));
         }
     }
 }
@@ -1250,12 +1254,18 @@ Optional<Declaration> Parser::consume_a_declaration(TokenStream<T>& input, Neste
     Declaration declaration {
         .name {},
         .value {},
+        .important = Important::No,
+        .original_value_text = {},
+        .original_full_text = {},
+        .source_position = {},
     };
     auto start_token_index = input.current_index();
 
     // 1. If the next token is an <ident-token>, consume a token from input and set decl’s name to the token’s value.
     if (input.next_token().is(Token::Type::Ident)) {
-        declaration.name = ((Token)input.consume_a_token()).ident();
+        auto token = (Token)input.consume_a_token();
+        declaration.source_position = token.start_position();
+        declaration.name = token.ident();
     }
     //    Otherwise, consume the remnants of a bad declaration from input, with nested, and return nothing.
     else {

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -33,6 +33,7 @@
 #include <LibWeb/CSS/StyleValues/TreeCountingFunctionStyleValue.h>
 #include <LibWeb/CSS/Supports.h>
 #include <LibWeb/CSS/URL.h>
+#include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS::Parser {
@@ -88,7 +89,7 @@ enum class IsUAStyleSheet {
     No,
 };
 
-struct ParsingParams {
+struct WEB_API ParsingParams {
     explicit ParsingParams(ParsingMode = ParsingMode::Normal);
     explicit ParsingParams(ValueParsingContext);
     explicit ParsingParams(JS::Realm&, ParsingMode = ParsingMode::Normal);
@@ -104,6 +105,17 @@ struct ParsingParams {
     Vector<RuleContext> rule_context;
     HashTable<FlyString> declared_namespaces;
 };
+
+struct DevToolsStyleDeclaration {
+    FlyString name;
+    String value;
+    Important important { Important::No };
+    bool is_custom_property { false };
+    bool is_name_valid { false };
+    bool is_valid { false };
+};
+
+WEB_API Vector<DevToolsStyleDeclaration> parse_css_declaration_block_for_devtools(ParsingParams const&, StringView);
 
 // The very large CSS Parser implementation code is broken up among several .cpp files:
 // Parser.cpp contains the core parser algorithms, defined in https://drafts.csswg.org/css-syntax
@@ -123,6 +135,7 @@ public:
         OrderedHashMap<FlyString, StyleProperty> custom_properties;
     };
     PropertiesAndCustomProperties parse_as_property_declaration_block();
+    Vector<DevToolsStyleDeclaration> parse_as_devtools_property_declaration_block();
     Vector<Descriptor> parse_as_descriptor_declaration_block(AtRuleID);
     CSSRule* parse_as_css_rule();
     Optional<StyleProperty> parse_as_supports_condition();

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -234,7 +234,9 @@ GC::Ptr<CSSStyleRule> Parser::convert_to_style_rule(QualifiedRule const& qualifi
             });
     }
     auto nested_rules = CSSRuleList::create(realm(), child_rules);
-    return CSSStyleRule::create(realm(), move(selectors), *declaration, *nested_rules);
+    auto style_rule = CSSStyleRule::create(realm(), move(selectors), *declaration, *nested_rules);
+    style_rule->set_source_position(qualified_rule.source_position);
+    return style_rule;
 }
 
 GC::Ptr<CSSImportRule> Parser::convert_to_import_rule(AtRule const& rule)

--- a/Libraries/LibWeb/CSS/Parser/RustTokenizer.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RustTokenizer.cpp
@@ -102,7 +102,7 @@ static Number::Type css_number_type_from_ffi(FFI::CssNumberType number_type)
     VERIFY_NOT_REACHED();
 }
 
-static Token::Position position_from_ffi(size_t line, size_t column)
+static SourcePosition position_from_ffi(size_t line, size_t column)
 {
     return { line, column };
 }

--- a/Libraries/LibWeb/CSS/Parser/SourcePosition.h
+++ b/Libraries/LibWeb/CSS/Parser/SourcePosition.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+struct SourcePosition {
+    size_t line { 0 };
+    size_t column { 0 };
+};

--- a/Libraries/LibWeb/CSS/Parser/Token.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Token.cpp
@@ -418,13 +418,13 @@ StringView Token::bracket_mirror_string() const
     return ""sv;
 }
 
-void Token::set_position_range(Badge<Tokenizer>, Position start, Position end)
+void Token::set_position_range(Badge<Tokenizer>, SourcePosition start, SourcePosition end)
 {
     m_start_position = start;
     m_end_position = end;
 }
 
-void Token::set_position_range(Badge<RustTokenizer>, Position start, Position end)
+void Token::set_position_range(Badge<RustTokenizer>, SourcePosition start, SourcePosition end)
 {
     m_start_position = start;
     m_end_position = end;

--- a/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Libraries/LibWeb/CSS/Parser/Token.h
@@ -9,6 +9,7 @@
 
 #include <AK/FlyString.h>
 #include <LibWeb/CSS/Number.h>
+#include <LibWeb/CSS/Parser/SourcePosition.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 
@@ -59,11 +60,6 @@ public:
     enum class HashType : u8 {
         Id,
         Unrestricted,
-    };
-
-    struct Position {
-        size_t line { 0 };
-        size_t column { 0 };
     };
 
     // Use this only to create types that don't have their own create_foo() methods below.
@@ -184,10 +180,10 @@ public:
     String to_debug_string() const;
 
     String const& original_source_text() const { return m_original_source_text; }
-    Position const& start_position() const { return m_start_position; }
-    Position const& end_position() const { return m_end_position; }
-    void set_position_range(Badge<Tokenizer>, Position start, Position end);
-    void set_position_range(Badge<RustTokenizer>, Position start, Position end);
+    SourcePosition const& start_position() const { return m_start_position; }
+    SourcePosition const& end_position() const { return m_end_position; }
+    void set_position_range(Badge<Tokenizer>, SourcePosition start, SourcePosition end);
+    void set_position_range(Badge<RustTokenizer>, SourcePosition start, SourcePosition end);
 
     bool operator==(Token const& other) const
     {
@@ -202,8 +198,8 @@ private:
     HashType m_hash_type { HashType::Unrestricted };
 
     String m_original_source_text;
-    Position m_start_position;
-    Position m_end_position;
+    SourcePosition m_start_position;
+    SourcePosition m_end_position;
 };
 
 }

--- a/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2026, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -104,10 +104,10 @@ private:
 
     String m_decoded_input;
     Utf8View m_utf8_view;
-    AK::Utf8CodePointIterator m_utf8_iterator;
-    AK::Utf8CodePointIterator m_prev_utf8_iterator;
-    Token::Position m_position;
-    Token::Position m_prev_position;
+    Utf8CodePointIterator m_utf8_iterator;
+    Utf8CodePointIterator m_prev_utf8_iterator;
+    SourcePosition m_position;
+    SourcePosition m_prev_position;
 };
 
 }

--- a/Libraries/LibWeb/CSS/Parser/Types.h
+++ b/Libraries/LibWeb/CSS/Parser/Types.h
@@ -47,6 +47,7 @@ struct QualifiedRule {
     Vector<ComponentValue> prelude;
     Vector<Declaration> declarations;
     Vector<RuleOrListOfDeclarations> child_rules;
+    Optional<SourcePosition> source_position = {};
 
     void for_each_as_declaration_list(FlyString const& rule_name, DeclarationVisitor&& visit) const;
 };
@@ -58,6 +59,7 @@ struct Declaration {
     Important important = Important::No;
     Optional<String> original_value_text = {};
     Optional<String> original_full_text = {};
+    Optional<SourcePosition> source_position = {};
 };
 
 struct SubstitutionFunctionsPresence {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -15,9 +15,11 @@
 #include <AK/FixedBitmap.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
+#include <AK/JsonObject.h>
 #include <AK/Math.h>
 #include <AK/NonnullRawPtr.h>
 #include <AK/QuickSort.h>
+#include <AK/Utf8View.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
@@ -32,6 +34,7 @@
 #include <LibWeb/CSS/CSSScopeRule.h>
 #include <LibWeb/CSS/CSSStyleProperties.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
+#include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/CSSTransition.h>
 #include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/ComputedProperties.h>
@@ -80,6 +83,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
@@ -1486,6 +1490,395 @@ StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::Abstr
             || !matching_rule_set.user_agent_rules.is_empty();
     }
     return matching_rule_set;
+}
+
+static bool custom_property_inherits(DOM::Document const& document, FlyString const& name)
+{
+    // A custom property inherits unless it has been registered with an explicit `inherits: false`.
+    auto registration = document.get_registered_custom_property(name);
+    return !registration.has_value() || registration->inherit;
+}
+
+enum class IsCustomProperty : u8 {
+    No,
+    Yes,
+};
+
+enum class Inherits : u8 {
+    No,
+    Yes,
+};
+
+enum class NameIsValid : u8 {
+    No,
+    Yes,
+};
+
+enum class IsValid : u8 {
+    No,
+    Yes,
+};
+
+static JsonObject serialize_devtools_style_declaration(
+    String name,
+    String value,
+    Important important,
+    IsCustomProperty is_custom_property,
+    Inherits inherits,
+    NameIsValid is_name_valid,
+    IsValid is_valid)
+{
+    JsonObject serialized_property;
+    serialized_property.set("name"sv, move(name));
+    serialized_property.set("value"sv, move(value));
+    serialized_property.set("priority"sv, important == Important::Yes ? "important"sv : ""sv);
+    serialized_property.set("isCustomProperty"sv, is_custom_property == IsCustomProperty::Yes);
+    serialized_property.set("inherits"sv, inherits == Inherits::Yes);
+    serialized_property.set("isNameValid"sv, is_name_valid == NameIsValid::Yes);
+    serialized_property.set("isValid"sv, is_valid == IsValid::Yes);
+    return serialized_property;
+}
+
+static JsonArray serialize_devtools_style_declarations(DOM::Document const& document, CSSStyleProperties const& declaration)
+{
+    JsonArray declarations;
+
+    auto serialize_property = [&](String name, StyleProperty const& property, IsCustomProperty is_custom_property, Inherits inherits) {
+        declarations.must_append(serialize_devtools_style_declaration(
+            move(name),
+            property.value->to_string(SerializationMode::Normal),
+            property.important,
+            is_custom_property,
+            inherits,
+            NameIsValid::Yes,
+            IsValid::Yes));
+    };
+
+    for (auto const& property : declaration.properties()) {
+        serialize_property(
+            string_from_property_id(property.property_id).to_string(),
+            property,
+            IsCustomProperty::No,
+            is_inherited_property(property.property_id) ? Inherits::Yes : Inherits::No);
+    }
+
+    for (auto const& custom_property : declaration.custom_properties())
+        serialize_property(
+            custom_property.key.to_string(),
+            custom_property.value,
+            IsCustomProperty::Yes,
+            custom_property_inherits(document, custom_property.key) ? Inherits::Yes : Inherits::No);
+
+    return declarations;
+}
+
+static JsonArray serialize_devtools_style_declarations(DOM::Document const& document, Vector<Parser::DevToolsStyleDeclaration> const& declarations)
+{
+    JsonArray serialized_declarations;
+
+    for (auto const& declaration : declarations) {
+        bool inherits = declaration.is_custom_property
+            ? custom_property_inherits(document, declaration.name)
+            : PropertyNameAndID::from_name(declaration.name)
+                  .map([](auto const& property) { return !property.is_custom_property() && is_inherited_property(property.id()); })
+                  .value_or(false);
+
+        serialized_declarations.must_append(serialize_devtools_style_declaration(
+            declaration.name.to_string(),
+            declaration.value,
+            declaration.important,
+            declaration.is_custom_property ? IsCustomProperty::Yes : IsCustomProperty::No,
+            inherits ? Inherits::Yes : Inherits::No,
+            declaration.is_name_valid ? NameIsValid::Yes : NameIsValid::No,
+            declaration.is_valid ? IsValid::Yes : IsValid::No));
+    }
+
+    return serialized_declarations;
+}
+
+static Vector<Parser::DevToolsStyleDeclaration> parse_devtools_style_declarations(DOM::Document const& document, StringView declaration_block)
+{
+    return Parser::parse_css_declaration_block_for_devtools(Parser::ParsingParams(document), declaration_block);
+}
+
+static Optional<size_t> source_offset_for_line_and_column(StringView source, SourcePosition const& position)
+{
+    size_t line = 0;
+    size_t column = 0;
+
+    Utf8View source_code_points { source };
+    for (auto it = source_code_points.begin(); it != source_code_points.end();) {
+        auto offset = source_code_points.byte_offset_of(it);
+        if (line == position.line && column == position.column)
+            return offset;
+
+        auto code_point = *it;
+        ++it;
+
+        if (code_point == '\r') {
+            if (offset + 1 < source.length() && source[offset + 1] == '\n')
+                ++it;
+            ++line;
+            column = 0;
+        } else if (code_point == '\n' || code_point == '\f') {
+            ++line;
+            column = 0;
+        } else {
+            ++column;
+        }
+    }
+
+    if (line == position.line && column == position.column)
+        return source.length();
+
+    return {};
+}
+
+static Optional<String> extract_css_declaration_block_from_source(CSSRule const& rule)
+{
+    if (rule.type() != CSSRule::Type::Style)
+        return {};
+
+    auto const* style_sheet = rule.parent_style_sheet();
+    if (!style_sheet)
+        return {};
+
+    auto const source_text = style_sheet->source_text();
+    if (!source_text.has_value())
+        return {};
+
+    auto const& source = *source_text;
+    auto source_view = source.bytes_as_string_view();
+    auto const& source_location = rule.source_location();
+    if (!source_location.has_value())
+        return {};
+
+    auto maybe_offset = source_offset_for_line_and_column(source_view, *source_location);
+    if (!maybe_offset.has_value())
+        return {};
+
+    Optional<u8> string_quote;
+    bool in_comment = false;
+    bool escaped = false;
+    Optional<size_t> block_start;
+    size_t block_depth = 0;
+
+    for (size_t offset = *maybe_offset; offset < source_view.length(); ++offset) {
+        auto ch = source_view[offset];
+        auto next_ch = offset + 1 < source_view.length() ? source_view[offset + 1] : '\0';
+
+        if (in_comment) {
+            if (ch == '*' && next_ch == '/') {
+                in_comment = false;
+                ++offset;
+            }
+            continue;
+        }
+
+        if (string_quote.has_value()) {
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (ch == *string_quote)
+                string_quote = {};
+            continue;
+        }
+
+        if (ch == '/' && next_ch == '*') {
+            in_comment = true;
+            ++offset;
+            continue;
+        }
+
+        if (ch == '"' || ch == '\'') {
+            string_quote = ch;
+            continue;
+        }
+
+        if (ch == '{') {
+            if (!block_start.has_value())
+                block_start = offset + 1;
+            ++block_depth;
+            continue;
+        }
+
+        if (ch == '}' && block_start.has_value()) {
+            VERIFY(block_depth > 0);
+            --block_depth;
+            if (block_depth == 0)
+                return MUST(String::from_utf8(source_view.substring_view(*block_start, offset - *block_start)));
+        }
+    }
+
+    return {};
+}
+
+static bool has_inherited_declaration(DOM::Document const& document, CSSStyleProperties const& declaration)
+{
+    if (any_of(declaration.properties(), [](auto const& property) {
+            return CSS::is_inherited_property(property.property_id);
+        })) {
+        return true;
+    }
+
+    return any_of(declaration.custom_properties(), [&](auto const& custom_property) {
+        return custom_property_inherits(document, custom_property.key);
+    });
+}
+
+static JsonArray serialize_devtools_selectors(MatchingRule const& rule)
+{
+    JsonArray selectors;
+    for (auto const& selector : rule.absolutized_selectors())
+        selectors.must_append(selector->serialize());
+    return selectors;
+}
+
+static JsonArray serialize_devtools_selector_specificities(MatchingRule const& rule)
+{
+    JsonArray specificities;
+    for (auto const& selector : rule.absolutized_selectors())
+        specificities.must_append(selector->specificity());
+    return specificities;
+}
+
+static JsonObject serialize_devtools_matching_rule(DOM::Document const& document, MatchingRule const& rule)
+{
+    auto const& declaration = rule.declaration();
+    auto authored_text = extract_css_declaration_block_from_source(*rule.rule);
+
+    JsonArray matched_selector_indexes;
+    matched_selector_indexes.must_append(rule.selector_index);
+
+    JsonObject serialized_rule;
+    serialized_rule.set("type"sv, to_underlying(rule.rule->type()));
+    serialized_rule.set("className"sv, rule.rule->type() == CSSRule::Type::Style ? "CSSStyleRule"sv : "CSSNestedDeclarations"sv);
+    serialized_rule.set("selectors"sv, serialize_devtools_selectors(rule));
+    serialized_rule.set("selectorsSpecificity"sv, serialize_devtools_selector_specificities(rule));
+    serialized_rule.set("matchedSelectorIndexes"sv, move(matched_selector_indexes));
+    serialized_rule.set("cssText"sv, rule.rule->css_text());
+    if (authored_text.has_value()) {
+        serialized_rule.set("authoredText"sv, *authored_text);
+        serialized_rule.set("declarations"sv, serialize_devtools_style_declarations(document, parse_devtools_style_declarations(document, authored_text->bytes_as_string_view())));
+    } else {
+        serialized_rule.set("authoredText"sv, declaration.serialized());
+        serialized_rule.set("declarations"sv, serialize_devtools_style_declarations(document, declaration));
+    }
+    serialized_rule.set("styleSheetIndex"sv, rule.style_sheet_index);
+    serialized_rule.set("ruleIndex"sv, rule.rule_index);
+    serialized_rule.set("isSystem"sv, rule.cascade_origin == CascadeOrigin::UserAgent);
+
+    return serialized_rule;
+}
+
+static JsonObject serialize_devtools_inline_style(DOM::Document const& document, DOM::AbstractElement abstract_element, CSSStyleProperties const& declaration)
+{
+    auto authored_text = abstract_element.element().get_attribute(HTML::AttributeNames::style);
+
+    JsonObject serialized_rule;
+    serialized_rule.set("type"sv, 100);
+    serialized_rule.set("className"sv, 100);
+    serialized_rule.set("cssText"sv, declaration.serialized());
+    if (authored_text.has_value()) {
+        serialized_rule.set("authoredText"sv, *authored_text);
+        serialized_rule.set("declarations"sv, serialize_devtools_style_declarations(document, parse_devtools_style_declarations(document, authored_text->bytes_as_string_view())));
+    } else {
+        serialized_rule.set("authoredText"sv, declaration.serialized());
+        serialized_rule.set("declarations"sv, serialize_devtools_style_declarations(document, declaration));
+    }
+    serialized_rule.set("isSystem"sv, false);
+    serialized_rule.set("nodeId"sv, abstract_element.element().unique_id().value());
+    return serialized_rule;
+}
+
+static void append_devtools_applied_style_entry(JsonArray& entries, JsonObject rule, Optional<UniqueNodeID> inherited_node_id = {})
+{
+    JsonObject entry;
+
+    JsonValue matched_selector_indexes { JsonArray {} };
+    if (auto value = rule.get("matchedSelectorIndexes"sv); value.has_value())
+        matched_selector_indexes = *value;
+    rule.remove("matchedSelectorIndexes"sv);
+    auto is_system = rule.get_bool("isSystem"sv).value_or(false);
+
+    entry.set("rule"sv, move(rule));
+    entry.set("isSystem"sv, is_system);
+    entry.set("matchedSelectorIndexes"sv, move(matched_selector_indexes));
+    if (inherited_node_id.has_value())
+        entry.set("inheritedNodeId"sv, inherited_node_id->value());
+    else
+        entry.set("inherited"sv, JsonValue {});
+
+    entries.must_append(move(entry));
+}
+
+static void append_devtools_rules_for_element(DOM::Document const& document, JsonArray& entries, auto const& matching_rule_set, bool include_user_agent_styles, Optional<UniqueNodeID> inherited_node_id = {})
+{
+    auto should_include_rule = [&](MatchingRule const& rule) {
+        return !inherited_node_id.has_value() || has_inherited_declaration(document, rule.declaration());
+    };
+
+    auto append_rules = [&](auto const& matching_rules) {
+        for (auto const& matching_rule : matching_rules.in_reverse()) {
+            auto const& rule = *matching_rule.rule;
+            if (!should_include_rule(rule))
+                continue;
+            append_devtools_applied_style_entry(entries, serialize_devtools_matching_rule(document, rule), inherited_node_id);
+        }
+    };
+
+    for (auto const& context : matching_rule_set.author_contexts.in_reverse()) {
+        for (auto const& layer : context.author_rules.in_reverse())
+            append_rules(layer.rules);
+    }
+    append_rules(matching_rule_set.user_rules);
+    if (include_user_agent_styles)
+        append_rules(matching_rule_set.user_agent_rules);
+}
+
+JsonArray StyleComputer::collect_devtools_applied_style_rules(DOM::AbstractElement abstract_element, bool include_inherited, bool include_user_agent_styles)
+{
+    JsonArray entries;
+
+    auto append_rules_for_abstract_element = [&](DOM::AbstractElement current_element, Optional<UniqueNodeID> inherited_node_id) {
+        if (auto inline_style = current_element.inline_style()) {
+            if (!inherited_node_id.has_value() || has_inherited_declaration(m_document, *inline_style))
+                append_devtools_applied_style_entry(entries, serialize_devtools_inline_style(m_document, current_element, *inline_style), inherited_node_id);
+        }
+
+        auto const first_ancestor = [&] -> GC::Ptr<DOM::Element const> {
+            if (current_element.pseudo_element().has_value())
+                return &current_element.element();
+            return current_element.element().parent_or_shadow_host_element();
+        }();
+
+        for (auto ancestor = first_ancestor; ancestor; ancestor = ancestor->parent_or_shadow_host_element())
+            push_ancestor(*ancestor);
+
+        ScopeGuard pop_ancestors = [&] {
+            for (auto ancestor = first_ancestor; ancestor; ancestor = ancestor->parent_or_shadow_host_element())
+                pop_ancestor(*ancestor);
+        };
+
+        bool did_match_any_pseudo_element_rules = false;
+        auto matching_rule_set = build_matching_rule_set(current_element, did_match_any_pseudo_element_rules, ComputeStyleMode::Normal);
+        append_devtools_rules_for_element(m_document, entries, matching_rule_set, include_user_agent_styles, inherited_node_id);
+    };
+
+    append_rules_for_abstract_element(abstract_element, {});
+
+    if (!include_inherited)
+        return entries;
+
+    for (auto current_element = abstract_element.element_to_inherit_style_from(); current_element.has_value(); current_element = current_element->element_to_inherit_style_from())
+        append_rules_for_abstract_element(*current_element, current_element->element().unique_id());
+
+    return entries;
 }
 
 // https://www.w3.org/TR/css-cascade/#cascading

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -48,6 +48,7 @@
 #include <LibWeb/CSS/SelectorEngine.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleProperty.h>
+#include <LibWeb/CSS/StyleScope.h>
 #include <LibWeb/CSS/StyleSheet.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
@@ -1760,6 +1761,26 @@ static JsonObject serialize_devtools_style_sheet_identifier(StyleSheetIdentifier
     return serialized_identifier;
 }
 
+static Optional<StyleSheetIdentifier> devtools_style_sheet_identifier_for_matching_rule(MatchingRule const& rule)
+{
+    if (rule.cascade_origin == CascadeOrigin::User) {
+        return StyleSheetIdentifier {
+            .type = StyleSheetIdentifier::Type::UserStyle,
+        };
+    }
+
+    if (rule.cascade_origin == CascadeOrigin::UserAgent) {
+        if (!rule.sheet)
+            return {};
+        return StyleScope::user_agent_style_sheet_identifier(*rule.sheet);
+    }
+
+    if (auto const* style_sheet = rule.rule->parent_style_sheet())
+        return style_sheet_identifier_for(*style_sheet);
+
+    return {};
+}
+
 static JsonObject serialize_devtools_matching_rule(DOM::Document const& document, MatchingRule const& rule)
 {
     auto const& declaration = rule.declaration();
@@ -1792,10 +1813,8 @@ static JsonObject serialize_devtools_matching_rule(DOM::Document const& document
         serialized_rule.set("column"sv, source_location->column + 1);
     }
 
-    if (auto const* style_sheet = rule.rule->parent_style_sheet()) {
-        if (auto identifier = style_sheet_identifier_for(*style_sheet); identifier.has_value())
-            serialized_rule.set("styleSheet"sv, serialize_devtools_style_sheet_identifier(identifier.release_value()));
-    }
+    if (auto identifier = devtools_style_sheet_identifier_for_matching_rule(rule); identifier.has_value())
+        serialized_rule.set("styleSheet"sv, serialize_devtools_style_sheet_identifier(identifier.release_value()));
 
     return serialized_rule;
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -49,6 +49,7 @@
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/CSS/StyleSheet.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
@@ -1747,6 +1748,18 @@ static JsonArray serialize_devtools_selector_specificities(MatchingRule const& r
     return specificities;
 }
 
+static JsonObject serialize_devtools_style_sheet_identifier(StyleSheetIdentifier const& identifier)
+{
+    JsonObject serialized_identifier;
+    serialized_identifier.set("type"sv, style_sheet_identifier_type_to_string(identifier.type));
+    if (identifier.dom_element_unique_id.has_value())
+        serialized_identifier.set("domElementUniqueId"sv, identifier.dom_element_unique_id->value());
+    if (identifier.url.has_value())
+        serialized_identifier.set("url"sv, *identifier.url);
+    serialized_identifier.set("ruleCount"sv, identifier.rule_count);
+    return serialized_identifier;
+}
+
 static JsonObject serialize_devtools_matching_rule(DOM::Document const& document, MatchingRule const& rule)
 {
     auto const& declaration = rule.declaration();
@@ -1772,6 +1785,17 @@ static JsonObject serialize_devtools_matching_rule(DOM::Document const& document
     serialized_rule.set("styleSheetIndex"sv, rule.style_sheet_index);
     serialized_rule.set("ruleIndex"sv, rule.rule_index);
     serialized_rule.set("isSystem"sv, rule.cascade_origin == CascadeOrigin::UserAgent);
+
+    if (auto const& source_location = rule.rule->source_location(); source_location.has_value()) {
+        // Our positions are 0-based, but DevTools expects them to be 1-based.
+        serialized_rule.set("line"sv, source_location->line + 1);
+        serialized_rule.set("column"sv, source_location->column + 1);
+    }
+
+    if (auto const* style_sheet = rule.rule->parent_style_sheet()) {
+        if (auto identifier = style_sheet_identifier_for(*style_sheet); identifier.has_value())
+            serialized_rule.set("styleSheet"sv, serialize_devtools_style_sheet_identifier(identifier.release_value()));
+    }
 
     return serialized_rule;
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/JsonArray.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <LibWeb/Animations/KeyframeEffect.h>
@@ -105,6 +106,7 @@ public:
     [[nodiscard]] GC::Ref<ComputedProperties> compute_style(DOM::AbstractElement, Optional<bool&> did_change_custom_properties = {}) const;
     [[nodiscard]] GC::Ref<ComputedProperties> compute_style_with_seeded_ancestors(DOM::AbstractElement);
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::AbstractElement, Optional<bool&> did_change_custom_properties) const;
+    [[nodiscard]] JsonArray collect_devtools_applied_style_rules(DOM::AbstractElement, bool include_inherited, bool include_user_agent_styles);
 
     struct ScopedMatchingRule {
         MatchingRule const* rule { nullptr };

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -404,7 +404,8 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
             if (scope_rule)
                 collect_scope_boundary_selector_dependencies(*scope_rule, style_cache);
 
-            for (CSS::Selector const& selector : absolutized_selectors) {
+            for (size_t selector_index = 0; selector_index < absolutized_selectors.size(); ++selector_index) {
+                auto const& selector = *absolutized_selectors[selector_index];
                 MatchingRule matching_rule {
                     .rule = &rule,
                     .sheet = sheet,
@@ -412,6 +413,7 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                     .scope_rule = scope_rule,
                     .default_namespace = sheet.default_namespace(),
                     .selector = selector,
+                    .selector_index = selector_index,
                     .style_sheet_index = style_sheet_index,
                     .rule_index = rule_index,
                     .specificity = selector.specificity(),

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -237,6 +237,33 @@ static CSSStyleSheet& svg_stylesheet()
     return *sheet;
 }
 
+void StyleScope::for_each_user_agent_stylesheet(bool include_quirks_mode_stylesheet, Function<void(CSS::CSSStyleSheet&, StyleSheetIdentifier const&)> const& callback)
+{
+    auto callback_with_identifier = [&](CSSStyleSheet& sheet, String url) {
+        StyleSheetIdentifier identifier {
+            .type = StyleSheetIdentifier::Type::UserAgent,
+            .url = move(url),
+        };
+        callback(sheet, identifier);
+    };
+
+    callback_with_identifier(default_stylesheet(), "CSS/Default.css"_string);
+    if (include_quirks_mode_stylesheet)
+        callback_with_identifier(quirks_mode_stylesheet(), "CSS/QuirksMode.css"_string);
+    callback_with_identifier(mathml_stylesheet(), "MathML/Default.css"_string);
+    callback_with_identifier(svg_stylesheet(), "SVG/Default.css"_string);
+}
+
+Optional<StyleSheetIdentifier> StyleScope::user_agent_style_sheet_identifier(CSS::CSSStyleSheet const& style_sheet)
+{
+    Optional<StyleSheetIdentifier> identifier;
+    for_each_user_agent_stylesheet(true, [&](auto& user_agent_style_sheet, auto const& user_agent_style_sheet_identifier) {
+        if (&style_sheet == &user_agent_style_sheet)
+            identifier = user_agent_style_sheet_identifier;
+    });
+    return identifier;
+}
+
 static GC::Ptr<CSSContainerRule const> current_container_rule(Vector<GC::Ptr<CSSContainerRule const>> const& container_rule_stack)
 {
     if (container_rule_stack.is_empty())
@@ -349,11 +376,9 @@ static void for_each_style_producing_rule_for_rule_cache(
 void StyleScope::for_each_stylesheet(CascadeOrigin cascade_origin, Function<void(CSS::CSSStyleSheet&)> const& callback) const
 {
     if (cascade_origin == CascadeOrigin::UserAgent) {
-        callback(default_stylesheet());
-        if (document().in_quirks_mode())
-            callback(quirks_mode_stylesheet());
-        callback(mathml_stylesheet());
-        callback(svg_stylesheet());
+        for_each_user_agent_stylesheet(document().in_quirks_mode(), [&](auto& sheet, auto const&) {
+            callback(sheet);
+        });
     }
     if (cascade_origin == CascadeOrigin::User) {
         auto& style_scope = const_cast<StyleScope&>(*this);

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -35,6 +35,7 @@ struct MatchingRule {
     GC::Ptr<CSSScopeRule const> scope_rule;
     Optional<FlyString> default_namespace;
     Selector const& selector;
+    size_t selector_index { 0 };
     size_t style_sheet_index { 0 };
     size_t rule_index { 0 };
 

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -22,6 +22,7 @@
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/SelectorInsights.h>
 #include <LibWeb/CSS/StyleInvalidationData.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -123,6 +124,8 @@ public:
     [[nodiscard]] RuleCache const& get_pseudo_class_rule_cache(PseudoClass) const;
 
     void for_each_stylesheet(CascadeOrigin, Function<void(CSS::CSSStyleSheet&)> const&) const;
+    static WEB_API void for_each_user_agent_stylesheet(bool include_quirks_mode_stylesheet, Function<void(CSS::CSSStyleSheet&, StyleSheetIdentifier const&)> const&);
+    static Optional<StyleSheetIdentifier> user_agent_style_sheet_identifier(CSS::CSSStyleSheet const&);
     void build_user_style_sheet_if_needed();
 
     void make_rule_cache_for_cascade_origin(CascadeOrigin, StyleCache&);

--- a/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Libraries/LibWeb/CSS/StyleSheet.h
@@ -24,6 +24,7 @@ public:
     virtual String type() const = 0;
 
     DOM::Element* owner_node() { return m_owner_node; }
+    DOM::Element const* owner_node() const { return m_owner_node; }
     void set_owner_node(DOM::Element*);
 
     Optional<String> href() const;
@@ -57,6 +58,7 @@ public:
     virtual void set_disabled(bool disabled) { m_disabled = disabled; }
 
     CSSStyleSheet* parent_style_sheet() { return m_parent_style_sheet; }
+    CSSStyleSheet const* parent_style_sheet() const { return m_parent_style_sheet; }
     void set_parent_css_style_sheet(CSSStyleSheet*);
 
 protected:

--- a/Libraries/LibWeb/CSS/StyleSheetIdentifier.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetIdentifier.cpp
@@ -5,8 +5,11 @@
  */
 
 #include "StyleSheetIdentifier.h"
+#include <AK/Debug.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
+#include <LibWeb/CSS/CSSStyleSheet.h>
+#include <LibWeb/DOM/Element.h>
 
 namespace Web::CSS {
 
@@ -40,6 +43,34 @@ Optional<StyleSheetIdentifier::Type> style_sheet_identifier_type_from_string(Str
     if (string == "UserStyle"sv)
         return StyleSheetIdentifier::Type::UserStyle;
     return {};
+}
+
+Optional<StyleSheetIdentifier> style_sheet_identifier_for(CSSStyleSheet const& sheet)
+{
+    StyleSheetIdentifier identifier {};
+
+    if (sheet.owner_rule()) {
+        identifier.type = StyleSheetIdentifier::Type::ImportRule;
+    } else if (auto* node = sheet.owner_node()) {
+        if (node->is_html_style_element() || node->is_svg_style_element()) {
+            identifier.type = StyleSheetIdentifier::Type::StyleElement;
+        } else if (node->is_html_link_element()) {
+            identifier.type = StyleSheetIdentifier::Type::LinkElement;
+        } else {
+            dbgln("Can't identify where style sheet came from; owner node is {}", node->debug_description());
+            identifier.type = StyleSheetIdentifier::Type::StyleElement;
+        }
+        identifier.dom_element_unique_id = node->unique_id();
+    } else {
+        dbgln("Style sheet has no owner rule or owner node; skipping");
+        return {};
+    }
+
+    if (auto sheet_url = sheet.href(); sheet_url.has_value())
+        identifier.url = sheet_url.release_value();
+
+    identifier.rule_count = sheet.rules().length();
+    return identifier;
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleSheetIdentifier.h
+++ b/Libraries/LibWeb/CSS/StyleSheetIdentifier.h
@@ -33,8 +33,8 @@ struct StyleSheetIdentifier {
     }
 };
 
-StringView style_sheet_identifier_type_to_string(StyleSheetIdentifier::Type);
-Optional<StyleSheetIdentifier::Type> style_sheet_identifier_type_from_string(StringView);
+WEB_API StringView style_sheet_identifier_type_to_string(StyleSheetIdentifier::Type);
+WEB_API Optional<StyleSheetIdentifier::Type> style_sheet_identifier_type_from_string(StringView);
 WEB_API Optional<StyleSheetIdentifier> style_sheet_identifier_for(CSSStyleSheet const&);
 
 }

--- a/Libraries/LibWeb/CSS/StyleSheetIdentifier.h
+++ b/Libraries/LibWeb/CSS/StyleSheetIdentifier.h
@@ -35,6 +35,7 @@ struct StyleSheetIdentifier {
 
 StringView style_sheet_identifier_type_to_string(StyleSheetIdentifier::Type);
 Optional<StyleSheetIdentifier::Type> style_sheet_identifier_type_from_string(StringView);
+WEB_API Optional<StyleSheetIdentifier> style_sheet_identifier_for(CSSStyleSheet const&);
 
 }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7664,11 +7664,11 @@ Optional<String> Document::get_style_sheet_source(CSS::StyleSheetIdentifier cons
             if (auto* node = Node::from_unique_id(*identifier.dom_element_unique_id)) {
                 if (node->is_html_style_element()) {
                     if (auto* sheet = as<HTML::HTMLStyleElement>(*node).sheet())
-                        return sheet->source_text({});
+                        return sheet->source_text();
                 }
                 if (node->is_svg_style_element()) {
                     if (auto* sheet = as<SVG::SVGStyleElement>(*node).sheet())
-                        return sheet->source_text({});
+                        return sheet->source_text();
                 }
             }
         }
@@ -7683,7 +7683,7 @@ Optional<String> Document::get_style_sheet_source(CSS::StyleSheetIdentifier cons
         if (m_style_sheets) {
             for (auto& style_sheet : m_style_sheets->sheets()) {
                 if (auto match = find_style_sheet_with_url(identifier.url.value(), style_sheet); match.has_value())
-                    return match->source_text({});
+                    return match->source_text();
             }
         }
 
@@ -7694,7 +7694,7 @@ Optional<String> Document::get_style_sheet_source(CSS::StyleSheetIdentifier cons
                     return;
 
                 if (auto match = find_style_sheet_with_url(identifier.url.value(), style_sheet); match.has_value())
-                    result = match->source_text({});
+                    result = match->source_text();
             });
             return result;
         }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1864,13 +1864,13 @@ void Application::stop_listening_for_dom_properties(DevTools::TabDescription con
     view->on_received_dom_node_properties = nullptr;
 }
 
-void Application::inspect_dom_node(DevTools::TabDescription const& description, DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) const
+void Application::inspect_dom_node(DevTools::TabDescription const& description, DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonObject options) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);
     if (!view.has_value())
         return;
 
-    view->inspect_dom_node(node_id, property_type, pseudo_element);
+    view->inspect_dom_node(node_id, property_type, pseudo_element, JsonValue { move(options) });
 }
 
 void Application::inspect_grid_layouts(DevTools::TabDescription const& description, Web::UniqueNodeID root_node_id, OnGridLayoutsReceived on_grid_layouts_received) const

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -273,7 +273,7 @@ private:
     virtual void inspect_accessibility_tree(DevTools::TabDescription const&, OnAccessibilityTreeInspectionComplete) const override;
     virtual void listen_for_dom_properties(DevTools::TabDescription const&, OnDOMNodePropertiesReceived) const override;
     virtual void stop_listening_for_dom_properties(DevTools::TabDescription const&) const override;
-    virtual void inspect_dom_node(DevTools::TabDescription const&, DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>) const override;
+    virtual void inspect_dom_node(DevTools::TabDescription const&, DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::PseudoElement>, JsonObject options = {}) const override;
     virtual void clear_inspected_dom_node(DevTools::TabDescription const&) const override;
     virtual void start_node_picker(DevTools::TabDescription const&, OnNodePickerEvent) const override;
     virtual void stop_node_picker(DevTools::TabDescription const&) const override;

--- a/Libraries/LibWebView/DOMNodeProperties.h
+++ b/Libraries/LibWebView/DOMNodeProperties.h
@@ -14,6 +14,7 @@ namespace WebView {
 
 struct WEBVIEW_API DOMNodeProperties {
     enum class Type {
+        AppliedStyleRules,
         ComputedStyle,
         Layout,
         UsedFonts,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -574,9 +574,9 @@ void ViewImplementation::did_receive_node_picker_hit_test(u64 request_id, Web::U
     });
 }
 
-void ViewImplementation::inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type property_type, Optional<Web::CSS::PseudoElement> pseudo_element)
+void ViewImplementation::inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type property_type, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options)
 {
-    client().async_inspect_dom_node(page_id(), property_type, node_id, pseudo_element);
+    client().async_inspect_dom_node(page_id(), property_type, node_id, pseudo_element, move(options));
 }
 
 void ViewImplementation::inspect_grid_layouts(Web::UniqueNodeID root_node_id)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -131,7 +131,7 @@ public:
     void node_picker_preview(Web::DevicePixelPoint);
     void node_picker_cancel();
 
-    void inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type, Optional<Web::CSS::PseudoElement> pseudo_element);
+    void inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options = {});
     void inspect_grid_layouts(Web::UniqueNodeID root_node_id);
     void inspect_current_grid(Web::UniqueNodeID node_id);
     void inspect_current_flexbox(Web::UniqueNodeID node_id, bool only_look_at_parents);

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/Compositor/CompositorHost.h>
 #include <LibWeb/CookieStore/CookieStore.h>
+#include <LibWeb/DOM/AbstractElement.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/CharacterData.h>
 #include <LibWeb/DOM/Document.h>
@@ -547,8 +548,6 @@ void ConnectionFromClient::inspect_dom_tree(u64 page_id)
 
 void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options_value)
 {
-    (void)options_value;
-
     auto page = this->page(page_id);
     if (!page.has_value())
         return;
@@ -556,8 +555,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
     clear_inspected_dom_node(page_id);
 
     auto* node = Web::DOM::Node::from_unique_id(node_id);
-    // Nodes without layout (aka non-visible nodes) don't have style computed.
-    if (!node || !node->layout_node() || !node->is_element()) {
+    if (!node || !node->is_element()) {
         async_did_inspect_dom_node(page_id, { property_type, {} });
         return;
     }
@@ -565,9 +563,19 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
     auto& element = as<Web::DOM::Element>(*node);
     node->document().set_inspected_node(node);
 
+    Web::DOM::AbstractElement abstract_element { element, pseudo_element };
+    node->document().update_style_for_element(abstract_element);
+
     auto properties = element.computed_properties(pseudo_element);
 
     if (!properties) {
+        async_did_inspect_dom_node(page_id, { property_type, {} });
+        return;
+    }
+
+    // Nodes without layout (aka non-visible nodes) do not have box metrics, but DevTools can still ask for their style
+    // rules and computed properties.
+    if (property_type == WebView::DOMNodeProperties::Type::Layout && !node->layout_node()) {
         async_did_inspect_dom_node(page_id, { property_type, {} });
         return;
     }
@@ -646,9 +654,20 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
         return serialized;
     };
 
+    auto serialize_applied_style_rules = [&]() {
+        JsonObject const empty_options;
+        auto const& options = options_value.is_object() ? options_value.as_object() : empty_options;
+        auto include_inherited = options.get_bool("inherited"sv).value_or(false);
+        auto include_user_agent_styles = options.get_string("filter"sv).map([](auto const& filter) { return filter == "ua"sv; }).value_or(false);
+        return node->document().style_computer().collect_devtools_applied_style_rules(abstract_element, include_inherited, include_user_agent_styles);
+    };
+
     JsonValue serialized;
 
     switch (property_type) {
+    case WebView::DOMNodeProperties::Type::AppliedStyleRules:
+        serialized = serialize_applied_style_rules();
+        break;
     case WebView::DOMNodeProperties::Type::ComputedStyle:
         serialized = serialize_computed_style();
         break;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -545,8 +545,10 @@ void ConnectionFromClient::inspect_dom_tree(u64 page_id)
     }
 }
 
-void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element)
+void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options_value)
 {
+    (void)options_value;
+
     auto page = this->page(page_id);
     if (!page.has_value())
         return;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <AK/Queue.h>
 #include <AK/RefPtr.h>
@@ -91,7 +92,7 @@ private:
     virtual void debug_request(u64 page_id, ByteString, ByteString) override;
     virtual void get_source(u64 page_id) override;
     virtual void inspect_dom_tree(u64 page_id) override;
-    virtual void inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) override;
+    virtual void inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options) override;
     virtual void inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) override;
     virtual void inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void inspect_current_flexbox(u64 page_id, Web::UniqueNodeID node_id, bool only_look_at_parents) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -19,6 +19,7 @@
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/CSSImportRule.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/DOM/CharacterData.h>
 #include <LibWeb/DOM/Document.h>
@@ -27,7 +28,6 @@
 #include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
-#include <LibWeb/HTML/HTMLLinkElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
@@ -1042,34 +1042,8 @@ void PageClient::console_peer_did_misbehave(char const* reason)
 
 static void gather_style_sheets(Vector<Web::CSS::StyleSheetIdentifier>& results, Web::CSS::CSSStyleSheet& sheet)
 {
-    Web::CSS::StyleSheetIdentifier identifier {};
-
-    bool valid = true;
-
-    if (sheet.owner_rule()) {
-        identifier.type = Web::CSS::StyleSheetIdentifier::Type::ImportRule;
-    } else if (auto* node = sheet.owner_node()) {
-        if (node->is_html_style_element() || node->is_svg_style_element()) {
-            identifier.type = Web::CSS::StyleSheetIdentifier::Type::StyleElement;
-        } else if (is<Web::HTML::HTMLLinkElement>(node)) {
-            identifier.type = Web::CSS::StyleSheetIdentifier::Type::LinkElement;
-        } else {
-            dbgln("Can't identify where style sheet came from; owner node is {}", node->debug_description());
-            identifier.type = Web::CSS::StyleSheetIdentifier::Type::StyleElement;
-        }
-        identifier.dom_element_unique_id = node->unique_id();
-    } else {
-        dbgln("Style sheet has no owner rule or owner node; skipping");
-        valid = false;
-    }
-
-    if (valid) {
-        if (auto sheet_url = sheet.href(); sheet_url.has_value())
-            identifier.url = sheet_url.release_value();
-
-        identifier.rule_count = sheet.rules().length();
-        results.append(move(identifier));
-    }
+    if (auto identifier = Web::CSS::style_sheet_identifier_for(sheet); identifier.has_value())
+        results.append(identifier.release_value());
 
     for (auto& import_rule : sheet.import_rules()) {
         if (import_rule->loaded_style_sheet()) {

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -19,6 +19,7 @@
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/CSSImportRule.h>
+#include <LibWeb/CSS/StyleScope.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/DOM/CharacterData.h>
@@ -1076,24 +1077,8 @@ Vector<Web::CSS::StyleSheetIdentifier> PageClient::list_style_sheets() const
         });
     }
 
-    // User-agent
-    results.append({
-        .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
-        .url = "CSS/Default.css"_string,
-    });
-    if (document && document->in_quirks_mode()) {
-        results.append({
-            .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
-            .url = "CSS/QuirksMode.css"_string,
-        });
-    }
-    results.append({
-        .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
-        .url = "MathML/Default.css"_string,
-    });
-    results.append({
-        .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
-        .url = "SVG/Default.css"_string,
+    Web::CSS::StyleScope::for_each_user_agent_stylesheet(document && document->in_quirks_mode(), [&](auto&, auto const& identifier) {
+        results.append(identifier);
     });
 
     return results;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -58,7 +58,7 @@ endpoint WebContentServer
     debug_request(u64 page_id, ByteString request, ByteString argument) =|
     get_source(u64 page_id) =|
     inspect_dom_tree(u64 page_id) =|
-    inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) =|
+    inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options) =|
     inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) =|
     inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) =|
     inspect_current_flexbox(u64 page_id, Web::UniqueNodeID node_id, bool only_look_at_parents) =|

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -189,6 +189,7 @@ static WebView::DOMNodeProperties make_computed_style()
 }
 
 static JsonObject serialized_fixture_style_sheet();
+static JsonObject serialized_fixture_user_agent_style_sheet();
 
 static WebView::DOMNodeProperties make_applied_style_rules()
 {
@@ -268,6 +269,46 @@ static WebView::DOMNodeProperties make_applied_style_rules()
     rule_entry.set("inheritedNodeId"sv, 1u);
     entries.must_append(move(rule_entry));
 
+    JsonArray user_agent_declarations;
+    JsonObject user_agent_display;
+    user_agent_display.set("name"sv, "display"sv);
+    user_agent_display.set("value"sv, "block"sv);
+    user_agent_display.set("priority"sv, ""sv);
+    user_agent_display.set("isCustomProperty"sv, false);
+    user_agent_display.set("isNameValid"sv, true);
+    user_agent_display.set("isValid"sv, true);
+    user_agent_display.set("inherits"sv, false);
+    user_agent_declarations.must_append(move(user_agent_display));
+
+    JsonArray user_agent_selectors;
+    user_agent_selectors.must_append("div"sv);
+
+    JsonArray user_agent_selector_specificities;
+    user_agent_selector_specificities.must_append(0x1u);
+
+    JsonArray user_agent_matched_selector_indexes;
+    user_agent_matched_selector_indexes.must_append(0u);
+
+    JsonObject user_agent_rule;
+    user_agent_rule.set("type"sv, 1);
+    user_agent_rule.set("className"sv, "CSSStyleRule"sv);
+    user_agent_rule.set("selectors"sv, move(user_agent_selectors));
+    user_agent_rule.set("selectorsSpecificity"sv, move(user_agent_selector_specificities));
+    user_agent_rule.set("cssText"sv, "div { display: block; }"sv);
+    user_agent_rule.set("authoredText"sv, "display: block;"sv);
+    user_agent_rule.set("declarations"sv, move(user_agent_declarations));
+    user_agent_rule.set("isSystem"sv, true);
+    user_agent_rule.set("line"sv, 12);
+    user_agent_rule.set("column"sv, 5);
+    user_agent_rule.set("styleSheet"sv, serialized_fixture_user_agent_style_sheet());
+
+    JsonObject user_agent_rule_entry;
+    user_agent_rule_entry.set("rule"sv, move(user_agent_rule));
+    user_agent_rule_entry.set("isSystem"sv, true);
+    user_agent_rule_entry.set("matchedSelectorIndexes"sv, move(user_agent_matched_selector_indexes));
+    user_agent_rule_entry.set("inherited"sv, JsonValue {});
+    entries.must_append(move(user_agent_rule_entry));
+
     return { WebView::DOMNodeProperties::Type::AppliedStyleRules, move(entries) };
 }
 
@@ -322,6 +363,22 @@ static JsonObject serialized_fixture_style_sheet()
     style_sheet.set("domElementUniqueId"sv, 9);
     style_sheet.set("url"sv, "https://example.test/style.css"sv);
     style_sheet.set("ruleCount"sv, 2);
+    return style_sheet;
+}
+
+static Web::CSS::StyleSheetIdentifier fixture_user_agent_style_sheet()
+{
+    return { .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
+        .url = "CSS/Default.css"_string,
+        .rule_count = 4 };
+}
+
+static JsonObject serialized_fixture_user_agent_style_sheet()
+{
+    JsonObject style_sheet;
+    style_sheet.set("type"sv, Web::CSS::style_sheet_identifier_type_to_string(Web::CSS::StyleSheetIdentifier::Type::UserAgent));
+    style_sheet.set("url"sv, "CSS/Default.css"sv);
+    style_sheet.set("ruleCount"sv, 4);
     return style_sheet;
 }
 
@@ -717,6 +774,7 @@ public:
         ++retrieve_style_sheets_call_count;
         Vector<Web::CSS::StyleSheetIdentifier> style_sheets;
         style_sheets.append(fixture_style_sheet());
+        style_sheets.append(fixture_user_agent_style_sheet());
         callback(move(style_sheets));
     }
 
@@ -1975,7 +2033,7 @@ TEST_CASE(styles_and_stylesheets)
     auto applied_entries = get_applied();
     EXPECT(session->delegate.last_inspected_dom_node_options.get_bool("inherited"sv).value());
     EXPECT(session->delegate.last_inspected_dom_node_options.get_bool("matchedSelectors"sv).value());
-    VERIFY(applied_entries.size() == 2u);
+    VERIFY(applied_entries.size() == 3u);
     EXPECT_EQ(style_rule_actor_count(*session->server), applied_entries.size());
 
     auto inline_rule = applied_entries.at(0).as_object().get_object("rule"sv).release_value();
@@ -2002,6 +2060,15 @@ TEST_CASE(styles_and_stylesheets)
     EXPECT_EQ(inherited_rule.get_integer<int>("column"sv).value(), 9);
     EXPECT(!inherited_rule.has("styleSheet"sv));
     EXPECT_EQ(inherited_rule_entry.get_array("matchedSelectorIndexes"sv)->at(0).as_integer<int>(), 0);
+
+    auto user_agent_rule_entry = applied_entries.at(2).as_object();
+    auto user_agent_rule = user_agent_rule_entry.get_object("rule"sv).release_value();
+    EXPECT(user_agent_rule_entry.get_bool("isSystem"sv).value());
+    EXPECT_EQ(user_agent_rule.get_array("selectors"sv)->at(0).as_string(), "div"sv);
+    EXPECT_EQ(user_agent_rule.get_string("parentStyleSheet"sv).value(), MUST(String::formatted("{}-stylesheet:1", style_sheets_actor)));
+    EXPECT_EQ(user_agent_rule.get_integer<int>("line"sv).value(), 12);
+    EXPECT_EQ(user_agent_rule.get_integer<int>("column"sv).value(), 5);
+    EXPECT(!user_agent_rule.has("styleSheet"sv));
     EXPECT(!client.request(page_style_actor, "isPositionEditable"sv).get_bool("value"sv).value());
 
     auto second_applied_entries = get_applied();
@@ -2038,7 +2105,7 @@ TEST_CASE(styles_and_stylesheets)
     while (style_resources.get_string("type"sv).value_or({}) != "resources-available-array"sv)
         style_resources = client.read_message();
     auto sheets = style_resources.get_array("array"sv)->at(0).as_array().at(1).as_array();
-    VERIFY(sheets.size() == 1u);
+    VERIFY(sheets.size() == 2u);
     auto resource_id = sheets.at(0).as_object().get_string("resourceId"sv).release_value();
 
     JsonObject get_text;

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -418,8 +418,9 @@ public:
         ++stop_listening_for_dom_properties_call_count;
     }
 
-    virtual void inspect_dom_node(DevTools::TabDescription const&, WebView::DOMNodeProperties::Type type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) const override
+    virtual void inspect_dom_node(DevTools::TabDescription const&, WebView::DOMNodeProperties::Type type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonObject options = {}) const override
     {
+        (void)options;
         ++inspect_dom_node_call_count;
         last_inspected_dom_node = node_id;
         last_inspected_pseudo_element = pseudo_element;

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -188,6 +188,8 @@ static WebView::DOMNodeProperties make_computed_style()
     return { WebView::DOMNodeProperties::Type::ComputedStyle, move(properties) };
 }
 
+static JsonObject serialized_fixture_style_sheet();
+
 static WebView::DOMNodeProperties make_applied_style_rules()
 {
     JsonArray entries;
@@ -255,6 +257,9 @@ static WebView::DOMNodeProperties make_applied_style_rules()
     rule.set("cssText"sv, "body div.fixture { color: rgb(1, 2, 3); }"sv);
     rule.set("authoredText"sv, "color: rgb(1, 2, 3);"sv);
     rule.set("declarations"sv, move(rule_declarations));
+    rule.set("line"sv, 4);
+    rule.set("column"sv, 9);
+    rule.set("styleSheet"sv, serialized_fixture_style_sheet());
 
     JsonObject rule_entry;
     rule_entry.set("rule"sv, move(rule));
@@ -308,6 +313,16 @@ static Web::CSS::StyleSheetIdentifier fixture_style_sheet()
         .dom_element_unique_id = 9,
         .url = "https://example.test/style.css"_string,
         .rule_count = 2 };
+}
+
+static JsonObject serialized_fixture_style_sheet()
+{
+    JsonObject style_sheet;
+    style_sheet.set("type"sv, Web::CSS::style_sheet_identifier_type_to_string(Web::CSS::StyleSheetIdentifier::Type::StyleElement));
+    style_sheet.set("domElementUniqueId"sv, 9);
+    style_sheet.set("url"sv, "https://example.test/style.css"sv);
+    style_sheet.set("ruleCount"sv, 2);
+    return style_sheet;
 }
 
 static JsonObject make_grid_line(double start, i32 number, i32 negative_number)
@@ -1982,6 +1997,10 @@ TEST_CASE(styles_and_stylesheets)
     EXPECT(inherited_rule.get_array("declarations"sv)->at(0).as_object().get_bool("isValid"sv).value());
     EXPECT(inherited_rule.get_array("declarations"sv)->at(1).as_object().get_bool("isNameValid"sv).value());
     EXPECT(!inherited_rule.get_array("declarations"sv)->at(1).as_object().get_bool("isValid"sv).value());
+    EXPECT_EQ(inherited_rule.get_string("parentStyleSheet"sv).value(), MUST(String::formatted("{}-stylesheet:0", style_sheets_actor)));
+    EXPECT_EQ(inherited_rule.get_integer<int>("line"sv).value(), 4);
+    EXPECT_EQ(inherited_rule.get_integer<int>("column"sv).value(), 9);
+    EXPECT(!inherited_rule.has("styleSheet"sv));
     EXPECT_EQ(inherited_rule_entry.get_array("matchedSelectorIndexes"sv)->at(0).as_integer<int>(), 0);
     EXPECT(!client.request(page_style_actor, "isPositionEditable"sv).get_bool("value"sv).value());
 

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -14,6 +14,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/Socket.h>
 #include <LibCore/System.h>
+#include <LibDevTools/Connection.h>
 #include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/DevToolsServer.h>
 #include <LibHTTP/Header.h>
@@ -1901,6 +1902,19 @@ TEST_CASE(styles_and_stylesheets)
     bad_get_text.set("type"sv, "getText"sv);
     bad_get_text.set("resourceId"sv, "missing:99"sv);
     EXPECT_EQ(client.request(move(bad_get_text)).get_string("error"sv).value(), "unknownActor"sv);
+}
+
+TEST_CASE(devtools_server_teardown_with_pending_actor_cleanup)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto tab_actor = actor_from(get_tab(client), "actor"sv);
+    session->server->unregister_actor(tab_actor);
+    session->server->connection()->on_connection_closed();
+    session->server.clear();
+    pump(session->loop);
 }
 
 TEST_CASE(console_network_navigation_and_accessibility)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -188,6 +188,84 @@ static WebView::DOMNodeProperties make_computed_style()
     return { WebView::DOMNodeProperties::Type::ComputedStyle, move(properties) };
 }
 
+static WebView::DOMNodeProperties make_applied_style_rules()
+{
+    JsonArray entries;
+
+    JsonArray inline_declarations;
+    JsonObject inline_display;
+    inline_display.set("name"sv, "display"sv);
+    inline_display.set("value"sv, "grid"sv);
+    inline_display.set("priority"sv, ""sv);
+    inline_display.set("isCustomProperty"sv, false);
+    inline_display.set("isNameValid"sv, true);
+    inline_display.set("isValid"sv, true);
+    inline_display.set("inherits"sv, false);
+    inline_declarations.must_append(move(inline_display));
+
+    JsonObject inline_rule;
+    inline_rule.set("type"sv, 100);
+    inline_rule.set("className"sv, 100);
+    inline_rule.set("cssText"sv, "display: grid;"sv);
+    inline_rule.set("authoredText"sv, "display: grid;"sv);
+    inline_rule.set("declarations"sv, move(inline_declarations));
+
+    JsonObject inline_entry;
+    inline_entry.set("rule"sv, move(inline_rule));
+    inline_entry.set("isSystem"sv, false);
+    inline_entry.set("matchedSelectorIndexes"sv, JsonArray {});
+    inline_entry.set("inherited"sv, JsonValue {});
+    entries.must_append(move(inline_entry));
+
+    JsonArray rule_declarations;
+    JsonObject rule_color;
+    rule_color.set("name"sv, "color"sv);
+    rule_color.set("value"sv, "rgb(1, 2, 3)"sv);
+    rule_color.set("priority"sv, ""sv);
+    rule_color.set("isCustomProperty"sv, false);
+    rule_color.set("isNameValid"sv, true);
+    rule_color.set("isValid"sv, true);
+    rule_color.set("inherits"sv, true);
+    rule_declarations.must_append(move(rule_color));
+
+    JsonObject rule_invalid_color;
+    rule_invalid_color.set("name"sv, "color"sv);
+    rule_invalid_color.set("value"sv, "invalid-value"sv);
+    rule_invalid_color.set("priority"sv, ""sv);
+    rule_invalid_color.set("isCustomProperty"sv, false);
+    rule_invalid_color.set("isNameValid"sv, true);
+    rule_invalid_color.set("isValid"sv, false);
+    rule_invalid_color.set("inherits"sv, true);
+    rule_declarations.must_append(move(rule_invalid_color));
+
+    JsonArray selectors;
+    selectors.must_append("body div.fixture"sv);
+
+    JsonArray selector_specificities;
+    selector_specificities.must_append(0x101u);
+
+    JsonArray matched_selector_indexes;
+    matched_selector_indexes.must_append(0u);
+
+    JsonObject rule;
+    rule.set("type"sv, 1);
+    rule.set("className"sv, "CSSStyleRule"sv);
+    rule.set("selectors"sv, move(selectors));
+    rule.set("selectorsSpecificity"sv, move(selector_specificities));
+    rule.set("cssText"sv, "body div.fixture { color: rgb(1, 2, 3); }"sv);
+    rule.set("authoredText"sv, "color: rgb(1, 2, 3);"sv);
+    rule.set("declarations"sv, move(rule_declarations));
+
+    JsonObject rule_entry;
+    rule_entry.set("rule"sv, move(rule));
+    rule_entry.set("isSystem"sv, false);
+    rule_entry.set("matchedSelectorIndexes"sv, move(matched_selector_indexes));
+    rule_entry.set("inheritedNodeId"sv, 1u);
+    entries.must_append(move(rule_entry));
+
+    return { WebView::DOMNodeProperties::Type::AppliedStyleRules, move(entries) };
+}
+
 static WebView::DOMNodeProperties make_layout()
 {
     JsonObject properties;
@@ -420,14 +498,16 @@ public:
 
     virtual void inspect_dom_node(DevTools::TabDescription const&, WebView::DOMNodeProperties::Type type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonObject options = {}) const override
     {
-        (void)options;
         ++inspect_dom_node_call_count;
         last_inspected_dom_node = node_id;
         last_inspected_pseudo_element = pseudo_element;
+        last_inspected_dom_node_options = move(options);
 
         Core::deferred_invoke([this, type] {
             VERIFY(on_dom_node_properties);
-            if (type == WebView::DOMNodeProperties::Type::ComputedStyle)
+            if (type == WebView::DOMNodeProperties::Type::AppliedStyleRules)
+                on_dom_node_properties(make_applied_style_rules());
+            else if (type == WebView::DOMNodeProperties::Type::ComputedStyle)
                 on_dom_node_properties(make_computed_style());
             else if (type == WebView::DOMNodeProperties::Type::Layout)
                 on_dom_node_properties(make_layout());
@@ -854,6 +934,7 @@ public:
     mutable Optional<Web::CSS::PseudoElement> last_highlighted_pseudo_element;
     mutable Optional<Web::UniqueNodeID> last_inspected_dom_node;
     mutable Optional<Web::CSS::PseudoElement> last_inspected_pseudo_element;
+    mutable JsonObject last_inspected_dom_node_options;
     mutable Optional<Web::UniqueNodeID> last_grid_root_node;
     mutable Optional<Web::UniqueNodeID> last_current_grid_node;
     mutable Optional<Web::UniqueNodeID> last_current_flexbox_node;
@@ -1029,6 +1110,16 @@ static JsonObject get_tab(ProtocolClient& client)
     auto tabs = client.request("root"sv, "listTabs"sv).get_array("tabs"sv).release_value();
     VERIFY(tabs.size() == 1u);
     return tabs.at(0).as_object();
+}
+
+static size_t style_rule_actor_count(DevTools::DevToolsServer const& server)
+{
+    size_t count = 0;
+    for (auto const& actor : server.actor_registry()) {
+        if (actor.key.bytes_as_string_view().contains("-style-rule"sv))
+            ++count;
+    }
+    return count;
 }
 
 static JsonObject get_frame_target(ProtocolClient& client, StringView tab_actor)
@@ -1856,11 +1947,50 @@ TEST_CASE(styles_and_stylesheets)
     auto root_actor = walker.get_object("root"sv)->get_string("actor"sv).release_value();
     auto div_actor = query_selector(client, walker_actor, root_actor, "div"sv);
 
-    JsonObject applied;
-    applied.set("to"sv, page_style_actor);
-    applied.set("type"sv, "getApplied"sv);
-    EXPECT(client.request(move(applied)).get_array("entries"sv)->is_empty());
+    auto get_applied = [&] {
+        JsonObject applied;
+        applied.set("to"sv, page_style_actor);
+        applied.set("type"sv, "getApplied"sv);
+        applied.set("node"sv, div_actor);
+        applied.set("inherited"sv, true);
+        applied.set("matchedSelectors"sv, true);
+        return client.request(move(applied)).get_array("entries"sv).release_value();
+    };
+
+    auto applied_entries = get_applied();
+    EXPECT(session->delegate.last_inspected_dom_node_options.get_bool("inherited"sv).value());
+    EXPECT(session->delegate.last_inspected_dom_node_options.get_bool("matchedSelectors"sv).value());
+    VERIFY(applied_entries.size() == 2u);
+    EXPECT_EQ(style_rule_actor_count(*session->server), applied_entries.size());
+
+    auto inline_rule = applied_entries.at(0).as_object().get_object("rule"sv).release_value();
+    auto inline_rule_actor = actor_from(inline_rule, "actor"sv);
+    EXPECT_EQ(inline_rule.get_integer<int>("type"sv).value(), 100);
+    EXPECT(inline_rule.get_array("ancestorData"sv)->is_empty());
+    EXPECT(!inline_rule.get_object("traits"sv)->get_bool("canSetRuleText"sv).value());
+    EXPECT_EQ(inline_rule.get_array("declarations"sv)->at(0).as_object().get_string("name"sv).value(), "display"sv);
+    EXPECT(inline_rule.get_array("declarations"sv)->at(0).as_object().get_bool("isNameValid"sv).value());
+    EXPECT(inline_rule.get_array("declarations"sv)->at(0).as_object().get_bool("isValid"sv).value());
+    EXPECT_EQ(client.request(inline_rule_actor, "getRuleText"sv).get_string("text"sv).value(), "display: grid;"sv);
+
+    auto inherited_rule_entry = applied_entries.at(1).as_object();
+    auto inherited_rule = inherited_rule_entry.get_object("rule"sv).release_value();
+    EXPECT_EQ(inherited_rule_entry.get_string("inherited"sv).value(), root_actor);
+    EXPECT_EQ(inherited_rule.get_array("selectors"sv)->at(0).as_string(), "body div.fixture"sv);
+    EXPECT_EQ(inherited_rule.get_array("declarations"sv)->at(0).as_object().get_string("name"sv).value(), "color"sv);
+    EXPECT(inherited_rule.get_array("declarations"sv)->at(0).as_object().get_bool("isNameValid"sv).value());
+    EXPECT(inherited_rule.get_array("declarations"sv)->at(0).as_object().get_bool("isValid"sv).value());
+    EXPECT(inherited_rule.get_array("declarations"sv)->at(1).as_object().get_bool("isNameValid"sv).value());
+    EXPECT(!inherited_rule.get_array("declarations"sv)->at(1).as_object().get_bool("isValid"sv).value());
+    EXPECT_EQ(inherited_rule_entry.get_array("matchedSelectorIndexes"sv)->at(0).as_integer<int>(), 0);
     EXPECT(!client.request(page_style_actor, "isPositionEditable"sv).get_bool("value"sv).value());
+
+    auto second_applied_entries = get_applied();
+    VERIFY(second_applied_entries.size() == applied_entries.size());
+    spin_until(session->loop, [&] {
+        return style_rule_actor_count(*session->server) == second_applied_entries.size()
+            && !session->server->actor_registry().contains(inline_rule_actor);
+    });
 
     JsonObject computed_request;
     computed_request.set("to"sv, page_style_actor);


### PR DESCRIPTION
<img width="2511" height="1080" alt="image" src="https://github.com/user-attachments/assets/f0d0114b-ccbc-498c-9112-1e70d537ced1" />

This lets us see not just the computed end-result properties, but the various style declarations that led to that. This is read-only for now, but overridden properties show up crossed-out, and invalid or unrecognized ones display the warning sign. The "jump to source" links also work, including for UA styles. Generally, it does what you think it should. :^)