### PR TITLE
LibWeb: Harden DOM and layout edge cases found by domato

### DIFF
--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Atomic.h>
+#include <AK/NumericLimits.h>
 #include <AK/TypeCasts.h>
 #include <AK/Utf16String.h>
 #include <LibGfx/Font/Font.h>
@@ -93,11 +94,24 @@ Font const& Font::bold_variant() const
     return *m_bold_variant;
 }
 
+static int scale_for_harfbuzz(float pixel_size)
+{
+    auto scaled_pixel_size = static_cast<double>(pixel_size) * text_shaping_resolution;
+    if (__builtin_isnan(scaled_pixel_size))
+        return 0;
+    if (scaled_pixel_size >= NumericLimits<int>::max())
+        return NumericLimits<int>::max();
+    if (scaled_pixel_size <= NumericLimits<int>::min())
+        return NumericLimits<int>::min();
+    return static_cast<int>(scaled_pixel_size);
+}
+
 hb_font_t* Font::harfbuzz_font() const
 {
     if (!m_harfbuzz_font) {
         m_harfbuzz_font = hb_font_create(typeface().harfbuzz_typeface());
-        hb_font_set_scale(m_harfbuzz_font, pixel_size() * text_shaping_resolution, pixel_size() * text_shaping_resolution);
+        auto harfbuzz_scale = scale_for_harfbuzz(pixel_size());
+        hb_font_set_scale(m_harfbuzz_font, harfbuzz_scale, harfbuzz_scale);
         // HarfBuzz uses ptem for AAT 'trak' table lookup; use CSS pixels instead of physical points here.
         hb_font_set_ptem(m_harfbuzz_font, pixel_size());
 

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -277,12 +277,12 @@ float measure_text_width(Utf16View const& string, Font const& font, float letter
     u32 glyph_count;
     auto const* positions = hb_buffer_get_glyph_positions(buffer, &glyph_count);
 
-    hb_position_t point_x = 0;
+    double point_x = 0;
     for (size_t i = 0; i < glyph_count; ++i)
         point_x += positions[i].x_advance;
 
     hb_buffer_destroy(buffer);
-    return point_x / text_shaping_resolution + glyph_count * letter_spacing;
+    return static_cast<float>(point_x / text_shaping_resolution + glyph_count * letter_spacing);
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -811,7 +811,8 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
     case PropertyID::GridColumn: {
         auto start = longhand(PropertyID::GridColumnStart);
         auto end = longhand(PropertyID::GridColumnEnd);
-        if (end->as_grid_track_placement().grid_track_placement().is_auto() || start == end) {
+        if ((end->is_grid_track_placement() && end->as_grid_track_placement().grid_track_placement().is_auto())
+            || start == end) {
             start->serialize(builder, mode);
             return;
         }
@@ -823,7 +824,8 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
     case PropertyID::GridRow: {
         auto start = longhand(PropertyID::GridRowStart);
         auto end = longhand(PropertyID::GridRowEnd);
-        if (end->as_grid_track_placement().grid_track_placement().is_auto() || start == end) {
+        if ((end->is_grid_track_placement() && end->as_grid_track_placement().grid_track_placement().is_auto())
+            || start == end) {
             start->serialize(builder, mode);
             return;
         }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7934,6 +7934,13 @@ Vector<GC::Root<Range>> Document::find_matching_text(String const& query, CaseSe
             VERIFY(end_dom_node);
             auto end_position = match_index.value() + utf16_query.length_in_code_units() - match_end_position->start_offset + match_end_position->dom_offset_within_node;
 
+            if (start_position > start_dom_node->length() || end_position > end_dom_node->length()) {
+                offset = match_index.value() + utf16_query.length_in_code_units() + 1;
+                if (offset >= text_view.length_in_code_units())
+                    break;
+                continue;
+            }
+
             matches.append(Range::create(*start_dom_node, start_position, *end_dom_node, end_position));
             match_start_position = match_end_position;
             offset = match_index.value() + utf16_query.length_in_code_units() + 1;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7934,7 +7934,11 @@ Vector<GC::Root<Range>> Document::find_matching_text(String const& query, CaseSe
             VERIFY(end_dom_node);
             auto end_position = match_index.value() + utf16_query.length_in_code_units() - match_end_position->start_offset + match_end_position->dom_offset_within_node;
 
-            if (start_position > start_dom_node->length() || end_position > end_dom_node->length()) {
+            if (&start_dom_node->root() != &end_dom_node->root()
+                || !start_dom_node->is_connected()
+                || !end_dom_node->is_connected()
+                || start_position > start_dom_node->length()
+                || end_position > end_dom_node->length()) {
                 offset = match_index.value() + utf16_query.length_in_code_units() + 1;
                 if (offset >= text_view.length_in_code_units())
                     break;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5744,7 +5744,10 @@ void Document::unload_a_document_and_its_descendants(GC::Ptr<Document> new_docum
                 auto increment_unloaded = GC::create_function(heap, [unload_state] { unload_state->did_process_child(); });
 
                 // 2. Unload a document and its descendants given childNavigable's active document, null, and incrementUnloaded.
-                child_navigable->active_document()->unload_a_document_and_its_descendants({}, increment_unloaded);
+                if (auto active_document = child_navigable->active_document())
+                    active_document->unload_a_document_and_its_descendants({}, increment_unloaded);
+                else
+                    increment_unloaded->function()();
             }));
     }
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2896,7 +2896,9 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
 
     auto scrolling_box_computed_properties = [&scrolling_box]() -> RefPtr<CSS::ComputedProperties const> {
         if (scrolling_box.is_document()) {
-            return scrolling_box.document().scrolling_element()->computed_properties();
+            if (auto scrolling_element = scrolling_box.document().scrolling_element())
+                return scrolling_element->computed_properties();
+            return nullptr;
         }
 
         if (auto const* element = as_if<DOM::Element>(scrolling_box)) {

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -1180,16 +1180,34 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
     Vector<GC::Root<Geometry::DOMRect>> rects;
     // FIXME: take Range collapsed into consideration
     // 2. Iterate the node included in Range
-    auto start_node = start_container();
-    if (!is<DOM::Text>(*start_node))
-        start_node = *start_node->child_at_index(m_start_offset);
+    GC::Ptr<Node> start_node = start_container();
+    if (!is<DOM::Text>(*start_node)) {
+        auto next_after_subtree = [](Node& node) -> GC::Ptr<Node> {
+            for (auto* current = &node; current; current = current->parent_node()) {
+                if (auto* next = current->next_sibling())
+                    return next;
+            }
+            return nullptr;
+        };
 
-    auto end_node = end_container();
+        auto* start_child = start_node->child_at_index(m_start_offset);
+        if (start_child) {
+            start_node = *start_child;
+        } else if (start_node->last_child()) {
+            start_node = next_after_subtree(*start_node);
+        } else {
+            start_node = start_node->next_in_pre_order();
+        }
+    }
+
+    GC::Ptr<Node> end_node = end_container();
     if (!is<DOM::Text>(*end_node)) {
         // end offset shouldn't be 0
         if (m_end_offset == 0)
             return Geometry::DOMRectList::create(realm(), {});
-        end_node = *end_node->child_at_index(m_end_offset - 1);
+        end_node = end_node->child_at_index(m_end_offset - 1);
+        if (!end_node)
+            return Geometry::DOMRectList::create(realm(), {});
     }
     for (GC::Ptr<Node> node = start_node; node && node != end_node->next_in_pre_order(); node = node->next_in_pre_order()) {
         auto selection_state = Painting::Paintable::SelectionState::Full;
@@ -1208,7 +1226,7 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
         if (node_type == NodeType::ELEMENT_NODE) {
             // 1. For each element selected by the range, whose parent is not selected by the range, include the border
             // areas returned by invoking getClientRects() on the element.
-            if (contains_node(*node) && !contains_node(*node->parent())) {
+            if (contains_node(*node) && (!node->parent() || !contains_node(*node->parent()))) {
                 auto const& element = static_cast<DOM::Element const&>(*node);
                 auto const element_rects = element.get_client_rects();
                 for (auto& rect : element_rects) {

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -365,6 +365,13 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
     }
 
     auto dump_fragment = [&](auto& fragment, size_t fragment_index) {
+        auto fragment_has_paintable = fragment.layout_node().first_paintable();
+        auto fragment_rect = [&] {
+            if (fragment_has_paintable)
+                return fragment.absolute_rect();
+            return CSSPixelRect { fragment.offset(), fragment.size() };
+        }();
+
         builder.append_repeated("  "sv, indent);
         builder.appendff("  {}frag {}{} from {} ",
             fragment_color_on,
@@ -374,9 +381,9 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
         builder.appendff("start: {}, length: {}, rect: {} baseline: {}\n",
             fragment.start_offset(),
             fragment.length_in_code_units(),
-            fragment.absolute_rect(),
+            fragment_rect,
             fragment.baseline());
-        if (fragment.length_in_code_units() > 0) {
+        if (fragment_has_paintable && fragment.length_in_code_units() > 0) {
             builder.append_repeated("  "sv, indent);
             builder.appendff("      \"{}\"\n", fragment.text());
         }

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -1142,8 +1142,7 @@ Optional<Utf16String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString
             auto background_color = resolved_background_color();
             if (!background_color)
                 return NumericLimits<u8>::max();
-            VERIFY(is<Layout::NodeWithStyle>(node->layout_node()));
-            return background_color->to_color(CSS::ColorResolutionContext::for_layout_node_with_style(*static_cast<Layout::NodeWithStyle*>(node->layout_node()))).value().alpha();
+            return background_color->to_color(CSS::ColorResolutionContext::for_element({ node_as_element() })).value().alpha();
         };
         while (resolved_background_alpha() == 0 && node->parent() && is<DOM::Element>(*node->parent()))
             node = node->parent();

--- a/Libraries/LibWeb/HTML/BarProp.cpp
+++ b/Libraries/LibWeb/HTML/BarProp.cpp
@@ -38,7 +38,10 @@ bool BarProp::visible() const
     }
 
     // 3. Return the negation of browsingContext's top-level browsing context's is popup.
-    return browsing_context->top_level_browsing_context()->is_popup() != TokenizedFeature::Popup::Yes;
+    auto top_level_browsing_context = browsing_context->top_level_browsing_context();
+    if (!top_level_browsing_context)
+        return true;
+    return top_level_browsing_context->is_popup() != TokenizedFeature::Popup::Yes;
 }
 
 void BarProp::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
+++ b/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
@@ -32,8 +32,8 @@ void check_if_access_between_two_browsing_contexts_should_be_reported(
         return;
 
     // 2. Assert: accessor's active document and accessed's active document are both fully active.
-    VERIFY(accessor->active_document()->is_fully_active());
-    VERIFY(accessed->active_document()->is_fully_active());
+    if (!accessor->active_document()->is_fully_active() || !accessed->active_document()->is_fully_active())
+        return;
 
     // 3. Let accessorTopDocument be accessor's top-level browsing context's active document.
     auto* accessor_top_document = accessor->top_level_browsing_context()->active_document();

--- a/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Libraries/LibWeb/HTML/Focus.cpp
@@ -415,7 +415,10 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     if (is_shadow_host(old_focus_target)) {
         auto shadow_root = static_cast<DOM::Element*>(old_focus_target)->shadow_root();
         if (shadow_root->delegates_focus()) {
-            auto top_level_traversable = old_focus_target->document().browsing_context()->top_level_traversable();
+            auto browsing_context = old_focus_target->document().browsing_context();
+            if (!browsing_context)
+                return;
+            auto top_level_traversable = browsing_context->top_level_traversable();
             if (auto currently_focused_area = top_level_traversable->currently_focused_area()) {
                 if (shadow_root->is_shadow_including_ancestor_of(*currently_focused_area)) {
                     old_focus_target = currently_focused_area;
@@ -436,7 +439,10 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     // NOTE: HTMLAreaElement is currently missing the shapes property
 
     // 4. Let old chain be the current focus chain of the top-level browsing context in which old focus target finds itself.
-    auto top_level_traversable = old_focus_target->document().browsing_context()->top_level_traversable();
+    auto browsing_context = old_focus_target->document().browsing_context();
+    if (!browsing_context)
+        return;
+    auto top_level_traversable = browsing_context->top_level_traversable();
     auto currently_focused_area = top_level_traversable->currently_focused_area();
     auto old_chain = focus_chain(currently_focused_area);
 

--- a/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -75,8 +75,8 @@ void HTMLBodyElement::apply_presentational_hints(Vector<CSS::StyleProperty>& pro
             if (color.has_value())
                 properties.append({ .property_id = CSS::PropertyID::Color, .value = CSS::ColorStyleValue::create_from_color(color.value(), CSS::ColorSyntax::Legacy) });
         } else if (name == HTML::AttributeNames::background) {
-            VERIFY(m_background_style_value);
-            properties.append({ .property_id = CSS::PropertyID::BackgroundImage, .value = CSS::StyleValueList::create({ *m_background_style_value }, CSS::StyleValueList::Separator::Comma) });
+            if (m_background_style_value)
+                properties.append({ .property_id = CSS::PropertyID::BackgroundImage, .value = CSS::StyleValueList::create({ *m_background_style_value }, CSS::StyleValueList::Separator::Comma) });
         }
     });
 
@@ -134,6 +134,7 @@ void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<String> 
             document().set_visited_link_color(color.value());
     } else if (name == HTML::AttributeNames::background) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:attr-background
+        m_background_style_value = nullptr;
         if (auto maybe_background_url = document().encoding_parse_url(value.value_or(String {})); maybe_background_url.has_value()) {
             m_background_style_value = CSS::ImageStyleValue::create(maybe_background_url.value());
             m_background_style_value->on_animate = [this] {

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -224,7 +224,7 @@ WebIDL::ExceptionOr<void> HTMLElement::set_outer_text(Utf16View const& value)
         MUST(fragment->append_child(document().create_text_node({})));
 
     // 6. Replace this with fragment within this's parent.
-    MUST(parent()->replace_child(fragment, *this));
+    TRY(parent()->replace_child(fragment, *this));
 
     // 7. If next is non-null and next's previous sibling is a Text node, then merge with the next text node given next's previous sibling.
     if (next && is<DOM::Text>(next->previous_sibling()))

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -314,6 +314,8 @@ static Vector<Variant<Utf16String, RequiredLineBreakCount>> rendered_text_collec
     auto* layout_node = node.layout_node();
     if (!layout_node)
         return items;
+    if (!layout_node->has_style_or_parent_with_style())
+        return items;
 
     auto const& computed_values = layout_node->computed_values();
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -153,7 +153,12 @@ void HTMLMediaElement::queue_a_media_element_task(Function<void()> steps)
 {
     // To queue a media element task with a media element element and a series of steps steps, queue an element task on the media element's
     // media element event task source given element and steps.
-    queue_an_element_task(media_element_event_task_source(), move(steps));
+    queue_an_element_task(media_element_event_task_source(), [element = GC::Weak { *this }, steps = move(steps)]() mutable {
+        auto self = element.ptr();
+        if (!self || !self->document().is_fully_active())
+            return;
+        steps();
+    });
 }
 
 void HTMLMediaElement::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -16,7 +16,10 @@
 #include <LibWeb/Layout/LayoutState.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
+#include <LibWeb/Painting/SVGForeignObjectPaintable.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/Painting/SVGPathPaintable.h>
+#include <LibWeb/Painting/SVGSVGPaintable.h>
 #include <LibWeb/Painting/TextPaintable.h>
 
 namespace Web::Layout {
@@ -583,6 +586,14 @@ void LayoutState::commit(Box& root)
             if (auto* svg_graphics_paintable = as_if<Painting::SVGGraphicsPaintable>(paintable.ptr());
                 svg_graphics_paintable && used_values.computed_svg_transforms().has_value()) {
                 svg_graphics_paintable->set_computed_transforms(*used_values.computed_svg_transforms());
+            }
+            if (auto* svg_foreign_object_paintable = as_if<Painting::SVGForeignObjectPaintable>(paintable.ptr());
+                svg_foreign_object_paintable && used_values.computed_svg_transforms().has_value()) {
+                svg_foreign_object_paintable->set_computed_transforms(*used_values.computed_svg_transforms());
+            }
+            if (auto* svg_svg_paintable = as_if<Painting::SVGSVGPaintable>(paintable.ptr());
+                svg_svg_paintable && used_values.computed_svg_transforms().has_value()) {
+                svg_svg_paintable->set_computed_transforms(*used_values.computed_svg_transforms());
             }
 
             if (auto* svg_path_paintable = as_if<Painting::SVGPathPaintable>(paintable.ptr())) {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1384,6 +1384,9 @@ DOM::Document const& Node::document() const
 // https://drafts.csswg.org/css-ui/#propdef-user-select
 CSS::UserSelect Node::user_select_used_value() const
 {
+    if (!has_style_or_parent_with_style())
+        return CSS::UserSelect::None;
+
     // The used value is the same as the computed value, except:
     auto computed_value = computed_values().user_select();
 

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/Layout/SVGMaskBox.h>
 #include <LibWeb/Layout/SVGPatternBox.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/SVG/SVGAElement.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGForeignObjectElement.h>
@@ -330,6 +331,7 @@ void SVGFormattingContext::layout_svg_element(Box const& child)
         };
         auto parent_svg_transform = get_parent_svg_transform(child);
         auto svg_transform = parent_svg_transform.multiply(foreign_object_element->element_transform());
+        child_state.set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
         auto to_css_pixels_transform = Gfx::AffineTransform {}.multiply(m_current_viewbox_transform).multiply(svg_transform);
         auto transformed_rect = to_css_pixels_transform.map(rect.to_type<float>()).to_type<CSSPixels>();
         child_state.set_content_offset(transformed_rect.location());

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -702,7 +702,7 @@ void TreeBuilder::restructure_block_node_in_inline_parent(NodeWithStyleAndBoxMod
     // We need to host the topmost inline ancestor and its previous siblings in an anonymous "before" wrapper. If an
     // inline wrapper does not already exist, we create a new one and add it to the nearest block ancestor.
     RefPtr<Node> before_wrapper;
-    if (auto last_child = nearest_block_ancestor.last_child(); last_child->is_anonymous() && last_child->children_are_inline()) {
+    if (auto last_child = nearest_block_ancestor.last_child(); last_child && last_child->is_anonymous() && last_child->children_are_inline()) {
         before_wrapper = last_child;
     } else {
         before_wrapper = nearest_block_ancestor.create_anonymous_wrapper();
@@ -758,24 +758,28 @@ void TreeBuilder::restructure_block_node_in_inline_parent(NodeWithStyleAndBoxMod
 
             auto style = element.computed_properties();
             auto new_layout_node = element.create_layout_node(*style);
-            auto& new_inline_node = static_cast<NodeWithStyleAndBoxModelMetrics&>(*new_layout_node);
+            if (!new_layout_node)
+                break;
+            auto* new_inline_node = as_if<NodeWithStyleAndBoxModelMetrics>(*new_layout_node);
+            if (!new_inline_node)
+                break;
             if (inline_node == topmost_inline_ancestor) {
                 // The topmost inline ancestor points to the middle wrapper, which in turns points to the original node.
-                new_inline_node.set_continuation_of_node({}, middle_wrapper.ptr());
-                topmost_inline_ancestor = new_inline_node;
+                new_inline_node->set_continuation_of_node({}, middle_wrapper);
+                topmost_inline_ancestor = *new_inline_node;
             } else {
                 // We need all other inline nodes to point to their original node so we can walk the continuation chain
                 // in LayoutState and create the right paintables.
-                new_inline_node.set_continuation_of_node({}, &static_cast<NodeWithStyleAndBoxModelMetrics&>(*inline_node));
+                new_inline_node->set_continuation_of_node({}, &static_cast<NodeWithStyleAndBoxModelMetrics&>(*inline_node));
             }
 
-            current_parent->append_child(new_inline_node);
-            current_parent = new_inline_node;
+            current_parent->append_child(*new_inline_node);
+            current_parent = *new_inline_node;
 
             // Replace the node in the ancestor stack with the new node.
             auto& node_with_style = static_cast<NodeWithStyle&>(*inline_node);
             if (auto stack_index = m_ancestor_stack.find_first_index(&node_with_style); stack_index.has_value())
-                m_ancestor_stack[stack_index.release_value()] = &new_inline_node;
+                m_ancestor_stack[stack_index.release_value()] = new_inline_node;
 
             // Stop recreating nodes when we've reached node's parent.
             if (inline_node == &parent)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1154,7 +1154,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
     // Giving an element style containment has the following effects:
     // 2. The effects of the 'content' property’s 'open-quote', 'close-quote', 'no-open-quote' and 'no-close-quote' must
     //    be scoped to the element’s sub-tree.
-    if (layout_node->has_style_containment()) {
+    if (layout_node->has_style_or_parent_with_style() && layout_node->has_style_containment()) {
         m_quote_nesting_level = prior_quote_nesting_level;
     }
 

--- a/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -94,6 +94,9 @@ static ColorStopList replace_transition_hints_with_normal_color_stops(ColorStopL
 
 static ColorStopList expand_repeat_length(ColorStopList const& color_stop_list, float repeat_length)
 {
+    VERIFY(isfinite(repeat_length));
+    VERIFY(repeat_length > 0);
+
     // https://drafts.csswg.org/css-images/#repeating-gradients
     // When rendered, however, the color-stops are repeated infinitely in both directions, with their
     // positions shifted by multiples of the difference between the last specified color-stop's position
@@ -139,6 +142,64 @@ static ColorStopList expand_repeat_length(ColorStopList const& color_stop_list, 
     }
 
     return color_stop_list_with_expanded_repeat;
+}
+
+static bool has_degenerate_repeat_length(ResolvedColorStopData const& resolved_color_stops)
+{
+    return resolved_color_stops.repeat_length.has_value()
+        && (!isfinite(*resolved_color_stops.repeat_length) || *resolved_color_stops.repeat_length <= 0);
+}
+
+static Gfx::Color average_color_for_degenerate_repeating_gradient(ColorStopList const& color_stop_list)
+{
+    VERIFY(!color_stop_list.is_empty());
+
+    if (color_stop_list.size() == 1)
+        return color_stop_list.first().color;
+
+    // https://drafts.csswg.org/css-images-3/#repeating-gradients
+    // For zero-length repeating gradients, average a gradient with the same
+    // colors and equally-spaced stops over an arbitrary non-zero distance.
+    float premultiplied_red = 0;
+    float premultiplied_green = 0;
+    float premultiplied_blue = 0;
+    float alpha = 0;
+    float const weight = 0.5f / static_cast<float>(color_stop_list.size() - 1);
+
+    auto add_weighted_color = [&](Gfx::Color color) {
+        auto color_alpha = color.alpha() / 255.0f;
+        alpha += color_alpha * weight;
+        premultiplied_red += color.red() / 255.0f * color_alpha * weight;
+        premultiplied_green += color.green() / 255.0f * color_alpha * weight;
+        premultiplied_blue += color.blue() / 255.0f * color_alpha * weight;
+    };
+
+    for (size_t i = 1; i < color_stop_list.size(); ++i) {
+        add_weighted_color(color_stop_list[i - 1].color);
+        add_weighted_color(color_stop_list[i].color);
+    }
+
+    if (alpha == 0)
+        return Gfx::Color::Transparent;
+
+    auto normalized_to_u8 = [](float value) -> u8 {
+        return clamp(lroundf(value * 255.0f), 0L, 255L);
+    };
+
+    return {
+        normalized_to_u8(premultiplied_red / alpha),
+        normalized_to_u8(premultiplied_green / alpha),
+        normalized_to_u8(premultiplied_blue / alpha),
+        normalized_to_u8(alpha),
+    };
+}
+
+static void normalize_degenerate_repeating_gradient(ResolvedColorStopData& resolved_color_stops)
+{
+    auto average_color = average_color_for_degenerate_repeating_gradient(resolved_color_stops.list);
+    resolved_color_stops.list = { { average_color, 0 }, { average_color, 1 } };
+    resolved_color_stops.repeat_length = {};
+    resolved_color_stops.repeating = false;
 }
 
 static ColorStopList expand_color_stops_for_painting(ColorStopList const& color_stop_list, Optional<float> repeat_length)
@@ -258,6 +319,9 @@ LinearGradientData resolve_linear_gradient_data(Layout::NodeWithStyle const& nod
         },
         linear_gradient.is_repeating());
 
+    if (has_degenerate_repeat_length(resolved_color_stops))
+        normalize_degenerate_repeating_gradient(resolved_color_stops);
+
     // Replace transition hints for painting; keep repeat_length for Skia's native tiling
     resolved_color_stops.list = replace_transition_hints_with_normal_color_stops(resolved_color_stops.list);
 
@@ -278,6 +342,9 @@ ConicGradientData resolve_conic_gradient_data(Layout::NodeWithStyle const& node,
         },
         conic_gradient.is_repeating());
 
+    if (has_degenerate_repeat_length(resolved_color_stops))
+        normalize_degenerate_repeating_gradient(resolved_color_stops);
+
     // Expand color stops for painting (replace transition hints and expand repeat length)
     resolved_color_stops.list = expand_color_stops_for_painting(resolved_color_stops.list, resolved_color_stops.repeat_length);
     resolved_color_stops.repeat_length = {};
@@ -296,6 +363,9 @@ RadialGradientData resolve_radial_gradient_data(Layout::NodeWithStyle const& nod
             return CSS::Length::from_style_value(position, CSS::Length::make_px(gradient_size.width())).absolute_length_to_px_without_rounding() / gradient_size.width().to_float();
         },
         radial_gradient.is_repeating());
+
+    if (has_degenerate_repeat_length(resolved_color_stops))
+        normalize_degenerate_repeating_gradient(resolved_color_stops);
 
     // Expand color stops for painting (replace transition hints and expand repeat length)
     resolved_color_stops.list = expand_color_stops_for_painting(resolved_color_stops.list, resolved_color_stops.repeat_length);

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -258,6 +258,8 @@ Painting::BorderRadiiData normalize_border_radii_data(Layout::Node const& node, 
     // NOTE: We iterate twice as a form of iterative refinement. A single scaling pass using
     // fixed-point arithmetic can result in small rounding errors, causing the scaled radii to
     // still slightly overflow the box dimensions. A second pass corrects this remaining error.
+    auto border_width = max(CSSPixels(0), border_rect.width());
+    auto border_height = max(CSSPixels(0), border_rect.height());
     for (int iteration = 0; iteration < 2; ++iteration) {
         auto s_top = radii_px.top_left.horizontal_radius + radii_px.top_right.horizontal_radius;
         auto s_right = radii_px.top_right.vertical_radius + radii_px.bottom_right.vertical_radius;
@@ -265,14 +267,14 @@ Painting::BorderRadiiData normalize_border_radii_data(Layout::Node const& node, 
         auto s_left = radii_px.bottom_left.vertical_radius + radii_px.top_left.vertical_radius;
 
         CSSPixelFraction f = 1;
-        if (s_top > border_rect.width())
-            f = min(f, border_rect.width() / s_top);
-        if (s_right > border_rect.height())
-            f = min(f, border_rect.height() / s_right);
-        if (s_bottom > border_rect.width())
-            f = min(f, border_rect.width() / s_bottom);
-        if (s_left > border_rect.height())
-            f = min(f, border_rect.height() / s_left);
+        if (s_top > 0 && s_top > border_width)
+            f = min(f, border_width / s_top);
+        if (s_right > 0 && s_right > border_height)
+            f = min(f, border_height / s_right);
+        if (s_bottom > 0 && s_bottom > border_width)
+            f = min(f, border_width / s_bottom);
+        if (s_left > 0 && s_left > border_height)
+            f = min(f, border_height / s_left);
 
         // If f is 1 or more, the radii fit perfectly and no more scaling is needed
         if (f >= 1)

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1044,8 +1044,11 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
     if (!m_own_scroll_frame_index.value())
         return {};
 
-    CSSPixelRect scrollable_overflow_rect = this->scrollable_overflow_rect().value();
-    CSSPixels scrollable_overflow_length = scrollable_overflow_rect.primary_size_for_orientation(orientation);
+    auto scrollable_overflow_rect = this->scrollable_overflow_rect();
+    if (!scrollable_overflow_rect.has_value())
+        return {};
+
+    CSSPixels scrollable_overflow_length = scrollable_overflow_rect->primary_size_for_orientation(orientation);
     if (scrollable_overflow_length == 0)
         return {};
 

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -275,6 +275,7 @@ public:
     RefPtr<PaintableBox const> nearest_scrollable_ancestor() const;
 
     using StickyInsets = Painting::StickyInsets;
+    bool has_sticky_insets() const { return !!m_sticky_insets; }
     StickyInsets const& sticky_insets() const { return *m_sticky_insets; }
     void set_sticky_insets(OwnPtr<StickyInsets> sticky_insets) { m_sticky_insets = move(sticky_insets); }
 

--- a/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Layout/SVGForeignObjectBox.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/Painting/SVGMaskable.h>
 
 namespace Web::Painting {
@@ -29,8 +30,13 @@ public:
     virtual Optional<CSSPixelRect> get_clip_area() const override { return get_svg_clip_area(); }
     virtual Optional<DisplayListResource> calculate_clip(DisplayListRecordingContext& context, CSSPixelRect const& clip_area) const override { return calculate_svg_clip_display_list(context, clip_area); }
 
+    void set_computed_transforms(SVGGraphicsPaintable::ComputedTransforms computed_transforms) { m_computed_transforms = computed_transforms; }
+    SVGGraphicsPaintable::ComputedTransforms const& computed_transforms() const { return m_computed_transforms; }
+
 protected:
     SVGForeignObjectPaintable(Layout::SVGForeignObjectBox const&);
+
+    SVGGraphicsPaintable::ComputedTransforms m_computed_transforms;
 };
 
 }

--- a/Libraries/LibWeb/Painting/SVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPaintable.cpp
@@ -64,8 +64,10 @@ CSSPixelRect SVGPaintable::compute_absolute_rect() const
 {
     if (auto* svg_svg_box = layout_box().first_ancestor_of_type<Layout::SVGSVGBox>()) {
         CSSPixelRect rect { offset(), content_size() };
-        for (Layout::Box const* ancestor = svg_svg_box; ancestor; ancestor = ancestor->containing_block())
-            rect.translate_by(ancestor->paintable_box()->offset());
+        for (Layout::Box const* ancestor = svg_svg_box; ancestor; ancestor = ancestor->containing_block()) {
+            if (auto paintable_box = ancestor->paintable_box())
+                rect.translate_by(paintable_box->offset());
+        }
         return rect;
     }
     return PaintableBox::compute_absolute_rect();

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Layout/SVGSVGBox.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
 
 namespace Web::Painting {
 
@@ -19,11 +20,16 @@ public:
     static void paint_svg_box(DisplayListRecordingContext& context, PaintableBox const& svg_box, PaintPhase phase);
     static void paint_descendants(DisplayListRecordingContext& context, PaintableBox const& paintable, PaintPhase phase);
 
+    void set_computed_transforms(SVGGraphicsPaintable::ComputedTransforms computed_transforms) { m_computed_transforms = computed_transforms; }
+    SVGGraphicsPaintable::ComputedTransforms const& computed_transforms() const { return m_computed_transforms; }
+
 protected:
     SVGSVGPaintable(Layout::SVGSVGBox const&);
 
 private:
     virtual bool is_svg_svg_paintable() const final { return true; }
+
+    SVGGraphicsPaintable::ComputedTransforms m_computed_transforms;
 };
 
 template<>

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -175,7 +175,7 @@ void ViewportPaintable::assign_scroll_frames()
 
     for_each_in_inclusive_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
         ScrollFrameIndex sticky_scroll_frame_index;
-        if (paintable_box.is_sticky_position()) {
+        if (paintable_box.is_sticky_position() && paintable_box.has_sticky_insets()) {
             auto parent_index = paintable_box.nearest_scroll_frame_index();
             sticky_scroll_frame_index = m_scroll_state.create_sticky_frame_for(paintable_box, parent_index);
             precompute_sticky_constraints(sticky_scroll_frame_index, paintable_box);

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -356,7 +356,7 @@ GC::Ref<SVGAnimatedLength> SVGElement::svg_animated_length_for_property(CSS::Pro
         if (auto const computed_properties = this->computed_properties()) {
             auto const& style_value = computed_properties->property(property);
 
-            if (!style_value.has_auto())
+            if (!style_value.has_auto() && (style_value.is_length() || style_value.is_percentage() || style_value.is_calculated()))
                 return SVGLength::from_length_percentage(realm(), CSS::LengthPercentage::from_style_value(style_value), read_only);
         }
         return SVGLength::create(realm(), 0, 0, read_only);

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -16,7 +16,9 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/SVGForeignObjectPaintable.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
+#include <LibWeb/Painting/SVGSVGPaintable.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
@@ -376,10 +378,21 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Op
     }
 
     auto svg_rect = owner_paintable->absolute_rect();
-    auto inv = static_cast<Painting::SVGGraphicsPaintable&>(*self_paintable).computed_transforms().svg_to_css_pixels_transform().inverse();
     auto rect = self_paintable->absolute_rect().to_type<float>().translated(-svg_rect.location().to_type<float>());
-    if (inv.has_value())
-        rect = inv->map(rect);
+    auto svg_to_css_pixels_transform = [&]() -> Optional<Gfx::AffineTransform> {
+        if (auto const* svg_graphics_paintable = as_if<Painting::SVGGraphicsPaintable>(*self_paintable))
+            return svg_graphics_paintable->computed_transforms().svg_to_css_pixels_transform();
+        if (auto const* svg_foreign_object_paintable = as_if<Painting::SVGForeignObjectPaintable>(*self_paintable))
+            return svg_foreign_object_paintable->computed_transforms().svg_to_css_pixels_transform();
+        if (auto const* svg_svg_paintable = as_if<Painting::SVGSVGPaintable>(*self_paintable))
+            return svg_svg_paintable->computed_transforms().svg_to_css_pixels_transform();
+        return {};
+    }();
+    if (svg_to_css_pixels_transform.has_value()) {
+        auto inv = svg_to_css_pixels_transform->inverse();
+        if (inv.has_value())
+            rect = inv->map(rect);
+    }
     return Geometry::DOMRect::create(realm(), rect);
 }
 

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -301,8 +301,10 @@ WebIDL::ExceptionOr<void> Selection::extend(GC::Ref<DOM::Node> node, unsigned of
     // 4. Let newRange be a new range.
     auto new_range = DOM::Range::create(*m_document);
 
+    auto old_anchor_and_new_focus_have_the_same_shadow_including_root = &old_anchor_node.shadow_including_root() == &new_focus_node->shadow_including_root();
+
     // 5. If node's root is not the same as the this's range's root, set the start newRange's start and end to newFocus.
-    if (&node->root() != &m_range->start_container()->root()) {
+    if (&node->root() != &m_range->start_container()->root() || !old_anchor_and_new_focus_have_the_same_shadow_including_root) {
         TRY(new_range->set_start(new_focus_node, new_focus_offset));
         TRY(new_range->set_end(new_focus_node, new_focus_offset));
     }
@@ -321,7 +323,7 @@ WebIDL::ExceptionOr<void> Selection::extend(GC::Ref<DOM::Node> node, unsigned of
     set_range(new_range);
 
     // 9. If newFocus is before oldAnchor, set this's direction to backwards. Otherwise, set it to forwards.
-    if (DOM::position_of_boundary_point_relative_to_other_boundary_point({ new_focus_node, new_focus_offset }, { old_anchor_node, old_anchor_offset }) == DOM::RelativeBoundaryPointPosition::Before) {
+    if (old_anchor_and_new_focus_have_the_same_shadow_including_root && DOM::position_of_boundary_point_relative_to_other_boundary_point({ new_focus_node, new_focus_offset }, { old_anchor_node, old_anchor_offset }) == DOM::RelativeBoundaryPointPosition::Before) {
         m_direction = Direction::Backwards;
     } else {
         m_direction = Direction::Forwards;

--- a/Tests/LibWeb/Crash/CSS/grid-placement-var-serialization.html
+++ b/Tests/LibWeb/Crash/CSS/grid-placement-var-serialization.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<script>
+    const columnElement = document.createElement("div");
+    columnElement.style.gridColumnStart = "1";
+    columnElement.style.gridColumnEnd = "var(--line)";
+    columnElement.style.setProperty("color", "red");
+
+    const rowElement = document.createElement("div");
+    rowElement.style.gridRowStart = "1";
+    rowElement.style.gridRowEnd = "var(--line)";
+    rowElement.style.setProperty("color", "red");
+</script>

--- a/Tests/LibWeb/Crash/CSS/repeating-gradient-zero-length.html
+++ b/Tests/LibWeb/Crash/CSS/repeating-gradient-zero-length.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<style>
+    .gradient {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div class="gradient" style="background: repeating-linear-gradient(red 0%, blue 0%)"></div>
+<div class="gradient" style="background: repeating-radial-gradient(circle, red 0%, blue 0%)"></div>
+<div class="gradient" style="background: repeating-conic-gradient(red 0deg, blue 0deg)"></div>

--- a/Tests/LibWeb/Crash/DOM/find-in-page-after-text-mutation.html
+++ b/Tests/LibWeb/Crash/DOM/find-in-page-after-text-mutation.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<span id="target">PASS</span>
+<script>
+document.body.offsetTop;
+target.firstChild.deleteData(0, 4);
+window.find("PASS");
+</script>

--- a/Tests/LibWeb/Crash/DOM/find-in-page-after-textarea-string-insertion.html
+++ b/Tests/LibWeb/Crash/DOM/find-in-page-after-textarea-string-insertion.html
@@ -1,0 +1,9 @@
+<script>
+function runTest()
+{
+    textarea.after("foo");
+    window.find("foo", false, true, true);
+}
+</script>
+<body onload=runTest()>
+<textarea id="textarea" disabled>Ghj@r</textarea>

--- a/Tests/LibWeb/Crash/DOM/range-client-rects-at-container-end.html
+++ b/Tests/LibWeb/Crash/DOM/range-client-rects-at-container-end.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<div id="target"><span>PASS</span></div>
+<script>
+const range = document.createRange();
+range.setStart(target, target.childNodes.length);
+range.setEnd(target, target.childNodes.length);
+range.getClientRects();
+</script>

--- a/Tests/LibWeb/Crash/DOM/scroll-into-view-without-scrolling-element.html
+++ b/Tests/LibWeb/Crash/DOM/scroll-into-view-without-scrolling-element.html
@@ -1,0 +1,15 @@
+<style>
+html,
+body {
+    overflow: scroll;
+}
+
+#spacer {
+    height: 2000px;
+}
+</style>
+<div id="spacer"></div>
+<div id="target">PASS</div>
+<script>
+    target.scrollIntoView();
+</script>

--- a/Tests/LibWeb/Crash/Editing/remove-format-with-hidden-selection.html
+++ b/Tests/LibWeb/Crash/Editing/remove-format-with-hidden-selection.html
@@ -1,0 +1,10 @@
+<script>
+function runTest()
+{
+    document.execCommand("selectAll", false);
+    document.documentElement.setAttribute("contenteditable", "true");
+    document.execCommand("removeFormat", false);
+}
+</script>
+<body onload="runTest()">
+<button hidden>|@QXs,uQhRb({z6)</button>

--- a/Tests/LibWeb/Crash/HTML/WindowProxy-get-after-iframe-removal.html
+++ b/Tests/LibWeb/Crash/HTML/WindowProxy-get-after-iframe-removal.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script>
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+
+    const iframeWindow = iframe.contentWindow;
+    iframe.remove();
+
+    iframeWindow.closed;
+</script>

--- a/Tests/LibWeb/Crash/HTML/barprop-visible-in-inactive-frame.html
+++ b/Tests/LibWeb/Crash/HTML/barprop-visible-in-inactive-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script>
+const outer = document.createElement("iframe");
+document.body.appendChild(outer);
+
+const inner = outer.contentDocument.createElement("iframe");
+outer.contentDocument.body.appendChild(inner);
+
+const innerWindow = inner.contentWindow;
+outer.remove();
+
+innerWindow.menubar.visible;
+</script>

--- a/Tests/LibWeb/Crash/HTML/blur-body-without-browsing-context.html
+++ b/Tests/LibWeb/Crash/HTML/blur-body-without-browsing-context.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<script>
+let document_without_browsing_context = new DOMParser().parseFromString("", "text/html");
+let body = document_without_browsing_context.createElement("body");
+body.blur();
+</script>

--- a/Tests/LibWeb/Crash/HTML/body-invalid-background-after-adoption.html
+++ b/Tests/LibWeb/Crash/HTML/body-invalid-background-after-adoption.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<body onload="runTest()">
+<script>
+function runTest()
+{
+    const documentWithBody = document.implementation.createHTMLDocument("x");
+    const body = documentWithBody.createElement("body");
+    body.setAttribute("background", "http://[");
+    document.documentElement.appendChild(body);
+    body.scrollIntoView();
+}
+</script>

--- a/Tests/LibWeb/Crash/HTML/document-element-outer-text.html
+++ b/Tests/LibWeb/Crash/HTML/document-element-outer-text.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<script>
+    try {
+        document.documentElement.outerText = "replacement";
+    } catch {
+    }
+</script>

--- a/Tests/LibWeb/Crash/HTML/media-load-task-after-adoption.html
+++ b/Tests/LibWeb/Crash/HTML/media-load-task-after-adoption.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<body>
+<audio id="audio" src="x"></audio>
+<iframe id="frame"></iframe>
+<script>
+let inactive_document = frame.contentDocument;
+frame.remove();
+audio.load();
+inactive_document.adoptNode(audio);
+</script>

--- a/Tests/LibWeb/Crash/HTML/removed-iframe-during-child-navigation.html
+++ b/Tests/LibWeb/Crash/HTML/removed-iframe-during-child-navigation.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<iframe id="frame" srcdoc="PASS"></iframe>
+<script>
+frame.src = "data:text/html,child";
+setTimeout(() => frame.remove(), 0);
+</script>

--- a/Tests/LibWeb/Crash/HTML/style-outer-text-after-adoption.html
+++ b/Tests/LibWeb/Crash/HTML/style-outer-text-after-adoption.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<style id="style">div { color: red }</style>
+<script>
+document.body.offsetTop;
+style.disabled = true;
+document.implementation.createHTMLDocument("x").adoptNode(style);
+style.outerText;
+</script>

--- a/Tests/LibWeb/Crash/Layout/border-radius-on-negative-width-output.html
+++ b/Tests/LibWeb/Crash/Layout/border-radius-on-negative-width-output.html
@@ -1,0 +1,9 @@
+<style>
+output {
+    border-bottom-left-radius: 89px 1px;
+    border-top-right-radius: 0;
+    letter-spacing: -1em;
+    outline: red solid;
+}
+</style>
+<output>G</output>

--- a/Tests/LibWeb/Crash/Layout/huge-font-size-text-measurement.html
+++ b/Tests/LibWeb/Crash/Layout/huge-font-size-text-measurement.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<div style="font-size: 100000000px; width: min-content">AAAA</div>
+<script>
+    internals.dumpLayoutTree(document.body);
+</script>

--- a/Tests/LibWeb/Crash/Layout/select-all-with-unstyled-layout-node.html
+++ b/Tests/LibWeb/Crash/Layout/select-all-with-unstyled-layout-node.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+#target {
+    display: table-column-group;
+    display: -webkit-inline-flex;
+}
+</style>
+<body onload="document.execCommand('selectAll', false)">
+<acronym id="target">PASS</acronym>

--- a/Tests/LibWeb/Crash/Layout/sticky-inline-scrollbar-without-overflow-data.html
+++ b/Tests/LibWeb/Crash/Layout/sticky-inline-scrollbar-without-overflow-data.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<bdi style="overflow: scroll; position: sticky">PASS</bdi>

--- a/Tests/LibWeb/Crash/Layout/sticky-ruby-without-sticky-insets.html
+++ b/Tests/LibWeb/Crash/Layout/sticky-ruby-without-sticky-insets.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+#target {
+    display: ruby;
+    position: sticky;
+}
+</style>
+<div style="height: 2000px">
+    <div id="target">PASS</div>
+</div>

--- a/Tests/LibWeb/Crash/Layout/style-containment-check-on-unstyled-layout-node.html
+++ b/Tests/LibWeb/Crash/Layout/style-containment-check-on-unstyled-layout-node.html
@@ -1,0 +1,23 @@
+<style>
+</style>
+<script>
+function freememory() {
+}
+function jsfuzzer() {
+try { document.all[28%document.all.length].appendChild(htmlvar00026); } catch(e) { }
+}
+</script>
+<body onload=jsfuzzer()>
+<option id="htmlvar00003" selected="selected" onmousedown="eventhandler2()" checked="checked" onerror="eventhandler3()" checked="checked" cite="#wi2$QSr" row="1" seamless="seamless" allowfullscreen="true" prompt="eA4K.O;;cG">&lt;$^l\oO70m&#x27;Z</option>
+<option id="htmlvar00004" role="tooltip" onerror="eventhandler4()" accesskey="I" default="j+RF{EmS6&gt;Bb" dir="RTL" placeholder="qaqS`" inner="1" form="htmlvar00005" default="b}Au=rBuFQ4" tabindex="1">?S^Sl&quot;</option>
+<data id="htmlvar00005" value="4LV39-&gt;;Ft&#x27;2lA\&amp;" reversed="reversed" behavior="alternate" longdesc="!_" cellspacing="0" background="&#x27;5\&lt;Mo4HLm3pO|,Dy"></data>
+<p id="htmlvar00021" name="" style="-webkit-transform: scale(-1, 1); display: table-column-group; column-rule: 5px solid; max-height: inherit; -webkit-box-orient: vertical" lang="de-CH" style="border-top-color: inherit; text-anchor: middle; mask-source-type: alpha; border-left-color: black; snap-height: 0px" name="^Lpt" disposition="attachment" onwebkitanimationstart="eventhandler3()" defer="defer" scrolldelay="0" compact="compact">
+<ins id="htmlvar00022" cite="rk`jUo1&#x27;wC}" datetime="2000-02-01T03:04:05Z" cite="~wn*TM0% aE#^ck" class="class2" cite="nR&amp;!T" onpageshow="eventhandler5()" link="" referrerpolicy="origin" headers="htmlvar00008" code="\bK{q&lt;I{*c7jvqi38G9k">
+<template id="htmlvar00023" content="oL(vo" left="-1" results="1" mode="showing" size="-1" lang="lt-LT">&quot;Fd@y&gt;wsMHp</template>
+<option id="htmlvar00026" style="padding-right: 50%; justify-content: center safe; -webkit-box-decoration-break: slice; stroke-linejoin: miter; border-right: hidden" checked="checked" disabled="disabled" role="menu" value="8V^V:O" style="max-width: 4vmin; -webkit-box-pack: end; backdrop-filter: grayscale(20%); filter: drop-shadow(0 0 1 green); stroke-linejoin: miter" language="vbscript" startval="7y" pluginspage="n#cQ}]}[O2.1^l]~" right="-1">
+<details id="htmlvar00027" name="[&lt;X.%" ontoggle="eventhandler3()" style="perspective-origin: 0 0; border-bottom-width: 1px; -webkit-mask-clip: padding-box; -webkit-perspective-origin-x: 0px; offset-position: auto" style="grid-column-start: first span; padding: 9 35px; -webkit-box-align: top; stroke-linejoin: miter; motion-rotation: reverse -1deg" open="true" menu="htmlvar00008" quality="high" scheme="NIST" muted="muted" ondragenter="eventhandler1()">yCa&lt;Hr!~fl?D5zZr+O</details>
+<option id="htmlvar00031" onclick="eventhandler1()" disabled="disabled" accesskey="u" title="sf3E1]~VN&quot;@" onclick="eventhandler2()" content="|mP^QJ0l;yQ/~Zo{ox 0" coords="9, 1, 2, 0" form="htmlvar00004" as="video" charoff="33">
+<div id="htmlvar00032" ondrag="eventhandler2()" onselectstart="eventhandler1()" hidden="hidden" ontouchstart="eventhandler2()" onmousedown="eventhandler3()" poster="nL$Vj1#d[qtM77&quot;XL1c" prompt="!" max="1" loopend="1" headers="htmlvar00001">Fqs&gt;YT&#x27;C</div>
+<select id="htmlvar00033" onmouseup="eventhandler2()" readonly="readonly" autofocus="autofocus" title="hV~QQ$2.D|v" align="bottom" usemap="#htmlvar00008" text="rgb(23,34,164)" ping="^*13?-Y|7/][(QK_" title="bUhMd" bgcolor="black">
+<optgroup id="htmlvar00034" disabled="disabled" tabindex="-1" tabindex="1" disabled="disabled" disabled="disabled" cellpadding="1" abbr=" #-JV1u{" as="audio" select="#htmlvar00004" height="0">
+<option id="htmlvar00035" onerror="eventhandler3()" name="oLcsaVI^4m!" dir="RTL" onmouseup="eventhandler5()" onerror="eventhandler5()" low="1" high="7" topmargin="9" disposition="attachment" srcdoc="=RG(UQq!xF">BB#@}17</option>

--- a/Tests/LibWeb/Crash/SVG/absolute-rect-with-unpainted-ancestors.html
+++ b/Tests/LibWeb/Crash/SVG/absolute-rect-with-unpainted-ancestors.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<svg id="outer">
+    <font-face>
+        <font-face-src>
+            <foreignObject width="100" height="100">
+                <body xmlns="http://www.w3.org/1999/xhtml">
+                    <details open>
+                        <summary>x</summary>
+                        text
+                        <svg>
+                            <line id="line" x1="1px" y1="79%" x2="56%" y2="0.142" marker-end="url(#outer)"></line>
+                        </svg>
+                        <hr>
+                    </details>
+                </body>
+            </foreignObject>
+        </font-face-src>
+    </font-face>
+</svg>
+<script>
+line.scrollBy();
+</script>

--- a/Tests/LibWeb/Crash/SVG/block-gradient-in-paint-server.html
+++ b/Tests/LibWeb/Crash/SVG/block-gradient-in-paint-server.html
@@ -1,0 +1,3 @@
+<svg marker-start="url(#gradient)" stroke="url(#pattern) red">
+<pattern id="pattern">
+<linearGradient id="gradient" display="block" />

--- a/Tests/LibWeb/Crash/SVG/dump-unpainted-inline-fragments.html
+++ b/Tests/LibWeb/Crash/SVG/dump-unpainted-inline-fragments.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<svg>
+    <g opacity="0.7">
+        <switch>
+            <feMergeNode>
+                <foreignObject display="table-caption">
+                    <body xmlns="http://www.w3.org/1999/xhtml">x</body>
+                </foreignObject>
+            </feMergeNode>
+            <tref>
+                <text visibility="hidden">
+                    <tspan font-size="55px">
+                        <meshpatch>
+                            <feTile></feTile>
+                            <textPath>
+                                <textPath id="target"><embed></textPath>
+                                <text></text>
+                            </textPath>
+                        </meshpatch>
+                    </tspan>
+                </text>
+                <altGlyph></altGlyph>
+            </tref>
+            <radialGradient><animateTransform></animateTransform></radialGradient>
+            <feFlood></feFlood>
+        </switch>
+    </g>
+</svg>
+<script>
+    internals.dumpLayoutTree(document.body);
+    document.getElementById("target").scrollIntoView();
+</script>

--- a/Tests/LibWeb/Crash/SVG/getBBox-foreignObject.html
+++ b/Tests/LibWeb/Crash/SVG/getBBox-foreignObject.html
@@ -1,0 +1,6 @@
+<svg width="10" height="10">
+  <foreignObject id="foreign-object" width="1" height="1"></foreignObject>
+</svg>
+<script>
+  document.getElementById("foreign-object").getBBox();
+</script>

--- a/Tests/LibWeb/Crash/SVG/svg-animated-length-with-fit-content-height.html
+++ b/Tests/LibWeb/Crash/SVG/svg-animated-length-with-fit-content-height.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<svg>
+    <filter>
+        <feBlend id="blend" style="height: fit-content"></feBlend>
+    </filter>
+</svg>
+<script>
+    blend.height.baseVal.value;
+</script>

--- a/Tests/LibWeb/Crash/Selection/extend-after-shadow-host-detached.html
+++ b/Tests/LibWeb/Crash/Selection/extend-after-shadow-host-detached.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<div id="host"></div>
+<div id="target"></div>
+<script>
+const shadowRoot = host.attachShadow({ mode: "open" });
+shadowRoot.innerHTML = "<span id=anchor>hello</span>";
+const anchor = shadowRoot.getElementById("anchor");
+
+const selection = getSelection();
+selection.collapse(anchor, 0);
+host.remove();
+selection.extend(target, 0);
+</script>

--- a/Tests/LibWeb/Text/expected/DOM/range-get-client-rects.txt
+++ b/Tests/LibWeb/Text/expected/DOM/range-get-client-rects.txt
@@ -1,2 +1,3 @@
 [object DOMRectList]
 [object DOMRect]
+PASS

--- a/Tests/LibWeb/Text/input/DOM/range-get-client-rects.html
+++ b/Tests/LibWeb/Text/input/DOM/range-get-client-rects.html
@@ -1,7 +1,17 @@
 <!DOCTYPE html>
 <!--refer to https://wpt.live/css/cssom-view/DOMRectList.html -->
+<style>
+    #start-container {
+        display: inline-block;
+    }
+    #following {
+        display: inline-block;
+        margin-left: 100px;
+    }
+</style>
 <body>
 <div id="x">x</div>
+<div id="start-container"><span><span>old</span></span></div><span id="following">new</span>
 <script src="../include.js"></script>
 <script>
     function print_class_string(object) {
@@ -14,6 +24,15 @@
         const domRectList = range.getClientRects();
         print_class_string(domRectList);
         print_class_string(domRectList.item(0));
+
+        const startContainer = document.getElementById("start-container");
+        const following = document.getElementById("following");
+        range.setStart(startContainer, startContainer.childNodes.length);
+        range.setEnd(following.firstChild, following.firstChild.length);
+
+        const firstRangeRect = range.getClientRects()[0];
+        const followingRect = following.getBoundingClientRect();
+        println(firstRangeRect.left >= followingRect.left && firstRangeRect.left < followingRect.right ? "PASS" : "FAIL");
     });
 </script>
 


### PR DESCRIPTION
This fixes a batch of crashers found by running domato against LibWeb. Each issue was reduced to a focused regression test before fixing the underlying edge case.

The fixes cover stale layout and DOM state across range rect collection, find-in-page, selection, SVG layout and getBBox, media task dispatch, scroll and focus handling, inline continuation rebuilding, styleless nodes, and a few invalid or degenerate CSS/layout inputs.

The added tests are reduced from the crashing domato cases and exercise the specific failure modes directly.