### PR TITLE
LibWeb: Avoid unnecessary min-content sizing in layout

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -406,8 +406,6 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     auto compute_width = [&](CSS::LengthOrAuto width) {
         // If 'width' is computed as 'auto', the used value is the "shrink-to-fit" width.
         if (width.is_auto()) {
-            auto result = calculate_shrink_to_fit_widths(box);
-
             if (available_space.width.is_definite()) {
                 // Find the available width: in this case, this is the width of the containing
                 // block minus the used values of 'margin-left', 'border-left-width', 'padding-left',
@@ -416,13 +414,19 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
                     - margin_left - computed_values.border_left().width - box_state.padding_left
                     - box_state.padding_right - computed_values.border_right().width - margin_right;
                 // Then the shrink-to-fit width is: min(max(preferred minimum width, available width), preferred width).
-                width = CSS::Length::make_px(min(max(result.preferred_minimum_width, available_width), result.preferred_width));
+                auto preferred_width = calculate_max_content_width(box);
+                if (preferred_width <= available_width) {
+                    width = CSS::Length::make_px(preferred_width);
+                } else {
+                    auto preferred_minimum_width = calculate_min_content_width(box);
+                    width = CSS::Length::make_px(min(max(preferred_minimum_width, available_width), preferred_width));
+                }
             } else if (available_space.width.is_indefinite() || available_space.width.is_max_content()) {
                 // Fold the formula for shrink-to-fit width for indefinite and max-content available width.
-                width = CSS::Length::make_px(result.preferred_width);
+                width = CSS::Length::make_px(calculate_max_content_width(box));
             } else {
                 // Fold the formula for shrink-to-fit width for min-content available width.
-                width = CSS::Length::make_px(min(result.preferred_minimum_width, result.preferred_width));
+                width = CSS::Length::make_px(calculate_min_content_width(box));
             }
         }
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2045,9 +2045,11 @@ CSSPixels FormattingContext::calculate_fit_content_width(Layout::Box const& box,
     // If the available space in a given axis is definite, equal to clamp(min-content size, stretch-fit size,
     // max-content size) (i.e. max(min-content size, min(max-content size, stretch-fit size))).
     if (available_space.width.is_definite()) {
-        return max(calculate_min_content_width(box),
-            min(calculate_stretch_fit_width(box, available_space.width),
-                calculate_max_content_width(box)));
+        auto stretch_fit_width = calculate_stretch_fit_width(box, available_space.width);
+        auto max_content_width = calculate_max_content_width(box);
+        if (max_content_width <= stretch_fit_width)
+            return max_content_width;
+        return max(calculate_min_content_width(box), stretch_fit_width);
     }
 
     // When sizing under a min-content constraint, equal to the min-content size.

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -923,6 +923,15 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             return width_of_containing_block - left - margin_left.to_px_or_zero(box) - border_left - padding_left - width.to_px_or_zero(box) - padding_right - border_right - margin_right.to_px_or_zero(box);
         };
 
+        auto calculate_shrink_to_fit_width = [&] {
+            auto available_width = solve_for_width().to_px(box);
+            auto preferred_width = calculate_max_content_width(box);
+            if (preferred_width <= available_width)
+                return preferred_width;
+            auto preferred_minimum_width = calculate_min_content_width(box);
+            return min(max(preferred_minimum_width, available_width), preferred_width);
+        };
+
         // If all three of 'left', 'width', and 'right' are 'auto':
         if (computed_left.is_auto() && width.is_auto() && computed_right.is_auto()) {
             // First set any 'auto' values for 'margin-left' and 'margin-right' to 0.
@@ -937,9 +946,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             // NOTE: As with compute_height_for_absolutely_positioned_non_replaced_element, we actually apply these
             //       steps in the opposite order since the static position may depend on the width of the box.
 
-            auto result = calculate_shrink_to_fit_widths(box);
-            auto available_width = solve_for_width();
-            CSSPixels content_width = min(max(result.preferred_minimum_width, available_width.to_px(box)), result.preferred_width);
+            auto content_width = calculate_shrink_to_fit_width();
             width = CSS::Length::make_px(content_width);
             m_state.get_mutable(box).set_content_width(content_width);
 
@@ -988,9 +995,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         // 1. 'left' and 'width' are 'auto' and 'right' is not 'auto',
         //    then the width is shrink-to-fit. Then solve for 'left'
         if (computed_left.is_auto() && width.is_auto() && !computed_right.is_auto()) {
-            auto result = calculate_shrink_to_fit_widths(box);
-            auto available_width = solve_for_width();
-            width = CSS::Length::make_px(min(max(result.preferred_minimum_width, available_width.to_px(box)), result.preferred_width));
+            width = CSS::Length::make_px(calculate_shrink_to_fit_width());
             left = solve_for_left();
         }
 
@@ -1009,9 +1014,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         // 3. 'width' and 'right' are 'auto' and 'left' is not 'auto',
         //    then the width is shrink-to-fit. Then solve for 'right'
         else if (width.is_auto() && computed_right.is_auto() && !computed_left.is_auto()) {
-            auto result = calculate_shrink_to_fit_widths(box);
-            auto available_width = solve_for_width();
-            width = CSS::Length::make_px(min(max(result.preferred_minimum_width, available_width.to_px(box)), result.preferred_width));
+            width = CSS::Length::make_px(calculate_shrink_to_fit_width());
             right = solve_for_right();
         }
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -139,8 +139,6 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     auto const& width_value = box.computed_values().width();
     CSSPixels unconstrained_width = 0;
     if (should_treat_width_as_auto(box, *m_available_space)) {
-        auto result = calculate_shrink_to_fit_widths(box);
-
         if (m_available_space->width.is_definite()) {
             auto available_width = m_available_space->width.to_px_or_zero()
                 - box_state.margin_left
@@ -150,11 +148,17 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
                 - box_state.border_right
                 - box_state.margin_right;
 
-            unconstrained_width = min(max(result.preferred_minimum_width, available_width), result.preferred_width);
+            auto preferred_width = calculate_max_content_width(box);
+            if (preferred_width <= available_width) {
+                unconstrained_width = preferred_width;
+            } else {
+                auto preferred_minimum_width = calculate_min_content_width(box);
+                unconstrained_width = min(max(preferred_minimum_width, available_width), preferred_width);
+            }
         } else if (m_available_space->width.is_min_content()) {
-            unconstrained_width = result.preferred_minimum_width;
+            unconstrained_width = calculate_min_content_width(box);
         } else {
-            unconstrained_width = result.preferred_width;
+            unconstrained_width = calculate_max_content_width(box);
         }
     } else {
         if (width_value.contains_percentage() && !m_available_space->width.is_definite()) {


### PR DESCRIPTION
Avoid eager min-content measurements in sizing paths where the result can already be resolved from max-content.

This applies the max-content-first shortcut to:

- auto-width floats using shrink-to-fit sizing
- non-replaced absolutely positioned auto-width boxes using shrink-to-fit sizing
- definite `fit-content` widths in the shared formatting context helper

In each case, if max-content is no larger than the available or stretch-fit width, the formula resolves to max-content and the min-content contribution cannot affect the used size.
