### PR TITLE
LibWeb: Remove ChunkSteps & ReadAllOn* dead code from Streams reader

### DIFF
--- a/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -60,12 +60,11 @@ void ReadableStreamDefaultReader::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://streams.spec.whatwg.org/#read-loop
-ReadLoopReadRequest::ReadLoopReadRequest(JS::Realm& realm, ReadableStreamDefaultReader& reader, GC::Ref<SuccessSteps> success_steps, GC::Ref<FailureSteps> failure_steps, GC::Ptr<ChunkSteps> chunk_steps)
+ReadLoopReadRequest::ReadLoopReadRequest(JS::Realm& realm, ReadableStreamDefaultReader& reader, GC::Ref<SuccessSteps> success_steps, GC::Ref<FailureSteps> failure_steps)
     : m_realm(realm)
     , m_reader(reader)
     , m_success_steps(success_steps)
     , m_failure_steps(failure_steps)
-    , m_chunk_steps(chunk_steps)
 {
 }
 
@@ -76,7 +75,6 @@ void ReadLoopReadRequest::visit_edges(Visitor& visitor)
     visitor.visit(m_reader);
     visitor.visit(m_success_steps);
     visitor.visit(m_failure_steps);
-    visitor.visit(m_chunk_steps);
 }
 
 // chunk steps, given chunk
@@ -89,15 +87,9 @@ void ReadLoopReadRequest::on_chunk(JS::Value chunk)
     }
 
     auto const& array = static_cast<JS::Uint8Array const&>(chunk.as_object());
-    auto buffer = array.data();
 
     // 2. Append the bytes represented by chunk to bytes.
-    m_bytes.append(buffer);
-
-    if (m_chunk_steps) {
-        // FIXME: Can we move the buffer out of the `chunk`? Unclear if that is safe.
-        m_chunk_steps->function()(MUST(ByteBuffer::copy(buffer)));
-    }
+    m_bytes.append(array.data());
 
     // FIXME: As the spec suggests, implement this non-recursively - instead of directly. It is not too big of a deal currently
     //        as we enqueue the entire blob buffer in one go, meaning that we only recurse a single time. Once we begin queuing

--- a/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -48,11 +48,8 @@ public:
     // failureSteps, which is an algorithm accepting a JavaScript value
     using FailureSteps = GC::Function<void(JS::Value error)>;
 
-    // AD-HOC: callback triggered on every chunk received from the stream.
-    using ChunkSteps = GC::Function<void(ByteBuffer)>;
-
 private:
-    ReadLoopReadRequest(JS::Realm&, ReadableStreamDefaultReader&, GC::Ref<SuccessSteps>, GC::Ref<FailureSteps>, GC::Ptr<ChunkSteps> = {});
+    ReadLoopReadRequest(JS::Realm&, ReadableStreamDefaultReader&, GC::Ref<SuccessSteps>, GC::Ref<FailureSteps>);
 
     virtual void visit_edges(Visitor&) override;
 
@@ -65,7 +62,6 @@ private:
     ByteBuffer m_bytes;
     GC::Ref<SuccessSteps> m_success_steps;
     GC::Ref<FailureSteps> m_failure_steps;
-    GC::Ptr<ChunkSteps> m_chunk_steps;
 };
 
 // https://streams.spec.whatwg.org/#readablestreamdefaultreader
@@ -77,16 +73,6 @@ class ReadableStreamDefaultReader final
 
 public:
     static WebIDL::ExceptionOr<GC::Ref<ReadableStreamDefaultReader>> construct_impl(JS::Realm&, GC::Ref<ReadableStream>);
-
-    // AD-HOC: Callback functions for read_all_chunks
-    // successSteps, which is an algorithm accepting a JavaScript value
-    using ReadAllOnSuccessSteps = GC::Function<void()>;
-
-    // failureSteps, which is an algorithm accepting a JavaScript value
-    using ReadAllOnFailureSteps = GC::Function<void(JS::Value error)>;
-
-    // AD-HOC: callback triggered on every chunk received from the stream.
-    using ReadAllOnChunkSteps = GC::Function<void(JS::Value chunk)>;
 
     virtual ~ReadableStreamDefaultReader() override = default;
 


### PR DESCRIPTION
Drop no-longer-reachable code for `ChunkSteps` & `ReadAllOn*` callbacks from Streams code. (Seems they got orphaned by the changes in c14d5f27f9c and eb0a51faf09.) Noticed this when working on 8e746504167 / #9965.
