### PR TITLE
LibMedia+LibWeb: Implement media element playback rate control

### DIFF
--- a/Libraries/LibMedia/Audio/AudioBuffer.cpp
+++ b/Libraries/LibMedia/Audio/AudioBuffer.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <AK/TypedTransfer.h>
+#include <LibMedia/Audio/AudioBuffer.h>
+
+namespace Audio {
+
+AudioBuffer::AudioBuffer(SampleSpecification sample_specification)
+    : m_sample_specification(sample_specification)
+{
+}
+
+void AudioBuffer::clear()
+{
+    m_frame_count = 0;
+    m_start_offset = 0;
+}
+
+void AudioBuffer::ensure_capacity(size_t required_frame_capacity)
+{
+    if (m_frame_capacity >= required_frame_capacity)
+        return;
+
+    auto new_frame_capacity = max(required_frame_capacity, max<size_t>(m_frame_capacity * 2, 1));
+    auto new_data = MUST(FixedArray<float>::create(new_frame_capacity * m_sample_specification.channel_count()));
+    for (size_t channel = 0; channel < m_sample_specification.channel_count(); channel++) {
+        auto new_channel = new_data.span().slice(channel * new_frame_capacity, m_frame_count);
+        copy_channel_from_buffer(channel, 0, new_channel);
+    }
+
+    m_data = move(new_data);
+    m_frame_capacity = new_frame_capacity;
+    m_start_offset = 0;
+}
+
+void AudioBuffer::copy_channel_to_buffer(ReadonlySpan<float> source, size_t channel, size_t destination_offset)
+{
+    VERIFY(channel < m_sample_specification.channel_count());
+    VERIFY(destination_offset <= m_frame_capacity);
+    VERIFY(source.size() <= m_frame_capacity - destination_offset);
+
+    auto write_offset = (m_start_offset + destination_offset) % m_frame_capacity;
+    auto first_chunk_size = min(source.size(), m_frame_capacity - write_offset);
+    auto channel_data = m_data.span().slice(channel * m_frame_capacity, m_frame_capacity);
+    AK::TypedTransfer<float>::copy(channel_data.slice(write_offset).data(), source.data(), first_chunk_size);
+
+    auto second_chunk_size = source.size() - first_chunk_size;
+    if (second_chunk_size > 0)
+        AK::TypedTransfer<float>::copy(channel_data.data(), source.slice(first_chunk_size).data(), second_chunk_size);
+}
+
+void AudioBuffer::copy_channel_from_buffer(size_t channel, size_t source_offset, Span<float> destination) const
+{
+    VERIFY(channel < m_sample_specification.channel_count());
+    VERIFY(source_offset <= m_frame_count);
+    VERIFY(destination.size() <= m_frame_count - source_offset);
+
+    if (destination.is_empty())
+        return;
+
+    auto read_offset = (m_start_offset + source_offset) % m_frame_capacity;
+    auto first_chunk_size = min(destination.size(), m_frame_capacity - read_offset);
+    auto channel_data = m_data.span().slice(channel * m_frame_capacity, m_frame_capacity);
+    AK::TypedTransfer<float>::copy(destination.data(), channel_data.slice(read_offset).data(), first_chunk_size);
+
+    auto second_chunk_size = destination.size() - first_chunk_size;
+    if (second_chunk_size > 0)
+        AK::TypedTransfer<float>::copy(destination.slice(first_chunk_size).data(), channel_data.data(), second_chunk_size);
+}
+
+void AudioBuffer::zero_channel(size_t channel, size_t destination_offset, size_t frame_count)
+{
+    VERIFY(channel < m_sample_specification.channel_count());
+    VERIFY(destination_offset <= m_frame_capacity);
+    VERIFY(frame_count <= m_frame_capacity - destination_offset);
+
+    auto write_offset = (m_start_offset + destination_offset) % m_frame_capacity;
+    auto first_chunk_size = min(frame_count, m_frame_capacity - write_offset);
+    auto channel_data = m_data.span().slice(channel * m_frame_capacity, m_frame_capacity);
+    for (auto& sample : channel_data.slice(write_offset, first_chunk_size))
+        sample = 0.0f;
+
+    auto second_chunk_size = frame_count - first_chunk_size;
+    if (second_chunk_size > 0) {
+        for (auto& sample : channel_data.slice(0, second_chunk_size))
+            sample = 0.0f;
+    }
+}
+
+void AudioBuffer::append(Media::AudioBlock const& block)
+{
+    VERIFY(block.sample_specification() == m_sample_specification);
+    if (block.frame_count() == 0)
+        return;
+
+    auto old_frame_count = m_frame_count;
+    ensure_capacity(m_frame_count + block.frame_count());
+    for (size_t channel = 0; channel < block.channel_count(); channel++)
+        copy_channel_to_buffer(block.channel_data(channel), channel, old_frame_count);
+    m_frame_count += block.frame_count();
+}
+
+void AudioBuffer::append_silence(size_t frame_count)
+{
+    if (frame_count == 0)
+        return;
+
+    auto old_frame_count = m_frame_count;
+    ensure_capacity(m_frame_count + frame_count);
+    for (size_t channel = 0; channel < m_sample_specification.channel_count(); channel++)
+        zero_channel(channel, old_frame_count, frame_count);
+    m_frame_count += frame_count;
+}
+
+void AudioBuffer::drop_front(size_t frame_count)
+{
+    VERIFY(frame_count <= m_frame_count);
+    if (frame_count == 0)
+        return;
+
+    m_frame_count -= frame_count;
+    if (m_frame_count == 0) {
+        m_start_offset = 0;
+        return;
+    }
+
+    m_start_offset = (m_start_offset + frame_count) % m_frame_capacity;
+}
+
+void AudioBuffer::copy_frames_to(size_t source_offset, size_t frame_count, size_t destination_offset, Media::AudioBlock& destination) const
+{
+    VERIFY(destination.sample_specification() == m_sample_specification);
+    VERIFY(source_offset <= m_frame_count);
+    VERIFY(frame_count <= m_frame_count - source_offset);
+    VERIFY(destination_offset <= destination.frame_count());
+    VERIFY(frame_count <= destination.frame_count() - destination_offset);
+
+    for (size_t channel = 0; channel < destination.channel_count(); channel++) {
+        auto destination_channel = destination.channel_data(channel).slice(destination_offset, frame_count);
+        copy_channel_from_buffer(channel, source_offset, destination_channel);
+    }
+}
+
+}

--- a/Libraries/LibMedia/Audio/AudioBuffer.h
+++ b/Libraries/LibMedia/Audio/AudioBuffer.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FixedArray.h>
+#include <LibMedia/Audio/SampleSpecification.h>
+#include <LibMedia/AudioBlock.h>
+
+namespace Audio {
+
+class AudioBuffer {
+public:
+    explicit AudioBuffer(SampleSpecification);
+
+    size_t frame_count() const { return m_frame_count; }
+
+    void clear();
+    void append(Media::AudioBlock const&);
+    void append_silence(size_t frame_count);
+    void drop_front(size_t frame_count);
+    void copy_frames_to(size_t source_offset, size_t frame_count, size_t destination_offset, Media::AudioBlock&) const;
+
+private:
+    void ensure_capacity(size_t required_frame_capacity);
+    void copy_channel_to_buffer(ReadonlySpan<float>, size_t channel, size_t destination_offset);
+    void copy_channel_from_buffer(size_t channel, size_t source_offset, Span<float>) const;
+    void zero_channel(size_t channel, size_t destination_offset, size_t frame_count);
+
+    SampleSpecification const m_sample_specification;
+    FixedArray<float> m_data;
+    size_t m_frame_capacity { 0 };
+    size_t m_frame_count { 0 };
+    size_t m_start_offset { 0 };
+};
+
+}

--- a/Libraries/LibMedia/Audio/TimeStretcher.h
+++ b/Libraries/LibMedia/Audio/TimeStretcher.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Time.h>
+#include <LibMedia/AudioBlock.h>
+#include <LibMedia/DecoderError.h>
+
+namespace Audio {
+
+class TimeStretcher {
+public:
+    virtual ~TimeStretcher() = default;
+
+    virtual i64 preroll_frame_count() const = 0;
+    virtual void flush(AK::Duration media_start_timestamp, i64 output_start_frame_index) = 0;
+
+    virtual void set_rate(float) = 0;
+
+    virtual void push_block(Media::AudioBlock const&) = 0;
+    virtual Media::DecoderErrorOr<Media::AudioBlock> retrieve_block() = 0;
+    virtual void signal_end_of_stream() = 0;
+};
+
+}

--- a/Libraries/LibMedia/Audio/WSOLAAlgorithm.cpp
+++ b/Libraries/LibMedia/Audio/WSOLAAlgorithm.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2012 The Chromium Authors
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// Source: chromium/media/filters/audio_renderer_algorithm.{h,cc}.
+
+#include <AK/Math.h>
+#include <AK/TypedTransfer.h>
+#include <LibMedia/Audio/WSOLAAlgorithm.h>
+#include <LibMedia/Audio/WSOLAInternals.h>
+
+namespace Audio {
+
+namespace {
+
+constexpr u64 OLA_WINDOW_SIZE_MS = 20;
+constexpr u64 WSOLA_SEARCH_INTERVAL_MS = 30;
+
+size_t window_size(u32 sample_rate)
+{
+    auto const frame_count = (static_cast<u64>(sample_rate) * OLA_WINDOW_SIZE_MS + 500) / 1000;
+    return max(frame_count + (frame_count & 1), 2);
+}
+
+size_t search_interval(u32 sample_rate)
+{
+    auto const frame_count = (static_cast<u64>(sample_rate) * WSOLA_SEARCH_INTERVAL_MS + 500) / 1000;
+    return max(frame_count, 1);
+}
+
+void zero_block(Media::AudioBlock& block)
+{
+    for (size_t channel = 0; channel < block.channel_count(); channel++) {
+        auto channel_data = block.channel_data(channel);
+        for (auto& sample : channel_data)
+            sample = 0.0f;
+    }
+}
+
+void zero_frames(Media::AudioBlock& block, size_t starting_frame, size_t frame_count)
+{
+    VERIFY(starting_frame <= block.frame_count());
+    VERIFY(frame_count <= block.frame_count() - starting_frame);
+    for (size_t channel = 0; channel < block.channel_count(); channel++) {
+        auto channel_data = block.channel_data(channel);
+        for (size_t frame = 0; frame < frame_count; frame++)
+            channel_data[starting_frame + frame] = 0.0f;
+    }
+}
+
+void copy_partial_frames(Media::AudioBlock const& source, size_t source_offset, size_t frame_count, size_t destination_offset, Media::AudioBlock& destination)
+{
+    VERIFY(source.sample_specification() == destination.sample_specification());
+    VERIFY(source_offset <= source.frame_count());
+    VERIFY(frame_count <= source.frame_count() - source_offset);
+    VERIFY(destination_offset <= destination.frame_count());
+    VERIFY(frame_count <= destination.frame_count() - destination_offset);
+
+    for (size_t channel = 0; channel < source.channel_count(); channel++) {
+        auto source_channel = source.channel_data(channel).slice(source_offset, frame_count);
+        auto destination_channel = destination.channel_data(channel).slice(destination_offset, frame_count);
+        AK::TypedTransfer<float>::copy(destination_channel.data(), source_channel.data(), frame_count);
+    }
+}
+
+}
+
+WSOLAAlgorithm::WSOLAAlgorithm(SampleSpecification sample_specification)
+    : m_sample_specification(sample_specification)
+    , m_audio_buffer(sample_specification)
+    , m_ola_window_size(window_size(sample_rate()))
+    , m_ola_hop_size(m_ola_window_size / 2)
+    , m_num_candidate_blocks(search_interval(sample_rate()))
+    , m_search_block_center_offset((m_num_candidate_blocks / 2) + ((m_ola_window_size / 2) - 1))
+{
+    VERIFY(m_sample_specification.is_valid());
+
+    m_ola_window.resize(m_ola_window_size);
+    WSOLAInternals::get_periodic_hanning_window(m_ola_window.span());
+
+    m_transition_window.resize(m_ola_window_size * 2);
+    WSOLAInternals::get_periodic_hanning_window(m_transition_window.span());
+
+    m_wsola_output = create_block(m_ola_window_size + m_ola_hop_size);
+    zero_block(m_wsola_output);
+
+    m_optimal_block = create_block(m_ola_window_size);
+    m_search_block = create_block(m_num_candidate_blocks + (m_ola_window_size - 1));
+    m_target_block = create_block(m_ola_window_size);
+}
+
+WSOLAAlgorithm::~WSOLAAlgorithm() = default;
+
+Media::AudioBlock WSOLAAlgorithm::create_block(size_t frame_count) const
+{
+    Media::AudioBlock block;
+    block.initialize(m_sample_specification, 0, frame_count);
+    return block;
+}
+
+void WSOLAAlgorithm::flush_buffers()
+{
+    m_audio_buffer.clear();
+
+    m_input_position_remainder = 0.0f;
+    m_search_block_center_index = 0;
+    m_search_block_index = 0;
+    m_target_block_index = 0;
+    m_num_complete_frames = 0;
+
+    zero_block(m_wsola_output);
+}
+
+void WSOLAAlgorithm::enqueue_buffer(Media::AudioBlock const& buffer_in)
+{
+    VERIFY(buffer_in.sample_specification() == m_sample_specification);
+    m_audio_buffer.append(buffer_in);
+}
+
+void WSOLAAlgorithm::mark_end_of_stream(float playback_rate)
+{
+    VERIFY(playback_rate > 0.0f);
+    auto const search_block_size = m_num_candidate_blocks + (m_ola_window_size - 1);
+    auto const padding = search_block_size + m_ola_window_size + m_ola_hop_size;
+    m_audio_buffer.append_silence(padding);
+}
+
+size_t WSOLAAlgorithm::fill_buffer(Media::AudioBlock& destination, size_t destination_offset, size_t requested_frames, float playback_rate)
+{
+    if (playback_rate == 0.0f)
+        return 0;
+    VERIFY(playback_rate > 0.0f);
+    VERIFY(destination.sample_specification() == m_sample_specification);
+
+    size_t rendered_frames = 0;
+    do {
+        rendered_frames += write_completed_frames_to(
+            requested_frames - rendered_frames,
+            destination_offset + rendered_frames, destination);
+    } while (rendered_frames < requested_frames && run_one_wsola_iteration(playback_rate));
+    return rendered_frames;
+}
+
+bool WSOLAAlgorithm::can_perform_wsola() const
+{
+    auto const search_block_size = m_num_candidate_blocks + (m_ola_window_size - 1);
+    auto const frames = m_audio_buffer.frame_count();
+    return m_target_block_index + static_cast<i64>(m_ola_window_size) <= static_cast<i64>(frames)
+        && m_search_block_index + static_cast<i64>(search_block_size) <= static_cast<i64>(frames);
+}
+
+bool WSOLAAlgorithm::target_is_within_search_region() const
+{
+    auto const search_block_size = m_num_candidate_blocks + (m_ola_window_size - 1);
+    return m_target_block_index >= m_search_block_index
+        && m_target_block_index + static_cast<i64>(m_ola_window_size) <= m_search_block_index + static_cast<i64>(search_block_size);
+}
+
+void WSOLAAlgorithm::peek_audio_with_zero_prepend(i64 read_offset_frames, Media::AudioBlock& destination)
+{
+    auto const destination_frame_count = destination.frame_count();
+    VERIFY(read_offset_frames <= static_cast<i64>(m_audio_buffer.frame_count()) - static_cast<i64>(destination_frame_count));
+
+    size_t write_offset = 0;
+    auto frames_to_read = destination_frame_count;
+    if (read_offset_frames < 0) {
+        auto num_zero_frames_appended = min(-static_cast<size_t>(read_offset_frames), frames_to_read);
+        read_offset_frames = 0;
+        frames_to_read -= num_zero_frames_appended;
+        write_offset = num_zero_frames_appended;
+        zero_frames(destination, 0, num_zero_frames_appended);
+    }
+    if (frames_to_read > 0)
+        m_audio_buffer.copy_frames_to(static_cast<size_t>(read_offset_frames), frames_to_read, write_offset, destination);
+}
+
+void WSOLAAlgorithm::get_optimal_block()
+{
+    i64 optimal_index = 0;
+
+    constexpr i64 exclude_interval_length_frames = 160;
+
+    if (target_is_within_search_region()) {
+        optimal_index = m_target_block_index;
+        peek_audio_with_zero_prepend(optimal_index, m_optimal_block);
+    } else {
+        peek_audio_with_zero_prepend(m_target_block_index, m_target_block);
+        peek_audio_with_zero_prepend(m_search_block_index, m_search_block);
+        auto last_optimal = m_target_block_index - static_cast<i64>(m_ola_hop_size) - m_search_block_index;
+        auto exclude_interval_low = last_optimal - (exclude_interval_length_frames / 2);
+        auto exclude_interval_high = last_optimal + (exclude_interval_length_frames / 2);
+        WSOLAInternals::Interval exclude_interval {
+            exclude_interval_low <= 0 ? 0 : static_cast<size_t>(exclude_interval_low),
+            exclude_interval_high <= 0 ? 0 : static_cast<size_t>(exclude_interval_high),
+        };
+
+        optimal_index = static_cast<i64>(WSOLAInternals::optimal_index(m_search_block, m_target_block, exclude_interval));
+
+        optimal_index += m_search_block_index;
+        peek_audio_with_zero_prepend(optimal_index, m_optimal_block);
+
+        for (size_t channel_index = 0; channel_index < m_sample_specification.channel_count(); channel_index++) {
+            auto optimal_channel = m_optimal_block.channel_data(channel_index);
+            auto target_channel = m_target_block.channel_data(channel_index);
+            for (size_t n = 0; n < m_ola_window_size; n++) {
+                optimal_channel[n] = (optimal_channel[n] * m_transition_window[n])
+                    + (target_channel[n] * m_transition_window[m_ola_window_size + n]);
+            }
+        }
+    }
+
+    m_target_block_index = optimal_index + static_cast<i64>(m_ola_hop_size);
+}
+
+bool WSOLAAlgorithm::run_one_wsola_iteration(float playback_rate)
+{
+    if (!can_perform_wsola())
+        return false;
+
+    get_optimal_block();
+
+    for (size_t channel_index = 0; channel_index < m_sample_specification.channel_count(); channel_index++) {
+        auto optimal_channel = m_optimal_block.channel_data(channel_index);
+        auto output_channel = m_wsola_output.channel_data(channel_index).slice(m_num_complete_frames);
+
+        for (size_t n = 0; n < m_ola_hop_size; n++) {
+            output_channel[n] = output_channel[n] * m_ola_window[m_ola_hop_size + n];
+            output_channel[n] += optimal_channel[n] * m_ola_window[n];
+        }
+
+        for (size_t n = 0; n < m_ola_hop_size; n++)
+            output_channel[m_ola_hop_size + n] = optimal_channel[m_ola_hop_size + n];
+    }
+
+    m_num_complete_frames += m_ola_hop_size;
+    auto input_position_advance = (static_cast<float>(m_ola_hop_size) * playback_rate) + m_input_position_remainder;
+    auto whole_input_frames = AK::round_to<i64>(input_position_advance);
+    m_input_position_remainder = input_position_advance - static_cast<float>(whole_input_frames);
+    m_search_block_center_index += whole_input_frames;
+    m_search_block_index = m_search_block_center_index - static_cast<i64>(m_search_block_center_offset);
+    remove_old_input_frames();
+    return true;
+}
+
+void WSOLAAlgorithm::remove_old_input_frames()
+{
+    auto const earliest_used_index = min(m_target_block_index, m_search_block_index);
+    if (earliest_used_index <= 0)
+        return;
+
+    m_audio_buffer.drop_front(static_cast<size_t>(earliest_used_index));
+    m_target_block_index -= earliest_used_index;
+    m_search_block_center_index -= earliest_used_index;
+    m_search_block_index -= earliest_used_index;
+}
+
+size_t WSOLAAlgorithm::write_completed_frames_to(size_t requested_frames, size_t destination_offset, Media::AudioBlock& destination)
+{
+    auto const rendered_frames = min(m_num_complete_frames, requested_frames);
+    if (rendered_frames == 0)
+        return 0;
+
+    copy_partial_frames(m_wsola_output, 0, rendered_frames, destination_offset, destination);
+
+    auto const frames_to_move = m_wsola_output.frame_count() - rendered_frames;
+    for (size_t channel_index = 0; channel_index < m_sample_specification.channel_count(); channel_index++) {
+        auto channel_data = m_wsola_output.channel_data(channel_index);
+        for (size_t i = 0; i < frames_to_move; i++)
+            channel_data[i] = channel_data[i + rendered_frames];
+    }
+    m_num_complete_frames -= rendered_frames;
+    return rendered_frames;
+}
+
+}

--- a/Libraries/LibMedia/Audio/WSOLAAlgorithm.h
+++ b/Libraries/LibMedia/Audio/WSOLAAlgorithm.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012 The Chromium Authors
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// Source: chromium/media/filters/audio_renderer_algorithm.{h,cc}.
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibMedia/Audio/AudioBuffer.h>
+#include <LibMedia/Audio/SampleSpecification.h>
+#include <LibMedia/AudioBlock.h>
+
+namespace Audio {
+
+class WSOLAAlgorithm {
+public:
+    explicit WSOLAAlgorithm(SampleSpecification);
+    ~WSOLAAlgorithm();
+
+    WSOLAAlgorithm(WSOLAAlgorithm const&) = delete;
+    WSOLAAlgorithm& operator=(WSOLAAlgorithm const&) = delete;
+
+    size_t fill_buffer(Media::AudioBlock& destination, size_t destination_offset, size_t requested_frames, float playback_rate);
+
+    void enqueue_buffer(Media::AudioBlock const&);
+
+    void flush_buffers();
+
+    void mark_end_of_stream(float playback_rate);
+
+    size_t buffered_frames() const { return m_audio_buffer.frame_count(); }
+
+    SampleSpecification const& sample_specification() const { return m_sample_specification; }
+    u32 sample_rate() const { return m_sample_specification.sample_rate(); }
+    u8 channel_count() const { return m_sample_specification.channel_count(); }
+    size_t ola_window_size() const { return m_ola_window_size; }
+    size_t ola_hop_size() const { return m_ola_hop_size; }
+
+private:
+    bool run_one_wsola_iteration(float playback_rate);
+
+    size_t write_completed_frames_to(size_t requested_frames, size_t destination_offset, Media::AudioBlock&);
+
+    void peek_audio_with_zero_prepend(i64 read_offset_frames, Media::AudioBlock& destination);
+
+    void get_optimal_block();
+
+    bool can_perform_wsola() const;
+
+    bool target_is_within_search_region() const;
+
+    void remove_old_input_frames();
+
+    Media::AudioBlock create_block(size_t frame_count) const;
+
+    SampleSpecification const m_sample_specification;
+
+    AudioBuffer m_audio_buffer;
+
+    size_t const m_ola_window_size;
+    size_t const m_ola_hop_size;
+    size_t const m_num_candidate_blocks;
+    size_t const m_search_block_center_offset;
+
+    float m_input_position_remainder { 0.0f };
+    i64 m_search_block_index { 0 };
+    i64 m_search_block_center_index { 0 };
+    i64 m_target_block_index { 0 };
+
+    size_t m_num_complete_frames { 0 };
+
+    Media::AudioBlock m_wsola_output;
+
+    Vector<float> m_ola_window;
+    Vector<float> m_transition_window;
+
+    Media::AudioBlock m_optimal_block;
+    Media::AudioBlock m_search_block;
+    Media::AudioBlock m_target_block;
+};
+
+}

--- a/Libraries/LibMedia/Audio/WSOLAInternals.cpp
+++ b/Libraries/LibMedia/Audio/WSOLAInternals.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2013 The Chromium Authors
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// Source: chromium/media/filters/wsola_internals.{h,cc}.
+
+#include <AK/Math.h>
+#include <AK/Vector.h>
+#include <LibMedia/Audio/WSOLAInternals.h>
+#include <LibMedia/AudioBlock.h>
+
+namespace Audio::WSOLAInternals {
+
+namespace {
+
+bool in_interval(size_t n, Interval interval)
+{
+    return n >= interval.low && n <= interval.high;
+}
+
+float multi_channel_similarity_measure(ReadonlySpan<float> dot_prod_a_b,
+    ReadonlySpan<float> energy_a, ReadonlySpan<float> energy_b)
+{
+    VERIFY(dot_prod_a_b.size() == energy_a.size());
+    VERIFY(energy_a.size() == energy_b.size());
+    constexpr float epsilon = 1e-12f;
+    auto similarity_measure = 0.0f;
+    for (size_t n = 0; n < dot_prod_a_b.size(); n++)
+        similarity_measure += dot_prod_a_b[n] / AK::sqrt((energy_a[n] * energy_b[n]) + epsilon);
+    return similarity_measure;
+}
+
+}
+
+void multi_channel_dot_product(Media::AudioBlock const& a, size_t frame_offset_a,
+    Media::AudioBlock const& b, size_t frame_offset_b,
+    size_t num_frames, Span<float> dot_product)
+{
+    VERIFY(a.channel_count() == b.channel_count());
+    VERIFY(dot_product.size() == a.channel_count());
+    VERIFY(frame_offset_a <= a.frame_count());
+    VERIFY(num_frames <= a.frame_count() - frame_offset_a);
+    VERIFY(frame_offset_b <= b.frame_count());
+    VERIFY(num_frames <= b.frame_count() - frame_offset_b);
+
+    for (size_t channel_index = 0; channel_index < a.channel_count(); channel_index++) {
+        auto channel_a = a.channel_data(channel_index).slice(frame_offset_a, num_frames);
+        auto channel_b = b.channel_data(channel_index).slice(frame_offset_b, num_frames);
+        auto sum = 0.0f;
+        for (size_t i = 0; i < num_frames; i++)
+            sum += channel_a[i] * channel_b[i];
+        dot_product[channel_index] = sum;
+    }
+}
+
+void multi_channel_moving_block_energies(Media::AudioBlock const& input,
+    size_t frames_per_window, Span<float> energy)
+{
+    auto num_blocks = input.frame_count() - (frames_per_window - 1);
+    auto channel_count = static_cast<size_t>(input.channel_count());
+    VERIFY(energy.size() == num_blocks * channel_count);
+
+    for (size_t channel_index = 0; channel_index < input.channel_count(); channel_index++) {
+        auto input_channel = input.channel_data(channel_index);
+
+        auto first_block_energy = 0.0f;
+        for (size_t i = 0; i < frames_per_window; i++)
+            first_block_energy += input_channel[i] * input_channel[i];
+        energy[channel_index] = first_block_energy;
+
+        for (size_t block_index = 1; block_index < num_blocks; block_index++) {
+            auto leaving_sample = input_channel[block_index - 1];
+            auto entering_sample = input_channel[block_index + frames_per_window - 1];
+            energy[channel_index + (block_index * channel_count)] = energy[channel_index + ((block_index - 1) * channel_count)]
+                - (leaving_sample * leaving_sample)
+                + (entering_sample * entering_sample);
+        }
+    }
+}
+
+void quadratic_interpolation(ReadonlySpan<float> y_values, float& extremum, float& extremum_value)
+{
+    VERIFY(y_values.size() == 3);
+    auto const a = (0.5f * (y_values[2] + y_values[0])) - y_values[1];
+    auto const b = 0.5f * (y_values[2] - y_values[0]);
+    auto const c = y_values[1];
+
+    if (a == 0.0f) {
+        extremum = 0.0f;
+        extremum_value = y_values[1];
+    } else {
+        auto const ext = -b / (2.0f * a);
+        extremum = ext;
+        extremum_value = (a * ext * ext) + (b * ext) + c;
+    }
+}
+
+size_t decimated_search(size_t decimation, Interval exclude_interval,
+    Media::AudioBlock const& target_block, Media::AudioBlock const& search_segment,
+    ReadonlySpan<float> energy_target_block,
+    ReadonlySpan<float> energy_candidate_blocks)
+{
+    auto channel_count = static_cast<size_t>(search_segment.channel_count());
+    auto block_size = target_block.frame_count();
+    auto num_candidate_blocks = search_segment.frame_count() - (block_size - 1);
+    Vector<float> dot_product;
+    dot_product.resize(channel_count);
+    float similarity[3];
+
+    size_t n = 0;
+    multi_channel_dot_product(target_block, 0, search_segment, n, block_size, dot_product.span());
+    similarity[0] = multi_channel_similarity_measure(
+        dot_product.span(), energy_target_block,
+        energy_candidate_blocks.slice(n * channel_count, channel_count));
+
+    auto best_similarity = similarity[0];
+    size_t optimal_block_index = 0;
+
+    n += decimation;
+    if (n >= num_candidate_blocks)
+        return 0;
+
+    multi_channel_dot_product(target_block, 0, search_segment, n, block_size, dot_product.span());
+    similarity[1] = multi_channel_similarity_measure(
+        dot_product.span(), energy_target_block,
+        energy_candidate_blocks.slice(n * channel_count, channel_count));
+
+    n += decimation;
+    if (n >= num_candidate_blocks)
+        return similarity[1] > similarity[0] ? decimation : 0;
+
+    for (; n < num_candidate_blocks; n += decimation) {
+        multi_channel_dot_product(target_block, 0, search_segment, n, block_size, dot_product.span());
+        similarity[2] = multi_channel_similarity_measure(
+            dot_product.span(), energy_target_block,
+            energy_candidate_blocks.slice(n * channel_count, channel_count));
+
+        bool is_local_max = (similarity[1] > similarity[0] && similarity[1] >= similarity[2])
+            || (similarity[1] >= similarity[0] && similarity[1] > similarity[2]);
+
+        if (is_local_max) {
+            float normalized_candidate_index;
+            float candidate_similarity;
+            quadratic_interpolation({ similarity, 3 }, normalized_candidate_index, candidate_similarity);
+
+            auto candidate_index = static_cast<i64>(n - decimation)
+                + AK::round_to<i64>(normalized_candidate_index * static_cast<float>(decimation));
+            if (candidate_similarity > best_similarity
+                && candidate_index >= 0
+                && !in_interval(static_cast<size_t>(candidate_index), exclude_interval)) {
+                optimal_block_index = static_cast<size_t>(candidate_index);
+                best_similarity = candidate_similarity;
+            }
+        } else if (n + decimation >= num_candidate_blocks
+            && similarity[2] > best_similarity
+            && !in_interval(n, exclude_interval)) {
+            optimal_block_index = n;
+            best_similarity = similarity[2];
+        }
+
+        similarity[0] = similarity[1];
+        similarity[1] = similarity[2];
+    }
+    return optimal_block_index;
+}
+
+size_t full_search(size_t low_limit, size_t high_limit, Interval exclude_interval,
+    Media::AudioBlock const& target_block, Media::AudioBlock const& search_block,
+    ReadonlySpan<float> energy_target_block,
+    ReadonlySpan<float> energy_candidate_blocks)
+{
+    auto channel_count = static_cast<size_t>(search_block.channel_count());
+    auto block_size = target_block.frame_count();
+    Vector<float> dot_product;
+    dot_product.resize(channel_count);
+
+    auto best_similarity = -AK::Infinity<float>;
+    size_t optimal_block_index = 0;
+
+    for (size_t n = low_limit; n <= high_limit; n++) {
+        if (in_interval(n, exclude_interval))
+            continue;
+        multi_channel_dot_product(target_block, 0, search_block, n, block_size, dot_product.span());
+        auto similarity = multi_channel_similarity_measure(
+            dot_product.span(), energy_target_block,
+            energy_candidate_blocks.slice(n * channel_count, channel_count));
+        if (similarity > best_similarity) {
+            best_similarity = similarity;
+            optimal_block_index = n;
+        }
+    }
+    return optimal_block_index;
+}
+
+size_t optimal_index(Media::AudioBlock const& search_block, Media::AudioBlock const& target_block,
+    Interval exclude_interval)
+{
+    VERIFY(search_block.channel_count() == target_block.channel_count());
+    auto channel_count = static_cast<size_t>(search_block.channel_count());
+    auto target_size = target_block.frame_count();
+    auto num_candidate_blocks = search_block.frame_count() - (target_size - 1);
+
+    constexpr size_t search_decimation = 5;
+
+    Vector<float> energy_target_block;
+    energy_target_block.resize(channel_count);
+    Vector<float> energy_candidate_blocks;
+    energy_candidate_blocks.resize(channel_count * num_candidate_blocks);
+
+    multi_channel_moving_block_energies(search_block, target_size, energy_candidate_blocks.span());
+    multi_channel_dot_product(target_block, 0, target_block, 0, target_size, energy_target_block.span());
+
+    auto coarse_index = decimated_search(
+        search_decimation, exclude_interval, target_block, search_block,
+        energy_target_block.span(), energy_candidate_blocks.span());
+
+    size_t low_limit = coarse_index < search_decimation ? 0 : coarse_index - search_decimation;
+    auto high_limit = min(num_candidate_blocks - 1, coarse_index + search_decimation);
+    return full_search(low_limit, high_limit, exclude_interval, target_block, search_block,
+        energy_target_block.span(), energy_candidate_blocks.span());
+}
+
+void get_periodic_hanning_window(Span<float> window)
+{
+    auto const scale = 2.0f * AK::Pi<float> / static_cast<float>(window.size());
+    for (size_t n = 0; n < window.size(); n++)
+        window[n] = 0.5f * (1.0f - AK::cos(static_cast<float>(n) * scale));
+}
+
+}

--- a/Libraries/LibMedia/Audio/WSOLAInternals.h
+++ b/Libraries/LibMedia/Audio/WSOLAInternals.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013 The Chromium Authors
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// Source: chromium/media/filters/wsola_internals.{h,cc}.
+
+#pragma once
+
+#include <AK/Span.h>
+#include <AK/Types.h>
+
+namespace Media {
+
+class AudioBlock;
+
+}
+
+namespace Audio::WSOLAInternals {
+
+struct Interval {
+    size_t low;
+    size_t high;
+};
+
+void multi_channel_dot_product(Media::AudioBlock const& a, size_t frame_offset_a,
+    Media::AudioBlock const& b, size_t frame_offset_b,
+    size_t num_frames, Span<float> dot_product);
+
+void multi_channel_moving_block_energies(Media::AudioBlock const& input,
+    size_t frames_per_window, Span<float> energy);
+
+void quadratic_interpolation(ReadonlySpan<float> y_values,
+    float& extremum, float& extremum_value);
+
+size_t decimated_search(size_t decimation, Interval exclude_interval,
+    Media::AudioBlock const& target_block, Media::AudioBlock const& search_segment,
+    ReadonlySpan<float> energy_target_block,
+    ReadonlySpan<float> energy_candidate_blocks);
+
+size_t full_search(size_t low_limit, size_t high_limit, Interval exclude_interval,
+    Media::AudioBlock const& target_block, Media::AudioBlock const& search_block,
+    ReadonlySpan<float> energy_target_block,
+    ReadonlySpan<float> energy_candidate_blocks);
+
+size_t optimal_index(Media::AudioBlock const& search_block, Media::AudioBlock const& target_block,
+    Interval exclude_interval);
+
+void get_periodic_hanning_window(Span<float> window);
+
+}

--- a/Libraries/LibMedia/Audio/WSOLATimeStretcher.cpp
+++ b/Libraries/LibMedia/Audio/WSOLATimeStretcher.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <AK/OwnPtr.h>
+#include <AK/SaturatingMath.h>
+#include <LibMedia/Audio/WSOLAAlgorithm.h>
+#include <LibMedia/Audio/WSOLATimeStretcher.h>
+
+namespace Audio {
+
+struct WSOLATimeStretcher::Impl {
+    SampleSpecification sample_specification;
+
+    NonnullOwnPtr<WSOLAAlgorithm> algorithm;
+
+    float rate { 1.0f };
+
+    i64 first_input_frame_after_flush { 0 };
+    i64 next_output_frame_index { 0 };
+    i64 expected_next_input_media_frame { 0 };
+    i64 input_frames_consumed_since_flush { 0 };
+    i64 input_end_frame_at_eos { 0 };
+    float media_frames_remainder { 0.0f };
+
+    bool eos_signalled { false };
+
+    size_t output_chunk_frames() const
+    {
+        return max<size_t>(1, AK::round_to<size_t>(sample_specification.sample_rate() * 0.03));
+    }
+
+    Impl(SampleSpecification sample_specification)
+        : sample_specification(sample_specification)
+        , algorithm(make<WSOLAAlgorithm>(sample_specification))
+    {
+    }
+};
+
+ErrorOr<NonnullOwnPtr<TimeStretcher>> WSOLATimeStretcher::create(SampleSpecification sample_specification)
+{
+    if (!sample_specification.is_valid())
+        return Error::from_string_literal("Invalid sample specification");
+
+    auto impl = adopt_own(*new Impl(sample_specification));
+    return adopt_own(*new WSOLATimeStretcher(move(impl)));
+}
+
+WSOLATimeStretcher::WSOLATimeStretcher(NonnullOwnPtr<Impl> impl)
+    : m_impl(move(impl))
+{
+}
+
+WSOLATimeStretcher::~WSOLATimeStretcher() = default;
+
+i64 WSOLATimeStretcher::preroll_frame_count() const
+{
+    auto const& impl = *m_impl;
+    return static_cast<i64>(AK::ceil(static_cast<float>(impl.algorithm->ola_window_size()) * impl.rate));
+}
+
+void WSOLATimeStretcher::set_rate(float rate)
+{
+    VERIFY(isfinite(rate));
+    VERIFY(rate > 0.0f);
+    m_impl->rate = rate;
+}
+
+void WSOLATimeStretcher::flush(AK::Duration media_start_timestamp, i64 output_start_frame_index)
+{
+    m_impl->algorithm->flush_buffers();
+    m_impl->input_frames_consumed_since_flush = 0;
+    m_impl->input_end_frame_at_eos = 0;
+    m_impl->media_frames_remainder = 0.0f;
+    m_impl->eos_signalled = false;
+
+    auto media_start_in_frames = media_start_timestamp.to_time_units(1, m_impl->sample_specification.sample_rate());
+    m_impl->first_input_frame_after_flush = media_start_in_frames;
+    m_impl->next_output_frame_index = output_start_frame_index;
+    m_impl->expected_next_input_media_frame = media_start_in_frames;
+}
+
+void WSOLATimeStretcher::push_block(Media::AudioBlock const& input)
+{
+    VERIFY(!input.is_empty());
+    auto& impl = *m_impl;
+    VERIFY(input.sample_specification() == impl.sample_specification);
+
+    auto block_start = input.first_frame_index();
+    auto frame_count = input.frame_count();
+    size_t frames_to_skip = 0;
+
+    auto gap = saturating_sub(block_start, impl.expected_next_input_media_frame);
+    if (gap > 0) {
+        constexpr i64 max_silence_chunk = 4096;
+        while (gap > 0) {
+            auto chunk_frame_count = static_cast<size_t>(min<i64>(gap, max_silence_chunk));
+            Media::AudioBlock silence;
+            silence.initialize(impl.sample_specification, impl.expected_next_input_media_frame, chunk_frame_count);
+            for (size_t channel_index = 0; channel_index < silence.channel_count(); channel_index++) {
+                auto channel = silence.channel_data(channel_index);
+                for (auto& sample : channel)
+                    sample = 0.0f;
+            }
+            impl.algorithm->enqueue_buffer(silence);
+            impl.expected_next_input_media_frame = saturating_add(impl.expected_next_input_media_frame, AK::clamp_to<i64>(chunk_frame_count));
+            gap -= static_cast<i64>(chunk_frame_count);
+        }
+    } else if (gap < 0) {
+        frames_to_skip = min(-static_cast<size_t>(gap), frame_count);
+        if (frames_to_skip == frame_count) {
+            impl.expected_next_input_media_frame = max(
+                impl.expected_next_input_media_frame, saturating_add(block_start, AK::clamp_to<i64>(frame_count)));
+            return;
+        }
+    }
+
+    auto const frames_to_append = frame_count - frames_to_skip;
+    Media::AudioBlock block_to_append;
+    block_to_append.initialize(impl.sample_specification, saturating_add(block_start, AK::clamp_to<i64>(frames_to_skip)), frames_to_append);
+    for (size_t channel_index = 0; channel_index < input.channel_count(); channel_index++) {
+        auto input_channel = input.channel_data(channel_index).slice(frames_to_skip, frames_to_append);
+        auto output_channel = block_to_append.channel_data(channel_index);
+        AK::TypedTransfer<float>::copy(output_channel.data(), input_channel.data(), frames_to_append);
+    }
+
+    impl.algorithm->enqueue_buffer(block_to_append);
+    impl.expected_next_input_media_frame = saturating_add(block_start, AK::clamp_to<i64>(frame_count));
+}
+
+void WSOLATimeStretcher::signal_end_of_stream()
+{
+    if (m_impl->eos_signalled)
+        return;
+    m_impl->input_end_frame_at_eos = m_impl->expected_next_input_media_frame;
+    m_impl->eos_signalled = true;
+    m_impl->algorithm->mark_end_of_stream(m_impl->rate);
+}
+
+Media::DecoderErrorOr<Media::AudioBlock> WSOLATimeStretcher::retrieve_block()
+{
+    auto const target_output_count = m_impl->output_chunk_frames();
+
+    Media::AudioBlock output_block;
+    output_block.initialize(m_impl->sample_specification, m_impl->next_output_frame_index, target_output_count);
+    auto const rendered = m_impl->algorithm->fill_buffer(output_block, 0, target_output_count, m_impl->rate);
+
+    if (rendered == 0) {
+        if (m_impl->eos_signalled)
+            return Media::DecoderError::with_description(Media::DecoderErrorCategory::EndOfStream, "End of stream"sv);
+        return Media::DecoderError::with_description(Media::DecoderErrorCategory::NeedsMoreInput, "Need more input"sv);
+    }
+
+    output_block.trim(rendered);
+
+    auto media_start_in_frames = saturating_add(m_impl->first_input_frame_after_flush, m_impl->input_frames_consumed_since_flush);
+    auto media_duration_in_frames_fractional = (static_cast<float>(rendered) * m_impl->rate) + m_impl->media_frames_remainder;
+    if (m_impl->eos_signalled) {
+        if (m_impl->input_end_frame_at_eos < media_start_in_frames)
+            return Media::DecoderError::with_description(Media::DecoderErrorCategory::EndOfStream, "End of stream"sv);
+        auto remaining_media_frames = static_cast<float>(m_impl->input_end_frame_at_eos - media_start_in_frames);
+        if (media_duration_in_frames_fractional > remaining_media_frames) {
+            auto remaining_output_frames_from_this_block = remaining_media_frames / m_impl->rate;
+            auto frames_to_keep = min(rendered, static_cast<size_t>(remaining_output_frames_from_this_block));
+            if (frames_to_keep == 0)
+                return Media::DecoderError::with_description(Media::DecoderErrorCategory::EndOfStream, "End of stream"sv);
+            output_block.trim(frames_to_keep);
+            media_duration_in_frames_fractional = static_cast<float>(frames_to_keep) * m_impl->rate;
+        }
+    }
+
+    auto media_duration_in_frames = static_cast<i64>(media_duration_in_frames_fractional);
+
+    output_block.set_media_time_start(AK::Duration::from_time_units(media_start_in_frames, 1, m_impl->sample_specification.sample_rate()));
+    output_block.set_media_time_duration(AK::Duration::from_time_units(media_duration_in_frames, 1, m_impl->sample_specification.sample_rate()));
+
+    m_impl->next_output_frame_index = saturating_add(m_impl->next_output_frame_index, AK::clamp_to<i64>(output_block.frame_count()));
+    m_impl->input_frames_consumed_since_flush = saturating_add(m_impl->input_frames_consumed_since_flush, media_duration_in_frames);
+    m_impl->media_frames_remainder = media_duration_in_frames_fractional - static_cast<float>(media_duration_in_frames);
+
+    return output_block;
+}
+
+}

--- a/Libraries/LibMedia/Audio/WSOLATimeStretcher.h
+++ b/Libraries/LibMedia/Audio/WSOLATimeStretcher.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <LibMedia/Audio/TimeStretcher.h>
+
+namespace Audio {
+
+class WSOLATimeStretcher final : public TimeStretcher {
+public:
+    static ErrorOr<NonnullOwnPtr<TimeStretcher>> create(SampleSpecification);
+    virtual ~WSOLATimeStretcher() override;
+
+    virtual i64 preroll_frame_count() const override;
+    virtual void flush(AK::Duration media_start_timestamp, i64 output_start_frame_index) override;
+    virtual void set_rate(float) override;
+    virtual void push_block(Media::AudioBlock const&) override;
+    virtual Media::DecoderErrorOr<Media::AudioBlock> retrieve_block() override;
+    virtual void signal_end_of_stream() override;
+
+private:
+    struct Impl;
+
+    explicit WSOLATimeStretcher(NonnullOwnPtr<Impl>);
+    NonnullOwnPtr<Impl> m_impl;
+};
+
+}

--- a/Libraries/LibMedia/AudioBlock.h
+++ b/Libraries/LibMedia/AudioBlock.h
@@ -6,53 +6,93 @@
 
 #pragma once
 
+#include <AK/Checked.h>
+#include <AK/FixedArray.h>
 #include <AK/Math.h>
+#include <AK/NumericLimits.h>
 #include <AK/SaturatingMath.h>
 #include <AK/Time.h>
-#include <AK/Vector.h>
 #include <LibMedia/Audio/SampleSpecification.h>
 
 namespace Media {
 
 class AudioBlock {
 public:
-    using Data = Vector<float>;
-
     Audio::SampleSpecification const& sample_specification() const { return m_sample_specification; }
     AK::Duration timestamp() const { return m_timestamp; }
     i64 timestamp_in_frames() const { return m_timestamp_in_frames; }
     i64 end_timestamp_in_frames() const { return saturating_add(m_timestamp_in_frames, AK::clamp_to<i64>(frame_count())); }
     AK::Duration end_timestamp() const { return AK::Duration::from_time_units(end_timestamp_in_frames(), 1, sample_rate()); }
-    Span<float> data() { return m_data; }
-    ReadonlySpan<float> data() const { return m_data; }
+    Span<float> channel_data(size_t channel)
+    {
+        VERIFY(channel < channel_count());
+        return m_data.span().slice(channel * frame_capacity(), m_frame_count);
+    }
+    ReadonlySpan<float> channel_data(size_t channel) const
+    {
+        VERIFY(channel < channel_count());
+        return m_data.span().slice(channel * frame_capacity(), m_frame_count);
+    }
+    float sample(size_t channel, size_t frame) const
+    {
+        return channel_data(channel)[frame];
+    }
+    void set_sample(size_t channel, size_t frame, float sample)
+    {
+        channel_data(channel)[frame] = sample;
+    }
 
     void clear()
     {
         m_sample_specification = {};
+        m_timestamp = {};
         m_timestamp_in_frames = 0;
-        m_data.clear_with_capacity();
+        m_frame_count = 0;
     }
-    template<typename Callback>
-    void emplace(Audio::SampleSpecification sample_specification, AK::Duration timestamp, Callback data_callback)
+    void initialize(Audio::SampleSpecification sample_specification, AK::Duration timestamp, size_t frame_count)
     {
         VERIFY(sample_specification.is_valid());
+        VERIFY(frame_count <= NumericLimits<i64>::max());
+        VERIFY(!Checked<size_t>::multiplication_would_overflow(frame_count, sample_specification.channel_count()));
         m_sample_specification = sample_specification;
         m_timestamp = timestamp;
         m_timestamp_in_frames = timestamp.to_time_units(1, sample_rate());
-        data_callback(m_data);
+        m_frame_count = frame_count;
+        ensure_frame_capacity(frame_count);
     }
-    template<typename Callback>
-    void emplace(Audio::SampleSpecification sample_specification, i64 timestamp_in_frames, Callback data_callback)
+    void initialize(Audio::SampleSpecification sample_specification, i64 timestamp_in_frames, size_t frame_count)
     {
         VERIFY(sample_specification.is_valid());
+        VERIFY(frame_count <= NumericLimits<i64>::max());
+        VERIFY(!Checked<size_t>::multiplication_would_overflow(frame_count, sample_specification.channel_count()));
         m_sample_specification = sample_specification;
         m_timestamp_in_frames = timestamp_in_frames;
         m_timestamp = AK::Duration::from_time_units(timestamp_in_frames, 1, sample_rate());
-        data_callback(m_data);
+        m_frame_count = frame_count;
+        ensure_frame_capacity(frame_count);
     }
     void trim(size_t frame_count)
     {
-        m_data.resize_and_keep_capacity(frame_count * channel_count());
+        VERIFY(frame_count <= m_frame_count);
+        m_frame_count = frame_count;
+    }
+    size_t copy_to_interleaved(Span<float> destination, size_t source_frame_offset = 0) const
+    {
+        VERIFY(!is_empty());
+        auto channels = channel_count();
+        VERIFY(destination.size() % channels == 0);
+
+        auto available_frames = frame_count();
+        if (source_frame_offset >= available_frames)
+            return 0;
+
+        auto frames_to_copy = min(destination.size() / channels, available_frames - source_frame_offset);
+        for (size_t channel = 0; channel < channels; channel++) {
+            auto source_channel = channel_data(channel).slice(source_frame_offset, frames_to_copy);
+            for (size_t frame = 0; frame < frames_to_copy; frame++)
+                destination[(frame * channels) + channel] = source_channel[frame];
+        }
+        return frames_to_copy * channels;
     }
     u32 sample_rate() const
     {
@@ -70,7 +110,7 @@ public:
     }
     size_t sample_count() const
     {
-        return data().size();
+        return frame_count() * channel_count();
     }
     u8 channel_count() const
     {
@@ -78,14 +118,30 @@ public:
     }
     size_t frame_count() const
     {
-        return sample_count() / channel_count();
+        return m_frame_count;
     }
 
 private:
+    size_t frame_capacity() const
+    {
+        if (!is_empty())
+            return m_data.size() / channel_count();
+        return 0;
+    }
+
+    void ensure_frame_capacity(size_t frame_count)
+    {
+        if (frame_capacity() >= frame_count)
+            return;
+        VERIFY(!Checked<size_t>::multiplication_would_overflow(frame_count, channel_count()));
+        m_data = MUST(FixedArray<float>::create(frame_count * channel_count()));
+    }
+
     Audio::SampleSpecification m_sample_specification;
     AK::Duration m_timestamp;
     i64 m_timestamp_in_frames { 0 };
-    Data m_data;
+    size_t m_frame_count { 0 };
+    FixedArray<float> m_data;
 };
 
 }

--- a/Libraries/LibMedia/AudioBlock.h
+++ b/Libraries/LibMedia/AudioBlock.h
@@ -20,7 +20,8 @@ class AudioBlock {
 public:
     Audio::SampleSpecification const& sample_specification() const { return m_sample_specification; }
     AK::Duration media_time_start() const { return m_media_time_start; }
-    AK::Duration media_time_end() const { return AK::Duration::from_time_units(end_frame_index(), 1, sample_rate()); }
+    AK::Duration media_time_duration() const { return m_media_time_duration; }
+    AK::Duration media_time_end() const { return m_media_time_start + m_media_time_duration; }
     i64 first_frame_index() const { return m_first_frame_index; }
     i64 end_frame_index() const { return saturating_add(m_first_frame_index, AK::clamp_to<i64>(frame_count())); }
     Span<float> channel_data(size_t channel)
@@ -46,6 +47,7 @@ public:
     {
         m_sample_specification = {};
         m_media_time_start = {};
+        m_media_time_duration = {};
         m_first_frame_index = 0;
         m_frame_count = 0;
     }
@@ -59,6 +61,7 @@ public:
         m_first_frame_index = media_time_start.to_time_units(1, sample_rate());
         m_frame_count = frame_count;
         ensure_frame_capacity(frame_count);
+        recalculate_media_duration_from_frame_count();
     }
     void initialize(Audio::SampleSpecification sample_specification, i64 first_frame_index, size_t frame_count)
     {
@@ -70,11 +73,13 @@ public:
         m_media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate());
         m_frame_count = frame_count;
         ensure_frame_capacity(frame_count);
+        recalculate_media_duration_from_frame_count();
     }
     void trim(size_t frame_count)
     {
         VERIFY(frame_count <= m_frame_count);
         m_frame_count = frame_count;
+        recalculate_media_duration_from_frame_count();
     }
     size_t copy_to_interleaved(Span<float> destination, size_t source_frame_offset = 0) const
     {
@@ -104,6 +109,17 @@ public:
         m_first_frame_index = first_frame_index;
         m_media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate());
     }
+    void set_media_time_start(AK::Duration media_time_start)
+    {
+        VERIFY(!is_empty());
+        m_media_time_start = media_time_start;
+    }
+    void set_media_time_duration(AK::Duration media_time_duration)
+    {
+        VERIFY(!is_empty());
+        VERIFY(!media_time_duration.is_negative());
+        m_media_time_duration = media_time_duration;
+    }
     bool is_empty() const
     {
         return !sample_specification().is_valid();
@@ -122,6 +138,11 @@ public:
     }
 
 private:
+    void recalculate_media_duration_from_frame_count()
+    {
+        m_media_time_duration = AK::Duration::from_time_units(AK::clamp_to<i64>(frame_count()), 1, sample_rate());
+    }
+
     size_t frame_capacity() const
     {
         if (!is_empty())
@@ -139,6 +160,7 @@ private:
 
     Audio::SampleSpecification m_sample_specification;
     AK::Duration m_media_time_start;
+    AK::Duration m_media_time_duration;
     i64 m_first_frame_index { 0 };
     size_t m_frame_count { 0 };
     FixedArray<float> m_data;

--- a/Libraries/LibMedia/AudioBlock.h
+++ b/Libraries/LibMedia/AudioBlock.h
@@ -19,10 +19,10 @@ namespace Media {
 class AudioBlock {
 public:
     Audio::SampleSpecification const& sample_specification() const { return m_sample_specification; }
-    AK::Duration timestamp() const { return m_timestamp; }
-    i64 timestamp_in_frames() const { return m_timestamp_in_frames; }
-    i64 end_timestamp_in_frames() const { return saturating_add(m_timestamp_in_frames, AK::clamp_to<i64>(frame_count())); }
-    AK::Duration end_timestamp() const { return AK::Duration::from_time_units(end_timestamp_in_frames(), 1, sample_rate()); }
+    AK::Duration media_time_start() const { return m_media_time_start; }
+    AK::Duration media_time_end() const { return AK::Duration::from_time_units(end_frame_index(), 1, sample_rate()); }
+    i64 first_frame_index() const { return m_first_frame_index; }
+    i64 end_frame_index() const { return saturating_add(m_first_frame_index, AK::clamp_to<i64>(frame_count())); }
     Span<float> channel_data(size_t channel)
     {
         VERIFY(channel < channel_count());
@@ -45,29 +45,29 @@ public:
     void clear()
     {
         m_sample_specification = {};
-        m_timestamp = {};
-        m_timestamp_in_frames = 0;
+        m_media_time_start = {};
+        m_first_frame_index = 0;
         m_frame_count = 0;
     }
-    void initialize(Audio::SampleSpecification sample_specification, AK::Duration timestamp, size_t frame_count)
+    void initialize(Audio::SampleSpecification sample_specification, AK::Duration media_time_start, size_t frame_count)
     {
         VERIFY(sample_specification.is_valid());
         VERIFY(frame_count <= NumericLimits<i64>::max());
         VERIFY(!Checked<size_t>::multiplication_would_overflow(frame_count, sample_specification.channel_count()));
         m_sample_specification = sample_specification;
-        m_timestamp = timestamp;
-        m_timestamp_in_frames = timestamp.to_time_units(1, sample_rate());
+        m_media_time_start = media_time_start;
+        m_first_frame_index = media_time_start.to_time_units(1, sample_rate());
         m_frame_count = frame_count;
         ensure_frame_capacity(frame_count);
     }
-    void initialize(Audio::SampleSpecification sample_specification, i64 timestamp_in_frames, size_t frame_count)
+    void initialize(Audio::SampleSpecification sample_specification, i64 first_frame_index, size_t frame_count)
     {
         VERIFY(sample_specification.is_valid());
         VERIFY(frame_count <= NumericLimits<i64>::max());
         VERIFY(!Checked<size_t>::multiplication_would_overflow(frame_count, sample_specification.channel_count()));
         m_sample_specification = sample_specification;
-        m_timestamp_in_frames = timestamp_in_frames;
-        m_timestamp = AK::Duration::from_time_units(timestamp_in_frames, 1, sample_rate());
+        m_first_frame_index = first_frame_index;
+        m_media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate());
         m_frame_count = frame_count;
         ensure_frame_capacity(frame_count);
     }
@@ -98,11 +98,11 @@ public:
     {
         return sample_specification().sample_rate();
     }
-    void set_timestamp_in_frames(i64 timestamp_in_frames)
+    void set_first_frame_index(i64 first_frame_index)
     {
         VERIFY(!is_empty());
-        m_timestamp_in_frames = timestamp_in_frames;
-        m_timestamp = AK::Duration::from_time_units(timestamp_in_frames, 1, sample_rate());
+        m_first_frame_index = first_frame_index;
+        m_media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate());
     }
     bool is_empty() const
     {
@@ -138,8 +138,8 @@ private:
     }
 
     Audio::SampleSpecification m_sample_specification;
-    AK::Duration m_timestamp;
-    i64 m_timestamp_in_frames { 0 };
+    AK::Duration m_media_time_start;
+    i64 m_first_frame_index { 0 };
     size_t m_frame_count { 0 };
     FixedArray<float> m_data;
 };

--- a/Libraries/LibMedia/AudioBlock.h
+++ b/Libraries/LibMedia/AudioBlock.h
@@ -10,20 +10,21 @@
 #include <AK/FixedArray.h>
 #include <AK/Math.h>
 #include <AK/NumericLimits.h>
-#include <AK/SaturatingMath.h>
-#include <AK/Time.h>
 #include <LibMedia/Audio/SampleSpecification.h>
+#include <LibMedia/AudioBlockTiming.h>
 
 namespace Media {
 
 class AudioBlock {
 public:
     Audio::SampleSpecification const& sample_specification() const { return m_sample_specification; }
-    AK::Duration media_time_start() const { return m_media_time_start; }
-    AK::Duration media_time_duration() const { return m_media_time_duration; }
-    AK::Duration media_time_end() const { return m_media_time_start + m_media_time_duration; }
-    i64 first_frame_index() const { return m_first_frame_index; }
-    i64 end_frame_index() const { return saturating_add(m_first_frame_index, AK::clamp_to<i64>(frame_count())); }
+    AudioBlockTiming const& timing() const { return m_timing; }
+    AudioBlockTiming& timing() { return m_timing; }
+    AK::Duration media_time_start() const { return m_timing.media_time_start(); }
+    AK::Duration media_time_duration() const { return m_timing.media_time_duration(); }
+    AK::Duration media_time_end() const { return m_timing.media_time_end(); }
+    i64 first_frame_index() const { return m_timing.first_frame_index(); }
+    i64 end_frame_index() const { return m_timing.end_frame_index(); }
     Span<float> channel_data(size_t channel)
     {
         VERIFY(channel < channel_count());
@@ -46,9 +47,7 @@ public:
     void clear()
     {
         m_sample_specification = {};
-        m_media_time_start = {};
-        m_media_time_duration = {};
-        m_first_frame_index = 0;
+        m_timing.clear();
         m_frame_count = 0;
     }
     void initialize(Audio::SampleSpecification sample_specification, AK::Duration media_time_start, size_t frame_count)
@@ -57,11 +56,9 @@ public:
         VERIFY(frame_count <= NumericLimits<i64>::max());
         VERIFY(!Checked<size_t>::multiplication_would_overflow(frame_count, sample_specification.channel_count()));
         m_sample_specification = sample_specification;
-        m_media_time_start = media_time_start;
-        m_first_frame_index = media_time_start.to_time_units(1, sample_rate());
         m_frame_count = frame_count;
+        m_timing.initialize(media_time_start, sample_rate(), AK::clamp_to<i64>(frame_count));
         ensure_frame_capacity(frame_count);
-        recalculate_media_duration_from_frame_count();
     }
     void initialize(Audio::SampleSpecification sample_specification, i64 first_frame_index, size_t frame_count)
     {
@@ -69,17 +66,15 @@ public:
         VERIFY(frame_count <= NumericLimits<i64>::max());
         VERIFY(!Checked<size_t>::multiplication_would_overflow(frame_count, sample_specification.channel_count()));
         m_sample_specification = sample_specification;
-        m_first_frame_index = first_frame_index;
-        m_media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate());
         m_frame_count = frame_count;
+        m_timing.initialize(first_frame_index, sample_rate(), AK::clamp_to<i64>(frame_count));
         ensure_frame_capacity(frame_count);
-        recalculate_media_duration_from_frame_count();
     }
     void trim(size_t frame_count)
     {
         VERIFY(frame_count <= m_frame_count);
         m_frame_count = frame_count;
-        recalculate_media_duration_from_frame_count();
+        m_timing.set_frame_count(sample_rate(), AK::clamp_to<i64>(frame_count));
     }
     size_t copy_to_interleaved(Span<float> destination, size_t source_frame_offset = 0) const
     {
@@ -106,19 +101,17 @@ public:
     void set_first_frame_index(i64 first_frame_index)
     {
         VERIFY(!is_empty());
-        m_first_frame_index = first_frame_index;
-        m_media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate());
+        m_timing.set_first_frame_index(first_frame_index, sample_rate());
     }
     void set_media_time_start(AK::Duration media_time_start)
     {
         VERIFY(!is_empty());
-        m_media_time_start = media_time_start;
+        m_timing.set_media_time_start(media_time_start);
     }
     void set_media_time_duration(AK::Duration media_time_duration)
     {
         VERIFY(!is_empty());
-        VERIFY(!media_time_duration.is_negative());
-        m_media_time_duration = media_time_duration;
+        m_timing.set_media_time_duration(media_time_duration);
     }
     bool is_empty() const
     {
@@ -138,11 +131,6 @@ public:
     }
 
 private:
-    void recalculate_media_duration_from_frame_count()
-    {
-        m_media_time_duration = AK::Duration::from_time_units(AK::clamp_to<i64>(frame_count()), 1, sample_rate());
-    }
-
     size_t frame_capacity() const
     {
         if (!is_empty())
@@ -159,9 +147,7 @@ private:
     }
 
     Audio::SampleSpecification m_sample_specification;
-    AK::Duration m_media_time_start;
-    AK::Duration m_media_time_duration;
-    i64 m_first_frame_index { 0 };
+    AudioBlockTiming m_timing;
     size_t m_frame_count { 0 };
     FixedArray<float> m_data;
 };

--- a/Libraries/LibMedia/AudioBlockTiming.h
+++ b/Libraries/LibMedia/AudioBlockTiming.h
@@ -22,6 +22,29 @@ public:
     i64 frame_count() const { return m_frame_count; }
     i64 end_frame_index() const { return saturating_add(m_first_frame_index, m_frame_count); }
 
+    bool contains_frame_index(i64 frame_index) const
+    {
+        return frame_index >= first_frame_index() && frame_index < end_frame_index();
+    }
+
+    AK::Duration media_time_at_frame_index(i64 frame_index) const
+    {
+        VERIFY(frame_count() > 0);
+        if (frame_index < first_frame_index()) {
+            auto frame_offset = AK::clamp_to<u32>(first_frame_index() - frame_index);
+            auto block_frame_count = AK::clamp_to<u32>(frame_count());
+            return media_time_start() - media_time_duration().scaled_by(frame_offset, block_frame_count);
+        }
+        if (frame_index == first_frame_index())
+            return media_time_start();
+        if (frame_index >= end_frame_index())
+            return media_time_end();
+
+        auto frame_offset = AK::clamp_to<u32>(frame_index - first_frame_index());
+        auto block_frame_count = AK::clamp_to<u32>(frame_count());
+        return media_time_start() + media_time_duration().scaled_by(frame_offset, block_frame_count);
+    }
+
     void clear()
     {
         m_media_time_start = {};

--- a/Libraries/LibMedia/AudioBlockTiming.h
+++ b/Libraries/LibMedia/AudioBlockTiming.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Math.h>
+#include <AK/SaturatingMath.h>
+#include <AK/Time.h>
+
+namespace Media {
+
+class AudioBlockTiming {
+public:
+    AK::Duration media_time_start() const { return m_media_time_start; }
+    AK::Duration media_time_duration() const { return m_media_time_duration; }
+    AK::Duration media_time_end() const { return m_media_time_start + m_media_time_duration; }
+
+    i64 first_frame_index() const { return m_first_frame_index; }
+    i64 frame_count() const { return m_frame_count; }
+    i64 end_frame_index() const { return saturating_add(m_first_frame_index, m_frame_count); }
+
+    void clear()
+    {
+        m_media_time_start = {};
+        m_media_time_duration = {};
+        m_first_frame_index = 0;
+        m_frame_count = 0;
+    }
+
+    void initialize(AK::Duration media_time_start, u32 sample_rate, i64 frame_count)
+    {
+        m_media_time_start = media_time_start;
+        m_first_frame_index = media_time_start.to_time_units(1, sample_rate);
+        m_frame_count = frame_count;
+        recalculate_media_duration_from_frame_count(sample_rate);
+    }
+
+    void initialize(i64 first_frame_index, u32 sample_rate, i64 frame_count)
+    {
+        m_first_frame_index = first_frame_index;
+        m_media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate);
+        m_frame_count = frame_count;
+        recalculate_media_duration_from_frame_count(sample_rate);
+    }
+
+    void set_frame_count(u32 sample_rate, i64 frame_count)
+    {
+        m_frame_count = frame_count;
+        recalculate_media_duration_from_frame_count(sample_rate);
+    }
+
+    void set_first_frame_index(i64 first_frame_index, u32 sample_rate)
+    {
+        m_first_frame_index = first_frame_index;
+        m_media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate);
+    }
+
+    void set_media_time_start(AK::Duration media_time_start) { m_media_time_start = media_time_start; }
+    void set_media_time_duration(AK::Duration media_time_duration)
+    {
+        VERIFY(!media_time_duration.is_negative());
+        m_media_time_duration = media_time_duration;
+    }
+
+private:
+    void recalculate_media_duration_from_frame_count(u32 sample_rate)
+    {
+        m_media_time_duration = AK::Duration::from_time_units(m_frame_count, 1, sample_rate);
+    }
+
+    AK::Duration m_media_time_start;
+    AK::Duration m_media_time_duration;
+    i64 m_first_frame_index { 0 };
+    i64 m_frame_count { 0 };
+};
+
+}

--- a/Libraries/LibMedia/AudioBlockTimingRing.h
+++ b/Libraries/LibMedia/AudioBlockTimingRing.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/Atomic.h>
+#include <AK/Optional.h>
+#include <LibMedia/AudioBlockTiming.h>
+
+namespace Media {
+
+class AudioBlockTimingRing {
+public:
+    static constexpr size_t capacity = 32;
+
+    void clear()
+    {
+        m_first_valid_sequence = m_latest_sequence.load() + 1;
+    }
+
+    void enqueue(AudioBlockTiming timing)
+    {
+        auto sequence = m_latest_sequence.load() + 1;
+        auto& slot = m_slots[sequence % capacity];
+
+        auto version = slot.version.load();
+        slot.version.store(version + 1);
+        slot.sequence = sequence;
+        slot.timing = timing;
+        slot.version.store(version + 2);
+
+        m_latest_sequence.store(sequence);
+    }
+
+    Optional<AudioBlockTiming> find_timing_for_frame_index(i64 frame_index) const
+    {
+        auto latest_sequence = m_latest_sequence.load();
+        auto first_valid_sequence = m_first_valid_sequence.load();
+        if (latest_sequence < first_valid_sequence)
+            return {};
+
+        Optional<AudioBlockTiming> oldest_timing;
+        auto sequence_count = min<u64>(latest_sequence - first_valid_sequence + 1, capacity);
+        for (u64 i = 0; i < sequence_count; ++i) {
+            auto sequence = latest_sequence - i;
+            if (sequence < first_valid_sequence)
+                break;
+
+            auto record = read_record(sequence);
+            if (!record.has_value())
+                continue;
+
+            auto const& timing = record->timing;
+            if (timing.contains_frame_index(frame_index))
+                return timing;
+            if (frame_index >= timing.end_frame_index())
+                return timing;
+            oldest_timing = timing;
+        }
+
+        return oldest_timing;
+    }
+
+private:
+    struct Record {
+        u64 sequence { 0 };
+        AudioBlockTiming timing;
+    };
+
+    struct Slot {
+        Atomic<u64> version { 0 };
+        u64 sequence { 0 };
+        AudioBlockTiming timing;
+    };
+
+    Optional<Record> read_record(u64 expected_sequence) const
+    {
+        auto const& slot = m_slots[expected_sequence % capacity];
+
+        auto version_before = slot.version.load();
+        if (version_before % 2 != 0)
+            return {};
+
+        Record record {
+            .sequence = slot.sequence,
+            .timing = slot.timing,
+        };
+
+        auto version_after = slot.version.load();
+        if (version_before != version_after || version_after % 2 != 0)
+            return {};
+        if (record.sequence != expected_sequence)
+            return {};
+        return record;
+    }
+
+    Atomic<u64> m_latest_sequence { 0 };
+    Atomic<u64> m_first_valid_sequence { 1 };
+    Array<Slot, capacity> m_slots;
+};
+
+}

--- a/Libraries/LibMedia/AudioBlockTimingRing.h
+++ b/Libraries/LibMedia/AudioBlockTimingRing.h
@@ -36,6 +36,18 @@ public:
         m_latest_sequence.store(sequence);
     }
 
+    Optional<AudioBlockTiming> latest_timing() const
+    {
+        auto latest_sequence = m_latest_sequence.load();
+        if (latest_sequence < m_first_valid_sequence.load())
+            return {};
+
+        auto record = read_record(latest_sequence);
+        if (!record.has_value())
+            return {};
+        return record->timing;
+    }
+
     Optional<AudioBlockTiming> find_timing_for_frame_index(i64 frame_index) const
     {
         auto latest_sequence = m_latest_sequence.load();

--- a/Libraries/LibMedia/CMakeLists.txt
+++ b/Libraries/LibMedia/CMakeLists.txt
@@ -1,7 +1,11 @@
 include(audio)
 
 set(SOURCES
+    Audio/AudioBuffer.cpp
     Audio/AudioDevices.cpp
+    Audio/WSOLAAlgorithm.cpp
+    Audio/WSOLAInternals.cpp
+    Audio/WSOLATimeStretcher.cpp
     Codecs/FLAC.cpp
     Codecs/Opus.cpp
     Codecs/Vorbis.cpp
@@ -22,6 +26,7 @@ set(SOURCES
     PlaybackStates/PlaybackStateHandler.cpp
     PlaybackStates/ResumingStateHandler.cpp
     Processors/AudioMixer.cpp
+    Processors/AudioTimeStretchProcessor.cpp
     Producers/DecodedAudioProducer.cpp
     Producers/DecodedVideoProducer.cpp
     Sinks/AudioPlaybackSink.cpp

--- a/Libraries/LibMedia/FFmpeg/FFmpegAudioConverter.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegAudioConverter.cpp
@@ -62,8 +62,8 @@ ErrorOr<void> FFmpegAudioConverter::set_sample_specifications(Audio::SampleSpeci
     auto output_sample_rate = static_cast<int>(output.sample_rate());
 
     auto allocation_result = swr_alloc_set_opts2(&m_context,
-        &output_channel_layout, AVSampleFormat::AV_SAMPLE_FMT_FLT, output_sample_rate,
-        &input_channel_layout, AVSampleFormat::AV_SAMPLE_FMT_FLT, input_sample_rate,
+        &output_channel_layout, AVSampleFormat::AV_SAMPLE_FMT_FLTP, output_sample_rate,
+        &input_channel_layout, AVSampleFormat::AV_SAMPLE_FMT_FLTP, input_sample_rate,
         0, nullptr);
     if (allocation_result < 0)
         return Error::from_string_view(av_error_code_to_string(allocation_result));
@@ -78,12 +78,15 @@ ErrorOr<void> FFmpegAudioConverter::set_sample_specifications(Audio::SampleSpeci
 
 void FFmpegAudioConverter::free_output_buffer()
 {
-    if (m_output_buffer == nullptr) {
+    if (m_output_buffers == nullptr) {
         VERIFY(m_output_buffer_frame_count == 0);
         return;
     }
-    av_freep(static_cast<void*>(&m_output_buffer));
-    VERIFY(m_output_buffer == nullptr);
+    // The output buffers is a pointer to an array of pointers to the same allocation, so we only want to free the
+    // at the first index, then free the array of pointers.
+    av_freep(static_cast<void*>(&m_output_buffers[0]));
+    av_freep(static_cast<void*>(&m_output_buffers));
+    VERIFY(m_output_buffers == nullptr);
     m_output_buffer_frame_count = 0;
 }
 
@@ -114,40 +117,41 @@ ErrorOr<void> FFmpegAudioConverter::convert(AudioBlock& input)
     VERIFY(m_input_sample_specification.is_valid());
     VERIFY(m_output_sample_specification.is_valid());
 
-    auto input_data = input.data();
-
     auto output_channel_count = m_output_sample_specification.channel_count();
-    auto output_frame_count = TRY(get_maximum_output_frames(input_data.size()));
+    auto output_frame_count = TRY(get_maximum_output_frames(input.sample_count()));
 
     if (output_frame_count > m_output_buffer_frame_count) {
         free_output_buffer();
-        auto alloc_samples_result = av_samples_alloc(&m_output_buffer, nullptr, output_channel_count, output_frame_count, AVSampleFormat::AV_SAMPLE_FMT_FLT, 0);
+        auto alloc_samples_result = av_samples_alloc_array_and_samples(&m_output_buffers, nullptr, output_channel_count, output_frame_count, AVSampleFormat::AV_SAMPLE_FMT_FLTP, 0);
         if (alloc_samples_result < 0)
             return Error::from_string_view(av_error_code_to_string(alloc_samples_result));
-        VERIFY(m_output_buffer != nullptr);
+        VERIFY(m_output_buffers != nullptr);
         m_output_buffer_frame_count = output_frame_count;
     }
 
-    auto const* input_buffer = input_data.reinterpret<u8 const>().data();
     // The input buffer size should already be safe to cast to int here.
-    auto input_frame_count = static_cast<int>(input_data.size() / m_input_sample_specification.channel_count());
+    auto input_frame_count = static_cast<int>(input.frame_count());
     VERIFY(input_frame_count >= 0);
 
-    auto converted_frames_result = swr_convert(m_context, &m_output_buffer, m_output_buffer_frame_count, &input_buffer, input_frame_count);
+    Array<u8 const*, Audio::ChannelMap::capacity()> input_buffers;
+    for (size_t channel = 0; channel < input.channel_count(); channel++)
+        input_buffers[channel] = input.channel_data(channel).reinterpret<u8 const>().data();
+
+    auto converted_frames_result = swr_convert(m_context, m_output_buffers, m_output_buffer_frame_count, input_buffers.data(), input_frame_count);
     if (converted_frames_result < 0)
         return Error::from_string_view(av_error_code_to_string(converted_frames_result));
     VERIFY(converted_frames_result <= m_output_buffer_frame_count);
     auto converted_frames = static_cast<size_t>(converted_frames_result);
 
-    input.emplace(m_output_sample_specification, input.timestamp(), [&](AudioBlock::Data& data) {
-        data.resize_and_keep_capacity(converted_frames * output_channel_count);
-        AK::TypedTransfer<float>::copy(data.data(), reinterpret_cast<float*>(m_output_buffer), data.size());
-    });
+    input.initialize(m_output_sample_specification, input.timestamp(), converted_frames);
+    for (size_t channel = 0; channel < output_channel_count; channel++)
+        AK::TypedTransfer<float>::copy(input.channel_data(channel).data(), reinterpret_cast<float*>(m_output_buffers[channel]), converted_frames);
     return {};
 }
 
 FFmpegAudioConverter::~FFmpegAudioConverter()
 {
+    free_output_buffer();
     swr_free(&m_context);
 }
 

--- a/Libraries/LibMedia/FFmpeg/FFmpegAudioConverter.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegAudioConverter.cpp
@@ -143,7 +143,7 @@ ErrorOr<void> FFmpegAudioConverter::convert(AudioBlock& input)
     VERIFY(converted_frames_result <= m_output_buffer_frame_count);
     auto converted_frames = static_cast<size_t>(converted_frames_result);
 
-    input.initialize(m_output_sample_specification, input.timestamp(), converted_frames);
+    input.initialize(m_output_sample_specification, input.media_time_start(), converted_frames);
     for (size_t channel = 0; channel < output_channel_count; channel++)
         AK::TypedTransfer<float>::copy(input.channel_data(channel).data(), reinterpret_cast<float*>(m_output_buffers[channel]), converted_frames);
     return {};

--- a/Libraries/LibMedia/FFmpeg/FFmpegAudioConverter.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegAudioConverter.h
@@ -35,7 +35,7 @@ private:
     Audio::SampleSpecification m_input_sample_specification;
     Audio::SampleSpecification m_output_sample_specification;
     SwrContext* m_context { nullptr };
-    u8* m_output_buffer { nullptr };
+    u8** m_output_buffers { nullptr };
     int m_output_buffer_frame_count { 0 };
 };
 

--- a/Libraries/LibMedia/FFmpeg/FFmpegAudioDecoder.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegAudioDecoder.cpp
@@ -169,48 +169,49 @@ DecoderErrorOr<void> FFmpegAudioDecoder::write_next_block(AudioBlock& block)
         auto channel_map = channel_map_result.release_value();
         auto sample_specification = Audio::SampleSpecification(m_frame->sample_rate, channel_map);
 
-        block.emplace(sample_specification, timestamp, [&](AudioBlock::Data& data) {
-            auto format = static_cast<AVSampleFormat>(m_frame->format);
-            auto is_planar = av_sample_fmt_is_planar(format) != 0;
-            auto planar_format = av_get_planar_sample_fmt(format);
+        auto format = static_cast<AVSampleFormat>(m_frame->format);
+        auto is_planar = av_sample_fmt_is_planar(format) != 0;
+        auto planar_format = av_get_planar_sample_fmt(format);
 
-            VERIFY(m_frame->nb_samples >= 0);
-            auto frame_count = static_cast<size_t>(m_frame->nb_samples);
-            auto channel_count = static_cast<size_t>(m_frame->ch_layout.nb_channels);
-            auto sample_count = frame_count * channel_count;
-            data.resize_and_keep_capacity(sample_count);
+        VERIFY(m_frame->nb_samples >= 0);
+        auto frame_count = static_cast<size_t>(m_frame->nb_samples);
+        auto channel_count = static_cast<size_t>(m_frame->ch_layout.nb_channels);
+        auto sample_count = frame_count * channel_count;
+        block.initialize(sample_specification, timestamp, frame_count);
 
-            auto sample_size = [&] {
-                switch (planar_format) {
-                case AV_SAMPLE_FMT_U8P:
-                    return sizeof(u8);
-                case AV_SAMPLE_FMT_S16P:
-                    return sizeof(i16);
-                case AV_SAMPLE_FMT_S32P:
-                    return sizeof(i32);
-                case AV_SAMPLE_FMT_FLTP:
-                    return sizeof(float);
-                case AV_SAMPLE_FMT_DBLP:
-                    return sizeof(double);
-                case AV_SAMPLE_FMT_S64P:
-                    return sizeof(i64);
-                default:
-                    VERIFY_NOT_REACHED();
-                }
-            }();
+        auto sample_size = [&] {
+            switch (planar_format) {
+            case AV_SAMPLE_FMT_U8P:
+                return sizeof(u8);
+            case AV_SAMPLE_FMT_S16P:
+                return sizeof(i16);
+            case AV_SAMPLE_FMT_S32P:
+                return sizeof(i32);
+            case AV_SAMPLE_FMT_FLTP:
+                return sizeof(float);
+            case AV_SAMPLE_FMT_DBLP:
+                return sizeof(double);
+            case AV_SAMPLE_FMT_S64P:
+                return sizeof(i64);
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        }();
 
-            VERIFY(m_frame->linesize[0] > 0);
-            if (is_planar)
-                VERIFY(static_cast<size_t>(m_frame->linesize[0]) >= frame_count * sample_size);
-            else
-                VERIFY(static_cast<size_t>(m_frame->linesize[0]) >= sample_count * sample_size);
+        VERIFY(m_frame->linesize[0] > 0);
+        if (is_planar)
+            VERIFY(static_cast<size_t>(m_frame->linesize[0]) >= frame_count * sample_size);
+        else
+            VERIFY(static_cast<size_t>(m_frame->linesize[0]) >= sample_count * sample_size);
 
-            for (size_t i = 0; i < sample_count; i++) {
+        for (size_t channel = 0; channel < channel_count; ++channel) {
+            auto channel_data = block.channel_data(channel);
+            for (size_t frame = 0; frame < frame_count; ++frame) {
                 size_t plane = 0;
-                size_t index_in_plane = i;
+                size_t index_in_plane = (frame * channel_count) + channel;
                 if (is_planar) {
-                    plane = i % channel_count;
-                    index_in_plane = i / channel_count;
+                    plane = channel;
+                    index_in_plane = frame;
                 }
 
                 auto float_sample = [&] {
@@ -231,9 +232,9 @@ DecoderErrorOr<void> FFmpegAudioDecoder::write_next_block(AudioBlock& block)
                         VERIFY_NOT_REACHED();
                     }
                 }();
-                data[i] = float_sample;
+                channel_data[frame] = float_sample;
             }
-        });
+        }
 
         return {};
     }

--- a/Libraries/LibMedia/Forward.h
+++ b/Libraries/LibMedia/Forward.h
@@ -28,6 +28,7 @@ class MediaStreamCursor;
 class MediaTimeProvider;
 class PlaybackManager;
 class ReadonlyBytesCursor;
+class AudioTimeStretchProcessor;
 class Track;
 class VideoDecoder;
 class VideoFrame;

--- a/Libraries/LibMedia/GenericTimeProvider.cpp
+++ b/Libraries/LibMedia/GenericTimeProvider.cpp
@@ -15,8 +15,12 @@ GenericTimeProvider::~GenericTimeProvider() = default;
 AK::Duration GenericTimeProvider::current_time() const
 {
     auto time = m_media_time;
-    if (m_monotonic_time_on_resume.has_value())
-        time += MonotonicTime::now() - m_monotonic_time_on_resume.value();
+    if (m_monotonic_time_on_resume.has_value()) {
+        auto elapsed = MonotonicTime::now() - m_monotonic_time_on_resume.value();
+        if (m_playback_rate != 1.0f)
+            elapsed = AK::Duration::from_seconds_f64(elapsed.to_seconds_f64() * m_playback_rate);
+        time += elapsed;
+    }
     return time;
 }
 
@@ -39,6 +43,18 @@ void GenericTimeProvider::seek(AK::Duration time)
         m_monotonic_time_on_resume.emplace(MonotonicTime::now());
 
     m_media_time = time;
+}
+
+void GenericTimeProvider::set_playback_rate(float rate)
+{
+    VERIFY(rate >= 0);
+    if (m_playback_rate == rate)
+        return;
+    if (m_monotonic_time_on_resume.has_value()) {
+        m_media_time = current_time();
+        m_monotonic_time_on_resume.emplace(MonotonicTime::now());
+    }
+    m_playback_rate = rate;
 }
 
 }

--- a/Libraries/LibMedia/GenericTimeProvider.h
+++ b/Libraries/LibMedia/GenericTimeProvider.h
@@ -19,10 +19,12 @@ public:
     virtual void resume() override;
     virtual void pause() override;
     virtual void seek(AK::Duration) override;
+    virtual void set_playback_rate(float) override;
 
 private:
     Optional<MonotonicTime> m_monotonic_time_on_resume;
     AK::Duration m_media_time;
+    float m_playback_rate { 1.0f };
 };
 
 }

--- a/Libraries/LibMedia/MediaTimeProvider.h
+++ b/Libraries/LibMedia/MediaTimeProvider.h
@@ -19,6 +19,7 @@ public:
     virtual void resume() = 0;
     virtual void pause() = 0;
     virtual void seek(AK::Duration) = 0;
+    virtual void set_playback_rate(float) = 0;
 };
 
 }

--- a/Libraries/LibMedia/PipelineStatus.h
+++ b/Libraries/LibMedia/PipelineStatus.h
@@ -23,20 +23,36 @@ enum class PipelineStatus : u8 {
 
 constexpr bool is_waiting_for_data(PipelineStatus status)
 {
-    if (status == PipelineStatus::Pending)
+    return status != PipelineStatus::HaveData;
+}
+
+constexpr bool is_terminal(PipelineStatus status)
+{
+    if (status == PipelineStatus::Error)
         return true;
-    if (status == PipelineStatus::MovedPosition)
-        return true;
-    if (status == PipelineStatus::Blocked)
+    if (status == PipelineStatus::EndOfStream)
         return true;
     return false;
 }
 
-constexpr bool can_carry_data(PipelineStatus status)
+constexpr bool resolves_seek(PipelineStatus status)
 {
-    if (status == PipelineStatus::HaveData)
+    if (!is_waiting_for_data(status))
         return true;
-    if (status == PipelineStatus::EndOfStream)
+    if (is_terminal(status))
+        return true;
+    return false;
+}
+
+constexpr bool status_change_should_wake(PipelineStatus previous, PipelineStatus current)
+{
+    if (previous == current)
+        return false;
+    if (!resolves_seek(current))
+        return false;
+    if (is_waiting_for_data(previous))
+        return true;
+    if (previous == PipelineStatus::EndOfStream)
         return true;
     return false;
 }

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -10,6 +10,7 @@
 #include <LibMedia/GenericTimeProvider.h>
 #include <LibMedia/PlaybackStates/StartingStateHandler.h>
 #include <LibMedia/Processors/AudioMixer.h>
+#include <LibMedia/Processors/AudioTimeStretchProcessor.h>
 #include <LibMedia/Producers/DecodedAudioProducer.h>
 #include <LibMedia/Producers/DecodedVideoProducer.h>
 #include <LibMedia/Sinks/AudioPlaybackSink.h>
@@ -116,13 +117,15 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
 
         if (!self->m_audio_output_disabled && !self->m_audio_sink && !self->m_audio_tracks.is_empty()) {
             self->m_audio_mixer = MUST(AudioMixer::try_create());
+            self->m_audio_time_stretch_processor = MUST(AudioTimeStretchProcessor::try_create());
             self->m_audio_sink = MUST(AudioPlaybackSink::try_create(
                 [self](PipelineStatus status) {
                     if (!self)
                         return;
                     self->on_audio_sink_state_changed(status);
                 }));
-            MUST(self->m_audio_sink->connect_input(*self->m_audio_mixer));
+            MUST(self->m_audio_time_stretch_processor->connect_input(*self->m_audio_mixer));
+            MUST(self->m_audio_sink->connect_input(*self->m_audio_time_stretch_processor));
             self->set_time_provider(*self->m_audio_sink);
             self->m_audio_sink->on_audio_output_error = [self](Error&& error) {
                 if (!self)
@@ -310,6 +313,7 @@ void PlaybackManager::disable_audio()
 {
     m_audio_buffering = false;
     m_audio_mixer = nullptr;
+    m_audio_time_stretch_processor = nullptr;
     m_audio_sink = nullptr;
     set_time_provider(make_ref_counted<GenericTimeProvider>());
     on_audio_sink_state_changed(PipelineStatus::EndOfStream);

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -344,8 +344,10 @@ void PlaybackManager::enable_an_audio_track(Track const& track)
 {
     auto& track_data = get_audio_data_for_track(track);
     VERIFY(!track_data.enabled);
-    if (m_audio_mixer)
+    if (m_audio_mixer) {
+        m_audio_mixer->seek(current_time());
         MUST(m_audio_mixer->connect_input(track_data.producer));
+    }
     track_data.enabled = true;
 }
 
@@ -353,8 +355,10 @@ void PlaybackManager::disable_an_audio_track(Track const& track)
 {
     auto& track_data = get_audio_data_for_track(track);
     VERIFY(track_data.enabled);
-    if (m_audio_mixer)
+    if (m_audio_mixer) {
+        m_audio_mixer->seek(current_time());
         m_audio_mixer->disconnect_input(track_data.producer);
+    }
     track_data.enabled = false;
 }
 

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -301,6 +301,7 @@ void PlaybackManager::set_time_provider(NonnullRefPtr<MediaTimeProvider> const& 
             continue;
         track_data.display->set_time_provider(provider);
     }
+    provider->set_playback_rate(m_playback_rate);
     if (is_playing())
         provider->resume();
 }
@@ -430,6 +431,12 @@ void PlaybackManager::set_volume(double volume)
 {
     if (m_audio_sink)
         m_audio_sink->set_volume(volume);
+}
+
+void PlaybackManager::set_playback_rate(float rate)
+{
+    m_playback_rate = rate;
+    m_time_provider->set_playback_rate(rate);
 }
 
 }

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -89,6 +89,7 @@ public:
     TimeRanges buffered_time_ranges() const;
 
     void set_volume(double);
+    void set_playback_rate(float);
 
     Function<void()> on_metadata_parsed;
     Function<void(DecoderError&&)> on_unsupported_format_error;
@@ -162,6 +163,7 @@ private:
     NonnullRefPtr<WeakPlaybackManagerLink> m_weak_link;
 
     NonnullRefPtr<MediaTimeProvider> m_time_provider;
+    float m_playback_rate { 1.0f };
 
     bool m_audio_output_disabled { false };
 

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -171,6 +171,7 @@ private:
     VideoTrackDatas m_video_track_datas;
 
     RefPtr<AudioMixer> m_audio_mixer;
+    RefPtr<AudioTimeStretchProcessor> m_audio_time_stretch_processor;
     RefPtr<AudioPlaybackSink> m_audio_sink;
     AudioTracks m_audio_tracks;
     AudioTrackDatas m_audio_track_datas;

--- a/Libraries/LibMedia/PlaybackStates/SeekingStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/SeekingStateHandler.h
@@ -63,7 +63,7 @@ public:
 
     virtual void on_audio_sink_state_changed(PipelineStatus status) override
     {
-        if (is_waiting_for_data(status))
+        if (!resolves_seek(status))
             return;
         m_audio_seek_pending = false;
         possibly_complete_seek();
@@ -71,7 +71,7 @@ public:
 
     virtual void on_video_sink_state_changed(Track const& track, PipelineStatus status) override
     {
-        if (is_waiting_for_data(status))
+        if (!resolves_seek(status))
             return;
         m_video_seeks_pending.remove(track);
         possibly_complete_seek();

--- a/Libraries/LibMedia/Processors/AudioMixer.cpp
+++ b/Libraries/LibMedia/Processors/AudioMixer.cpp
@@ -187,7 +187,7 @@ PipelineStatus AudioMixer::combined_input_status() const
     for (auto& [input, input_data] : m_inputs) {
         if (!input_data.current_block.is_empty()
             && input_data.current_block.sample_specification() == m_sample_specification
-            && input_data.current_block.end_timestamp_in_frames() > m_next_frame_to_write) {
+            && input_data.current_block.end_frame_index() > m_next_frame_to_write) {
             status = select_combined_pipeline_status(status, PipelineStatus::HaveData);
             continue;
         }
@@ -270,7 +270,7 @@ void AudioMixer::pull(AudioBlock& into)
                 return false;
             if (current_block.sample_specification() != m_sample_specification)
                 return false;
-            if (current_block.end_timestamp_in_frames() <= input_data.next_frame)
+            if (current_block.end_frame_index() <= input_data.next_frame)
                 return false;
             return true;
         }();
@@ -288,7 +288,7 @@ void AudioMixer::pull(AudioBlock& into)
             continue;
         }
 
-        auto first_frame_offset = current_block.timestamp_in_frames();
+        auto first_frame_offset = current_block.first_frame_index();
         if (first_frame_offset >= frames_end_cap) {
             input_data.next_frame = frames_end_cap;
             continue;

--- a/Libraries/LibMedia/Processors/AudioMixer.cpp
+++ b/Libraries/LibMedia/Processors/AudioMixer.cpp
@@ -186,10 +186,12 @@ void AudioMixer::set_wake_handler(PipelineWakeHandler handler)
 
 void AudioMixer::dispatch_wake()
 {
+    {
+        Sync::MutexLocker locker { m_mutex };
+        m_downstream_needs_wake = false;
+    }
     if (m_wake_handler)
         m_wake_handler();
-    Sync::MutexLocker locker { m_mutex };
-    m_downstream_needs_wake = false;
 }
 
 PipelineStatus AudioMixer::combined_input_status() const

--- a/Libraries/LibMedia/Processors/AudioMixer.cpp
+++ b/Libraries/LibMedia/Processors/AudioMixer.cpp
@@ -37,7 +37,7 @@ ErrorOr<void> AudioMixer::connect_input(NonnullRefPtr<AudioProducer> const& inpu
         {
             Sync::MutexLocker locker { m_mutex };
             m_status = combined_input_status();
-            should_wake_downstream = m_downstream_needs_wake && !is_waiting_for_data(m_status);
+            should_wake_downstream = status_change_should_wake(m_last_returned_status, m_status);
             if (m_moved_position_pending)
                 m_status = PipelineStatus::MovedPosition;
         }
@@ -69,7 +69,7 @@ void AudioMixer::disconnect_input_while_locked(NonnullRefPtr<AudioProducer> cons
     input->set_wake_handler(nullptr);
     m_inputs.remove(input);
     m_status = combined_input_status();
-    if (m_downstream_needs_wake && !is_waiting_for_data(m_status)) {
+    if (status_change_should_wake(m_last_returned_status, m_status)) {
         Core::deferred_invoke([self = NonnullRefPtr(*this)] {
             self->dispatch_wake();
         });
@@ -151,7 +151,7 @@ void AudioMixer::seek(AK::Duration timestamp)
         }
 
         m_status = PipelineStatus::Pending;
-        m_downstream_needs_wake = true;
+        m_last_returned_status = PipelineStatus::Pending;
     }
 
     if (m_inputs.is_empty()) {
@@ -175,7 +175,7 @@ PipelineStatus AudioMixer::status() const
     m_status = combined_input_status();
     if (m_moved_position_pending)
         m_status = PipelineStatus::MovedPosition;
-    m_downstream_needs_wake = is_waiting_for_data(m_status);
+    m_last_returned_status = m_status;
     return m_status;
 }
 
@@ -186,10 +186,6 @@ void AudioMixer::set_wake_handler(PipelineWakeHandler handler)
 
 void AudioMixer::dispatch_wake()
 {
-    {
-        Sync::MutexLocker locker { m_mutex };
-        m_downstream_needs_wake = false;
-    }
     if (m_wake_handler)
         m_wake_handler();
 }
@@ -205,7 +201,7 @@ PipelineStatus AudioMixer::combined_input_status() const
             continue;
         }
 
-        if (!can_carry_data(input_data.last_status)) {
+        if (is_waiting_for_data(input_data.last_status) && !is_terminal(input_data.last_status)) {
             while ((input_data.last_status = input->status()) == PipelineStatus::MovedPosition) {
                 input->pull(input_data.current_block);
                 VERIFY(input_data.current_block.is_empty());
@@ -243,6 +239,7 @@ void AudioMixer::pull(AudioBlock& into)
 
     auto combined_status_after_mix = PipelineStatus::EndOfStream;
     i64 latest_mixed_frame = frames_end_cap;
+    i64 latest_frame_containing_data = buffer_start_frame;
 
     for (auto& [input, input_data] : m_inputs)
         input_data.next_frame = buffer_start_frame;
@@ -331,6 +328,7 @@ void AudioMixer::pull(AudioBlock& into)
         }
 
         input_data.next_frame = next_frame + static_cast<i64>(frames_to_write);
+        latest_frame_containing_data = max(latest_frame_containing_data, input_data.next_frame);
     }
 
     for (auto& [input, input_data] : m_inputs) {
@@ -340,13 +338,20 @@ void AudioMixer::pull(AudioBlock& into)
     }
 
     VERIFY(latest_mixed_frame >= buffer_start_frame);
-    auto frame_count = static_cast<size_t>(latest_mixed_frame - buffer_start_frame);
-
     if (combined_status_after_mix == PipelineStatus::EndOfStream) {
-        m_next_frame_to_write = frames_end_cap;
+        if (latest_frame_containing_data > buffer_start_frame) {
+            auto frame_count = static_cast<size_t>(latest_frame_containing_data - buffer_start_frame);
+            into.trim(frame_count);
+            m_next_frame_to_write += static_cast<i64>(frame_count);
+            m_status = PipelineStatus::HaveData;
+            return;
+        }
+        into.clear();
         m_status = PipelineStatus::EndOfStream;
         return;
     }
+
+    auto frame_count = static_cast<size_t>(latest_mixed_frame - buffer_start_frame);
 
     if (frame_count == 0) {
         into.clear();

--- a/Libraries/LibMedia/Processors/AudioMixer.cpp
+++ b/Libraries/LibMedia/Processors/AudioMixer.cpp
@@ -227,7 +227,6 @@ void AudioMixer::pull(AudioBlock& into)
 
     auto buffer_start_frame = m_next_frame_to_write;
     auto frames_end_cap = buffer_start_frame + static_cast<i64>(max_frame_count);
-    auto write_size = max_frame_count * channel_count;
 
     auto combined_status_after_mix = PipelineStatus::EndOfStream;
     i64 latest_mixed_frame = frames_end_cap;
@@ -235,96 +234,97 @@ void AudioMixer::pull(AudioBlock& into)
     for (auto& [input, input_data] : m_inputs)
         input_data.next_frame = buffer_start_frame;
 
-    into.emplace(m_sample_specification, buffer_start_frame, [&](AudioBlock::Data& data) {
-        data.resize_and_keep_capacity(write_size);
-        for (size_t i = 0; i < write_size; i++)
-            data[i] = 0.0f;
+    into.initialize(m_sample_specification, buffer_start_frame, max_frame_count);
+    for (size_t channel = 0; channel < channel_count; ++channel)
+        into.channel_data(channel).fill(0.0f);
 
-        while (true) {
-            struct MixTarget {
-                AudioProducer& input;
-                InputMixingData& input_data;
-            };
-            auto mix_target = [&] {
-                Optional<MixTarget> result;
-                for (auto& [input, input_data] : m_inputs) {
-                    if (input_data.next_frame >= frames_end_cap)
-                        continue;
-                    if (!result.has_value() || input_data.next_frame < result->input_data.next_frame)
-                        result = { input, input_data };
-                }
-                return result;
-            }();
-            if (!mix_target.has_value())
-                break;
-            auto [input, input_data] = mix_target.release_value();
-
-            auto& current_block = input_data.current_block;
-            input_data.last_status = input.status();
-            while (input_data.last_status == PipelineStatus::MovedPosition) {
-                input.pull(current_block);
-                VERIFY(current_block.is_empty());
-                input_data.last_status = input.status();
-            }
-
-            auto current_block_is_usable = [&] {
-                if (current_block.is_empty())
-                    return false;
-                if (current_block.sample_specification() != m_sample_specification)
-                    return false;
-                if (current_block.end_timestamp_in_frames() <= input_data.next_frame)
-                    return false;
-                return true;
-            }();
-
-            if (!current_block_is_usable) {
-                current_block.clear();
-                if (input_data.last_status == PipelineStatus::EndOfStream) {
-                    input_data.next_frame = frames_end_cap;
+    while (true) {
+        struct MixTarget {
+            AudioProducer& input;
+            InputMixingData& input_data;
+        };
+        auto mix_target = [&] {
+            Optional<MixTarget> result;
+            for (auto& [input, input_data] : m_inputs) {
+                if (input_data.next_frame >= frames_end_cap)
                     continue;
-                }
-                if (input_data.last_status != PipelineStatus::HaveData)
-                    break;
-                input.pull(current_block);
-                VERIFY(!current_block.is_empty());
-                continue;
+                if (!result.has_value() || input_data.next_frame < result->input_data.next_frame)
+                    result = { input, input_data };
             }
+            return result;
+        }();
+        if (!mix_target.has_value())
+            break;
+        auto [input, input_data] = mix_target.release_value();
 
-            auto first_frame_offset = current_block.timestamp_in_frames();
-            if (first_frame_offset >= frames_end_cap) {
+        auto& current_block = input_data.current_block;
+        input_data.last_status = input.status();
+        while (input_data.last_status == PipelineStatus::MovedPosition) {
+            input.pull(current_block);
+            VERIFY(current_block.is_empty());
+            input_data.last_status = input.status();
+        }
+
+        auto current_block_is_usable = [&] {
+            if (current_block.is_empty())
+                return false;
+            if (current_block.sample_specification() != m_sample_specification)
+                return false;
+            if (current_block.end_timestamp_in_frames() <= input_data.next_frame)
+                return false;
+            return true;
+        }();
+
+        if (!current_block_is_usable) {
+            current_block.clear();
+            if (input_data.last_status == PipelineStatus::EndOfStream) {
                 input_data.next_frame = frames_end_cap;
                 continue;
             }
-
-            auto next_frame = max(input_data.next_frame, first_frame_offset);
-
-            VERIFY(next_frame >= first_frame_offset);
-            auto index_in_block = static_cast<size_t>((next_frame - first_frame_offset) * channel_count);
-            VERIFY(index_in_block < current_block.sample_count());
-
-            VERIFY(next_frame >= buffer_start_frame);
-            auto index_in_buffer = static_cast<size_t>((next_frame - buffer_start_frame) * channel_count);
-            VERIFY(index_in_buffer < write_size);
-
-            VERIFY(current_block.sample_count() >= index_in_block);
-            auto write_count = current_block.sample_count() - index_in_block;
-            write_count = min(write_count, write_size - index_in_buffer);
-            VERIFY(write_count > 0);
-            VERIFY(index_in_buffer + write_count <= write_size);
-            VERIFY(write_count % channel_count == 0);
-
-            for (size_t i = 0; i < write_count; i++)
-                data[index_in_buffer + i] += current_block.data()[index_in_block + i];
-
-            input_data.next_frame = next_frame + static_cast<i64>(write_count / channel_count);
+            if (input_data.last_status != PipelineStatus::HaveData)
+                break;
+            input.pull(current_block);
+            VERIFY(!current_block.is_empty());
+            continue;
         }
 
-        for (auto& [input, input_data] : m_inputs) {
-            VERIFY(input_data.last_status != PipelineStatus::MovedPosition);
-            latest_mixed_frame = min(latest_mixed_frame, input_data.next_frame);
-            combined_status_after_mix = select_combined_pipeline_status(combined_status_after_mix, input_data.last_status);
+        auto first_frame_offset = current_block.timestamp_in_frames();
+        if (first_frame_offset >= frames_end_cap) {
+            input_data.next_frame = frames_end_cap;
+            continue;
         }
-    });
+
+        auto next_frame = max(input_data.next_frame, first_frame_offset);
+
+        VERIFY(next_frame >= first_frame_offset);
+        auto frame_index_in_block = static_cast<size_t>(next_frame - first_frame_offset);
+        VERIFY(frame_index_in_block < current_block.frame_count());
+
+        VERIFY(next_frame >= buffer_start_frame);
+        auto frame_index_in_buffer = static_cast<size_t>(next_frame - buffer_start_frame);
+        VERIFY(frame_index_in_buffer < max_frame_count);
+
+        VERIFY(current_block.frame_count() >= frame_index_in_block);
+        auto frames_to_write = current_block.frame_count() - frame_index_in_block;
+        frames_to_write = min(frames_to_write, max_frame_count - frame_index_in_buffer);
+        VERIFY(frames_to_write > 0);
+        VERIFY(frame_index_in_buffer + frames_to_write <= max_frame_count);
+
+        for (size_t channel = 0; channel < channel_count; ++channel) {
+            auto input_channel = current_block.channel_data(channel).slice(frame_index_in_block, frames_to_write);
+            auto output_channel = into.channel_data(channel).slice(frame_index_in_buffer, frames_to_write);
+            for (size_t frame = 0; frame < frames_to_write; ++frame)
+                output_channel[frame] += input_channel[frame];
+        }
+
+        input_data.next_frame = next_frame + static_cast<i64>(frames_to_write);
+    }
+
+    for (auto& [input, input_data] : m_inputs) {
+        VERIFY(input_data.last_status != PipelineStatus::MovedPosition);
+        latest_mixed_frame = min(latest_mixed_frame, input_data.next_frame);
+        combined_status_after_mix = select_combined_pipeline_status(combined_status_after_mix, input_data.last_status);
+    }
 
     VERIFY(latest_mixed_frame >= buffer_start_frame);
     auto frame_count = static_cast<size_t>(latest_mixed_frame - buffer_start_frame);

--- a/Libraries/LibMedia/Processors/AudioMixer.cpp
+++ b/Libraries/LibMedia/Processors/AudioMixer.cpp
@@ -49,6 +49,7 @@ ErrorOr<void> AudioMixer::connect_input(NonnullRefPtr<AudioProducer> const& inpu
             disconnect_input_while_locked(input);
             return result.release_error();
         }
+        input->set_playback_rate(m_playback_rate);
         input->seek(mix_head_timestamp());
         if (m_started)
             input->start();
@@ -116,6 +117,16 @@ void AudioMixer::start()
 Audio::SampleSpecification AudioMixer::sample_specification() const
 {
     return m_sample_specification;
+}
+
+void AudioMixer::set_playback_rate(float rate)
+{
+    Sync::MutexLocker locker { m_mutex };
+    if (m_playback_rate == rate)
+        return;
+    for (auto& [input, input_data] : m_inputs)
+        input->set_playback_rate(rate);
+    m_playback_rate = rate;
 }
 
 AK::Duration AudioMixer::mix_head_timestamp() const

--- a/Libraries/LibMedia/Processors/AudioMixer.h
+++ b/Libraries/LibMedia/Processors/AudioMixer.h
@@ -33,6 +33,8 @@ public:
 
     virtual void seek(AK::Duration timestamp) override;
 
+    virtual void set_playback_rate(float) override;
+
     virtual ErrorOr<void> set_output_sample_specification(Audio::SampleSpecification) override;
     Audio::SampleSpecification sample_specification() const;
 
@@ -60,6 +62,7 @@ private:
     Audio::SampleSpecification m_sample_specification;
     mutable HashMap<NonnullRefPtr<AudioProducer>, InputMixingData> m_inputs;
     i64 m_next_frame_to_write { 0 };
+    float m_playback_rate { 1.0f };
     bool m_started { false };
     bool m_moved_position_pending { false };
     mutable bool m_downstream_needs_wake { true };

--- a/Libraries/LibMedia/Processors/AudioMixer.h
+++ b/Libraries/LibMedia/Processors/AudioMixer.h
@@ -65,10 +65,10 @@ private:
     float m_playback_rate { 1.0f };
     bool m_started { false };
     bool m_moved_position_pending { false };
-    mutable bool m_downstream_needs_wake { true };
 
     PipelineWakeHandler m_wake_handler;
     mutable PipelineStatus m_status { PipelineStatus::Pending };
+    mutable PipelineStatus m_last_returned_status { PipelineStatus::Pending };
 };
 
 }

--- a/Libraries/LibMedia/Processors/AudioTimeStretchProcessor.cpp
+++ b/Libraries/LibMedia/Processors/AudioTimeStretchProcessor.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <AK/TypedTransfer.h>
+#include <LibMedia/Audio/WSOLATimeStretcher.h>
+#include <LibMedia/Processors/AudioTimeStretchProcessor.h>
+
+namespace Media {
+
+ErrorOr<NonnullRefPtr<AudioTimeStretchProcessor>> AudioTimeStretchProcessor::try_create()
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) AudioTimeStretchProcessor);
+}
+
+AudioTimeStretchProcessor::AudioTimeStretchProcessor() = default;
+
+AudioTimeStretchProcessor::~AudioTimeStretchProcessor()
+{
+    Sync::MutexLocker locker { m_mutex };
+    if (m_input != nullptr)
+        m_input->set_wake_handler(nullptr);
+}
+
+ErrorOr<void> AudioTimeStretchProcessor::connect_input(NonnullRefPtr<AudioProducer> const& input)
+{
+    Sync::MutexLocker locker { m_mutex };
+    VERIFY(m_input == nullptr);
+    m_input = input;
+    input->set_wake_handler([this] {
+        bool should_wake_downstream;
+        {
+            Sync::MutexLocker locker { m_mutex };
+            auto status = PipelineStatus::HaveData;
+            if (m_pending_block.is_empty())
+                status = produce_block_while_locked(m_pending_block);
+            if (!m_pending_block.is_empty())
+                status = PipelineStatus::HaveData;
+            should_wake_downstream = m_downstream_needs_wake && resolves_seek(status);
+        }
+        if (should_wake_downstream)
+            dispatch_wake();
+    });
+
+    if (m_sample_specification.is_valid()) {
+        if (auto result = input->set_output_sample_specification(m_sample_specification); result.is_error()) {
+            input->set_wake_handler(nullptr);
+            m_input = nullptr;
+            return result.release_error();
+        }
+        if (m_started)
+            input->start();
+    }
+    return {};
+}
+
+void AudioTimeStretchProcessor::disconnect_input(NonnullRefPtr<AudioProducer> const& input)
+{
+    Sync::MutexLocker locker { m_mutex };
+    VERIFY(m_input == input);
+    input->set_wake_handler(nullptr);
+    m_input = nullptr;
+}
+
+void AudioTimeStretchProcessor::seek(AK::Duration timestamp)
+{
+    RefPtr<AudioProducer> input;
+    {
+        Sync::MutexLocker locker { m_mutex };
+        VERIFY(m_sample_specification.is_valid());
+        auto sample_rate = m_sample_specification.sample_rate();
+        auto target_frame = timestamp.to_time_units(1, sample_rate);
+        auto output_frame = target_frame;
+
+        ensure_stretcher_while_locked();
+        auto prerolled_target_frame = max(target_frame - m_stretcher->preroll_frame_count(), 0);
+        auto actual_preroll_delta = target_frame - prerolled_target_frame;
+        target_frame = prerolled_target_frame;
+        output_frame = output_frame - AK::round_to<i64>(static_cast<float>(actual_preroll_delta) / m_playback_rate);
+
+        m_next_emit_media_time = AK::Duration::from_time_units(target_frame, 1, sample_rate);
+        m_next_output_frame = output_frame;
+
+        m_stretcher->flush(m_next_emit_media_time, m_next_output_frame);
+
+        m_moved_position_pending = true;
+        m_pending_block.clear();
+        m_downstream_needs_wake = true;
+        m_stretcher_reached_eos = false;
+
+        input = m_input;
+        timestamp = m_next_emit_media_time;
+    }
+
+    if (input != nullptr) {
+        input->seek(timestamp);
+        return;
+    }
+
+    dispatch_wake();
+}
+
+ErrorOr<void> AudioTimeStretchProcessor::set_output_sample_specification(Audio::SampleSpecification sample_specification)
+{
+    Sync::MutexLocker locker { m_mutex };
+    if (m_sample_specification == sample_specification)
+        return {};
+    m_sample_specification = sample_specification;
+    m_stretcher = nullptr;
+    m_pending_block.clear();
+    m_stretcher_reached_eos = false;
+    if (m_input != nullptr)
+        TRY(m_input->set_output_sample_specification(sample_specification));
+    return {};
+}
+
+void AudioTimeStretchProcessor::start()
+{
+    Sync::MutexLocker locker { m_mutex };
+    m_started = true;
+    if (m_input != nullptr)
+        m_input->start();
+}
+
+void AudioTimeStretchProcessor::set_wake_handler(PipelineWakeHandler handler)
+{
+    m_wake_handler = move(handler);
+}
+
+void AudioTimeStretchProcessor::dispatch_wake()
+{
+    {
+        Sync::MutexLocker locker { m_mutex };
+        m_downstream_needs_wake = false;
+    }
+    if (m_wake_handler)
+        m_wake_handler();
+}
+
+void AudioTimeStretchProcessor::set_playback_rate(float rate)
+{
+    VERIFY(isfinite(rate));
+    VERIFY(rate > 0.0f);
+
+    bool should_wake_downstream = false;
+    {
+        Sync::MutexLocker locker { m_mutex };
+        if (m_playback_rate == rate)
+            return;
+        m_playback_rate = rate;
+        should_wake_downstream = m_downstream_needs_wake;
+    }
+
+    if (should_wake_downstream)
+        dispatch_wake();
+}
+
+void AudioTimeStretchProcessor::ensure_stretcher_while_locked() const
+{
+    if (m_stretcher) {
+        m_stretcher->set_rate(m_playback_rate);
+        return;
+    }
+    VERIFY(m_sample_specification.is_valid());
+    m_stretcher = MUST(Audio::WSOLATimeStretcher::create(m_sample_specification));
+    m_stretcher->set_rate(m_playback_rate);
+    m_stretcher->flush(m_next_emit_media_time, m_next_output_frame);
+}
+
+void AudioTimeStretchProcessor::maybe_recover_from_stale_upstream_eos_while_locked() const
+{
+    if (!m_stretcher_reached_eos)
+        return;
+
+    auto status = m_input->status();
+    while (status == PipelineStatus::MovedPosition) {
+        m_input->pull(m_input_block);
+        VERIFY(m_input_block.is_empty());
+        status = m_input->status();
+    }
+    if (is_terminal(status))
+        return;
+
+    m_stretcher->flush(m_next_emit_media_time, m_next_output_frame);
+    m_input_block.clear();
+    m_stretcher_reached_eos = false;
+}
+
+PipelineStatus AudioTimeStretchProcessor::produce_block_while_locked(AudioBlock& into) const
+{
+    if (m_input == nullptr || !m_sample_specification.is_valid())
+        return PipelineStatus::Pending;
+
+    VERIFY(m_playback_rate != 0.0f);
+
+    auto pull_input = [&](AudioBlock& input_block) -> PipelineStatus {
+        auto status = m_input->status();
+        while (status == PipelineStatus::MovedPosition) {
+            m_input->pull(input_block);
+            VERIFY(input_block.is_empty());
+            status = m_input->status();
+        }
+        if (status == PipelineStatus::HaveData)
+            m_input->pull(input_block);
+        else
+            input_block.clear();
+        return status;
+    };
+
+    ensure_stretcher_while_locked();
+    maybe_recover_from_stale_upstream_eos_while_locked();
+
+    while (true) {
+        auto result = m_stretcher->retrieve_block();
+        if (!result.is_error()) {
+            into = result.release_value();
+            m_next_output_frame = into.end_frame_index();
+            m_next_emit_media_time = into.media_time_end();
+            return PipelineStatus::HaveData;
+        }
+        if (result.error().category() == DecoderErrorCategory::EndOfStream) {
+            into.clear();
+            m_stretcher_reached_eos = true;
+            return PipelineStatus::EndOfStream;
+        }
+        if (result.error().category() != DecoderErrorCategory::NeedsMoreInput) {
+            into.clear();
+            return PipelineStatus::Error;
+        }
+
+        auto status = pull_input(m_input_block);
+        if (status == PipelineStatus::EndOfStream) {
+            VERIFY(m_input_block.is_empty());
+            m_stretcher->signal_end_of_stream();
+            m_stretcher_reached_eos = false;
+            continue;
+        }
+        if (m_input_block.is_empty()) {
+            into.clear();
+            return status;
+        }
+        VERIFY(status == PipelineStatus::HaveData);
+        VERIFY(m_input_block.sample_specification() == m_sample_specification);
+        m_stretcher->push_block(m_input_block);
+    }
+}
+
+PipelineStatus AudioTimeStretchProcessor::status() const
+{
+    Sync::MutexLocker locker { m_mutex };
+    auto status = PipelineStatus::HaveData;
+    if (m_pending_block.is_empty())
+        status = produce_block_while_locked(m_pending_block);
+    if (!m_pending_block.is_empty())
+        status = PipelineStatus::HaveData;
+
+    if (m_moved_position_pending)
+        status = PipelineStatus::MovedPosition;
+    m_downstream_needs_wake = is_waiting_for_data(status);
+    return status;
+}
+
+void AudioTimeStretchProcessor::pull(AudioBlock& into)
+{
+    Sync::MutexLocker locker { m_mutex };
+
+    if (m_moved_position_pending) {
+        m_moved_position_pending = false;
+        into.clear();
+        return;
+    }
+
+    if (!m_pending_block.is_empty()) {
+        into.initialize(m_pending_block.sample_specification(), m_pending_block.first_frame_index(), m_pending_block.frame_count());
+        for (size_t channel = 0; channel < into.channel_count(); channel++)
+            AK::TypedTransfer<float>::copy(into.channel_data(channel).data(), m_pending_block.channel_data(channel).data(), into.frame_count());
+        into.set_media_time_start(m_pending_block.media_time_start());
+        into.set_media_time_duration(m_pending_block.media_time_duration());
+        m_pending_block.clear();
+        return;
+    }
+
+    into.clear();
+}
+
+}

--- a/Libraries/LibMedia/Processors/AudioTimeStretchProcessor.h
+++ b/Libraries/LibMedia/Processors/AudioTimeStretchProcessor.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <LibMedia/Audio/SampleSpecification.h>
+#include <LibMedia/Audio/TimeStretcher.h>
+#include <LibMedia/AudioBlock.h>
+#include <LibMedia/Export.h>
+#include <LibMedia/PipelineStatus.h>
+#include <LibMedia/Processors/AudioProcessor.h>
+#include <LibMedia/Producers/AudioProducer.h>
+#include <LibSync/Mutex.h>
+
+namespace Media {
+
+class MEDIA_API AudioTimeStretchProcessor final : public AudioProcessor {
+public:
+    static ErrorOr<NonnullRefPtr<AudioTimeStretchProcessor>> try_create();
+    AudioTimeStretchProcessor();
+    virtual ~AudioTimeStretchProcessor() override;
+
+    virtual ErrorOr<void> connect_input(NonnullRefPtr<AudioProducer> const&) override;
+    virtual void disconnect_input(NonnullRefPtr<AudioProducer> const&) override;
+
+    virtual void seek(AK::Duration) override;
+    virtual ErrorOr<void> set_output_sample_specification(Audio::SampleSpecification) override;
+    virtual void start() override;
+
+    virtual PipelineStatus status() const override;
+    virtual void pull(AudioBlock&) override;
+    virtual void set_wake_handler(PipelineWakeHandler) override;
+    virtual void set_playback_rate(float) override;
+
+private:
+    void ensure_stretcher_while_locked() const;
+    void maybe_recover_from_stale_upstream_eos_while_locked() const;
+    PipelineStatus produce_block_while_locked(AudioBlock&) const;
+    void dispatch_wake();
+
+    mutable Sync::Mutex m_mutex;
+    Audio::SampleSpecification m_sample_specification;
+    RefPtr<AudioProducer> m_input;
+
+    float m_playback_rate { 1.0f };
+    mutable OwnPtr<Audio::TimeStretcher> m_stretcher;
+    bool m_started { false };
+
+    mutable i64 m_next_output_frame { 0 };
+    mutable AK::Duration m_next_emit_media_time;
+    mutable bool m_stretcher_reached_eos { false };
+
+    mutable AudioBlock m_input_block;
+    mutable AudioBlock m_pending_block;
+    mutable bool m_downstream_needs_wake { true };
+    bool m_moved_position_pending { false };
+
+    PipelineWakeHandler m_wake_handler;
+};
+
+}

--- a/Libraries/LibMedia/Producers/AudioProducer.h
+++ b/Libraries/LibMedia/Producers/AudioProducer.h
@@ -26,6 +26,11 @@ public:
     virtual void set_wake_handler(PipelineWakeHandler) = 0;
 
     virtual void seek(AK::Duration timestamp) = 0;
+
+    virtual void set_playback_rate(float rate)
+    {
+        VERIFY(rate == 1.0f);
+    }
 };
 
 }

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -239,7 +239,7 @@ void DecodedAudioProducer::ThreadData::pull(AudioBlock& into)
     }
     if (!m_queue.is_empty()) {
         into = m_queue.dequeue();
-        m_earliest_available_timestamp = into.end_timestamp();
+        m_earliest_available_timestamp = into.media_time_end();
         wake();
         return;
     }
@@ -350,7 +350,7 @@ void DecodedAudioProducer::ThreadData::invoke_on_main_thread(Invokee invokee)
 
 void DecodedAudioProducer::ThreadData::dispatch_block_end_time(AudioBlock const& block)
 {
-    auto end_time = block.end_timestamp();
+    auto end_time = block.media_time_end();
     if (end_time < m_duration)
         return;
     m_duration = end_time;
@@ -368,7 +368,7 @@ void DecodedAudioProducer::ThreadData::queue_block(AudioBlock&& block)
     if (m_seek_id.load() != m_last_processed_seek_id)
         return;
     dispatch_block_end_time(block);
-    m_latest_available_timestamp = block.end_timestamp();
+    m_latest_available_timestamp = block.media_time_end();
     m_queue.enqueue(move(block));
     VERIFY(!m_queue.tail().is_empty());
     dispatch_wake_if_needed_while_locked();
@@ -396,9 +396,9 @@ DecoderErrorOr<void> DecodedAudioProducer::ThreadData::retrieve_next_block(Audio
     if (convert_result.is_error())
         return DecoderError::format(DecoderErrorCategory::NotImplemented, "Sample specification conversion failed: {}", convert_result.error().string_literal());
 
-    if (block.timestamp_in_frames() < m_last_output_frame)
-        block.set_timestamp_in_frames(m_last_output_frame);
-    m_last_output_frame = block.end_timestamp_in_frames();
+    if (block.first_frame_index() < m_last_output_frame)
+        block.set_first_frame_index(m_last_output_frame);
+    m_last_output_frame = block.end_frame_index();
     return {};
 }
 
@@ -493,7 +493,7 @@ bool DecodedAudioProducer::ThreadData::handle_seek()
                     return true;
                 }
 
-                if (current_block.timestamp() > timestamp) {
+                if (current_block.media_time_start() > timestamp) {
                     auto locker = take_lock();
                     resolve_seek(seek_id, moved_position);
 

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -11,6 +11,8 @@
 #include <LibCore/Forward.h>
 #include <LibMedia/Audio/PlaybackStream.h>
 #include <LibMedia/AudioBlock.h>
+#include <LibMedia/AudioBlockTiming.h>
+#include <LibMedia/AudioBlockTimingRing.h>
 #include <LibMedia/PipelineStatus.h>
 #include <LibMedia/Producers/AudioProducer.h>
 #include <LibSync/ConditionVariable.h>
@@ -46,6 +48,7 @@ public:
     size_t m_block_tail { 0 };
     size_t m_block_count { 0 };
     i64 m_next_frame_to_play { 0 };
+    AudioBlockTimingRing m_block_timings;
 
     PipelineStateChangeHandler m_on_state_changed;
     PipelineStatus m_last_pull_status { PipelineStatus::Pending };
@@ -82,6 +85,7 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                         output_thread_data->m_block_head = 0;
                         output_thread_data->m_block_tail = 0;
                         output_thread_data->m_block_count = 0;
+                        output_thread_data->m_block_timings.clear();
                         output_thread_data->m_last_real_data_end_in_frames = output_thread_data->m_next_frame_to_play;
                         output_thread_data->m_waiting_for_upstream_data = false;
                         output_thread_data->m_output_condition.broadcast();
@@ -131,6 +135,7 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                         VERIFY(can_carry_data(status));
                         output_thread_data->m_block_tail = (output_thread_data->m_block_tail + 1) % OUTPUT_BLOCK_QUEUE_CAPACITY;
                         output_thread_data->m_block_count++;
+                        output_thread_data->m_block_timings.enqueue(output_block.timing());
 
                         if (output_thread_data->m_playback_stream)
                             output_thread_data->m_playback_stream->notify_data_available();
@@ -341,11 +346,22 @@ AK::Duration AudioPlaybackSink::current_time() const
 {
     if (m_temporary_time.has_value())
         return m_temporary_time.value();
-    if (!m_output_thread_data->m_playback_stream)
-        return m_last_media_time;
+    if (!m_output_thread_data->m_playback_stream || !m_sample_specification.is_valid())
+        return m_minimum_media_time;
 
     auto stream_time = m_output_thread_data->m_playback_stream->total_time_played();
-    return m_last_media_time + (stream_time - m_last_stream_time);
+    auto stream_delta = stream_time - m_anchor_stream_time;
+    auto frames_played = stream_delta.to_time_units(1, m_sample_specification.sample_rate());
+    auto current_output_frame_index = m_anchor_output_frame_index + frames_played;
+
+    auto maybe_timing = m_output_thread_data->m_block_timings.find_timing_for_frame_index(current_output_frame_index);
+    if (!maybe_timing.has_value())
+        return m_minimum_media_time;
+
+    auto time = maybe_timing->media_time_at_frame_index(current_output_frame_index);
+    time = max(time, m_minimum_media_time);
+    m_minimum_media_time = time;
+    return time;
 }
 
 void AudioPlaybackSink::resume()
@@ -359,11 +375,9 @@ void AudioPlaybackSink::resume()
     if (!m_output_thread_data->m_playback_stream)
         return;
     m_output_thread_data->m_playback_stream->resume()
-        ->when_resolved([self = NonnullRefPtr(*this)](auto new_stream_time) {
-            self->m_main_thread_event_loop.deferred_invoke([self, new_stream_time]() {
-                auto new_media_time = self->m_last_media_time + (new_stream_time - self->m_last_stream_time);
-                self->m_last_stream_time = new_stream_time;
-                self->m_last_media_time = new_media_time;
+        ->when_resolved([self = NonnullRefPtr(*this)](auto new_device_time) {
+            self->m_main_thread_event_loop.deferred_invoke([self, new_device_time]() {
+                self->m_anchor_stream_time = new_device_time;
             });
         })
         .when_rejected([](auto&& error) {
@@ -378,7 +392,15 @@ void AudioPlaybackSink::pause()
     if (!m_output_thread_data->m_playback_stream)
         return;
     m_output_thread_data->m_playback_stream->drain_buffer_and_suspend()
-        ->when_resolved([]() {
+        ->when_resolved([self = NonnullRefPtr(*this)]() {
+            auto new_stream_time = self->m_output_thread_data->m_playback_stream->total_time_played();
+
+            self->m_main_thread_event_loop.deferred_invoke([self, new_stream_time]() {
+                auto stream_delta = new_stream_time - self->m_anchor_stream_time;
+                auto frames_played = stream_delta.to_time_units(1, self->m_sample_specification.sample_rate());
+                self->m_anchor_output_frame_index += frames_played;
+                self->m_anchor_stream_time = new_stream_time;
+            });
         })
         .when_rejected([](auto&& error) {
             warnln("Unexpected error while pausing AudioPlaybackSink: {}", error.string_literal());
@@ -389,6 +411,7 @@ void AudioPlaybackSink::seek(AK::Duration time)
 {
     bool already_draining_for_seek = m_temporary_time.has_value();
     m_temporary_time = time;
+    m_minimum_media_time = time;
 
     if (!m_output_thread_data->m_playback_stream)
         return;
@@ -404,6 +427,7 @@ void AudioPlaybackSink::seek(AK::Duration time)
         m_output_thread_data->m_last_dispatched_status = PipelineStatus::Pending;
 
         m_output_thread_data->m_waiting_for_upstream_data = true;
+        m_output_thread_data->m_block_timings.clear();
     }
 
     if (m_output_thread_data->m_input != nullptr)
@@ -417,8 +441,10 @@ void AudioPlaybackSink::seek(AK::Duration time)
             auto new_stream_time = self->m_output_thread_data->m_playback_stream->total_time_played();
 
             self->m_main_thread_event_loop.deferred_invoke([self, new_stream_time]() {
-                self->m_last_stream_time = new_stream_time;
-                self->m_last_media_time = self->m_temporary_time.release_value();
+                self->m_anchor_stream_time = new_stream_time;
+                auto seek_target = self->m_temporary_time.release_value();
+                self->m_anchor_output_frame_index = seek_target.to_time_units(1, self->m_sample_specification.sample_rate());
+                self->m_minimum_media_time = seek_target;
 
                 if (self->m_playing)
                     self->resume();

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -130,6 +130,10 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                         output_thread_data->m_output_condition.wait();
                         continue;
                     }
+                    if (output_thread_data->m_playback_rate == 0.0f) {
+                        output_thread_data->m_output_condition.wait();
+                        continue;
+                    }
                     if (output_thread_data->m_audio_processor_should_exit)
                         continue;
                     output_thread_data->m_waiting_for_upstream_data = true;
@@ -246,7 +250,8 @@ ErrorOr<void> AudioPlaybackSink::connect_input(NonnullRefPtr<AudioProducer> cons
             disconnect_input_while_locked(input);
             return result.release_error();
         }
-        input->set_playback_rate(m_output_thread_data->m_playback_rate);
+        if (m_output_thread_data->m_playback_rate != 0.0f)
+            input->set_playback_rate(m_output_thread_data->m_playback_rate);
         input->seek(current_time());
         input->start();
     }
@@ -316,8 +321,7 @@ void AudioPlaybackSink::create_playback_stream()
             self->m_output_thread_data->m_output_condition.broadcast();
         }
 
-        if (self->m_playing)
-            self->resume();
+        self->update_playback_stream_state();
     });
 
     promise->when_rejected([self = NonnullRefPtr(*this)](auto& error) {
@@ -420,13 +424,44 @@ AK::Duration AudioPlaybackSink::current_time() const
 void AudioPlaybackSink::resume()
 {
     m_playing = true;
+    update_playback_stream_state();
+}
 
-    // If we're in the middle of the seek() callbacks, let those take care of resuming.
+void AudioPlaybackSink::pause()
+{
+    m_playing = false;
+    update_playback_stream_state();
+}
+
+bool AudioPlaybackSink::effectively_paused() const
+{
+    if (!m_playing)
+        return true;
+    if (m_output_thread_data->m_playback_rate == 0.0f)
+        return true;
     if (m_temporary_time.has_value())
-        return;
+        return true;
+    return false;
+}
 
+void AudioPlaybackSink::update_playback_stream_state()
+{
+    if (effectively_paused()) {
+        pause_playback_stream();
+        return;
+    }
+
+    resume_playback_stream();
+}
+
+void AudioPlaybackSink::resume_playback_stream()
+{
+    if (m_stream_state == StreamState::Playing)
+        return;
     if (!m_output_thread_data->m_playback_stream)
         return;
+
+    m_stream_state = StreamState::Playing;
     m_output_thread_data->m_playback_stream->resume()
         ->when_resolved([self = NonnullRefPtr(*this)](auto new_device_time) {
             self->m_main_thread_event_loop.deferred_invoke([self, new_device_time]() {
@@ -438,12 +473,14 @@ void AudioPlaybackSink::resume()
         });
 }
 
-void AudioPlaybackSink::pause()
+void AudioPlaybackSink::pause_playback_stream()
 {
-    m_playing = false;
-
+    if (m_stream_state == StreamState::Suspended)
+        return;
     if (!m_output_thread_data->m_playback_stream)
         return;
+
+    m_stream_state = StreamState::Suspended;
     m_output_thread_data->m_playback_stream->drain_buffer_and_suspend()
         ->when_resolved([self = NonnullRefPtr(*this)]() {
             auto new_stream_time = self->m_output_thread_data->m_playback_stream->total_time_played();
@@ -491,6 +528,7 @@ void AudioPlaybackSink::seek(AK::Duration time)
     if (already_draining_for_seek)
         return;
 
+    m_stream_state = StreamState::Suspended;
     m_output_thread_data->m_playback_stream->drain_buffer_and_suspend()
         ->when_resolved([self = NonnullRefPtr(*this)]() {
             auto new_stream_time = self->m_output_thread_data->m_playback_stream->total_time_played();
@@ -501,8 +539,7 @@ void AudioPlaybackSink::seek(AK::Duration time)
                 self->m_anchor_output_frame_index = seek_target.to_time_units(1, self->m_output_thread_data->m_sample_specification.sample_rate());
                 self->m_minimum_media_time = seek_target;
 
-                if (self->m_playing)
-                    self->resume();
+                self->update_playback_stream_state();
             });
         })
         .when_rejected([](auto&& error) {
@@ -531,8 +568,11 @@ void AudioPlaybackSink::set_playback_rate(float rate)
         input = m_output_thread_data->m_input;
         m_output_thread_data->m_playback_rate = rate;
     }
-    if (input != nullptr)
+
+    if (input != nullptr && rate != 0.0f)
         input->set_playback_rate(rate);
+
+    update_playback_stream_state();
 }
 
 }

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -37,6 +37,7 @@ public:
     void dispatch_state_if_changed(PipelineStatus, u32 seek_id);
 
     RefPtr<Audio::PlaybackStream> m_playback_stream;
+    Audio::SampleSpecification m_sample_specification;
     RefPtr<AudioProducer> m_input;
     Core::EventLoop& m_main_thread_event_loop;
 
@@ -196,8 +197,9 @@ ErrorOr<void> AudioPlaybackSink::connect_input(NonnullRefPtr<AudioProducer> cons
         output_thread_data.m_waiting_for_upstream_data = false;
         output_thread_data.m_output_condition.broadcast();
     });
-    if (m_sample_specification.is_valid()) {
-        if (auto result = input->set_output_sample_specification(m_sample_specification); result.is_error()) {
+    auto const& sample_specification = m_output_thread_data->m_sample_specification;
+    if (sample_specification.is_valid()) {
+        if (auto result = input->set_output_sample_specification(sample_specification); result.is_error()) {
             Sync::MutexLocker locker { m_output_thread_data->m_output_mutex };
             disconnect_input_while_locked(input);
             return result.release_error();
@@ -241,10 +243,11 @@ void AudioPlaybackSink::create_playback_stream()
     auto promise = Audio::PlaybackStream::create(Audio::OutputState::Suspended, target_latency_ms, move(data_callback));
 
     promise->when_resolved([self = NonnullRefPtr(*this)](auto& stream) {
-        self->m_sample_specification = stream->sample_specification();
+        auto sample_specification = stream->sample_specification();
+        self->m_output_thread_data->m_sample_specification = sample_specification;
         auto const& input = self->m_output_thread_data->m_input;
         if (input != nullptr) {
-            if (auto result = input->set_output_sample_specification(self->m_sample_specification); result.is_error()) {
+            if (auto result = input->set_output_sample_specification(sample_specification); result.is_error()) {
                 if (self->on_audio_output_error)
                     self->on_audio_output_error(result.release_error());
                 return;
@@ -353,12 +356,13 @@ AK::Duration AudioPlaybackSink::current_time() const
 {
     if (m_temporary_time.has_value())
         return m_temporary_time.value();
-    if (!m_output_thread_data->m_playback_stream || !m_sample_specification.is_valid())
+    auto const& sample_specification = m_output_thread_data->m_sample_specification;
+    if (!m_output_thread_data->m_playback_stream || !sample_specification.is_valid())
         return m_minimum_media_time;
 
     auto stream_time = m_output_thread_data->m_playback_stream->total_time_played();
     auto stream_delta = stream_time - m_anchor_stream_time;
-    auto frames_played = stream_delta.to_time_units(1, m_sample_specification.sample_rate());
+    auto frames_played = stream_delta.to_time_units(1, sample_specification.sample_rate());
     auto current_output_frame_index = m_anchor_output_frame_index + frames_played;
 
     auto maybe_timing = m_output_thread_data->m_block_timings.find_timing_for_frame_index(current_output_frame_index);
@@ -404,7 +408,7 @@ void AudioPlaybackSink::pause()
 
             self->m_main_thread_event_loop.deferred_invoke([self, new_stream_time]() {
                 auto stream_delta = new_stream_time - self->m_anchor_stream_time;
-                auto frames_played = stream_delta.to_time_units(1, self->m_sample_specification.sample_rate());
+                auto frames_played = stream_delta.to_time_units(1, self->m_output_thread_data->m_sample_specification.sample_rate());
                 self->m_anchor_output_frame_index += frames_played;
                 self->m_anchor_stream_time = new_stream_time;
             });
@@ -423,7 +427,7 @@ void AudioPlaybackSink::seek(AK::Duration time)
     if (!m_output_thread_data->m_playback_stream)
         return;
 
-    auto seek_target_in_frames = time.to_time_units(1, m_sample_specification.sample_rate());
+    auto seek_target_in_frames = time.to_time_units(1, m_output_thread_data->m_sample_specification.sample_rate());
     {
         Sync::MutexLocker locker { m_output_thread_data->m_output_mutex };
         m_output_thread_data->m_seek_id++;
@@ -450,7 +454,7 @@ void AudioPlaybackSink::seek(AK::Duration time)
             self->m_main_thread_event_loop.deferred_invoke([self, new_stream_time]() {
                 self->m_anchor_stream_time = new_stream_time;
                 auto seek_target = self->m_temporary_time.release_value();
-                self->m_anchor_output_frame_index = seek_target.to_time_units(1, self->m_sample_specification.sample_rate());
+                self->m_anchor_output_frame_index = seek_target.to_time_units(1, self->m_output_thread_data->m_sample_specification.sample_rate());
                 self->m_minimum_media_time = seek_target;
 
                 if (self->m_playing)

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -298,17 +298,13 @@ ReadonlySpan<float> AudioPlaybackSink::OutputThreadData::move_output_to_playback
             continue;
         }
 
-        auto offset_in_head_samples = static_cast<size_t>(m_next_frame_to_play - block_start_frame) * channel_count;
-        auto samples_remaining_in_head = head_block.sample_count() - offset_in_head_samples;
-        auto samples_to_copy = min(samples_remaining_in_head, buffer.size() - samples_written);
-
-        for (size_t i = 0; i < samples_to_copy; i++)
-            buffer[samples_written + i] = head_block.data()[offset_in_head_samples + i];
+        auto offset_in_head_frames = static_cast<size_t>(m_next_frame_to_play - block_start_frame);
+        auto samples_to_copy = head_block.copy_to_interleaved(buffer.slice(samples_written), offset_in_head_frames);
 
         samples_written += samples_to_copy;
         m_next_frame_to_play += static_cast<i64>(samples_to_copy / channel_count);
 
-        if (offset_in_head_samples + samples_to_copy == head_block.sample_count()) {
+        if ((offset_in_head_frames * channel_count) + samples_to_copy == head_block.sample_count()) {
             m_block_head = (m_block_head + 1) % OUTPUT_BLOCK_QUEUE_CAPACITY;
             m_block_count--;
         }

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -92,6 +92,11 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                         output_thread_data->m_output_condition.broadcast();
                         continue;
                     }
+                    if (!is_waiting_for_data(status)) {
+                        Sync::MutexLocker locker { output_thread_data->m_output_mutex };
+                        output_thread_data->m_last_pull_status = status;
+                        output_thread_data->m_waiting_for_upstream_data = false;
+                    }
                 }
 
                 u32 seek_id_at_pull;

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -49,6 +49,7 @@ public:
     size_t m_block_count { 0 };
     i64 m_next_frame_to_play { 0 };
     AudioBlockTimingRing m_block_timings;
+    float m_playback_rate { 1.0f };
 
     PipelineStateChangeHandler m_on_state_changed;
     PipelineStatus m_last_pull_status { PipelineStatus::Pending };
@@ -196,6 +197,7 @@ ErrorOr<void> AudioPlaybackSink::connect_input(NonnullRefPtr<AudioProducer> cons
             disconnect_input_while_locked(input);
             return result.release_error();
         }
+        input->set_playback_rate(m_output_thread_data->m_playback_rate);
         input->seek(current_time());
         input->start();
     }
@@ -465,6 +467,19 @@ void AudioPlaybackSink::set_volume(double volume)
                 // FIXME: Do we even need this function to return a promise?
             });
     }
+}
+
+void AudioPlaybackSink::set_playback_rate(float rate)
+{
+    VERIFY(rate >= 0);
+    RefPtr<AudioProducer> input;
+    {
+        Sync::MutexLocker locker { m_output_thread_data->m_output_mutex };
+        input = m_output_thread_data->m_input;
+        m_output_thread_data->m_playback_rate = rate;
+    }
+    if (input != nullptr)
+        input->set_playback_rate(rate);
 }
 
 }

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -25,6 +25,13 @@ namespace Media {
 
 static constexpr size_t OUTPUT_BLOCK_QUEUE_CAPACITY = 4;
 
+static bool audio_processor_will_enqueue(PipelineStatus status)
+{
+    if (status == PipelineStatus::EndOfStream)
+        return true;
+    return !is_waiting_for_data(status);
+}
+
 class AudioPlaybackSink::OutputThreadData : public AtomicRefCounted<OutputThreadData> {
 public:
     OutputThreadData(PipelineStateChangeHandler on_state_changed)
@@ -51,6 +58,7 @@ public:
     i64 m_next_frame_to_play { 0 };
     AudioBlockTimingRing m_block_timings;
     float m_playback_rate { 1.0f };
+    float m_eos_media_frame_remainder { 0.0f };
 
     PipelineStateChangeHandler m_on_state_changed;
     PipelineStatus m_last_pull_status { PipelineStatus::Pending };
@@ -89,11 +97,12 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                         output_thread_data->m_block_count = 0;
                         output_thread_data->m_block_timings.clear();
                         output_thread_data->m_last_real_data_end_in_frames = output_thread_data->m_next_frame_to_play;
+                        output_thread_data->m_eos_media_frame_remainder = 0.0f;
                         output_thread_data->m_waiting_for_upstream_data = false;
                         output_thread_data->m_output_condition.broadcast();
                         continue;
                     }
-                    if (!is_waiting_for_data(status)) {
+                    if (audio_processor_will_enqueue(status)) {
                         Sync::MutexLocker locker { output_thread_data->m_output_mutex };
                         output_thread_data->m_last_pull_status = status;
                         output_thread_data->m_waiting_for_upstream_data = false;
@@ -131,15 +140,42 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                 auto status = input->status();
                 if (status == PipelineStatus::MovedPosition)
                     continue;
-                input->pull(output_block);
+                if (status == PipelineStatus::EndOfStream)
+                    output_block.clear();
+                else
+                    input->pull(output_block);
 
                 {
                     Sync::MutexLocker locker { output_thread_data->m_output_mutex };
                     if (output_thread_data->m_seek_id != seek_id_at_pull)
                         continue;
                     output_thread_data->m_last_pull_status = status;
+                    if (status == PipelineStatus::EndOfStream) {
+                        VERIFY(output_block.is_empty());
+                        VERIFY(output_thread_data->m_sample_specification.is_valid());
+                        auto channel_count = output_thread_data->m_sample_specification.channel_count();
+                        size_t frame_count = 1024 / channel_count;
+                        VERIFY(frame_count > 0);
+                        auto maybe_previous_timing = output_thread_data->m_block_timings.latest_timing();
+                        auto first_frame_index = max(output_thread_data->m_last_real_data_end_in_frames, output_thread_data->m_next_frame_to_play);
+                        if (maybe_previous_timing.has_value())
+                            first_frame_index = max(first_frame_index, maybe_previous_timing->end_frame_index());
+                        output_block.initialize(output_thread_data->m_sample_specification, first_frame_index, frame_count);
+                        for (size_t channel = 0; channel < output_block.channel_count(); channel++)
+                            output_block.channel_data(channel).fill(0.0f);
+
+                        auto sample_rate = output_thread_data->m_sample_specification.sample_rate();
+                        auto media_frame_count_with_remainder = (frame_count * output_thread_data->m_playback_rate) + output_thread_data->m_eos_media_frame_remainder;
+                        auto media_frame_count = static_cast<i64>(media_frame_count_with_remainder);
+                        output_thread_data->m_eos_media_frame_remainder = media_frame_count_with_remainder - media_frame_count;
+                        auto media_time_start = AK::Duration::from_time_units(first_frame_index, 1, sample_rate);
+                        if (maybe_previous_timing.has_value())
+                            media_time_start = maybe_previous_timing->media_time_at_frame_index(first_frame_index);
+                        output_block.set_media_time_start(media_time_start);
+                        output_block.set_media_time_duration(AK::Duration::from_time_units(media_frame_count, 1, sample_rate));
+                    }
                     if (!output_block.is_empty()) {
-                        VERIFY(can_carry_data(status));
+                        VERIFY(audio_processor_will_enqueue(status));
                         output_thread_data->m_block_tail = (output_thread_data->m_block_tail + 1) % OUTPUT_BLOCK_QUEUE_CAPACITY;
                         output_thread_data->m_block_count++;
                         output_thread_data->m_block_timings.enqueue(output_block.timing());
@@ -147,14 +183,20 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                         if (output_thread_data->m_playback_stream)
                             output_thread_data->m_playback_stream->notify_data_available();
 
-                        if (status == PipelineStatus::HaveData)
+                        if (status == PipelineStatus::HaveData) {
                             output_thread_data->m_last_real_data_end_in_frames = output_block.end_frame_index();
+                            output_thread_data->m_eos_media_frame_remainder = 0.0f;
+                        }
                     }
 
-                    output_thread_data->m_waiting_for_upstream_data = !can_carry_data(status);
+                    output_thread_data->m_waiting_for_upstream_data = !audio_processor_will_enqueue(status);
 
-                    if (!can_carry_data(output_thread_data->m_last_dispatched_status) && can_carry_data(status))
-                        output_thread_data->dispatch_state_if_changed(status, seek_id_at_pull);
+                    if (!status_change_should_wake(output_thread_data->m_last_dispatched_status, status))
+                        continue;
+                    if (is_waiting_for_data(status) && output_thread_data->m_next_frame_to_play < output_thread_data->m_last_real_data_end_in_frames)
+                        continue;
+
+                    output_thread_data->dispatch_state_if_changed(status, seek_id_at_pull);
                 }
             }
 
@@ -436,6 +478,8 @@ void AudioPlaybackSink::seek(AK::Duration time)
 
         m_output_thread_data->m_last_pull_status = PipelineStatus::Pending;
         m_output_thread_data->m_last_dispatched_status = PipelineStatus::Pending;
+        m_output_thread_data->m_last_real_data_end_in_frames = seek_target_in_frames;
+        m_output_thread_data->m_eos_media_frame_remainder = 0.0f;
 
         m_output_thread_data->m_waiting_for_upstream_data = true;
         m_output_thread_data->m_block_timings.clear();

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -136,7 +136,7 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                             output_thread_data->m_playback_stream->notify_data_available();
 
                         if (status == PipelineStatus::HaveData)
-                            output_thread_data->m_last_real_data_end_in_frames = output_block.end_timestamp_in_frames();
+                            output_thread_data->m_last_real_data_end_in_frames = output_block.end_frame_index();
                     }
 
                     output_thread_data->m_waiting_for_upstream_data = !can_carry_data(status);
@@ -279,7 +279,7 @@ ReadonlySpan<float> AudioPlaybackSink::OutputThreadData::move_output_to_playback
     while (samples_written < buffer.size() && m_block_count > 0) {
         auto const& head_block = m_blocks[m_block_head];
         auto channel_count = head_block.channel_count();
-        auto block_start_frame = head_block.timestamp_in_frames();
+        auto block_start_frame = head_block.first_frame_index();
         auto block_end_frame = block_start_frame + static_cast<i64>(head_block.frame_count());
 
         if (m_next_frame_to_play >= block_end_frame) {

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
@@ -40,6 +40,8 @@ public:
     virtual void pause() override;
     virtual void seek(AK::Duration) override;
 
+    virtual void set_playback_rate(float) override;
+
     void set_volume(double);
 
     Function<void(Error&&)> on_audio_output_error;

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
@@ -11,7 +11,6 @@
 #include <AK/RefPtr.h>
 #include <LibCore/EventLoop.h>
 #include <LibMedia/Audio/Forward.h>
-#include <LibMedia/Audio/SampleSpecification.h>
 #include <LibMedia/Export.h>
 #include <LibMedia/Forward.h>
 #include <LibMedia/MediaTimeProvider.h>

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
@@ -55,9 +55,10 @@ private:
     bool m_playing { false };
     double m_volume { 1 };
 
-    AK::Duration m_last_stream_time;
-    AK::Duration m_last_media_time;
+    AK::Duration m_anchor_stream_time;
+    i64 m_anchor_output_frame_index { 0 };
     Optional<AK::Duration> m_temporary_time;
+    mutable AK::Duration m_minimum_media_time;
 
     NonnullRefPtr<OutputThreadData> m_output_thread_data;
 };

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
@@ -51,8 +51,6 @@ private:
 
     Core::EventLoop& m_main_thread_event_loop;
 
-    Audio::SampleSpecification m_sample_specification;
-
     bool m_started_creating_playback_stream { false };
     bool m_playing { false };
     double m_volume { 1 };

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.h
@@ -46,12 +46,22 @@ public:
     Function<void(Error&&)> on_audio_output_error;
 
 private:
+    enum class StreamState {
+        Suspended,
+        Playing,
+    };
+
     void create_playback_stream();
+    bool effectively_paused() const;
+    void update_playback_stream_state();
+    void resume_playback_stream();
+    void pause_playback_stream();
 
     Core::EventLoop& m_main_thread_event_loop;
 
     bool m_started_creating_playback_stream { false };
     bool m_playing { false };
+    StreamState m_stream_state { StreamState::Suspended };
     double m_volume { 1 };
 
     AK::Duration m_anchor_stream_time;

--- a/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
+++ b/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
@@ -55,7 +55,7 @@ ErrorOr<void> DisplayingVideoSink::connect_input(NonnullRefPtr<VideoProducer> co
     input->set_wake_handler([this, input] {
         auto status = PipelineStatus::Pending;
         consume_moved_position_signals(status);
-        if (is_waiting_for_data(status))
+        if (!resolves_seek(status))
             return;
         dispatch_state_if_changed(status);
     });
@@ -143,7 +143,7 @@ DisplayingVideoSinkUpdateResult DisplayingVideoSink::update()
             if (m_seek_status == SeekStatus::FrameInvalidated)
                 m_current_frame.clear();
         }
-        if (!is_waiting_for_data(last_status))
+        if (resolves_seek(last_status))
             m_seek_status = SeekStatus::None;
         if (m_seek_status != SeekStatus::None)
             break;

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -2592,9 +2592,8 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::set_playback_rate(double new_value)
     // on setting, the user agent must follow these steps:
 
     // 1. If the given value is not supported by the user agent, then throw a "NotSupportedError" DOMException.
-    // FIXME: We need to support playback rates other than 1 for this to be even remotely useful.
-    if (new_value != 1.0)
-        return WebIDL::NotSupportedError::create(realm(), "Playback rates other than 1 are not supported."_utf16);
+    if (!isfinite(new_value) || new_value < 0.0 || new_value > 64.0)
+        return WebIDL::NotSupportedError::create(realm(), "Playback rate is outside of the supported range."_utf16);
 
     // When the defaultPlaybackRate or playbackRate attributes change value (either by being set by script or by being changed directly by the user agent, e.g. in response to user
     // control), the user agent must queue a media element task given the media element to fire an event named ratechange at the media element.

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1781,6 +1781,8 @@ void HTMLMediaElement::set_up_playback_manager_for_remote()
     m_playback_manager = Media::PlaybackManager::create();
     m_playback_manager->set_audio_output_disabled(document().page().client().is_headless());
 
+    m_playback_manager->set_playback_rate(static_cast<float>(m_playback_rate));
+
     m_has_enabled_preferred_audio_track = false;
     m_has_selected_preferred_video_track = false;
 
@@ -1855,6 +1857,8 @@ void HTMLMediaElement::set_up_playback_manager_for_local()
 {
     m_playback_manager = Media::PlaybackManager::create();
     m_playback_manager->set_audio_output_disabled(document().page().client().is_headless());
+
+    m_playback_manager->set_playback_rate(static_cast<float>(m_playback_rate));
 
     m_has_enabled_preferred_audio_track = false;
     m_has_selected_preferred_video_track = false;
@@ -2602,9 +2606,11 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::set_playback_rate(double new_value)
 
     // 2. Set playbackRate to the new value, and if the element is potentially playing, change the playback speed.
     m_playback_rate = new_value;
-    if (potentially_playing()) {
-        // FIXME: Do this once playback speeds other than 1 are supported.
-    }
+    // AD-HOC: Set the playback rate even when not potentially playing. The spec mandates that the media time advances
+    //         by playbackRate units of media time per unit time on the clock. There's no reason this shouldn't be set
+    //         always.
+    if (m_playback_manager)
+        m_playback_manager->set_playback_rate(static_cast<float>(new_value));
 
     return {};
 }

--- a/Meta/Linters/check_style.py
+++ b/Meta/Linters/check_style.py
@@ -25,6 +25,10 @@ LICENSE_HEADER_CHECK_EXCLUDES = {
     "AK/Checked.h",
     "AK/Function.h",
     "Libraries/LibCore/SocketpairWindows.cpp",
+    "Libraries/LibMedia/Audio/WSOLAAlgorithm.cpp",
+    "Libraries/LibMedia/Audio/WSOLAAlgorithm.h",
+    "Libraries/LibMedia/Audio/WSOLAInternals.cpp",
+    "Libraries/LibMedia/Audio/WSOLAInternals.h",
 }
 
 # We check that "#pragma once" is present

--- a/Tests/LibMedia/TestFFmpegAudioNormalization.cpp
+++ b/Tests/LibMedia/TestFFmpegAudioNormalization.cpp
@@ -99,16 +99,18 @@ static void decode_and_expect()
             producer->pull(block);
         if (status == Media::PipelineStatus::HaveData) {
             EXPECT(!block.is_empty());
-            for (float sample : block.data()) {
-                EXPECT(sample >= -1.0f);
-                if constexpr (sizeof(Sample) >= sizeof(i32))
-                    EXPECT(sample <= 1.0f);
-                else
-                    EXPECT(sample < 1.0f);
-                if (sample == -1.0f)
-                    saw_negative_full_scale_sample = true;
-                if (sample > 0.0f)
-                    saw_positive_peak_sample = true;
+            for (size_t channel = 0; channel < block.channel_count(); ++channel) {
+                for (float sample : block.channel_data(channel)) {
+                    EXPECT(sample >= -1.0f);
+                    if constexpr (sizeof(Sample) >= sizeof(i32))
+                        EXPECT(sample <= 1.0f);
+                    else
+                        EXPECT(sample < 1.0f);
+                    if (sample == -1.0f)
+                        saw_negative_full_scale_sample = true;
+                    if (sample > 0.0f)
+                        saw_positive_peak_sample = true;
+                }
             }
             decoded_frame_count += block.frame_count();
         } else if (status == Media::PipelineStatus::EndOfStream) {

--- a/Tests/LibMedia/TestMediaCommon.h
+++ b/Tests/LibMedia/TestMediaCommon.h
@@ -109,8 +109,8 @@ static inline void decode_audio(StringView path, u32 sample_rate, u8 channel_cou
             if (expected_channel_map.has_value())
                 EXPECT_EQ(block.sample_specification().channel_map(), expected_channel_map.value());
 
-            VERIFY(frame_count == 0 || last_frame <= block.timestamp_in_frames());
-            last_frame = block.timestamp_in_frames() + static_cast<i64>(block.frame_count());
+            VERIFY(frame_count == 0 || last_frame <= block.first_frame_index());
+            last_frame = block.first_frame_index() + static_cast<i64>(block.frame_count());
 
             frame_count += block.frame_count();
         } else if (status == Media::PipelineStatus::EndOfStream) {


### PR DESCRIPTION
The chosen algorithm is Chromium's WSOLA, which produces good results for speech while retaining decent quality for background music and sounds.

The pipeline needed some changes to handle EOS properly after the mixer, which involved introducing more PipelineStatus concepts to make the sleep/wake/seek/terminal behaviors consistent throughout.

The playback rate allowed range is more permissive than Chromium and Firefox for now, allowing up to 64x while they only allow 16x. That extra headroom may be useful later in order to test frame skipping and video playback quality stats.

[playback-rate.webm](https://github.com/user-attachments/assets/7d4b3ead-0119-41f1-83b9-c9b71cbb49ac)
