### PR TITLE
LibWeb: Preserve inline handler ordering after parse failure

### DIFF
--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -519,7 +519,7 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(FlyString 
         // 7. If body is not parsable as FunctionBody or if parsing detects an early error, then follow these substeps:
         if (!rust_compilation.has_value() || rust_compilation->is_error()) {
             // 1. Set eventHandler's value to null.
-            handler_map.remove(event_handler_iterator);
+            event_handler->value = GC::Ptr<WebIDL::CallbackType> {};
 
             // FIXME: 2. Report the error for the appropriate script and with the appropriate position (line number and column number) given by location, using settings object's global object.
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/events/inline-event-handler-ordering.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/events/inline-event-handler-ordering.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	Inline event handlers retain their ordering when invalid and force-compiled
+Pass	Inline event handlers retain their ordering when invalid and force-compiled via dispatch
+Pass	Inline event handlers retain their ordering when invalid and lazy-compiled

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/events/inline-event-handler-ordering.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/events/inline-event-handler-ordering.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Inline event handlers retain their ordering even when invalid</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<body>
+<script>
+setup({ allow_uncaught_exception: true });
+var events = [];
+
+test(function() {
+  events = [];
+  var e = document.createElement("div");
+  document.body.appendChild(e);
+  e.addEventListener("click", function() { events.push("ONE") });
+  e.setAttribute("onclick", "window.open(");
+  e.addEventListener("click", function() { events.push("THREE") });
+  // Try to compile the event handler.
+  e.onclick;
+  e.setAttribute("onclick", "events.push('TWO')");
+  e.dispatchEvent(new Event("click"));
+  var expected_events = ["ONE", "TWO", "THREE"];
+  assert_array_equals(events, expected_events);
+}, "Inline event handlers retain their ordering when invalid and force-compiled");
+
+test(function() {
+  events = [];
+  var e = document.createElement("div");
+  document.body.appendChild(e);
+  e.addEventListener("click", function() { events.push("ONE") });
+  e.setAttribute("onclick", "window.open(");
+  e.addEventListener("click", function() { events.push("THREE") });
+  e.dispatchEvent(new Event("click"));
+  e.setAttribute("onclick", "events.push('TWO')");
+  e.dispatchEvent(new Event("click"));
+  var expected_events = ["ONE", "THREE", "ONE", "TWO", "THREE"];
+  assert_array_equals(events, expected_events);
+}, "Inline event handlers retain their ordering when invalid and force-compiled via dispatch");
+
+test(function() {
+  events = [];
+  var e = document.createElement("div");
+  document.body.appendChild(e);
+  e.addEventListener("click", function() { events.push("ONE") });
+  e.setAttribute("onclick", "window.open(");
+  e.addEventListener("click", function() { events.push("THREE") });
+  e.setAttribute("onclick", "events.push('TWO')");
+  e.dispatchEvent(new Event("click"));
+  var expected_events = ["ONE", "TWO", "THREE"];
+  assert_array_equals(events, expected_events);
+}, "Inline event handlers retain their ordering when invalid and lazy-compiled");
+</script>
+</body>


### PR DESCRIPTION
On inline handler parse failure, keep the event handler map entry and set its value to null instead of removing it. This preserves the handler listener’s position so a later valid attribute value does not get appended out of order.