### PR TITLE
LibURL: Reverse host labels before searching the public suffix table

### DIFF
--- a/Meta/Generators/generate_public_suffix_data.py
+++ b/Meta/Generators/generate_public_suffix_data.py
@@ -81,9 +81,21 @@ PublicSuffixData::PublicSuffixData()
 {    
 }
 
+static bool is_reversed_public_suffix(StringView reversed_host)
+{
+    return binary_search(s_public_suffixes, reversed_host);
+}
+
 bool PublicSuffixData::is_public_suffix(StringView host)
 {
-    return binary_search(s_public_suffixes, host);
+    // Empty labels are kept so that inputs such as "com." do not match the bare "com" entry.
+    auto labels = host.split_view('.', SplitBehavior::KeepEmpty);
+    labels.reverse();
+
+    StringBuilder reversed_host;
+    reversed_host.join('.', labels);
+
+    return is_reversed_public_suffix(reversed_host.string_view());
 }
 
 Optional<String> PublicSuffixData::get_public_suffix(StringView string)
@@ -98,7 +110,7 @@ Optional<String> PublicSuffixData::get_public_suffix(StringView string)
         search_string.append(overall_search_string.string_view());
         search_string.append(part);
 
-        if (is_public_suffix(search_string.string_view())) {
+        if (is_reversed_public_suffix(search_string.string_view())) {
             overall_search_string.append(part);
             overall_search_string.append('.');
             continue;
@@ -108,7 +120,7 @@ Optional<String> PublicSuffixData::get_public_suffix(StringView string)
         search_string.append(overall_search_string.string_view());
         search_string.append('.');
 
-        if (is_public_suffix(search_string.string_view())) {
+        if (is_reversed_public_suffix(search_string.string_view())) {
             overall_search_string.append(part);
             overall_search_string.append('.');
             continue;

--- a/Tests/LibURL/TestPublicSuffix.cpp
+++ b/Tests/LibURL/TestPublicSuffix.cpp
@@ -14,6 +14,11 @@ TEST_CASE(is_public_suffix)
 
     EXPECT(public_suffix_data->is_public_suffix("com"sv));
     EXPECT(public_suffix_data->is_public_suffix("com.br"sv));
+    EXPECT(public_suffix_data->is_public_suffix("co.uk"sv));
+    EXPECT(public_suffix_data->is_public_suffix("ac.uk"sv));
+    EXPECT(public_suffix_data->is_public_suffix("gov.uk"sv));
+    EXPECT(public_suffix_data->is_public_suffix("com.au"sv));
+    EXPECT(public_suffix_data->is_public_suffix("co.jp"sv));
 
     EXPECT(!public_suffix_data->is_public_suffix(""sv));
     EXPECT(!public_suffix_data->is_public_suffix("."sv));
@@ -46,4 +51,7 @@ TEST_CASE(get_public_suffix)
     EXPECT_EQ(public_suffix_data->get_public_suffix("..com."sv), "com"sv);
     EXPECT_EQ(public_suffix_data->get_public_suffix("com.br"sv), "com.br"sv);
     EXPECT_EQ(public_suffix_data->get_public_suffix("not-a-public-suffix.com.br"sv), "com.br"sv);
+    EXPECT_EQ(public_suffix_data->get_public_suffix("co.uk"sv), "co.uk"sv);
+    EXPECT_EQ(public_suffix_data->get_public_suffix("bbc.co.uk"sv), "co.uk"sv);
+    EXPECT_EQ(public_suffix_data->get_public_suffix("www.bbc.co.uk"sv), "co.uk"sv);
 }


### PR DESCRIPTION
The generated public suffix table stores each entry with it's labels reversed, but the lookup we were using didn't reverse its input before searching. This led to multi-label public suffixes not matching when they should have.

NB: We previously had a unit test intended to cover this that used "com.br", but this was passing coincidentally because "br.com" is also a valid public suffix.

This fixes an issue on https://autotrader.co.uk/car-search, where requests to the image-serving CDN were returning 403 because we were sending a cookie from the wrong registerable domain due to this bug

Before:

<img width="1086" height="766" alt="image" src="https://github.com/user-attachments/assets/03b36885-b8d5-44dd-bba8-a063a419b744" />


After:

<img width="1086" height="766" alt="image" src="https://github.com/user-attachments/assets/614deacb-e298-457e-96b8-538a0529b268" />
