### PR TITLE
Fuzzers: Bail from ASN1 fuzzer on malformed input

### DIFF
--- a/Libraries/LibCrypto/ASN1/DER.h
+++ b/Libraries/LibCrypto/ASN1/DER.h
@@ -157,16 +157,19 @@ public:
             return Error::from_string_literal("ASN1::Decoder: Trying to drop using a decoder that is EOF");
 
         auto previous_position = m_stack;
+        auto previous_tag = m_current_tag;
 
         auto tag_or_error = peek();
         if (tag_or_error.is_error()) {
             m_stack = move(previous_position);
+            m_current_tag = move(previous_tag);
             return tag_or_error.release_error();
         }
 
         auto length_or_error = read_length();
         if (length_or_error.is_error()) {
             m_stack = move(previous_position);
+            m_current_tag = move(previous_tag);
             return length_or_error.release_error();
         }
 
@@ -175,6 +178,7 @@ public:
         auto bytes_result = read_bytes(length);
         if (bytes_result.is_error()) {
             m_stack = move(previous_position);
+            m_current_tag = move(previous_tag);
             return bytes_result.release_error();
         }
 
@@ -192,16 +196,19 @@ public:
             return Error::from_string_literal("ASN1::Decoder: Trying to read using a decoder that is EOF");
 
         auto previous_position = m_stack;
+        auto previous_tag = m_current_tag;
 
         auto tag_or_error = peek();
         if (tag_or_error.is_error()) {
             m_stack = move(previous_position);
+            m_current_tag = move(previous_tag);
             return tag_or_error.release_error();
         }
 
         auto length_or_error = read_length();
         if (length_or_error.is_error()) {
             m_stack = move(previous_position);
+            m_current_tag = move(previous_tag);
             return length_or_error.release_error();
         }
 
@@ -211,6 +218,7 @@ public:
         auto value_or_error = read_value<ValueType>(class_override.value_or(tag.class_), kind_override.value_or(tag.kind), length);
         if (value_or_error.is_error()) {
             m_stack = move(previous_position);
+            m_current_tag = move(previous_tag);
             return value_or_error.release_error();
         }
 

--- a/Meta/Lagom/Fuzzers/FuzzASN1.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzASN1.cpp
@@ -13,8 +13,10 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
     AK::set_debug_enabled(false);
 
     Crypto::ASN1::Decoder decoder(ReadonlyBytes { data, size });
-    while (!decoder.eof())
-        (void)decoder.drop();
+    while (!decoder.eof()) {
+        if (decoder.drop().is_error())
+            break;
+    }
 
     return 0;
 }

--- a/Tests/LibCrypto/TestASN1.cpp
+++ b/Tests/LibCrypto/TestASN1.cpp
@@ -238,3 +238,27 @@ TEST_CASE(test_encoder_constructed)
     MUST(decoder.leave());                                                 // Sequence
     EXPECT(decoder.eof());                                                 // no other data
 }
+
+TEST_CASE(test_decoder_restores_state_after_failed_read)
+{
+    // A Boolean tag declaring a length of 5, but only 3 value bytes are present.
+    u8 const data[] { 0x01, 0x05, 0x00, 0x00, 0x00 };
+    Crypto::ASN1::Decoder decoder({ data, sizeof(data) });
+
+    EXPECT(decoder.read<bool>().is_error());
+
+    // The first failed read should leave the decoder state unchanged, so a second drop should have the same result.
+    EXPECT(decoder.read<bool>().is_error());
+}
+
+TEST_CASE(test_decoder_restores_state_after_failed_drop)
+{
+    // A Boolean tag declaring a length of 5, but only 3 value bytes are present.
+    u8 const data[] { 0x01, 0x05, 0x00, 0x00, 0x00 };
+    Crypto::ASN1::Decoder decoder({ data, sizeof(data) });
+
+    EXPECT(decoder.drop().is_error());
+
+    // The first failed drop should leave the decoder state unchanged, so a second drop should have the same result.
+    EXPECT(decoder.drop().is_error());
+}


### PR DESCRIPTION
Previously, the return value of `drop()` wasn't being checked, so malformed input could cause `drop()` to fail and reading of further bytes to stall, leading to an infinite loop.

This issue was hit very quickly by the fuzzer, blocking much progress.

I've included a fix for a second issue found by the fuzzer, due to failed reads not being fully rolled back.