### PR TITLE
Documentation: List ncurses as a build dependency

### DIFF
--- a/.devcontainer/features/ladybird/install-fedora.sh
+++ b/.devcontainer/features/ladybird/install-fedora.sh
@@ -6,5 +6,5 @@ dnf install -y git gh
 
 # Ladybird dev dependencies
 dnf install -y autoconf-archive automake bison ccache cmake curl google-noto-sans-mono-fonts liberation-sans-fonts \
-    libdrm-devel libglvnd-devel libtool nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib perl-Time-Piece qt6-qtbase-devel \
+    libdrm-devel libglvnd-devel libtool nasm ncurses-devel ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib perl-Time-Piece qt6-qtbase-devel \
     qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static

--- a/.devcontainer/features/ladybird/install-ubuntu.sh
+++ b/.devcontainer/features/ladybird/install-ubuntu.sh
@@ -31,7 +31,7 @@ install_cmake() {
 ### Install packages
 
 apt update -y
-apt install -y autoconf autoconf-archive automake bison build-essential ccache curl fonts-liberation2 git libdrm-dev libgl1-mesa-dev libtool libxkbcommon-dev lsb-release nasm ninja-build pkg-config python3 qt6-base-dev qt6-tools-dev-tools qt6-wayland shellcheck tar unzip zip
+apt install -y autoconf autoconf-archive automake bison build-essential ccache curl fonts-liberation2 git libdrm-dev libgl1-mesa-dev libncurses-dev libtool libxkbcommon-dev lsb-release nasm ninja-build pkg-config python3 qt6-base-dev qt6-tools-dev-tools qt6-wayland shellcheck tar unzip zip
 
 install_cmake
 

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -17,7 +17,7 @@ CMake 3.30 or newer must be available in $PATH.
 
 <!-- Note: If you change something here, please also change it in the `devcontainer/devcontainer.json` file. -->
 ```bash
-sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git libdrm-dev libgl1-mesa-dev libtool nasm ninja-build pkg-config python3-venv qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
+sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git libdrm-dev libgl1-mesa-dev libncurses-dev libtool nasm ninja-build pkg-config python3-venv qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
 ```
 
 #### CMake 3.30 or newer:
@@ -87,13 +87,13 @@ sudo pacman -S libpulse
 ### Fedora or derivatives:
 
 ```
-sudo dnf install autoconf-archive automake ccache cmake curl git libdrm-devel liberation-sans-fonts libglvnd-devel libtool nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib perl-Time-Piece qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
+sudo dnf install autoconf-archive automake ccache cmake curl git libdrm-devel liberation-sans-fonts libglvnd-devel libtool nasm ncurses-devel ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib perl-Time-Piece qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
 ```
 
 ### openSUSE:
 
 ```
-sudo zypper install autoconf-archive automake ccache cmake curl gcc14 gcc14-c++ git liberation-fonts libglvnd-devel libtool nasm ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel tar unzip zip
+sudo zypper install autoconf-archive automake ccache cmake curl gcc14 gcc14-c++ git liberation-fonts libglvnd-devel libtool nasm ncurses-devel ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel tar unzip zip
 ```
 
 If one or more of the base repository packages are flagged as having an out-of-date version during the build process, you may need add the `devel:tools:building` repository. For example, on Leap 15.6, the `autoconf` package might be version 2.69, whereas the `gperf` package requires 2.70 to build.
@@ -139,7 +139,7 @@ This virtual environment can be created once and reused in future shell sessions
 
 ```
 sudo xbps-install -Su # (optional) ensure packages are up to date to avoid "Transaction aborted due to unresolved dependencies."
-sudo xbps-install -S git bash gcc python3 curl cmake libtool zip unzip linux-headers make pkg-config autoconf automake autoconf-archive nasm MesaLib-devel ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel
+sudo xbps-install -S git bash gcc python3 curl cmake libtool zip unzip linux-headers make pkg-config autoconf automake autoconf-archive nasm ncurses-devel MesaLib-devel ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel
 ```
 
 ### NixOS or with Nix:


### PR DESCRIPTION
**Problem:** _`configure: error: libncurses, libcurses, libtermcap or libtinfo is required!`_ local-build failure in vcpkg `libedit` compilation.

**Cause:** dfb2656 replaced the in-tree `LibLine` with `libedit`, which vcpkg builds, and `libedit`’s configure needs system ncurses (or termcap/tinfo).

**Fix:** Add the ncurses dev package to dependency lists for distros that ship it separately: `libncurses-dev` on Debian/Ubuntu, and `ncurses-devel` on Fedora/openSUSE/Void — and into the dev-container install scripts. (Arch and macOS already ship the necessary headers.). Fixes https://github.com/LadybirdBrowser/ladybird/issues/9946.
