### PR TITLE
LibWeb+LibJS: Do less work for cached bytecode

### DIFF
--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -745,23 +745,9 @@ impl DecodedCacheBlob {
         self.source_len
     }
 
-    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        self.metadata.source_ranges_are_valid(source_len)
-            && self.metadata.indices_are_valid()
-            && self.program.source_ranges_are_valid(source_len)
-            && self.program.indices_are_valid()
-    }
-
-    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
-        self.metadata.validate_cached_bytecode()?;
-        self.program.validate_cached_bytecode()
-    }
-
     pub(crate) fn validate_for_materialization(&mut self, source_len: usize) -> Result<(), ValidationErrorKind> {
-        if !self.source_ranges_are_valid(source_len) {
-            return Err(ValidationErrorKind::InvalidLength);
-        }
-        self.validate_cached_bytecode()?;
+        self.metadata.validate_for_materialization(source_len)?;
+        self.program.validate_for_materialization(source_len)?;
         self.has_been_validated_for_materialization = true;
         Ok(())
     }
@@ -1885,46 +1871,32 @@ impl DecodedDeclarationMetadata {
         }
     }
 
-    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+    fn validate_for_materialization(&self, source_len: usize) -> Result<(), ValidationErrorKind> {
         match self {
             Self::Script {
                 declaration_functions, ..
+            } => {
+                for function in declaration_functions {
+                    function.validate_for_materialization(source_len)?;
+                }
+                Ok(())
             }
-            | Self::Module {
-                declaration_functions, ..
-            } => declaration_functions
-                .iter()
-                .all(|function| function.source_ranges_are_valid(source_len)),
-        }
-    }
-
-    fn indices_are_valid(&self) -> bool {
-        match self {
-            Self::Script { .. } => true,
             Self::Module {
                 metadata,
                 declaration_functions,
             } => {
-                declaration_functions.len() == metadata.function_names.len()
-                    && metadata.lexical_bindings.iter().all(|binding| {
-                        binding.function_index < 0
-                            || usize::try_from(binding.function_index)
+                if declaration_functions.len() != metadata.function_names.len()
+                    || metadata.lexical_bindings.iter().any(|binding| {
+                        binding.function_index >= 0
+                            && !usize::try_from(binding.function_index)
                                 .is_ok_and(|index| index < declaration_functions.len())
                     })
-            }
-        }
-    }
+                {
+                    return Err(ValidationErrorKind::InvalidLength);
+                }
 
-    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
-        match self {
-            Self::Script {
-                declaration_functions, ..
-            }
-            | Self::Module {
-                declaration_functions, ..
-            } => {
                 for function in declaration_functions {
-                    function.precompiled.validate_cached_bytecode()?;
+                    function.validate_for_materialization(source_len)?;
                 }
                 Ok(())
             }
@@ -2798,16 +2770,8 @@ impl DecodedProgramRecord {
         self.executable.validate();
     }
 
-    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        self.executable.source_ranges_are_valid(source_len)
-    }
-
-    fn indices_are_valid(&self) -> bool {
-        self.executable.indices_are_valid()
-    }
-
-    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
-        self.executable.validate_cached_bytecode()
+    fn validate_for_materialization(&self, source_len: usize) -> Result<(), ValidationErrorKind> {
+        self.executable.validate_for_materialization(source_len)
     }
 }
 
@@ -2928,7 +2892,17 @@ impl DecodedExecutableRecord {
         self.class_blueprints.validate();
     }
 
-    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
+    fn validate_for_materialization(&self, source_len: usize) -> Result<(), ValidationErrorKind> {
+        if self
+            .length_identifier
+            .is_some_and(|index| (index as usize) >= self.property_key_table.len())
+        {
+            return Err(ValidationErrorKind::InvalidLength);
+        }
+        self.shared_functions.validate_for_materialization(source_len)?;
+        self.class_blueprints
+            .validate_for_materialization(source_len, self.shared_functions.len())?;
+
         let bounds = FFIValidatorBounds {
             number_of_registers: self.number_of_registers,
             number_of_locals: self.local_variables.len() as u32,
@@ -2978,20 +2952,7 @@ impl DecodedExecutableRecord {
         )
         .map_err(|error| error.kind)?;
 
-        self.shared_functions.validate_cached_bytecode()?;
-
         Ok(())
-    }
-
-    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        self.shared_functions.source_ranges_are_valid(source_len)
-            && self.class_blueprints.source_ranges_are_valid(source_len)
-    }
-
-    fn indices_are_valid(&self) -> bool {
-        self.length_identifier
-            .is_none_or(|index| (index as usize) < self.property_key_table.len())
-            && self.class_blueprints.indices_are_valid(self.shared_functions.len())
     }
 }
 
@@ -3019,21 +2980,13 @@ impl DecodedCachedExecutableRecord {
         );
     }
 
-    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
+    fn validate_for_materialization(&self, source_len: usize) -> Result<(), ValidationErrorKind> {
         let mut decoder = self.bytes.decoder();
         let executable = ExecutableRecord::decode(&mut decoder).ok_or(ValidationErrorKind::InvalidLength)?;
         if !decoder.is_empty() {
             return Err(ValidationErrorKind::InvalidLength);
         }
-        executable.validate_cached_bytecode()
-    }
-
-    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        let mut decoder = self.bytes.decoder();
-        let Some(executable) = ExecutableRecord::decode(&mut decoder) else {
-            return false;
-        };
-        decoder.is_empty() && executable.source_ranges_are_valid(source_len)
+        executable.validate_for_materialization(source_len)
     }
 
     fn validate(&self) {
@@ -3466,29 +3419,16 @@ impl DecodedFunctionTable {
         decoder.is_empty().then_some(values)
     }
 
-    fn for_each(&self, mut callback: impl FnMut(DecodedFunctionRecord) -> Option<()>) -> Option<()> {
-        let mut decoder = self.sequence.decoder();
-        for _ in 0..self.sequence.len() {
-            callback(FunctionRecord::decode(&mut decoder)?)?;
-        }
-        decoder.is_empty().then_some(())
-    }
-
-    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
+    fn validate_for_materialization(&self, source_len: usize) -> Result<(), ValidationErrorKind> {
         let mut decoder = self.sequence.decoder();
         for _ in 0..self.sequence.len() {
             let function = FunctionRecord::decode(&mut decoder).ok_or(ValidationErrorKind::InvalidLength)?;
-            function.precompiled.validate_cached_bytecode()?;
+            function.validate_for_materialization(source_len)?;
         }
         decoder
             .is_empty()
             .then_some(())
             .ok_or(ValidationErrorKind::InvalidLength)
-    }
-
-    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        self.for_each(|function| function.source_ranges_are_valid(source_len).then_some(()))
-            .is_some()
     }
 }
 
@@ -3623,9 +3563,11 @@ impl DecodedFunctionRecord {
         validate_function_metadata(&self.metadata);
     }
 
-    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        source_span_is_valid(self.source_text_start, self.source_text_end, source_len)
-            && self.precompiled.source_ranges_are_valid(source_len)
+    fn validate_for_materialization(&self, source_len: usize) -> Result<(), ValidationErrorKind> {
+        if !source_span_is_valid(self.source_text_start, self.source_text_end, source_len) {
+            return Err(ValidationErrorKind::InvalidLength);
+        }
+        self.precompiled.validate_for_materialization(source_len)
     }
 }
 
@@ -3824,14 +3766,16 @@ impl DecodedClassBlueprintTable {
         decoder.is_empty().then_some(())
     }
 
-    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        self.for_each(|blueprint| blueprint.source_range_is_valid(source_len).then_some(()))
-            .is_some()
-    }
-
-    fn indices_are_valid(&self, shared_function_count: usize) -> bool {
-        self.for_each(|blueprint| blueprint.indices_are_valid(shared_function_count).then_some(()))
-            .is_some()
+    fn validate_for_materialization(
+        &self,
+        source_len: usize,
+        shared_function_count: usize,
+    ) -> Result<(), ValidationErrorKind> {
+        self.for_each(|blueprint| {
+            (blueprint.source_range_is_valid(source_len) && blueprint.indices_are_valid(shared_function_count))
+                .then_some(())
+        })
+        .ok_or(ValidationErrorKind::InvalidLength)
     }
 }
 
@@ -4183,10 +4127,13 @@ mod tests {
     }
 
     #[test]
-    fn cached_function_source_ranges_include_nested_functions() {
+    fn cached_function_validation_includes_nested_source_ranges() {
         let nested_function = function_payload(20, 21);
         let executable = cached_executable_with_shared_function(Some(nested_function));
 
-        assert!(!executable.source_ranges_are_valid(10));
+        assert_eq!(
+            executable.validate_for_materialization(10),
+            Err(ValidationErrorKind::InvalidLength)
+        );
     }
 }

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -712,6 +712,7 @@ impl CacheBlob<'_> {
             is_strict_mode: bool::decode(decoder)?,
             metadata: DeclarationMetadataRecord::decode(decoder)?,
             program: ProgramRecord::decode(decoder)?,
+            has_been_validated_for_materialization: false,
         })
     }
 }
@@ -723,6 +724,12 @@ pub(crate) struct DecodedCacheBlob {
     is_strict_mode: bool,
     metadata: DecodedDeclarationMetadata,
     program: DecodedProgramRecord,
+    has_been_validated_for_materialization: bool,
+}
+
+#[derive(Clone, Copy)]
+enum CachedBytecodeValidation {
+    Validated,
 }
 
 impl DecodedCacheBlob {
@@ -738,16 +745,32 @@ impl DecodedCacheBlob {
         self.source_len
     }
 
-    pub(crate) fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
         self.metadata.source_ranges_are_valid(source_len)
             && self.metadata.indices_are_valid()
             && self.program.source_ranges_are_valid(source_len)
             && self.program.indices_are_valid()
     }
 
-    pub(crate) fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
+    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
         self.metadata.validate_cached_bytecode()?;
         self.program.validate_cached_bytecode()
+    }
+
+    pub(crate) fn validate_for_materialization(&mut self, source_len: usize) -> Result<(), ValidationErrorKind> {
+        if !self.source_ranges_are_valid(source_len) {
+            return Err(ValidationErrorKind::InvalidLength);
+        }
+        self.validate_cached_bytecode()?;
+        self.has_been_validated_for_materialization = true;
+        Ok(())
+    }
+
+    fn verify_has_been_validated_for_materialization(&self) {
+        assert!(
+            self.has_been_validated_for_materialization,
+            "decoded bytecode cache blob must be validated before materialization"
+        );
     }
 
     pub(crate) unsafe fn materialize_script(
@@ -758,6 +781,7 @@ impl DecodedCacheBlob {
         gdi_context: *mut c_void,
     ) -> *mut c_void {
         unsafe {
+            self.verify_has_been_validated_for_materialization();
             let Self {
                 program_type,
                 is_strict_mode,
@@ -795,7 +819,13 @@ impl DecodedCacheBlob {
             ) {
                 return std::ptr::null_mut();
             }
-            materialize_executable(program.executable, vm_ptr, source_code_ptr, shared_function_data_owner)
+            materialize_executable(
+                program.executable,
+                vm_ptr,
+                source_code_ptr,
+                shared_function_data_owner,
+                CachedBytecodeValidation::Validated,
+            )
         }
     }
 
@@ -809,6 +839,7 @@ impl DecodedCacheBlob {
         tla_executable_out: *mut *mut c_void,
     ) -> *mut c_void {
         unsafe {
+            self.verify_has_been_validated_for_materialization();
             if callbacks.is_null() {
                 return std::ptr::null_mut();
             }
@@ -851,8 +882,13 @@ impl DecodedCacheBlob {
 
             match program.kind {
                 ProgramKind::AsyncModule => {
-                    let exec_ptr =
-                        materialize_executable(program.executable, vm_ptr, source_code_ptr, shared_function_data_owner);
+                    let exec_ptr = materialize_executable(
+                        program.executable,
+                        vm_ptr,
+                        source_code_ptr,
+                        shared_function_data_owner,
+                        CachedBytecodeValidation::Validated,
+                    );
                     if !tla_executable_out.is_null() {
                         *tla_executable_out = exec_ptr;
                     }
@@ -862,7 +898,13 @@ impl DecodedCacheBlob {
                     if !tla_executable_out.is_null() {
                         *tla_executable_out = std::ptr::null_mut();
                     }
-                    materialize_executable(program.executable, vm_ptr, source_code_ptr, shared_function_data_owner)
+                    materialize_executable(
+                        program.executable,
+                        vm_ptr,
+                        source_code_ptr,
+                        shared_function_data_owner,
+                        CachedBytecodeValidation::Validated,
+                    )
                 }
             }
         }
@@ -876,6 +918,7 @@ impl DecodedCacheBlob {
         existing_shared_function_data_ptrs: &[*mut c_void],
     ) -> *mut c_void {
         unsafe {
+            self.verify_has_been_validated_for_materialization();
             if existing_executable_ptr.is_null() {
                 return std::ptr::null_mut();
             }
@@ -921,6 +964,7 @@ impl DecodedCacheBlob {
                 vm_ptr,
                 source_code_ptr,
                 &mut pending_function_installs,
+                CachedBytecodeValidation::Validated,
             );
             if executable_ptr.is_null() {
                 return std::ptr::null_mut();
@@ -945,6 +989,7 @@ impl DecodedCacheBlob {
         tla_executable_out: *mut *mut c_void,
     ) -> *mut c_void {
         unsafe {
+            self.verify_has_been_validated_for_materialization();
             let Self {
                 program_type,
                 has_top_level_await,
@@ -988,6 +1033,7 @@ impl DecodedCacheBlob {
                         vm_ptr,
                         source_code_ptr,
                         &mut pending_function_installs,
+                        CachedBytecodeValidation::Validated,
                     );
                     if exec_ptr.is_null() {
                         return std::ptr::null_mut();
@@ -1017,6 +1063,7 @@ impl DecodedCacheBlob {
                         vm_ptr,
                         source_code_ptr,
                         &mut pending_function_installs,
+                        CachedBytecodeValidation::Validated,
                     );
                     if executable_ptr.is_null() {
                         return std::ptr::null_mut();
@@ -1056,6 +1103,7 @@ unsafe fn prepare_declaration_function_installs(
                 vm_ptr,
                 source_code_ptr,
                 pending_function_installs,
+                CachedBytecodeValidation::Validated,
             )
             .is_null()
             {
@@ -1097,6 +1145,7 @@ unsafe fn materialize_script_declaration_metadata(
                 vm_ptr,
                 source_code_ptr,
                 shared_function_data_owner,
+                CachedBytecodeValidation::Validated,
             );
             if sfd_ptr.is_null() {
                 return false;
@@ -1181,7 +1230,14 @@ unsafe fn materialize_module_declaration_metadata(
             (cb.push_var_name)(module_context, name.as_ptr(), name.len());
         }
         for (function, name) in declaration_functions.into_iter().zip(metadata.function_names.iter()) {
-            let sfd_ptr = materialize_function(function, true, vm_ptr, source_code_ptr, shared_function_data_owner);
+            let sfd_ptr = materialize_function(
+                function,
+                true,
+                vm_ptr,
+                source_code_ptr,
+                shared_function_data_owner,
+                CachedBytecodeValidation::Validated,
+            );
             if sfd_ptr.is_null() {
                 return false;
             }
@@ -1319,6 +1375,7 @@ impl PendingFunctionInstall {
         unsafe {
             match self.replacement {
                 PendingFunctionInstallReplacement::CachedBytecode(cached_executable) => {
+                    cached_executable.verify_has_been_validated_for_materialization();
                     let cached_executable_ptr = Box::into_raw(Box::new(cached_executable)) as *mut c_void;
                     crate::bytecode::ffi::rust_sfd_install_cached_bytecode_executable(
                         self.existing_sfd_ptr,
@@ -1351,11 +1408,12 @@ impl PendingFunctionInstall {
 }
 
 unsafe fn materialize_function(
-    function: DecodedFunctionRecord,
+    mut function: DecodedFunctionRecord,
     outer_strict: bool,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
     shared_function_data_owner: crate::bytecode::ffi::SharedFunctionDataOwner,
+    validation: CachedBytecodeValidation,
 ) -> *mut c_void {
     unsafe {
         let (_parameter_name_storage, parameter_names): (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) = function
@@ -1412,6 +1470,7 @@ unsafe fn materialize_function(
             crate::bytecode::ffi::rust_sfd_set_class_field_initializer_name(sfd_ptr, name, name_len, *is_private);
         }
 
+        function.precompiled.mark_as_validated(validation);
         let cached_executable_ptr = Box::into_raw(Box::new(function.precompiled)) as *mut c_void;
         crate::bytecode::ffi::rust_sfd_set_cached_bytecode_executable(
             sfd_ptr,
@@ -1430,12 +1489,13 @@ unsafe fn materialize_function(
 }
 
 unsafe fn prepare_function_install(
-    function: DecodedFunctionRecord,
+    mut function: DecodedFunctionRecord,
     outer_strict: bool,
     existing_shared_function_data: &mut ExistingSharedFunctionData<'_>,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
     pending_function_installs: &mut Vec<PendingFunctionInstall>,
+    validation: CachedBytecodeValidation,
 ) -> *mut c_void {
     unsafe {
         let (_parameter_name_storage, parameter_names): (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) = function
@@ -1479,6 +1539,7 @@ unsafe fn prepare_function_install(
         }
 
         if crate::bytecode::ffi::rust_sfd_executable(existing_sfd_ptr).is_null() {
+            function.precompiled.mark_as_validated(validation);
             pending_function_installs.push(PendingFunctionInstall {
                 existing_sfd_ptr,
                 replacement: PendingFunctionInstallReplacement::CachedBytecode(function.precompiled),
@@ -1487,6 +1548,7 @@ unsafe fn prepare_function_install(
             return existing_sfd_ptr;
         }
 
+        function.precompiled.mark_as_validated(validation);
         let Some(executable) = function.precompiled.decode_executable() else {
             return std::ptr::null_mut();
         };
@@ -1497,6 +1559,7 @@ unsafe fn prepare_function_install(
             vm_ptr,
             source_code_ptr,
             pending_function_installs,
+            validation,
         );
         if executable_ptr.is_null() {
             return std::ptr::null_mut();
@@ -1531,7 +1594,13 @@ pub(crate) unsafe fn materialize_cached_function(
         } else {
             crate::bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr)
         };
-        materialize_executable(executable, vm_ptr, source_code_ptr, shared_function_data_owner)
+        materialize_executable(
+            executable,
+            vm_ptr,
+            source_code_ptr,
+            shared_function_data_owner,
+            CachedBytecodeValidation::Validated,
+        )
     }
 }
 
@@ -1550,6 +1619,7 @@ unsafe fn materialize_executable(
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
     shared_function_data_owner: crate::bytecode::ffi::SharedFunctionDataOwner,
+    validation: CachedBytecodeValidation,
 ) -> *mut c_void {
     unsafe {
         let mut pending_function_installs = Vec::new();
@@ -1560,6 +1630,7 @@ unsafe fn materialize_executable(
             vm_ptr,
             source_code_ptr,
             &mut pending_function_installs,
+            validation,
         )
     }
 }
@@ -1571,6 +1642,7 @@ unsafe fn materialize_executable_for_install(
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
     pending_function_installs: &mut Vec<PendingFunctionInstall>,
+    validation: CachedBytecodeValidation,
 ) -> *mut c_void {
     unsafe {
         let DecodedExecutableRecord {
@@ -1630,10 +1702,17 @@ unsafe fn materialize_executable_for_install(
                     vm_ptr,
                     source_code_ptr,
                     pending_function_installs,
+                    validation,
                 ) as *const c_void
             } else {
-                materialize_function(function, strict, vm_ptr, source_code_ptr, shared_function_data_owner)
-                    as *const c_void
+                materialize_function(
+                    function,
+                    strict,
+                    vm_ptr,
+                    source_code_ptr,
+                    shared_function_data_owner,
+                    validation,
+                ) as *const c_void
             };
             sfd_ptrs.push(sfd_ptr);
         }
@@ -2918,28 +2997,48 @@ impl DecodedExecutableRecord {
 
 struct DecodedCachedExecutableRecord {
     bytes: DecodedBytecodeBytes,
+    has_been_validated_for_materialization: bool,
 }
 
 impl DecodedCachedExecutableRecord {
     fn decode_executable(&self) -> Option<DecodedExecutableRecord> {
+        self.verify_has_been_validated_for_materialization();
         let mut decoder = self.bytes.decoder();
         let executable = ExecutableRecord::decode(&mut decoder)?;
         decoder.is_empty().then_some(executable)
     }
 
+    fn mark_as_validated(&mut self, _: CachedBytecodeValidation) {
+        self.has_been_validated_for_materialization = true;
+    }
+
+    fn verify_has_been_validated_for_materialization(&self) {
+        assert!(
+            self.has_been_validated_for_materialization,
+            "cached bytecode executable must be validated before materialization"
+        );
+    }
+
     fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
-        self.decode_executable()
-            .ok_or(ValidationErrorKind::InvalidLength)?
-            .validate_cached_bytecode()
+        let mut decoder = self.bytes.decoder();
+        let executable = ExecutableRecord::decode(&mut decoder).ok_or(ValidationErrorKind::InvalidLength)?;
+        if !decoder.is_empty() {
+            return Err(ValidationErrorKind::InvalidLength);
+        }
+        executable.validate_cached_bytecode()
     }
 
     fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        self.decode_executable()
-            .is_some_and(|executable| executable.source_ranges_are_valid(source_len))
+        let mut decoder = self.bytes.decoder();
+        let Some(executable) = ExecutableRecord::decode(&mut decoder) else {
+            return false;
+        };
+        decoder.is_empty() && executable.source_ranges_are_valid(source_len)
     }
 
     fn validate(&self) {
         let _ = self.bytes.len();
+        let _ = self.has_been_validated_for_materialization;
     }
 }
 
@@ -3672,6 +3771,7 @@ impl PrecompiledFunctionRecord<'_> {
         decoder.align_bytes_payload_to(BYTECODE_ALIGNMENT)?;
         Some(DecodedCachedExecutableRecord {
             bytes: DecodedBytecodeBytes::decode(decoder)?,
+            has_been_validated_for_materialization: false,
         })
     }
 }
@@ -3953,6 +4053,7 @@ mod tests {
 
         DecodedCachedExecutableRecord {
             bytes: DecodedBytecodeBytes::Owned(encoder.finish()),
+            has_been_validated_for_materialization: false,
         }
     }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -746,6 +746,12 @@ impl DecodedCacheBlob {
     }
 
     pub(crate) fn validate_for_materialization(&mut self, source_len: usize) -> Result<(), ValidationErrorKind> {
+        if self.source_len != source_len {
+            return Err(ValidationErrorKind::InvalidLength);
+        }
+        if self.has_been_validated_for_materialization {
+            return Ok(());
+        }
         self.metadata.validate_for_materialization(source_len)?;
         self.program.validate_for_materialization(source_len)?;
         self.has_been_validated_for_materialization = true;

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -741,10 +741,6 @@ impl DecodedCacheBlob {
         self.program.validate();
     }
 
-    pub(crate) fn source_len(&self) -> usize {
-        self.source_len
-    }
-
     pub(crate) fn validate_for_materialization(&mut self, source_len: usize) -> Result<(), ValidationErrorKind> {
         if self.source_len != source_len {
             return Err(ValidationErrorKind::InvalidLength);

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -920,20 +920,6 @@ pub unsafe extern "C" fn rust_free_decoded_bytecode_cache_blob(blob: *mut Decode
     }
 }
 
-/// Return the decoded source length carried by a decoded bytecode cache blob.
-///
-/// # Safety
-/// `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob_with_owner()`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_decoded_bytecode_cache_source_len(blob: *const DecodedBytecodeCacheBlob) -> usize {
-    unsafe {
-        if blob.is_null() {
-            return 0;
-        }
-        (*blob)._blob.source_len()
-    }
-}
-
 /// Validate a decoded bytecode cache blob before materializing it.
 ///
 /// # Safety

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -934,6 +934,25 @@ pub unsafe extern "C" fn rust_decoded_bytecode_cache_source_len(blob: *const Dec
     }
 }
 
+/// Validate a decoded bytecode cache blob before materializing it.
+///
+/// # Safety
+/// `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob_with_owner()`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_validate_decoded_bytecode_cache_blob(
+    blob: *mut DecodedBytecodeCacheBlob,
+    source_len: usize,
+) -> bool {
+    unsafe {
+        abort_on_panic(|| {
+            if blob.is_null() {
+                return false;
+            }
+            (*blob)._blob.validate_for_materialization(source_len).is_ok()
+        })
+    }
+}
+
 /// Materialize a decoded script bytecode cache blob. Consumes and frees the blob.
 ///
 /// # Safety

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -955,11 +955,8 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_script(
             if blob.is_null() {
                 return std::ptr::null_mut();
             }
-            let blob = Box::from_raw(blob);
-            if !blob._blob.source_ranges_are_valid(source_len) {
-                return std::ptr::null_mut();
-            }
-            if blob._blob.validate_cached_bytecode().is_err() {
+            let mut blob = Box::from_raw(blob);
+            if blob._blob.validate_for_materialization(source_len).is_err() {
                 return std::ptr::null_mut();
             }
             blob._blob
@@ -992,11 +989,8 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_module(
             if blob.is_null() {
                 return std::ptr::null_mut();
             }
-            let blob = Box::from_raw(blob);
-            if !blob._blob.source_ranges_are_valid(source_len) {
-                return std::ptr::null_mut();
-            }
-            if blob._blob.validate_cached_bytecode().is_err() {
+            let mut blob = Box::from_raw(blob);
+            if blob._blob.validate_for_materialization(source_len).is_err() {
                 return std::ptr::null_mut();
             }
             blob._blob.materialize_module(
@@ -1037,7 +1031,7 @@ pub unsafe extern "C" fn rust_install_bytecode_cache_script(
             if blob.is_null() {
                 return std::ptr::null_mut();
             }
-            let blob = Box::from_raw(blob);
+            let mut blob = Box::from_raw(blob);
             let existing_declaration_functions = if existing_declaration_function_count == 0 {
                 &[]
             } else {
@@ -1046,10 +1040,7 @@ pub unsafe extern "C" fn rust_install_bytecode_cache_script(
                 }
                 std::slice::from_raw_parts(existing_declaration_function_ptrs, existing_declaration_function_count)
             };
-            if !blob._blob.source_ranges_are_valid(source_len) {
-                return std::ptr::null_mut();
-            }
-            if blob._blob.validate_cached_bytecode().is_err() {
+            if blob._blob.validate_for_materialization(source_len).is_err() {
                 return std::ptr::null_mut();
             }
             blob._blob.install_script(
@@ -1091,7 +1082,7 @@ pub unsafe extern "C" fn rust_install_bytecode_cache_module(
             if blob.is_null() {
                 return std::ptr::null_mut();
             }
-            let blob = Box::from_raw(blob);
+            let mut blob = Box::from_raw(blob);
             let existing_declaration_functions = if existing_declaration_function_count == 0 {
                 &[]
             } else {
@@ -1100,10 +1091,7 @@ pub unsafe extern "C" fn rust_install_bytecode_cache_module(
                 }
                 std::slice::from_raw_parts(existing_declaration_function_ptrs, existing_declaration_function_count)
             };
-            if !blob._blob.source_ranges_are_valid(source_len) {
-                return std::ptr::null_mut();
-            }
-            if blob._blob.validate_cached_bytecode().is_err() {
+            if blob._blob.validate_for_materialization(source_len).is_err() {
                 return std::ptr::null_mut();
             }
             blob._blob.install_module(

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -426,7 +426,7 @@ ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& 
 
 struct BytecodeCacheBlobOwner {
     Core::ImmutableBytes bytes;
-    NonnullRefPtr<Core::WeakEventLoopReference> event_loop;
+    Core::EventLoop* event_loop { nullptr };
 };
 
 static void free_bytecode_cache_blob_owner(void* owner)
@@ -435,13 +435,10 @@ static void free_bytecode_cache_blob_owner(void* owner)
     if (!owner_ptr)
         return;
 
-    auto origin = owner_ptr->event_loop->take();
-    if (!origin) {
-        (void)owner_ptr.leak_ptr();
+    if (owner_ptr->event_loop) {
+        owner_ptr->event_loop->deferred_invoke([owner = move(owner_ptr)] { (void)owner; });
         return;
     }
-
-    origin->deferred_invoke([owner = move(owner_ptr)] { (void)owner; });
 }
 
 static void* clone_bytecode_cache_blob_owner(void const* owner)
@@ -452,18 +449,14 @@ static void* clone_bytecode_cache_blob_owner(void const* owner)
 
 DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash)
 {
-    return decode_bytecode_cache_blob(move(bytes), expected_type, source_hash, Core::EventLoop::current_weak());
-}
-
-DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash, NonnullRefPtr<Core::WeakEventLoopReference> event_loop)
-{
-    auto* owner = new BytecodeCacheBlobOwner { move(bytes), move(event_loop) };
+    auto* owner = new BytecodeCacheBlobOwner { move(bytes) };
     return rust_decode_bytecode_cache_blob_with_owner(owner->bytes.bytes().data(), owner->bytes.bytes().size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size(), owner, clone_bytecode_cache_blob_owner, free_bytecode_cache_blob_owner);
 }
 
-size_t decoded_bytecode_cache_source_length(DecodedBytecodeCacheBlob const* blob)
+DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash, Core::EventLoop& event_loop)
 {
-    return rust_decoded_bytecode_cache_source_len(blob);
+    auto* owner = new BytecodeCacheBlobOwner { move(bytes), &event_loop };
+    return rust_decode_bytecode_cache_blob_with_owner(owner->bytes.bytes().data(), owner->bytes.bytes().size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size(), owner, clone_bytecode_cache_blob_owner, free_bytecode_cache_blob_owner);
 }
 
 bool validate_decoded_bytecode_cache_blob(DecodedBytecodeCacheBlob* blob, size_t source_length)

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -382,11 +382,6 @@ static void collect_builtin_function(void* ctx, void* sfd_ptr, uint16_t const*, 
 
 // --- Compile functions ---
 
-bool rust_pipeline_available()
-{
-    return true;
-}
-
 ParsedProgram* parse_program(u16 const* utf16_data, size_t length_in_code_units, ProgramType type, size_t line_number_offset)
 {
     return rust_parse_program(utf16_data, length_in_code_units, static_cast<u8>(type), line_number_offset, g_dump_ast, g_dump_ast_use_color);

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -11,6 +11,7 @@
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
 #include <AK/kmalloc.h>
+#include <LibCore/EventLoop.h>
 #include <LibGC/DeferGC.h>
 #include <LibJS/Bytecode/ClassBlueprint.h>
 #include <LibJS/Bytecode/Debug.h>
@@ -40,8 +41,8 @@ namespace JS::RustIntegration {
 
 // --- Shared helpers ---
 
-// Bytecode cache materialization validates decoded cache bytecode before rebuilding Executables. Materialization paths
-// flip this flag for the duration of their work so rust_create_executable() does not run the same validator again.
+// Bytecode cache blobs are validated before rebuilding Executables. Materialization paths flip this flag for the
+// duration of their work so rust_create_executable() does not run the same validator again.
 static thread_local bool s_skip_bytecode_validation_for_prevalidated_cache = false;
 
 static Utf16View utf16_view_from_bytes(uint16_t const* data, size_t len)
@@ -423,25 +424,51 @@ ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& 
     return bytes;
 }
 
+struct BytecodeCacheBlobOwner {
+    Core::ImmutableBytes bytes;
+    NonnullRefPtr<Core::WeakEventLoopReference> event_loop;
+};
+
 static void free_bytecode_cache_blob_owner(void* owner)
 {
-    delete static_cast<Core::ImmutableBytes*>(owner);
+    auto owner_ptr = adopt_own_if_nonnull(static_cast<BytecodeCacheBlobOwner*>(owner));
+    if (!owner_ptr)
+        return;
+
+    auto origin = owner_ptr->event_loop->take();
+    if (!origin) {
+        (void)owner_ptr.leak_ptr();
+        return;
+    }
+
+    origin->deferred_invoke([owner = move(owner_ptr)] { (void)owner; });
 }
 
 static void* clone_bytecode_cache_blob_owner(void const* owner)
 {
-    return new Core::ImmutableBytes(*static_cast<Core::ImmutableBytes const*>(owner));
+    auto const& existing_owner = *static_cast<BytecodeCacheBlobOwner const*>(owner);
+    return new Core::ImmutableBytes(existing_owner.bytes);
 }
 
 DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash)
 {
-    auto* owner = new Core::ImmutableBytes(move(bytes));
-    return rust_decode_bytecode_cache_blob_with_owner(owner->bytes().data(), owner->bytes().size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size(), owner, clone_bytecode_cache_blob_owner, free_bytecode_cache_blob_owner);
+    return decode_bytecode_cache_blob(move(bytes), expected_type, source_hash, Core::EventLoop::current_weak());
+}
+
+DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash, NonnullRefPtr<Core::WeakEventLoopReference> event_loop)
+{
+    auto* owner = new BytecodeCacheBlobOwner { move(bytes), move(event_loop) };
+    return rust_decode_bytecode_cache_blob_with_owner(owner->bytes.bytes().data(), owner->bytes.bytes().size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size(), owner, clone_bytecode_cache_blob_owner, free_bytecode_cache_blob_owner);
 }
 
 size_t decoded_bytecode_cache_source_length(DecodedBytecodeCacheBlob const* blob)
 {
     return rust_decoded_bytecode_cache_source_len(blob);
+}
+
+bool validate_decoded_bytecode_cache_blob(DecodedBytecodeCacheBlob* blob, size_t source_length)
+{
+    return rust_validate_decoded_bytecode_cache_blob(blob, source_length);
 }
 
 void free_decoded_bytecode_cache_blob(DecodedBytecodeCacheBlob* blob)

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -40,10 +40,9 @@ namespace JS::RustIntegration {
 
 // --- Shared helpers ---
 
-// Bytecode cache materialization rebuilds executables from disk, which is untrusted input. Materialization paths flip
-// this flag for the duration of their work so that the in-process bytecode validator runs even in release builds; the
-// normal Rust pipeline path leaves it off and keeps the existing debug/sanitizer-only behavior.
-static thread_local bool s_validate_materialized_bytecode_cache_executables = false;
+// Bytecode cache materialization validates decoded cache bytecode before rebuilding Executables. Materialization paths
+// flip this flag for the duration of their work so rust_create_executable() does not run the same validator again.
+static thread_local bool s_skip_bytecode_validation_for_prevalidated_cache = false;
 
 static Utf16View utf16_view_from_bytes(uint16_t const* data, size_t len)
 {
@@ -506,7 +505,7 @@ Optional<Result<ScriptResult, Vector<ParserError>>> materialize_bytecode_cache_s
         return {};
 
     GC::DeferGC defer_gc(realm.vm().heap());
-    TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+    TemporaryChange skip_cache_executable_validation { s_skip_bytecode_validation_for_prevalidated_cache, true };
     ScriptGdiBuilder builder;
 
     void* exec_ptr = rust_materialize_bytecode_cache_script(blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(), &builder.shared_function_data, &builder);
@@ -683,7 +682,7 @@ Optional<Result<ModuleResult, Vector<ParserError>>> materialize_bytecode_cache_m
         return {};
 
     GC::DeferGC defer_gc(realm.vm().heap());
-    TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+    TemporaryChange skip_cache_executable_validation { s_skip_bytecode_validation_for_prevalidated_cache, true };
     ModuleBuilder builder;
     ModuleCallbacks callbacks {
         .set_has_top_level_await = module_set_has_top_level_await,
@@ -741,7 +740,7 @@ GC::Ptr<Bytecode::Executable> try_install_bytecode_cache_script(DecodedBytecodeC
     GC::Root<Bytecode::Executable> executable;
     {
         GC::DeferGC defer_gc(realm.vm().heap());
-        TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+        TemporaryChange skip_cache_executable_validation { s_skip_bytecode_validation_for_prevalidated_cache, true };
 
         executable = static_cast<Bytecode::Executable*>(rust_install_bytecode_cache_script(
             blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(), &existing_executable,
@@ -771,7 +770,7 @@ Optional<ModuleBytecodeCacheInstallResult> try_install_bytecode_cache_module(Dec
         existing_shared_function_data_ptrs.unchecked_append(function);
 
     GC::DeferGC defer_gc(realm.vm().heap());
-    TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+    TemporaryChange skip_cache_executable_validation { s_skip_bytecode_validation_for_prevalidated_cache, true };
 
     void* top_level_await_executable = nullptr;
     auto* exec = static_cast<Bytecode::Executable*>(rust_install_bytecode_cache_module(
@@ -899,7 +898,7 @@ GC::Ptr<Bytecode::Executable> compile_function(VM& vm, SharedFunctionInstanceDat
 
     if (shared_data.m_cached_bytecode_executable) {
         GC::DeferGC defer_gc(vm.heap());
-        TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+        TemporaryChange skip_cache_executable_validation { s_skip_bytecode_validation_for_prevalidated_cache, true };
         auto* exec = static_cast<Bytecode::Executable*>(rust_materialize_bytecode_cache_function(
             shared_data.m_cached_bytecode_executable,
             &vm,
@@ -1258,16 +1257,13 @@ extern "C" void* rust_create_executable(
         delete bp;
     }
 
-    auto const is_materializing_bytecode_cache = JS::RustIntegration::s_validate_materialized_bytecode_cache_executables;
 #if !defined(NDEBUG) || defined(HAS_ADDRESS_SANITIZER)
-    auto const should_validate_bytecode = true;
+    auto const should_validate_bytecode = !JS::RustIntegration::s_skip_bytecode_validation_for_prevalidated_cache;
 #else
-    auto const should_validate_bytecode = is_materializing_bytecode_cache;
+    auto const should_validate_bytecode = false;
 #endif
     if (should_validate_bytecode) {
         if (auto validation = JS::Bytecode::validate_bytecode(*executable, basic_block_offsets.span()); validation.is_error()) {
-            if (is_materializing_bytecode_cache)
-                return nullptr;
 #if !defined(NDEBUG) || defined(HAS_ADDRESS_SANITIZER)
             VERIFY_NOT_REACHED();
 #else

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -91,9 +91,6 @@ struct ModuleResult {
     GC::Root<SharedFunctionInstanceData> tla_shared_data;
 };
 
-// Check if the Rust pipeline is available for off-thread parsing.
-JS_API bool rust_pipeline_available();
-
 // Parse a program (script or module) without GC interaction. Thread-safe.
 JS_API FFI::ParsedProgram* parse_program(u16 const* utf16_data, size_t length_in_code_units, ProgramType type, size_t line_number_offset = 0);
 

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -115,10 +115,7 @@ JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledPro
 
 // Decode an ImmutableBytes-backed bytecode cache blob into a parser-free cache handle.
 JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes, ProgramType, ReadonlyBytes source_hash);
-JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes, ProgramType, ReadonlyBytes source_hash, NonnullRefPtr<Core::WeakEventLoopReference>);
-
-// Return the decoded source length carried by a bytecode cache blob.
-JS_API size_t decoded_bytecode_cache_source_length(FFI::DecodedBytecodeCacheBlob const*);
+JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes, ProgramType, ReadonlyBytes source_hash, Core::EventLoop&);
 
 // Validate a decoded bytecode cache blob before materialization. Thread-safe.
 JS_API bool validate_decoded_bytecode_cache_blob(FFI::DecodedBytecodeCacheBlob*, size_t source_length);

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -13,6 +13,7 @@
 #include <AK/Result.h>
 #include <AK/Span.h>
 #include <AK/Utf16FlyString.h>
+#include <LibCore/Forward.h>
 #include <LibCore/ImmutableBytes.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/Root.h>
@@ -114,9 +115,13 @@ JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledPro
 
 // Decode an ImmutableBytes-backed bytecode cache blob into a parser-free cache handle.
 JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes, ProgramType, ReadonlyBytes source_hash);
+JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes, ProgramType, ReadonlyBytes source_hash, NonnullRefPtr<Core::WeakEventLoopReference>);
 
 // Return the decoded source length carried by a bytecode cache blob.
 JS_API size_t decoded_bytecode_cache_source_length(FFI::DecodedBytecodeCacheBlob const*);
+
+// Validate a decoded bytecode cache blob before materialization. Thread-safe.
+JS_API bool validate_decoded_bytecode_cache_blob(FFI::DecodedBytecodeCacheBlob*, size_t source_length);
 
 // Free a decoded bytecode cache blob.
 JS_API void free_decoded_bytecode_cache_blob(FFI::DecodedBytecodeCacheBlob*);

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -62,6 +62,8 @@ struct BytecodeCacheContext {
     u64 vary_key { 0 };
 };
 
+using BytecodeCacheSourceHash = ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8>;
+
 struct BytecodeCacheInstallTarget {
     GC::Weak<JS::Script> script;
     GC::Weak<JS::SourceTextModule> module;
@@ -104,7 +106,7 @@ struct BytecodeCacheInstallTarget {
     }
 };
 
-static ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> bytecode_cache_source_hash(ReadonlyBytes source_bytes, StringView source_encoding)
+static BytecodeCacheSourceHash bytecode_cache_source_hash(ReadonlyBytes source_bytes, StringView source_encoding)
 {
     auto hasher = ::Crypto::Hash::SHA256::create();
     hasher->update(source_bytes);
@@ -168,12 +170,12 @@ static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::
 // Reparsing here is intentional: the execution-path compile only eagerly generates top-level bytecode plus direct
 // IIFEs, while the cache wants every nested function compiled so that warm loads avoid lazy compile work entirely. Once
 // the blob is back on the main thread, try to install that same blob into the live script/module before storing it.
-static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode const> original_source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, BytecodeCacheContext cache_context, BytecodeCacheInstallTarget install_target, ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> source_hash)
+static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode const> original_source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, BytecodeCacheContext cache_context, BytecodeCacheInstallTarget install_target, BytecodeCacheSourceHash source_hash)
 {
     auto filename = original_source_code->filename();
     auto source_code = original_source_code->code();
     auto& main_thread_event_loop = Core::EventLoop::current();
-    auto* callback = new Function<void(ByteBuffer, ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8>)>(
+    auto* callback = new Function<void(ByteBuffer, BytecodeCacheSourceHash)>(
         [cache_context = move(cache_context), install_target = move(install_target), original_source_code = move(original_source_code), type](ByteBuffer blob, auto source_hash) mutable {
             if (blob.is_empty()) {
                 install_target.finish_generation_without_install();
@@ -294,6 +296,31 @@ static void compile_remaining_module_functions_off_thread(ModuleScript& module_s
 
             compile_remaining_functions_off_thread(*top_level_await_shared_data->m_executable, source_code);
         });
+}
+
+struct BytecodeCachePreparation {
+    Core::ImmutableBytes bytecode;
+    Function<void(JS::FFI::DecodedBytecodeCacheBlob*)> on_prepared;
+};
+
+static void prepare_bytecode_cache_off_thread(Core::ImmutableBytes bytecode, JS::RustIntegration::ProgramType type, size_t source_length, BytecodeCacheSourceHash source_hash, Function<void(JS::FFI::DecodedBytecodeCacheBlob*)> on_prepared)
+{
+    auto* preparation = new BytecodeCachePreparation { move(bytecode), move(on_prepared) };
+    auto& main_thread_event_loop = Core::EventLoop::current();
+
+    Threading::ThreadPool::the().submit([preparation, type, source_length, source_hash, &main_thread_event_loop]() mutable {
+        auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(move(preparation->bytecode), type, source_hash.bytes(), main_thread_event_loop);
+        if (bytecode_cache && !JS::RustIntegration::validate_decoded_bytecode_cache_blob(bytecode_cache, source_length)) {
+            JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
+            bytecode_cache = nullptr;
+        }
+
+        main_thread_event_loop.deferred_invoke([bytecode_cache, preparation]() {
+            preparation->on_prepared(bytecode_cache);
+            delete preparation;
+            perform_a_microtask_checkpoint();
+        });
+    });
 }
 
 // Submit parsing and top-level bytecode generation to the thread pool, then bounce back to the main thread via
@@ -685,37 +712,80 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
         auto on_complete_root = GC::make_root(on_complete);
         auto settings_root = GC::make_root(settings_object);
         auto response_url_string = response_url.to_byte_string();
-        auto source_bytes = body_bytes_view(body_bytes);
+        auto source_byte_storage = body_bytes.template get<Core::ImmutableBytes>();
+        auto source_bytes = source_byte_storage.bytes();
         auto const& bytecode = response->javascript_bytecode_cache();
         Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
         auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *response, response_url);
-        Optional<decltype(bytecode_cache_source_hash(source_bytes, extracted_character_encoding))> source_hash;
+        Optional<BytecodeCacheSourceHash> source_hash;
         if (bytecode.has_value() || bytecode_cache_context.has_value())
             source_hash = bytecode_cache_source_hash(source_bytes, extracted_character_encoding);
-        // Warm-cache fast path: a sidecar arrived with the response, decode it, and try to materialize a script
-        // straight from the cached bytecode without parsing or compiling. Pass non-moved source_code / response_url
-        // so the fallback compile path below can reuse them if materialization is rejected.
+
+        // Warm-cache fast path: a sidecar arrived with the response. Decode and validate it off-thread, then try to
+        // materialize a script straight from the validated cached bytecode without parsing or compiling.
         if (bytecode.has_value()) {
-            if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Script, source_hash->bytes())) {
-                auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*fallback_decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
-                if (JS::RustIntegration::decoded_bytecode_cache_source_length(bytecode_cache) != source_length) {
-                    JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
-                } else {
-                    source_code = JS::SourceCode::create(
-                        String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
-                        source_length,
-                        String::from_utf8(extracted_character_encoding).release_value_but_fixme_should_propagate_errors(),
-                        body_bytes.template get<Core::ImmutableBytes>());
-                    auto script = ClassicScript::create_from_bytecode_cache(response_url_string, *source_code, settings_object, response_url, bytecode_cache, muted_errors);
-                    // Bytecode validation runs during materialization and may reject a structurally valid blob whose
-                    // bytecode is corrupt. Treat that as a cache miss and fall through to off-thread source compile.
-                    if (script->parse_error().is_null()) {
-                        on_complete->function()(script);
-                        return;
+            auto source_encoding = String::from_utf8(extracted_character_encoding).release_value_but_fixme_should_propagate_errors();
+            auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*fallback_decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
+            prepare_bytecode_cache_off_thread(*bytecode, JS::RustIntegration::ProgramType::Script, source_length, *source_hash,
+                [response_url = move(response_url), response_url_string = move(response_url_string),
+                    source_byte_storage = move(source_byte_storage),
+                    bytecode_cache_context = move(bytecode_cache_context),
+                    source_hash = move(source_hash),
+                    source_encoding = move(source_encoding),
+                    source_length,
+                    muted_errors, on_complete_root = move(on_complete_root),
+                    settings_root = move(settings_root)](auto* bytecode_cache) mutable {
+                    Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
+                    if (bytecode_cache) {
+                        source_code = JS::SourceCode::create(
+                            String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                            source_length,
+                            source_encoding,
+                            source_byte_storage);
+                        auto script = ClassicScript::create_from_bytecode_cache(response_url_string, *source_code, *settings_root, response_url, bytecode_cache, muted_errors);
+                        if (script->parse_error().is_null()) {
+                            on_complete_root->function()(script);
+                            return;
+                        }
+                        source_code = {};
                     }
-                    source_code = {};
-                }
-            }
+
+                    if (!source_code.has_value()) {
+                        auto fallback_decoder = TextCodec::decoder_for(source_encoding);
+                        VERIFY(fallback_decoder.has_value());
+                        source_code = JS::SourceCode::create(
+                            String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                            Utf16String::from_utf8(decode_source_text(*fallback_decoder, source_byte_storage.bytes()).release_value_but_fixme_should_propagate_errors()));
+                    }
+
+                    compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Script, 1,
+                        [response_url = move(response_url), response_url_string = move(response_url_string),
+                            bytecode_cache_context = move(bytecode_cache_context),
+                            source_hash = move(source_hash),
+                            muted_errors, on_complete_root = move(on_complete_root),
+                            settings_root = move(settings_root)](auto result, auto source_code) mutable {
+                            auto source_code_for_cache = source_code;
+                            auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
+                            auto script = result.compiled
+                                ? ClassicScript::create_from_pre_compiled(move(response_url_string), move(source_code), *settings_root, move(response_url), result.compiled, muted_errors)
+                                : ClassicScript::create_from_pre_parsed(move(response_url_string), move(source_code), *settings_root, move(response_url), result.parsed, muted_errors);
+                            BytecodeCacheInstallTarget install_target;
+                            if (auto* script_record = script->script_record()) {
+                                install_target.script = *script_record;
+                                if (!should_generate_bytecode_cache) {
+                                    if (auto* executable = script_record->cached_executable())
+                                        compile_remaining_functions_off_thread(*executable, source_code_for_cache);
+                                }
+                            }
+                            on_complete_root->function()(script);
+                            if (should_generate_bytecode_cache) {
+                                install_target.begin_generation();
+                                VERIFY(source_hash.has_value());
+                                schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
+                            }
+                        });
+                });
+            return;
         }
 
         if (!source_code.has_value()) {
@@ -1090,33 +1160,81 @@ void fetch_single_module_script(JS::Realm& realm,
                 auto url_string = url.to_byte_string();
                 auto response_url = response->url().value_or({});
                 auto module_type_string = module_type.to_byte_string();
-                auto source_bytes = body_bytes_view(body_bytes);
+                auto source_byte_storage = body_bytes.get<Core::ImmutableBytes>();
+                auto source_bytes = source_byte_storage.bytes();
                 auto const& bytecode = internal_response->javascript_bytecode_cache();
                 Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
                 auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *internal_response, response_url);
-                Optional<decltype(bytecode_cache_source_hash(source_bytes, "UTF-8"sv))> source_hash;
+                Optional<BytecodeCacheSourceHash> source_hash;
                 if (bytecode.has_value() || bytecode_cache_context.has_value())
                     source_hash = bytecode_cache_source_hash(source_bytes, "UTF-8"sv);
                 if (bytecode.has_value()) {
-                    if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Module, source_hash->bytes())) {
-                        auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
-                        if (JS::RustIntegration::decoded_bytecode_cache_source_length(bytecode_cache) != source_length) {
-                            JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
-                        } else {
-                            source_code = JS::SourceCode::create(
-                                String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
-                                source_length,
-                                "UTF-8"_string,
-                                body_bytes.template get<Core::ImmutableBytes>());
-                            auto module_script = ModuleScript::create_from_bytecode_cache(url_string, *source_code, settings_object, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
-                            if (module_script && module_script->parse_error().is_null()) {
-                                settings_object.module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
-                                on_complete->function()(module_script);
-                                return;
+                    auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
+                    prepare_bytecode_cache_off_thread(*bytecode, JS::RustIntegration::ProgramType::Module, source_length, *source_hash,
+                        [url = move(url), url_string = move(url_string), response_url = move(response_url),
+                            module_type_string = move(module_type_string),
+                            source_byte_storage = move(source_byte_storage),
+                            bytecode_cache_context = move(bytecode_cache_context),
+                            source_hash = move(source_hash),
+                            source_length,
+                            on_complete_root = move(on_complete_root),
+                            settings_root = move(settings_root)](auto* bytecode_cache) mutable {
+                            Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
+                            if (bytecode_cache) {
+                                source_code = JS::SourceCode::create(
+                                    String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                                    source_length,
+                                    "UTF-8"_string,
+                                    source_byte_storage);
+                                auto module_script = ModuleScript::create_from_bytecode_cache(url_string, *source_code, *settings_root, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
+                                if (module_script && module_script->parse_error().is_null()) {
+                                    settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
+                                    on_complete_root->function()(module_script);
+                                    return;
+                                }
+                                source_code = {};
                             }
-                            source_code = {};
-                        }
-                    }
+
+                            if (!source_code.has_value()) {
+                                auto fallback_decoder = TextCodec::decoder_for("UTF-8"sv);
+                                VERIFY(fallback_decoder.has_value());
+                                source_code = JS::SourceCode::create(
+                                    String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                                    Utf16String::from_utf8(decode_source_text(*fallback_decoder, source_byte_storage.bytes()).release_value_but_fixme_should_propagate_errors()));
+                            }
+
+                            compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Module, 0,
+                                [url = move(url), url_string = move(url_string), response_url = move(response_url),
+                                    module_type_string = move(module_type_string),
+                                    bytecode_cache_context = move(bytecode_cache_context),
+                                    source_hash = move(source_hash),
+                                    on_complete_root = move(on_complete_root),
+                                    settings_root = move(settings_root)](auto result, auto source_code) mutable {
+                                    auto source_code_for_cache = source_code;
+                                    auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
+                                    auto module_script = result.compiled
+                                        ? ModuleScript::create_from_pre_compiled(url_string, move(source_code), *settings_root, move(response_url), result.compiled).release_value_but_fixme_should_propagate_errors()
+                                        : ModuleScript::create_from_pre_parsed(url_string, move(source_code), *settings_root, move(response_url), result.parsed).release_value_but_fixme_should_propagate_errors();
+                                    BytecodeCacheInstallTarget install_target;
+                                    if (module_script) {
+                                        module_script->record().visit(
+                                            [](Empty) {},
+                                            [&](GC::Ref<JS::SourceTextModule> module) { install_target.module = module; },
+                                            [](GC::Ref<JS::SyntheticModule>) {},
+                                            [](GC::Ref<WebAssembly::WebAssemblyModule>) {});
+                                        if (!should_generate_bytecode_cache)
+                                            compile_remaining_module_functions_off_thread(*module_script, source_code_for_cache);
+                                    }
+                                    settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
+                                    on_complete_root->function()(module_script);
+                                    if (should_generate_bytecode_cache) {
+                                        install_target.begin_generation();
+                                        VERIFY(source_hash.has_value());
+                                        schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
+                                    }
+                                });
+                        });
+                    return;
                 }
 
                 if (!source_code.has_value()) {

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -682,83 +682,74 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
         // FIXME: Pass options.
         auto response_url = response->url().value_or({});
 
-        // If the Rust pipeline is available, parse off the main thread.
-        if (JS::RustIntegration::rust_pipeline_available()) {
-            auto on_complete_root = GC::make_root(on_complete);
-            auto settings_root = GC::make_root(settings_object);
-            auto response_url_string = response_url.to_byte_string();
-            auto source_bytes = body_bytes_view(body_bytes);
-            auto const& bytecode = response->javascript_bytecode_cache();
-            Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
-            auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *response, response_url);
-            Optional<decltype(bytecode_cache_source_hash(source_bytes, extracted_character_encoding))> source_hash;
-            if (bytecode.has_value() || bytecode_cache_context.has_value())
-                source_hash = bytecode_cache_source_hash(source_bytes, extracted_character_encoding);
-            // Warm-cache fast path: a sidecar arrived with the response, decode it, and try to materialize a script
-            // straight from the cached bytecode without parsing or compiling. Pass non-moved source_code / response_url
-            // so the fallback compile path below can reuse them if materialization is rejected.
-            if (bytecode.has_value()) {
-                if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Script, source_hash->bytes())) {
-                    auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*fallback_decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
-                    if (JS::RustIntegration::decoded_bytecode_cache_source_length(bytecode_cache) != source_length) {
-                        JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
-                    } else {
-                        source_code = JS::SourceCode::create(
-                            String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
-                            source_length,
-                            String::from_utf8(extracted_character_encoding).release_value_but_fixme_should_propagate_errors(),
-                            body_bytes.template get<Core::ImmutableBytes>());
-                        auto script = ClassicScript::create_from_bytecode_cache(response_url_string, *source_code, settings_object, response_url, bytecode_cache, muted_errors);
-                        // Bytecode validation runs during materialization and may reject a structurally valid blob whose
-                        // bytecode is corrupt. Treat that as a cache miss and fall through to off-thread source compile.
-                        if (script->parse_error().is_null()) {
-                            on_complete->function()(script);
-                            return;
-                        }
-                        source_code = {};
+        auto on_complete_root = GC::make_root(on_complete);
+        auto settings_root = GC::make_root(settings_object);
+        auto response_url_string = response_url.to_byte_string();
+        auto source_bytes = body_bytes_view(body_bytes);
+        auto const& bytecode = response->javascript_bytecode_cache();
+        Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
+        auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *response, response_url);
+        Optional<decltype(bytecode_cache_source_hash(source_bytes, extracted_character_encoding))> source_hash;
+        if (bytecode.has_value() || bytecode_cache_context.has_value())
+            source_hash = bytecode_cache_source_hash(source_bytes, extracted_character_encoding);
+        // Warm-cache fast path: a sidecar arrived with the response, decode it, and try to materialize a script
+        // straight from the cached bytecode without parsing or compiling. Pass non-moved source_code / response_url
+        // so the fallback compile path below can reuse them if materialization is rejected.
+        if (bytecode.has_value()) {
+            if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Script, source_hash->bytes())) {
+                auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*fallback_decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
+                if (JS::RustIntegration::decoded_bytecode_cache_source_length(bytecode_cache) != source_length) {
+                    JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
+                } else {
+                    source_code = JS::SourceCode::create(
+                        String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                        source_length,
+                        String::from_utf8(extracted_character_encoding).release_value_but_fixme_should_propagate_errors(),
+                        body_bytes.template get<Core::ImmutableBytes>());
+                    auto script = ClassicScript::create_from_bytecode_cache(response_url_string, *source_code, settings_object, response_url, bytecode_cache, muted_errors);
+                    // Bytecode validation runs during materialization and may reject a structurally valid blob whose
+                    // bytecode is corrupt. Treat that as a cache miss and fall through to off-thread source compile.
+                    if (script->parse_error().is_null()) {
+                        on_complete->function()(script);
+                        return;
                     }
+                    source_code = {};
                 }
             }
-
-            if (!source_code.has_value()) {
-                source_code = JS::SourceCode::create(
-                    String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
-                    Utf16String::from_utf8(decode_source_text(*fallback_decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
-            }
-
-            compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Script, 1,
-                [response_url = move(response_url), response_url_string = move(response_url_string),
-                    bytecode_cache_context = move(bytecode_cache_context),
-                    source_hash = move(source_hash),
-                    muted_errors, on_complete_root = move(on_complete_root),
-                    settings_root = move(settings_root)](auto result, auto source_code) mutable {
-                    auto source_code_for_cache = source_code;
-                    auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
-                    auto script = result.compiled
-                        ? ClassicScript::create_from_pre_compiled(move(response_url_string), move(source_code), *settings_root, move(response_url), result.compiled, muted_errors)
-                        : ClassicScript::create_from_pre_parsed(move(response_url_string), move(source_code), *settings_root, move(response_url), result.parsed, muted_errors);
-                    BytecodeCacheInstallTarget install_target;
-                    if (auto* script_record = script->script_record()) {
-                        install_target.script = *script_record;
-                        if (!should_generate_bytecode_cache) {
-                            if (auto* executable = script_record->cached_executable())
-                                compile_remaining_functions_off_thread(*executable, source_code_for_cache);
-                        }
-                    }
-                    on_complete_root->function()(script);
-                    if (should_generate_bytecode_cache) {
-                        install_target.begin_generation();
-                        VERIFY(source_hash.has_value());
-                        schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
-                    }
-                });
-        } else {
-            auto source_text = decode_source_text(*fallback_decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
-            auto script = ClassicScript::create(response_url.to_byte_string(), source_text, settings_object, response_url, 1, muted_errors);
-
-            // 8. Run onComplete given script.
-            on_complete->function()(script);
         }
+
+        if (!source_code.has_value()) {
+            source_code = JS::SourceCode::create(
+                String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                Utf16String::from_utf8(decode_source_text(*fallback_decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
+        }
+
+        compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Script, 1,
+            [response_url = move(response_url), response_url_string = move(response_url_string),
+                bytecode_cache_context = move(bytecode_cache_context),
+                source_hash = move(source_hash),
+                muted_errors, on_complete_root = move(on_complete_root),
+                settings_root = move(settings_root)](auto result, auto source_code) mutable {
+                auto source_code_for_cache = source_code;
+                auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
+                auto script = result.compiled
+                    ? ClassicScript::create_from_pre_compiled(move(response_url_string), move(source_code), *settings_root, move(response_url), result.compiled, muted_errors)
+                    : ClassicScript::create_from_pre_parsed(move(response_url_string), move(source_code), *settings_root, move(response_url), result.parsed, muted_errors);
+                BytecodeCacheInstallTarget install_target;
+                if (auto* script_record = script->script_record()) {
+                    install_target.script = *script_record;
+                    if (!should_generate_bytecode_cache) {
+                        if (auto* executable = script_record->cached_executable())
+                            compile_remaining_functions_off_thread(*executable, source_code_for_cache);
+                    }
+                }
+                on_complete_root->function()(script);
+                if (should_generate_bytecode_cache) {
+                    install_target.begin_generation();
+                    VERIFY(source_hash.has_value());
+                    schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
+                }
+            });
     };
 
     Fetch::Fetching::fetch(element->realm(), request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
@@ -1094,82 +1085,77 @@ void fetch_single_module_script(JS::Realm& realm,
             if (mime_type.has_value() && mime_type->is_javascript() && module_type == "javascript-or-wasm") {
                 auto decoder = TextCodec::decoder_for("UTF-8"sv);
                 VERIFY(decoder.has_value());
-                // If the Rust pipeline is available, parse off the main thread.
-                if (JS::RustIntegration::rust_pipeline_available()) {
-                    auto on_complete_root = GC::make_root(on_complete);
-                    auto settings_root = GC::make_root(settings_object);
-                    auto url_string = url.to_byte_string();
-                    auto response_url = response->url().value_or({});
-                    auto module_type_string = module_type.to_byte_string();
-                    auto source_bytes = body_bytes_view(body_bytes);
-                    auto const& bytecode = internal_response->javascript_bytecode_cache();
-                    Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
-                    auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *internal_response, response_url);
-                    Optional<decltype(bytecode_cache_source_hash(source_bytes, "UTF-8"sv))> source_hash;
-                    if (bytecode.has_value() || bytecode_cache_context.has_value())
-                        source_hash = bytecode_cache_source_hash(source_bytes, "UTF-8"sv);
-                    if (bytecode.has_value()) {
-                        if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Module, source_hash->bytes())) {
-                            auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
-                            if (JS::RustIntegration::decoded_bytecode_cache_source_length(bytecode_cache) != source_length) {
-                                JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
-                            } else {
-                                source_code = JS::SourceCode::create(
-                                    String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
-                                    source_length,
-                                    "UTF-8"_string,
-                                    body_bytes.template get<Core::ImmutableBytes>());
-                                auto module_script = ModuleScript::create_from_bytecode_cache(url_string, *source_code, settings_object, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
-                                if (module_script && module_script->parse_error().is_null()) {
-                                    settings_object.module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
-                                    on_complete->function()(module_script);
-                                    return;
-                                }
-                                source_code = {};
+                auto on_complete_root = GC::make_root(on_complete);
+                auto settings_root = GC::make_root(settings_object);
+                auto url_string = url.to_byte_string();
+                auto response_url = response->url().value_or({});
+                auto module_type_string = module_type.to_byte_string();
+                auto source_bytes = body_bytes_view(body_bytes);
+                auto const& bytecode = internal_response->javascript_bytecode_cache();
+                Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
+                auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *internal_response, response_url);
+                Optional<decltype(bytecode_cache_source_hash(source_bytes, "UTF-8"sv))> source_hash;
+                if (bytecode.has_value() || bytecode_cache_context.has_value())
+                    source_hash = bytecode_cache_source_hash(source_bytes, "UTF-8"sv);
+                if (bytecode.has_value()) {
+                    if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Module, source_hash->bytes())) {
+                        auto source_length = TextCodec::convert_input_to_utf16_length_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, StringView { source_bytes }).release_value_but_fixme_should_propagate_errors();
+                        if (JS::RustIntegration::decoded_bytecode_cache_source_length(bytecode_cache) != source_length) {
+                            JS::RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
+                        } else {
+                            source_code = JS::SourceCode::create(
+                                String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                                source_length,
+                                "UTF-8"_string,
+                                body_bytes.template get<Core::ImmutableBytes>());
+                            auto module_script = ModuleScript::create_from_bytecode_cache(url_string, *source_code, settings_object, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
+                            if (module_script && module_script->parse_error().is_null()) {
+                                settings_object.module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
+                                on_complete->function()(module_script);
+                                return;
                             }
+                            source_code = {};
                         }
                     }
-
-                    if (!source_code.has_value()) {
-                        source_code = JS::SourceCode::create(
-                            String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
-                            Utf16String::from_utf8(decode_source_text(*decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
-                    }
-
-                    compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Module, 0,
-                        [url = move(url), url_string = move(url_string), response_url = move(response_url),
-                            module_type_string = move(module_type_string),
-                            bytecode_cache_context = move(bytecode_cache_context),
-                            source_hash = move(source_hash),
-                            on_complete_root = move(on_complete_root),
-                            settings_root = move(settings_root)](auto result, auto source_code) mutable {
-                            auto source_code_for_cache = source_code;
-                            auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
-                            auto module_script = result.compiled
-                                ? ModuleScript::create_from_pre_compiled(url_string, move(source_code), *settings_root, move(response_url), result.compiled).release_value_but_fixme_should_propagate_errors()
-                                : ModuleScript::create_from_pre_parsed(url_string, move(source_code), *settings_root, move(response_url), result.parsed).release_value_but_fixme_should_propagate_errors();
-                            BytecodeCacheInstallTarget install_target;
-                            if (module_script) {
-                                module_script->record().visit(
-                                    [](Empty) {},
-                                    [&](GC::Ref<JS::SourceTextModule> module) { install_target.module = module; },
-                                    [](GC::Ref<JS::SyntheticModule>) {},
-                                    [](GC::Ref<WebAssembly::WebAssemblyModule>) {});
-                                if (!should_generate_bytecode_cache)
-                                    compile_remaining_module_functions_off_thread(*module_script, source_code_for_cache);
-                            }
-                            settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
-                            on_complete_root->function()(module_script);
-                            if (should_generate_bytecode_cache) {
-                                install_target.begin_generation();
-                                VERIFY(source_hash.has_value());
-                                schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
-                            }
-                        });
-                    return;
                 }
-                auto source_text = decode_source_text(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
-                module_script = ModuleScript::create_a_javascript_module_script(url.to_byte_string(), source_text, settings_object, response->url().value_or({})).release_value_but_fixme_should_propagate_errors();
+
+                if (!source_code.has_value()) {
+                    source_code = JS::SourceCode::create(
+                        String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
+                        Utf16String::from_utf8(decode_source_text(*decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
+                }
+
+                compile_off_thread(source_code.release_value(), JS::RustIntegration::ProgramType::Module, 0,
+                    [url = move(url), url_string = move(url_string), response_url = move(response_url),
+                        module_type_string = move(module_type_string),
+                        bytecode_cache_context = move(bytecode_cache_context),
+                        source_hash = move(source_hash),
+                        on_complete_root = move(on_complete_root),
+                        settings_root = move(settings_root)](auto result, auto source_code) mutable {
+                        auto source_code_for_cache = source_code;
+                        auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
+                        auto module_script = result.compiled
+                            ? ModuleScript::create_from_pre_compiled(url_string, move(source_code), *settings_root, move(response_url), result.compiled).release_value_but_fixme_should_propagate_errors()
+                            : ModuleScript::create_from_pre_parsed(url_string, move(source_code), *settings_root, move(response_url), result.parsed).release_value_but_fixme_should_propagate_errors();
+                        BytecodeCacheInstallTarget install_target;
+                        if (module_script) {
+                            module_script->record().visit(
+                                [](Empty) {},
+                                [&](GC::Ref<JS::SourceTextModule> module) { install_target.module = module; },
+                                [](GC::Ref<JS::SyntheticModule>) {},
+                                [](GC::Ref<WebAssembly::WebAssemblyModule>) {});
+                            if (!should_generate_bytecode_cache)
+                                compile_remaining_module_functions_off_thread(*module_script, source_code_for_cache);
+                        }
+                        settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
+                        on_complete_root->function()(module_script);
+                        if (should_generate_bytecode_cache) {
+                            install_target.begin_generation();
+                            VERIFY(source_hash.has_value());
+                            schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value(), move(install_target), source_hash.release_value());
+                        }
+                    });
+                return;
             }
 
             // FIXME: 3. If mimeType is a JavaScript MIME type and moduleType is "javascript-or-wasm", then set moduleScript to


### PR DESCRIPTION
This makes warm bytecode cache hits do less work.

Previously, cache blobs were decoded and validated on the main thread, and validation also repeated some of the same walking/checking work before executables were installed. This branch moves blob decode/validation to the thread pool, keeps the cached bytes mmap-backed, and makes validation state explicit so we do not validate the same cached executable twice.

Bonus: also removes the always-true rust_pipeline_available branch.