### PR TITLE
LibWeb: Run `removed_from` for descendants when shadow root removed

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1493,6 +1493,14 @@ void Element::set_shadow_root(GC::Ptr<ShadowRoot> shadow_root)
     if (m_shadow_root) {
         m_shadow_root->set_host(nullptr);
         m_shadow_root->set_is_connected(false);
+        // NB: We don't need to run the removed steps if the children have already been disconnected (or were never
+        //     connected in the first place)
+        if (is_connected()) {
+            m_shadow_root->for_each_shadow_including_descendant([&](DOM::Node& descendant) {
+                descendant.removed_from(IsSubtreeRoot::No, m_shadow_root, *m_shadow_root);
+                return TraversalDecision::Continue;
+            });
+        }
     }
     m_shadow_root = move(shadow_root);
     if (m_shadow_root) {

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1804,13 +1804,29 @@ void Node::inserted()
     set_needs_style_update(true);
 }
 
+void Node::clear_layout_node_paintables()
+{
+    if (!m_layout_node)
+        return;
+
+    m_layout_node->clear_paintables();
+
+    // NB: Block-in-inline splitting can create multiple layout nodes for a single DOM node. Only the last one is stored
+    //     in m_layout_node so we need to clear the paintables for the continued nodes as well
+    auto* node_with_metrics = as_if<Layout::NodeWithStyleAndBoxModelMetrics>(*m_layout_node);
+    if (!node_with_metrics)
+        return;
+
+    for (auto* continuation = node_with_metrics->continuation_of_node(); continuation; continuation = continuation->continuation_of_node())
+        continuation->clear_paintables();
+}
+
 void Node::removed_from(IsSubtreeRoot, Node*, Node&)
 {
     m_is_connected = false;
     m_in_editable_subtree = false;
     m_inside_blocking_wheel_event_handler = false;
-    if (m_layout_node)
-        m_layout_node->clear_paintables();
+    clear_layout_node_paintables();
     m_layout_node = nullptr;
     m_paintable = nullptr;
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -539,6 +539,7 @@ private:
     void insert_before_impl(GC::Ref<Node>, GC::Ptr<Node> child);
     void append_child_impl(GC::Ref<Node>);
     void remove_child_impl(GC::Ref<Node>);
+    void clear_layout_node_paintables();
 
     static Optional<StringView> first_valid_id(StringView, Document const&);
 

--- a/Tests/LibWeb/Crash/DOM/block-in-inline-removal-crash.html
+++ b/Tests/LibWeb/Crash/DOM/block-in-inline-removal-crash.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<body></body>
+<script>
+    (async () => {
+        for (let i = 0; i < 30; ++i) {
+            (() => {
+                // Block in inline - the span should be split into two layout nodes.
+                let host = document.createElement("div");
+                let span = document.createElement("span");
+                span.style.background = "red";
+                span.appendChild(document.createElement("div")).textContent = "x";
+                host.appendChild(span);
+                document.body.appendChild(host);
+
+                // Force layout + paint - fill paintable caches
+                internals.dumpDisplayList();
+
+                // Remove the span element - should clear paintable caches for all layout nodes, not just the last one.
+                span.remove();
+            })();
+
+            // Collect the removed element, nulling the layout nodes' weak DOM-node pointers.
+            for (let j = 0; j < 10000; ++j) ({ junk: j });
+            internals.gc();
+
+            // Yield, so the event loop's rendering step rebuilds the layout tree and detaches the lingering cached copy.
+            await new Promise(resolve => setTimeout(resolve));
+        }
+    })();
+</script>

--- a/Tests/LibWeb/Crash/DOM/shadow-root-children-removed-on-attribute-change.html
+++ b/Tests/LibWeb/Crash/DOM/shadow-root-children-removed-on-attribute-change.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<body></body>
+<script>
+    (async () => {
+        for (let i = 0; i < 30; ++i) {
+            (() => {
+                const input = document.createElement("input");
+                input.type = "number";
+                document.body.appendChild(input);
+
+                // Force layout
+                internals.dumpDisplayList();
+
+                // Rebuild the shadow tree, removing it's elements
+                input.type = "number";
+            })();
+
+            // Force GC of the shadow tree DOM nodes
+            for (let j = 0; j < 10000; ++j) ({ junk: j });
+            internals.gc();
+
+            // Yield, so the event loop's rendering step rebuilds the layout tree and detaches the lingering layout nodes.
+            await new Promise(resolve => setTimeout(resolve));
+        }
+    })();
+</script>


### PR DESCRIPTION
This is only relevant for UA-internal shadow roots (specifically those created by `HTMLInputElement` and `MediaControls`) since they are the only ones which can be removed from their hosts.
    
Previously after removing a shadow root from it's host we left it's descendants' paintables' caches to be cleared during the next layout update.
    
This was fine prior to 9340d2d, when layout nodes kept the relevant DOM nodes alive, however, layout nodes now only keep weak references so these DOM nodes can be GC'd before the paintables' caches are removed causing a crash.
    
We now run the `removed_from` steps for the shadow tree's elements before removing the shadow root from its host in line with how we handle removal of DOM nodes in other cases - this clears their paintables' caches immediately while the DOM nodes are still alive.
    
Fixes an intermittent [crash](https://github.com/LadybirdBrowser/ladybird/actions/runs/27138656025/job/80097595707?pr=9977) in Layout/input/pdf-viewer.pdf. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9999.