### PR TITLE
LibWeb: Fix crash when reading a detached or out-of-bounds stream chunk

### DIFF
--- a/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -89,7 +89,7 @@ void ReadLoopReadRequest::on_chunk(JS::Value chunk)
     }
 
     auto const& array = static_cast<JS::Uint8Array const&>(chunk.as_object());
-    auto buffer = array.viewed_array_buffer()->bytes().slice(array.byte_offset(), array.byte_length().length());
+    auto buffer = array.data();
 
     // 2. Append the bytes represented by chunk to bytes.
     m_bytes.append(buffer);

--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-read-detached-chunk.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-read-detached-chunk.txt
@@ -1,0 +1,1 @@
+resolved length=0

--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-read-out-of-bounds-chunk.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-read-out-of-bounds-chunk.txt
@@ -1,0 +1,1 @@
+resolved length=0

--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-read-subview-chunk.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-read-subview-chunk.txt
@@ -1,0 +1,1 @@
+length=3 bytes=12,13,14

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-read-detached-chunk.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-read-detached-chunk.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        // Reading a stream whose chunk is a Uint8Array backed by a detached ArrayBuffer must resolve with an empty
+        // result, not crash. (issue #9965)
+        const buffer = new ArrayBuffer(8);
+        const view = new Uint8Array(buffer);
+        view.set([0x41, 0x42, 0x43, 0x44]);
+        buffer.transfer();
+
+        const stream = new ReadableStream({
+            start(controller) {
+                controller.enqueue(view);
+                controller.close();
+            },
+        });
+
+        try {
+            const out = await new Response(stream).arrayBuffer();
+            println(`resolved length=${out.byteLength}`);
+        } catch (e) {
+            println(`rejected: ${e.name}: ${e.message}`);
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-read-out-of-bounds-chunk.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-read-out-of-bounds-chunk.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        // A fixed-length view whose resizable ArrayBuffer is shrunk below it becomes out-of-bounds; reading such a
+        // chunk must resolve empty, not crash. (issue #9965)
+        const buffer = new ArrayBuffer(8, { maxByteLength: 8 });
+        const view = new Uint8Array(buffer, 4, 4);
+        buffer.resize(2);
+
+        const stream = new ReadableStream({
+            start(controller) {
+                controller.enqueue(view);
+                controller.close();
+            },
+        });
+
+        try {
+            const out = await new Response(stream).arrayBuffer();
+            println(`resolved length=${out.byteLength}`);
+        } catch (e) {
+            println(`rejected: ${e.name}: ${e.message}`);
+        }
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-read-subview-chunk.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-read-subview-chunk.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        // A valid Uint8Array chunk with a non-zero byteOffset must round-trip its exact bytes through
+        // Response.arrayBuffer(). (issue #9965)
+        const backing = new Uint8Array([10, 11, 12, 13, 14, 15]);
+        const view = new Uint8Array(backing.buffer, 2, 3); // bytes [12, 13, 14]
+
+        const stream = new ReadableStream({
+            start(controller) {
+                controller.enqueue(view);
+                controller.close();
+            },
+        });
+
+        const out = new Uint8Array(await new Response(stream).arrayBuffer());
+        println(`length=${out.length} bytes=${Array.from(out).join(",")}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
**Problem:** Crash when reading a `ReadableStream` whose chunk is a `Uint8Array` backed by a detached `ArrayBuffer`.

**Cause:** The `ReadLoopReadRequest::on_chunk` code skipped existing guards when extracting the chunk bytes — leading to `bytes()` getting called on the detached buffer, which tripped an assert.

**Fix:** Read the chunk through `Uint8Array::data()` — which guards for the case where the view is detached (or out-of-bounds). That aligns things with what the sibling `IncrementalReadLoopReadRequest` was already doing. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9965.
