### PR TITLE
Meta: Retry the vcpkg bootstrap to ride out transient download failures

### DIFF
--- a/Meta/Utils/build_vcpkg.py
+++ b/Meta/Utils/build_vcpkg.py
@@ -9,6 +9,7 @@ import json
 import pathlib
 import subprocess
 import sys
+import time
 
 META_SOURCE_DIR = pathlib.Path(__file__).resolve().parent.parent
 LADYBIRD_SOURCE_DIR = META_SOURCE_DIR.parent
@@ -53,7 +54,20 @@ def build_vcpkg():
     if platform.libc_name() == "musl":
         arguments.append("-musl")
 
-    subprocess.check_call(args=arguments, cwd=vcpkg_checkout)
+    max_attempts = 3
+    for attempt in range(1, max_attempts + 1):
+        try:
+            subprocess.check_call(args=arguments, cwd=vcpkg_checkout)
+            return
+        except subprocess.CalledProcessError:
+            if attempt == max_attempts:
+                raise
+            delay_seconds = 15 * attempt
+            print(
+                f"vcpkg bootstrap failed (attempt {attempt}); retrying in {delay_seconds}s",
+                file=sys.stderr,
+            )
+            time.sleep(delay_seconds)
 
 
 def main():


### PR DESCRIPTION
**Problem:** CI jobs were very often failing at the install-vcpkg step, after the prebuilt-vcpkg-tool download fails with an HTTP 504.

**Cause:** The `bootstrap-vcpkg.sh` script’s curl call retries span only a few seconds — too soon to get past an outage — and the `build_vcpkg.py` script runs with no retry at all. So one transient 504 hard-fails everything.

**Fix:** Do the bootstrap in `build_vcpkg.py` with retries and some backoff — so one transient download failure no longer breaks the entire build.
