### PR TITLE
LibWeb: Skip compositor metadata during display list painting

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -294,6 +294,9 @@ void DisplayListPlayer::execute_impl(
     };
 
     DisplayList::for_each_command_header(commands, [&](DisplayListCommandHeader const& header, ReadonlyBytes payload) {
+        if (display_list_command_is_compositor_metadata(header.type))
+            return;
+
         auto bounding_rect = header.has_bounding_rect
             ? Optional<Gfx::IntRect>(header.bounding_rect)
             : Optional<Gfx::IntRect> {};

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -78,6 +78,22 @@ enum class DisplayListCommandType : u8 {
 #undef ENUMERATE_DISPLAY_LIST_COMMAND_TYPE
 };
 
+constexpr bool display_list_command_is_compositor_metadata(DisplayListCommandType type)
+{
+    switch (type) {
+    case DisplayListCommandType::CompositorScrollNode:
+    case DisplayListCommandType::CompositorStickyArea:
+    case DisplayListCommandType::CompositorWheelHitTestTarget:
+    case DisplayListCommandType::CompositorWheelHitTestTargetWithCornerRadii:
+    case DisplayListCommandType::CompositorMainThreadWheelEventRegion:
+    case DisplayListCommandType::CompositorViewportScrollbar:
+    case DisplayListCommandType::CompositorBlockingWheelEventRegion:
+        return true;
+    default:
+        return false;
+    }
+}
+
 enum class CompositorScrollNodeKind : u8 {
     Viewport,
     Element,


### PR DESCRIPTION
Display-list replay used to feed compositor-only metadata commands through the normal painting path. Scroll nodes, wheel hit-test regions, main-thread wheel regions, and viewport scrollbar metadata do not draw in the Skia player, but each command still paid visual-context switching, clip rejection, and no-op dispatch overhead.

Keep those commands in the display list for async scrolling and dumps, but skip them at the start of painting replay. This keeps the metadata available to the compositor while removing thousands of no-op paint-side commands from heavy scrolling pages.

With this change rasterization goes down from 13 ms to 1ms on my computer for page in
https://github.com/LadybirdBrowser/ladybird/issues/9929