### PR TITLE
LibWeb: Clip nested display lists to their destination rect

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -858,6 +858,7 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
 {
     auto& canvas = surface().canvas();
     canvas.save();
+    canvas.clipRect(to_skia_rect(command.rect));
     canvas.translate(command.rect.x(), command.rect.y());
     ScrollStateSnapshot scroll_state_snapshot;
     auto const& nested_display_list = resource_storage().display_list_resource(command.display_list_id);

--- a/Tests/LibWeb/Ref/data/svg-image-content-outside-viewport.svg
+++ b/Tests/LibWeb/Ref/data/svg-image-content-outside-viewport.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100" overflow="visible">
+  <rect width="100" height="100" fill="green"/>
+  <rect x="100" y="0" width="100" height="100" fill="red"/>
+  <rect x="0" y="100" width="100" height="100" fill="red"/>
+</svg>

--- a/Tests/LibWeb/Ref/expected/svg-image-clipped-to-viewport-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-image-clipped-to-viewport-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+  body { margin: 0; background: white; }
+  div { width: 100px; height: 100px; background: green; }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/svg-image-clipped-to-viewport.html
+++ b/Tests/LibWeb/Ref/input/svg-image-clipped-to-viewport.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-image-clipped-to-viewport-ref.html" />
+<style>
+  body { margin: 0; background: white; }
+  img { display: block; width: 100px; height: 100px; }
+</style>
+<img src="../data/svg-image-content-outside-viewport.svg">


### PR DESCRIPTION
SVG image content drawn outside the image's viewport escaped the image box, because `PaintNestedDisplayList` playback translated to the destination rect without clipping to it. We now clip it during playback.

This regressed in 852c7a10f35b3669e4f9fc080e72f8c6b48573d2, causing artefacts to appear on https://wpt.fyi:

Before:
<img width="1797" height="1024" alt="image" src="https://github.com/user-attachments/assets/7895761b-8116-43e3-8b21-fd0d15debe54" />

After:
<img width="1797" height="1024" alt="image" src="https://github.com/user-attachments/assets/6d9aad45-8110-4f88-9881-18806e0d39d0" />
