### PR TITLE
LibURL: Advance past the '@' delimiter after batch-parsing userinfo

### DIFF
--- a/Libraries/LibURL/Rust/src/url/parser.rs
+++ b/Libraries/LibURL/Rust/src/url/parser.rs
@@ -671,8 +671,10 @@ pub(crate) fn basic_parse_into(
                         username_builder.push_str(&encoded_authority);
                     }
 
-                    // NB: Since we have batch processed the username/password, we need to move the pointer past those code points.
-                    pointer += authority_length;
+                    // NB: Since we have batch processed the username/password, we need to move the pointer past those
+                    //     code points and the U+0040 (@) delimiter.
+                    pointer += authority_length + '@'.len_utf8();
+                    continue;
                 }
                 // 2. Otherwise, if one of the following is true:
                 //    * c is the EOF code point, U+002F (/), U+003F (?), or U+0023 (#)

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -575,6 +575,25 @@ TEST_CASE(username_and_password)
     }
 }
 
+TEST_CASE(non_ascii_userinfo)
+{
+    {
+        auto url = URL::Parser::basic_parse("http://é@é"sv);
+        EXPECT(url.has_value());
+        EXPECT_EQ(url->username(), "%C3%A9"sv);
+        EXPECT(url->password().is_empty());
+        EXPECT_EQ(url->serialized_host(), "xn--9ca"sv);
+    }
+
+    {
+        auto url = URL::Parser::basic_parse("http://é@example.com"sv);
+        EXPECT(url.has_value());
+        EXPECT_EQ(url->username(), "%C3%A9"sv);
+        EXPECT(url->password().is_empty());
+        EXPECT_EQ(url->serialized_host(), "example.com"sv);
+    }
+}
+
 TEST_CASE(ascii_only_url)
 {
     {


### PR DESCRIPTION
After batch-processing the userinfo, the authority state advanced the parse pointer onto the '@' and relied on the end-of-loop increment to step past it. That increment uses the byte length of the authority's first code point, not the delimiter's. When the first code point was multi-byte, the pointer overshot into the middle of a code point and the next iteration sliced the string at a non-char boundary causing the process to panic. We now step past the delimiter explicitly so we don't need to rely on the end of loop increment to do so.

This can be tested by pasting "http://é@é" into the URL bar, which would previously panic.