### PR TITLE
LibJS: Treat an unresolvable named time zone as UTC instead of crashing

### DIFF
--- a/Libraries/LibJS/Runtime/Date.cpp
+++ b/Libraries/LibJS/Runtime/Date.cpp
@@ -414,6 +414,15 @@ Vector<Crypto::SignedBigInteger> get_named_time_zone_epoch_nanoseconds(StringVie
     return result;
 }
 
+// ICU can report a time zone as available yet fail resolving an offset for it. So treat it as UTC. See issue #9884.
+static Unicode::TimeZoneOffset time_zone_offset_or_utc(StringView time_zone_identifier, UnixDateTime time)
+{
+    auto offset = Unicode::time_zone_offset(time_zone_identifier, time);
+    if (!offset.has_value())
+        return Unicode::TimeZoneOffset { .offset = AK::Duration {}, .in_dst = Unicode::TimeZoneOffset::InDST::No };
+    return offset.release_value();
+}
+
 // 21.4.1.21 GetNamedTimeZoneOffsetNanoseconds ( timeZoneIdentifier, epochNanoseconds ), https://tc39.es/ecma262/#sec-getnamedtimezoneoffsetnanoseconds
 Unicode::TimeZoneOffset get_named_time_zone_offset_nanoseconds(StringView time_zone_identifier, Crypto::SignedBigInteger const& epoch_nanoseconds)
 {
@@ -422,10 +431,7 @@ Unicode::TimeZoneOffset get_named_time_zone_offset_nanoseconds(StringView time_z
     auto seconds = big_floor(epoch_nanoseconds, Temporal::NANOSECONDS_PER_SECOND);
     auto time = UnixDateTime::from_seconds_since_epoch(clip_bigint_to_sane_time(seconds));
 
-    auto offset = Unicode::time_zone_offset(time_zone_identifier, time);
-    VERIFY(offset.has_value());
-
-    return offset.release_value();
+    return time_zone_offset_or_utc(time_zone_identifier, time);
 }
 
 // 21.4.1.21 GetNamedTimeZoneOffsetNanoseconds ( timeZoneIdentifier, epochNanoseconds ), https://tc39.es/ecma262/#sec-getnamedtimezoneoffsetnanoseconds
@@ -435,10 +441,7 @@ Unicode::TimeZoneOffset get_named_time_zone_offset_milliseconds(StringView time_
     auto seconds = epoch_milliseconds / 1000.0;
     auto time = UnixDateTime::from_seconds_since_epoch(clip_double_to_sane_time(seconds));
 
-    auto offset = Unicode::time_zone_offset(time_zone_identifier, time);
-    VERIFY(offset.has_value());
-
-    return offset.release_value();
+    return time_zone_offset_or_utc(time_zone_identifier, time);
 }
 
 static Optional<String> cached_system_time_zone_identifier;
@@ -458,8 +461,13 @@ String system_time_zone_identifier()
 
     if (!is_offset_time_zone_identifier(system_time_zone_string)) {
         auto time_zone_identifier = Intl::get_available_named_time_zone_identifier(system_time_zone_string);
-        if (!time_zone_identifier.has_value())
-            return "UTC"_string;
+
+        // The host time zone may be one that ICU enumerates but can't resolve an offset for. In that case, per step 1,
+        // fall back to UTC — rather than handing a broken identifier to downstream time-zone math. See issue #9884.
+        if (!time_zone_identifier.has_value() || !Unicode::time_zone_offset(time_zone_identifier->primary_identifier, UnixDateTime::now()).has_value()) {
+            cached_system_time_zone_identifier = "UTC"_string;
+            return *cached_system_time_zone_identifier;
+        }
 
         system_time_zone_string = time_zone_identifier->primary_identifier;
     }

--- a/Libraries/LibJS/Runtime/Date.h
+++ b/Libraries/LibJS/Runtime/Date.h
@@ -88,7 +88,7 @@ i64 clip_bigint_to_sane_time(Crypto::SignedBigInteger const& value);
 i64 clip_double_to_sane_time(double value);
 Vector<Crypto::SignedBigInteger> get_named_time_zone_epoch_nanoseconds(StringView time_zone_identifier, Temporal::ISODateTime const&);
 Unicode::TimeZoneOffset get_named_time_zone_offset_nanoseconds(StringView time_zone_identifier, Crypto::SignedBigInteger const& epoch_nanoseconds);
-Unicode::TimeZoneOffset get_named_time_zone_offset_milliseconds(StringView time_zone_identifier, double epoch_milliseconds);
+JS_API Unicode::TimeZoneOffset get_named_time_zone_offset_milliseconds(StringView time_zone_identifier, double epoch_milliseconds);
 String system_time_zone_identifier();
 JS_API void clear_system_time_zone_cache();
 double local_time(double time);

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,6 +1,7 @@
 ladybird_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
 ladybird_test(test-primitive-string.cpp LibJS LIBS LibJS LibGC)
 ladybird_test(test-bytecode-cache.cpp LibJS LIBS LibCrypto LibGC LibJS)
+ladybird_test(test-date.cpp LibJS LIBS LibJS LibUnicode)
 
 ladybird_testjs_test(test-js.cpp test-js LIBS LibGC)
 set_tests_properties(test-js PROPERTIES ENVIRONMENT "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}")

--- a/Tests/LibJS/test-date.cpp
+++ b/Tests/LibJS/test-date.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Time.h>
+#include <LibJS/Runtime/Date.h>
+#include <LibTest/TestCase.h>
+#include <LibUnicode/TimeZone.h>
+
+TEST_CASE(unresolvable_named_time_zone_offset_is_utc)
+{
+    // ICU can't resolve an offset for a bogus identifier — so the lookup returns nothing. The function must treat that
+    // as UTC (a zero offset) rather than VERIFY-crashing. Regression test for issue #9884.
+    auto offset = JS::get_named_time_zone_offset_milliseconds("Area/DoesNotExist"sv, 0.0);
+    EXPECT_EQ(offset.offset.to_milliseconds(), 0);
+}


### PR DESCRIPTION
**Problem:** Crash in `get_named_time_zone_offset_milliseconds`.

**Cause:** We accepted the system time zone in one ICU path but looked up the offset for it through another path. On a host where those disagree, the enumeration reports a zone `createTimeZone` resolves to ICU’s `Etc/Unknown` — so `time_zone_offset` returned nothing, tripping an assert.

**Fix:** If we can’t resolve an offset for a time zone, treat it as UTC. Return a zero offset from both `get_named_time_zone_offset` overloads when ICU yields nothing. And when the host zone is unresolvable, fall back to UTC — keeping a broken identifier out of all downstream time-zone math. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9884.
