### PR TITLE
test-web: Scan for variant tests in advance instead of querying them when they're loaded

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -144,29 +144,6 @@ WebIDL::ExceptionOr<void> Internals::load_reference_test_metadata()
     return {};
 }
 
-// https://web-platform-tests.org/writing-tests/testharness.html#variants
-WebIDL::ExceptionOr<void> Internals::load_test_variants()
-{
-    auto& page = this->page();
-
-    auto* document = page.top_level_browsing_context().active_document();
-    if (!document)
-        return vm().throw_completion<JS::InternalError>("No active document available"sv);
-
-    auto variant_nodes = TRY(document->query_selector_all("meta[name=variant]"sv));
-
-    JsonArray variants;
-    for (size_t i = 0; i < variant_nodes->length(); ++i) {
-        auto const* variant_node = variant_nodes->item(i);
-        auto content = as<DOM::Element>(variant_node)->get_attribute_value(HTML::AttributeNames::content);
-        variants.must_append(content);
-    }
-
-    // Always fire callback so test runner knows variant check is complete.
-    page.client().page_did_receive_test_variant_metadata(variants);
-    return {};
-}
-
 void Internals::gc()
 {
     vm().heap().collect_garbage();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -42,7 +42,6 @@ public:
     void signal_test_is_done(String const& text);
     void set_test_timeout(double milliseconds);
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
-    WebIDL::ExceptionOr<void> load_test_variants();
 
     WebIDL::ExceptionOr<String> set_time_zone(StringView time_zone);
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -4,7 +4,6 @@ interface Internals {
     undefined signalTestIsDone(DOMString text);
     undefined setTestTimeout(double milliseconds);
     undefined loadReferenceTestMetadata();
-    undefined loadTestVariants();
 
     DOMString setTimeZone(DOMString timeZone);
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -509,7 +509,6 @@ public:
     virtual void page_did_finish_test([[maybe_unused]] String const& text) { }
     virtual void page_did_set_test_timeout([[maybe_unused]] double milliseconds) { }
     virtual void page_did_receive_reference_test_metadata(JsonValue) { }
-    virtual void page_did_receive_test_variant_metadata(JsonValue) { }
 
     virtual void page_did_set_browser_zoom([[maybe_unused]] double factor) { }
     virtual void page_did_set_device_pixel_ratio_for_testing([[maybe_unused]] double ratio) { }

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -283,7 +283,6 @@ public:
     Function<void(String const&)> on_test_finish;
     Function<void(double milliseconds)> on_set_test_timeout;
     Function<void(JsonValue)> on_reference_test_metadata;
-    Function<void(JsonValue)> on_test_variant_metadata;
     Function<void(size_t current_match_index, Optional<size_t> const& total_match_count)> on_find_in_page;
     Function<void(Gfx::Color)> on_theme_color_change;
     Function<void(Gfx::Color)> on_page_background_color_change;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -454,14 +454,6 @@ void WebContentClient::did_receive_reference_test_metadata(u64 page_id, JsonValu
     }
 }
 
-void WebContentClient::did_receive_test_variant_metadata(u64 page_id, JsonValue metadata)
-{
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_test_variant_metadata)
-            view->on_test_variant_metadata(metadata);
-    }
-}
-
 void WebContentClient::did_set_browser_zoom(u64 page_id, double factor)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -180,7 +180,6 @@ private:
     virtual void did_finish_test(u64 page_id, String text) override;
     virtual void did_set_test_timeout(u64 page_id, double milliseconds) override;
     virtual void did_receive_reference_test_metadata(u64 page_id, JsonValue) override;
-    virtual void did_receive_test_variant_metadata(u64 page_id, JsonValue) override;
     virtual void did_set_browser_zoom(u64 page_id, double factor) override;
     virtual void did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> total_match_count) override;
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -426,11 +426,6 @@ void PageClient::page_did_receive_reference_test_metadata(JsonValue metadata)
     client().async_did_receive_reference_test_metadata(m_id, metadata);
 }
 
-void PageClient::page_did_receive_test_variant_metadata(JsonValue metadata)
-{
-    client().async_did_receive_test_variant_metadata(m_id, metadata);
-}
-
 void PageClient::page_did_set_browser_zoom(double factor)
 {
     auto traversable = page().top_level_traversable();

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -199,7 +199,6 @@ private:
     virtual void page_did_finish_test(String const& text) override;
     virtual void page_did_set_test_timeout(double milliseconds) override;
     virtual void page_did_receive_reference_test_metadata(JsonValue) override;
-    virtual void page_did_receive_test_variant_metadata(JsonValue) override;
     virtual void page_did_set_browser_zoom(double factor) override;
     virtual void page_did_set_device_pixel_ratio_for_testing(double ratio) override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -146,7 +146,6 @@ endpoint WebContentClient
     did_finish_test(u64 page_id, String text) =|
     did_set_test_timeout(u64 page_id, double milliseconds) =|
     did_receive_reference_test_metadata(u64 page_id, JsonValue result) =|
-    did_receive_test_variant_metadata(u64 page_id, JsonValue result) =|
 
     did_set_browser_zoom(u64 page_id, double factor) =|
 

--- a/Tests/LibWeb/test-web/Display.cpp
+++ b/Tests/LibWeb/test-web/Display.cpp
@@ -121,11 +121,8 @@ void Display::on_test_finished(size_t view_index, Test const& test, TestResult r
     case TestResult::Skipped:
         ++skipped_count;
         break;
-    case TestResult::Expanded:
-        break;
     }
-    if (result != TestResult::Expanded)
-        ++completed_tests;
+    ++completed_tests;
 
     if (view_index >= view_states().size())
         return;

--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -51,7 +51,6 @@ enum class TestResult {
     Skipped,
     Timeout,
     Crashed,
-    Expanded,
 };
 
 constexpr StringView test_result_to_string(TestResult result)
@@ -67,8 +66,6 @@ constexpr StringView test_result_to_string(TestResult result)
         return "Timeout"sv;
     case TestResult::Crashed:
         return "Crashed"sv;
-    case TestResult::Expanded:
-        return "Expanded"sv;
     }
     VERIFY_NOT_REACHED();
 }
@@ -99,7 +96,6 @@ struct Test {
     bool did_finish_test { false };
     bool did_finish_loading { false };
     bool did_inject_js { false };
-    bool did_check_variants { false };
 
     RefTestExpectationType ref_test_expectation_type {};
     Optional<URL::URL> ref_test_expectation_url {};

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -18,6 +18,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Enumerate.h>
 #include <AK/Function.h>
+#include <AK/GenericLexer.h>
 #include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
 #include <AK/Platform.h>
@@ -157,6 +158,153 @@ static ErrorOr<void> skip_async_scrolling_tests_unless_enabled(Application const
     if (!FileSystem::exists(path))
         return {};
     return enumerate_test_files_recursively(path, s_skipped_tests);
+}
+
+static bool is_html_space(char ch)
+{
+    return ch == '\t' || ch == '\n' || ch == '\f' || ch == '\r' || ch == ' ';
+}
+
+static bool is_htmlish_text_test(Test const& test)
+{
+    if (test.mode != TestMode::Text)
+        return false;
+
+    auto lexical_path = LexicalPath(test.input_path);
+    auto extension = lexical_path.extension();
+    return extension == "htm"sv || extension == "html"sv || extension == "xht"sv || extension == "xhtml"sv;
+}
+
+static void skip_to_end_of_tag(GenericLexer& lexer)
+{
+    while (!lexer.is_eof()) {
+        auto ch = lexer.consume();
+        if (ch == '"' || ch == '\'') {
+            lexer.ignore_until(ch);
+            lexer.consume_specific(ch);
+            continue;
+        }
+
+        if (ch == '>')
+            return;
+    }
+}
+
+static void skip_until_case_insensitive(GenericLexer& lexer, StringView needle)
+{
+    while (!lexer.is_eof()) {
+        auto next = lexer.peek_string(needle.length());
+        if (next.has_value() && next->equals_ignoring_ascii_case(needle)) {
+            lexer.ignore(needle.length());
+            return;
+        }
+
+        lexer.ignore();
+    }
+}
+
+static StringView consume_html_attribute_value(GenericLexer& lexer)
+{
+    lexer.ignore_while(is_html_space);
+
+    if (lexer.next_is('"') || lexer.next_is('\'')) {
+        auto quote = lexer.consume();
+        auto value = lexer.consume_until(quote);
+        lexer.consume_specific(quote);
+        return value;
+    }
+
+    return lexer.consume_until([](auto ch) {
+        return is_html_space(ch) || ch == '>';
+    });
+}
+
+static ErrorOr<Vector<String>> read_static_test_variants(Test const& test)
+{
+    Vector<String> variants;
+    if (!is_htmlish_text_test(test))
+        return variants;
+
+    auto file = TRY(Core::File::open(test.input_path, Core::File::OpenMode::Read));
+    auto contents = TRY(file->read_until_eof());
+
+    GenericLexer lexer { StringView { contents } };
+    while (!lexer.is_eof()) {
+        lexer.ignore_until('<');
+        if (!lexer.consume_specific('<'))
+            break;
+
+        if (lexer.consume_specific("!--"sv)) {
+            skip_until_case_insensitive(lexer, "-->"sv);
+            continue;
+        }
+
+        lexer.ignore_while(is_html_space);
+
+        if (lexer.consume_specific('/') || lexer.consume_specific('!') || lexer.consume_specific('?')) {
+            skip_to_end_of_tag(lexer);
+            continue;
+        }
+
+        auto tag_name = lexer.consume_until([](auto ch) {
+            return is_html_space(ch) || ch == '/' || ch == '>';
+        });
+
+        if (tag_name.equals_ignoring_ascii_case("script"sv)) {
+            skip_to_end_of_tag(lexer);
+            skip_until_case_insensitive(lexer, "</script"sv);
+            skip_to_end_of_tag(lexer);
+            continue;
+        }
+
+        if (tag_name.equals_ignoring_ascii_case("style"sv)) {
+            skip_to_end_of_tag(lexer);
+            skip_until_case_insensitive(lexer, "</style"sv);
+            skip_to_end_of_tag(lexer);
+            continue;
+        }
+
+        if (!tag_name.equals_ignoring_ascii_case("meta"sv)) {
+            skip_to_end_of_tag(lexer);
+            continue;
+        }
+
+        Optional<StringView> name_attribute;
+        Optional<StringView> content_attribute;
+
+        while (!lexer.is_eof()) {
+            lexer.ignore_while(is_html_space);
+
+            if (lexer.consume_specific('>'))
+                break;
+            if (lexer.consume_specific('/'))
+                continue;
+
+            auto attribute_name = lexer.consume_until([](auto ch) {
+                return is_html_space(ch) || ch == '=' || ch == '/' || ch == '>';
+            });
+            if (attribute_name.is_empty()) {
+                lexer.ignore();
+                continue;
+            }
+
+            lexer.ignore_while(is_html_space);
+
+            StringView attribute_value = ""sv;
+            if (lexer.consume_specific('='))
+                attribute_value = consume_html_attribute_value(lexer);
+
+            if (attribute_name.equals_ignoring_ascii_case("name"sv))
+                name_attribute = attribute_value;
+            else if (attribute_name.equals_ignoring_ascii_case("content"sv))
+                content_attribute = attribute_value;
+        }
+
+        if (name_attribute.has_value() && name_attribute->equals_ignoring_ascii_case("variant"sv) && content_attribute.has_value())
+            variants.append(TRY(String::from_utf8(*content_attribute)));
+    }
+
+    return variants;
 }
 
 static ErrorOr<void> collect_dump_tests(Application const& app, Vector<Test>& tests, StringView path, StringView trail, TestMode mode)
@@ -567,6 +715,36 @@ static void apply_variant_to_test(Test& test, String variant)
         test.expectation_path = ByteString::formatted("{}@{}.txt", title, variant_suffix);
     else
         test.expectation_path = ByteString::formatted("{}/{}@{}.txt", dir, title, variant_suffix);
+}
+
+// https://web-platform-tests.org/writing-tests/testharness.html#variants
+static ErrorOr<void> expand_tests_with_static_variants(Vector<Test>& tests)
+{
+    Vector<Test> expanded_tests;
+    expanded_tests.ensure_capacity(tests.size());
+
+    for (auto& test : tests) {
+        if (test.variant.has_value() || s_skipped_tests.contains_slow(test.input_path)) {
+            expanded_tests.append(move(test));
+            continue;
+        }
+
+        auto variants = TRY(read_static_test_variants(test));
+        if (variants.is_empty()) {
+            expanded_tests.append(move(test));
+            continue;
+        }
+
+        expanded_tests.ensure_capacity(expanded_tests.size() + variants.size());
+        for (auto const& variant : variants) {
+            auto variant_test = test;
+            apply_variant_to_test(variant_test, variant);
+            expanded_tests.append(move(variant_test));
+        }
+    }
+
+    tests = move(expanded_tests);
+    return {};
 }
 
 static void expand_test_with_variants(TestRunContext& context, size_t base_test_index, ReadonlySpan<String> variants)
@@ -1245,6 +1423,8 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             }
         }
     }
+
+    TRY(expand_tests_with_static_variants(tests));
 
     if (app.shuffle)
         shuffle(tests);

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -549,6 +549,26 @@ pre { margin: 0; padding: 16px; font-family: ui-monospace, monospace; font-size:
     return {};
 }
 
+static void apply_variant_to_test(Test& test, String variant)
+{
+    VERIFY(variant.starts_with('?'));
+
+    test.variant = move(variant);
+
+    // relative_path uses '?' for display, safe_relative_path uses '@' for filesystem.
+    auto variant_suffix = test.variant->bytes_as_string_view().substring_view(1);
+    test.relative_path = ByteString::formatted("{}?{}", test.relative_path, variant_suffix);
+    test.safe_relative_path = ByteString::formatted("{}@{}", test.safe_relative_path, variant_suffix);
+
+    // Expected file: test@variant_suffix.txt
+    auto dir = LexicalPath::dirname(test.expectation_path);
+    auto title = LexicalPath::title(LexicalPath::basename(test.input_path));
+    if (dir.is_empty())
+        test.expectation_path = ByteString::formatted("{}@{}.txt", title, variant_suffix);
+    else
+        test.expectation_path = ByteString::formatted("{}/{}@{}.txt", dir, title, variant_suffix);
+}
+
 static void expand_test_with_variants(TestRunContext& context, size_t base_test_index, ReadonlySpan<String> variants)
 {
     VERIFY(!variants.is_empty());
@@ -562,20 +582,10 @@ static void expand_test_with_variants(TestRunContext& context, size_t base_test_
         variant_test.run_index = base_test.run_index;
         variant_test.total_runs = base_test.total_runs;
         variant_test.input_path = base_test.input_path;
-        variant_test.variant = variant;
-
-        // relative_path uses '?' for display, safe_relative_path uses '@' for filesystem
-        auto variant_suffix = StringView { variant }.substring_view(1);
-        variant_test.relative_path = ByteString::formatted("{}?{}", base_test.relative_path, variant_suffix);
-        variant_test.safe_relative_path = ByteString::formatted("{}@{}", base_test.safe_relative_path, variant_suffix);
-
-        // Expected file: test@variant_suffix.txt
-        auto dir = LexicalPath::dirname(base_test.expectation_path);
-        auto title = LexicalPath::title(LexicalPath::basename(base_test.input_path));
-        if (dir.is_empty())
-            variant_test.expectation_path = ByteString::formatted("{}@{}.txt", title, variant_suffix);
-        else
-            variant_test.expectation_path = ByteString::formatted("{}/{}@{}.txt", dir, title, variant_suffix);
+        variant_test.expectation_path = base_test.expectation_path;
+        variant_test.relative_path = base_test.relative_path;
+        variant_test.safe_relative_path = base_test.safe_relative_path;
+        apply_variant_to_test(variant_test, variant);
 
         // Set the index before appending so it matches the position in the vector
         variant_test.index = context.tests.size();
@@ -1230,16 +1240,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
     for (auto& test : tests) {
         for (auto const& [glob, variant] : explicit_variants) {
             if (test.relative_path.matches(glob, CaseSensitivity::CaseSensitive)) {
-                test.variant = variant;
-                auto variant_suffix = variant.bytes_as_string_view().substring_view(1);
-                test.relative_path = ByteString::formatted("{}?{}", test.relative_path, variant_suffix);
-                test.safe_relative_path = ByteString::formatted("{}@{}", test.safe_relative_path, variant_suffix);
-                auto dir = LexicalPath::dirname(test.expectation_path);
-                auto title = LexicalPath::title(LexicalPath::basename(test.input_path));
-                if (dir.is_empty())
-                    test.expectation_path = ByteString::formatted("{}@{}.txt", title, variant_suffix);
-                else
-                    test.expectation_path = ByteString::formatted("{}/{}@{}.txt", dir, title, variant_suffix);
+                apply_variant_to_test(test, variant);
                 break;
             }
         }

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -747,37 +747,6 @@ static ErrorOr<void> expand_tests_with_static_variants(Vector<Test>& tests)
     return {};
 }
 
-static void expand_test_with_variants(TestRunContext& context, size_t base_test_index, ReadonlySpan<String> variants)
-{
-    VERIFY(!variants.is_empty());
-
-    context.tests.ensure_capacity(context.tests.size() + variants.size());
-    auto const& base_test = context.tests[base_test_index];
-
-    for (auto const& variant : variants) {
-        Test variant_test;
-        variant_test.mode = base_test.mode;
-        variant_test.run_index = base_test.run_index;
-        variant_test.total_runs = base_test.total_runs;
-        variant_test.input_path = base_test.input_path;
-        variant_test.expectation_path = base_test.expectation_path;
-        variant_test.relative_path = base_test.relative_path;
-        variant_test.safe_relative_path = base_test.safe_relative_path;
-        apply_variant_to_test(variant_test, variant);
-
-        // Set the index before appending so it matches the position in the vector
-        variant_test.index = context.tests.size();
-        context.tests.unchecked_append(move(variant_test));
-    }
-
-    // Add variants.size() because the original test will decrement tests_remaining when
-    // it completes as Expanded, and each variant will also decrement when it completes.
-    context.tests_remaining += variants.size();
-
-    // For display, add (variants.size() - 1) since Expanded tests don't count in s_completed_tests
-    context.total_tests += variants.size() - 1;
-}
-
 static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test, URL::URL const& url)
 {
     auto test_index = test.index;
@@ -857,36 +826,6 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
             });
         };
     } else if (test.mode == TestMode::Text) {
-        // Set up variant detection callback.
-        view.on_test_variant_metadata = [&view, &context, test_index, on_test_complete](JsonValue metadata) {
-            // Verify this IPC response is for the current test on this view (use index to avoid dangling pointer issues)
-            auto current_index = s_current_test_index_by_view.get(&view);
-            if (!current_index.has_value() || *current_index != test_index)
-                return;
-
-            auto& test = context.tests[test_index];
-            if (test.variant.has_value())
-                return;
-
-            auto const& variants_array = metadata.as_array();
-
-            if (!variants_array.is_empty()) {
-                Vector<String> variants;
-                variants.ensure_capacity(variants_array.size());
-                for (auto const& variant : variants_array.values())
-                    variants.unchecked_append(variant.as_string());
-
-                expand_test_with_variants(context, test_index, variants);
-                view.on_test_complete({ test_index, TestResult::Expanded });
-                return;
-            }
-
-            auto& test_after_check = context.tests[test_index];
-            test_after_check.did_check_variants = true;
-            if (test_after_check.did_finish_test)
-                on_test_complete();
-        };
-
         view.on_load_finish = [&view, &context, test_index, on_test_complete](auto const& loaded_url) {
             // page_did_finish_loading is already top-level-only (Document.cpp gates it on navigable->is_traversable()).
             // We accept *any* top-level URL here — not just the test's original URL; otherwise a test that navigates
@@ -897,11 +836,6 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
             auto& test = context.tests[test_index];
             test.did_finish_loading = true;
 
-            if (!test.variant.has_value())
-                view.run_javascript("internals.loadTestVariants();"_string);
-            else
-                test.did_check_variants = true;
-
             if (test.expectation_path.is_empty()) {
                 auto promise = view.request_internal_page_info(WebView::PageInfoType::Text);
 
@@ -910,7 +844,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
                     test.text = text;
                     on_test_complete();
                 });
-            } else if (test.did_finish_test && test.did_check_variants) {
+            } else if (test.did_finish_test) {
                 on_test_complete();
             }
         };
@@ -920,7 +854,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
             test.text = text;
             test.did_finish_test = true;
 
-            if (test.did_finish_loading && test.did_check_variants)
+            if (test.did_finish_loading)
                 on_test_complete();
         };
     } else if (test.mode == TestMode::Crash) {
@@ -1514,7 +1448,6 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             view->on_load_finish = {};
             view->on_test_finish = {};
             view->on_reference_test_metadata = {};
-            view->on_test_variant_metadata = {};
             view->on_set_test_timeout = {};
 
             // Disconnect child crash handlers so old child crashes don't affect the next test
@@ -1579,7 +1512,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
                 if (result.result != TestResult::Crashed)
                     test_run_capture.write_test_output(*view);
 
-                bool const is_non_passing_result = result.result != TestResult::Pass && result.result != TestResult::Expanded;
+                bool const is_non_passing_result = result.result != TestResult::Pass;
                 bool const should_trigger_fail_fast = result.result == TestResult::Fail || result.result == TestResult::Timeout || result.result == TestResult::Crashed;
 
                 if (is_non_passing_result)


### PR DESCRIPTION
Instead of loading tests and then asking them if they have variants (which has been flaky) identify them during test collection by scanning their contents.

Without these changes, I was getting rare flakes on `Text/input/wpt-import/navigation-api/state/history-pushState.html` and `Text/input/wpt-import/navigation-api/state/history-replaceState.html` where they wouldn't get replaced with their variants. (At the rate of a run repeating them 1000 times would get a couple of failures.) With these changes, that no longer happens, tried with I think 5000 runs at this point.

I expected this to have some performance impact but actually I'm not seeing any. A test run on my macBook is about 60 seconds with or without these changes.