### PR TITLE
Fuzzers: Avoid crash on empty input in MatroskaReader fuzzer

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzMatroskaReader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMatroskaReader.cpp
@@ -11,7 +11,12 @@
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
     AK::set_debug_enabled(false);
-    auto stream = Media::IncrementallyPopulatedStream::create_from_data({ data, size });
+
+    auto stream = Media::IncrementallyPopulatedStream::create_empty();
+    if (size > 0)
+        stream->add_chunk_at(0, { data, size });
+    stream->close();
+
     auto matroska_reader_result = Media::Matroska::Reader::from_stream(stream->create_cursor());
     if (matroska_reader_result.is_error())
         return 0;


### PR DESCRIPTION
Previously, the fuzzer would crash on empty input because `IncrementallyPopulatedStream::add_chunk_at()` expects non-empty data.