### PR TITLE
LibWeb: Use FormDataEntryValue for FormData.get()

### DIFF
--- a/Libraries/LibWeb/XHR/FormData.idl
+++ b/Libraries/LibWeb/XHR/FormData.idl
@@ -8,9 +8,7 @@ interface FormData {
     undefined append(USVString name, USVString value);
     undefined append(USVString name, Blob blobValue, optional USVString filename);
     undefined delete(USVString name);
-    // FIXME: The BindingsGenerator is not able to resolve the Variant's visit for FormDataEntryValue when
-    // the return value for one function returns an optional FormDataEntryValue while the others does not.
-    (File or USVString)? get(USVString name);
+    FormDataEntryValue? get(USVString name);
     sequence<FormDataEntryValue> getAll(USVString name);
     boolean has(USVString name);
     undefined set(USVString name, USVString value);


### PR DESCRIPTION
The bindings generator can now resolve nullable FormDataEntryValue return types, so remove the expanded union spelling and the old FIXME.