### PR TITLE
LibWeb: Avoid inflating 0fr grid rows from hidden overflow

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1582,8 +1582,14 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
         // If the grid container is being sized under a min- or max-content constraint, use the items' limited
         // min-content contributions in place of their minimum contributions here.
         auto item_size_contribution = [&] {
-            if (available_size.is_intrinsic_sizing_constraint())
+            if (available_size.is_intrinsic_sizing_constraint()) {
+                // https://drafts.csswg.org/css-grid-2/#min-size-auto
+                // A grid item's automatic minimum size is zero if its computed overflow is a scrollable
+                // overflow value. Preserve that zero minimum for collapsed zero-flex tracks.
+                if (total_flex == 0 && item.box.is_scroll_container())
+                    return calculate_minimum_contribution(item, dimension);
                 return calculate_limited_min_content_contribution(item, dimension);
+            }
             return calculate_minimum_contribution(item, dimension);
         }();
         // NB: Subtract the space already accounted for by non-flexible spanned tracks (sized in 11.5.3), since only

--- a/Tests/LibWeb/Text/expected/grid/zero-flex-row-overflow-hidden-grid-item.txt
+++ b/Tests/LibWeb/Text/expected/grid/zero-flex-row-overflow-hidden-grid-item.txt
@@ -1,0 +1,7 @@
+root: top=0 height=35
+outer: top=0 height=34
+button: top=0 height=34
+collapsible: top=34 height=0
+clip: top=34 height=0
+list: top=35 height=104
+after: top=35 height=0

--- a/Tests/LibWeb/Text/input/grid/zero-flex-row-overflow-hidden-grid-item.html
+++ b/Tests/LibWeb/Text/input/grid/zero-flex-row-overflow-hidden-grid-item.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+ul,
+li {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+#root {
+    display: flex;
+    flex-direction: column;
+    row-gap: 1px;
+    width: 231px;
+}
+
+#outer {
+    position: relative;
+    width: 100%;
+}
+
+#button {
+    height: 34px;
+    min-height: 34px;
+}
+
+#collapsible {
+    display: grid;
+    grid-template-rows: 0fr;
+}
+
+#clip {
+    overflow: hidden;
+}
+
+#list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 1px;
+    overflow: hidden;
+    position: relative;
+    row-gap: 1px;
+}
+
+.item {
+    height: 34px;
+    min-height: 34px;
+}
+</style>
+<ul id="root">
+    <li id="outer">
+        <div id="button"></div>
+        <div id="collapsible">
+            <div id="clip">
+                <ul id="list">
+                    <li class="item"></li>
+                    <li class="item"></li>
+                    <li class="item"></li>
+                </ul>
+            </div>
+        </div>
+    </li>
+    <li id="after"></li>
+</ul>
+<script>
+test(() => {
+    for (const id of ["root", "outer", "button", "collapsible", "clip", "list", "after"]) {
+        const rect = document.getElementById(id).getBoundingClientRect();
+        println(`${id}: top=${rect.top} height=${rect.height}`);
+    }
+});
+</script>


### PR DESCRIPTION
Use the grid item minimum contribution when an intrinsic flexible track sizing pass sees a scroll-container item crossing only zero-flex tracks. This keeps collapsed 0fr rows from contributing their hidden contents to an ancestor flex item's automatic height.

Add a text test covering an overflow-hidden grid item in a 0fr row inside a column flex container, matching the dashboard sidebar pattern.

Visual progression on the Cloudflare dashboard (sidebar on left side).

Before:
<img width="1355" height="882" alt="Screenshot 2026-06-08 at 02 39 15" src="https://github.com/user-attachments/assets/5f1a657b-ef9d-49cc-ba99-1e1c954c8b60" />

After:
<img width="1355" height="882" alt="Screenshot 2026-06-08 at 02 33 34" src="https://github.com/user-attachments/assets/6e8e2bec-a8be-409f-9795-d09bbe522a03" />
