### PR TITLE
LibWeb: Fix a couple spec bugs in `StylePropertyMap.set()`

### DIFF
--- a/Libraries/LibWeb/CSS/StylePropertyMap.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.cpp
@@ -148,10 +148,6 @@ WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, Readonl
     // 6. Let props be the value of this’s [[declarations]] internal slot.
     auto& props = declarations();
 
-    // 7. If props[property] exists, remove it.
-    // FIXME: Avoid converting to string and back.
-    TRY(props.remove_property(property->name()));
-
     // 8. Let values to set be an empty list.
     StyleValueVector values_to_set;
 
@@ -167,6 +163,12 @@ WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, Readonl
 
         values_to_set.append(move(internal_representation));
     }
+
+    // 7. If props[property] exists, remove it.
+    // FIXME: Avoid converting to string and back.
+    // FIXME: We handle this after creating the internal representations (step 9) so that we maintain the original
+    //        value in the case that fails - see https://github.com/w3c/css-houdini-drafts/issues/1175
+    TRY(props.remove_property(property->name()));
 
     // AD-HOC: To match the behavior of our parser we should store values of list-valued longhands as lists even if
     //         there is only one value, except in some rare circumstances.

--- a/Libraries/LibWeb/CSS/StylePropertyMap.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.cpp
@@ -131,6 +131,11 @@ WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, Readonl
     if ((property->is_custom_property() || property_is_single_valued(property->id())) && values.size() > 1)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, MUST(String::formatted("Property '{}' only accepts a single value", property_name)) };
 
+    // FIXME: The spec doesn't say how to handle empty `values`, but other browsers throw a TypeError so let's do that
+    //        too - see https://github.com/w3c/css-houdini-drafts/issues/1176
+    if (values.is_empty())
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, MUST(String::formatted("Property '{}' requires at least one value", property_name)) };
+
     // 4. If any of the items in values have a non-null [[associatedProperty]] internal slot, and that slot’s value is
     //    anything other than property, throw a TypeError.
     if (any_have_non_matching_associated_property(property->name(), values))

--- a/Tests/LibWeb/Text/expected/css/typed-om-set-empty-values.txt
+++ b/Tests/LibWeb/Text/expected/css/typed-om-set-empty-values.txt
@@ -1,0 +1,3 @@
+Initial style: width: 10px;
+Empty set threw TypeError
+After empty set: width: 10px;

--- a/Tests/LibWeb/Text/expected/css/typed-om-set-invalid-value-preserves-existing.txt
+++ b/Tests/LibWeb/Text/expected/css/typed-om-set-invalid-value-preserves-existing.txt
@@ -1,0 +1,3 @@
+Initial style: width: 10px;
+Invalid set threw TypeError
+After invalid set: width: 10px;

--- a/Tests/LibWeb/Text/input/css/typed-om-set-empty-values.html
+++ b/Tests/LibWeb/Text/input/css/typed-om-set-empty-values.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+    <div id="foo"></div>
+    <script src="../include.js"></script>
+    <script>
+        test(() => {
+            foo.attributeStyleMap.set("width", CSS.px(10));
+            println(`Initial style: ${foo.getAttribute("style")}`);
+
+            try {
+                foo.attributeStyleMap.set("width");
+                println("FAIL: Empty set did not throw");
+            } catch (e) {
+                println(`Empty set threw ${e.name}`);
+            }
+
+            println(`After empty set: ${foo.getAttribute("style")}`);
+        });
+    </script>
+</html>

--- a/Tests/LibWeb/Text/input/css/typed-om-set-invalid-value-preserves-existing.html
+++ b/Tests/LibWeb/Text/input/css/typed-om-set-invalid-value-preserves-existing.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+    <div id="foo"></div>
+    <script src="../include.js"></script>
+    <script>
+        test(() => {
+            foo.attributeStyleMap.set("width", CSS.px(10));
+            println(`Initial style: ${foo.getAttribute("style")}`);
+
+            try {
+                foo.attributeStyleMap.set("width", "not a width");
+                println("FAIL: Invalid set did not throw");
+            } catch (e) {
+                println(`Invalid set threw ${e.name}`);
+            }
+
+            println(`After invalid set: ${foo.getAttribute("style")}`);
+        });
+    </script>
+</html>


### PR DESCRIPTION
This PR fixes two small spec bugs in `StylePropertyMap.set()` - see individual commits for details.

Fixes #9969, fixes #9970