### PR TITLE
LibWeb: SVG path parsing optimizations

### DIFF
--- a/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -38,7 +38,7 @@ Path AttributeParser::parse_path_data(StringView input)
         // Invalid. "A path data segment (if there is one) must begin with a "moveto" command."
         return Path { {} };
     }
-    return Path { parser.m_instructions };
+    return Path { move(parser.m_instructions) };
 }
 
 Optional<float> AttributeParser::parse_coordinate(StringView input)

--- a/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -34,7 +34,7 @@ Path AttributeParser::parse_path_data(StringView input)
         if (maybe_error.is_error())
             break;
     }
-    if (!parser.m_instructions.is_empty() && parser.m_instructions[0].type != PathInstructionType::Move) {
+    if (!parser.m_instructions.is_empty() && !parser.m_instructions[0].has<MoveToInstruction>()) {
         // Invalid. "A path data segment (if there is one) must begin with a "moveto" command."
         return Path { {} };
     }
@@ -177,8 +177,10 @@ ErrorOr<void> AttributeParser::parse_moveto()
     bool is_first = true;
     for (auto& pair : TRY(parse_coordinate_pair_sequence())) {
         // NOTE: "M 1 2 3 4" is equivalent to "M 1 2 L 3 4".
-        auto type = is_first ? PathInstructionType::Move : PathInstructionType::Line;
-        m_instructions.append({ type, absolute, pair });
+        if (is_first)
+            m_instructions.append(MoveToInstruction { absolute, pair });
+        else
+            m_instructions.append(LineToInstruction { absolute, pair });
         is_first = false;
     }
 
@@ -187,9 +189,10 @@ ErrorOr<void> AttributeParser::parse_moveto()
 
 void AttributeParser::parse_closepath()
 {
-    bool absolute = consume() == 'Z';
+    // NB: Z and z are equivalent
+    consume();
     parse_whitespace();
-    m_instructions.append({ PathInstructionType::ClosePath, absolute, {} });
+    m_instructions.append(ClosePathInstruction {});
 }
 
 ErrorOr<void> AttributeParser::parse_lineto()
@@ -197,7 +200,7 @@ ErrorOr<void> AttributeParser::parse_lineto()
     bool absolute = consume() == 'L';
     parse_whitespace();
     for (auto& pair : TRY(parse_coordinate_pair_sequence()))
-        m_instructions.append({ PathInstructionType::Line, absolute, pair });
+        m_instructions.append(LineToInstruction { absolute, pair });
 
     return {};
 }
@@ -207,7 +210,7 @@ ErrorOr<void> AttributeParser::parse_horizontal_lineto()
     bool absolute = consume() == 'H';
     parse_whitespace();
     for (auto coordinate : TRY(parse_coordinate_sequence()))
-        m_instructions.append({ PathInstructionType::HorizontalLine, absolute, { coordinate } });
+        m_instructions.append(HorizontalLineToInstruction { absolute, coordinate });
 
     return {};
 }
@@ -217,7 +220,7 @@ ErrorOr<void> AttributeParser::parse_vertical_lineto()
     bool absolute = consume() == 'V';
     parse_whitespace();
     for (auto coordinate : TRY(parse_coordinate_sequence()))
-        m_instructions.append({ PathInstructionType::VerticalLine, absolute, { coordinate } });
+        m_instructions.append(VerticalLineToInstruction { absolute, coordinate });
 
     return {};
 }
@@ -228,7 +231,13 @@ ErrorOr<void> AttributeParser::parse_curveto()
     parse_whitespace();
 
     while (true) {
-        m_instructions.append({ PathInstructionType::Curve, absolute, TRY(parse_coordinate_pair_triplet()) });
+        auto coordinate_pair_triplet = TRY(parse_coordinate_pair_triplet());
+        m_instructions.append(CurveToInstruction {
+            absolute,
+            { coordinate_pair_triplet[0], coordinate_pair_triplet[1] },
+            { coordinate_pair_triplet[2], coordinate_pair_triplet[3] },
+            { coordinate_pair_triplet[4], coordinate_pair_triplet[5] },
+        });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -244,7 +253,12 @@ ErrorOr<void> AttributeParser::parse_smooth_curveto()
     parse_whitespace();
 
     while (true) {
-        m_instructions.append({ PathInstructionType::SmoothCurve, absolute, TRY(parse_coordinate_pair_double()) });
+        auto coordinate_pair_double = TRY(parse_coordinate_pair_double());
+        m_instructions.append(SmoothCurveToInstruction {
+            absolute,
+            { coordinate_pair_double[0], coordinate_pair_double[1] },
+            { coordinate_pair_double[2], coordinate_pair_double[3] },
+        });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -260,7 +274,12 @@ ErrorOr<void> AttributeParser::parse_quadratic_bezier_curveto()
     parse_whitespace();
 
     while (true) {
-        m_instructions.append({ PathInstructionType::QuadraticBezierCurve, absolute, TRY(parse_coordinate_pair_double()) });
+        auto coordinate_pair_double = TRY(parse_coordinate_pair_double());
+        m_instructions.append(QuadraticBezierCurveToInstruction {
+            absolute,
+            { coordinate_pair_double[0], coordinate_pair_double[1] },
+            { coordinate_pair_double[2], coordinate_pair_double[3] },
+        });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -276,7 +295,7 @@ ErrorOr<void> AttributeParser::parse_smooth_quadratic_bezier_curveto()
     parse_whitespace();
 
     while (true) {
-        m_instructions.append({ PathInstructionType::SmoothQuadraticBezierCurve, absolute, TRY(parse_coordinate_pair()) });
+        m_instructions.append(SmoothQuadraticBezierCurveToInstruction { absolute, TRY(parse_coordinate_pair()) });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -293,7 +312,15 @@ ErrorOr<void> AttributeParser::parse_elliptical_arc()
 
     while (true) {
         auto argument = TRY(parse_elliptical_arc_argument());
-        m_instructions.append({ PathInstructionType::EllipticalArc, absolute, move(argument) });
+        m_instructions.append(EllipticalArcInstruction {
+            argument[0],
+            argument[1],
+            argument[2],
+            absolute,
+            argument[3] != 0,
+            argument[4] != 0,
+            { argument[5], argument[6] },
+        });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())

--- a/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -123,20 +123,7 @@ Vector<Gfx::FloatPoint> AttributeParser::parse_points(StringView input)
 
     parser.parse_whitespace();
 
-    auto coordinate_pair_sequence_or_error = parser.parse_coordinate_pair_sequence();
-    if (coordinate_pair_sequence_or_error.is_error())
-        return {};
-
-    auto coordinate_pair_sequence = coordinate_pair_sequence_or_error.release_value();
-
-    // FIXME: This is awkward. Can we return Gfx::FloatPoints from some of these parsing methods instead of Vector<float>?
-    Vector<Gfx::FloatPoint> points;
-    points.ensure_capacity(coordinate_pair_sequence.size());
-
-    for (auto const& pair : coordinate_pair_sequence)
-        points.empend(pair[0], pair[1]);
-
-    return points;
+    return parser.parse_coordinate_pair_sequence().value_or(Vector<Gfx::FloatPoint> {});
 }
 
 ErrorOr<void> AttributeParser::parse_drawto()
@@ -232,12 +219,7 @@ ErrorOr<void> AttributeParser::parse_curveto()
 
     while (true) {
         auto coordinate_pair_triplet = TRY(parse_coordinate_pair_triplet());
-        m_instructions.append(CurveToInstruction {
-            absolute,
-            { coordinate_pair_triplet[0], coordinate_pair_triplet[1] },
-            { coordinate_pair_triplet[2], coordinate_pair_triplet[3] },
-            { coordinate_pair_triplet[4], coordinate_pair_triplet[5] },
-        });
+        m_instructions.append(CurveToInstruction { absolute, coordinate_pair_triplet[0], coordinate_pair_triplet[1], coordinate_pair_triplet[2] });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -254,11 +236,7 @@ ErrorOr<void> AttributeParser::parse_smooth_curveto()
 
     while (true) {
         auto coordinate_pair_double = TRY(parse_coordinate_pair_double());
-        m_instructions.append(SmoothCurveToInstruction {
-            absolute,
-            { coordinate_pair_double[0], coordinate_pair_double[1] },
-            { coordinate_pair_double[2], coordinate_pair_double[3] },
-        });
+        m_instructions.append(SmoothCurveToInstruction { absolute, coordinate_pair_double[0], coordinate_pair_double[1] });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -275,11 +253,7 @@ ErrorOr<void> AttributeParser::parse_quadratic_bezier_curveto()
 
     while (true) {
         auto coordinate_pair_double = TRY(parse_coordinate_pair_double());
-        m_instructions.append(QuadraticBezierCurveToInstruction {
-            absolute,
-            { coordinate_pair_double[0], coordinate_pair_double[1] },
-            { coordinate_pair_double[2], coordinate_pair_double[3] },
-        });
+        m_instructions.append(QuadraticBezierCurveToInstruction { absolute, coordinate_pair_double[0], coordinate_pair_double[1] });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -357,14 +331,13 @@ ErrorOr<i32> AttributeParser::parse_integer()
     return parse_result->value;
 }
 
-ErrorOr<Vector<float>> AttributeParser::parse_coordinate_pair()
+ErrorOr<Gfx::FloatPoint> AttributeParser::parse_coordinate_pair()
 {
-    Vector<float> coordinates;
-    coordinates.append(TRY(parse_coordinate()));
+    auto x = TRY(parse_coordinate());
     if (match_comma_whitespace())
         parse_comma_whitespace();
-    coordinates.append(TRY(parse_coordinate()));
-    return coordinates;
+    auto y = TRY(parse_coordinate());
+    return Gfx::FloatPoint { x, y };
 }
 
 ErrorOr<Vector<float>> AttributeParser::parse_coordinate_sequence()
@@ -388,9 +361,9 @@ ErrorOr<Vector<float>> AttributeParser::parse_coordinate_sequence()
     return sequence;
 }
 
-ErrorOr<Vector<Vector<float>>> AttributeParser::parse_coordinate_pair_sequence()
+ErrorOr<Vector<Gfx::FloatPoint>> AttributeParser::parse_coordinate_pair_sequence()
 {
-    Vector<Vector<float>> sequence;
+    Vector<Gfx::FloatPoint> sequence;
     bool is_first = true;
     while (true) {
         auto coordinate_pair_or_error = parse_coordinate_pair();
@@ -409,26 +382,26 @@ ErrorOr<Vector<Vector<float>>> AttributeParser::parse_coordinate_pair_sequence()
     return sequence;
 }
 
-ErrorOr<Vector<float>> AttributeParser::parse_coordinate_pair_double()
+ErrorOr<Vector<Gfx::FloatPoint, 2>> AttributeParser::parse_coordinate_pair_double()
 {
-    Vector<float> coordinates;
-    coordinates.extend(TRY(parse_coordinate_pair()));
+    Vector<Gfx::FloatPoint, 2> coordinates;
+    coordinates.unchecked_append(TRY(parse_coordinate_pair()));
     if (match_comma_whitespace())
         parse_comma_whitespace();
-    coordinates.extend(TRY(parse_coordinate_pair()));
+    coordinates.unchecked_append(TRY(parse_coordinate_pair()));
     return coordinates;
 }
 
-ErrorOr<Vector<float>> AttributeParser::parse_coordinate_pair_triplet()
+ErrorOr<Vector<Gfx::FloatPoint, 3>> AttributeParser::parse_coordinate_pair_triplet()
 {
-    Vector<float> coordinates;
-    coordinates.extend(TRY(parse_coordinate_pair()));
+    Vector<Gfx::FloatPoint, 3> coordinates;
+    coordinates.unchecked_append(TRY(parse_coordinate_pair()));
     if (match_comma_whitespace())
         parse_comma_whitespace();
-    coordinates.extend(TRY(parse_coordinate_pair()));
+    coordinates.unchecked_append(TRY(parse_coordinate_pair()));
     if (match_comma_whitespace())
         parse_comma_whitespace();
-    coordinates.extend(TRY(parse_coordinate_pair()));
+    coordinates.unchecked_append(TRY(parse_coordinate_pair()));
     return coordinates;
 }
 
@@ -450,7 +423,9 @@ ErrorOr<Vector<float>> AttributeParser::parse_elliptical_arc_argument()
     numbers.append(TRY(parse_flag()));
     if (match_comma_whitespace())
         parse_comma_whitespace();
-    numbers.extend(TRY(parse_coordinate_pair()));
+    auto point = TRY(parse_coordinate_pair());
+    numbers.append(point.x());
+    numbers.append(point.y());
 
     return numbers;
 }

--- a/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -285,16 +285,24 @@ ErrorOr<void> AttributeParser::parse_elliptical_arc()
     parse_whitespace();
 
     while (true) {
-        auto argument = TRY(parse_elliptical_arc_argument());
-        m_instructions.append(EllipticalArcInstruction {
-            argument[0],
-            argument[1],
-            argument[2],
-            absolute,
-            argument[3] != 0,
-            argument[4] != 0,
-            { argument[5], argument[6] },
-        });
+        auto rx = TRY(parse_number());
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
+        auto ry = TRY(parse_number());
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
+        auto x_axis_rotation = TRY(parse_number());
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
+        auto large_arc_flag = TRY(parse_flag());
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
+        auto sweep_flag = TRY(parse_flag());
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
+        auto point = TRY(parse_coordinate_pair());
+
+        m_instructions.append(EllipticalArcInstruction { rx, ry, x_axis_rotation, absolute, large_arc_flag, sweep_flag, point });
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_coordinate())
@@ -405,31 +413,6 @@ ErrorOr<Vector<Gfx::FloatPoint, 3>> AttributeParser::parse_coordinate_pair_tripl
     return coordinates;
 }
 
-ErrorOr<Vector<float>> AttributeParser::parse_elliptical_arc_argument()
-{
-    Vector<float> numbers;
-    numbers.append(TRY(parse_number()));
-    if (match_comma_whitespace())
-        parse_comma_whitespace();
-    numbers.append(TRY(parse_number()));
-    if (match_comma_whitespace())
-        parse_comma_whitespace();
-    numbers.append(TRY(parse_number()));
-    if (match_comma_whitespace())
-        parse_comma_whitespace();
-    numbers.append(TRY(parse_flag()));
-    if (match_comma_whitespace())
-        parse_comma_whitespace();
-    numbers.append(TRY(parse_flag()));
-    if (match_comma_whitespace())
-        parse_comma_whitespace();
-    auto point = TRY(parse_coordinate_pair());
-    numbers.append(point.x());
-    numbers.append(point.y());
-
-    return numbers;
-}
-
 void AttributeParser::parse_whitespace(bool must_match_once)
 {
     bool matched = false;
@@ -476,7 +459,7 @@ ErrorOr<float> AttributeParser::parse_nonnegative_number()
     return parse_result->value;
 }
 
-ErrorOr<float> AttributeParser::parse_flag()
+ErrorOr<bool> AttributeParser::parse_flag()
 {
     if (!match('0') && !match('1'))
         return Error::from_string_literal("Expected flag");

--- a/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -123,7 +123,16 @@ Vector<Gfx::FloatPoint> AttributeParser::parse_points(StringView input)
 
     parser.parse_whitespace();
 
-    return parser.parse_coordinate_pair_sequence().value_or(Vector<Gfx::FloatPoint> {});
+    Vector<Gfx::FloatPoint> points;
+
+    auto result = parser.parse_coordinate_pair_sequence([&](Gfx::FloatPoint point) {
+        points.append(point);
+    });
+
+    if (result.is_error())
+        return {};
+
+    return points;
 }
 
 ErrorOr<void> AttributeParser::parse_drawto()
@@ -162,14 +171,14 @@ ErrorOr<void> AttributeParser::parse_moveto()
     parse_whitespace();
 
     bool is_first = true;
-    for (auto& pair : TRY(parse_coordinate_pair_sequence())) {
+    TRY(parse_coordinate_pair_sequence([&](Gfx::FloatPoint pair) {
         // NOTE: "M 1 2 3 4" is equivalent to "M 1 2 L 3 4".
         if (is_first)
             m_instructions.append(MoveToInstruction { absolute, pair });
         else
             m_instructions.append(LineToInstruction { absolute, pair });
         is_first = false;
-    }
+    }));
 
     return {};
 }
@@ -186,8 +195,9 @@ ErrorOr<void> AttributeParser::parse_lineto()
 {
     bool absolute = consume() == 'L';
     parse_whitespace();
-    for (auto& pair : TRY(parse_coordinate_pair_sequence()))
-        m_instructions.append(LineToInstruction { absolute, pair });
+    TRY(parse_coordinate_pair_sequence([&](Gfx::FloatPoint point) {
+        m_instructions.append(LineToInstruction { absolute, point });
+    }));
 
     return {};
 }
@@ -196,8 +206,9 @@ ErrorOr<void> AttributeParser::parse_horizontal_lineto()
 {
     bool absolute = consume() == 'H';
     parse_whitespace();
-    for (auto coordinate : TRY(parse_coordinate_sequence()))
+    TRY(parse_coordinate_sequence([&](float coordinate) {
         m_instructions.append(HorizontalLineToInstruction { absolute, coordinate });
+    }));
 
     return {};
 }
@@ -206,8 +217,9 @@ ErrorOr<void> AttributeParser::parse_vertical_lineto()
 {
     bool absolute = consume() == 'V';
     parse_whitespace();
-    for (auto coordinate : TRY(parse_coordinate_sequence()))
+    TRY(parse_coordinate_sequence([&](float coordinate) {
         m_instructions.append(VerticalLineToInstruction { absolute, coordinate });
+    }));
 
     return {};
 }
@@ -348,9 +360,8 @@ ErrorOr<Gfx::FloatPoint> AttributeParser::parse_coordinate_pair()
     return Gfx::FloatPoint { x, y };
 }
 
-ErrorOr<Vector<float>> AttributeParser::parse_coordinate_sequence()
+ErrorOr<void> AttributeParser::parse_coordinate_sequence(Function<void(float)> const& callback)
 {
-    Vector<float> sequence;
     bool is_first = true;
     while (true) {
         auto coordinate_or_error = parse_coordinate();
@@ -360,18 +371,17 @@ ErrorOr<Vector<float>> AttributeParser::parse_coordinate_sequence()
             break;
         }
         is_first = false;
-        sequence.append(coordinate_or_error.release_value());
+        callback(coordinate_or_error.release_value());
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_comma_whitespace() && !match_coordinate())
             break;
     }
-    return sequence;
+    return {};
 }
 
-ErrorOr<Vector<Gfx::FloatPoint>> AttributeParser::parse_coordinate_pair_sequence()
+ErrorOr<void> AttributeParser::parse_coordinate_pair_sequence(Function<void(Gfx::FloatPoint)> const& callback)
 {
-    Vector<Gfx::FloatPoint> sequence;
     bool is_first = true;
     while (true) {
         auto coordinate_pair_or_error = parse_coordinate_pair();
@@ -381,13 +391,13 @@ ErrorOr<Vector<Gfx::FloatPoint>> AttributeParser::parse_coordinate_pair_sequence
             break;
         }
         is_first = false;
-        sequence.append(coordinate_pair_or_error.release_value());
+        callback(coordinate_pair_or_error.release_value());
         if (match_comma_whitespace())
             parse_comma_whitespace();
         if (!match_comma_whitespace() && !match_coordinate())
             break;
     }
-    return sequence;
+    return {};
 }
 
 ErrorOr<Vector<Gfx::FloatPoint, 2>> AttributeParser::parse_coordinate_pair_double()

--- a/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Libraries/LibWeb/SVG/AttributeParser.h
@@ -178,12 +178,11 @@ private:
     ErrorOr<Vector<Gfx::FloatPoint>> parse_coordinate_pair_sequence();
     ErrorOr<Vector<Gfx::FloatPoint, 2>> parse_coordinate_pair_double();
     ErrorOr<Vector<Gfx::FloatPoint, 3>> parse_coordinate_pair_triplet();
-    ErrorOr<Vector<float>> parse_elliptical_arc_argument();
     void parse_whitespace(bool must_match_once = false);
     void parse_comma_whitespace();
     ErrorOr<float> parse_number();
     ErrorOr<float> parse_nonnegative_number();
-    ErrorOr<float> parse_flag();
+    ErrorOr<bool> parse_flag();
     // -1 if negative, +1 otherwise
     int parse_sign();
 

--- a/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Libraries/LibWeb/SVG/AttributeParser.h
@@ -174,8 +174,8 @@ private:
     ErrorOr<float> parse_coordinate();
     ErrorOr<i32> parse_integer();
     ErrorOr<Gfx::FloatPoint> parse_coordinate_pair();
-    ErrorOr<Vector<float>> parse_coordinate_sequence();
-    ErrorOr<Vector<Gfx::FloatPoint>> parse_coordinate_pair_sequence();
+    ErrorOr<void> parse_coordinate_sequence(Function<void(float)> const& callback);
+    ErrorOr<void> parse_coordinate_pair_sequence(Function<void(Gfx::FloatPoint)> const& callback);
     ErrorOr<Vector<Gfx::FloatPoint, 2>> parse_coordinate_pair_double();
     ErrorOr<Vector<Gfx::FloatPoint, 3>> parse_coordinate_pair_triplet();
     void parse_whitespace(bool must_match_once = false);

--- a/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Libraries/LibWeb/SVG/AttributeParser.h
@@ -173,11 +173,11 @@ private:
     ErrorOr<float> parse_length();
     ErrorOr<float> parse_coordinate();
     ErrorOr<i32> parse_integer();
-    ErrorOr<Vector<float>> parse_coordinate_pair();
+    ErrorOr<Gfx::FloatPoint> parse_coordinate_pair();
     ErrorOr<Vector<float>> parse_coordinate_sequence();
-    ErrorOr<Vector<Vector<float>>> parse_coordinate_pair_sequence();
-    ErrorOr<Vector<float>> parse_coordinate_pair_double();
-    ErrorOr<Vector<float>> parse_coordinate_pair_triplet();
+    ErrorOr<Vector<Gfx::FloatPoint>> parse_coordinate_pair_sequence();
+    ErrorOr<Vector<Gfx::FloatPoint, 2>> parse_coordinate_pair_double();
+    ErrorOr<Vector<Gfx::FloatPoint, 3>> parse_coordinate_pair_triplet();
     ErrorOr<Vector<float>> parse_elliptical_arc_argument();
     void parse_whitespace(bool must_match_once = false);
     void parse_comma_whitespace();

--- a/Libraries/LibWeb/SVG/Path.cpp
+++ b/Libraries/LibWeb/SVG/Path.cpp
@@ -21,8 +21,8 @@ static void serialize_path_instruction(PathInstruction const& instruction, Strin
             builder.appendff(
                 "{} {} {}",
                 move_to.absolute ? 'M' : 'm',
-                move_to.point[0],
-                move_to.point[1]);
+                move_to.point.x(),
+                move_to.point.y());
         },
         [&](ClosePathInstruction const&) {
             // NB: This is always canonicalized as Z, not z.
@@ -32,8 +32,8 @@ static void serialize_path_instruction(PathInstruction const& instruction, Strin
             builder.appendff(
                 "{} {} {}",
                 line_to.absolute ? 'L' : 'l',
-                line_to.point[0],
-                line_to.point[1]);
+                line_to.point.x(),
+                line_to.point.y());
         },
         [&](HorizontalLineToInstruction const& horizontal_line_to) {
             builder.appendff(
@@ -51,37 +51,37 @@ static void serialize_path_instruction(PathInstruction const& instruction, Strin
             builder.appendff(
                 "{} {} {} {} {} {} {}",
                 curve_to.absolute ? 'C' : 'c',
-                curve_to.control_point_1[0],
-                curve_to.control_point_1[1],
-                curve_to.control_point_2[0],
-                curve_to.control_point_2[1],
-                curve_to.point[0],
-                curve_to.point[1]);
+                curve_to.control_point_1.x(),
+                curve_to.control_point_1.y(),
+                curve_to.control_point_2.x(),
+                curve_to.control_point_2.y(),
+                curve_to.point.x(),
+                curve_to.point.y());
         },
         [&](SmoothCurveToInstruction const& smooth_curve_to) {
             builder.appendff(
                 "{} {} {} {} {}",
                 smooth_curve_to.absolute ? 'S' : 's',
-                smooth_curve_to.control_point_2[0],
-                smooth_curve_to.control_point_2[1],
-                smooth_curve_to.point[0],
-                smooth_curve_to.point[1]);
+                smooth_curve_to.control_point_2.x(),
+                smooth_curve_to.control_point_2.y(),
+                smooth_curve_to.point.x(),
+                smooth_curve_to.point.y());
         },
         [&](QuadraticBezierCurveToInstruction const& quadratic_bezier_curve_to) {
             builder.appendff(
                 "{} {} {} {} {}",
                 quadratic_bezier_curve_to.absolute ? 'Q' : 'q',
-                quadratic_bezier_curve_to.control_point[0],
-                quadratic_bezier_curve_to.control_point[1],
-                quadratic_bezier_curve_to.point[0],
-                quadratic_bezier_curve_to.point[1]);
+                quadratic_bezier_curve_to.control_point.x(),
+                quadratic_bezier_curve_to.control_point.y(),
+                quadratic_bezier_curve_to.point.x(),
+                quadratic_bezier_curve_to.point.y());
         },
         [&](SmoothQuadraticBezierCurveToInstruction const& smooth_quadratic_bezier_curve_to) {
             builder.appendff(
                 "{} {} {}",
                 smooth_quadratic_bezier_curve_to.absolute ? 'T' : 't',
-                smooth_quadratic_bezier_curve_to.point[0],
-                smooth_quadratic_bezier_curve_to.point[1]);
+                smooth_quadratic_bezier_curve_to.point.x(),
+                smooth_quadratic_bezier_curve_to.point.y());
         },
         [&](EllipticalArcInstruction const& elliptical_arc) {
             builder.appendff(
@@ -92,8 +92,8 @@ static void serialize_path_instruction(PathInstruction const& instruction, Strin
                 elliptical_arc.x_axis_rotation,
                 elliptical_arc.large_arc ? 1 : 0,
                 elliptical_arc.sweep ? 1 : 0,
-                elliptical_arc.point[0],
-                elliptical_arc.point[1]);
+                elliptical_arc.point.x(),
+                elliptical_arc.point.y());
         });
 }
 
@@ -102,14 +102,14 @@ static void serialize_path_instruction(PathInstruction const& instruction, Strin
     instruction.visit(
         [](MoveToInstruction const& move_to) {
             dbgln("Move (absolute={})", move_to.absolute);
-            dbgln("    x={}, y={}", move_to.point[0], move_to.point[1]);
+            dbgln("    x={}, y={}", move_to.point.x(), move_to.point.y());
         },
         [](ClosePathInstruction const&) {
             dbgln("ClosePath");
         },
         [](LineToInstruction const& line_to) {
             dbgln("Line (absolute={})", line_to.absolute);
-            dbgln("    x={}, y={}", line_to.point[0], line_to.point[1]);
+            dbgln("    x={}, y={}", line_to.point.x(), line_to.point.y());
         },
         [](HorizontalLineToInstruction const& horizontal_line_to) {
             dbgln("HorizontalLine (absolute={})", horizontal_line_to.absolute);
@@ -121,19 +121,19 @@ static void serialize_path_instruction(PathInstruction const& instruction, Strin
         },
         [](CurveToInstruction const& curve_to) {
             dbgln("Curve (absolute={})", curve_to.absolute);
-            dbgln("    (x1={}, y1={}, x2={}, y2={}), (x={}, y={})", curve_to.control_point_1[0], curve_to.control_point_1[1], curve_to.control_point_2[0], curve_to.control_point_2[1], curve_to.point[0], curve_to.point[1]);
+            dbgln("    (x1={}, y1={}, x2={}, y2={}), (x={}, y={})", curve_to.control_point_1.x(), curve_to.control_point_1.y(), curve_to.control_point_2.x(), curve_to.control_point_2.y(), curve_to.point.x(), curve_to.point.y());
         },
         [](SmoothCurveToInstruction const& smooth_curve_to) {
             dbgln("SmoothCurve (absolute={})", smooth_curve_to.absolute);
-            dbgln("    (x2={}, y2={}), (x={}, y={})", smooth_curve_to.control_point_2[0], smooth_curve_to.control_point_2[1], smooth_curve_to.point[0], smooth_curve_to.point[1]);
+            dbgln("    (x2={}, y2={}), (x={}, y={})", smooth_curve_to.control_point_2.x(), smooth_curve_to.control_point_2.y(), smooth_curve_to.point.x(), smooth_curve_to.point.y());
         },
         [](QuadraticBezierCurveToInstruction const& quadratic_bezier_curve_to) {
             dbgln("QuadraticBezierCurve (absolute={})", quadratic_bezier_curve_to.absolute);
-            dbgln("    (x1={}, y1={}), (x={}, y={})", quadratic_bezier_curve_to.control_point[0], quadratic_bezier_curve_to.control_point[1], quadratic_bezier_curve_to.point[0], quadratic_bezier_curve_to.point[1]);
+            dbgln("    (x1={}, y1={}), (x={}, y={})", quadratic_bezier_curve_to.control_point.x(), quadratic_bezier_curve_to.control_point.y(), quadratic_bezier_curve_to.point.x(), quadratic_bezier_curve_to.point.y());
         },
         [](SmoothQuadraticBezierCurveToInstruction const& smooth_quadratic_bezier_curve_to) {
             dbgln("SmoothQuadraticBezierCurve (absolute={})", smooth_quadratic_bezier_curve_to.absolute);
-            dbgln("    x={}, y={}", smooth_quadratic_bezier_curve_to.point[0], smooth_quadratic_bezier_curve_to.point[1]);
+            dbgln("    x={}, y={}", smooth_quadratic_bezier_curve_to.point.x(), smooth_quadratic_bezier_curve_to.point.y());
         },
         [](EllipticalArcInstruction const& elliptical_arc) {
             dbgln("EllipticalArc (absolute={})", elliptical_arc.absolute);
@@ -143,8 +143,8 @@ static void serialize_path_instruction(PathInstruction const& instruction, Strin
                 elliptical_arc.x_axis_rotation,
                 elliptical_arc.large_arc,
                 elliptical_arc.sweep,
-                elliptical_arc.point[0],
-                elliptical_arc.point[1]);
+                elliptical_arc.point.x(),
+                elliptical_arc.point.y());
         });
 }
 
@@ -166,22 +166,20 @@ Gfx::Path Path::to_gfx_path() const
 
         instruction.visit(
             [&](MoveToInstruction const& move_to_instruction) {
-                Gfx::FloatPoint point = { move_to_instruction.point[0], move_to_instruction.point[1] };
                 if (move_to_instruction.absolute) {
-                    path.move_to(point);
+                    path.move_to(move_to_instruction.point);
                 } else {
-                    path.move_to(point + last_point);
+                    path.move_to(move_to_instruction.point + last_point);
                 }
             },
             [&](ClosePathInstruction const&) {
                 path.close();
             },
             [&](LineToInstruction const& line_to_instruction) {
-                Gfx::FloatPoint point = { line_to_instruction.point[0], line_to_instruction.point[1] };
                 if (line_to_instruction.absolute) {
-                    path.line_to(point);
+                    path.line_to(line_to_instruction.point);
                 } else {
-                    path.line_to(point + last_point);
+                    path.line_to(line_to_instruction.point + last_point);
                 }
             },
             [&](HorizontalLineToInstruction const& horizontal_line_to_instruction) {
@@ -202,24 +200,21 @@ Gfx::Path Path::to_gfx_path() const
                 Gfx::FloatPoint next_point;
 
                 if (elliptical_arc_instruction.absolute)
-                    next_point = { elliptical_arc_instruction.point[0], elliptical_arc_instruction.point[1] };
+                    next_point = elliptical_arc_instruction.point;
                 else
-                    next_point = { elliptical_arc_instruction.point[0] + last_point.x(), elliptical_arc_instruction.point[1] + last_point.y() };
+                    next_point = elliptical_arc_instruction.point + last_point;
 
                 path.elliptical_arc_to(next_point, { elliptical_arc_instruction.rx, elliptical_arc_instruction.ry }, x_axis_rotation, elliptical_arc_instruction.large_arc, elliptical_arc_instruction.sweep);
             },
             [&](QuadraticBezierCurveToInstruction const& quadratic_bezier_curve_to_instruction) {
                 clear_last_control_point = false;
 
-                Gfx::FloatPoint through = { quadratic_bezier_curve_to_instruction.control_point[0], quadratic_bezier_curve_to_instruction.control_point[1] };
-                Gfx::FloatPoint point = { quadratic_bezier_curve_to_instruction.point[0], quadratic_bezier_curve_to_instruction.point[1] };
-
                 if (quadratic_bezier_curve_to_instruction.absolute) {
-                    path.quadratic_bezier_curve_to(through, point);
-                    previous_control_point = through;
+                    path.quadratic_bezier_curve_to(quadratic_bezier_curve_to_instruction.control_point, quadratic_bezier_curve_to_instruction.point);
+                    previous_control_point = quadratic_bezier_curve_to_instruction.control_point;
                 } else {
-                    auto control_point = through + last_point;
-                    path.quadratic_bezier_curve_to(control_point, point + last_point);
+                    auto control_point = quadratic_bezier_curve_to_instruction.control_point + last_point;
+                    path.quadratic_bezier_curve_to(control_point, quadratic_bezier_curve_to_instruction.point + last_point);
                     previous_control_point = control_point;
                 }
             },
@@ -235,12 +230,10 @@ Gfx::Path Path::to_gfx_path() const
                 auto dy_end_control = last_point.dy_relative_to(previous_control_point.value());
                 auto control_point = Gfx::FloatPoint { last_point.x() + dx_end_control, last_point.y() + dy_end_control };
 
-                Gfx::FloatPoint end_point = { smooth_quadratic_bezier_curve_to_instruction.point[0], smooth_quadratic_bezier_curve_to_instruction.point[1] };
-
                 if (smooth_quadratic_bezier_curve_to_instruction.absolute) {
-                    path.quadratic_bezier_curve_to(control_point, end_point);
+                    path.quadratic_bezier_curve_to(control_point, smooth_quadratic_bezier_curve_to_instruction.point);
                 } else {
-                    path.quadratic_bezier_curve_to(control_point, end_point + last_point);
+                    path.quadratic_bezier_curve_to(control_point, smooth_quadratic_bezier_curve_to_instruction.point + last_point);
                 }
 
                 previous_control_point = control_point;
@@ -248,9 +241,9 @@ Gfx::Path Path::to_gfx_path() const
             [&](CurveToInstruction const& curve_to_instruction) {
                 clear_last_control_point = false;
 
-                Gfx::FloatPoint c1 = { curve_to_instruction.control_point_1[0], curve_to_instruction.control_point_1[1] };
-                Gfx::FloatPoint c2 = { curve_to_instruction.control_point_2[0], curve_to_instruction.control_point_2[1] };
-                Gfx::FloatPoint p2 = { curve_to_instruction.point[0], curve_to_instruction.point[1] };
+                Gfx::FloatPoint c1 = curve_to_instruction.control_point_1;
+                Gfx::FloatPoint c2 = curve_to_instruction.control_point_2;
+                Gfx::FloatPoint p2 = curve_to_instruction.point;
 
                 if (!curve_to_instruction.absolute) {
                     p2 += last_point;
@@ -275,8 +268,8 @@ Gfx::Path Path::to_gfx_path() const
                 auto reflected_previous_control_x = last_point.x() - previous_control_point.value().dx_relative_to(last_point);
                 auto reflected_previous_control_y = last_point.y() - previous_control_point.value().dy_relative_to(last_point);
                 Gfx::FloatPoint c1 = Gfx::FloatPoint { reflected_previous_control_x, reflected_previous_control_y };
-                Gfx::FloatPoint c2 = { smooth_curve_to_instruction.control_point_2[0], smooth_curve_to_instruction.control_point_2[1] };
-                Gfx::FloatPoint p2 = { smooth_curve_to_instruction.point[0], smooth_curve_to_instruction.point[1] };
+                Gfx::FloatPoint c2 = smooth_curve_to_instruction.control_point_2;
+                Gfx::FloatPoint p2 = smooth_curve_to_instruction.point;
                 if (!smooth_curve_to_instruction.absolute) {
                     p2 += last_point;
                     c2 += last_point;

--- a/Libraries/LibWeb/SVG/Path.cpp
+++ b/Libraries/LibWeb/SVG/Path.cpp
@@ -61,58 +61,49 @@ void PathInstruction::dump() const
     switch (type) {
     case PathInstructionType::Move:
         dbgln("Move (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); i += 2)
-            dbgln("    x={}, y={}", data[i], data[i + 1]);
+        dbgln("    x={}, y={}", data[0], data[1]);
         break;
     case PathInstructionType::ClosePath:
-        dbgln("ClosePath (absolute={})", absolute);
+        dbgln("ClosePath");
         break;
     case PathInstructionType::Line:
         dbgln("Line (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); i += 2)
-            dbgln("    x={}, y={}", data[i], data[i + 1]);
+        dbgln("    x={}, y={}", data[0], data[1]);
         break;
     case PathInstructionType::HorizontalLine:
         dbgln("HorizontalLine (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); ++i)
-            dbgln("    x={}", data[i]);
+        dbgln("    x={}", data[0]);
         break;
     case PathInstructionType::VerticalLine:
         dbgln("VerticalLine (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); ++i)
-            dbgln("    y={}", data[i]);
+        dbgln("    y={}", data[0]);
         break;
     case PathInstructionType::Curve:
         dbgln("Curve (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); i += 6)
-            dbgln("    (x1={}, y1={}, x2={}, y2={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3], data[i + 4], data[i + 5]);
+        dbgln("    (x1={}, y1={}, x2={}, y2={}), (x={}, y={})", data[0], data[1], data[2], data[3], data[4], data[5]);
         break;
     case PathInstructionType::SmoothCurve:
         dbgln("SmoothCurve (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); i += 4)
-            dbgln("    (x2={}, y2={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3]);
+        dbgln("    (x2={}, y2={}), (x={}, y={})", data[0], data[1], data[2], data[3]);
         break;
     case PathInstructionType::QuadraticBezierCurve:
         dbgln("QuadraticBezierCurve (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); i += 4)
-            dbgln("    (x1={}, y1={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3]);
+        dbgln("    (x1={}, y1={}), (x={}, y={})", data[0], data[1], data[2], data[3]);
         break;
     case PathInstructionType::SmoothQuadraticBezierCurve:
         dbgln("SmoothQuadraticBezierCurve (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); i += 2)
-            dbgln("    x={}, y={}", data[i], data[i + 1]);
+        dbgln("    x={}, y={}", data[0], data[1]);
         break;
     case PathInstructionType::EllipticalArc:
         dbgln("EllipticalArc (absolute={})", absolute);
-        for (size_t i = 0; i < data.size(); i += 7)
-            dbgln("    (rx={}, ry={}) x-axis-rotation={}, large-arc-flag={}, sweep-flag={}, (x={}, y={})",
-                data[i],
-                data[i + 1],
-                data[i + 2],
-                data[i + 3],
-                data[i + 4],
-                data[i + 5],
-                data[i + 6]);
+        dbgln("    (rx={}, ry={}) x-axis-rotation={}, large-arc-flag={}, sweep-flag={}, (x={}, y={})",
+            data[0],
+            data[1],
+            data[2],
+            data[3],
+            data[4],
+            data[5],
+            data[6]);
         break;
     case PathInstructionType::Invalid:
         dbgln("Invalid");

--- a/Libraries/LibWeb/SVG/Path.cpp
+++ b/Libraries/LibWeb/SVG/Path.cpp
@@ -14,266 +14,282 @@
 
 namespace Web::SVG {
 
-void PathInstruction::serialize(StringBuilder& builder) const
+static void serialize_path_instruction(PathInstruction const& instruction, StringBuilder& builder)
 {
-    switch (type) {
-    case PathInstructionType::Move:
-        builder.append(absolute ? 'M' : 'm');
-        break;
-    case PathInstructionType::ClosePath:
-        // NB: This is always canonicalized as Z, not z.
-        builder.append('Z');
-        break;
-    case PathInstructionType::Line:
-        builder.append(absolute ? 'L' : 'l');
-        break;
-    case PathInstructionType::HorizontalLine:
-        builder.append(absolute ? 'H' : 'h');
-        break;
-    case PathInstructionType::VerticalLine:
-        builder.append(absolute ? 'V' : 'v');
-        break;
-    case PathInstructionType::Curve:
-        builder.append(absolute ? 'C' : 'c');
-        break;
-    case PathInstructionType::SmoothCurve:
-        builder.append(absolute ? 'S' : 's');
-        break;
-    case PathInstructionType::QuadraticBezierCurve:
-        builder.append(absolute ? 'Q' : 'q');
-        break;
-    case PathInstructionType::SmoothQuadraticBezierCurve:
-        builder.append(absolute ? 'T' : 't');
-        break;
-    case PathInstructionType::EllipticalArc:
-        builder.append(absolute ? 'A' : 'a');
-        break;
-    case PathInstructionType::Invalid:
-        break;
-    }
-
-    for (auto const& value : data)
-        builder.appendff(" {}", value);
+    instruction.visit(
+        [&](MoveToInstruction const& move_to) {
+            builder.appendff(
+                "{} {} {}",
+                move_to.absolute ? 'M' : 'm',
+                move_to.point[0],
+                move_to.point[1]);
+        },
+        [&](ClosePathInstruction const&) {
+            // NB: This is always canonicalized as Z, not z.
+            builder.append('Z');
+        },
+        [&](LineToInstruction const& line_to) {
+            builder.appendff(
+                "{} {} {}",
+                line_to.absolute ? 'L' : 'l',
+                line_to.point[0],
+                line_to.point[1]);
+        },
+        [&](HorizontalLineToInstruction const& horizontal_line_to) {
+            builder.appendff(
+                "{} {}",
+                horizontal_line_to.absolute ? 'H' : 'h',
+                horizontal_line_to.x);
+        },
+        [&](VerticalLineToInstruction const& vertical_line_to) {
+            builder.appendff(
+                "{} {}",
+                vertical_line_to.absolute ? 'V' : 'v',
+                vertical_line_to.y);
+        },
+        [&](CurveToInstruction const& curve_to) {
+            builder.appendff(
+                "{} {} {} {} {} {} {}",
+                curve_to.absolute ? 'C' : 'c',
+                curve_to.control_point_1[0],
+                curve_to.control_point_1[1],
+                curve_to.control_point_2[0],
+                curve_to.control_point_2[1],
+                curve_to.point[0],
+                curve_to.point[1]);
+        },
+        [&](SmoothCurveToInstruction const& smooth_curve_to) {
+            builder.appendff(
+                "{} {} {} {} {}",
+                smooth_curve_to.absolute ? 'S' : 's',
+                smooth_curve_to.control_point_2[0],
+                smooth_curve_to.control_point_2[1],
+                smooth_curve_to.point[0],
+                smooth_curve_to.point[1]);
+        },
+        [&](QuadraticBezierCurveToInstruction const& quadratic_bezier_curve_to) {
+            builder.appendff(
+                "{} {} {} {} {}",
+                quadratic_bezier_curve_to.absolute ? 'Q' : 'q',
+                quadratic_bezier_curve_to.control_point[0],
+                quadratic_bezier_curve_to.control_point[1],
+                quadratic_bezier_curve_to.point[0],
+                quadratic_bezier_curve_to.point[1]);
+        },
+        [&](SmoothQuadraticBezierCurveToInstruction const& smooth_quadratic_bezier_curve_to) {
+            builder.appendff(
+                "{} {} {}",
+                smooth_quadratic_bezier_curve_to.absolute ? 'T' : 't',
+                smooth_quadratic_bezier_curve_to.point[0],
+                smooth_quadratic_bezier_curve_to.point[1]);
+        },
+        [&](EllipticalArcInstruction const& elliptical_arc) {
+            builder.appendff(
+                "{} {} {} {} {} {} {} {}",
+                elliptical_arc.absolute ? 'A' : 'a',
+                elliptical_arc.rx,
+                elliptical_arc.ry,
+                elliptical_arc.x_axis_rotation,
+                elliptical_arc.large_arc ? 1 : 0,
+                elliptical_arc.sweep ? 1 : 0,
+                elliptical_arc.point[0],
+                elliptical_arc.point[1]);
+        });
 }
 
-void PathInstruction::dump() const
+[[maybe_unused]] static void dump_path_instruction(PathInstruction const& instruction)
 {
-    switch (type) {
-    case PathInstructionType::Move:
-        dbgln("Move (absolute={})", absolute);
-        dbgln("    x={}, y={}", data[0], data[1]);
-        break;
-    case PathInstructionType::ClosePath:
-        dbgln("ClosePath");
-        break;
-    case PathInstructionType::Line:
-        dbgln("Line (absolute={})", absolute);
-        dbgln("    x={}, y={}", data[0], data[1]);
-        break;
-    case PathInstructionType::HorizontalLine:
-        dbgln("HorizontalLine (absolute={})", absolute);
-        dbgln("    x={}", data[0]);
-        break;
-    case PathInstructionType::VerticalLine:
-        dbgln("VerticalLine (absolute={})", absolute);
-        dbgln("    y={}", data[0]);
-        break;
-    case PathInstructionType::Curve:
-        dbgln("Curve (absolute={})", absolute);
-        dbgln("    (x1={}, y1={}, x2={}, y2={}), (x={}, y={})", data[0], data[1], data[2], data[3], data[4], data[5]);
-        break;
-    case PathInstructionType::SmoothCurve:
-        dbgln("SmoothCurve (absolute={})", absolute);
-        dbgln("    (x2={}, y2={}), (x={}, y={})", data[0], data[1], data[2], data[3]);
-        break;
-    case PathInstructionType::QuadraticBezierCurve:
-        dbgln("QuadraticBezierCurve (absolute={})", absolute);
-        dbgln("    (x1={}, y1={}), (x={}, y={})", data[0], data[1], data[2], data[3]);
-        break;
-    case PathInstructionType::SmoothQuadraticBezierCurve:
-        dbgln("SmoothQuadraticBezierCurve (absolute={})", absolute);
-        dbgln("    x={}, y={}", data[0], data[1]);
-        break;
-    case PathInstructionType::EllipticalArc:
-        dbgln("EllipticalArc (absolute={})", absolute);
-        dbgln("    (rx={}, ry={}) x-axis-rotation={}, large-arc-flag={}, sweep-flag={}, (x={}, y={})",
-            data[0],
-            data[1],
-            data[2],
-            data[3],
-            data[4],
-            data[5],
-            data[6]);
-        break;
-    case PathInstructionType::Invalid:
-        dbgln("Invalid");
-        break;
-    }
+    instruction.visit(
+        [](MoveToInstruction const& move_to) {
+            dbgln("Move (absolute={})", move_to.absolute);
+            dbgln("    x={}, y={}", move_to.point[0], move_to.point[1]);
+        },
+        [](ClosePathInstruction const&) {
+            dbgln("ClosePath");
+        },
+        [](LineToInstruction const& line_to) {
+            dbgln("Line (absolute={})", line_to.absolute);
+            dbgln("    x={}, y={}", line_to.point[0], line_to.point[1]);
+        },
+        [](HorizontalLineToInstruction const& horizontal_line_to) {
+            dbgln("HorizontalLine (absolute={})", horizontal_line_to.absolute);
+            dbgln("    x={}", horizontal_line_to.x);
+        },
+        [](VerticalLineToInstruction const& vertical_line_to) {
+            dbgln("VerticalLine (absolute={})", vertical_line_to.absolute);
+            dbgln("    y={}", vertical_line_to.y);
+        },
+        [](CurveToInstruction const& curve_to) {
+            dbgln("Curve (absolute={})", curve_to.absolute);
+            dbgln("    (x1={}, y1={}, x2={}, y2={}), (x={}, y={})", curve_to.control_point_1[0], curve_to.control_point_1[1], curve_to.control_point_2[0], curve_to.control_point_2[1], curve_to.point[0], curve_to.point[1]);
+        },
+        [](SmoothCurveToInstruction const& smooth_curve_to) {
+            dbgln("SmoothCurve (absolute={})", smooth_curve_to.absolute);
+            dbgln("    (x2={}, y2={}), (x={}, y={})", smooth_curve_to.control_point_2[0], smooth_curve_to.control_point_2[1], smooth_curve_to.point[0], smooth_curve_to.point[1]);
+        },
+        [](QuadraticBezierCurveToInstruction const& quadratic_bezier_curve_to) {
+            dbgln("QuadraticBezierCurve (absolute={})", quadratic_bezier_curve_to.absolute);
+            dbgln("    (x1={}, y1={}), (x={}, y={})", quadratic_bezier_curve_to.control_point[0], quadratic_bezier_curve_to.control_point[1], quadratic_bezier_curve_to.point[0], quadratic_bezier_curve_to.point[1]);
+        },
+        [](SmoothQuadraticBezierCurveToInstruction const& smooth_quadratic_bezier_curve_to) {
+            dbgln("SmoothQuadraticBezierCurve (absolute={})", smooth_quadratic_bezier_curve_to.absolute);
+            dbgln("    x={}, y={}", smooth_quadratic_bezier_curve_to.point[0], smooth_quadratic_bezier_curve_to.point[1]);
+        },
+        [](EllipticalArcInstruction const& elliptical_arc) {
+            dbgln("EllipticalArc (absolute={})", elliptical_arc.absolute);
+            dbgln("    (rx={}, ry={}) x-axis-rotation={}, large-arc-flag={}, sweep-flag={}, (x={}, y={})",
+                elliptical_arc.rx,
+                elliptical_arc.ry,
+                elliptical_arc.x_axis_rotation,
+                elliptical_arc.large_arc,
+                elliptical_arc.sweep,
+                elliptical_arc.point[0],
+                elliptical_arc.point[1]);
+        });
 }
 
 Gfx::Path Path::to_gfx_path() const
 {
     Gfx::Path path;
     Optional<Gfx::FloatPoint> previous_control_point;
-    PathInstructionType last_instruction = PathInstructionType::Invalid;
+    PathInstruction const* last_instruction = nullptr;
 
     for (auto& instruction : m_instructions) {
         // If the first path element uses relative coordinates, we treat them as absolute by making them relative to (0, 0).
         auto last_point = path.last_point();
 
-        auto& absolute = instruction.absolute;
-        auto& data = instruction.data;
-
         if constexpr (PATH_DEBUG) {
-            instruction.dump();
+            dump_path_instruction(instruction);
         }
 
         bool clear_last_control_point = true;
 
-        switch (instruction.type) {
-        case PathInstructionType::Move: {
-            Gfx::FloatPoint point = { data[0], data[1] };
-            if (absolute) {
-                path.move_to(point);
-            } else {
-                path.move_to(point + last_point);
-            }
-            break;
-        }
-        case PathInstructionType::ClosePath:
-            path.close();
-            break;
-        case PathInstructionType::Line: {
-            Gfx::FloatPoint point = { data[0], data[1] };
-            if (absolute) {
-                path.line_to(point);
-            } else {
-                path.line_to(point + last_point);
-            }
-            break;
-        }
-        case PathInstructionType::HorizontalLine: {
-            if (absolute)
-                path.line_to(Gfx::FloatPoint { data[0], last_point.y() });
-            else
-                path.line_to(Gfx::FloatPoint { data[0] + last_point.x(), last_point.y() });
-            break;
-        }
-        case PathInstructionType::VerticalLine: {
-            if (absolute)
-                path.line_to(Gfx::FloatPoint { last_point.x(), data[0] });
-            else
-                path.line_to(Gfx::FloatPoint { last_point.x(), data[0] + last_point.y() });
-            break;
-        }
-        case PathInstructionType::EllipticalArc: {
-            double rx = data[0];
-            double ry = data[1];
-            double x_axis_rotation = AK::to_radians(static_cast<double>(data[2]));
-            double large_arc_flag = data[3];
-            double sweep_flag = data[4];
+        instruction.visit(
+            [&](MoveToInstruction const& move_to_instruction) {
+                Gfx::FloatPoint point = { move_to_instruction.point[0], move_to_instruction.point[1] };
+                if (move_to_instruction.absolute) {
+                    path.move_to(point);
+                } else {
+                    path.move_to(point + last_point);
+                }
+            },
+            [&](ClosePathInstruction const&) {
+                path.close();
+            },
+            [&](LineToInstruction const& line_to_instruction) {
+                Gfx::FloatPoint point = { line_to_instruction.point[0], line_to_instruction.point[1] };
+                if (line_to_instruction.absolute) {
+                    path.line_to(point);
+                } else {
+                    path.line_to(point + last_point);
+                }
+            },
+            [&](HorizontalLineToInstruction const& horizontal_line_to_instruction) {
+                if (horizontal_line_to_instruction.absolute)
+                    path.line_to(Gfx::FloatPoint { horizontal_line_to_instruction.x, last_point.y() });
+                else
+                    path.line_to(Gfx::FloatPoint { horizontal_line_to_instruction.x + last_point.x(), last_point.y() });
+            },
+            [&](VerticalLineToInstruction const& vertical_line_to_instruction) {
+                if (vertical_line_to_instruction.absolute)
+                    path.line_to(Gfx::FloatPoint { last_point.x(), vertical_line_to_instruction.y });
+                else
+                    path.line_to(Gfx::FloatPoint { last_point.x(), vertical_line_to_instruction.y + last_point.y() });
+            },
+            [&](EllipticalArcInstruction const& elliptical_arc_instruction) {
+                auto x_axis_rotation = AK::to_radians(static_cast<double>(elliptical_arc_instruction.x_axis_rotation));
 
-            Gfx::FloatPoint next_point;
+                Gfx::FloatPoint next_point;
 
-            if (absolute)
-                next_point = { data[5], data[6] };
-            else
-                next_point = { data[5] + last_point.x(), data[6] + last_point.y() };
+                if (elliptical_arc_instruction.absolute)
+                    next_point = { elliptical_arc_instruction.point[0], elliptical_arc_instruction.point[1] };
+                else
+                    next_point = { elliptical_arc_instruction.point[0] + last_point.x(), elliptical_arc_instruction.point[1] + last_point.y() };
 
-            path.elliptical_arc_to(next_point, { rx, ry }, x_axis_rotation, large_arc_flag != 0, sweep_flag != 0);
-            break;
-        }
-        case PathInstructionType::QuadraticBezierCurve: {
-            clear_last_control_point = false;
+                path.elliptical_arc_to(next_point, { elliptical_arc_instruction.rx, elliptical_arc_instruction.ry }, x_axis_rotation, elliptical_arc_instruction.large_arc, elliptical_arc_instruction.sweep);
+            },
+            [&](QuadraticBezierCurveToInstruction const& quadratic_bezier_curve_to_instruction) {
+                clear_last_control_point = false;
 
-            Gfx::FloatPoint through = { data[0], data[1] };
-            Gfx::FloatPoint point = { data[2], data[3] };
+                Gfx::FloatPoint through = { quadratic_bezier_curve_to_instruction.control_point[0], quadratic_bezier_curve_to_instruction.control_point[1] };
+                Gfx::FloatPoint point = { quadratic_bezier_curve_to_instruction.point[0], quadratic_bezier_curve_to_instruction.point[1] };
 
-            if (absolute) {
-                path.quadratic_bezier_curve_to(through, point);
-                previous_control_point = through;
-            } else {
-                auto control_point = through + last_point;
-                path.quadratic_bezier_curve_to(control_point, point + last_point);
+                if (quadratic_bezier_curve_to_instruction.absolute) {
+                    path.quadratic_bezier_curve_to(through, point);
+                    previous_control_point = through;
+                } else {
+                    auto control_point = through + last_point;
+                    path.quadratic_bezier_curve_to(control_point, point + last_point);
+                    previous_control_point = control_point;
+                }
+            },
+            [&](SmoothQuadraticBezierCurveToInstruction const& smooth_quadratic_bezier_curve_to_instruction) {
+                clear_last_control_point = false;
+
+                if (!previous_control_point.has_value()
+                    || (!last_instruction || (!last_instruction->has<QuadraticBezierCurveToInstruction>() && !last_instruction->has<SmoothQuadraticBezierCurveToInstruction>()))) {
+                    previous_control_point = last_point;
+                }
+
+                auto dx_end_control = last_point.dx_relative_to(previous_control_point.value());
+                auto dy_end_control = last_point.dy_relative_to(previous_control_point.value());
+                auto control_point = Gfx::FloatPoint { last_point.x() + dx_end_control, last_point.y() + dy_end_control };
+
+                Gfx::FloatPoint end_point = { smooth_quadratic_bezier_curve_to_instruction.point[0], smooth_quadratic_bezier_curve_to_instruction.point[1] };
+
+                if (smooth_quadratic_bezier_curve_to_instruction.absolute) {
+                    path.quadratic_bezier_curve_to(control_point, end_point);
+                } else {
+                    path.quadratic_bezier_curve_to(control_point, end_point + last_point);
+                }
+
                 previous_control_point = control_point;
-            }
-            break;
-        }
-        case PathInstructionType::SmoothQuadraticBezierCurve: {
-            clear_last_control_point = false;
+            },
+            [&](CurveToInstruction const& curve_to_instruction) {
+                clear_last_control_point = false;
 
-            if (!previous_control_point.has_value()
-                || ((last_instruction != PathInstructionType::QuadraticBezierCurve) && (last_instruction != PathInstructionType::SmoothQuadraticBezierCurve))) {
-                previous_control_point = last_point;
-            }
+                Gfx::FloatPoint c1 = { curve_to_instruction.control_point_1[0], curve_to_instruction.control_point_1[1] };
+                Gfx::FloatPoint c2 = { curve_to_instruction.control_point_2[0], curve_to_instruction.control_point_2[1] };
+                Gfx::FloatPoint p2 = { curve_to_instruction.point[0], curve_to_instruction.point[1] };
 
-            auto dx_end_control = last_point.dx_relative_to(previous_control_point.value());
-            auto dy_end_control = last_point.dy_relative_to(previous_control_point.value());
-            auto control_point = Gfx::FloatPoint { last_point.x() + dx_end_control, last_point.y() + dy_end_control };
+                if (!curve_to_instruction.absolute) {
+                    p2 += last_point;
+                    c1 += last_point;
+                    c2 += last_point;
+                }
+                path.cubic_bezier_curve_to(c1, c2, p2);
+                previous_control_point = c2;
+            },
+            [&](SmoothCurveToInstruction const& smooth_curve_to_instruction) {
+                clear_last_control_point = false;
 
-            Gfx::FloatPoint end_point = { data[0], data[1] };
+                if (!previous_control_point.has_value()
+                    || (!last_instruction || (!last_instruction->has<CurveToInstruction>() && !last_instruction->has<SmoothCurveToInstruction>()))) {
+                    previous_control_point = last_point;
+                }
 
-            if (absolute) {
-                path.quadratic_bezier_curve_to(control_point, end_point);
-            } else {
-                path.quadratic_bezier_curve_to(control_point, end_point + last_point);
-            }
+                // 9.5.2. Reflected control points https://svgwg.org/svg2-draft/paths.html#ReflectedControlPoints
+                // If the current point is (curx, cury) and the final control point of the previous path segment is (oldx2, oldy2),
+                // then the reflected point (i.e., (newx1, newy1), the first control point of the current path segment) is:
+                // (newx1, newy1) = (curx - (oldx2 - curx), cury - (oldy2 - cury))
+                auto reflected_previous_control_x = last_point.x() - previous_control_point.value().dx_relative_to(last_point);
+                auto reflected_previous_control_y = last_point.y() - previous_control_point.value().dy_relative_to(last_point);
+                Gfx::FloatPoint c1 = Gfx::FloatPoint { reflected_previous_control_x, reflected_previous_control_y };
+                Gfx::FloatPoint c2 = { smooth_curve_to_instruction.control_point_2[0], smooth_curve_to_instruction.control_point_2[1] };
+                Gfx::FloatPoint p2 = { smooth_curve_to_instruction.point[0], smooth_curve_to_instruction.point[1] };
+                if (!smooth_curve_to_instruction.absolute) {
+                    p2 += last_point;
+                    c2 += last_point;
+                }
+                path.cubic_bezier_curve_to(c1, c2, p2);
 
-            previous_control_point = control_point;
-            break;
-        }
-
-        case PathInstructionType::Curve: {
-            clear_last_control_point = false;
-
-            Gfx::FloatPoint c1 = { data[0], data[1] };
-            Gfx::FloatPoint c2 = { data[2], data[3] };
-            Gfx::FloatPoint p2 = { data[4], data[5] };
-            if (!absolute) {
-                p2 += last_point;
-                c1 += last_point;
-                c2 += last_point;
-            }
-            path.cubic_bezier_curve_to(c1, c2, p2);
-
-            previous_control_point = c2;
-            break;
-        }
-
-        case PathInstructionType::SmoothCurve: {
-            clear_last_control_point = false;
-
-            if (!previous_control_point.has_value()
-                || ((last_instruction != PathInstructionType::Curve) && (last_instruction != PathInstructionType::SmoothCurve))) {
-                previous_control_point = last_point;
-            }
-
-            // 9.5.2. Reflected control points https://svgwg.org/svg2-draft/paths.html#ReflectedControlPoints
-            // If the current point is (curx, cury) and the final control point of the previous path segment is (oldx2, oldy2),
-            // then the reflected point (i.e., (newx1, newy1), the first control point of the current path segment) is:
-            // (newx1, newy1) = (curx - (oldx2 - curx), cury - (oldy2 - cury))
-            auto reflected_previous_control_x = last_point.x() - previous_control_point.value().dx_relative_to(last_point);
-            auto reflected_previous_control_y = last_point.y() - previous_control_point.value().dy_relative_to(last_point);
-            Gfx::FloatPoint c1 = Gfx::FloatPoint { reflected_previous_control_x, reflected_previous_control_y };
-            Gfx::FloatPoint c2 = { data[0], data[1] };
-            Gfx::FloatPoint p2 = { data[2], data[3] };
-            if (!absolute) {
-                p2 += last_point;
-                c2 += last_point;
-            }
-            path.cubic_bezier_curve_to(c1, c2, p2);
-
-            previous_control_point = c2;
-            break;
-        }
-        case PathInstructionType::Invalid:
-            VERIFY_NOT_REACHED();
-        }
+                previous_control_point = c2;
+            });
 
         if (clear_last_control_point) {
             previous_control_point = Gfx::FloatPoint {};
         }
-        last_instruction = instruction.type;
+        last_instruction = &instruction;
     }
 
     return path;
@@ -289,7 +305,7 @@ String Path::serialize() const
         } else {
             builder.append(' ');
         }
-        instruction.serialize(builder);
+        serialize_path_instruction(instruction, builder);
     }
     return builder.to_string_without_validation();
 }

--- a/Libraries/LibWeb/SVG/Path.h
+++ b/Libraries/LibWeb/SVG/Path.h
@@ -18,7 +18,7 @@ namespace Web::SVG {
 
 struct MoveToInstruction {
     bool absolute;
-    Vector<float> point;
+    Gfx::FloatPoint point;
 
     bool operator==(MoveToInstruction const&) const = default;
 };
@@ -29,7 +29,7 @@ struct ClosePathInstruction {
 
 struct LineToInstruction {
     bool absolute;
-    Vector<float> point;
+    Gfx::FloatPoint point;
 
     bool operator==(LineToInstruction const&) const = default;
 };
@@ -50,32 +50,32 @@ struct VerticalLineToInstruction {
 
 struct CurveToInstruction {
     bool absolute;
-    Vector<float> control_point_1;
-    Vector<float> control_point_2;
-    Vector<float> point;
+    Gfx::FloatPoint control_point_1;
+    Gfx::FloatPoint control_point_2;
+    Gfx::FloatPoint point;
 
     bool operator==(CurveToInstruction const&) const = default;
 };
 
 struct SmoothCurveToInstruction {
     bool absolute;
-    Vector<float> control_point_2;
-    Vector<float> point;
+    Gfx::FloatPoint control_point_2;
+    Gfx::FloatPoint point;
 
     bool operator==(SmoothCurveToInstruction const&) const = default;
 };
 
 struct QuadraticBezierCurveToInstruction {
     bool absolute;
-    Vector<float> control_point;
-    Vector<float> point;
+    Gfx::FloatPoint control_point;
+    Gfx::FloatPoint point;
 
     bool operator==(QuadraticBezierCurveToInstruction const&) const = default;
 };
 
 struct SmoothQuadraticBezierCurveToInstruction {
     bool absolute;
-    Vector<float> point;
+    Gfx::FloatPoint point;
 
     bool operator==(SmoothQuadraticBezierCurveToInstruction const&) const = default;
 };
@@ -87,7 +87,7 @@ struct EllipticalArcInstruction {
     bool absolute;
     bool large_arc;
     bool sweep;
-    Vector<float> point;
+    Gfx::FloatPoint point;
 
     bool operator==(EllipticalArcInstruction const&) const = default;
 };

--- a/Libraries/LibWeb/SVG/Path.h
+++ b/Libraries/LibWeb/SVG/Path.h
@@ -12,34 +12,87 @@
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/Point.h>
 
 namespace Web::SVG {
 
-enum class PathInstructionType : u8 {
-    Move,
-    ClosePath,
-    Line,
-    HorizontalLine,
-    VerticalLine,
-    Curve,
-    SmoothCurve,
-    QuadraticBezierCurve,
-    SmoothQuadraticBezierCurve,
-    EllipticalArc,
-    Invalid,
-};
-
-struct PathInstruction {
-    PathInstructionType type;
+struct MoveToInstruction {
     bool absolute;
-    Vector<float> data;
+    Vector<float> point;
 
-    bool operator==(PathInstruction const&) const = default;
-
-    void serialize(StringBuilder&) const;
-
-    void dump() const;
+    bool operator==(MoveToInstruction const&) const = default;
 };
+
+struct ClosePathInstruction {
+    bool operator==(ClosePathInstruction const&) const = default;
+};
+
+struct LineToInstruction {
+    bool absolute;
+    Vector<float> point;
+
+    bool operator==(LineToInstruction const&) const = default;
+};
+
+struct HorizontalLineToInstruction {
+    bool absolute;
+    float x;
+
+    bool operator==(HorizontalLineToInstruction const&) const = default;
+};
+
+struct VerticalLineToInstruction {
+    bool absolute;
+    float y;
+
+    bool operator==(VerticalLineToInstruction const&) const = default;
+};
+
+struct CurveToInstruction {
+    bool absolute;
+    Vector<float> control_point_1;
+    Vector<float> control_point_2;
+    Vector<float> point;
+
+    bool operator==(CurveToInstruction const&) const = default;
+};
+
+struct SmoothCurveToInstruction {
+    bool absolute;
+    Vector<float> control_point_2;
+    Vector<float> point;
+
+    bool operator==(SmoothCurveToInstruction const&) const = default;
+};
+
+struct QuadraticBezierCurveToInstruction {
+    bool absolute;
+    Vector<float> control_point;
+    Vector<float> point;
+
+    bool operator==(QuadraticBezierCurveToInstruction const&) const = default;
+};
+
+struct SmoothQuadraticBezierCurveToInstruction {
+    bool absolute;
+    Vector<float> point;
+
+    bool operator==(SmoothQuadraticBezierCurveToInstruction const&) const = default;
+};
+
+struct EllipticalArcInstruction {
+    float rx;
+    float ry;
+    float x_axis_rotation;
+    bool absolute;
+    bool large_arc;
+    bool sweep;
+    Vector<float> point;
+
+    bool operator==(EllipticalArcInstruction const&) const = default;
+};
+
+using PathInstruction = Variant<MoveToInstruction, ClosePathInstruction, LineToInstruction, HorizontalLineToInstruction, VerticalLineToInstruction, CurveToInstruction, SmoothCurveToInstruction, QuadraticBezierCurveToInstruction, SmoothQuadraticBezierCurveToInstruction, EllipticalArcInstruction>;
 
 class Path {
 public:

--- a/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -32,7 +32,7 @@ void SVGPathElement::attribute_changed(FlyString const& name, Optional<String> c
     Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == "d") {
-        m_path = AttributeParser::parse_path_data(value.value_or(String {}));
+        m_path = AttributeParser::parse_path_data(value.map([](String const& path_string) { return path_string.bytes_as_string_view(); }).value_or(StringView {}));
         set_needs_layout_update(DOM::SetNeedsLayoutReason::StyleChange);
     }
 }


### PR DESCRIPTION
A few optimizations to SVG path parsing, primarily around avoiding copies and `Vector` allocations.

Collectively reduce time spent in `SVGPathElement::attribute_changed` by 25% (from 120ms to 90ms) when loading https://chatgpt.com on my machine.

See individual commits for details.