### PR TITLE
LibWeb: Fix Navigation API same-document history traversal

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -638,14 +638,15 @@ GC::Ptr<TraversableNavigable> Navigable::top_level_traversable()
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#set-the-ongoing-navigation
-void Navigable::set_ongoing_navigation(Variant<Empty, Traversal, String> ongoing_navigation)
+void Navigable::set_ongoing_navigation(Variant<Empty, Traversal, String> ongoing_navigation, NavigationAPIAbortBehavior navigation_api_abort_behavior)
 {
     // 1. If navigable's ongoing navigation is equal to newValue, then return.
     if (m_ongoing_navigation == ongoing_navigation)
         return;
 
     // 2. Inform the navigation API about aborting navigation given navigable.
-    inform_the_navigation_api_about_aborting_navigation();
+    if (navigation_api_abort_behavior == NavigationAPIAbortBehavior::Abort)
+        inform_the_navigation_api_about_aborting_navigation();
 
     // 3. Set navigable's ongoing navigation to newValue.
     auto was_traversal = m_ongoing_navigation.has<Traversal>();

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -136,8 +136,13 @@ public:
         Tag
     };
 
+    enum class NavigationAPIAbortBehavior {
+        Abort,
+        Preserve
+    };
+
     Variant<Empty, Traversal, String> ongoing_navigation() const { return m_ongoing_navigation; }
-    void set_ongoing_navigation(Variant<Empty, Traversal, String> ongoing_navigation);
+    void set_ongoing_navigation(Variant<Empty, Traversal, String> ongoing_navigation, NavigationAPIAbortBehavior = NavigationAPIAbortBehavior::Abort);
 
     void populate_session_history_entry_document(
         URL::URL url,

--- a/Libraries/LibWeb/HTML/NavigateEvent.h
+++ b/Libraries/LibWeb/HTML/NavigateEvent.h
@@ -56,10 +56,12 @@ public:
     InterceptionState interception_state() const { return m_interception_state; }
     Vector<NavigationInterceptHandler> const& navigation_handler_list() const { return m_navigation_handler_list; }
     Optional<SerializationRecord> classic_history_api_state() const { return m_classic_history_api_state; }
+    bool has_started_navigate_event_intercept_commit_handler_steps() const { return m_has_started_navigate_event_intercept_commit_handler_steps; }
 
     void set_abort_controller(GC::Ref<DOM::AbortController> c) { m_abort_controller = c; }
     void set_interception_state(InterceptionState s) { m_interception_state = s; }
     void set_classic_history_api_state(Optional<SerializationRecord> r) { m_classic_history_api_state = move(r); }
+    void set_has_started_navigate_event_intercept_commit_handler_steps() { m_has_started_navigate_event_intercept_commit_handler_steps = true; }
 
     void finish(bool did_fulfill);
 
@@ -76,6 +78,8 @@ private:
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigateevent-interception-state
     InterceptionState m_interception_state = InterceptionState::None;
+
+    bool m_has_started_navigate_event_intercept_commit_handler_steps { false };
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigateevent-navigation-handler-list
     Vector<NavigationInterceptHandler> m_navigation_handler_list;

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -930,6 +930,110 @@ void Navigation::notify_about_the_committed_to_entry(GC::Ref<NavigationAPIMethod
     WebIDL::resolve_promise(realm, api_method_tracker->committed_promise, nhe);
 }
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigate-event-intercept-commit-handler-steps
+void Navigation::run_the_navigate_event_intercept_commit_handler_steps(GC::Ref<NavigateEvent> event, GC::Ptr<NavigationAPIMethodTracker> api_method_tracker)
+{
+    VERIFY(!event->has_started_navigate_event_intercept_commit_handler_steps());
+    event->set_has_started_navigate_event_intercept_commit_handler_steps();
+
+    auto& realm = relevant_realm(*this);
+
+    // 1. Let promisesList be an empty list.
+    GC::RootVector<GC::Ref<WebIDL::Promise>> promises_list;
+
+    // 2. For each handler of event's navigation handler list:
+    for (auto const& handler : event->navigation_handler_list()) {
+        // 1. Append the result of invoking handler with an empty arguments list to promisesList.
+        auto result = WebIDL::invoke_callback(handler, {}, {});
+        // NB: This should be equivalent to converting a promise to a promise capability.
+        promises_list.append(WebIDL::create_resolved_promise(realm, result.value()));
+    }
+
+    // 3. If promisesList's size is 0, then set promisesList to « a promise resolved with undefined ».
+    // NOTE: There is a subtle timing difference between how waiting for all schedules its success and failure
+    //       steps when given zero promises versus ≥1 promises. For most uses of waiting for all, this does not matter.
+    //       However, with this API, there are so many events and promise handlers which could fire around the same time
+    //       that the difference is pretty easily observable: it can cause the event/promise handler sequence to vary.
+    //       (Some of the events and promises involved include: navigatesuccess / navigateerror, currententrychange,
+    //       dispose, apiMethodTracker's promises, and the navigation.transition.finished promise.)
+    if (promises_list.size() == 0) {
+        promises_list.append(WebIDL::create_resolved_promise(realm, JS::js_undefined()));
+    }
+
+    // 4. Wait for all of promisesList, with the following success steps:
+    WebIDL::wait_for_all(
+        realm, promises_list, [event, this, api_method_tracker](auto const&) -> void {
+            // 1. If event's relevant global object is not fully active, then abort these steps.
+            auto& relevant_global_object = as<HTML::Window>(HTML::relevant_global_object(*event));
+            auto& realm = event->realm();
+            if (!relevant_global_object.associated_document().is_fully_active())
+                return;
+
+            // 2. If event's abort controller's signal is aborted, then abort these steps.
+            if (event->abort_controller()->signal()->aborted())
+                return;
+
+            // 3. Assert: event equals navigation's ongoing navigate event.
+            VERIFY(event == m_ongoing_navigate_event);
+
+            // 4. Set navigation's ongoing navigate event to null.
+            m_ongoing_navigate_event = nullptr;
+
+            // 5. Finish event given true.
+            event->finish(true);
+
+            // 6. If apiMethodTracker is non-null, then resolve the finished promise for apiMethodTracker.
+            if (api_method_tracker != nullptr)
+                resolve_the_finished_promise(*api_method_tracker);
+
+            // FIXME: Implement https://dom.spec.whatwg.org/#concept-event-fire somewhere
+            // 7. Fire an event named navigatesuccess at navigation.
+            dispatch_event(DOM::Event::create(realm, EventNames::navigatesuccess));
+
+            // 8. If navigation's transition is not null, then resolve navigation's transition's finished promise with undefined.
+            if (m_transition != nullptr)
+                WebIDL::resolve_promise(realm, m_transition->finished(), JS::js_undefined());
+
+            // 9. Set navigation's transition to null.
+            m_transition = nullptr; },
+        // and the following failure step given reason:
+        [event, this, api_method_tracker](JS::Value rejection_reason) -> void {
+            // NB: This inlines "process navigate event handler failure" using the rejected JavaScript value directly.
+            auto& relevant_global_object = as<HTML::Window>(HTML::relevant_global_object(*event));
+            auto& realm = event->realm();
+            if (!relevant_global_object.associated_document().is_fully_active())
+                return;
+
+            if (event->abort_controller()->signal()->aborted())
+                return;
+
+            VERIFY(event == m_ongoing_navigate_event);
+
+            m_ongoing_navigate_event = nullptr;
+
+            event->finish(false);
+
+            auto error_info = extract_error_information(vm(), rejection_reason);
+
+            if (api_method_tracker != nullptr)
+                reject_the_finished_promise(*api_method_tracker, rejection_reason);
+
+            Bindings::ErrorEventInit event_init = {};
+            event_init.message = error_info.message;
+            event_init.filename = error_info.filename;
+            event_init.lineno = error_info.lineno;
+            event_init.colno = error_info.colno;
+            event_init.error = error_info.error;
+
+            dispatch_event(ErrorEvent::create(realm, EventNames::navigateerror, event_init));
+
+            if (m_transition)
+                WebIDL::reject_promise(realm, m_transition->finished(), rejection_reason);
+
+            m_transition = nullptr;
+        });
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
 bool Navigation::inner_navigate_event_firing_algorithm(
     Bindings::NavigationType navigation_type,
@@ -1201,121 +1305,23 @@ bool Navigation::inner_navigate_event_firing_algorithm(
         }
     }
 
-    // 34. If endResultIsSameDocument is true:
+    auto const defer_traverse_commit_handler_steps = navigation_type == Bindings::NavigationType::Traverse && end_result_is_same_document;
+
     if (end_result_is_same_document) {
-        // 1. Let promisesList be an empty list.
-        GC::RootVector<GC::Ref<WebIDL::Promise>> promises_list;
-
-        // 2. For each handler of event's navigation handler list:
-        for (auto const& handler : event->navigation_handler_list()) {
-            // 1. Append the result of invoking handler with an empty arguments list to promisesList.
-            auto result = WebIDL::invoke_callback(handler, {}, {});
-            // This *should* be equivalent to converting a promise to a promise capability
-            promises_list.append(WebIDL::create_resolved_promise(realm, result.value()));
-        }
-
-        // 3. If promisesList's size is 0, then set promisesList to « a promise resolved with undefined ».
-        // NOTE: There is a subtle timing difference between how waiting for all schedules its success and failure
-        //       steps when given zero promises versus ≥1 promises. For most uses of waiting for all, this does not matter.
-        //       However, with this API, there are so many events and promise handlers which could fire around the same time
-        //       that the difference is pretty easily observable: it can cause the event/promise handler sequence to vary.
-        //       (Some of the events and promises involved include: navigatesuccess / navigateerror, currententrychange,
-        //       dispose, apiMethodTracker's promises, and the navigation.transition.finished promise.)
-        if (promises_list.size() == 0) {
-            promises_list.append(WebIDL::create_resolved_promise(realm, JS::js_undefined()));
-        }
-
-        // 4. Wait for all of promisesList, with the following success steps:
-        WebIDL::wait_for_all(
-            realm, promises_list, [event, this, api_method_tracker](auto const&) -> void {
-                // 1. If event's relevant global object's associated Document is not fully active, then abort these steps.
-                auto& relevant_global_object = as<HTML::Window>(HTML::relevant_global_object(*event));
-                auto& realm = event->realm();
-                if (!relevant_global_object.associated_document().is_fully_active())
-                    return;
-
-                // 2. If event's abort controller's signal is aborted, then abort these steps.
-                if (event->abort_controller()->signal()->aborted())
-                    return;
-
-                // 3. Assert: event equals navigation's ongoing navigate event.
-                VERIFY(event == m_ongoing_navigate_event);
-
-                // 4. Set navigation's ongoing navigate event to null.
-                m_ongoing_navigate_event = nullptr;
-
-                // 5. Finish event given true.
-                event->finish(true);
-                
-                // 6. If apiMethodTracker is non-null, then resolve the finished promise for apiMethodTracker.
-                if (api_method_tracker != nullptr)
-                    resolve_the_finished_promise(*api_method_tracker);
-
-                // FIXME: Implement https://dom.spec.whatwg.org/#concept-event-fire somewhere
-                // 7. Fire an event named navigatesuccess at navigation.
-                dispatch_event(DOM::Event::create(realm, EventNames::navigatesuccess));
-
-                // 8. If navigation's transition is not null, then resolve navigation's transition's finished promise with undefined.
-                if (m_transition != nullptr)
-                    WebIDL::resolve_promise(realm, m_transition->finished(), JS::js_undefined());
-
-                // 9. Set navigation's transition to null.
-                m_transition = nullptr; },
-            // and the following failure steps given reason rejectionReason:
-            [event, this, api_method_tracker](JS::Value rejection_reason) -> void {
-                // 1. If event's relevant global object's associated Document is not fully active, then abort these steps.
-                auto& relevant_global_object = as<HTML::Window>(HTML::relevant_global_object(*event));
-                auto& realm = event->realm();
-                if (!relevant_global_object.associated_document().is_fully_active())
-                    return;
-
-                // 2. If event's abort controller's signal is aborted, then abort these steps.
-                if (event->abort_controller()->signal()->aborted())
-                    return;
-
-                // 3. Assert: event equals navigation's ongoing navigate event.
-                VERIFY(event == m_ongoing_navigate_event);
-
-                // 4. Set navigation's ongoing navigate event to null.
-                m_ongoing_navigate_event = nullptr;
-
-                // 5. Finish event given false.
-                event->finish(false);
-
-                // 6. Let errorInfo be the result of extracting error information from rejectionReason.
-                auto error_info = extract_error_information(vm(), rejection_reason);
-
-                // 7. If apiMethodTracker is non-null, then reject the finished promise for apiMethodTracker with rejectionReason.
-                if (api_method_tracker != nullptr)
-                    reject_the_finished_promise(*api_method_tracker, rejection_reason);
-
-                // 8. Fire an event named navigateerror at navigation using ErrorEvent,with additional attributes
-                //    initialized according to errorInfo.
-                Bindings::ErrorEventInit event_init = {};
-                event_init.message = error_info.message;
-                event_init.filename = error_info.filename;
-                event_init.lineno = error_info.lineno;
-                event_init.colno = error_info.colno;
-                event_init.error = error_info.error;
-
-                dispatch_event(ErrorEvent::create(realm, EventNames::navigateerror, event_init));
-
-                // 9. If navigation's transition is not null, then reject navigation's transition's finished promise with rejectionReason.
-                if (m_transition)
-                    WebIDL::reject_promise(realm, m_transition->finished(), rejection_reason);
-
-                // 10. Set navigation's transition to null.
-                m_transition = nullptr;
-            });
+        // NB: Same-document Navigation API entry updates run these steps after currententrychange.
+        //     If those steps have not started here, run them as a fallback for same-document paths
+        //     that did not update entries.
+        if (!defer_traverse_commit_handler_steps && !event->has_started_navigate_event_intercept_commit_handler_steps())
+            run_the_navigate_event_intercept_commit_handler_steps(event, api_method_tracker);
     }
 
-    // 35. Otherwise, if apiMethodTracker is non-null, then clean up apiMethodTracker.
+    // If endResultIsSameDocument is false and apiMethodTracker is non-null, then clean up apiMethodTracker.
     else if (api_method_tracker != nullptr) {
         clean_up(*api_method_tracker);
     }
 
-    // 36. Clean up after running script given navigation's relevant settings object.
-    // Handled by TemporaryExecutionContext destructor from step 31
+    // Clean up after running script given navigation's relevant settings object.
+    // NB: Handled by TemporaryExecutionContext destructor.
 
     // 37. If event's interception state is "none", then return true.
     // 38. Return false.
@@ -1570,22 +1576,35 @@ void Navigation::update_the_navigation_api_entries_for_a_same_document_navigatio
     if (m_ongoing_api_method_tracker != nullptr)
         notify_about_the_committed_to_entry(*m_ongoing_api_method_tracker, *current_entry());
 
-    // 9. Prepare to run script given navigation's relevant settings object.
-    prepare_to_run_script(relevant_settings_object(*this));
+    // 9. Let navigateEvent be navigation's ongoing navigate event.
+    auto navigate_event = m_ongoing_navigate_event;
 
-    // 10. Fire an event named currententrychange at navigation using NavigationCurrentEntryChangeEvent,
+    // 10. Let apiMethodTracker be navigation's ongoing API method tracker.
+    auto api_method_tracker = m_ongoing_api_method_tracker;
+
+    // 11. Prepare to run script given navigation's relevant settings object.
+    TemporaryExecutionContext execution_context { realm, TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+    // 12. Fire an event named currententrychange at navigation using NavigationCurrentEntryChangeEvent,
     //     with its navigationType attribute initialized to navigationType and its from initialized to oldCurrentNHE.
     Bindings::NavigationCurrentEntryChangeEventInit event_init { Bindings::EventInit {}, *old_current_nhe, navigation_type };
     dispatch_event(NavigationCurrentEntryChangeEvent::construct_impl(realm, EventNames::currententrychange, event_init));
 
-    // 11. For each disposedNHE of disposedNHEs:
+    // 13. For each disposedNHE of disposedNHEs:
     for (auto& disposed_nhe : disposed_nhes) {
         // 1. Fire an event named dispose at disposedNHE.
         disposed_nhe->dispatch_event(DOM::Event::create(realm, EventNames::dispose, {}));
     }
 
-    // 12. Clean up after running script given navigation's relevant settings object.
-    clean_up_after_running_script(relevant_settings_object(*this));
+    // 14. Run the navigate event intercept commit handler steps given navigation, navigateEvent, and apiMethodTracker.
+    if (navigate_event != nullptr
+        && navigate_event == m_ongoing_navigate_event
+        && !navigate_event->has_started_navigate_event_intercept_commit_handler_steps()) {
+        run_the_navigate_event_intercept_commit_handler_steps(*navigate_event, api_method_tracker);
+    }
+
+    // 15. Clean up after running script given navigation's relevant settings object.
+    // NB: Handled by TemporaryExecutionContext destructor from step 11.
 }
 
 }

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -1142,13 +1142,47 @@ bool Navigation::inner_navigate_event_firing_algorithm(
         //         promise as handled at the equivalent place.
         WebIDL::mark_promise_as_handled(*m_transition->committed());
 
-        // 6. If navigationType is "traverse", then set navigation's suppress normal scroll restoration during ongoing navigation to true.
-        // NOTE: If event's scroll behavior was set to "after-transition", then scroll restoration will happen as part of finishing
-        //       the relevant NavigateEvent. Otherwise, there will be no scroll restoration. That is, no navigation which is intercepted
-        //       by intercept() goes through the normal scroll restoration process; scroll restoration for such navigations
-        //       is either done manually, by the web developer, or is done after the transition.
-        if (navigation_type == Bindings::NavigationType::Traverse)
+        // Switch on event's navigationType:
+        // - "traverse":
+        if (navigation_type == Bindings::NavigationType::Traverse) {
+            // 1. Set navigation's suppress normal scroll restoration during ongoing navigation to true.
+            // NOTE: If event's scroll behavior was set to "after-transition", then scroll restoration will happen as part of finishing
+            //       the relevant NavigateEvent. Otherwise, there will be no scroll restoration. That is, no navigation which is intercepted
+            //       by intercept() goes through the normal scroll restoration process; scroll restoration for such navigations
+            //       is either done manually, by the web developer, or is done after the transition.
             m_suppress_scroll_restoration_during_ongoing_navigation = true;
+
+            // 2. Let userInvolvement be "none".
+            auto user_involvement_for_resume = UserNavigationInvolvement::None;
+
+            // 3. If event's userInitiated is true, then set userInvolvement to "activation".
+            if (event->user_initiated())
+                user_involvement_for_resume = UserNavigationInvolvement::Activation;
+
+            // NOTE: At this point after interception, it is not consequential whether the
+            //       activation was a result of browser UI.
+
+            // 4. Append the following session history traversal steps to navigable's traversable navigable:
+            auto destination_entry = event->destination()->navigation_history_entry();
+            VERIFY(destination_entry);
+            auto target_step = destination_entry->session_history_entry().step().get<int>();
+            auto traversable = navigable->traversable_navigable();
+            traversable->append_session_history_traversal_steps(GC::create_function(heap(), [this, event, traversable, target_step, user_involvement_for_resume](NonnullRefPtr<Core::Promise<Empty>> signal) {
+                // NB: This appended step can run after a later navigation has aborted the intercepted
+                //     traverse. In that case, the aborted traverse must not be resumed.
+                if (event->abort_controller()->signal()->aborted() || event != m_ongoing_navigate_event) {
+                    signal->resolve({});
+                    return;
+                }
+
+                // 1. Resume applying the traverse history step given event's destination's entry's session history entry's step,
+                //    navigable's traversable navigable, and userInvolvement.
+                traversable->resume_applying_the_traverse_history_step(target_step, user_involvement_for_resume,
+                    GC::create_function(traversable->heap(), [signal](HistoryStepResult) {
+                        signal->resolve({});
+                    }));
+            }));
+        }
 
         // 7. If navigationType is "push" or "replace", then run the URL and history update steps given document and
         //    event's destination's URL, with serializedData set to event's classic history API state and historyHandling

--- a/Libraries/LibWeb/HTML/Navigation.h
+++ b/Libraries/LibWeb/HTML/Navigation.h
@@ -126,6 +126,7 @@ private:
     void reject_the_finished_promise(GC::Ref<NavigationAPIMethodTracker>, JS::Value exception);
     void clean_up(GC::Ref<NavigationAPIMethodTracker>);
     void notify_about_the_committed_to_entry(GC::Ref<NavigationAPIMethodTracker>, GC::Ref<NavigationHistoryEntry>);
+    void run_the_navigate_event_intercept_commit_handler_steps(GC::Ref<NavigateEvent>, GC::Ptr<NavigationAPIMethodTracker>);
 
     bool inner_navigate_event_firing_algorithm(
         Bindings::NavigationType,

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -464,6 +464,7 @@ public:
         UserNavigationInvolvement user_involvement,
         Optional<Bindings::NavigationType> navigation_type,
         TraversableNavigable::SynchronousNavigation synchronous_navigation,
+        Navigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
         GC::Ptr<DOM::Document> pending_document,
         GC::Ref<OnApplyHistoryStepComplete> on_complete)
         : m_traversable(traversable)
@@ -473,6 +474,7 @@ public:
         , m_user_involvement(user_involvement)
         , m_navigation_type(navigation_type)
         , m_synchronous_navigation(synchronous_navigation)
+        , m_navigation_api_abort_behavior(navigation_api_abort_behavior)
         , m_pending_document(pending_document)
         , m_on_complete(on_complete)
         , m_timeout(Platform::Timer::create_single_shot(heap(), TIMEOUT_MS, GC::create_function(heap(), [this] {
@@ -579,6 +581,7 @@ private:
     UserNavigationInvolvement m_user_involvement;
     Optional<Bindings::NavigationType> m_navigation_type;
     TraversableNavigable::SynchronousNavigation m_synchronous_navigation;
+    Navigable::NavigationAPIAbortBehavior m_navigation_api_abort_behavior;
     GC::Ptr<DOM::Document> m_pending_document;
     GC::Ptr<OnApplyHistoryStepComplete> m_on_complete;
     GC::Ref<Platform::Timer> m_timeout;
@@ -642,7 +645,7 @@ void ApplyHistoryStepState::start()
         navigable->set_current_session_history_entry(target_entry);
 
         // 3. Set navigable's ongoing navigation to "traversal".
-        navigable->set_ongoing_navigation(HTML::Navigable::Traversal::Tag);
+        navigable->set_ongoing_navigation(HTML::Navigable::Traversal::Tag, m_navigation_api_abort_behavior);
 
         m_changing_navigables.append(*navigable);
     }
@@ -1014,7 +1017,7 @@ void ApplyHistoryStepState::process_continuations()
         // 10. If changingNavigableContinuation's update-only is true, or targetEntry's document is displayedDocument, then:
         if (continuation->update_only || continuation->resolved_document.ptr() == displayed_document.ptr()) {
             // 1. Set the ongoing navigation for navigable to null.
-            navigable->set_ongoing_navigation({});
+            navigable->set_ongoing_navigation({}, m_navigation_api_abort_behavior);
 
             // 2. Queue a global task on the navigation and traversal task source given navigable's active window to perform afterPotentialUnloads.
             queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), after_potential_unload);
@@ -1112,6 +1115,7 @@ void TraversableNavigable::apply_the_history_step(
     UserNavigationInvolvement user_involvement,
     Optional<Bindings::NavigationType> navigation_type,
     SynchronousNavigation synchronous_navigation,
+    Navigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
     GC::Ptr<DOM::Document> pending_document,
     GC::Ref<OnApplyHistoryStepComplete> on_complete)
 {
@@ -1140,11 +1144,16 @@ void TraversableNavigable::apply_the_history_step(
     // 4. Let navigablesCrossingDocuments be the result of getting all navigables that might experience a cross-document traversal given traversable and targetStep.
     auto navigables_crossing_documents = get_all_navigables_that_might_experience_a_cross_document_traversal(target_step);
 
+    // NB: Same-document traversals finish their NavigateEvent during the Navigation API entry
+    //     update, after currententrychange. Preserve that event while applying the history step.
+    if (navigation_type == Bindings::NavigationType::Traverse && navigables_crossing_documents.is_empty())
+        navigation_api_abort_behavior = Navigable::NavigationAPIAbortBehavior::Preserve;
+
     // 5. If checkForCancelation is true, and the result of checking if unloading is canceled given navigablesCrossingDocuments, traversable, targetStep,
     //    and userInvolvement is not "continue", then return that result.
     if (check_for_cancelation) {
         check_if_unloading_is_canceled(navigables_crossing_documents, *this, target_step, user_involvement,
-            GC::create_function(heap(), [this, step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, pending_document, on_complete](CheckIfUnloadingIsCanceledResult result) mutable {
+            GC::create_function(heap(), [this, step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document, on_complete](CheckIfUnloadingIsCanceledResult result) mutable {
                 if (result == CheckIfUnloadingIsCanceledResult::CanceledByBeforeUnload) {
                     on_complete->function()(HistoryStepResult::CanceledByBeforeUnload);
                     return;
@@ -1153,13 +1162,13 @@ void TraversableNavigable::apply_the_history_step(
                     on_complete->function()(HistoryStepResult::CanceledByNavigate);
                     return;
                 }
-                apply_the_history_step_after_unload_check(step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, pending_document, on_complete);
+                apply_the_history_step_after_unload_check(step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document, on_complete);
             }));
         return;
     }
 
     // 6. Let changingNavigables be the result of get all navigables whose current session history entry will change or reload given traversable and targetStep.
-    apply_the_history_step_after_unload_check(step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, pending_document, on_complete);
+    apply_the_history_step_after_unload_check(step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document, on_complete);
 }
 
 void TraversableNavigable::apply_the_history_step_after_unload_check(
@@ -1169,11 +1178,12 @@ void TraversableNavigable::apply_the_history_step_after_unload_check(
     UserNavigationInvolvement user_involvement,
     Optional<Bindings::NavigationType> navigation_type,
     SynchronousNavigation synchronous_navigation,
+    Navigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
     GC::Ptr<DOM::Document> pending_document,
     GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
     auto state = heap().allocate<ApplyHistoryStepState>(*this, step, target_step, source_snapshot_params,
-        user_involvement, navigation_type, synchronous_navigation, pending_document, on_complete);
+        user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document, on_complete);
 
     VERIFY(!m_apply_history_step_state || m_paused_apply_history_step_state);
     m_apply_history_step_state = state;
@@ -1593,7 +1603,7 @@ void TraversableNavigable::update_for_navigable_creation_or_destruction(GC::Ref<
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step to traversable given false, null, null, null, and null.
-    apply_the_history_step(step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No, nullptr, on_complete);
+    apply_the_history_step(step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No, Navigable::NavigationAPIAbortBehavior::Abort, nullptr, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-reload-history-step
@@ -1603,7 +1613,7 @@ void TraversableNavigable::apply_the_reload_history_step(UserNavigationInvolveme
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step step to traversable given true, null, null, null, and "reload".
-    apply_the_history_step(step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, nullptr, on_complete);
+    apply_the_history_step(step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, Navigable::NavigationAPIAbortBehavior::Abort, nullptr, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-push/replace-history-step
@@ -1611,13 +1621,13 @@ void TraversableNavigable::apply_the_push_or_replace_history_step(int step, Hist
 {
     // 1. Return the result of applying the history step step to traversable given false, null, null, userInvolvement, and historyHandling.
     auto navigation_type = history_handling == HistoryHandlingBehavior::Replace ? Bindings::NavigationType::Replace : Bindings::NavigationType::Push;
-    apply_the_history_step(step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, pending_document, on_complete);
+    apply_the_history_step(step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, Navigable::NavigationAPIAbortBehavior::Abort, pending_document, on_complete);
 }
 
 void TraversableNavigable::apply_the_traverse_history_step(int step, GC::Ptr<SourceSnapshotParams> source_snapshot_params, GC::Ptr<Navigable> initiator_to_check, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
     // 1. Return the result of applying the history step step to traversable given true, sourceSnapshotParams, initiatorToCheck, userInvolvement, and "traverse".
-    apply_the_history_step(step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, nullptr, on_complete);
+    apply_the_history_step(step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, Navigable::NavigationAPIAbortBehavior::Abort, nullptr, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#resume-applying-the-traverse-history-step
@@ -1629,7 +1639,9 @@ void TraversableNavigable::resume_applying_the_traverse_history_step(int step, U
     // NOTE: When resuming a traverse, we are already past the cancelation, initiator, and
     //       source snapshot checks, and this traversal has already been determined to be a
     //       same-document traversal. Hence, we can pass false and null for those arguments.
-    apply_the_history_step(step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, nullptr, on_complete);
+    // NB: The committed navigate event remains ongoing until the same-document entry update runs
+    //     the navigate event intercept commit handler steps.
+    apply_the_history_step(step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, Navigable::NavigationAPIAbortBehavior::Preserve, nullptr, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#close-a-top-level-traversable

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -1235,9 +1235,9 @@ public:
             // 2. Let targetEntry be the result of getting the target history entry given traversable and targetStep.
             m_target_entry = m_traversable->get_the_target_history_entry(target_step.value());
 
-            // 3. If targetEntry is not traversable's current session history entry, and targetEntry's document state's origin is not the same as
-            //    traversable's current session history entry's document state's origin, then:
-            if (m_target_entry != m_traversable->current_session_history_entry() && m_target_entry->document_state()->origin() != m_traversable->current_session_history_entry()->document_state()->origin()) {
+            // 3. If targetEntry is not traversable's current session history entry, and targetEntry's document state's origin is the same as
+            //    traversable's current session history entry's document state's origin:
+            if (m_target_entry != m_traversable->current_session_history_entry() && m_target_entry->document_state()->origin() == m_traversable->current_session_history_entry()->document_state()->origin()) {
 
                 // 1. Let eventsFired be false.
 
@@ -1618,6 +1618,18 @@ void TraversableNavigable::apply_the_traverse_history_step(int step, GC::Ptr<Sou
 {
     // 1. Return the result of applying the history step step to traversable given true, sourceSnapshotParams, initiatorToCheck, userInvolvement, and "traverse".
     apply_the_history_step(step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, nullptr, on_complete);
+}
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#resume-applying-the-traverse-history-step
+void TraversableNavigable::resume_applying_the_traverse_history_step(int step, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
+{
+    // To resume applying the traverse history step given a non-negative integer step, a traversable
+    // navigable traversable, and user navigation involvement userInvolvement, apply step to
+    // traversable given false, null, null, userInvolvement, and "traverse".
+    // NOTE: When resuming a traverse, we are already past the cancelation, initiator, and
+    //       source snapshot checks, and this traversal has already been determined to be a
+    //       same-document traversal. Hence, we can pass false and null for those arguments.
+    apply_the_history_step(step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, nullptr, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#close-a-top-level-traversable

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -60,6 +60,7 @@ public:
     HistoryObjectLengthAndIndex get_the_history_object_length_and_index(int) const;
 
     void apply_the_traverse_history_step(int, GC::Ptr<SourceSnapshotParams>, GC::Ptr<Navigable>, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
+    void resume_applying_the_traverse_history_step(int, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
     void apply_the_reload_history_step(UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
     enum class SynchronousNavigation : bool {
         Yes,

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -137,6 +137,7 @@ private:
         UserNavigationInvolvement user_involvement,
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation,
+        Navigable::NavigationAPIAbortBehavior,
         GC::Ptr<DOM::Document> pending_document,
         GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
@@ -147,6 +148,7 @@ private:
         UserNavigationInvolvement user_involvement,
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation,
+        Navigable::NavigationAPIAbortBehavior,
         GC::Ptr<DOM::Document> pending_document,
         GC::Ref<OnApplyHistoryStepComplete> on_complete);
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -19,6 +19,7 @@ Text/input/css/font-face-load-dedups-same-url.html
 ; pushState with path URL requires HTTP(s) scheme.
 Text/input/navigation/history-replace-push-then-back.html
 Text/input/navigation/intercepted-traverse-updates-history-entry.html
+Text/input/navigation/non-intercepted-traverse-updates-history-entry.html
 Text/input/navigation/aborted-intercepted-traverse-does-not-resume.html
 
 ; CSS @font-face url() requires HTTP(s) scheme.

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -18,6 +18,8 @@ Text/input/css/font-face-load-dedups-same-url.html
 
 ; pushState with path URL requires HTTP(s) scheme.
 Text/input/navigation/history-replace-push-then-back.html
+Text/input/navigation/intercepted-traverse-updates-history-entry.html
+Text/input/navigation/aborted-intercepted-traverse-does-not-resume.html
 
 ; CSS @font-face url() requires HTTP(s) scheme.
 Text/input/selection-rect-consistency-with-kerning.html

--- a/Tests/LibWeb/Text/expected/navigation/aborted-intercepted-traverse-does-not-resume.txt
+++ b/Tests/LibWeb/Text/expected/navigation/aborted-intercepted-traverse-does-not-resume.txt
@@ -1,0 +1,9 @@
+navigate type=traverse destination=/r/programming current=/r/programming/comments/post location=/r/programming/comments/post
+navigateerror current=/r/programming/comments/post location=/r/programming/comments/post
+navigate type=push destination=/r/programming/comments/post#other current=/r/programming/comments/post location=/r/programming/comments/post
+currententrychange type=push current=/r/programming/comments/post#other location=/r/programming/comments/post#other
+navigatesuccess current=/r/programming/comments/post#other location=/r/programming/comments/post#other
+navigate type=traverse destination=/r/programming/comments/post current=/r/programming/comments/post#other location=/r/programming/comments/post#other
+currententrychange type=traverse current=/r/programming/comments/post location=/r/programming/comments/post
+navigatesuccess current=/r/programming/comments/post location=/r/programming/comments/post
+final current=/r/programming/comments/post location=/r/programming/comments/post

--- a/Tests/LibWeb/Text/expected/navigation/intercepted-traverse-updates-history-entry.txt
+++ b/Tests/LibWeb/Text/expected/navigation/intercepted-traverse-updates-history-entry.txt
@@ -1,0 +1,4 @@
+navigate destination=/r/programming current=/r/programming/comments/post location=/r/programming/comments/post
+handler current=/r/programming/comments/post location=/r/programming/comments/post
+navigatesuccess current=/r/programming/comments/post location=/r/programming/comments/post
+currententrychange current=/r/programming location=/r/programming

--- a/Tests/LibWeb/Text/expected/navigation/non-intercepted-traverse-updates-history-entry.txt
+++ b/Tests/LibWeb/Text/expected/navigation/non-intercepted-traverse-updates-history-entry.txt
@@ -1,4 +1,3 @@
 navigate destination=/r/programming current=/r/programming/comments/post location=/r/programming/comments/post
 currententrychange current=/r/programming location=/r/programming
-handler current=/r/programming location=/r/programming
 navigatesuccess current=/r/programming location=/r/programming

--- a/Tests/LibWeb/Text/input/navigation/aborted-intercepted-traverse-does-not-resume.html
+++ b/Tests/LibWeb/Text/input/navigation/aborted-intercepted-traverse-does-not-resume.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let sawTraverseNavigate = false;
+        let sawVerificationCurrentEntryChange = false;
+        let sawVerificationNavigateSuccess = false;
+        let traverseNavigateCount = 0;
+        let startedVerificationBack = false;
+        let finished = false;
+
+        function pathAndHashFromURL(url) {
+            const parsed = new URL(url);
+            return `${parsed.pathname}${parsed.hash}`;
+        }
+
+        function locationPathAndHash() {
+            return `${location.pathname}${location.hash}`;
+        }
+
+        function maybeDone() {
+            if (finished)
+                return;
+            if (!sawTraverseNavigate || !sawVerificationCurrentEntryChange || !sawVerificationNavigateSuccess)
+                return;
+            if (locationPathAndHash() !== "/r/programming/comments/post" || pathAndHashFromURL(navigation.currentEntry.url) !== "/r/programming/comments/post")
+                return;
+
+            finished = true;
+            println(`final current=${pathAndHashFromURL(navigation.currentEntry.url)} location=${locationPathAndHash()}`);
+            done();
+        }
+
+        navigation.addEventListener("navigate", event => {
+            if (!sawTraverseNavigate && event.navigationType !== "traverse")
+                return;
+
+            println(`navigate type=${event.navigationType} destination=${pathAndHashFromURL(event.destination.url)} current=${pathAndHashFromURL(navigation.currentEntry.url)} location=${locationPathAndHash()}`);
+
+            if (event.navigationType !== "traverse")
+                return;
+
+            ++traverseNavigateCount;
+            if (traverseNavigateCount !== 1)
+                return;
+
+            sawTraverseNavigate = true;
+            event.intercept({
+                handler() {
+                    println(`unexpected traverse handler current=${pathAndHashFromURL(navigation.currentEntry.url)} location=${locationPathAndHash()}`);
+                },
+            });
+
+            Promise.resolve().then(() => {
+                navigation.navigate("#other", { history: "push" });
+            });
+        });
+
+        navigation.addEventListener("currententrychange", event => {
+            if (!sawTraverseNavigate)
+                return;
+
+            println(`currententrychange type=${event.navigationType} current=${pathAndHashFromURL(navigation.currentEntry.url)} location=${locationPathAndHash()}`);
+
+            if (event.navigationType === "traverse" && traverseNavigateCount < 2) {
+                done();
+                return;
+            }
+
+            if (event.navigationType === "traverse")
+                sawVerificationCurrentEntryChange = true;
+
+            maybeDone();
+        });
+
+        navigation.addEventListener("navigatesuccess", () => {
+            if (!sawTraverseNavigate)
+                return;
+
+            println(`navigatesuccess current=${pathAndHashFromURL(navigation.currentEntry.url)} location=${locationPathAndHash()}`);
+
+            if (!startedVerificationBack && locationPathAndHash() === "/r/programming/comments/post#other") {
+                startedVerificationBack = true;
+                history.back();
+                return;
+            }
+
+            if (startedVerificationBack && locationPathAndHash() === "/r/programming/comments/post")
+                sawVerificationNavigateSuccess = true;
+
+            maybeDone();
+        });
+
+        navigation.addEventListener("navigateerror", () => {
+            if (!sawTraverseNavigate)
+                return;
+
+            println(`navigateerror current=${pathAndHashFromURL(navigation.currentEntry.url)} location=${locationPathAndHash()}`);
+        });
+
+        history.replaceState({}, "", "/r/programming");
+        history.pushState({}, "", "/r/programming/comments/post");
+        history.back();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/intercepted-traverse-updates-history-entry.html
+++ b/Tests/LibWeb/Text/input/navigation/intercepted-traverse-updates-history-entry.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let sawTraverseNavigate = false;
+        let sawTraverseHandler = false;
+        let sawTraverseCurrentEntryChange = false;
+        let sawNavigateSuccess = false;
+        let finished = false;
+
+        function pathFromURL(url) {
+            return new URL(url).pathname;
+        }
+
+        function maybeDone() {
+            if (finished)
+                return;
+            if (!sawTraverseNavigate || !sawTraverseHandler || !sawTraverseCurrentEntryChange || !sawNavigateSuccess)
+                return;
+            if (location.pathname !== "/r/programming" || pathFromURL(navigation.currentEntry.url) !== "/r/programming")
+                return;
+
+            finished = true;
+            done();
+        }
+
+        navigation.addEventListener("navigate", event => {
+            if (event.navigationType !== "traverse")
+                return;
+
+            sawTraverseNavigate = true;
+            println(`navigate destination=${pathFromURL(event.destination.url)} current=${pathFromURL(navigation.currentEntry.url)} location=${location.pathname}`);
+
+            event.intercept({
+                handler() {
+                    sawTraverseHandler = true;
+                    println(`handler current=${pathFromURL(navigation.currentEntry.url)} location=${location.pathname}`);
+                    maybeDone();
+                },
+            });
+        });
+
+        navigation.addEventListener("currententrychange", event => {
+            if (event.navigationType !== "traverse")
+                return;
+
+            sawTraverseCurrentEntryChange = true;
+            println(`currententrychange current=${pathFromURL(navigation.currentEntry.url)} location=${location.pathname}`);
+            maybeDone();
+        });
+
+        navigation.addEventListener("navigatesuccess", () => {
+            if (!sawTraverseNavigate || !sawTraverseHandler)
+                return;
+
+            sawNavigateSuccess = true;
+            println(`navigatesuccess current=${pathFromURL(navigation.currentEntry.url)} location=${location.pathname}`);
+            maybeDone();
+        });
+
+        history.replaceState({}, "", "/r/programming");
+        history.pushState({}, "", "/r/programming/comments/post");
+        history.back();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/non-intercepted-traverse-updates-history-entry.html
+++ b/Tests/LibWeb/Text/input/navigation/non-intercepted-traverse-updates-history-entry.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let sawTraverseNavigate = false;
+        let sawTraverseCurrentEntryChange = false;
+        let sawNavigateSuccess = false;
+        let finished = false;
+
+        function pathFromURL(url) {
+            return new URL(url).pathname;
+        }
+
+        function maybeDone() {
+            if (finished)
+                return;
+            if (!sawTraverseNavigate || !sawTraverseCurrentEntryChange || !sawNavigateSuccess)
+                return;
+            if (location.pathname !== "/r/programming" || pathFromURL(navigation.currentEntry.url) !== "/r/programming")
+                return;
+
+            finished = true;
+            done();
+        }
+
+        navigation.addEventListener("navigate", event => {
+            if (event.navigationType !== "traverse")
+                return;
+
+            sawTraverseNavigate = true;
+            println(`navigate destination=${pathFromURL(event.destination.url)} current=${pathFromURL(navigation.currentEntry.url)} location=${location.pathname}`);
+        });
+
+        navigation.addEventListener("currententrychange", event => {
+            if (event.navigationType !== "traverse")
+                return;
+
+            sawTraverseCurrentEntryChange = true;
+            println(`currententrychange current=${pathFromURL(navigation.currentEntry.url)} location=${location.pathname}`);
+            maybeDone();
+        });
+
+        navigation.addEventListener("navigatesuccess", () => {
+            if (!sawTraverseNavigate)
+                return;
+
+            sawNavigateSuccess = true;
+            println(`navigatesuccess current=${pathFromURL(navigation.currentEntry.url)} location=${location.pathname}`);
+            maybeDone();
+        });
+
+        navigation.addEventListener("navigateerror", () => {
+            if (!sawTraverseNavigate)
+                return;
+
+            println("navigateerror");
+            done();
+        });
+
+        history.replaceState({}, "", "/r/programming");
+        history.pushState({}, "", "/r/programming/comments/post");
+        history.back();
+    });
+</script>


### PR DESCRIPTION
This fixes same-document history traversals that fire Navigation API `navigate` events, including intercepted traversals that previously stopped after updating the URL and non-intercepted traversals that could abort their own event before `currententrychange` and `navigatesuccess`.

The patch queues the spec's resume step for intercepted traversals, skips that resume when the `NavigateEvent` has already been aborted or replaced, and preserves same-document traverse events until the Navigation API entry update completes.

Text coverage covers intercepted traversal, non-intercepted traversal, and an aborted intercepted traversal that is superseded before the queued step runs. The tests avoid timing assumptions by using deterministic Navigation API and history operations.