### PR TITLE
CI: Bump lint-code.yml to the 2026.06.02 image, like the rest of CI

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.25
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02
 
     steps:
       - uses: actions/checkout@v6.0.3


### PR DESCRIPTION
Otherwise, without this change, the Lint Code job intermittently fails — for the same cause described in 61d0fca133: `rustup` tries to auto-install `1.96.0` the first time a proxied `cargo` runs — and depending on timing, that can lead to a crate ending up seeing `rustc`, but not `cargo`.
