### PR TITLE
LibCore: Keep main event loops alive for process lifetime

### DIFF
--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -54,8 +54,7 @@ bool EventLoop::is_running()
 
 EventLoop& EventLoop::current()
 {
-    if (!current_event_loop())
-        dbgln("No EventLoop is present, unable to return current one!");
+    VERIFY(current_event_loop());
     return *current_event_loop();
 }
 
@@ -92,6 +91,7 @@ void EventLoop::spin_until(Function<bool()> goal_condition)
 
 size_t EventLoop::pump(WaitMode mode)
 {
+    VERIFY(current_event_loop() == this);
     return m_impl->pump(mode == WaitMode::WaitForEvents ? EventLoopImplementation::PumpMode::WaitForEvents : EventLoopImplementation::PumpMode::DontWaitForEvents);
 }
 

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -42,6 +42,11 @@ EventLoop::~EventLoop()
         current_event_loop() = nullptr;
 }
 
+EventLoop& EventLoop::initialize_for_current_thread()
+{
+    return *new EventLoop;
+}
+
 bool EventLoop::is_running()
 {
     return current_event_loop() != nullptr;

--- a/Libraries/LibCore/EventLoop.h
+++ b/Libraries/LibCore/EventLoop.h
@@ -44,7 +44,6 @@ class CORE_API EventLoop {
     AK_MAKE_NONMOVABLE(EventLoop);
     AK_MAKE_NONCOPYABLE(EventLoop);
 
-private:
 public:
     enum class WaitMode {
         WaitForEvents,
@@ -53,6 +52,9 @@ public:
 
     EventLoop();
     ~EventLoop();
+
+    // Create an event loop for the current thread and keep it alive for the rest of the program.
+    static EventLoop& initialize_for_current_thread();
 
     // Pump the event loop until its exit is requested.
     int exec();

--- a/Libraries/LibDNS/Resolver.h
+++ b/Libraries/LibDNS/Resolver.h
@@ -479,12 +479,12 @@ public:
 
             lookup_path = "system-resolver-bg"sv;
 
-            auto main_thread_event_loop_reference = Core::EventLoop::current_weak();
+            auto& main_thread_event_loop = Core::EventLoop::current();
 
             auto submit_worker = [&, this](Core::Socket::AddressFamily family) {
                 Threading::ThreadPool::the().submit(
                     [this, name, state = our_state, family,
-                        main_thread_event_loop_reference]() mutable {
+                        &main_thread_event_loop]() mutable {
                         auto worker_started_at = MonotonicTime::now();
                         auto record_or_error = Core::Socket::resolve_host(name, Core::Socket::SocketType::Stream, family);
                         auto worker_finished_at = MonotonicTime::now();
@@ -493,11 +493,7 @@ public:
                             .work_ms = (worker_finished_at - worker_started_at).to_milliseconds(),
                         };
 
-                        auto main_thread_event_loop = main_thread_event_loop_reference->take();
-                        if (!main_thread_event_loop)
-                            return;
-
-                        main_thread_event_loop->deferred_invoke(
+                        main_thread_event_loop.deferred_invoke(
                             [this, name, state, family,
                                 record_or_error = move(record_or_error),
                                 timing]() mutable {

--- a/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.cpp
@@ -12,21 +12,18 @@
 
 namespace Audio {
 
-#define TRY_OR_REJECT_AND_EXIT(expression)                                                                              \
-    ({                                                                                                                  \
-        auto&& __temporary_result = (expression);                                                                       \
-        if (__temporary_result.is_error()) [[unlikely]] {                                                               \
-            warnln("Failure in PulseAudio control thread: {}", __temporary_result.error().string_literal());            \
-            auto event_loop = main_thread_event_loop->take();                                                           \
-            if (!event_loop)                                                                                            \
-                return 1;                                                                                               \
-            event_loop->deferred_invoke([promise = move(promise), error = __temporary_result.release_error()] mutable { \
-                promise->reject(move(error));                                                                           \
-            });                                                                                                         \
-            internal_state->exit();                                                                                     \
-            return 1;                                                                                                   \
-        }                                                                                                               \
-        __temporary_result.release_value();                                                                             \
+#define TRY_OR_REJECT_AND_EXIT(expression)                                                                                         \
+    ({                                                                                                                             \
+        auto&& __temporary_result = (expression);                                                                                  \
+        if (__temporary_result.is_error()) [[unlikely]] {                                                                          \
+            warnln("Failure in PulseAudio control thread: {}", __temporary_result.error().string_literal());                       \
+            main_thread_event_loop.deferred_invoke([promise = move(promise), error = __temporary_result.release_error()] mutable { \
+                promise->reject(move(error));                                                                                      \
+            });                                                                                                                    \
+            internal_state->exit();                                                                                                \
+            return 1;                                                                                                              \
+        }                                                                                                                          \
+        __temporary_result.release_value();                                                                                        \
     })
 
 NonnullRefPtr<PlaybackStream::CreatePromise> PlaybackStream::create(OutputState initial_output_state, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
@@ -43,9 +40,10 @@ NonnullRefPtr<PlaybackStream::CreatePromise> PlaybackStreamPulseAudio::create(Ou
     // Create an internal state for the control thread to hold on to.
     auto internal_state = MUST(adopt_nonnull_ref_or_enomem(new (nothrow) InternalState()));
     auto playback_stream = MUST(adopt_nonnull_ref_or_enomem(new (nothrow) PlaybackStreamPulseAudio(internal_state)));
+    auto& main_thread_event_loop = Core::EventLoop::current();
 
     // Create the control thread and start it.
-    auto thread = MUST(Threading::Thread::try_create("Audio Control"sv, [=, main_thread_event_loop = Core::EventLoop::current_weak(), data_request_callback = move(data_request_callback)]() mutable {
+    auto thread = MUST(Threading::Thread::try_create("Audio Control"sv, [=, &main_thread_event_loop, data_request_callback = move(data_request_callback)]() mutable {
         auto context = TRY_OR_REJECT_AND_EXIT(PulseAudioContext::the());
         internal_state->set_stream(TRY_OR_REJECT_AND_EXIT(context->create_stream(initial_state, target_latency_ms, [data_request_callback = move(data_request_callback)](PulseAudioStream&, Span<float> buffer) {
             return data_request_callback(buffer);
@@ -56,10 +54,7 @@ NonnullRefPtr<PlaybackStream::CreatePromise> PlaybackStreamPulseAudio::create(Ou
         TRY_OR_REJECT_AND_EXIT(internal_state->stream()->set_volume(1.0));
 
         {
-            auto event_loop = main_thread_event_loop->take();
-            if (!event_loop)
-                return 1;
-            event_loop->deferred_invoke([promise = move(promise), playback_stream = move(playback_stream)] mutable {
+            main_thread_event_loop.deferred_invoke([promise = move(promise), playback_stream = move(playback_stream)] mutable {
                 promise->resolve(move(playback_stream));
             });
         }

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -29,7 +29,7 @@ DecoderErrorOr<NonnullRefPtr<Demuxer>> PlaybackManager::create_demuxer_for_strea
     return FFmpeg::FFmpegDemuxer::from_stream(stream);
 }
 
-DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlaybackManager const& self, NonnullRefPtr<Demuxer> const& demuxer, NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop_reference)
+DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlaybackManager const& self, NonnullRefPtr<Demuxer> const& demuxer, Core::EventLoop& main_thread_event_loop)
 {
     // Create the video tracks and their producers.
     auto all_video_tracks = TRY(demuxer->get_tracks_for_type(TrackType::Video));
@@ -39,7 +39,7 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
     supported_video_tracks.ensure_capacity(all_video_tracks.size());
     supported_video_track_datas.ensure_capacity(all_video_tracks.size());
     for (auto const& track : all_video_tracks) {
-        auto video_producer_result = DecodedVideoProducer::try_create(main_thread_event_loop_reference, demuxer, track);
+        auto video_producer_result = DecodedVideoProducer::try_create(main_thread_event_loop, demuxer, track);
         if (video_producer_result.is_error())
             continue;
         supported_video_tracks.append(track);
@@ -56,7 +56,7 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
     supported_audio_tracks.ensure_capacity(all_audio_tracks.size());
     supported_audio_track_datas.ensure_capacity(all_audio_tracks.size());
     for (auto const& track : all_audio_tracks) {
-        auto audio_producer_result = DecodedAudioProducer::try_create(main_thread_event_loop_reference, demuxer, track);
+        auto audio_producer_result = DecodedAudioProducer::try_create(main_thread_event_loop, demuxer, track);
         if (audio_producer_result.is_error())
             continue;
         auto audio_producer = audio_producer_result.release_value();
@@ -79,8 +79,7 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
     auto duration = demuxer->total_duration().value_or(AK::Duration::zero());
     auto start_time_realtime = demuxer->start_time_realtime();
 
-    auto main_thread_event_loop = main_thread_event_loop_reference->take();
-    main_thread_event_loop->deferred_invoke([self, video_tracks = move(supported_video_tracks), video_track_datas = move(supported_video_track_datas), preferred_video_track, audio_tracks = move(supported_audio_tracks), audio_track_datas = move(supported_audio_track_datas), preferred_audio_track, duration, start_time_realtime] mutable {
+    main_thread_event_loop.deferred_invoke([self, video_tracks = move(supported_video_tracks), video_track_datas = move(supported_video_track_datas), preferred_video_track, audio_tracks = move(supported_audio_tracks), audio_track_datas = move(supported_audio_track_datas), preferred_audio_track, duration, start_time_realtime] mutable {
         if (!self)
             return;
 
@@ -167,12 +166,9 @@ PlaybackManager::~PlaybackManager()
     m_weak_link->revoke({});
 }
 
-static void handle_media_init_error(WeakPlaybackManager self, NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop_reference, DecoderError error)
+static void handle_media_init_error(WeakPlaybackManager self, Core::EventLoop& main_thread_event_loop, DecoderError error)
 {
-    auto main_thread_event_loop = main_thread_event_loop_reference->take();
-    if (!main_thread_event_loop)
-        return;
-    main_thread_event_loop->deferred_invoke([self = move(self), error = move(error)] mutable {
+    main_thread_event_loop.deferred_invoke([self = move(self), error = move(error)] mutable {
         if (!self)
             return;
         if (self->on_unsupported_format_error)
@@ -183,30 +179,30 @@ static void handle_media_init_error(WeakPlaybackManager self, NonnullRefPtr<Core
 void PlaybackManager::add_media_source(NonnullRefPtr<MediaStream> const& stream)
 {
     auto self = weak();
-    auto main_thread_event_loop_reference = Core::EventLoop::current_weak();
+    auto& main_thread_event_loop = Core::EventLoop::current();
 
-    Threading::ThreadPool::the().submit([self = move(self), stream, main_thread_event_loop_reference = move(main_thread_event_loop_reference)] mutable {
+    Threading::ThreadPool::the().submit([self = move(self), stream, &main_thread_event_loop] mutable {
         auto demuxer_or_error = create_demuxer_for_stream(stream);
         if (demuxer_or_error.is_error()) {
-            handle_media_init_error(move(self), move(main_thread_event_loop_reference), demuxer_or_error.release_error());
+            handle_media_init_error(move(self), main_thread_event_loop, demuxer_or_error.release_error());
             return;
         }
 
-        auto maybe_error = prepare_playback_from_demuxer(self, demuxer_or_error.release_value(), main_thread_event_loop_reference);
+        auto maybe_error = prepare_playback_from_demuxer(self, demuxer_or_error.release_value(), main_thread_event_loop);
         if (maybe_error.is_error())
-            handle_media_init_error(move(self), move(main_thread_event_loop_reference), maybe_error.release_error());
+            handle_media_init_error(move(self), main_thread_event_loop, maybe_error.release_error());
     });
 }
 
 void PlaybackManager::add_media_source(NonnullRefPtr<Demuxer> const& demuxer)
 {
     auto self = weak();
-    auto main_thread_event_loop_reference = Core::EventLoop::current_weak();
+    auto& main_thread_event_loop = Core::EventLoop::current();
 
-    Threading::ThreadPool::the().submit([self = move(self), demuxer, main_thread_event_loop_reference = move(main_thread_event_loop_reference)] mutable {
-        auto maybe_error = prepare_playback_from_demuxer(self, demuxer, main_thread_event_loop_reference);
+    Threading::ThreadPool::the().submit([self = move(self), demuxer, &main_thread_event_loop] mutable {
+        auto maybe_error = prepare_playback_from_demuxer(self, demuxer, main_thread_event_loop);
         if (maybe_error.is_error())
-            handle_media_init_error(move(self), move(main_thread_event_loop_reference), maybe_error.release_error());
+            handle_media_init_error(move(self), main_thread_event_loop, maybe_error.release_error());
     });
 }
 

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -151,7 +151,7 @@ private:
     }
 
     static DecoderErrorOr<NonnullRefPtr<Demuxer>> create_demuxer_for_stream(NonnullRefPtr<MediaStream> const&);
-    static DecoderErrorOr<void> prepare_playback_from_demuxer(WeakPlaybackManager const&, NonnullRefPtr<Demuxer> const&, NonnullRefPtr<Core::WeakEventLoopReference> const&);
+    static DecoderErrorOr<void> prepare_playback_from_demuxer(WeakPlaybackManager const&, NonnullRefPtr<Demuxer> const&, Core::EventLoop&);
 
     template<typename T, typename... Args>
     void replace_state_handler(Args&&... args);

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -20,7 +20,7 @@ namespace Media {
 
 static constexpr int AUTO_SUSPEND_IDLE_TIMEOUT_MS = 10000;
 
-DecoderErrorOr<NonnullRefPtr<DecodedAudioProducer>> DecodedAudioProducer::try_create(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track)
+DecoderErrorOr<NonnullRefPtr<DecodedAudioProducer>> DecodedAudioProducer::try_create(Core::EventLoop& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track)
 {
     auto converter = DECODER_TRY_ALLOC(FFmpeg::FFmpegAudioConverter::try_create());
 
@@ -96,7 +96,7 @@ TimeRanges DecodedAudioProducer::buffered_time_ranges() const
     return m_thread_data->buffered_time_ranges();
 }
 
-DecodedAudioProducer::ThreadData::ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track, AK::Duration duration, NonnullOwnPtr<Audio::AudioConverter>&& converter)
+DecodedAudioProducer::ThreadData::ThreadData(Core::EventLoop& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track, AK::Duration duration, NonnullOwnPtr<Audio::AudioConverter>&& converter)
     : m_main_thread_event_loop(main_thread_event_loop)
     , m_demuxer(demuxer)
     , m_track(track)
@@ -336,10 +336,7 @@ void DecodedAudioProducer::ThreadData::invoke_on_main_thread_while_locked(Invoke
 {
     if (m_requested_state == RequestedState::Exit)
         return;
-    auto event_loop = m_main_thread_event_loop->take();
-    if (!event_loop.is_alive())
-        return;
-    event_loop->deferred_invoke([self = NonnullRefPtr(*this), invokee = move(invokee)] mutable {
+    m_main_thread_event_loop.deferred_invoke([self = NonnullRefPtr(*this), invokee = move(invokee)] mutable {
         invokee(self);
     });
 }

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.h
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.h
@@ -38,7 +38,7 @@ public:
     using ErrorHandler = Function<void(DecoderError&&)>;
     using BlockEndTimeHandler = Function<void(AK::Duration)>;
 
-    static DecoderErrorOr<NonnullRefPtr<DecodedAudioProducer>> try_create(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track);
+    static DecoderErrorOr<NonnullRefPtr<DecodedAudioProducer>> try_create(Core::EventLoop& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track);
     DecodedAudioProducer(NonnullRefPtr<ThreadData> const&);
     ~DecodedAudioProducer();
 
@@ -59,7 +59,7 @@ public:
 private:
     class ThreadData final : public AtomicRefCounted<ThreadData> {
     public:
-        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, AK::Duration, NonnullOwnPtr<Audio::AudioConverter>&&);
+        ThreadData(Core::EventLoop& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, AK::Duration, NonnullOwnPtr<Audio::AudioConverter>&&);
         ~ThreadData();
 
         void set_error_handler(ErrorHandler&&);
@@ -115,7 +115,7 @@ private:
         void note_consumer_activity_while_locked() const;
         void wait_for_queue_space_or_auto_suspend_while_locked();
 
-        NonnullRefPtr<Core::WeakEventLoopReference> m_main_thread_event_loop;
+        Core::EventLoop& m_main_thread_event_loop;
 
         mutable Sync::Mutex m_mutex;
         mutable Sync::ConditionVariable m_wait_condition { m_mutex };

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -18,7 +18,7 @@ namespace Media {
 
 static constexpr int AUTO_SUSPEND_IDLE_TIMEOUT_MS = 10000;
 
-DecoderErrorOr<NonnullRefPtr<DecodedVideoProducer>> DecodedVideoProducer::try_create(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track)
+DecoderErrorOr<NonnullRefPtr<DecodedVideoProducer>> DecodedVideoProducer::try_create(Core::EventLoop& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track)
 {
     TRY(demuxer->create_context_for_track(track));
     auto duration = TRY(demuxer->duration_of_track(track));
@@ -169,7 +169,7 @@ void DecodedVideoProducer::seek(AK::Duration timestamp)
     m_thread_data->seek(timestamp);
 }
 
-DecodedVideoProducer::ThreadData::ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track, AK::Duration duration)
+DecodedVideoProducer::ThreadData::ThreadData(Core::EventLoop& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track, AK::Duration duration)
     : m_main_thread_event_loop(main_thread_event_loop)
     , m_demuxer(demuxer)
     , m_track(track)
@@ -302,10 +302,7 @@ void DecodedVideoProducer::ThreadData::invoke_on_main_thread_while_locked(Invoke
 {
     if (m_requested_state == RequestedState::Exit)
         return;
-    auto event_loop = m_main_thread_event_loop->take();
-    if (!event_loop.is_alive())
-        return;
-    event_loop->deferred_invoke([self = NonnullRefPtr(*this), invokee = move(invokee)] mutable {
+    m_main_thread_event_loop.deferred_invoke([self = NonnullRefPtr(*this), invokee = move(invokee)] mutable {
         invokee(self);
     });
 }

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.h
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.h
@@ -38,7 +38,7 @@ public:
     using ErrorHandler = Function<void(DecoderError&&)>;
     using FrameEndTimeHandler = Function<void(AK::Duration)>;
 
-    static DecoderErrorOr<NonnullRefPtr<DecodedVideoProducer>> try_create(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&);
+    static DecoderErrorOr<NonnullRefPtr<DecodedVideoProducer>> try_create(Core::EventLoop& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&);
 
     DecodedVideoProducer(NonnullRefPtr<ThreadData> const&);
     ~DecodedVideoProducer();
@@ -60,7 +60,7 @@ public:
 private:
     class ThreadData final : public AtomicRefCounted<ThreadData> {
     public:
-        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, AK::Duration);
+        ThreadData(Core::EventLoop& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, AK::Duration);
         ~ThreadData();
 
         void set_error_handler(ErrorHandler&&);
@@ -114,7 +114,7 @@ private:
         void note_consumer_activity_while_locked() const;
         void wait_for_queue_space_or_auto_suspend_while_locked();
 
-        NonnullRefPtr<Core::WeakEventLoopReference> m_main_thread_event_loop;
+        Core::EventLoop& m_main_thread_event_loop;
 
         mutable Sync::Mutex m_mutex;
         mutable Sync::ConditionVariable m_wait_condition { m_mutex };

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -26,7 +26,7 @@ static constexpr size_t OUTPUT_BLOCK_QUEUE_CAPACITY = 4;
 class AudioPlaybackSink::OutputThreadData : public AtomicRefCounted<OutputThreadData> {
 public:
     OutputThreadData(PipelineStateChangeHandler on_state_changed)
-        : m_main_thread_event_loop(Core::EventLoop::current_weak())
+        : m_main_thread_event_loop(Core::EventLoop::current())
         , m_on_state_changed(move(on_state_changed))
     {
     }
@@ -36,7 +36,7 @@ public:
 
     RefPtr<Audio::PlaybackStream> m_playback_stream;
     RefPtr<AudioProducer> m_input;
-    NonnullRefPtr<Core::WeakEventLoopReference> m_main_thread_event_loop;
+    Core::EventLoop& m_main_thread_event_loop;
 
     mutable Sync::Mutex m_output_mutex;
     mutable Sync::ConditionVariable m_output_condition { m_output_mutex };
@@ -332,15 +332,13 @@ void AudioPlaybackSink::OutputThreadData::dispatch_state_if_changed(PipelineStat
     if (status == m_last_dispatched_status)
         return;
     m_last_dispatched_status = status;
-    if (auto event_loop = m_main_thread_event_loop->take(); event_loop.is_alive()) {
-        event_loop->deferred_invoke([self = NonnullRefPtr(*this), status, seek_id] {
-            Sync::MutexLocker locker { self->m_output_mutex };
-            if (self->m_seek_id != seek_id)
-                return;
-            if (self->m_on_state_changed)
-                self->m_on_state_changed(status);
-        });
-    }
+    m_main_thread_event_loop.deferred_invoke([self = NonnullRefPtr(*this), status, seek_id] {
+        Sync::MutexLocker locker { self->m_output_mutex };
+        if (self->m_seek_id != seek_id)
+            return;
+        if (self->m_on_state_changed)
+            self->m_on_state_changed(status);
+    });
 }
 
 AK::Duration AudioPlaybackSink::current_time() const

--- a/Libraries/LibWeb/CSS/FontLoading.cpp
+++ b/Libraries/LibWeb/CSS/FontLoading.cpp
@@ -61,17 +61,13 @@ void prepare_vector_font_data_off_thread(ByteBuffer data, Function<void(ErrorOr<
     // Keep the callback on the origin thread so any GC roots it captures are
     // also destroyed there.
     auto* callback = new Function<void(ErrorOr<Core::AnonymousBuffer>)>(move(on_complete));
-    auto event_loop_weak = Core::EventLoop::current_weak();
+    auto& origin_event_loop = Core::EventLoop::current();
 
     Threading::ThreadPool::the().submit(
-        [data = move(data), callback, event_loop_weak = move(event_loop_weak)]() mutable {
+        [data = move(data), callback, &origin_event_loop]() mutable {
             auto result = WOFF2::convert_to_ttf(data);
 
-            auto origin = event_loop_weak->take();
-            if (!origin)
-                return;
-
-            origin->deferred_invoke([callback, result = move(result)]() mutable {
+            origin_event_loop.deferred_invoke([callback, result = move(result)]() mutable {
                 (*callback)(move(result));
                 delete callback;
             });

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -172,7 +172,7 @@ static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode cons
 {
     auto filename = original_source_code->filename();
     auto source_code = original_source_code->code();
-    auto event_loop_weak = Core::EventLoop::current_weak();
+    auto& main_thread_event_loop = Core::EventLoop::current();
     auto* callback = new Function<void(ByteBuffer, ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8>)>(
         [cache_context = move(cache_context), install_target = move(install_target), original_source_code = move(original_source_code), type](ByteBuffer blob, auto source_hash) mutable {
             if (blob.is_empty()) {
@@ -188,7 +188,7 @@ static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode cons
             (void)ResourceLoader::the().request_client()->store_cache_associated_data(cache_context.url, cache_context.method, *cache_context.request_headers, cache_context.vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, immutable_blob.bytes());
         });
 
-    Threading::ThreadPool::the().submit([filename = move(filename), source_code = move(source_code), type, line_number_offset, callback, event_loop_weak = move(event_loop_weak), source_hash]() mutable {
+    Threading::ThreadPool::the().submit([filename = move(filename), source_code = move(source_code), type, line_number_offset, callback, &main_thread_event_loop, source_hash]() mutable {
         auto source = JS::SourceCode::create(move(filename), move(source_code));
         ByteBuffer blob;
 
@@ -205,11 +205,7 @@ static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode cons
             }
         }
 
-        auto origin = event_loop_weak->take();
-        if (!origin)
-            return;
-
-        origin->deferred_invoke([blob = move(blob), source_hash, callback]() mutable {
+        main_thread_event_loop.deferred_invoke([blob = move(blob), source_hash, callback]() mutable {
             (*callback)(move(blob), source_hash);
             delete callback;
         });
@@ -263,20 +259,17 @@ static void compile_remaining_functions_off_thread(JS::Bytecode::Executable& exe
             }
         });
 
-    auto event_loop_weak = Core::EventLoop::current_weak();
+    auto& main_thread_event_loop = Core::EventLoop::current();
 
     Threading::ThreadPool::the().submit([function_asts = move(function_asts), length,
                                             callback,
-                                            event_loop_weak = move(event_loop_weak)]() mutable {
+                                            &main_thread_event_loop]() mutable {
         Vector<JS::FFI::CompiledFunction*> compiled_functions;
         compiled_functions.ensure_capacity(function_asts.size());
         for (auto* function_ast : function_asts)
             compiled_functions.append(JS::RustIntegration::compile_function_off_thread(function_ast, length, false));
 
-        auto origin = event_loop_weak->take();
-        if (!origin)
-            return;
-        origin->deferred_invoke([compiled_functions = move(compiled_functions), callback]() mutable {
+        main_thread_event_loop.deferred_invoke([compiled_functions = move(compiled_functions), callback]() mutable {
             (*callback)(move(compiled_functions));
             delete callback;
         });
@@ -308,7 +301,7 @@ static void compile_remaining_module_functions_off_thread(ModuleScript& module_s
 // report them through the same Script/ModuleScript construction paths; successful programs come back as CompiledProgram
 // artifacts whose GC-backed Executable materialization must still happen on the main thread.
 // NB: The SourceCode stays on the main thread inside the heap-allocated callback. The worker thread only receives raw
-//     UTF-16 data pointers, and the callback intentionally leaks if the event loop is destroyed during compilation.
+//     UTF-16 data pointers.
 static void compile_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, Function<void(OffThreadCompiledProgram, NonnullRefPtr<JS::SourceCode const>)> on_compiled)
 {
     // Extract the raw data the parser needs while still on the main thread.
@@ -321,11 +314,11 @@ static void compile_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, 
             on_compiled(result, move(source_code));
         });
 
-    auto event_loop_weak = Core::EventLoop::current_weak();
+    auto& main_thread_event_loop = Core::EventLoop::current();
 
     Threading::ThreadPool::the().submit([utf16_data, length, type, line_number_offset,
                                             callback,
-                                            event_loop_weak = move(event_loop_weak)]() {
+                                            &main_thread_event_loop]() {
         auto* parsed = JS::RustIntegration::parse_program(utf16_data, length, type, line_number_offset);
         OffThreadCompiledProgram result { .parsed = parsed };
         if (parsed && !JS::RustIntegration::parsed_program_has_errors(parsed)) {
@@ -333,10 +326,7 @@ static void compile_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, 
             result.parsed = nullptr;
         }
 
-        auto origin = event_loop_weak->take();
-        if (!origin)
-            return;
-        origin->deferred_invoke([result, callback]() {
+        main_thread_event_loop.deferred_invoke([result, callback]() {
             (*callback)(result);
             delete callback;
             // AD-HOC: Perform a microtask checkpoint so that any microtasks queued by the callback (e.g. promise

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -451,7 +451,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 
     initialize_actions();
 
-    m_event_loop = create_platform_event_loop();
+    m_event_loop = &create_platform_event_loop();
     TRY(launch_services());
 
     return {};
@@ -1036,9 +1036,9 @@ ErrorOr<int> Application::execute()
     return m_event_loop->exec();
 }
 
-NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
+Core::EventLoop& Application::create_platform_event_loop()
 {
-    return make<Core::EventLoop>();
+    return Core::EventLoop::initialize_for_current_thread();
 }
 
 void Application::add_child_process(WebView::Process&& process)

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -213,7 +213,7 @@ protected:
 
     virtual void create_platform_arguments(Core::ArgsParser&) { }
     virtual void create_platform_options(BrowserOptions&, RequestServerOptions&, WebContentOptions&) { }
-    virtual NonnullOwnPtr<Core::EventLoop> create_platform_event_loop();
+    virtual Core::EventLoop& create_platform_event_loop();
 
     virtual Optional<ByteString> ask_user_for_download_path([[maybe_unused]] StringView file) const { return {}; }
 
@@ -352,7 +352,7 @@ private:
 
     OwnPtr<Core::TimeZoneWatcher> m_time_zone_watcher;
 
-    OwnPtr<Core::EventLoop> m_event_loop;
+    Core::EventLoop* m_event_loop { nullptr };
     OwnPtr<ProcessManager> m_process_manager;
 
     RefPtr<Action> m_reload_action;

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -284,13 +284,10 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
     m_pending_async_presents.append(context_id, viewport_rect, prepared_frame->bitmap_id);
     auto* pending_present = &m_pending_async_presents.last();
 
-    auto event_loop_reference = Core::EventLoop::current_weak();
+    auto& event_loop = Core::EventLoop::current();
     auto self = NonnullRefPtr { *this };
-    m_display_list_player->flush_async(*prepared_frame->rendered_surface, [self = move(self), event_loop_reference = move(event_loop_reference), pending_present] {
-        auto event_loop = event_loop_reference->take();
-        if (!event_loop.is_alive())
-            return;
-        event_loop->deferred_invoke([self = move(self), pending_present] {
+    m_display_list_player->flush_async(*prepared_frame->rendered_surface, [self = move(self), &event_loop, pending_present] {
+        event_loop.deferred_invoke([self = move(self), pending_present] {
             self->did_finish_async_present(*pending_present);
         });
     });

--- a/Services/Compositor/VSyncScheduler.cpp
+++ b/Services/Compositor/VSyncScheduler.cpp
@@ -76,7 +76,7 @@ static CVReturn display_link_callback(CVDisplayLinkRef, CVTimeStamp const*, CVTi
 
 class DisplayLinkState final : public AtomicRefCounted<DisplayLinkState> {
 public:
-    static RefPtr<DisplayLinkState> create(u64 display_id, NonnullRefPtr<Core::WeakEventLoopReference> event_loop, Function<void()>&& tick_callback)
+    static RefPtr<DisplayLinkState> create(u64 display_id, Core::EventLoop& event_loop, Function<void()>&& tick_callback)
     {
         CVDisplayLinkRef display_link = nullptr;
 
@@ -88,7 +88,7 @@ public:
         if (result != kCVReturnSuccess || !display_link)
             return nullptr;
 
-        auto state = adopt_ref(*new DisplayLinkState(move(event_loop), display_link));
+        auto state = adopt_ref(*new DisplayLinkState(event_loop, display_link));
 
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -114,7 +114,7 @@ public:
     bool consume_tick_request();
     bool is_valid() const;
 
-    NonnullRefPtr<Core::WeakEventLoopReference> event_loop;
+    Core::EventLoop& event_loop;
     Function<void()> tick_callback;
     Atomic<bool> invalidated { false };
     Atomic<bool> tick_requested { false };
@@ -122,8 +122,8 @@ public:
     NonnullRefPtr<Core::Timer> idle_stop_timer;
 
 private:
-    DisplayLinkState(NonnullRefPtr<Core::WeakEventLoopReference> event_loop, CVDisplayLinkRef display_link)
-        : event_loop(move(event_loop))
+    DisplayLinkState(Core::EventLoop& event_loop, CVDisplayLinkRef display_link)
+        : event_loop(event_loop)
         , display_link(display_link)
         , idle_stop_timer(Core::Timer::create_single_shot(display_link_idle_stop_delay_ms, [this] {
             stop_display_link_if_idle();
@@ -217,7 +217,7 @@ class CVDisplayLinkVSyncScheduler final : public VSyncScheduler {
 public:
     static OwnPtr<CVDisplayLinkVSyncScheduler> try_create(u64 display_id, Function<void()>&& tick_callback)
     {
-        auto state = DisplayLinkState::create(display_id, Core::EventLoop::current_weak(), move(tick_callback));
+        auto state = DisplayLinkState::create(display_id, Core::EventLoop::current(), move(tick_callback));
         if (!state)
             return nullptr;
         return adopt_own(*new CVDisplayLinkVSyncScheduler(state.release_nonnull()));
@@ -248,11 +248,7 @@ static CVReturn display_link_callback(CVDisplayLinkRef, CVTimeStamp const*, CVTi
     if (!state->consume_tick_request())
         return kCVReturnSuccess;
 
-    auto event_loop = state->event_loop->take();
-    if (!event_loop.is_alive())
-        return kCVReturnSuccess;
-
-    event_loop->deferred_invoke([state = move(state)] {
+    state->event_loop.deferred_invoke([state = move(state)] {
         if (!state->is_valid())
             return;
         state->tick_callback();

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -45,7 +45,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         Gfx::SkiaBackendContext::initialize_gpu_backend();
     auto skia_backend_context = Gfx::SkiaBackendContext::the_main_thread_context();
 
-    Core::EventLoop event_loop;
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<Compositor::ConnectionFromClient>(
         mach_server_name, move(skia_backend_context), !disable_async_scrolling));
 

--- a/Services/ImageDecoder/main.cpp
+++ b/Services/ImageDecoder/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     if (wait_for_debugger)
         Core::Process::wait_for_debugger_and_break();
 
-    Core::EventLoop event_loop;
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<ImageDecoder::ConnectionFromClient>(mach_server_name));
 

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -71,7 +71,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     MUST(Core::System::signal(SIGPIPE, SIG_IGN));
 #endif
 
-    Core::EventLoop event_loop;
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
     // FIXME: Have another way to signal the event loop to gracefully quit on windows.
 #ifndef AK_OS_WINDOWS
     Core::EventLoop::register_signal(SIGINT, handle_signal);

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -127,7 +127,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         return -1;
     }
 
-    Core::EventLoop event_loop;
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
 
     WebView::platform_init();
 

--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -128,7 +128,7 @@ Session::Session(NonnullRefPtr<Client> client, JsonObject const& capabilities, S
     , m_options(capabilities)
     , m_session_id(move(session_id))
     , m_session_flags(flags)
-    , m_event_loop(Core::EventLoop::current_weak())
+    , m_event_loop(Core::EventLoop::current())
 {
 }
 
@@ -278,9 +278,7 @@ ErrorOr<void> Session::create_server(NonnullRefPtr<ServerPromise> promise)
     m_web_content_mach_port_server->on_bootstrap_request = [this, promise](auto request) {
         auto result = m_transport_bootstrap_server.handle_bootstrap_request(request.pid, move(request.reply_port));
         if (result.is_error()) {
-            auto event_loop = m_event_loop->take();
-            VERIFY(event_loop);
-            event_loop->deferred_invoke([promise, error = result.release_error()]() mutable {
+            m_event_loop.deferred_invoke([promise, error = result.release_error()]() mutable {
                 promise->resolve(move(error));
             });
             return;
@@ -291,9 +289,7 @@ ErrorOr<void> Session::create_server(NonnullRefPtr<ServerPromise> promise)
                 VERIFY_NOT_REACHED();
             },
             [this, promise](IPC::TransportBootstrapMachServer::OnDemandTransport& transport) {
-                auto event_loop = m_event_loop->take();
-                VERIFY(event_loop);
-                event_loop->deferred_invoke([this, promise, transport = move(transport.ports)]() mutable {
+                m_event_loop.deferred_invoke([this, promise, transport = move(transport.ports)]() mutable {
                     if (auto result = accept_web_content_transport(make<IPC::Transport>(move(transport.receive_right), move(transport.send_right)), promise); result.is_error())
                         promise->resolve(result.release_error());
                 });

--- a/Services/WebDriver/Session.h
+++ b/Services/WebDriver/Session.h
@@ -112,7 +112,7 @@ private:
 
     ByteString m_web_content_endpoint;
     Optional<Core::Process> m_browser_process;
-    NonnullRefPtr<Core::WeakEventLoopReference> m_event_loop;
+    Core::EventLoop& m_event_loop;
 
 #if defined(AK_OS_MACOS)
     OwnPtr<IPC::MachBootstrapListener> m_web_content_mach_port_server;

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -115,7 +115,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto webdriver_socket_path = ByteString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));
     TRY(Core::Directory::create(webdriver_socket_path, Core::Directory::CreateDirectories::Yes));
 
-    Core::EventLoop loop;
+    auto& loop = Core::EventLoop::initialize_for_current_thread();
     auto server = TRY(Core::TCPServer::try_create());
 
     HashTable<NonnullRefPtr<WebDriver::Client>> clients;

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -77,7 +77,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     auto worker_type = TRY(agent_type_from_string(worker_type_string));
 
-    Core::EventLoop event_loop;
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
 
     WebView::platform_init();
 

--- a/Tests/LibMedia/TestDataProducers.cpp
+++ b/Tests/LibMedia/TestDataProducers.cpp
@@ -40,7 +40,7 @@ TEST_CASE(audio_producer_underspecified_5_1_channel_map)
     auto tracks = TRY_OR_FAIL(demuxer->get_tracks_for_type(Media::TrackType::Audio));
     VERIFY(!tracks.is_empty());
 
-    auto producer = TRY_OR_FAIL(Media::DecodedAudioProducer::try_create(Core::EventLoop::current_weak(), demuxer, tracks[0]));
+    auto producer = TRY_OR_FAIL(Media::DecodedAudioProducer::try_create(loop, demuxer, tracks[0]));
 
     producer->start();
 

--- a/Tests/LibMedia/TestFFmpegAudioNormalization.cpp
+++ b/Tests/LibMedia/TestFFmpegAudioNormalization.cpp
@@ -79,7 +79,7 @@ static void decode_and_expect()
 
     auto tracks = TRY_OR_FAIL(demuxer->get_tracks_for_type(Media::TrackType::Audio));
     VERIFY(!tracks.is_empty());
-    auto producer = TRY_OR_FAIL(Media::DecodedAudioProducer::try_create(Core::EventLoop::current_weak(), demuxer, tracks[0]));
+    auto producer = TRY_OR_FAIL(Media::DecodedAudioProducer::try_create(loop, demuxer, tracks[0]));
 
     producer->set_error_handler([&](Media::DecoderError&&) {
         FAIL("An error occurred while decoding generated WAV data.");

--- a/Tests/LibMedia/TestMediaCommon.h
+++ b/Tests/LibMedia/TestMediaCommon.h
@@ -83,7 +83,7 @@ static inline void decode_audio(StringView path, u32 sample_rate, u8 channel_cou
     }());
     auto tracks = TRY_OR_FAIL(demuxer->get_tracks_for_type(Media::TrackType::Audio));
     VERIFY(!tracks.is_empty());
-    auto producer = TRY_OR_FAIL(Media::DecodedAudioProducer::try_create(Core::EventLoop::current_weak(), demuxer, tracks[0]));
+    auto producer = TRY_OR_FAIL(Media::DecodedAudioProducer::try_create(loop, demuxer, tracks[0]));
 
     producer->set_error_handler([&](Media::DecoderError&&) {
         FAIL("An error occurred while decoding.");

--- a/UI/Android/src/main/cpp/ImageDecoderService.cpp
+++ b/UI/Android/src/main/cpp/ImageDecoderService.cpp
@@ -13,7 +13,7 @@
 
 ErrorOr<int> service_main(int ipc_socket)
 {
-    Core::EventLoop event_loop;
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
 
     auto socket = TRY(Core::LocalSocket::adopt_fd(ipc_socket));
     auto client = TRY(ImageDecoder::ConnectionFromClient::try_create(make<IPC::Transport>(move(socket))));

--- a/UI/Android/src/main/cpp/RequestServerService.cpp
+++ b/UI/Android/src/main/cpp/RequestServerService.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> service_main(int ipc_socket)
 
     RequestServer::g_default_certificate_path = ByteString::formatted("{}/cacert.pem", WebView::s_ladybird_resource_root);
 
-    Core::EventLoop event_loop;
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
 
     auto socket = TRY(Core::LocalSocket::adopt_fd(ipc_socket));
     auto client = TRY(RequestServer::ConnectionFromClient::try_create(make<IPC::Transport>(move(socket))));

--- a/UI/Android/src/main/cpp/WebContentService.cpp
+++ b/UI/Android/src/main/cpp/WebContentService.cpp
@@ -46,7 +46,7 @@ static ErrorOr<void> load_autoplay_allowlist();
 
 ErrorOr<int> service_main(int ipc_socket)
 {
-    Core::EventLoop event_loop;
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPlugin);
 

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -18,7 +18,7 @@ class Application final : public WebView::Application {
 private:
     explicit Application();
 
-    virtual NonnullOwnPtr<Core::EventLoop> create_platform_event_loop() override;
+    virtual Core::EventLoop& create_platform_event_loop() override;
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -27,7 +27,7 @@ namespace Ladybird {
 
 Application::Application() = default;
 
-NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
+Core::EventLoop& Application::create_platform_event_loop()
 {
     if (!browser_options().headless_mode.has_value()) {
         Core::EventLoopManager::install(*new EventLoopManagerMacOS);

--- a/UI/Gtk/Application.cpp
+++ b/UI/Gtk/Application.cpp
@@ -22,7 +22,7 @@ Application::~Application()
     g_clear_object(&m_adw_application);
 }
 
-NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
+Core::EventLoop& Application::create_platform_event_loop()
 {
     if (!browser_options().headless_mode.has_value()) {
         Core::EventLoopManager::install(*new EventLoopManagerGtk);
@@ -42,10 +42,10 @@ NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
         setup_dbus_handlers();
     }
 
-    auto event_loop = WebView::Application::create_platform_event_loop();
+    auto& event_loop = WebView::Application::create_platform_event_loop();
 
     if (!browser_options().headless_mode.has_value())
-        static_cast<EventLoopImplementationGtk&>(event_loop->impl()).set_main_loop();
+        static_cast<EventLoopImplementationGtk&>(event_loop.impl()).set_main_loop();
 
     return event_loop;
 }

--- a/UI/Gtk/Application.h
+++ b/UI/Gtk/Application.h
@@ -44,7 +44,7 @@ public:
 private:
     explicit Application();
 
-    virtual NonnullOwnPtr<Core::EventLoop> create_platform_event_loop() override;
+    virtual Core::EventLoop& create_platform_event_loop() override;
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -124,17 +124,17 @@ void Application::create_platform_options(WebView::BrowserOptions&, WebView::Req
     web_content_options.config_path = Settings::the()->directory();
 }
 
-NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
+Core::EventLoop& Application::create_platform_event_loop()
 {
     if (!browser_options().headless_mode.has_value()) {
         Core::EventLoopManager::install(*new EventLoopManagerQt);
         m_application = make<LadybirdQApplication>(arguments());
     }
 
-    auto event_loop = WebView::Application::create_platform_event_loop();
+    auto& event_loop = WebView::Application::create_platform_event_loop();
 
     if (!browser_options().headless_mode.has_value())
-        static_cast<EventLoopImplementationQt&>(event_loop->impl()).set_main_loop();
+        static_cast<EventLoopImplementationQt&>(event_loop.impl()).set_main_loop();
 
     return event_loop;
 }

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -42,7 +42,7 @@ private:
     explicit Application();
 
     virtual void create_platform_options(WebView::BrowserOptions&, WebView::RequestServerOptions&, WebView::WebContentOptions&) override;
-    virtual NonnullOwnPtr<Core::EventLoop> create_platform_event_loop() override;
+    virtual Core::EventLoop& create_platform_event_loop() override;
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;

--- a/Utilities/dns.cpp
+++ b/Utilities/dns.cpp
@@ -71,7 +71,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         return 1;
     }
 
-    Core::EventLoop loop;
+    auto& loop = Core::EventLoop::initialize_for_current_thread();
 
     DNS::Resolver resolver {
         [&] -> ErrorOr<DNS::Resolver::SocketResult> {

--- a/Utilities/dump-html-tree.cpp
+++ b/Utilities/dump-html-tree.cpp
@@ -329,7 +329,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     StringView input { input_data };
 
-    [[maybe_unused]] Core::EventLoop event_loop;
+    [[maybe_unused]] auto& event_loop = Core::EventLoop::initialize_for_current_thread();
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPlugin);
     Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(false));
     Web::Bindings::initialize_main_thread_vm(Web::Bindings::AgentType::SimilarOriginWindow);

--- a/Utilities/wasm.cpp
+++ b/Utilities/wasm.cpp
@@ -615,7 +615,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         }
 #endif
 
-        Core::EventLoop main_loop;
+        Core::EventLoop::initialize_for_current_thread();
         // First, resolve the linked modules
         Vector<NonnullRefPtr<Wasm::ModuleInstance>> linked_instances;
         Vector<NonnullRefPtr<Wasm::Module>> linked_modules;


### PR DESCRIPTION
Make process main loops use `Core::EventLoop::initialize_for_current_thread()` so their lifetime is independent of normal object teardown. Tighten `EventLoop::current()` and `EventLoop::pump()` checks so the current-loop invariant is enforced directly.

With those loops intentionally alive for the process lifetime, update browser frontends, helper services, utilities, LibMedia, LibWeb, LibDNS, WebDriver, and Compositor callbacks to keep direct `Core::EventLoop` references instead of routing through `WeakEventLoopReference`. This removes dead-loop checks from off-thread completion paths that always target the main loop.