### PR TITLE
LibWeb: Move CSS image loading state out of ImageStyleValue

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -31,7 +31,7 @@ struct AnimationUpdateContext {
     struct ElementData {
         using PropertyMap = HashMap<CSS::PropertyID, NonnullRefPtr<CSS::StyleValue const>>;
         PropertyMap animated_properties_before_update;
-        GC::Ptr<CSS::ComputedProperties> target_style;
+        RefPtr<CSS::ComputedProperties> target_style;
     };
 
     ~AnimationUpdateContext();

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -171,7 +171,9 @@ void CSSImportRule::fetch()
         .environment_settings_object = HTML::relevant_settings_object(parent_style_sheet),
         .value = RuleOrDeclaration::Rule {
             .parent_style_sheet = &parent_style_sheet,
-        }
+        },
+        .style_resource_base_url = {},
+        .parent_style_sheet_origin_clean = {},
     };
     (void)fetch_a_style_resource(URL { href() }, rule_or_declaration, Fetch::Infrastructure::Request::Destination::Style, CorsMode::NoCors,
         [strong_this = GC::Ref { *this }, parent_style_sheet = GC::Ref { parent_style_sheet }, document = m_document](auto response, auto maybe_byte_stream) {
@@ -231,7 +233,7 @@ void CSSImportRule::fetch()
             imported_style_sheet->set_origin_clean(parent_style_sheet->is_origin_clean());
 
             // 6. If response is not CORS-same-origin, unset importedStylesheet’s origin-clean flag.
-            if (!response->is_cors_cross_origin())
+            if (!response->is_cors_same_origin())
                 imported_style_sheet->set_origin_clean(false);
 
             // 7. Set rule’s styleSheet to importedStylesheet.
@@ -249,7 +251,10 @@ void CSSImportRule::set_style_sheet(GC::Ref<CSSStyleSheet> style_sheet)
             m_style_sheet->add_owning_document_or_shadow_root(*owning_document_or_shadow_root);
     }
 
-    if (auto document = m_style_sheet->owning_document())
+    auto document = m_style_sheet->owning_document();
+    if (!document && m_parent_style_sheet)
+        document = m_parent_style_sheet->owning_document();
+    if (document)
         m_style_sheet->load_pending_image_resources(*document);
 
     m_style_sheet->invalidate_owners(DOM::StyleInvalidationReason::CSSImportRule);

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -535,8 +535,10 @@ void CSSStyleSheet::load_pending_image_resources(DOM::Document& document)
 
     auto pending = move(m_pending_image_values);
     for (auto const& weak_image_value : pending) {
-        if (auto* image_value = weak_image_value.ptr())
+        if (auto* image_value = weak_image_value.ptr()) {
+            image_value->update_style_sheet_resource_context(*this);
             image_value->load_any_resources(document);
+        }
     }
 }
 

--- a/Libraries/LibWeb/CSS/CascadedProperties.cpp
+++ b/Libraries/LibWeb/CSS/CascadedProperties.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/WeakInlines.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/PropertyID.h>
@@ -12,21 +13,13 @@
 
 namespace Web::CSS {
 
-GC_DEFINE_ALLOCATOR(CascadedProperties);
-
 CascadedProperties::CascadedProperties() = default;
 
 CascadedProperties::~CascadedProperties() = default;
 
-void CascadedProperties::visit_edges(Visitor& visitor)
+NonnullRefPtr<CascadedProperties> CascadedProperties::create()
 {
-    Base::visit_edges(visitor);
-    for (auto const& [property_id, entries] : m_properties) {
-        for (auto const& entry : entries) {
-            visitor.visit(entry.source);
-            visitor.visit(entry.source_shadow_root);
-        }
-    }
+    return adopt_ref(*new CascadedProperties);
 }
 
 void CascadedProperties::revert_property(PropertyID property_id, Important important, CascadeOrigin cascade_origin)
@@ -61,7 +54,7 @@ void CascadedProperties::revert_layer_property(PropertyID property_id, Important
         return entry.property.property_id == property_id
             && entry.property.important == important
             && entry.origin == cascade_origin
-            && entry.source_shadow_root == source_shadow_root
+            && entry.source_shadow_root.ptr() == source_shadow_root
             && layer_name == entry.layer_name;
     });
     if (entries.is_empty()) {
@@ -77,7 +70,7 @@ void CascadedProperties::set_property(PropertyID property_id, NonnullRefPtr<Styl
     auto& entries = m_properties.ensure(property_id);
 
     for (auto& entry : entries.in_reverse()) {
-        if (entry.origin == origin && entry.layer_name == layer_name && entry.source_shadow_root == source_shadow_root) {
+        if (entry.origin == origin && entry.layer_name == layer_name && entry.source_shadow_root.ptr() == source_shadow_root) {
             if (entry.property.important == Important::Yes && important == Important::No)
                 return;
             entry.property = StyleProperty {
@@ -86,8 +79,8 @@ void CascadedProperties::set_property(PropertyID property_id, NonnullRefPtr<Styl
                 .value = value,
             };
             entry.cascade_index = m_next_cascade_index++;
-            entry.source = source;
-            entry.source_shadow_root = source_shadow_root;
+            entry.source = source.ptr();
+            entry.source_shadow_root = source_shadow_root.ptr();
             return;
         }
     }
@@ -101,8 +94,8 @@ void CascadedProperties::set_property(PropertyID property_id, NonnullRefPtr<Styl
         .cascade_index = m_next_cascade_index++,
         .origin = origin,
         .layer_name = move(layer_name),
-        .source = source,
-        .source_shadow_root = source_shadow_root,
+        .source = source.ptr(),
+        .source_shadow_root = source_shadow_root.ptr(),
     });
 }
 
@@ -133,7 +126,7 @@ GC::Ptr<CSSStyleDeclaration const> CascadedProperties::property_source(PropertyI
     if (!m_contained_properties_cache.get(to_underlying(property_id)))
         return nullptr;
 
-    return m_properties.get(property_id)->last().source;
+    return m_properties.get(property_id)->last().source.ptr();
 }
 
 GC::Ptr<DOM::ShadowRoot const> CascadedProperties::property_source_shadow_root(PropertyID property_id) const
@@ -141,7 +134,7 @@ GC::Ptr<DOM::ShadowRoot const> CascadedProperties::property_source_shadow_root(P
     if (!m_contained_properties_cache.get(to_underlying(property_id)))
         return nullptr;
 
-    return m_properties.get(property_id)->last().source_shadow_root;
+    return m_properties.get(property_id)->last().source_shadow_root.ptr();
 }
 
 Optional<StyleProperty> CascadedProperties::style_property(PropertyID property_id) const

--- a/Libraries/LibWeb/CSS/CascadedProperties.h
+++ b/Libraries/LibWeb/CSS/CascadedProperties.h
@@ -7,8 +7,10 @@
 #pragma once
 
 #include <AK/FixedBitmap.h>
-#include <LibGC/CellAllocator.h>
-#include <LibJS/Heap/Cell.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <LibGC/Ptr.h>
+#include <LibGC/Weak.h>
 #include <LibWeb/CSS/CascadeOrigin.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/Selector.h>
@@ -18,12 +20,11 @@
 
 namespace Web::CSS {
 
-class CascadedProperties final : public JS::Cell {
-    GC_CELL(CascadedProperties, JS::Cell);
-    GC_DECLARE_ALLOCATOR(CascadedProperties);
-
+class CascadedProperties final : public RefCounted<CascadedProperties> {
 public:
-    virtual ~CascadedProperties() override;
+    static NonnullRefPtr<CascadedProperties> create();
+
+    ~CascadedProperties();
 
     [[nodiscard]] RefPtr<StyleValue const> property(PropertyID) const;
     [[nodiscard]] PropertyID property_with_higher_priority(PropertyID, PropertyID) const;
@@ -39,15 +40,13 @@ public:
 private:
     CascadedProperties();
 
-    virtual void visit_edges(Visitor&) override;
-
     struct Entry {
         StyleProperty property;
         size_t cascade_index { 0 };
         CascadeOrigin origin;
         Optional<FlyString> layer_name;
-        GC::Ptr<CSS::CSSStyleDeclaration const> source;
-        GC::Ptr<DOM::ShadowRoot const> source_shadow_root;
+        GC::Weak<CSS::CSSStyleDeclaration const> source;
+        GC::Weak<DOM::ShadowRoot const> source_shadow_root;
     };
     HashMap<PropertyID, Vector<Entry>> m_properties;
     size_t m_next_cascade_index { 0 };

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -8,7 +8,6 @@
 #include <AK/NonnullRawPtr.h>
 #include <AK/TypeCasts.h>
 #include <LibCore/DirIterator.h>
-#include <LibGC/CellAllocator.h>
 #include <LibWeb/Animations/AnimationTimeline.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
 #include <LibWeb/Animations/ScrollTimeline.h>
@@ -57,15 +56,13 @@
 
 namespace Web::CSS {
 
-GC_DEFINE_ALLOCATOR(ComputedProperties);
-
 ComputedProperties::ComputedProperties() = default;
 
 ComputedProperties::~ComputedProperties() = default;
 
-void ComputedProperties::visit_edges(Visitor& visitor)
+NonnullRefPtr<ComputedProperties> ComputedProperties::create()
 {
-    Base::visit_edges(visitor);
+    return adopt_ref(*new ComputedProperties);
 }
 
 bool ComputedProperties::is_property_important(PropertyID property_id) const

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -9,12 +9,11 @@
 
 #include <AK/HashMap.h>
 #include <AK/NonnullRefPtr.h>
-#include <LibGC/CellAllocator.h>
+#include <AK/RefCounted.h>
 #include <LibGC/Ptr.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/FontCascadeList.h>
 #include <LibGfx/Forward.h>
-#include <LibJS/Heap/Cell.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/EasingFunction.h>
 #include <LibWeb/CSS/FontFeatureData.h>
@@ -40,14 +39,13 @@ enum class AnimatedPropertyResultOfTransition : u8 {
     Yes
 };
 
-class WEB_API ComputedProperties final : public JS::Cell {
-    GC_CELL(ComputedProperties, JS::Cell);
-    GC_DECLARE_ALLOCATOR(ComputedProperties);
-
+class WEB_API ComputedProperties final : public RefCounted<ComputedProperties> {
 public:
+    static NonnullRefPtr<ComputedProperties> create();
+
     static constexpr double normal_line_height_scale = 1.15;
 
-    virtual ~ComputedProperties() override;
+    ~ComputedProperties();
 
     template<typename Callback>
     inline void for_each_property(Callback callback) const
@@ -290,8 +288,6 @@ public:
 
 private:
     ComputedProperties();
-
-    virtual void visit_edges(Visitor&) override;
 
     Overflow overflow(PropertyID) const;
     Vector<ShadowData> shadow(PropertyID, Layout::Node const&) const;

--- a/Libraries/LibWeb/CSS/Fetch.cpp
+++ b/Libraries/LibWeb/CSS/Fetch.cpp
@@ -17,12 +17,21 @@ namespace Web::CSS {
 
 // https://drafts.csswg.org/css-values-4/#style-resource-base-url
 
-struct StyleSheetAndURL {
+struct StyleResourceContext {
     GC::Ptr<CSSStyleSheet> sheet;
+    Optional<bool> parent_style_sheet_origin_clean;
     ::URL::URL url;
 };
-static StyleSheetAndURL style_resource_base_url(RuleOrDeclaration css_rule_or_declaration)
+static StyleResourceContext style_resource_context(RuleOrDeclaration css_rule_or_declaration)
 {
+    if (css_rule_or_declaration.style_resource_base_url.has_value()) {
+        return {
+            nullptr,
+            css_rule_or_declaration.parent_style_sheet_origin_clean,
+            css_rule_or_declaration.style_resource_base_url.value()
+        };
+    }
+
     // 1. Let sheet be null.
     GC::Ptr<CSSStyleSheet> sheet;
 
@@ -43,22 +52,25 @@ static StyleSheetAndURL style_resource_base_url(RuleOrDeclaration css_rule_or_de
     if (sheet) {
         // 1. If sheet’s stylesheet base URL is not null, return sheet’s stylesheet base URL.
         if (auto base_url = sheet->base_url(); base_url.has_value())
-            return { sheet, base_url.value() };
+            return { sheet, sheet->is_origin_clean(), base_url.value() };
 
         // 2. If sheet’s location is not null, return sheet’s location.
         if (auto location = sheet->location(); location.has_value())
-            return { sheet, location.value() };
+            return { sheet, sheet->is_origin_clean(), location.value() };
     }
 
     // 5. Return cssRuleOrDeclaration’s relevant settings object’s API base URL.
-    return { sheet, css_rule_or_declaration.environment_settings_object->api_base_url() };
+    auto api_base_url = css_rule_or_declaration.environment_settings_object->api_base_url();
+    if (sheet)
+        return { sheet, sheet->is_origin_clean(), api_base_url };
+    return { nullptr, {}, api_base_url };
 }
 
 // https://drafts.csswg.org/css-values-4/#resolve-a-style-resource-url
 static Optional<::URL::URL> resolve_a_style_resource_url(StyleResourceURL const& url_value, RuleOrDeclaration css_rule_or_declaration)
 {
     // 1. Let baseURL be the style resource base URL given cssRuleOrDeclaration.
-    auto [_, base_url] = style_resource_base_url(css_rule_or_declaration);
+    auto base_url = style_resource_context(css_rule_or_declaration).url;
 
     // 2. Return the result of the URL parser steps with urlValue’s url and base.
     auto url_string = url_value.visit(
@@ -104,13 +116,13 @@ static GC::Ptr<Fetch::Infrastructure::Request> fetch_a_style_resource_impl(Style
     // 6. If req’s mode is "cors", and sheet is not null, then set req’s referrer to the style resource base URL given cssRuleOrDeclaration. [CSSOM]
     // FIXME: Spec issue - sheet is not defined as a variable, we use the sheet determined from 'style resource base URL' instead.
     //        https://github.com/w3c/csswg-drafts/issues/12288
-    auto [sheet, base_url] = style_resource_base_url(css_rule_or_declaration);
-    if (request->mode() == Fetch::Infrastructure::Request::Mode::CORS && sheet)
-        request->set_referrer(base_url);
+    auto context = style_resource_context(css_rule_or_declaration);
+    if (request->mode() == Fetch::Infrastructure::Request::Mode::CORS && (context.sheet || context.parent_style_sheet_origin_clean.has_value()))
+        request->set_referrer(context.url);
 
     // 7. If sheet’s origin-clean flag is set, set req’s initiator type to "css". [CSSOM]
-    if (sheet) {
-        if (sheet->is_origin_clean())
+    if (context.sheet || context.parent_style_sheet_origin_clean.has_value()) {
+        if (context.parent_style_sheet_origin_clean.value_or(false))
             request->set_initiator_type(Fetch::Infrastructure::Request::InitiatorType::CSS);
     } else {
         // AD-HOC: If the resource is not associated with a stylesheet, we must still set an initiator type in order

--- a/Libraries/LibWeb/CSS/Fetch.h
+++ b/Libraries/LibWeb/CSS/Fetch.h
@@ -35,6 +35,8 @@ struct RuleOrDeclaration {
 
     GC::Ref<HTML::EnvironmentSettingsObject> environment_settings_object;
     Variant<StyleDeclaration, Rule> value;
+    Optional<::URL::URL> style_resource_base_url;
+    Optional<bool> parent_style_sheet_origin_clean;
 };
 
 // https://drafts.csswg.org/css-values-4/#fetch-a-style-resource

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -829,7 +829,9 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
         .environment_settings_object = document().relevant_settings_object(),
         .value = RuleOrDeclaration::Rule {
             .parent_style_sheet = font_face.parent_rule()->parent_style_sheet(),
-        }
+        },
+        .style_resource_base_url = {},
+        .parent_style_sheet_origin_clean = {},
     };
 
     auto key = urls.first().to_string();

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -79,6 +79,7 @@
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 #include <LibWeb/CSS/StyleValues/UnicodeRangeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/UnresolvedStyleValue.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Infra/CharacterTypes.h>
@@ -2694,6 +2695,7 @@ RefPtr<ImageSetStyleValue const> Parser::parse_image_set_function(TokenStream<Co
 
     Vector<ImageSetStyleValue::Option> options;
     options.ensure_capacity(image_set_options_tokens.size());
+    auto style_resource_base_url = m_document ? Optional<::URL::URL> { m_document->base_url() } : Optional<::URL::URL> {};
     for (auto const& option_tokens_list : image_set_options_tokens) {
         if (option_tokens_list.first_matching([](auto const& component_value) { return component_value.contains_attr_tainted_value(); }).has_value())
             return nullptr;
@@ -2704,7 +2706,7 @@ RefPtr<ImageSetStyleValue const> Parser::parse_image_set_function(TokenStream<Co
         RefPtr<AbstractImageStyleValue const> image;
         if (option_tokens.next_token().is(Token::Type::String)) {
             auto url = URL { option_tokens.consume_a_token().token().string().to_string() };
-            image = ImageStyleValue::create(url);
+            image = ImageStyleValue::create(url, style_resource_base_url);
         } else {
             image = parse_image_value(option_tokens, AllowImageSet::No);
         }
@@ -2768,7 +2770,8 @@ RefPtr<AbstractImageStyleValue const> Parser::parse_image_value(TokenStream<Comp
         // FIXME: Remove this special case once mask-image accepts `<image>`.
         if (!url->url().starts_with('#')) {
             tokens.discard_a_mark();
-            return ImageStyleValue::create(url.release_value());
+            auto style_resource_base_url = m_document ? Optional<::URL::URL> { m_document->base_url() } : Optional<::URL::URL> {};
+            return ImageStyleValue::create(url.release_value(), move(style_resource_base_url));
         }
         tokens.restore_a_mark();
         return nullptr;

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1929,9 +1929,9 @@ JsonArray StyleComputer::collect_devtools_applied_style_rules(DOM::AbstractEleme
 
 // https://www.w3.org/TR/css-cascade/#cascading
 // https://drafts.csswg.org/css-cascade-5/#layering
-GC::Ref<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::AbstractElement abstract_element, bool did_match_any_pseudo_element_rules, ComputeStyleMode mode, MatchingRuleSet const& matching_rule_set) const
+NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::AbstractElement abstract_element, bool did_match_any_pseudo_element_rules, ComputeStyleMode mode, MatchingRuleSet const& matching_rule_set) const
 {
-    auto cascaded_properties = m_document->heap().allocate<CascadedProperties>();
+    auto cascaded_properties = CascadedProperties::create();
     if (mode == ComputeStyleMode::CreatePseudoElementStyleIfNeeded) {
         if (!did_match_any_pseudo_element_rules)
             return cascaded_properties;
@@ -2457,9 +2457,9 @@ void StyleComputer::transform_box_type_if_needed(ComputedProperties& style, DOM:
         style.set_property(PropertyID::Display, DisplayStyleValue::create(new_display));
 }
 
-GC::Ref<ComputedProperties> StyleComputer::create_document_style() const
+NonnullRefPtr<ComputedProperties> StyleComputer::create_document_style() const
 {
-    auto style = document().heap().allocate<CSS::ComputedProperties>();
+    auto style = CSS::ComputedProperties::create();
     for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
         auto property_id = static_cast<PropertyID>(i);
         style->set_property(property_id, property_initial_value(property_id));
@@ -2472,13 +2472,13 @@ GC::Ref<ComputedProperties> StyleComputer::create_document_style() const
     return style;
 }
 
-GC::Ref<ComputedProperties> StyleComputer::compute_style(DOM::AbstractElement abstract_element, Optional<bool&> did_change_custom_properties) const
+NonnullRefPtr<ComputedProperties> StyleComputer::compute_style(DOM::AbstractElement abstract_element, Optional<bool&> did_change_custom_properties) const
 {
     auto& style_scope = abstract_element.style_scope();
     return *compute_style_impl(abstract_element, ComputeStyleMode::Normal, did_change_custom_properties, style_scope);
 }
 
-GC::Ref<ComputedProperties> StyleComputer::compute_style_with_seeded_ancestors(DOM::AbstractElement abstract_element)
+NonnullRefPtr<ComputedProperties> StyleComputer::compute_style_with_seeded_ancestors(DOM::AbstractElement abstract_element)
 {
     auto const first_ancestor = [&] -> GC::Ptr<DOM::Element const> {
         if (abstract_element.pseudo_element().has_value())
@@ -2498,13 +2498,13 @@ GC::Ref<ComputedProperties> StyleComputer::compute_style_with_seeded_ancestors(D
     return compute_style(abstract_element);
 }
 
-GC::Ptr<ComputedProperties> StyleComputer::compute_pseudo_element_style_if_needed(DOM::AbstractElement abstract_element, Optional<bool&> did_change_custom_properties) const
+RefPtr<ComputedProperties> StyleComputer::compute_pseudo_element_style_if_needed(DOM::AbstractElement abstract_element, Optional<bool&> did_change_custom_properties) const
 {
     auto& style_scope = abstract_element.style_scope();
     return compute_style_impl(abstract_element, ComputeStyleMode::CreatePseudoElementStyleIfNeeded, did_change_custom_properties, style_scope);
 }
 
-GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractElement abstract_element, ComputeStyleMode mode, Optional<bool&> did_change_custom_properties, StyleScope const& style_scope) const
+RefPtr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractElement abstract_element, ComputeStyleMode mode, Optional<bool&> did_change_custom_properties, StyleScope const& style_scope) const
 {
     style_scope.build_rule_cache_if_needed();
 
@@ -2760,11 +2760,11 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
     return CSS::LengthStyleValue::create(CSS::Length::make_px(current_size_in_px));
 }
 
-GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties) const
+NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties) const
 {
     VERIFY(computation_context_cache_is_empty());
 
-    auto computed_style = document().heap().allocate<CSS::ComputedProperties>();
+    auto computed_style = CSS::ComputedProperties::create();
 
     bool recascaded_font_size_depends_on_viewport_metrics = false;
     auto new_font_size = recascade_font_size_if_needed(abstract_element, cascaded_properties, recascaded_font_size_depends_on_viewport_metrics);

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -101,11 +101,11 @@ public:
     void push_ancestor(DOM::Element const&);
     void pop_ancestor(DOM::Element const&);
 
-    [[nodiscard]] GC::Ref<ComputedProperties> create_document_style() const;
+    [[nodiscard]] NonnullRefPtr<ComputedProperties> create_document_style() const;
 
-    [[nodiscard]] GC::Ref<ComputedProperties> compute_style(DOM::AbstractElement, Optional<bool&> did_change_custom_properties = {}) const;
-    [[nodiscard]] GC::Ref<ComputedProperties> compute_style_with_seeded_ancestors(DOM::AbstractElement);
-    [[nodiscard]] GC::Ptr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::AbstractElement, Optional<bool&> did_change_custom_properties) const;
+    [[nodiscard]] NonnullRefPtr<ComputedProperties> compute_style(DOM::AbstractElement, Optional<bool&> did_change_custom_properties = {}) const;
+    [[nodiscard]] NonnullRefPtr<ComputedProperties> compute_style_with_seeded_ancestors(DOM::AbstractElement);
+    [[nodiscard]] RefPtr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::AbstractElement, Optional<bool&> did_change_custom_properties) const;
     [[nodiscard]] JsonArray collect_devtools_applied_style_rules(DOM::AbstractElement, bool include_inherited, bool include_user_agent_styles);
 
     struct ScopedMatchingRule {
@@ -129,7 +129,7 @@ public:
 
     void collect_animation_into(DOM::AbstractElement, GC::Ref<Animations::KeyframeEffect> animation, ComputedProperties&) const;
 
-    [[nodiscard]] GC::Ref<ComputedProperties> compute_properties(DOM::AbstractElement, CascadedProperties&) const;
+    [[nodiscard]] NonnullRefPtr<ComputedProperties> compute_properties(DOM::AbstractElement, CascadedProperties&) const;
 
     void compute_property_values(ComputedProperties&, Optional<DOM::AbstractElement>) const;
     void process_animation_definitions(ComputedProperties const& computed_properties, CascadedProperties const&, DOM::AbstractElement& abstract_element) const;
@@ -182,8 +182,8 @@ private:
 
     [[nodiscard]] MatchingRuleSet build_matching_rule_set(DOM::AbstractElement, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
 
-    [[nodiscard]] GC::Ptr<ComputedProperties> compute_style_impl(DOM::AbstractElement, ComputeStyleMode, Optional<bool&> did_change_custom_properties, StyleScope const&) const;
-    [[nodiscard]] GC::Ref<CascadedProperties> compute_cascaded_values(DOM::AbstractElement, bool did_match_any_pseudo_element_rules, ComputeStyleMode, MatchingRuleSet const&) const;
+    [[nodiscard]] RefPtr<ComputedProperties> compute_style_impl(DOM::AbstractElement, ComputeStyleMode, Optional<bool&> did_change_custom_properties, StyleScope const&) const;
+    [[nodiscard]] NonnullRefPtr<CascadedProperties> compute_cascaded_values(DOM::AbstractElement, bool did_match_any_pseudo_element_rules, ComputeStyleMode, MatchingRuleSet const&) const;
     void compute_custom_properties(ComputedProperties&, DOM::AbstractElement) const;
     void start_needed_transitions(ComputedProperties const& old_style, ComputedProperties& new_style, DOM::AbstractElement) const;
     void resolve_effective_overflow_values(ComputedProperties&) const;

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -19,13 +19,13 @@ class AbstractImageStyleValue : public StyleValue {
 public:
     using StyleValue::StyleValue;
 
-    virtual Optional<CSSPixels> natural_width() const { return {}; }
-    virtual Optional<CSSPixels> natural_height() const { return {}; }
+    virtual Optional<CSSPixels> natural_width(DOM::Document const&) const { return {}; }
+    virtual Optional<CSSPixels> natural_height(DOM::Document const&) const { return {}; }
 
-    virtual Optional<CSSPixelFraction> natural_aspect_ratio() const
+    virtual Optional<CSSPixelFraction> natural_aspect_ratio(DOM::Document const& document) const
     {
-        auto width = natural_width();
-        auto height = natural_height();
+        auto width = natural_width(document);
+        auto height = natural_height(document);
         if (width.has_value() && height.has_value() && *height != 0)
             return *width / *height;
         return {};
@@ -35,10 +35,10 @@ public:
     virtual void load_any_resources(Layout::NodeWithStyle const&);
     virtual void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const { }
 
-    virtual bool is_paintable() const = 0;
-    virtual void paint(DisplayListRecordingContext& context, DevicePixelRect const& dest_rect, ImageRendering) const = 0;
+    virtual bool is_paintable(DOM::Document const&) const = 0;
+    virtual void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, ImageRendering) const = 0;
 
-    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const { return {}; }
+    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const { return {}; }
 
     virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 };

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
@@ -54,7 +54,7 @@ void ConicGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& node
     m_resolved->position = m_properties.position->resolved(node, CSSPixelRect { { 0, 0 }, size });
 }
 
-void ConicGradientStyleValue::paint(DisplayListRecordingContext& context, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
+void ConicGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
 {
     VERIFY(m_resolved.has_value());
     auto destination_rect = dest_rect.to_type<int>();

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
@@ -26,7 +26,7 @@ public:
 
     virtual void serialize(StringBuilder&, SerializationMode) const override;
 
-    void paint(DisplayListRecordingContext&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
+    void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
 
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
     virtual bool equals(StyleValue const& other) const override;
@@ -47,7 +47,7 @@ public:
 
     float angle_degrees() const;
 
-    bool is_paintable() const override { return true; }
+    bool is_paintable(DOM::Document const&) const override { return true; }
 
     void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -58,12 +58,11 @@ bool CursorStyleValue::is_computationally_independent() const
 Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithStyle const& layout_node) const
 {
     auto const& image = *m_properties.image;
-    if (!image.is_paintable()) {
+    auto const& document = layout_node.document();
+    if (!image.is_paintable(document)) {
         const_cast<AbstractImageStyleValue&>(image).load_any_resources(const_cast<DOM::Document&>(layout_node.document()));
         return {};
     }
-
-    auto const& document = layout_node.document();
 
     auto const& current_color = layout_node.computed_values().color();
 
@@ -82,7 +81,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         // 32x32 is selected arbitrarily.
         // FIXME: Ask the OS for the default size?
         CSSPixelSize const default_cursor_size { 32, 32 };
-        auto cursor_css_size = run_default_sizing_algorithm({}, {}, { image.natural_width(), image.natural_height(), image.natural_aspect_ratio() }, default_cursor_size);
+        auto cursor_css_size = run_default_sizing_algorithm({}, {}, { image.natural_width(document), image.natural_height(document), image.natural_aspect_ratio(document) }, default_cursor_size);
         // FIXME: How do we determine what cursor sizes the OS allows?
         // We don't multiply by the pixel ratio, because we want to use the image's actual pixel size.
         DevicePixelSize cursor_device_size { cursor_css_size.to_type<double>().to_rounded<int>() };
@@ -113,7 +112,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         DisplayListRecordingContext paint_context { display_list_recorder, document.page().palette(), document.page().client().device_pixels_per_css_pixel(), document.page().chrome_metrics() };
 
         image.resolve_for_size(layout_node, CSSPixelSize { bitmap.size() });
-        image.paint(paint_context, DevicePixelRect { bitmap.rect() }, ImageRendering::Auto);
+        image.paint(paint_context, document, DevicePixelRect { bitmap.rect() }, ImageRendering::Auto);
 
         switch (document.page().client().display_list_player_type()) {
         case DisplayListPlayerType::SkiaGPUIfAvailable:

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -64,14 +64,6 @@ AbstractImageStyleValue const* ImageSetStyleValue::select_image(double device_pi
     return nullptr;
 }
 
-void ImageSetStyleValue::visit_edges(JS::Cell::Visitor& visitor) const
-{
-    Base::visit_edges(visitor);
-    visitor.visit(m_style_sheet);
-    for (auto const& option : m_options)
-        option.image->visit_edges(visitor);
-}
-
 void ImageSetStyleValue::serialize(StringBuilder& builder, SerializationMode mode) const
 {
     builder.append("image-set("sv);
@@ -126,32 +118,30 @@ bool ImageSetStyleValue::is_computationally_independent() const
 void ImageSetStyleValue::load_any_resources(DOM::Document& document)
 {
     auto dpr = document.page().client().device_pixels_per_css_pixel();
-    if (auto const* image = select_image(dpr); image && image != m_selected_image) {
-        const_cast<AbstractImageStyleValue&>(*image).set_style_sheet(m_style_sheet.ptr());
+    if (auto const* image = select_image(dpr); image && image != m_selected_image)
         m_selected_image = image;
-    }
     if (m_selected_image)
         const_cast<AbstractImageStyleValue&>(*m_selected_image).load_any_resources(document);
 }
 
-Optional<CSSPixels> ImageSetStyleValue::natural_width() const
+Optional<CSSPixels> ImageSetStyleValue::natural_width(DOM::Document const& document) const
 {
     if (m_selected_image)
-        return m_selected_image->natural_width();
+        return m_selected_image->natural_width(document);
     return {};
 }
 
-Optional<CSSPixels> ImageSetStyleValue::natural_height() const
+Optional<CSSPixels> ImageSetStyleValue::natural_height(DOM::Document const& document) const
 {
     if (m_selected_image)
-        return m_selected_image->natural_height();
+        return m_selected_image->natural_height(document);
     return {};
 }
 
-Optional<CSSPixelFraction> ImageSetStyleValue::natural_aspect_ratio() const
+Optional<CSSPixelFraction> ImageSetStyleValue::natural_aspect_ratio(DOM::Document const& document) const
 {
     if (m_selected_image)
-        return m_selected_image->natural_aspect_ratio();
+        return m_selected_image->natural_aspect_ratio(document);
     return {};
 }
 
@@ -161,30 +151,29 @@ void ImageSetStyleValue::resolve_for_size(Layout::NodeWithStyle const& layout_no
         m_selected_image->resolve_for_size(layout_node, size);
 }
 
-bool ImageSetStyleValue::is_paintable() const
+bool ImageSetStyleValue::is_paintable(DOM::Document const& document) const
 {
     if (m_selected_image)
-        return m_selected_image->is_paintable();
+        return m_selected_image->is_paintable(document);
     return false;
 }
 
-void ImageSetStyleValue::paint(DisplayListRecordingContext& context, DevicePixelRect const& dest_rect, ImageRendering image_rendering) const
+void ImageSetStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, ImageRendering image_rendering) const
 {
     if (m_selected_image)
-        m_selected_image->paint(context, dest_rect, image_rendering);
+        m_selected_image->paint(context, document, dest_rect, image_rendering);
 }
 
-Optional<Gfx::Color> ImageSetStyleValue::color_if_single_pixel_bitmap() const
+Optional<Gfx::Color> ImageSetStyleValue::color_if_single_pixel_bitmap(DOM::Document const& document) const
 {
     if (m_selected_image)
-        return m_selected_image->color_if_single_pixel_bitmap();
+        return m_selected_image->color_if_single_pixel_bitmap(document);
     return {};
 }
 
 void ImageSetStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
 {
     Base::set_style_sheet(style_sheet);
-    m_style_sheet = style_sheet;
 
     // Propagate the style sheet to candidate images whose type() filter does not exclude them. This ensures the
     // candidate images register themselves as pending image resources on the style sheet, so their fetches start when

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
@@ -9,7 +9,6 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <LibGC/Weak.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 
 namespace Web::CSS {
@@ -27,22 +26,20 @@ public:
     static ValueComparingNonnullRefPtr<ImageSetStyleValue const> create(Vector<Option>);
     virtual ~ImageSetStyleValue() override = default;
 
-    virtual void visit_edges(JS::Cell::Visitor&) const override;
-
     virtual void serialize(StringBuilder&, SerializationMode) const override;
     virtual bool equals(StyleValue const& other) const override;
     virtual bool is_computationally_independent() const override;
 
     virtual void load_any_resources(DOM::Document&) override;
 
-    virtual Optional<CSSPixels> natural_width() const override;
-    virtual Optional<CSSPixels> natural_height() const override;
-    virtual Optional<CSSPixelFraction> natural_aspect_ratio() const override;
+    virtual Optional<CSSPixels> natural_width(DOM::Document const&) const override;
+    virtual Optional<CSSPixels> natural_height(DOM::Document const&) const override;
+    virtual Optional<CSSPixelFraction> natural_aspect_ratio(DOM::Document const&) const override;
 
     virtual void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
-    virtual bool is_paintable() const override;
-    virtual void paint(DisplayListRecordingContext&, DevicePixelRect const&, ImageRendering) const override;
-    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const override;
+    virtual bool is_paintable(DOM::Document const&) const override;
+    virtual void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const&, ImageRendering) const override;
+    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
 
     AbstractImageStyleValue const* selected_image() const { return m_selected_image; }
 
@@ -55,7 +52,6 @@ private:
     AbstractImageStyleValue const* select_image(double device_pixels_per_css_pixel) const;
 
     Vector<Option> m_options;
-    GC::Weak<CSSStyleSheet> m_style_sheet;
     mutable AbstractImageStyleValue const* m_selected_image { nullptr };
 };
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -8,7 +8,8 @@
  */
 
 #include <AK/AnyOf.h>
-#include <AK/NeverDestroyed.h>
+#include <LibGC/Function.h>
+#include <LibGC/Weak.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/ComputedValues.h>
@@ -26,93 +27,94 @@
 
 namespace Web::CSS {
 
-static HashTable<ImageStyleValue const*>& active_animation_timers()
-{
-    static NeverDestroyed<HashTable<ImageStyleValue const*>> timers;
-    return *timers;
-}
-
-ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::create(URL const& url)
-{
-    return adopt_ref(*new (nothrow) ImageStyleValue(url));
-}
-
-ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::create(::URL::URL const& url)
-{
-    return adopt_ref(*new (nothrow) ImageStyleValue(URL { url.to_string() }));
-}
-
-ImageStyleValue::ImageStyleValue(URL const& url)
-    : AbstractImageStyleValue(Type::Image)
-    , m_url(url)
+ImageStyleValueResource::ImageStyleValueResource(::URL::URL url)
+    : m_url(move(url))
 {
 }
 
-ImageStyleValue::~ImageStyleValue() = default;
-
-u64 ImageStyleValue::active_animation_timer_count(DOM::Document const& document)
+ImageStyleValueResource::~ImageStyleValueResource()
 {
-    u64 count = 0;
-    for (auto const* image_style_value : active_animation_timers()) {
-        if (any_of(image_style_value->m_clients, [&](auto const* client) {
-                return client->document() == &document;
-            }))
-            ++count;
-    }
-    return count;
+    stop_animation_timer();
 }
 
-void ImageStyleValue::visit_edges(JS::Cell::Visitor& visitor) const
+void ImageStyleValueResource::visit_edges(JS::Cell::Visitor& visitor)
 {
-    Base::visit_edges(visitor);
-    // FIXME: visit_edges in non-GC allocated classes is confusing pattern.
-    //        Consider making StyleValue to be GC allocated instead.
     visitor.visit(m_resource_request);
-    visitor.visit(m_style_sheet);
     visitor.visit(m_timer);
 }
 
-void ImageStyleValue::load_any_resources(DOM::Document& document)
+void ImageStyleValueResource::set_resource_request(DOM::Document& document, GC::Ref<HTML::SharedResourceRequest> resource_request)
 {
-    if (m_resource_request)
-        return;
-    m_document = &document;
-
-    RuleOrDeclaration rule_or_declaration {
-        .environment_settings_object = document.relevant_settings_object(),
-        .value = RuleOrDeclaration::Rule {
-            .parent_style_sheet = m_style_sheet.ptr(),
-        }
-    };
-
-    m_resource_request = fetch_an_external_image_for_a_stylesheet(m_url, rule_or_declaration, m_style_sheet ? *m_style_sheet->owning_document() : document);
-
-    if (m_resource_request) {
-        m_resource_request->add_callbacks(
-            weak_callback(*this, [](auto& self) {
-                if (!self.m_document)
-                    return;
-
-                for (auto* client : self.m_clients)
-                    client->image_style_value_did_update(self);
-
-                auto image_data = self.m_resource_request->image_data();
-                if (image_data->is_animated() && image_data->frame_count() > 1) {
-                    for (auto* client : self.m_clients) {
-                        if (auto document = client->document()) {
-                            self.start_animation_timer_if_needed(*document);
-                            break;
-                        }
-                    }
-                }
-            }),
-            nullptr);
+    if (m_resource_request.ptr() != resource_request.ptr()) {
+        m_resource_request = resource_request;
+        m_has_resource_request_callbacks = false;
+        m_current_frame_index = 0;
+        m_loops_completed = 0;
     }
+
+    add_callbacks_if_needed(document);
 }
 
-void ImageStyleValue::start_animation_timer_if_needed(DOM::Document& document) const
+void ImageStyleValueResource::register_image_style_value(DOM::Document& document, ImageStyleValue const& image_style_value)
 {
-    if (m_clients.is_empty() || !is_animatable())
+    m_image_style_values.set(&image_style_value);
+    add_callbacks_if_needed(document);
+    start_animation_timer_if_needed(document);
+}
+
+void ImageStyleValueResource::unregister_image_style_value(ImageStyleValue const& image_style_value)
+{
+    m_image_style_values.remove(&image_style_value);
+    if (m_image_style_values.is_empty())
+        stop_animation_timer();
+}
+
+GC::Ptr<HTML::DecodedImageData> ImageStyleValueResource::image_data() const
+{
+    if (!m_resource_request)
+        return nullptr;
+    return m_resource_request->image_data();
+}
+
+Optional<Gfx::DecodedImageFrame> ImageStyleValueResource::frame(size_t frame_index, Gfx::IntSize size) const
+{
+    if (auto image_data = this->image_data())
+        return image_data->frame(frame_index, size);
+    return {};
+}
+
+bool ImageStyleValueResource::has_active_animation_timer() const
+{
+    return m_timer && m_timer->is_active();
+}
+
+void ImageStyleValueResource::add_callbacks_if_needed(DOM::Document& document)
+{
+    if (!m_resource_request || m_has_resource_request_callbacks)
+        return;
+
+    m_has_resource_request_callbacks = true;
+    m_resource_request->add_callbacks(
+        [weak_document = GC::Weak(document), url = m_url] {
+            if (auto document = weak_document.ptr()) {
+                if (auto* resource = document->css_image_resource(url))
+                    resource->notify_image_style_values_did_update(*document);
+            }
+        },
+        nullptr);
+}
+
+void ImageStyleValueResource::notify_image_style_values_did_update(DOM::Document& document)
+{
+    for (auto const* image_style_value : m_image_style_values)
+        image_style_value->notify_clients_did_update();
+
+    start_animation_timer_if_needed(document);
+}
+
+void ImageStyleValueResource::start_animation_timer_if_needed(DOM::Document& document)
+{
+    if (m_image_style_values.is_empty() || !is_animatable())
         return;
 
     if (m_timer && m_timer->is_active())
@@ -121,27 +123,23 @@ void ImageStyleValue::start_animation_timer_if_needed(DOM::Document& document) c
     if (!m_timer) {
         auto timer = Platform::Timer::create(document.heap());
         m_timer = timer;
-        auto weak_self = make_weak_ptr<ImageStyleValue>();
-        timer->on_timeout = GC::create_function(document.heap(), [weak_self] {
-            if (weak_self)
-                weak_self->animate();
+        timer->on_timeout = GC::create_function(document.heap(), [weak_document = GC::Weak(document), url = m_url] {
+            if (auto document = weak_document.ptr())
+                document->animate_css_image_resource(url);
         });
     }
 
     m_timer->set_interval(current_frame_duration());
     m_timer->start();
-    active_animation_timers().set(this);
 }
 
-void ImageStyleValue::stop_animation_timer() const
+void ImageStyleValueResource::stop_animation_timer()
 {
-    if (m_timer && m_timer->is_active()) {
+    if (m_timer && m_timer->is_active())
         m_timer->stop();
-        active_animation_timers().remove(this);
-    }
 }
 
-bool ImageStyleValue::is_animatable() const
+bool ImageStyleValueResource::is_animatable() const
 {
     auto image_data = this->image_data();
     if (!image_data || !image_data->is_animated() || image_data->frame_count() <= 1)
@@ -150,13 +148,13 @@ bool ImageStyleValue::is_animatable() const
     return !animation_has_completed();
 }
 
-bool ImageStyleValue::animation_has_completed() const
+bool ImageStyleValueResource::animation_has_completed() const
 {
     auto image_data = this->image_data();
     return image_data && image_data->loop_count() > 0 && m_loops_completed == image_data->loop_count();
 }
 
-int ImageStyleValue::current_frame_duration() const
+int ImageStyleValueResource::current_frame_duration() const
 {
     auto image_data = this->image_data();
     if (!image_data)
@@ -165,7 +163,7 @@ int ImageStyleValue::current_frame_duration() const
     return image_data->frame_duration(m_current_frame_index);
 }
 
-void ImageStyleValue::animate()
+void ImageStyleValueResource::animate(DOM::Document&)
 {
     if (!m_resource_request)
         return;
@@ -186,20 +184,54 @@ void ImageStyleValue::animate()
             stop_animation_timer();
     }
 
-    if (on_animate)
-        on_animate();
+    for (auto const* image_style_value : m_image_style_values)
+        image_style_value->notify_did_animate();
 }
 
-bool ImageStyleValue::is_paintable() const
+ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::create(URL const& url)
 {
-    return image_data();
+    return adopt_ref(*new (nothrow) ImageStyleValue(url));
 }
 
-Optional<Gfx::DecodedImageFrame> ImageStyleValue::frame(size_t frame_index, Gfx::IntSize size) const
+ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::create(URL const& url, Optional<::URL::URL> style_resource_base_url)
 {
-    if (auto image_data = this->image_data())
-        return image_data->frame(frame_index, size);
-    return {};
+    return adopt_ref(*new (nothrow) ImageStyleValue(url, move(style_resource_base_url)));
+}
+
+ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::create(::URL::URL const& url)
+{
+    return adopt_ref(*new (nothrow) ImageStyleValue(URL { url.to_string() }));
+}
+
+ImageStyleValue::ImageStyleValue(URL const& url, Optional<::URL::URL> style_resource_base_url)
+    : AbstractImageStyleValue(Type::Image)
+    , m_url(url)
+    , m_style_resource_base_url(move(style_resource_base_url))
+{
+}
+
+ImageStyleValue::~ImageStyleValue() = default;
+
+u64 ImageStyleValue::active_animation_timer_count(DOM::Document const& document)
+{
+    return document.active_css_image_animation_timer_count();
+}
+
+void ImageStyleValue::load_any_resources(DOM::Document& document)
+{
+    RuleOrDeclaration rule_or_declaration {
+        .environment_settings_object = document.relevant_settings_object(),
+        .value = RuleOrDeclaration::Rule {},
+        .style_resource_base_url = m_style_resource_base_url,
+        .parent_style_sheet_origin_clean = m_parent_style_sheet_origin_clean,
+    };
+
+    auto resource_request = fetch_an_external_image_for_a_stylesheet(m_url, rule_or_declaration, document);
+    if (!resource_request)
+        return;
+
+    if (auto* resource = document.css_image_resource(resource_request->url()))
+        resource->set_resource_request(document, *resource_request);
 }
 
 void ImageStyleValue::serialize(StringBuilder& builder, SerializationMode) const
@@ -214,54 +246,82 @@ bool ImageStyleValue::equals(StyleValue const& other) const
     return m_url == other.as_image().m_url;
 }
 
-Optional<CSSPixels> ImageStyleValue::natural_width() const
+Optional<CSSPixels> ImageStyleValue::natural_width(DOM::Document const& document) const
 {
-    if (auto image_data = this->image_data())
+    if (auto image_data = this->image_data(document))
         return image_data->intrinsic_width();
     return {};
 }
 
-Optional<CSSPixels> ImageStyleValue::natural_height() const
+Optional<CSSPixels> ImageStyleValue::natural_height(DOM::Document const& document) const
 {
-    if (auto image_data = this->image_data())
+    if (auto image_data = this->image_data(document))
         return image_data->intrinsic_height();
     return {};
 }
 
-Optional<CSSPixelFraction> ImageStyleValue::natural_aspect_ratio() const
+Optional<CSSPixelFraction> ImageStyleValue::natural_aspect_ratio(DOM::Document const& document) const
 {
-    if (auto image_data = this->image_data())
+    if (auto image_data = this->image_data(document))
         return image_data->intrinsic_aspect_ratio();
     return {};
 }
 
-void ImageStyleValue::paint(DisplayListRecordingContext& context, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const
+bool ImageStyleValue::is_paintable(DOM::Document const& document) const
 {
-    auto image_data = this->image_data();
+    return image_data(document);
+}
+
+void ImageStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const
+{
+    auto image_data = this->image_data(document);
     if (!image_data)
         return;
 
+    auto current_frame_index = this->current_frame_index(document);
     auto dest_int_rect = dest_rect.to_type<int>();
-    auto rect = image_data->frame_rect(m_current_frame_index).value_or(dest_int_rect);
+    auto rect = image_data->frame_rect(current_frame_index).value_or(dest_int_rect);
     auto scaling_mode = to_gfx_scaling_mode(image_rendering, rect.size(), dest_int_rect.size());
-    image_data->paint(context, m_current_frame_index, dest_int_rect, scaling_mode);
+    image_data->paint(context, current_frame_index, dest_int_rect, scaling_mode);
 }
 
-Optional<Gfx::DecodedImageFrame> ImageStyleValue::current_frame(DevicePixelRect const& dest_rect) const
+Optional<Gfx::DecodedImageFrame> ImageStyleValue::current_frame(DOM::Document const& document, DevicePixelRect const& dest_rect) const
 {
-    return frame(m_current_frame_index, dest_rect.size().to_type<int>());
+    return frame(document, current_frame_index(document), dest_rect.size().to_type<int>());
 }
 
-GC::Ptr<HTML::DecodedImageData> ImageStyleValue::image_data() const
+size_t ImageStyleValue::current_frame_index(DOM::Document const& document) const
 {
-    if (!m_resource_request)
+    auto resolved_url = this->resolved_url(document);
+    if (!resolved_url.has_value())
+        return 0;
+
+    if (auto const* resource = document.css_image_resource(*resolved_url))
+        return resource->current_frame_index();
+    return 0;
+}
+
+GC::Ptr<HTML::DecodedImageData> ImageStyleValue::image_data(DOM::Document const& document) const
+{
+    auto resolved_url = this->resolved_url(document);
+    if (!resolved_url.has_value())
         return nullptr;
-    return m_resource_request->image_data();
+
+    if (auto const* resource = document.css_image_resource(*resolved_url)) {
+        if (auto image_data = resource->image_data())
+            return image_data;
+    }
+
+    auto const& shared_resource_requests = document.shared_resource_requests();
+    auto it = shared_resource_requests.find(*resolved_url);
+    if (it == shared_resource_requests.end())
+        return nullptr;
+    return it->value->image_data();
 }
 
-Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap() const
+Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap(DOM::Document const& document) const
 {
-    if (auto decoded_frame = frame(m_current_frame_index); decoded_frame.has_value()) {
+    if (auto decoded_frame = frame(document, current_frame_index(document)); decoded_frame.has_value()) {
         auto const& bitmap = decoded_frame->bitmap();
         if (bitmap.width() == 1 && bitmap.height() == 1)
             return bitmap.get_pixel(0, 0);
@@ -272,13 +332,27 @@ Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap() const
 void ImageStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
 {
     Base::set_style_sheet(style_sheet);
-    m_style_sheet = style_sheet;
 
-    if (m_style_sheet)
-        m_style_sheet->register_pending_image_value(*this);
+    m_style_resource_base_url.clear();
+    m_parent_style_sheet_origin_clean.clear();
+    m_should_absolutize_url_for_computed_value = false;
+
+    if (style_sheet) {
+        update_style_sheet_resource_context(*style_sheet);
+        style_sheet->register_pending_image_value(*this);
+    }
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> ImageStyleValue::absolutized(ComputationContext const&) const
+void ImageStyleValue::update_style_sheet_resource_context(CSSStyleSheet const& style_sheet)
+{
+    m_style_resource_base_url = style_sheet.base_url()
+                                    .value_or_lazy_evaluated_optional([&]() { return style_sheet.location(); })
+                                    .value_or_lazy_evaluated_optional([&]() { return HTML::relevant_settings_object(style_sheet).api_base_url(); });
+    m_parent_style_sheet_origin_clean = style_sheet.is_origin_clean();
+    m_should_absolutize_url_for_computed_value = true;
+}
+
+ValueComparingNonnullRefPtr<StyleValue const> ImageStyleValue::absolutized(ComputationContext const& context) const
 {
     if (m_url.url().is_empty())
         return *this;
@@ -286,22 +360,32 @@ ValueComparingNonnullRefPtr<StyleValue const> ImageStyleValue::absolutized(Compu
     // FIXME: The spec has been updated to handle this better. The computation of the base URL here is roughly based on:
     //        https://drafts.csswg.org/css-values-4/#style-resource-base-url
     //        https://github.com/w3c/csswg-drafts/pull/12261
-    auto base_url = [&]() -> Optional<::URL::URL> {
-        if (m_style_sheet) {
-            return m_style_sheet->base_url()
-                .value_or_lazy_evaluated_optional([&]() { return m_style_sheet->location(); })
-                .value_or_lazy_evaluated_optional([&]() { return HTML::relevant_settings_object(*m_style_sheet).api_base_url(); });
-        }
-
-        if (m_document)
-            return m_document->base_url();
-
-        return {};
-    }();
+    auto base_url = m_style_resource_base_url;
+    if (!base_url.has_value() && context.abstract_element.has_value())
+        base_url = context.abstract_element->document().base_url();
 
     if (base_url.has_value()) {
-        if (auto resolved_url = DOMURL::parse(m_url.url(), *base_url); resolved_url.has_value())
-            return ImageStyleValue::create(*resolved_url);
+        if (m_should_absolutize_url_for_computed_value) {
+            if (DOMURL::parse(m_url.url()).has_value()) {
+                auto absolutized_image = adopt_ref(*new (nothrow) ImageStyleValue(m_url, *base_url));
+                absolutized_image->m_parent_style_sheet_origin_clean = m_parent_style_sheet_origin_clean;
+                absolutized_image->m_should_absolutize_url_for_computed_value = true;
+                return absolutized_image;
+            }
+
+            if (auto resolved_url = DOMURL::parse(m_url.url(), *base_url); resolved_url.has_value()) {
+                auto absolutized_image = adopt_ref(*new (nothrow) ImageStyleValue(URL { resolved_url->to_string(), m_url.type(), m_url.request_url_modifiers() }, *base_url));
+                absolutized_image->m_parent_style_sheet_origin_clean = m_parent_style_sheet_origin_clean;
+                absolutized_image->m_should_absolutize_url_for_computed_value = true;
+                return absolutized_image;
+            }
+
+            return *this;
+        }
+
+        auto absolutized_image = adopt_ref(*new (nothrow) ImageStyleValue(m_url, *base_url));
+        absolutized_image->m_parent_style_sheet_origin_clean = m_parent_style_sheet_origin_clean;
+        return absolutized_image;
     }
 
     return *this;
@@ -311,17 +395,85 @@ void ImageStyleValue::register_client(Client& client) const
 {
     auto result = m_clients.set(&client);
     VERIFY(result == AK::HashSetResult::InsertedNewEntry);
-    if (auto document = client.document())
-        start_animation_timer_if_needed(*document);
+    auto document = client.document();
+    if (!document)
+        return;
+
+    auto resolved_url = this->resolved_url(*document);
+    if (!resolved_url.has_value())
+        return;
+
+    client.m_registered_url = *resolved_url;
+    auto& resource = document->ensure_css_image_resource(*resolved_url);
+    auto& shared_resource_requests = document->shared_resource_requests();
+    auto it = shared_resource_requests.find(*resolved_url);
+    if (it != shared_resource_requests.end())
+        resource.set_resource_request(*document, *it->value);
+    resource.register_image_style_value(*document, *this);
 }
 
 void ImageStyleValue::unregister_client(Client& client) const
 {
+    auto document = client.document();
+    auto registered_url = move(client.m_registered_url);
+    client.m_registered_url.clear();
+
     auto did_remove = m_clients.remove(&client);
     VERIFY(did_remove);
 
-    if (m_clients.is_empty())
-        stop_animation_timer();
+    if (!document || !registered_url.has_value())
+        return;
+
+    if (any_of(m_clients, [&](auto const* remaining_client) {
+            return remaining_client->document() == document
+                && remaining_client->m_registered_url.has_value()
+                && *remaining_client->m_registered_url == *registered_url;
+        }))
+        return;
+
+    if (auto* resource = document->css_image_resource(*registered_url))
+        resource->unregister_image_style_value(*this);
+    document->remove_css_image_resource_if_unused(*registered_url);
+}
+
+void ImageStyleValue::notify_clients_did_update() const
+{
+    for (auto* client : m_clients)
+        client->image_style_value_did_update(const_cast<ImageStyleValue&>(*this));
+}
+
+void ImageStyleValue::notify_did_animate() const
+{
+    if (on_animate)
+        on_animate();
+}
+
+Optional<::URL::URL> ImageStyleValue::resolved_url(DOM::Document const& document) const
+{
+    if (m_url.url().is_empty())
+        return {};
+
+    return DOMURL::parse(m_url.url(), style_resource_base_url(document));
+}
+
+::URL::URL ImageStyleValue::style_resource_base_url(DOM::Document const& document) const
+{
+    return m_style_resource_base_url.value_or_lazy_evaluated([&] {
+        return document.relevant_settings_object().api_base_url();
+    });
+}
+
+Optional<Gfx::DecodedImageFrame> ImageStyleValue::frame(DOM::Document const& document, size_t frame_index, Gfx::IntSize size) const
+{
+    auto resolved_url = this->resolved_url(document);
+    if (resolved_url.has_value()) {
+        if (auto const* resource = document.css_image_resource(*resolved_url))
+            return resource->frame(frame_index, size);
+    }
+
+    if (auto image_data = this->image_data(document))
+        return image_data->frame(frame_index, size);
+    return {};
 }
 
 ImageStyleValue::Client::Client(DOM::Document& document, ImageStyleValue const& image_style_value)

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -15,11 +15,51 @@
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibURL/URL.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 #include <LibWeb/CSS/URL.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
+
+class ImageStyleValue;
+
+class ImageStyleValueResource {
+public:
+    explicit ImageStyleValueResource(::URL::URL);
+    ~ImageStyleValueResource();
+
+    void visit_edges(JS::Cell::Visitor&);
+
+    void set_resource_request(DOM::Document&, GC::Ref<HTML::SharedResourceRequest>);
+    void register_image_style_value(DOM::Document&, ImageStyleValue const&);
+    void unregister_image_style_value(ImageStyleValue const&);
+    bool can_be_removed() const { return m_image_style_values.is_empty(); }
+
+    [[nodiscard]] GC::Ptr<HTML::DecodedImageData> image_data() const;
+    [[nodiscard]] Optional<Gfx::DecodedImageFrame> frame(size_t frame_index, Gfx::IntSize = {}) const;
+    [[nodiscard]] size_t current_frame_index() const { return m_current_frame_index; }
+    [[nodiscard]] bool has_active_animation_timer() const;
+
+    void animate(DOM::Document&);
+
+private:
+    void add_callbacks_if_needed(DOM::Document&);
+    void notify_image_style_values_did_update(DOM::Document&);
+    void start_animation_timer_if_needed(DOM::Document&);
+    void stop_animation_timer();
+    bool is_animatable() const;
+    bool animation_has_completed() const;
+    int current_frame_duration() const;
+
+    ::URL::URL m_url;
+    GC::Ptr<HTML::SharedResourceRequest> m_resource_request;
+    GC::Ptr<Platform::Timer> m_timer;
+    HashTable<ImageStyleValue const*> m_image_style_values;
+    size_t m_current_frame_index { 0 };
+    size_t m_loops_completed { 0 };
+    bool m_has_resource_request_callbacks { false };
+};
 
 class ImageStyleValue final
     : public AbstractImageStyleValue
@@ -42,14 +82,14 @@ public:
 
         ImageStyleValue const& m_image_style_value;
         GC::Weak<DOM::Document> m_document;
+        Optional<::URL::URL> m_registered_url;
     };
 
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(URL const&);
+    static ValueComparingNonnullRefPtr<ImageStyleValue const> create(URL const&, Optional<::URL::URL> style_resource_base_url);
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(::URL::URL const&);
     virtual ~ImageStyleValue() override;
     static u64 active_animation_timer_count(DOM::Document const&);
-
-    virtual void visit_edges(JS::Cell::Visitor& visitor) const override;
 
     virtual void serialize(StringBuilder&, SerializationMode) const override;
     virtual bool equals(StyleValue const& other) const override;
@@ -58,49 +98,46 @@ public:
 
     virtual void load_any_resources(DOM::Document&) override;
 
-    Optional<CSSPixels> natural_width() const override;
-    Optional<CSSPixels> natural_height() const override;
-    Optional<CSSPixelFraction> natural_aspect_ratio() const override;
+    Optional<CSSPixels> natural_width(DOM::Document const&) const override;
+    Optional<CSSPixels> natural_height(DOM::Document const&) const override;
+    Optional<CSSPixelFraction> natural_aspect_ratio(DOM::Document const&) const override;
 
-    virtual bool is_paintable() const override;
-    void paint(DisplayListRecordingContext& context, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
+    virtual bool is_paintable(DOM::Document const&) const override;
+    void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
 
-    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const override;
-    Optional<Gfx::DecodedImageFrame> current_frame(DevicePixelRect const& dest_rect) const;
+    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
+    Optional<Gfx::DecodedImageFrame> current_frame(DOM::Document const&, DevicePixelRect const& dest_rect) const;
+    size_t current_frame_index(DOM::Document const&) const;
 
     mutable Function<void()> on_animate;
 
-    GC::Ptr<HTML::DecodedImageData> image_data() const;
+    GC::Ptr<HTML::DecodedImageData> image_data(DOM::Document const&) const;
 
 private:
+    friend class ImageStyleValueResource;
     friend class Client;
-    ImageStyleValue(URL const&);
+    friend class CSSStyleSheet;
+    ImageStyleValue(URL const&, Optional<::URL::URL> style_resource_base_url = {});
 
     void register_client(Client&) const;
     void unregister_client(Client&) const;
+    void notify_clients_did_update() const;
+    void notify_did_animate() const;
+    void update_style_sheet_resource_context(CSSStyleSheet const&);
+    Optional<::URL::URL> resolved_url(DOM::Document const&) const;
+    ::URL::URL style_resource_base_url(DOM::Document const&) const;
 
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
 
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
-    void start_animation_timer_if_needed(DOM::Document&) const;
-    void stop_animation_timer() const;
-    bool is_animatable() const;
-    bool animation_has_completed() const;
-    int current_frame_duration() const;
-    void animate();
-    Optional<Gfx::DecodedImageFrame> frame(size_t frame_index, Gfx::IntSize = {}) const;
-
-    GC::Weak<HTML::SharedResourceRequest> m_resource_request;
-    GC::Weak<CSSStyleSheet> m_style_sheet;
+    Optional<Gfx::DecodedImageFrame> frame(DOM::Document const&, size_t frame_index, Gfx::IntSize = {}) const;
 
     URL m_url;
-    GC::Weak<DOM::Document> m_document;
-
-    size_t m_current_frame_index { 0 };
-    size_t m_loops_completed { 0 };
+    Optional<::URL::URL> m_style_resource_base_url;
+    Optional<bool> m_parent_style_sheet_origin_clean;
+    bool m_should_absolutize_url_for_computed_value { false };
 
     mutable HashTable<Client*> m_clients;
-    mutable GC::Weak<Platform::Timer> m_timer;
 };
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -145,7 +145,7 @@ void LinearGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& nod
     }
 }
 
-void LinearGradientStyleValue::paint(DisplayListRecordingContext& context, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
+void LinearGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
 {
     VERIFY(m_resolved.has_value());
     context.display_list_recorder().fill_rect_with_linear_gradient(dest_rect.to_type<int>(), m_resolved.value());

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
@@ -83,8 +83,8 @@ public:
 
     void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 
-    bool is_paintable() const override { return true; }
-    void paint(DisplayListRecordingContext& context, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
+    bool is_paintable(DOM::Document const&) const override { return true; }
+    void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
 
 private:
     LinearGradientStyleValue(GradientDirection direction, Vector<ColorStopListElement> color_stop_list, GradientType type, GradientRepeating repeating, ValueComparingRefPtr<StyleValue const> color_interpolation_method, ColorSyntax color_syntax)

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -111,7 +111,7 @@ bool RadialGradientStyleValue::is_computationally_independent() const
         && (!m_properties.color_interpolation_method || m_properties.color_interpolation_method->is_computationally_independent());
 }
 
-void RadialGradientStyleValue::paint(DisplayListRecordingContext& context, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
+void RadialGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
 {
     VERIFY(m_resolved.has_value());
     auto center = context.rounded_device_point(m_resolved->center).to_type<int>();

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -32,7 +32,7 @@ public:
 
     virtual void serialize(StringBuilder&, SerializationMode) const override;
 
-    void paint(DisplayListRecordingContext&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
+    void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
 
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
     virtual bool equals(StyleValue const& other) const override;
@@ -52,7 +52,7 @@ public:
         return ColorInterpolationMethodStyleValue::default_color_interpolation_method(m_properties.color_syntax);
     }
 
-    bool is_paintable() const override { return true; }
+    bool is_paintable(DOM::Document const&) const override { return true; }
 
     void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 

--- a/Libraries/LibWeb/CSS/URL.h
+++ b/Libraries/LibWeb/CSS/URL.h
@@ -53,6 +53,7 @@ public:
     URL(String url, Type = Type::Url, Vector<RequestURLModifier> = {});
 
     String const& url() const { return m_url; }
+    Type type() const { return m_type; }
     Vector<RequestURLModifier> const& request_url_modifiers() const { return m_request_url_modifiers; }
 
     String to_string() const;

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/DOM/AbstractElement.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -141,7 +142,7 @@ bool AbstractElement::is_before(AbstractElement const& other) const
     return this_node && other_node && this_node->is_before(*other_node);
 }
 
-GC::Ptr<CSS::ComputedProperties const> AbstractElement::computed_properties() const
+CSS::ComputedProperties const* AbstractElement::computed_properties() const
 {
     return m_element->computed_properties(m_pseudo_element);
 }

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -46,7 +46,7 @@ public:
 
     void set_inheritance_override(GC::Ref<Element> element) { m_inheritance_override = element; }
 
-    GC::Ptr<CSS::ComputedProperties const> computed_properties() const;
+    CSS::ComputedProperties const* computed_properties() const;
     GC::Ptr<CSS::CSSStyleProperties const> inline_style() const;
 
     void set_custom_property_data(RefPtr<CSS::CustomPropertyData const>);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -70,6 +70,7 @@
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RandomValueSharingStyleValue.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/TransitionEvent.h>
@@ -728,6 +729,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_query_containers_needing_container_query_evaluation_after_layout);
 
     visitor.visit(m_shared_resource_requests);
+    for (auto& resource : m_css_image_resources)
+        resource.value->visit_edges(visitor);
 
     visitor.visit(m_associated_animation_timelines);
     visitor.visit(m_list_of_available_images);
@@ -6704,6 +6707,64 @@ void Document::set_latest_entry(RefPtr<HTML::SessionHistoryEntry> entry)
 HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>>& Document::shared_resource_requests()
 {
     return m_shared_resource_requests;
+}
+
+HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>> const& Document::shared_resource_requests() const
+{
+    return m_shared_resource_requests;
+}
+
+CSS::ImageStyleValueResource* Document::css_image_resource(URL::URL const& url)
+{
+    auto it = m_css_image_resources.find(url);
+    if (it == m_css_image_resources.end())
+        return nullptr;
+    return it->value.ptr();
+}
+
+CSS::ImageStyleValueResource const* Document::css_image_resource(URL::URL const& url) const
+{
+    auto it = m_css_image_resources.find(url);
+    if (it == m_css_image_resources.end())
+        return nullptr;
+    return it->value.ptr();
+}
+
+CSS::ImageStyleValueResource& Document::ensure_css_image_resource(URL::URL const& url)
+{
+    if (auto* resource = css_image_resource(url))
+        return *resource;
+
+    auto resource = make<CSS::ImageStyleValueResource>(url);
+    auto& resource_ref = *resource;
+    m_css_image_resources.set(url, move(resource));
+    return resource_ref;
+}
+
+void Document::remove_css_image_resource_if_unused(URL::URL const& url)
+{
+    auto it = m_css_image_resources.find(url);
+    if (it == m_css_image_resources.end())
+        return;
+    if (!it->value->can_be_removed())
+        return;
+    m_css_image_resources.remove(it);
+}
+
+void Document::animate_css_image_resource(URL::URL const& url)
+{
+    if (auto* resource = css_image_resource(url))
+        resource->animate(*this);
+}
+
+u64 Document::active_css_image_animation_timer_count() const
+{
+    u64 count = 0;
+    for (auto const& it : m_css_image_resources) {
+        if (it.value->has_active_animation_timer())
+            ++count;
+    }
+    return count;
 }
 
 void Document::prune_image_resource_caches()

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2293,7 +2293,7 @@ static CSS::RequiredInvalidationAfterStyleChange recompute_style_for_targeted_st
     return {};
 }
 
-GC::Ptr<CSS::ComputedProperties const> Document::update_style_for_element(AbstractElement const& abstract_element, StyleUpdateMode mode)
+CSS::ComputedProperties const* Document::update_style_for_element(AbstractElement const& abstract_element, StyleUpdateMode mode)
 {
     // Refresh computed properties for an abstract element without requiring every unrelated dirty element in the
     // document to be resolved. This walks the flat-tree inheritance chain and re-cascades from the rootmost stale
@@ -2352,7 +2352,7 @@ GC::Ptr<CSS::ComputedProperties const> Document::update_style_for_element(Abstra
             ancestor_needs_descendant_style_recompute = true;
         }
 
-        if (auto const* properties = ancestor->computed_properties().ptr(); properties && properties->display().is_none()) {
+        if (auto const properties = ancestor->computed_properties(); properties && properties->display().is_none()) {
             topmost_display_none_index = i - 1;
             if (mode == StyleUpdateMode::StopAtDisplayNone && !topmost_element_requiring_style.has_value())
                 return nullptr;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -55,6 +55,12 @@
 #include <LibWeb/TrustedTypes/InjectionSink.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
+namespace Web::CSS {
+
+class ImageStyleValueResource;
+
+}
+
 namespace Web::DOM {
 
 enum class QuirksMode {
@@ -809,6 +815,13 @@ public:
     void update_for_history_step_application(NonnullRefPtr<HTML::SessionHistoryEntry>, bool do_not_reactivate, size_t script_history_length, size_t script_history_index, Optional<Bindings::NavigationType> navigation_type, Optional<Vector<NonnullRefPtr<HTML::SessionHistoryEntry>>> entries_for_navigation_api = {}, RefPtr<HTML::SessionHistoryEntry> previous_entry_for_activation = {}, bool update_navigation_api = true);
 
     HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>>& shared_resource_requests();
+    HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>> const& shared_resource_requests() const;
+    CSS::ImageStyleValueResource* css_image_resource(URL::URL const&);
+    CSS::ImageStyleValueResource const* css_image_resource(URL::URL const&) const;
+    CSS::ImageStyleValueResource& ensure_css_image_resource(URL::URL const&);
+    void remove_css_image_resource_if_unused(URL::URL const&);
+    void animate_css_image_resource(URL::URL const&);
+    u64 active_css_image_animation_timer_count() const;
     void prune_image_resource_caches();
 
     void restore_the_history_object_state(NonnullRefPtr<HTML::SessionHistoryEntry> entry);
@@ -1451,6 +1464,7 @@ private:
     RefPtr<HTML::SessionHistoryEntry> m_latest_entry;
 
     HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>> m_shared_resource_requests;
+    HashMap<URL::URL, OwnPtr<CSS::ImageStyleValueResource>> m_css_image_resources;
 
     // https://www.w3.org/TR/web-animations-1/#timeline-associated-with-a-document
     HashTable<GC::Ref<Animations::AnimationTimeline>> m_associated_animation_timelines;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -400,7 +400,7 @@ public:
         Normal,
         StopAtDisplayNone,
     };
-    GC::Ptr<CSS::ComputedProperties const> update_style_for_element(AbstractElement const&, StyleUpdateMode = StyleUpdateMode::Normal);
+    CSS::ComputedProperties const* update_style_for_element(AbstractElement const&, StyleUpdateMode = StyleUpdateMode::Normal);
     [[nodiscard]] bool element_needs_style_update(AbstractElement const&) const;
     void update_layout(UpdateLayoutReason);
     void update_layout_if_needed_for_node(Node const&, UpdateLayoutReason);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -195,7 +195,6 @@ void Element::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_custom_element_registry);
     visitor.visit(m_custom_element_definition);
     visitor.visit(m_custom_state_set);
-    visitor.visit(m_computed_properties);
     visitor.visit(m_computed_style_map_cache);
     visitor.visit(m_attribute_style_map);
     if (m_pseudo_element_data) {
@@ -807,32 +806,32 @@ Optional<GC::RootVector<GC::Ref<DOM::Element>>> Element::get_the_attribute_assoc
     return elements;
 }
 
-GC::Ptr<Layout::Node> Element::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> Element::create_layout_node(CSS::ComputedProperties const& style)
 {
     if (local_name() == "noscript" && document().is_scripting_enabled())
         return nullptr;
 
-    auto display = style->display();
+    auto display = style.display();
     return create_layout_node_for_display_type(document(), display, style, this);
 }
 
-GC::Ptr<Layout::NodeWithStyle> Element::create_layout_node_for_display_type(DOM::Document& document, CSS::Display const& display, GC::Ref<CSS::ComputedProperties> style, Element* element)
+GC::Ptr<Layout::NodeWithStyle> Element::create_layout_node_for_display_type(DOM::Document& document, CSS::Display const& display, CSS::ComputedProperties const& style, Element* element)
 {
     if (display.is_none())
         return {};
 
     if (display.is_table_inside() || display.is_table_row_group() || display.is_table_header_group() || display.is_table_footer_group() || display.is_table_row())
-        return document.heap().allocate<Layout::Box>(document, element, move(style));
+        return document.heap().allocate<Layout::Box>(document, element, style);
 
     if (display.is_list_item())
-        return document.heap().allocate<Layout::ListItemBox>(document, element, move(style));
+        return document.heap().allocate<Layout::ListItemBox>(document, element, style);
 
     if (display.is_table_cell())
-        return document.heap().allocate<Layout::BlockContainer>(document, element, move(style));
+        return document.heap().allocate<Layout::BlockContainer>(document, element, style);
 
     if (display.is_table_column() || display.is_table_column_group() || display.is_table_caption()) {
         // FIXME: This is just an incorrect placeholder until we improve table layout support.
-        return document.heap().allocate<Layout::BlockContainer>(document, element, move(style));
+        return document.heap().allocate<Layout::BlockContainer>(document, element, style);
     }
 
     if (display.is_math_inside()) {
@@ -840,35 +839,35 @@ GC::Ptr<Layout::NodeWithStyle> Element::create_layout_node_for_display_type(DOM:
         // MathML elements with a computed display value equal to block math or inline math control box generation
         // and layout according to their tag name, as described in the relevant sections.
         // FIXME: Figure out what kind of node we should make for them. For now, we'll stick with a generic Box.
-        return document.heap().allocate<Layout::BlockContainer>(document, element, move(style));
+        return document.heap().allocate<Layout::BlockContainer>(document, element, style);
     }
 
     if (display.is_inline_outside()) {
         if (display.is_flow_root_inside())
-            return document.heap().allocate<Layout::BlockContainer>(document, element, move(style));
+            return document.heap().allocate<Layout::BlockContainer>(document, element, style);
         if (display.is_flow_inside())
-            return document.heap().allocate<Layout::InlineNode>(document, element, move(style));
+            return document.heap().allocate<Layout::InlineNode>(document, element, style);
         if (display.is_flex_inside())
-            return document.heap().allocate<Layout::Box>(document, element, move(style));
+            return document.heap().allocate<Layout::Box>(document, element, style);
         if (display.is_grid_inside())
-            return document.heap().allocate<Layout::Box>(document, element, move(style));
+            return document.heap().allocate<Layout::Box>(document, element, style);
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Support display: {}", display.to_string());
-        return document.heap().allocate<Layout::InlineNode>(document, element, move(style));
+        return document.heap().allocate<Layout::InlineNode>(document, element, style);
     }
 
     if (display.is_flex_inside() || display.is_grid_inside())
-        return document.heap().allocate<Layout::Box>(document, element, move(style));
+        return document.heap().allocate<Layout::Box>(document, element, style);
 
     if (display.is_flow_inside() || display.is_flow_root_inside() || display.is_contents())
-        return document.heap().allocate<Layout::BlockContainer>(document, element, move(style));
+        return document.heap().allocate<Layout::BlockContainer>(document, element, style);
 
     dbgln("FIXME: CSS display '{}' not implemented yet.", display.to_string());
 
     // FIXME: We don't actually support `display: block ruby`, this is just a hack to prevent a crash
     if (display.is_ruby_inside())
-        return document.heap().allocate<Layout::BlockContainer>(document, element, move(style));
+        return document.heap().allocate<Layout::BlockContainer>(document, element, style);
 
-    return document.heap().allocate<Layout::InlineNode>(document, element, move(style));
+    return document.heap().allocate<Layout::InlineNode>(document, element, style);
 }
 
 void Element::apply_presentational_hints(Vector<CSS::StyleProperty>& properties) const
@@ -2890,7 +2889,7 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
     target_bounding_border_box.set_bottom(target_bounding_border_box.bottom() + scroll_margin_top + scroll_margin_bottom);
     target_bounding_border_box.set_left(target_bounding_border_box.left() - scroll_margin_left);
 
-    auto scrolling_box_computed_properties = [&scrolling_box]() -> GC::Ptr<CSS::ComputedProperties const> {
+    auto scrolling_box_computed_properties = [&scrolling_box]() -> RefPtr<CSS::ComputedProperties const> {
         if (scrolling_box.is_document()) {
             return scrolling_box.document().scrolling_element()->computed_properties();
         }
@@ -3638,7 +3637,7 @@ size_t Element::attribute_list_size() const
     return m_attributes ? m_attributes->length() : 0;
 }
 
-GC::Ptr<CSS::ComputedProperties> Element::computed_properties(Optional<CSS::PseudoElement> pseudo_element_type)
+RefPtr<CSS::ComputedProperties> Element::computed_properties(Optional<CSS::PseudoElement> pseudo_element_type)
 {
     if (pseudo_element_type.has_value()) {
         if (auto pseudo_element = get_pseudo_element(*pseudo_element_type); pseudo_element.has_value())
@@ -3648,7 +3647,7 @@ GC::Ptr<CSS::ComputedProperties> Element::computed_properties(Optional<CSS::Pseu
     return m_computed_properties;
 }
 
-GC::Ptr<CSS::ComputedProperties const> Element::computed_properties(Optional<CSS::PseudoElement> pseudo_element_type) const
+RefPtr<CSS::ComputedProperties const> Element::computed_properties(Optional<CSS::PseudoElement> pseudo_element_type) const
 {
     if (pseudo_element_type.has_value()) {
         if (auto pseudo_element = get_pseudo_element(*pseudo_element_type); pseudo_element.has_value())
@@ -3658,7 +3657,7 @@ GC::Ptr<CSS::ComputedProperties const> Element::computed_properties(Optional<CSS
     return m_computed_properties;
 }
 
-void Element::set_computed_properties(Optional<CSS::PseudoElement> pseudo_element_type, GC::Ptr<CSS::ComputedProperties> style)
+void Element::set_computed_properties(Optional<CSS::PseudoElement> pseudo_element_type, RefPtr<CSS::ComputedProperties> style)
 {
     if (pseudo_element_type.has_value()) {
         VERIFY(is_synthetic_pseudo_element(pseudo_element_type.value()));

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -208,9 +208,9 @@ public:
     GC::Ptr<Layout::NodeWithStyle> unsafe_layout_node();
     GC::Ptr<Layout::NodeWithStyle const> unsafe_layout_node() const;
 
-    GC::Ptr<CSS::ComputedProperties> computed_properties(Optional<CSS::PseudoElement> = {});
-    GC::Ptr<CSS::ComputedProperties const> computed_properties(Optional<CSS::PseudoElement> = {}) const;
-    void set_computed_properties(Optional<CSS::PseudoElement>, GC::Ptr<CSS::ComputedProperties>);
+    RefPtr<CSS::ComputedProperties> computed_properties(Optional<CSS::PseudoElement> = {});
+    RefPtr<CSS::ComputedProperties const> computed_properties(Optional<CSS::PseudoElement> = {}) const;
+    void set_computed_properties(Optional<CSS::PseudoElement>, RefPtr<CSS::ComputedProperties>);
 
     Optional<SyntheticPseudoElement&> get_synthetic_pseudo_element(CSS::PseudoElement) const;
     Optional<PseudoElement&> get_pseudo_element(CSS::PseudoElement) const;
@@ -361,7 +361,7 @@ public:
     [[nodiscard]] Vector<CSSPixelRect> client_rects_assuming_layout_clean() const;
     [[nodiscard]] CSSPixelRect bounding_client_rect_assuming_layout_clean() const;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>);
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&);
     virtual void adjust_computed_style(CSS::ComputedProperties&) { }
 
     virtual void did_receive_focus() { }
@@ -369,7 +369,7 @@ public:
     bool should_indicate_focus() const;
     virtual bool is_focusable() const override;
 
-    static GC::Ptr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, GC::Ref<CSS::ComputedProperties>, Element*);
+    static GC::Ptr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, CSS::ComputedProperties const&, Element*);
 
     void clear_removed_attributes_for_style_invalidation() { m_removed_attributes_for_style_invalidation.clear(); }
     bool has_removed_attribute_for_style_invalidation(FlyString const& attribute_name) const
@@ -704,7 +704,7 @@ private:
     GC::Ptr<ShadowRoot> m_shadow_root;
     GC::Ptr<DOMTokenList> m_part_list;
 
-    GC::Ptr<CSS::ComputedProperties> m_computed_properties;
+    RefPtr<CSS::ComputedProperties> m_computed_properties;
     RefPtr<CSS::CustomPropertyData const> m_custom_property_data;
 
     using PseudoElementData = HashMap<CSS::PseudoElement, GC::Ref<PseudoElement>>;

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -20,7 +20,6 @@ void SyntheticPseudoElement::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
-    visitor.visit(m_computed_properties);
     visitor.visit(m_layout_node);
     if (m_counters_set)
         m_counters_set->visit_edges(visitor);
@@ -61,7 +60,7 @@ GC::Ptr<Layout::NodeWithStyle> ElementReferencePseudoElement::unsafe_layout_node
     return m_referenced_element->unsafe_layout_node();
 }
 
-GC::Ptr<CSS::ComputedProperties> ElementReferencePseudoElement::computed_properties() const
+RefPtr<CSS::ComputedProperties> ElementReferencePseudoElement::computed_properties() const
 {
     return m_referenced_element->computed_properties({});
 }

--- a/Libraries/LibWeb/DOM/PseudoElement.h
+++ b/Libraries/LibWeb/DOM/PseudoElement.h
@@ -9,6 +9,7 @@
 #include <AK/OwnPtr.h>
 #include <LibGC/CellAllocator.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/CustomPropertyData.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -25,7 +26,7 @@ public:
     virtual GC::Ptr<Layout::NodeWithStyle> layout_node() const = 0;
     virtual GC::Ptr<Layout::NodeWithStyle> unsafe_layout_node() const = 0;
 
-    virtual GC::Ptr<CSS::ComputedProperties> computed_properties() const = 0;
+    virtual RefPtr<CSS::ComputedProperties> computed_properties() const = 0;
 
     virtual RefPtr<CSS::CustomPropertyData const> custom_property_data() const = 0;
     virtual void set_custom_property_data(RefPtr<CSS::CustomPropertyData const> value) = 0;
@@ -39,8 +40,8 @@ class WEB_API SyntheticPseudoElement : public PseudoElement {
     GC::Ptr<Layout::NodeWithStyle> unsafe_layout_node() const override { return m_layout_node; }
     void set_layout_node(GC::Ptr<Layout::NodeWithStyle> value) { m_layout_node = value; }
 
-    GC::Ptr<CSS::ComputedProperties> computed_properties() const override { return m_computed_properties; }
-    void set_computed_properties(GC::Ptr<CSS::ComputedProperties> value) { m_computed_properties = value; }
+    RefPtr<CSS::ComputedProperties> computed_properties() const override { return m_computed_properties; }
+    void set_computed_properties(RefPtr<CSS::ComputedProperties> value) { m_computed_properties = value; }
 
     RefPtr<CSS::CustomPropertyData const> custom_property_data() const override { return m_custom_property_data; }
     void set_custom_property_data(RefPtr<CSS::CustomPropertyData const> value) override { m_custom_property_data = move(value); }
@@ -57,7 +58,7 @@ class WEB_API SyntheticPseudoElement : public PseudoElement {
 
 private:
     GC::Ptr<Layout::NodeWithStyle> m_layout_node;
-    GC::Ptr<CSS::ComputedProperties> m_computed_properties;
+    RefPtr<CSS::ComputedProperties> m_computed_properties;
     RefPtr<CSS::CustomPropertyData const> m_custom_property_data;
     OwnPtr<CSS::CountersSet> m_counters_set;
     CSSPixelPoint m_scroll_offset {};
@@ -86,7 +87,7 @@ class WEB_API ElementReferencePseudoElement : public PseudoElement {
     GC::Ptr<Layout::NodeWithStyle> layout_node() const override;
     GC::Ptr<Layout::NodeWithStyle> unsafe_layout_node() const override;
 
-    GC::Ptr<CSS::ComputedProperties> computed_properties() const override;
+    RefPtr<CSS::ComputedProperties> computed_properties() const override;
 
     RefPtr<CSS::CustomPropertyData const> custom_property_data() const override;
     void set_custom_property_data(RefPtr<CSS::CustomPropertyData const> value) override;

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -37,7 +37,7 @@ void HTMLAudioElement::adjust_computed_style(CSS::ComputedProperties& style)
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
 }
 
-GC::Ptr<Layout::Node> HTMLAudioElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLAudioElement::create_layout_node(CSS::ComputedProperties const& style)
 {
     return heap().allocate<Layout::AudioBox>(document(), *this, style);
 }

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.h
@@ -29,7 +29,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -29,9 +29,9 @@ void HTMLBRElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> HTMLBRElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLBRElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::BreakNode>(document(), *this, move(style));
+    return heap().allocate<Layout::BreakNode>(document(), *this, style);
 }
 
 bool HTMLBRElement::is_presentational_hint(FlyString const& name) const

--- a/Libraries/LibWeb/HTML/HTMLBRElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.h
@@ -17,7 +17,7 @@ class HTMLBRElement final : public HTMLElement {
 public:
     virtual ~HTMLBRElement() override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     virtual bool is_presentational_hint(FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;

--- a/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -35,8 +35,6 @@ HTMLBodyElement::~HTMLBodyElement() = default;
 void HTMLBodyElement::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    if (m_background_style_value)
-        m_background_style_value->visit_edges(visitor);
 }
 
 void HTMLBodyElement::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -239,9 +239,9 @@ void HTMLCanvasElement::attribute_changed(FlyString const& local_name, Optional<
     }
 }
 
-GC::Ptr<Layout::Node> HTMLCanvasElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLCanvasElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::CanvasBox>(document(), *this, move(style));
+    return heap().allocate<Layout::CanvasBox>(document(), *this, style);
 }
 
 void HTMLCanvasElement::adjust_computed_style(CSS::ComputedProperties& style)

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -68,7 +68,7 @@ private:
     virtual bool is_presentational_hint(FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 
     template<typename ContextType>

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -92,7 +92,7 @@ Layout::FieldSetBox* HTMLFieldSetElement::layout_node()
     return static_cast<Layout::FieldSetBox*>(Node::layout_node());
 }
 
-GC::Ptr<Layout::Node> HTMLFieldSetElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLFieldSetElement::create_layout_node(CSS::ComputedProperties const& style)
 {
     return heap().allocate<Layout::FieldSetBox>(document(), *this, style);
 }

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -42,7 +42,7 @@ public:
 
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::group; }
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     Layout::FieldSetBox* layout_node();
     Layout::FieldSetBox const* layout_node() const;
 

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -40,9 +40,9 @@ void HTMLIFrameElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> HTMLIFrameElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLIFrameElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::NavigableContainerViewport>(document(), *this, move(style));
+    return heap().allocate<Layout::NavigableContainerViewport>(document(), *this, style);
 }
 
 void HTMLIFrameElement::adjust_computed_style(CSS::ComputedProperties& style)

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -23,7 +23,7 @@ class HTMLIFrameElement final
 public:
     virtual ~HTMLIFrameElement() override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 
     // ^EventTarget

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -296,9 +296,9 @@ void HTMLImageElement::form_associated_element_attribute_changed(FlyString const
     }
 }
 
-GC::Ptr<Layout::Node> HTMLImageElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLImageElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::ImageBox>(document(), *this, move(style), *this);
+    return heap().allocate<Layout::ImageBox>(document(), *this, style, *this);
 }
 
 void HTMLImageElement::adjust_computed_style(CSS::ComputedProperties& style)

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -136,7 +136,7 @@ private:
     // https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element:dimension-attributes
     virtual bool supports_dimension_attributes() const override { return true; }
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 
     virtual void did_set_viewport_rect(CSSPixelRect const&) override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -132,7 +132,7 @@ void HTMLInputElement::set_being_activated(bool activated)
         set_needs_repaint();
 }
 
-GC::Ptr<Layout::Node> HTMLInputElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLInputElement::create_layout_node(CSS::ComputedProperties const& style)
 {
     if (type_state() == TypeAttributeState::Hidden)
         return nullptr;
@@ -140,15 +140,15 @@ GC::Ptr<Layout::Node> HTMLInputElement::create_layout_node(GC::Ref<CSS::Computed
     // NOTE: Image inputs are `appearance: none` per the default UA style,
     //       but we still need to create an ImageBox for them, or no image will get loaded.
     if (type_state() == TypeAttributeState::ImageButton) {
-        return heap().allocate<Layout::ImageBox>(document(), *this, move(style), *this);
+        return heap().allocate<Layout::ImageBox>(document(), *this, style, *this);
     }
 
     // https://drafts.csswg.org/css-ui/#appearance-switching
     // This specification introduces the appearance property to provide some control over this behavior.
     // In particular, using appearance: none allows authors to suppress the native appearance of widgets,
     // giving them a primitive appearance where CSS can be used to restyle them.
-    if (style->appearance() == CSS::Appearance::None) {
-        return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
+    if (style.appearance() == CSS::Appearance::None) {
+        return Element::create_layout_node_for_display_type(document(), style.display(), style, this);
     }
 
     switch (type_state()) {
@@ -156,18 +156,18 @@ GC::Ptr<Layout::Node> HTMLInputElement::create_layout_node(GC::Ref<CSS::Computed
     case TypeAttributeState::SubmitButton:
     case TypeAttributeState::Button:
     case TypeAttributeState::ResetButton:
-        return heap().allocate<Layout::BlockContainer>(document(), this, move(style));
+        return heap().allocate<Layout::BlockContainer>(document(), this, style);
     case TypeAttributeState::Checkbox:
-        return heap().allocate<Layout::CheckBox>(document(), *this, move(style));
+        return heap().allocate<Layout::CheckBox>(document(), *this, style);
     case TypeAttributeState::RadioButton:
-        return heap().allocate<Layout::RadioButton>(document(), *this, move(style));
+        return heap().allocate<Layout::RadioButton>(document(), *this, style);
     case TypeAttributeState::Range:
-        return heap().allocate<Layout::RangeInputBox>(document(), *this, move(style));
+        return heap().allocate<Layout::RangeInputBox>(document(), *this, style);
     case TypeAttributeState::Color:
     case TypeAttributeState::FileUpload:
-        return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
+        return Element::create_layout_node_for_display_type(document(), style.display(), style, this);
     default:
-        return heap().allocate<Layout::TextInputBox>(document(), *this, move(style));
+        return heap().allocate<Layout::TextInputBox>(document(), *this, style);
     }
 }
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -64,7 +64,7 @@ class WEB_API HTMLInputElement final
 public:
     virtual ~HTMLInputElement() override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
     virtual void set_being_activated(bool) override;
 

--- a/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
@@ -40,9 +40,9 @@ HTMLFormElement* HTMLLegendElement::form()
     return nullptr;
 }
 
-GC::Ptr<Layout::Node> HTMLLegendElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLLegendElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::LegendBox>(document(), *this, move(style));
+    return heap().allocate<Layout::LegendBox>(document(), *this, style);
 }
 
 Layout::LegendBox* HTMLLegendElement::layout_node()

--- a/Libraries/LibWeb/HTML/HTMLLegendElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLegendElement.h
@@ -20,7 +20,7 @@ public:
 
     HTMLFormElement* form();
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     Layout::LegendBox* layout_node();
     Layout::LegendBox const* layout_node() const;
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -194,16 +194,16 @@ void HTMLObjectElement::set_data(String const& data)
     set_attribute_value(HTML::AttributeNames::data, data);
 }
 
-GC::Ptr<Layout::Node> HTMLObjectElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLObjectElement::create_layout_node(CSS::ComputedProperties const& style)
 {
     switch (m_representation) {
     case Representation::Children:
-        return NavigableContainer::create_layout_node(move(style));
+        return NavigableContainer::create_layout_node(style);
     case Representation::ContentNavigable:
-        return heap().allocate<Layout::NavigableContainerViewport>(document(), *this, move(style));
+        return heap().allocate<Layout::NavigableContainerViewport>(document(), *this, style);
     case Representation::Image:
         if (image_data())
-            return heap().allocate<Layout::ImageBox>(document(), *this, move(style), *this);
+            return heap().allocate<Layout::ImageBox>(document(), *this, style, *this);
         break;
     default:
         break;

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -62,7 +62,7 @@ private:
     virtual bool is_presentational_hint(FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 
     bool has_ancestor_media_element_or_object_element_not_showing_fallback_content() const;

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -482,7 +482,7 @@ Optional<String> HTMLTextAreaElement::placeholder_value() const
     return get_attribute_value(HTML::AttributeNames::placeholder);
 }
 
-GC::Ptr<Layout::Node> HTMLTextAreaElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLTextAreaElement::create_layout_node(CSS::ComputedProperties const& style)
 {
     return heap().allocate<Layout::TextAreaBox>(document(), *this, style);
 }

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -154,7 +154,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     void set_raw_value(Utf16String);
 

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -68,7 +68,7 @@ void HTMLVideoElement::attribute_changed(FlyString const& name, Optional<String>
     }
 }
 
-GC::Ptr<Layout::Node> HTMLVideoElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> HTMLVideoElement::create_layout_node(CSS::ComputedProperties const& style)
 {
     return heap().allocate<Layout::VideoBox>(document(), *this, style);
 }

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -74,7 +74,7 @@ private:
     // https://html.spec.whatwg.org/multipage/media.html#the-video-element:dimension-attributes
     virtual bool supports_dimension_attributes() const override { return true; }
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     WebIDL::ExceptionOr<void> determine_element_poster_frame(Optional<String> const& poster);
 

--- a/Libraries/LibWeb/Layout/AudioBox.cpp
+++ b/Libraries/LibWeb/Layout/AudioBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(AudioBox);
 
-AudioBox::AudioBox(DOM::Document& document, DOM::Element& element, GC::Ref<CSS::ComputedProperties> style)
+AudioBox::AudioBox(DOM::Document& document, DOM::Element& element, CSS::ComputedProperties const& style)
     : ReplacedBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/AudioBox.h
+++ b/Libraries/LibWeb/Layout/AudioBox.h
@@ -28,7 +28,7 @@ private:
     // Treat the audio element as if it was not a replaced element, sizing based on its content.
     // Thus, it can fit to the shadow DOM controls, instead of having a hardcoded height.
     virtual bool has_auto_content_box_size() const override { return false; }
-    AudioBox(DOM::Document&, DOM::Element&, GC::Ref<CSS::ComputedProperties>);
+    AudioBox(DOM::Document&, DOM::Element&, CSS::ComputedProperties const&);
 };
 
 }

--- a/Libraries/LibWeb/Layout/BlockContainer.cpp
+++ b/Libraries/LibWeb/Layout/BlockContainer.cpp
@@ -11,8 +11,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(BlockContainer);
 
-BlockContainer::BlockContainer(DOM::Document& document, DOM::Node* node, GC::Ref<CSS::ComputedProperties> style)
-    : Box(document, node, move(style))
+BlockContainer::BlockContainer(DOM::Document& document, DOM::Node* node, CSS::ComputedProperties const& style)
+    : Box(document, node, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/BlockContainer.h
+++ b/Libraries/LibWeb/Layout/BlockContainer.h
@@ -17,7 +17,7 @@ class BlockContainer : public Box {
     GC_DECLARE_ALLOCATOR(BlockContainer);
 
 public:
-    BlockContainer(DOM::Document&, DOM::Node*, GC::Ref<CSS::ComputedProperties>);
+    BlockContainer(DOM::Document&, DOM::Node*, CSS::ComputedProperties const&);
     BlockContainer(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
     virtual ~BlockContainer() override;
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1499,8 +1499,8 @@ void BlockFormattingContext::ensure_sizes_correct_for_left_offset_calculation(Li
 
     // If an image is used, the marker's dimensions are the same as the image.
     if (auto const* list_style_image = marker.list_style_image()) {
-        marker_state.set_content_width(list_style_image->natural_width().value_or(0));
-        marker_state.set_content_height(list_style_image->natural_height().value_or(0));
+        marker_state.set_content_width(list_style_image->natural_width(marker.document()).value_or(0));
+        marker_state.set_content_height(list_style_image->natural_height(marker.document()).value_or(0));
         return;
     }
 

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -17,8 +17,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(Box);
 
-Box::Box(DOM::Document& document, DOM::Node* node, GC::Ref<CSS::ComputedProperties> style)
-    : NodeWithStyleAndBoxModelMetrics(document, node, move(style))
+Box::Box(DOM::Document& document, DOM::Node* node, CSS::ComputedProperties const& style)
+    : NodeWithStyleAndBoxModelMetrics(document, node, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -70,7 +70,7 @@ public:
     void reset_cached_intrinsic_sizes() const { m_cached_intrinsic_sizes.clear(); }
 
 protected:
-    Box(DOM::Document&, DOM::Node*, GC::Ref<CSS::ComputedProperties>);
+    Box(DOM::Document&, DOM::Node*, CSS::ComputedProperties const&);
     Box(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
     virtual CSS::SizeWithAspectRatio compute_auto_content_box_size() const { return natural_size(); }
 

--- a/Libraries/LibWeb/Layout/BreakNode.cpp
+++ b/Libraries/LibWeb/Layout/BreakNode.cpp
@@ -12,8 +12,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(BreakNode);
 
-BreakNode::BreakNode(DOM::Document& document, HTML::HTMLBRElement& element, GC::Ref<CSS::ComputedProperties> style)
-    : Layout::NodeWithStyleAndBoxModelMetrics(document, &element, move(style))
+BreakNode::BreakNode(DOM::Document& document, HTML::HTMLBRElement& element, CSS::ComputedProperties const& style)
+    : Layout::NodeWithStyleAndBoxModelMetrics(document, &element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/BreakNode.h
+++ b/Libraries/LibWeb/Layout/BreakNode.h
@@ -16,7 +16,7 @@ class BreakNode final : public NodeWithStyleAndBoxModelMetrics {
     GC_DECLARE_ALLOCATOR(BreakNode);
 
 public:
-    BreakNode(DOM::Document&, HTML::HTMLBRElement&, GC::Ref<CSS::ComputedProperties>);
+    BreakNode(DOM::Document&, HTML::HTMLBRElement&, CSS::ComputedProperties const&);
     virtual ~BreakNode() override;
 
     HTML::HTMLBRElement const& dom_node() const { return as<HTML::HTMLBRElement>(*Node::dom_node()); }

--- a/Libraries/LibWeb/Layout/CanvasBox.cpp
+++ b/Libraries/LibWeb/Layout/CanvasBox.cpp
@@ -11,8 +11,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(CanvasBox);
 
-CanvasBox::CanvasBox(DOM::Document& document, HTML::HTMLCanvasElement& element, GC::Ref<CSS::ComputedProperties> style)
-    : ReplacedBox(document, element, move(style))
+CanvasBox::CanvasBox(DOM::Document& document, HTML::HTMLCanvasElement& element, CSS::ComputedProperties const& style)
+    : ReplacedBox(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/CanvasBox.h
+++ b/Libraries/LibWeb/Layout/CanvasBox.h
@@ -16,7 +16,7 @@ class CanvasBox final : public ReplacedBox {
     GC_DECLARE_ALLOCATOR(CanvasBox);
 
 public:
-    CanvasBox(DOM::Document&, HTML::HTMLCanvasElement&, GC::Ref<CSS::ComputedProperties>);
+    CanvasBox(DOM::Document&, HTML::HTMLCanvasElement&, CSS::ComputedProperties const&);
     virtual ~CanvasBox() override;
 
     HTML::HTMLCanvasElement const& dom_node() const { return static_cast<HTML::HTMLCanvasElement const&>(*ReplacedBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/CheckBox.cpp
+++ b/Libraries/LibWeb/Layout/CheckBox.cpp
@@ -13,8 +13,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(CheckBox);
 
-CheckBox::CheckBox(DOM::Document& document, HTML::HTMLInputElement& element, GC::Ref<CSS::ComputedProperties> style)
-    : ReplacedBox(document, element, move(style))
+CheckBox::CheckBox(DOM::Document& document, HTML::HTMLInputElement& element, CSS::ComputedProperties const& style)
+    : ReplacedBox(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/CheckBox.h
+++ b/Libraries/LibWeb/Layout/CheckBox.h
@@ -16,7 +16,7 @@ class CheckBox final : public ReplacedBox {
     GC_DECLARE_ALLOCATOR(CheckBox);
 
 public:
-    CheckBox(DOM::Document&, HTML::HTMLInputElement&, GC::Ref<CSS::ComputedProperties>);
+    CheckBox(DOM::Document&, HTML::HTMLInputElement&, CSS::ComputedProperties const&);
     virtual ~CheckBox() override;
 
 private:

--- a/Libraries/LibWeb/Layout/FieldSetBox.cpp
+++ b/Libraries/LibWeb/Layout/FieldSetBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(FieldSetBox);
 
-FieldSetBox::FieldSetBox(DOM::Document& document, DOM::Element& element, GC::Ref<CSS::ComputedProperties> style)
+FieldSetBox::FieldSetBox(DOM::Document& document, DOM::Element& element, CSS::ComputedProperties const& style)
     : BlockContainer(document, &element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/FieldSetBox.h
+++ b/Libraries/LibWeb/Layout/FieldSetBox.h
@@ -18,7 +18,7 @@ class FieldSetBox final : public BlockContainer {
     GC_DECLARE_ALLOCATOR(FieldSetBox);
 
 public:
-    FieldSetBox(DOM::Document&, DOM::Element&, GC::Ref<CSS::ComputedProperties>);
+    FieldSetBox(DOM::Document&, DOM::Element&, CSS::ComputedProperties const&);
     virtual ~FieldSetBox() override;
 
     DOM::Element& dom_node() { return static_cast<DOM::Element&>(*BlockContainer::dom_node()); }

--- a/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -15,8 +15,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(ImageBox);
 
-ImageBox::ImageBox(DOM::Document& document, GC::Ptr<DOM::Element> element, GC::Ref<CSS::ComputedProperties> style, ImageProvider const& image_provider)
-    : ReplacedBox(document, element, move(style))
+ImageBox::ImageBox(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style, ImageProvider const& image_provider)
+    : ReplacedBox(document, element, style)
     , m_image_provider(image_provider)
 {
 }

--- a/Libraries/LibWeb/Layout/ImageBox.h
+++ b/Libraries/LibWeb/Layout/ImageBox.h
@@ -16,7 +16,7 @@ class ImageBox final : public ReplacedBox {
     GC_DECLARE_ALLOCATOR(ImageBox);
 
 public:
-    ImageBox(DOM::Document&, GC::Ptr<DOM::Element>, GC::Ref<CSS::ComputedProperties>, ImageProvider const&);
+    ImageBox(DOM::Document&, GC::Ptr<DOM::Element>, CSS::ComputedProperties const&, ImageProvider const&);
     virtual ~ImageBox() override;
 
     bool renders_as_alt_text() const;

--- a/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -16,8 +16,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(InlineNode);
 
-InlineNode::InlineNode(DOM::Document& document, DOM::Element* element, GC::Ref<CSS::ComputedProperties> style)
-    : Layout::NodeWithStyleAndBoxModelMetrics(document, element, move(style))
+InlineNode::InlineNode(DOM::Document& document, DOM::Element* element, CSS::ComputedProperties const& style)
+    : Layout::NodeWithStyleAndBoxModelMetrics(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/InlineNode.h
+++ b/Libraries/LibWeb/Layout/InlineNode.h
@@ -15,7 +15,7 @@ class InlineNode final : public NodeWithStyleAndBoxModelMetrics {
     GC_DECLARE_ALLOCATOR(InlineNode);
 
 public:
-    InlineNode(DOM::Document&, DOM::Element*, GC::Ref<CSS::ComputedProperties>);
+    InlineNode(DOM::Document&, DOM::Element*, CSS::ComputedProperties const&);
     virtual ~InlineNode() override;
 
     NonnullRefPtr<Painting::PaintableWithLines> create_paintable_for_line_with_index(size_t line_index) const;

--- a/Libraries/LibWeb/Layout/LegendBox.cpp
+++ b/Libraries/LibWeb/Layout/LegendBox.cpp
@@ -10,8 +10,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(LegendBox);
 
-LegendBox::LegendBox(DOM::Document& document, DOM::Element& element, GC::Ref<CSS::ComputedProperties> style)
-    : BlockContainer(document, &element, move(style))
+LegendBox::LegendBox(DOM::Document& document, DOM::Element& element, CSS::ComputedProperties const& style)
+    : BlockContainer(document, &element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/LegendBox.h
+++ b/Libraries/LibWeb/Layout/LegendBox.h
@@ -16,7 +16,7 @@ class LegendBox final : public BlockContainer {
     GC_DECLARE_ALLOCATOR(LegendBox);
 
 public:
-    LegendBox(DOM::Document&, DOM::Element&, GC::Ref<CSS::ComputedProperties>);
+    LegendBox(DOM::Document&, DOM::Element&, CSS::ComputedProperties const&);
     virtual ~LegendBox() override;
 
     DOM::Element& dom_node() { return static_cast<DOM::Element&>(*Box::dom_node()); }

--- a/Libraries/LibWeb/Layout/ListItemBox.cpp
+++ b/Libraries/LibWeb/Layout/ListItemBox.cpp
@@ -12,8 +12,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(ListItemBox);
 
-ListItemBox::ListItemBox(DOM::Document& document, DOM::Element* element, GC::Ref<CSS::ComputedProperties> style)
-    : Layout::BlockContainer(document, element, move(style))
+ListItemBox::ListItemBox(DOM::Document& document, DOM::Element* element, CSS::ComputedProperties const& style)
+    : Layout::BlockContainer(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/ListItemBox.h
+++ b/Libraries/LibWeb/Layout/ListItemBox.h
@@ -16,7 +16,7 @@ class ListItemBox final : public BlockContainer {
     GC_DECLARE_ALLOCATOR(ListItemBox);
 
 public:
-    ListItemBox(DOM::Document&, DOM::Element*, GC::Ref<CSS::ComputedProperties>);
+    ListItemBox(DOM::Document&, DOM::Element*, CSS::ComputedProperties const&);
     virtual ~ListItemBox() override;
 
     DOM::Element& dom_node() { return static_cast<DOM::Element&>(*BlockContainer::dom_node()); }

--- a/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -14,8 +14,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(ListItemMarkerBox);
 
-ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType style_type, CSS::ListStylePosition style_position, GC::Ref<DOM::Element> list_item_element, GC::Ref<CSS::ComputedProperties> style)
-    : Box(document, nullptr, move(style))
+ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType style_type, CSS::ListStylePosition style_position, GC::Ref<DOM::Element> list_item_element, CSS::ComputedProperties const& style)
+    : Box(document, nullptr, style)
     , m_list_style_type(style_type)
     , m_list_style_position(style_position)
     , m_list_item_element(list_item_element)

--- a/Libraries/LibWeb/Layout/ListItemMarkerBox.h
+++ b/Libraries/LibWeb/Layout/ListItemMarkerBox.h
@@ -19,7 +19,7 @@ class ListItemMarkerBox final : public Box {
 public:
     static bool counter_style_is_rendered_with_custom_image(RefPtr<CSS::CounterStyle const> const& counter_style);
 
-    explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, CSS::ListStylePosition, GC::Ref<DOM::Element>, GC::Ref<CSS::ComputedProperties>);
+    explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, CSS::ListStylePosition, GC::Ref<DOM::Element>, CSS::ComputedProperties const&);
     virtual ~ListItemMarkerBox() override;
 
     Optional<String> text() const;

--- a/Libraries/LibWeb/Layout/NavigableContainerViewport.cpp
+++ b/Libraries/LibWeb/Layout/NavigableContainerViewport.cpp
@@ -17,8 +17,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(NavigableContainerViewport);
 
-NavigableContainerViewport::NavigableContainerViewport(DOM::Document& document, HTML::NavigableContainer& element, GC::Ref<CSS::ComputedProperties> style)
-    : ReplacedBox(document, element, move(style))
+NavigableContainerViewport::NavigableContainerViewport(DOM::Document& document, HTML::NavigableContainer& element, CSS::ComputedProperties const& style)
+    : ReplacedBox(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/NavigableContainerViewport.h
+++ b/Libraries/LibWeb/Layout/NavigableContainerViewport.h
@@ -16,7 +16,7 @@ class NavigableContainerViewport final : public ReplacedBox {
     GC_DECLARE_ALLOCATOR(NavigableContainerViewport);
 
 public:
-    NavigableContainerViewport(DOM::Document&, HTML::NavigableContainer&, GC::Ref<CSS::ComputedProperties>);
+    NavigableContainerViewport(DOM::Document&, HTML::NavigableContainer&, CSS::ComputedProperties const&);
     virtual ~NavigableContainerViewport() override;
 
     [[nodiscard]] HTML::NavigableContainer const& dom_node() const { return as<HTML::NavigableContainer>(*ReplacedBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -600,7 +600,7 @@ bool Node::is_sticky_position() const
     return position == CSS::Positioning::Sticky;
 }
 
-NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, GC::Ref<CSS::ComputedProperties> computed_style)
+NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, CSS::ComputedProperties const& computed_style)
     : Node(document, node)
     , m_computed_values(make<CSS::ComputedValues>())
 {
@@ -615,6 +615,11 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullOw
 {
     m_has_style = true;
     m_is_body = node && node == document.body();
+}
+
+NodeWithStyleAndBoxModelMetrics::NodeWithStyleAndBoxModelMetrics(DOM::Document& document, DOM::Node* node, CSS::ComputedProperties const& style)
+    : NodeWithStyle(document, node, style)
+{
 }
 
 NodeWithStyle::ImageObserver::ImageObserver(NodeWithStyle& owner, NonnullRefPtr<CSS::ImageStyleValue const> image)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -652,7 +652,7 @@ void NodeWithStyle::ImageObserver::image_style_value_did_update(CSS::ImageStyleV
 
 void NodeWithStyle::ImageObserver::visit_edges(JS::Cell::Visitor& visitor) const
 {
-    m_image->visit_edges(visitor);
+    (void)visitor;
 }
 
 void NodeWithStyle::finalize()
@@ -702,9 +702,6 @@ void NodeWithStyle::visit_edges(Visitor& visitor)
         m_list_style_image->visit_edges(visitor);
 
     m_computed_values->visit_edges(visitor);
-
-    for (auto const& image_observer : m_image_observers)
-        image_observer->visit_edges(visitor);
 }
 
 void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -343,7 +343,7 @@ public:
     void set_layout_index(u32 index) { m_layout_index = index; }
 
 protected:
-    NodeWithStyle(DOM::Document&, DOM::Node*, GC::Ref<CSS::ComputedProperties>);
+    NodeWithStyle(DOM::Document&, DOM::Node*, CSS::ComputedProperties const&);
     NodeWithStyle(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
 
 private:
@@ -379,10 +379,7 @@ public:
     virtual void visit_edges(Cell::Visitor& visitor) override;
 
 protected:
-    NodeWithStyleAndBoxModelMetrics(DOM::Document& document, DOM::Node* node, GC::Ref<CSS::ComputedProperties> style)
-        : NodeWithStyle(document, node, style)
-    {
-    }
+    NodeWithStyleAndBoxModelMetrics(DOM::Document&, DOM::Node*, CSS::ComputedProperties const&);
 
     NodeWithStyleAndBoxModelMetrics(DOM::Document& document, DOM::Node* node, NonnullOwnPtr<CSS::ComputedValues> computed_values)
         : NodeWithStyle(document, node, move(computed_values))

--- a/Libraries/LibWeb/Layout/RadioButton.cpp
+++ b/Libraries/LibWeb/Layout/RadioButton.cpp
@@ -14,8 +14,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(RadioButton);
 
-RadioButton::RadioButton(DOM::Document& document, HTML::HTMLInputElement& element, GC::Ref<CSS::ComputedProperties> style)
-    : ReplacedBox(document, element, move(style))
+RadioButton::RadioButton(DOM::Document& document, HTML::HTMLInputElement& element, CSS::ComputedProperties const& style)
+    : ReplacedBox(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/RadioButton.h
+++ b/Libraries/LibWeb/Layout/RadioButton.h
@@ -16,7 +16,7 @@ class RadioButton final : public ReplacedBox {
     GC_DECLARE_ALLOCATOR(RadioButton);
 
 public:
-    RadioButton(DOM::Document&, HTML::HTMLInputElement&, GC::Ref<CSS::ComputedProperties>);
+    RadioButton(DOM::Document&, HTML::HTMLInputElement&, CSS::ComputedProperties const&);
     virtual ~RadioButton() override;
 
 private:

--- a/Libraries/LibWeb/Layout/RangeInputBox.cpp
+++ b/Libraries/LibWeb/Layout/RangeInputBox.cpp
@@ -10,8 +10,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(RangeInputBox);
 
-RangeInputBox::RangeInputBox(DOM::Document& document, GC::Ptr<DOM::Element> element, GC::Ref<CSS::ComputedProperties> style)
-    : BlockContainer(document, element, move(style))
+RangeInputBox::RangeInputBox(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style)
+    : BlockContainer(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/RangeInputBox.h
+++ b/Libraries/LibWeb/Layout/RangeInputBox.h
@@ -16,7 +16,7 @@ class RangeInputBox final : public BlockContainer {
     GC_DECLARE_ALLOCATOR(RangeInputBox);
 
 public:
-    RangeInputBox(DOM::Document&, GC::Ptr<DOM::Element>, GC::Ref<CSS::ComputedProperties>);
+    RangeInputBox(DOM::Document&, GC::Ptr<DOM::Element>, CSS::ComputedProperties const&);
 
     virtual ~RangeInputBox() override = default;
 

--- a/Libraries/LibWeb/Layout/ReplacedBox.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedBox.cpp
@@ -11,8 +11,8 @@
 
 namespace Web::Layout {
 
-ReplacedBox::ReplacedBox(DOM::Document& document, GC::Ptr<DOM::Element> element, GC::Ref<CSS::ComputedProperties> style)
-    : Box(document, element, move(style))
+ReplacedBox::ReplacedBox(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style)
+    : Box(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/ReplacedBox.h
+++ b/Libraries/LibWeb/Layout/ReplacedBox.h
@@ -15,7 +15,7 @@ class ReplacedBox : public Box {
     GC_CELL(ReplacedBox, Box);
 
 public:
-    ReplacedBox(DOM::Document&, GC::Ptr<DOM::Element>, GC::Ref<CSS::ComputedProperties>);
+    ReplacedBox(DOM::Document&, GC::Ptr<DOM::Element>, CSS::ComputedProperties const&);
     virtual ~ReplacedBox() override;
 
     GC::Ptr<DOM::Element const> dom_node() const { return as<DOM::Element>(Node::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGBox.cpp
@@ -10,8 +10,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGBox);
 
-SVGBox::SVGBox(DOM::Document& document, SVG::SVGElement& element, GC::Ref<CSS::ComputedProperties> style)
-    : Box(document, &element, move(style))
+SVGBox::SVGBox(DOM::Document& document, SVG::SVGElement& element, CSS::ComputedProperties const& style)
+    : Box(document, &element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/SVGBox.h
+++ b/Libraries/LibWeb/Layout/SVGBox.h
@@ -17,7 +17,7 @@ class SVGBox : public Box {
     GC_DECLARE_ALLOCATOR(SVGBox);
 
 public:
-    SVGBox(DOM::Document&, SVG::SVGElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGBox(DOM::Document&, SVG::SVGElement&, CSS::ComputedProperties const&);
     virtual ~SVGBox() override = default;
 
     SVG::SVGElement& dom_node() { return as<SVG::SVGElement>(*Box::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGClipBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGClipBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGClipBox);
 
-SVGClipBox::SVGClipBox(DOM::Document& document, SVG::SVGClipPathElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGClipBox::SVGClipBox(DOM::Document& document, SVG::SVGClipPathElement& element, CSS::ComputedProperties const& style)
     : SVGBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGClipBox.h
+++ b/Libraries/LibWeb/Layout/SVGClipBox.h
@@ -17,7 +17,7 @@ class SVGClipBox final : public SVGBox {
     GC_DECLARE_ALLOCATOR(SVGClipBox);
 
 public:
-    SVGClipBox(DOM::Document&, SVG::SVGClipPathElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGClipBox(DOM::Document&, SVG::SVGClipPathElement&, CSS::ComputedProperties const&);
     virtual ~SVGClipBox() override = default;
 
     SVG::SVGClipPathElement& dom_node() { return as<SVG::SVGClipPathElement>(SVGBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGForeignObjectBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGForeignObjectBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGForeignObjectBox);
 
-SVGForeignObjectBox::SVGForeignObjectBox(DOM::Document& document, SVG::SVGForeignObjectElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGForeignObjectBox::SVGForeignObjectBox(DOM::Document& document, SVG::SVGForeignObjectElement& element, CSS::ComputedProperties const& style)
     : BlockContainer(document, &element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGForeignObjectBox.h
+++ b/Libraries/LibWeb/Layout/SVGForeignObjectBox.h
@@ -18,7 +18,7 @@ class SVGForeignObjectBox final : public BlockContainer {
     GC_DECLARE_ALLOCATOR(SVGForeignObjectBox);
 
 public:
-    SVGForeignObjectBox(DOM::Document&, SVG::SVGForeignObjectElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGForeignObjectBox(DOM::Document&, SVG::SVGForeignObjectElement&, CSS::ComputedProperties const&);
     virtual ~SVGForeignObjectBox() override = default;
 
     SVG::SVGForeignObjectElement& dom_node() { return static_cast<SVG::SVGForeignObjectElement&>(*BlockContainer::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
@@ -14,7 +14,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGGeometryBox);
 
-SVGGeometryBox::SVGGeometryBox(DOM::Document& document, SVG::SVGGeometryElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGGeometryBox::SVGGeometryBox(DOM::Document& document, SVG::SVGGeometryElement& element, CSS::ComputedProperties const& style)
     : SVGGraphicsBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGGeometryBox.h
+++ b/Libraries/LibWeb/Layout/SVGGeometryBox.h
@@ -17,7 +17,7 @@ class SVGGeometryBox final : public SVGGraphicsBox {
     GC_DECLARE_ALLOCATOR(SVGGeometryBox);
 
 public:
-    SVGGeometryBox(DOM::Document&, SVG::SVGGeometryElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGGeometryBox(DOM::Document&, SVG::SVGGeometryElement&, CSS::ComputedProperties const&);
     virtual ~SVGGeometryBox() override = default;
 
     SVG::SVGGeometryElement& dom_node() { return static_cast<SVG::SVGGeometryElement&>(SVGGraphicsBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGGraphicsBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGGraphicsBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGGraphicsBox);
 
-SVGGraphicsBox::SVGGraphicsBox(DOM::Document& document, SVG::SVGGraphicsElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGGraphicsBox::SVGGraphicsBox(DOM::Document& document, SVG::SVGGraphicsElement& element, CSS::ComputedProperties const& style)
     : SVGBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGGraphicsBox.h
+++ b/Libraries/LibWeb/Layout/SVGGraphicsBox.h
@@ -18,7 +18,7 @@ class WEB_API SVGGraphicsBox : public SVGBox {
     GC_DECLARE_ALLOCATOR(SVGGraphicsBox);
 
 public:
-    SVGGraphicsBox(DOM::Document&, SVG::SVGGraphicsElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGGraphicsBox(DOM::Document&, SVG::SVGGraphicsElement&, CSS::ComputedProperties const&);
     virtual ~SVGGraphicsBox() override = default;
 
     SVG::SVGGraphicsElement& dom_node() { return as<SVG::SVGGraphicsElement>(SVGBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGImageBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGImageBox.cpp
@@ -13,7 +13,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGImageBox);
 
-SVGImageBox::SVGImageBox(DOM::Document& document, SVG::SVGGraphicsElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGImageBox::SVGImageBox(DOM::Document& document, SVG::SVGGraphicsElement& element, CSS::ComputedProperties const& style)
     : SVGGraphicsBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGImageBox.h
+++ b/Libraries/LibWeb/Layout/SVGImageBox.h
@@ -17,7 +17,7 @@ class SVGImageBox : public SVGGraphicsBox {
     GC_DECLARE_ALLOCATOR(SVGImageBox);
 
 public:
-    SVGImageBox(DOM::Document&, SVG::SVGGraphicsElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGImageBox(DOM::Document&, SVG::SVGGraphicsElement&, CSS::ComputedProperties const&);
     virtual ~SVGImageBox() override = default;
 
     SVG::SVGImageElement& dom_node() { return static_cast<SVG::SVGImageElement&>(SVGGraphicsBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGMaskBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGMaskBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGMaskBox);
 
-SVGMaskBox::SVGMaskBox(DOM::Document& document, SVG::SVGMaskElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGMaskBox::SVGMaskBox(DOM::Document& document, SVG::SVGMaskElement& element, CSS::ComputedProperties const& style)
     : SVGGraphicsBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGMaskBox.h
+++ b/Libraries/LibWeb/Layout/SVGMaskBox.h
@@ -17,7 +17,7 @@ class SVGMaskBox : public SVGGraphicsBox {
     GC_DECLARE_ALLOCATOR(SVGMaskBox);
 
 public:
-    SVGMaskBox(DOM::Document&, SVG::SVGMaskElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGMaskBox(DOM::Document&, SVG::SVGMaskElement&, CSS::ComputedProperties const&);
     virtual ~SVGMaskBox() override = default;
 
     virtual bool is_svg_mask_box() const override { return true; }

--- a/Libraries/LibWeb/Layout/SVGPatternBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGPatternBox.cpp
@@ -11,7 +11,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGPatternBox);
 
-SVGPatternBox::SVGPatternBox(DOM::Document& document, SVG::SVGPatternElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGPatternBox::SVGPatternBox(DOM::Document& document, SVG::SVGPatternElement& element, CSS::ComputedProperties const& style)
     : SVGBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGPatternBox.h
+++ b/Libraries/LibWeb/Layout/SVGPatternBox.h
@@ -16,7 +16,7 @@ class SVGPatternBox final : public SVGBox {
     GC_DECLARE_ALLOCATOR(SVGPatternBox);
 
 public:
-    SVGPatternBox(DOM::Document&, SVG::SVGPatternElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGPatternBox(DOM::Document&, SVG::SVGPatternElement&, CSS::ComputedProperties const&);
     virtual ~SVGPatternBox() override = default;
 
     SVG::SVGPatternElement& dom_node() { return as<SVG::SVGPatternElement>(SVGBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGSVGBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGSVGBox.cpp
@@ -15,7 +15,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGSVGBox);
 
-SVGSVGBox::SVGSVGBox(DOM::Document& document, SVG::SVGSVGElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGSVGBox::SVGSVGBox(DOM::Document& document, SVG::SVGSVGElement& element, CSS::ComputedProperties const& style)
     : ReplacedBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGSVGBox.h
+++ b/Libraries/LibWeb/Layout/SVGSVGBox.h
@@ -16,7 +16,7 @@ class SVGSVGBox final : public ReplacedBox {
     GC_DECLARE_ALLOCATOR(SVGSVGBox);
 
 public:
-    SVGSVGBox(DOM::Document&, SVG::SVGSVGElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGSVGBox(DOM::Document&, SVG::SVGSVGElement&, CSS::ComputedProperties const&);
     virtual ~SVGSVGBox() override = default;
 
     SVG::SVGSVGElement& dom_node() { return as<SVG::SVGSVGElement>(*ReplacedBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGTextBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGTextBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGTextBox);
 
-SVGTextBox::SVGTextBox(DOM::Document& document, SVG::SVGTextPositioningElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGTextBox::SVGTextBox(DOM::Document& document, SVG::SVGTextPositioningElement& element, CSS::ComputedProperties const& style)
     : SVGGraphicsBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGTextBox.h
+++ b/Libraries/LibWeb/Layout/SVGTextBox.h
@@ -17,7 +17,7 @@ class SVGTextBox final : public SVGGraphicsBox {
     GC_DECLARE_ALLOCATOR(SVGTextBox);
 
 public:
-    SVGTextBox(DOM::Document&, SVG::SVGTextPositioningElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGTextBox(DOM::Document&, SVG::SVGTextPositioningElement&, CSS::ComputedProperties const&);
     virtual ~SVGTextBox() override = default;
 
     SVG::SVGTextPositioningElement& dom_node() { return static_cast<SVG::SVGTextPositioningElement&>(SVGGraphicsBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/SVGTextPathBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGTextPathBox.cpp
@@ -11,7 +11,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(SVGTextPathBox);
 
-SVGTextPathBox::SVGTextPathBox(DOM::Document& document, SVG::SVGTextPathElement& element, GC::Ref<CSS::ComputedProperties> style)
+SVGTextPathBox::SVGTextPathBox(DOM::Document& document, SVG::SVGTextPathElement& element, CSS::ComputedProperties const& style)
     : SVGGraphicsBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/SVGTextPathBox.h
+++ b/Libraries/LibWeb/Layout/SVGTextPathBox.h
@@ -16,7 +16,7 @@ class SVGTextPathBox final : public SVGGraphicsBox {
     GC_DECLARE_ALLOCATOR(SVGTextPathBox);
 
 public:
-    SVGTextPathBox(DOM::Document&, SVG::SVGTextPathElement&, GC::Ref<CSS::ComputedProperties>);
+    SVGTextPathBox(DOM::Document&, SVG::SVGTextPathElement&, CSS::ComputedProperties const&);
     virtual ~SVGTextPathBox() override = default;
 
     SVG::SVGTextPathElement& dom_node() { return static_cast<SVG::SVGTextPathElement&>(SVGGraphicsBox::dom_node()); }

--- a/Libraries/LibWeb/Layout/TableWrapper.cpp
+++ b/Libraries/LibWeb/Layout/TableWrapper.cpp
@@ -10,8 +10,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(TableWrapper);
 
-TableWrapper::TableWrapper(DOM::Document& document, DOM::Node* node, GC::Ref<CSS::ComputedProperties> style)
-    : BlockContainer(document, node, move(style))
+TableWrapper::TableWrapper(DOM::Document& document, DOM::Node* node, CSS::ComputedProperties const& style)
+    : BlockContainer(document, node, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/TableWrapper.h
+++ b/Libraries/LibWeb/Layout/TableWrapper.h
@@ -15,7 +15,7 @@ class TableWrapper : public BlockContainer {
     GC_DECLARE_ALLOCATOR(TableWrapper);
 
 public:
-    TableWrapper(DOM::Document&, DOM::Node*, GC::Ref<CSS::ComputedProperties>);
+    TableWrapper(DOM::Document&, DOM::Node*, CSS::ComputedProperties const&);
     TableWrapper(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
     virtual ~TableWrapper() override;
 

--- a/Libraries/LibWeb/Layout/TextAreaBox.cpp
+++ b/Libraries/LibWeb/Layout/TextAreaBox.cpp
@@ -10,8 +10,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(TextAreaBox);
 
-TextAreaBox::TextAreaBox(DOM::Document& document, GC::Ptr<DOM::Element> element, GC::Ref<CSS::ComputedProperties> style)
-    : BlockContainer(document, element, move(style))
+TextAreaBox::TextAreaBox(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style)
+    : BlockContainer(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/TextAreaBox.h
+++ b/Libraries/LibWeb/Layout/TextAreaBox.h
@@ -16,7 +16,7 @@ class TextAreaBox : public BlockContainer {
     GC_DECLARE_ALLOCATOR(TextAreaBox);
 
 public:
-    TextAreaBox(DOM::Document&, GC::Ptr<DOM::Element>, GC::Ref<CSS::ComputedProperties>);
+    TextAreaBox(DOM::Document&, GC::Ptr<DOM::Element>, CSS::ComputedProperties const&);
 
     HTML::HTMLTextAreaElement const& dom_node() const { return static_cast<HTML::HTMLTextAreaElement const&>(*Box::dom_node()); }
 

--- a/Libraries/LibWeb/Layout/TextInputBox.cpp
+++ b/Libraries/LibWeb/Layout/TextInputBox.cpp
@@ -10,8 +10,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(TextInputBox);
 
-TextInputBox::TextInputBox(DOM::Document& document, GC::Ptr<DOM::Element> element, GC::Ref<CSS::ComputedProperties> style)
-    : BlockContainer(document, element, move(style))
+TextInputBox::TextInputBox(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style)
+    : BlockContainer(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/TextInputBox.h
+++ b/Libraries/LibWeb/Layout/TextInputBox.h
@@ -16,7 +16,7 @@ class TextInputBox : public BlockContainer {
     GC_DECLARE_ALLOCATOR(TextInputBox);
 
 public:
-    TextInputBox(DOM::Document&, GC::Ptr<DOM::Element>, GC::Ref<CSS::ComputedProperties>);
+    TextInputBox(DOM::Document&, GC::Ptr<DOM::Element>, CSS::ComputedProperties const&);
 
     HTML::HTMLInputElement const& dom_node() const { return static_cast<HTML::HTMLInputElement const&>(*Box::dom_node()); }
     static CSS::SizeWithAspectRatio auto_content_box_size_for_text_control(HTML::HTMLInputElement const&, Box const&);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -911,7 +911,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
 
     auto& document = dom_node.document();
     auto& style_computer = document.style_computer();
-    GC::Ptr<CSS::ComputedProperties> style;
+    RefPtr<CSS::ComputedProperties> style;
     CSS::Display display;
 
     if (!should_create_layout_node) {

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -216,16 +216,41 @@ public:
         unregister_image_style_value_client();
     }
 
-    virtual bool is_image_available() const override { return m_image->is_paintable(); }
+    virtual bool is_image_available() const override
+    {
+        if (auto document = this->document())
+            return m_image->is_paintable(*document);
+        return false;
+    }
 
-    virtual Optional<CSSPixels> intrinsic_width() const override { return m_image->natural_width(); }
-    virtual Optional<CSSPixels> intrinsic_height() const override { return m_image->natural_height(); }
-    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override { return m_image->natural_aspect_ratio(); }
+    virtual Optional<CSSPixels> intrinsic_width() const override
+    {
+        if (auto document = this->document())
+            return m_image->natural_width(*document);
+        return {};
+    }
+
+    virtual Optional<CSSPixels> intrinsic_height() const override
+    {
+        if (auto document = this->document())
+            return m_image->natural_height(*document);
+        return {};
+    }
+
+    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override
+    {
+        if (auto document = this->document())
+            return m_image->natural_aspect_ratio(*document);
+        return {};
+    }
 
     virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize size) const override
     {
+        auto document = this->document();
+        if (!document)
+            return {};
         auto rect = DevicePixelRect { DevicePixelPoint {}, size.to_type<DevicePixels>() };
-        return m_image->current_frame(rect);
+        return m_image->current_frame(*document, rect);
     }
 
     virtual void set_visible_in_viewport(bool) override { }
@@ -247,10 +272,18 @@ public:
         m_layout_node = layout_node;
     }
 
-    virtual size_t current_frame_index() const override { return 0; }
+    virtual size_t current_frame_index() const override
+    {
+        if (auto document = this->document())
+            return m_image->current_frame_index(*document);
+        return 0;
+    }
+
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override
     {
-        return m_image->image_data();
+        if (auto document = this->document())
+            return m_image->image_data(*document);
+        return nullptr;
     }
 
 private:
@@ -264,7 +297,6 @@ private:
     {
         Base::visit_edges(visitor);
         visitor.visit(m_layout_node);
-        m_image->visit_edges(visitor);
     }
 
     virtual void image_provider_visit_edges(Visitor& visitor) const override

--- a/Libraries/LibWeb/Layout/VideoBox.cpp
+++ b/Libraries/LibWeb/Layout/VideoBox.cpp
@@ -13,7 +13,7 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(VideoBox);
 
-VideoBox::VideoBox(DOM::Document& document, DOM::Element& element, GC::Ref<CSS::ComputedProperties> style)
+VideoBox::VideoBox(DOM::Document& document, DOM::Element& element, CSS::ComputedProperties const& style)
     : ReplacedBox(document, element, style)
 {
 }

--- a/Libraries/LibWeb/Layout/VideoBox.h
+++ b/Libraries/LibWeb/Layout/VideoBox.h
@@ -24,7 +24,7 @@ public:
     virtual RefPtr<Painting::Paintable> create_paintable() const override;
 
 private:
-    VideoBox(DOM::Document&, DOM::Element&, GC::Ref<CSS::ComputedProperties>);
+    VideoBox(DOM::Document&, DOM::Element&, CSS::ComputedProperties const&);
     virtual CSS::SizeWithAspectRatio natural_size() const override;
 };
 

--- a/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Libraries/LibWeb/Layout/Viewport.cpp
@@ -18,8 +18,8 @@ namespace Web::Layout {
 
 GC_DEFINE_ALLOCATOR(Viewport);
 
-Viewport::Viewport(DOM::Document& document, GC::Ref<CSS::ComputedProperties> style)
-    : BlockContainer(document, &document, move(style))
+Viewport::Viewport(DOM::Document& document, CSS::ComputedProperties const& style)
+    : BlockContainer(document, &document, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/Viewport.h
+++ b/Libraries/LibWeb/Layout/Viewport.h
@@ -16,7 +16,7 @@ class Viewport final : public BlockContainer {
     GC_DECLARE_ALLOCATOR(Viewport);
 
 public:
-    explicit Viewport(DOM::Document&, GC::Ref<CSS::ComputedProperties>);
+    explicit Viewport(DOM::Document&, CSS::ComputedProperties const&);
     virtual ~Viewport() override;
 
     struct TextPosition {

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -303,7 +303,8 @@ void paint_background(DisplayListRecordingContext& context, PaintableBox const& 
         auto tile_rows = (repeat_y && y_step > 0) ? ceil((css_clip_rect.bottom() - image_y).to_double() / y_step.to_double()) : 1.0;
         auto tile_count = tile_columns * tile_rows;
 
-        if (auto color = image.color_if_single_pixel_bitmap(); color.has_value()) {
+        auto const& document = paintable_box.layout_node().document();
+        if (auto color = image.color_if_single_pixel_bitmap(document); color.has_value()) {
             // OPTIMIZATION: If the image is a single pixel, we can just fill the whole area with it.
             //               However, we must first figure out the real coverage area, taking repeat etc into account.
 
@@ -324,7 +325,7 @@ void paint_background(DisplayListRecordingContext& context, PaintableBox const& 
             if (dest_rect.height() == 0)
                 dest_rect.set_height(1);
 
-            auto frame = static_cast<CSS::ImageStyleValue const&>(image).current_frame(dest_rect);
+            auto frame = static_cast<CSS::ImageStyleValue const&>(image).current_frame(document, dest_rect);
             if (!frame.has_value())
                 return;
             auto scaling_mode = to_gfx_scaling_mode(image_rendering, frame->size(), dest_rect.size().to_type<int>());
@@ -345,7 +346,7 @@ void paint_background(DisplayListRecordingContext& context, PaintableBox const& 
             DisplayListRecorder tile_recorder(*tile_display_list, visual_context_tree, display_list_recorder.resource_storage());
             tile_recorder.translate(-tile_device_rect.location().to_type<int>());
             auto tile_context = context.clone(tile_recorder);
-            image.paint(tile_context, tile_device_rect, image_rendering);
+            image.paint(tile_context, document, tile_device_rect, image_rendering);
 
             // A pattern repeats along both axes. On any non-repeating axis, constrain the coverage to a single tile.
             auto coverage = clip_rect;
@@ -372,7 +373,7 @@ void paint_background(DisplayListRecordingContext& context, PaintableBox const& 
             });
         } else {
             for_each_image_device_rect([&](auto const& image_device_rect) {
-                image.paint(context, image_device_rect, image_rendering);
+                image.paint(context, document, image_device_rect, image_rendering);
             });
         }
 
@@ -404,7 +405,8 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
 
     Vector<ResolvedBackgroundLayerData> resolved_layers;
     for (auto const& layer : layers) {
-        if (!layer.background_image->is_paintable())
+        auto const& document = paintable_box.layout_node().document();
+        if (!layer.background_image->is_paintable(document))
             continue;
 
         auto background_positioning_area = get_box(layer.origin, border_box, paintable_box).rect;
@@ -432,7 +434,7 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
         }
         auto concrete_image_size = CSS::run_default_sizing_algorithm(
             specified_width, specified_height,
-            { image.natural_width(), image.natural_height(), image.natural_aspect_ratio() },
+            { image.natural_width(document), image.natural_height(document), image.natural_aspect_ratio(document) },
             background_positioning_area.size());
 
         // If the image has no size, there's nothing to paint.

--- a/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -44,7 +44,7 @@ void MarkerPaintable::paint(DisplayListRecordingContext& context, PaintPhase pha
 
     if (auto const* list_style_image = layout_box().list_style_image()) {
         list_style_image->resolve_for_size(layout_box(), marker_rect.size());
-        list_style_image->paint(context, device_rect, computed_values().image_rendering());
+        list_style_image->paint(context, layout_box().document(), device_rect, computed_values().image_rendering());
         return;
     }
 

--- a/Libraries/LibWeb/SVG/SVGAElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGAElement.cpp
@@ -75,9 +75,9 @@ GC::Ref<DOM::DOMTokenList> SVGAElement::rel_list()
     return *m_rel_list;
 }
 
-GC::Ptr<Layout::Node> SVGAElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGAElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGGraphicsBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGGraphicsBox>(document(), *this, style);
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements

--- a/Libraries/LibWeb/SVG/SVGAElement.h
+++ b/Libraries/LibWeb/SVG/SVGAElement.h
@@ -25,7 +25,7 @@ public:
 
     GC::Ref<DOM::DOMTokenList> rel_list();
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
 private:
     SVGAElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
@@ -36,7 +36,7 @@ void SVGClipPathElement::attribute_changed(FlyString const& name, Optional<Strin
         m_clip_path_units = AttributeParser::parse_units(value.value_or(String {}));
 }
 
-GC::Ptr<Layout::Node> SVGClipPathElement::create_layout_node(GC::Ref<CSS::ComputedProperties>)
+GC::Ptr<Layout::Node> SVGClipPathElement::create_layout_node(CSS::ComputedProperties const&)
 {
     // Clip paths are handled as a special case in the TreeBuilder.
     return nullptr;

--- a/Libraries/LibWeb/SVG/SVGClipPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGClipPathElement.h
@@ -34,7 +34,7 @@ public:
         return m_clip_path_units.value_or(ClipPathUnits::UserSpaceOnUse);
     }
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
 private:
     SVGClipPathElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGDefsElement.h
+++ b/Libraries/LibWeb/SVG/SVGDefsElement.h
@@ -17,7 +17,7 @@ class SVGDefsElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGDefsElement();
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override
     {
         return nullptr;
     }

--- a/Libraries/LibWeb/SVG/SVGDescElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGDescElement.cpp
@@ -25,7 +25,7 @@ void SVGDescElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> SVGDescElement::create_layout_node(GC::Ref<CSS::ComputedProperties>)
+GC::Ptr<Layout::Node> SVGDescElement::create_layout_node(CSS::ComputedProperties const&)
 {
     return nullptr;
 }

--- a/Libraries/LibWeb/SVG/SVGDescElement.h
+++ b/Libraries/LibWeb/SVG/SVGDescElement.h
@@ -19,7 +19,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGFEFloodElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGFEFloodElement.cpp
@@ -32,9 +32,9 @@ void SVGFEFloodElement::visit_edges(Cell::Visitor& visitor)
     SVGFilterPrimitiveStandardAttributes::visit_edges(visitor);
 }
 
-GC::Ptr<Layout::Node> SVGFEFloodElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGFEFloodElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGBox>(document(), *this, style);
 }
 
 // https://www.w3.org/TR/filter-effects-1/#FloodColorProperty

--- a/Libraries/LibWeb/SVG/SVGFEFloodElement.h
+++ b/Libraries/LibWeb/SVG/SVGFEFloodElement.h
@@ -21,7 +21,7 @@ class SVGFEFloodElement final
 public:
     virtual ~SVGFEFloodElement() override = default;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     Gfx::Color flood_color();
     float flood_opacity() const;

--- a/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
@@ -47,9 +47,9 @@ void SVGForeignObjectElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_height);
 }
 
-GC::Ptr<Layout::Node> SVGForeignObjectElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGForeignObjectElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGForeignObjectBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGForeignObjectBox>(document(), *this, style);
 }
 
 GC::Ref<SVG::SVGAnimatedLength> SVGForeignObjectElement::x()

--- a/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
+++ b/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
@@ -18,7 +18,7 @@ class SVGForeignObjectElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGForeignObjectElement() override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     GC::Ref<SVG::SVGAnimatedLength> x();
     GC::Ref<SVG::SVGAnimatedLength> y();

--- a/Libraries/LibWeb/SVG/SVGGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGElement.cpp
@@ -26,9 +26,9 @@ void SVGGElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> SVGGElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGGElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGGraphicsBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGGraphicsBox>(document(), *this, style);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGGElement.h
+++ b/Libraries/LibWeb/SVG/SVGGElement.h
@@ -17,7 +17,7 @@ class SVGGElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGGElement() override = default;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
 private:
     virtual bool is_svg_g_element() const final { return true; }

--- a/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
@@ -28,9 +28,9 @@ void SVGGeometryElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_path_length);
 }
 
-GC::Ptr<Layout::Node> SVGGeometryElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGGeometryElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGGeometryBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGGeometryBox>(document(), *this, style);
 }
 
 float SVGGeometryElement::get_total_length()

--- a/Libraries/LibWeb/SVG/SVGGeometryElement.h
+++ b/Libraries/LibWeb/SVG/SVGGeometryElement.h
@@ -16,7 +16,7 @@ class SVGGeometryElement : public SVGGraphicsElement {
     WEB_PLATFORM_OBJECT(SVGGeometryElement, SVGGraphicsElement);
 
 public:
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) = 0;
 

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -206,9 +206,9 @@ void SVGImageElement::fetch_the_document(URL::URL const& url)
     }
 }
 
-GC::Ptr<Layout::Node> SVGImageElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGImageElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGImageBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGImageBox>(document(), *this, style);
 }
 
 bool SVGImageElement::is_image_available() const

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -56,7 +56,7 @@ protected:
     void fetch_the_document(URL::URL const& url);
 
 private:
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     void animate();
 
     GC::Ptr<SVG::SVGAnimatedLength> m_x;

--- a/Libraries/LibWeb/SVG/SVGMaskElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGMaskElement.cpp
@@ -27,7 +27,7 @@ void SVGMaskElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> SVGMaskElement::create_layout_node(GC::Ref<CSS::ComputedProperties>)
+GC::Ptr<Layout::Node> SVGMaskElement::create_layout_node(CSS::ComputedProperties const&)
 {
     // Masks are handled as a special case in the TreeBuilder.
     return nullptr;

--- a/Libraries/LibWeb/SVG/SVGMaskElement.h
+++ b/Libraries/LibWeb/SVG/SVGMaskElement.h
@@ -32,7 +32,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     CSSPixelRect resolve_masking_area(CSSPixelRect const& mask_target) const;
 

--- a/Libraries/LibWeb/SVG/SVGMetadataElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGMetadataElement.cpp
@@ -25,7 +25,7 @@ void SVGMetadataElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> SVGMetadataElement::create_layout_node(GC::Ref<CSS::ComputedProperties>)
+GC::Ptr<Layout::Node> SVGMetadataElement::create_layout_node(CSS::ComputedProperties const&)
 {
     return nullptr;
 }

--- a/Libraries/LibWeb/SVG/SVGMetadataElement.h
+++ b/Libraries/LibWeb/SVG/SVGMetadataElement.h
@@ -20,7 +20,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGPatternElement.h
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.h
@@ -46,7 +46,7 @@ public:
 
     Optional<Painting::PaintStyle> to_gfx_paint_style(SVGPaintContext const&, DisplayListRecordingContext&, Layout::Node const& target_layout_node) const;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override { return nullptr; }
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override { return nullptr; }
 
 protected:
     SVGPatternElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -46,9 +46,9 @@ void SVGSVGElement::visit_edges(Visitor& visitor)
     visitor.visit(m_active_view_element);
 }
 
-GC::Ptr<Layout::Node> SVGSVGElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGSVGElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGSVGBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGSVGBox>(document(), *this, style);
 }
 
 RefPtr<CSS::StyleValue const> SVGSVGElement::width_style_value_from_attribute() const

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -25,7 +25,7 @@ class SVGSVGElement final : public SVGGraphicsElement
     GC_DECLARE_ALLOCATOR(SVGSVGElement);
 
 public:
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     virtual bool requires_svg_container() const override { return false; }
     virtual bool is_svg_container() const override { return true; }

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -62,7 +62,7 @@ bool SVGSymbolElement::is_direct_child_of_use_shadow_tree() const
     return is<SVGUseElement>(host);
 }
 
-GC::Ptr<Layout::Node> SVGSymbolElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGSymbolElement::create_layout_node(CSS::ComputedProperties const& style)
 {
     // https://svgwg.org/svg2-draft/render.html#TermNeverRenderedElement
     // [..] it also includes a ‘symbol’ element that is not the instance root of a use-element shadow tree.

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -29,7 +29,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     bool is_direct_child_of_use_shadow_tree() const;
 

--- a/Libraries/LibWeb/SVG/SVGTSpanElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTSpanElement.cpp
@@ -24,11 +24,11 @@ void SVGTSpanElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> SVGTSpanElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGTSpanElement::create_layout_node(CSS::ComputedProperties const& style)
 {
     // Text must be within an SVG <text> element.
     if (first_flat_tree_ancestor_of_type<SVGTextElement>())
-        return heap().allocate<Layout::SVGTextBox>(document(), *this, move(style));
+        return heap().allocate<Layout::SVGTextBox>(document(), *this, style);
     return {};
 }
 

--- a/Libraries/LibWeb/SVG/SVGTSpanElement.h
+++ b/Libraries/LibWeb/SVG/SVGTSpanElement.h
@@ -17,7 +17,7 @@ class SVGTSpanElement : public SVGTextPositioningElement {
     GC_DECLARE_ALLOCATOR(SVGTSpanElement);
 
 public:
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
 protected:
     SVGTSpanElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGTextElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextElement.cpp
@@ -23,9 +23,9 @@ void SVGTextElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> SVGTextElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGTextElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGTextBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGTextBox>(document(), *this, style);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGTextElement.h
+++ b/Libraries/LibWeb/SVG/SVGTextElement.h
@@ -17,7 +17,7 @@ class SVGTextElement : public SVGTextPositioningElement {
     GC_DECLARE_ALLOCATOR(SVGTextElement);
 
 public:
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
 protected:
     SVGTextElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
@@ -64,9 +64,9 @@ void SVGTextPathElement::visit_edges(Cell::Visitor& visitor)
     SVGURIReferenceMixin::visit_edges(visitor);
 }
 
-GC::Ptr<Layout::Node> SVGTextPathElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGTextPathElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGTextPathBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGTextPathBox>(document(), *this, style);
 }
 
 };

--- a/Libraries/LibWeb/SVG/SVGTextPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGTextPathElement.h
@@ -22,7 +22,7 @@ class SVGTextPathElement
     GC_DECLARE_ALLOCATOR(SVGTextPathElement);
 
 public:
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     GC::Ptr<SVGGeometryElement const> path_or_shape() const;
 

--- a/Libraries/LibWeb/SVG/SVGTitleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTitleElement.cpp
@@ -25,7 +25,7 @@ void SVGTitleElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-GC::Ptr<Layout::Node> SVGTitleElement::create_layout_node(GC::Ref<CSS::ComputedProperties>)
+GC::Ptr<Layout::Node> SVGTitleElement::create_layout_node(CSS::ComputedProperties const&)
 {
     return nullptr;
 }

--- a/Libraries/LibWeb/SVG/SVGTitleElement.h
+++ b/Libraries/LibWeb/SVG/SVGTitleElement.h
@@ -19,7 +19,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     virtual void children_changed(ChildrenChangedMetadata const&) override;
 };
 

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -315,9 +315,9 @@ GC::Ptr<SVGElement> SVGUseElement::animated_instance_root() const
     return instance_root();
 }
 
-GC::Ptr<Layout::Node> SVGUseElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
+GC::Ptr<Layout::Node> SVGUseElement::create_layout_node(CSS::ComputedProperties const& style)
 {
-    return heap().allocate<Layout::SVGGraphicsBox>(document(), *this, move(style));
+    return heap().allocate<Layout::SVGGraphicsBox>(document(), *this, style);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -48,7 +48,7 @@ private:
 
     virtual bool is_svg_use_element() const override { return true; }
 
-    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     void process_the_url(Optional<String> const& href);
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -25,6 +25,11 @@ Text/input/navigation/aborted-intercepted-traverse-does-not-resume.html
 ; CSS @font-face url() requires HTTP(s) scheme.
 Text/input/selection-rect-consistency-with-kerning.html
 
+; CSS image referrer checks require an HTTP document URL.
+Text/input/css/css-image-snapshotted-stylesheet-referrer.html
+Text/input/css/css-imported-image-origin-clean.html
+Text/input/css/css-inline-import-initiator-type.html
+
 ; Form submission to /common/blank.html requires HTTP(s) scheme.
 Text/input/wpt-import/custom-elements/form-associated/form-disabled-callback.html
 

--- a/Tests/LibWeb/Text/expected/css/animated-background-image-timer-stops-after-base-change.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-background-image-timer-stops-after-base-change.txt
@@ -1,0 +1,2 @@
+active animations before base change: 1
+active animations after removal: 0

--- a/Tests/LibWeb/Text/expected/css/css-image-snapshotted-stylesheet-referrer.txt
+++ b/Tests/LibWeb/Text/expected/css/css-image-snapshotted-stylesheet-referrer.txt
@@ -1,0 +1,1 @@
+Referer is stylesheet URL: true

--- a/Tests/LibWeb/Text/expected/css/css-imported-image-origin-clean.txt
+++ b/Tests/LibWeb/Text/expected/css/css-imported-image-origin-clean.txt
@@ -1,0 +1,4 @@
+Imported background image applied: true
+Imported image requested: true
+Imported image resource timing entries: 0
+Imported image initiator type: missing

--- a/Tests/LibWeb/Text/expected/css/css-inline-import-initiator-type.txt
+++ b/Tests/LibWeb/Text/expected/css/css-inline-import-initiator-type.txt
@@ -1,0 +1,1 @@
+Inline @import initiator type: css

--- a/Tests/LibWeb/Text/expected/css/inline-relative-css-image-base-url.txt
+++ b/Tests/LibWeb/Text/expected/css/inline-relative-css-image-base-url.txt
@@ -1,0 +1,4 @@
+Computed URL before base change: url("../wpt-import/images/anim-gr.gif")
+Computed URL after base change: url("../wpt-import/images/anim-gr.gif")
+active animations before base change: 1
+active animations after base change: 1

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-stops-after-base-change.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-stops-after-base-change.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div
+    id="target"
+    style="
+        width: 100px;
+        height: 50px;
+        background-image: url('../wpt-import/images/anim-gr.gif');
+    "
+></div>
+<script>
+    asyncTest(async done => {
+        await new Promise(resolve => window.addEventListener("load", resolve));
+
+        internals.dumpLayoutTree(document);
+        const activeAnimationsBeforeBaseChange =
+            internals.activeImageStyleValueAnimationCount();
+        println(
+            `active animations before base change: ${activeAnimationsBeforeBaseChange}`
+        );
+
+        const base = document.createElement("base");
+        base.href = "../";
+        document.head.append(base);
+
+        target.remove();
+        internals.dumpLayoutTree(document);
+        const activeAnimationsAfterRemoval =
+            internals.activeImageStyleValueAnimationCount();
+        println(`active animations after removal: ${activeAnimationsAfterRemoval}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/css-image-snapshotted-stylesheet-referrer.html
+++ b/Tests/LibWeb/Text/input/css/css-image-snapshotted-stylesheet-referrer.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    const imagePath = "/echo/css-image-snapshotted-stylesheet-referrer.png";
+    const stylesheetPath = "/echo/css-image-snapshotted-stylesheet-referrer.css";
+
+    function registerEchoResponse(response) {
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", "/echo", false);
+        xhr.setRequestHeader("Content-Type", "application/json");
+        xhr.send(JSON.stringify(response));
+    }
+
+    const transparentPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+    registerEchoResponse({
+        method: "GET",
+        path: imagePath,
+        status: 200,
+        headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Cache-Control": "no-store",
+            "Content-Type": "image/png",
+        },
+        body_encoding: "base64",
+        body: transparentPng,
+    });
+
+    registerEchoResponse({
+        method: "GET",
+        path: stylesheetPath,
+        status: 200,
+        headers: {
+            "Cache-Control": "no-store",
+            "Content-Type": "text/css",
+        },
+        body: `#target {
+            background-image: url("${imagePath}" cross-origin(anonymous));
+            height: 1px;
+            width: 1px;
+        }`,
+    });
+
+    asyncTest(done => {
+        window.addEventListener("load", async () => {
+            const response = await fetch(`/recorded-request-headers${imagePath}`);
+            const headers = await response.json();
+
+            const stylesheetUrl = new URL(stylesheetPath, location.href).href;
+            const referer = headers["Referer"]?.[0] ?? null;
+            println(`Referer is stylesheet URL: ${referer === stylesheetUrl}`);
+            done();
+        });
+    });
+</script>
+<link rel="stylesheet" href="/echo/css-image-snapshotted-stylesheet-referrer.css">
+<div id="target"></div>

--- a/Tests/LibWeb/Text/input/css/css-imported-image-origin-clean.html
+++ b/Tests/LibWeb/Text/input/css/css-imported-image-origin-clean.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    const imagePath = "/echo/css-imported-image-origin-clean.png";
+    const stylesheetPath = "/echo/css-imported-image-origin-clean.css";
+
+    function registerEchoResponse(response) {
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", "/echo", false);
+        xhr.setRequestHeader("Content-Type", "application/json");
+        xhr.send(JSON.stringify(response));
+    }
+
+    const transparentPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+    registerEchoResponse({
+        method: "GET",
+        path: imagePath,
+        status: 200,
+        headers: {
+            "Cache-Control": "no-store",
+            "Content-Type": "image/png",
+        },
+        body_encoding: "base64",
+        body: transparentPng,
+    });
+
+    const sameOriginImageUrl = new URL(imagePath, location.href).href;
+    registerEchoResponse({
+        method: "GET",
+        path: stylesheetPath,
+        status: 200,
+        headers: {
+            "Cache-Control": "no-store",
+            "Content-Type": "text/css",
+        },
+        body: `#target {
+            background-image: url("${sameOriginImageUrl}");
+            height: 1px;
+            width: 1px;
+        }`,
+    });
+
+    const crossOriginStylesheetUrl = new URL(stylesheetPath, location.href);
+    crossOriginStylesheetUrl.hostname = uniqueLocalhostHostname(
+        "css-imported-image-origin-clean"
+    );
+
+    document.write(`<style>@import url("${crossOriginStylesheetUrl.href}");</style>`);
+
+    asyncTest(done => {
+        window.addEventListener("load", () => {
+            (async () => {
+                const backgroundImage = getComputedStyle(
+                    document.getElementById("target")
+                ).backgroundImage;
+                println(`Imported background image applied: ${backgroundImage.includes(imagePath)}`);
+
+                const imageEntries = performance.getEntriesByType("resource").filter(
+                    entry => entry.name === sameOriginImageUrl
+                );
+                const response = await fetch(`/recorded-request-headers${imagePath}`);
+                const responseText = await response.text();
+                let headers = {};
+                try {
+                    headers = JSON.parse(responseText);
+                } catch {
+                    // No recorded headers response means the image was not requested.
+                }
+                println(`Imported image requested: ${Object.keys(headers).length > 0}`);
+                println(`Imported image resource timing entries: ${imageEntries.length}`);
+                println(
+                    `Imported image initiator type: ${imageEntries[0]?.initiatorType ?? "missing"}`
+                );
+                done();
+            })().catch(error => {
+                println(`Caught error while checking imported image: ${error}`);
+                done();
+            });
+        });
+    });
+</script>
+<div id="target"></div>

--- a/Tests/LibWeb/Text/input/css/css-inline-import-initiator-type.html
+++ b/Tests/LibWeb/Text/input/css/css-inline-import-initiator-type.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    const importPath = "/echo/css-inline-import-initiator-type.css";
+
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", "/echo", false);
+    xhr.setRequestHeader("Content-Type", "application/json");
+    xhr.send(JSON.stringify({
+        method: "GET",
+        path: importPath,
+        status: 200,
+        headers: {
+            "Cache-Control": "no-store",
+            "Content-Type": "text/css",
+        },
+        body: "",
+    }));
+</script>
+<style>
+@import url("/echo/css-inline-import-initiator-type.css");
+</style>
+<script>
+    asyncTest(done => {
+        window.addEventListener("load", () => {
+            const entry = performance.getEntriesByType("resource").find(
+                entry => entry.name.endsWith(importPath)
+            );
+            println(`Inline @import initiator type: ${entry?.initiatorType ?? "missing"}`);
+            done();
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/inline-relative-css-image-base-url.html
+++ b/Tests/LibWeb/Text/input/css/inline-relative-css-image-base-url.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div
+    id="target"
+    style="
+        width: 1px;
+        height: 1px;
+        background-image: url('../wpt-import/images/anim-gr.gif');
+    "
+></div>
+<script>
+    asyncTest(done => {
+        window.addEventListener("load", () => {
+            internals.dumpLayoutTree(document);
+            const activeAnimationsBeforeBaseChange =
+                internals.activeImageStyleValueAnimationCount();
+
+            const beforeBaseChange = getComputedStyle(target).backgroundImage;
+            const base = document.createElement("base");
+            base.href = "../wpt-import/";
+            document.head.append(base);
+            const afterBaseChange = getComputedStyle(target).backgroundImage;
+
+            internals.dumpLayoutTree(document);
+            const activeAnimationsAfterBaseChange =
+                internals.activeImageStyleValueAnimationCount();
+
+            println(
+                `Computed URL before base change: ${beforeBaseChange}`
+            );
+            println(`Computed URL after base change: ${afterBaseChange}`);
+            println(
+                `active animations before base change: ${activeAnimationsBeforeBaseChange}`
+            );
+            println(
+                `active animations after base change: ${activeAnimationsAfterBaseChange}`
+            );
+            done();
+        });
+    });
+</script>


### PR DESCRIPTION
This moves CSS image resource loading state from `ImageStyleValue` into `Document`, keyed by resolved image URL. `ImageStyleValue` now keeps URL metadata and client tracking, while shared resource requests, decoded image data, animation timers, and current frame state live with the document.

The branch also makes `ComputedProperties` and `CascadedProperties` refcounted instead of GC-managed, since they no longer contain strong references to GC-managed data.

Added text coverage for inline relative image URLs after base URL changes, stylesheet referrer handling, imported stylesheet origin-clean behavior, inline `@import` initiator type, and animated CSS image cleanup across base changes, hidden elements, layout teardown, and layout node replacement.