### PR TITLE
CI: Fix recurring Rust toolchain flake in the libjs-test262 job

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: 'blacksmith-16vcpu-ubuntu-2404'
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.25
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird
@@ -78,6 +78,9 @@ jobs:
         run: |
           mkdir -p old-libjs-data
           cp -R libjs-data/test262 libjs-data/wasm old-libjs-data
+
+      - name: Warm up the Rust toolchain
+        run: rustup toolchain install
 
       - name: Build test262-runner, test-js, test-wasm and test-js-bytecode
         run: |


### PR DESCRIPTION
**Problem:** The `libjs-test262` job was failing — often — with _`cargo is not installed for the toolchain 1.96.0`_, while building the Rust crates.

**Cause:** The job ran in an older CI image lacking `1.96.0` — making runtime `rustup` try to auto-install `1.96.0` the first time a proxied `cargo` ran. And because the build compiles multiple Rust crates in parallel, several `cargo` invocations hit the missing toolchain at once — and each started a `rustup` install of the same toolchain. And `rustup` apparently isn’t safe against concurrent installs: Its in-place component swap shuffles files out to a temp directory, and a crate that reads the toolchain mid-swap sees `rustc` — but not `cargo`. Whether it corrupts depends on timing — so the failure is intermittent, and a re-run usually “fixes” it.

**Fix:** Update the job to the current `ladybird-ci:2026.06.02` image — which already has `1.96.0` (with `cargo`) baked in — so no runtime install happens and there’s nothing to race. As an additional guard, also install the pinned toolchain *explicitly*, before the parallel build: so any install happens exactly once — and serially — rather than being raced.
