### PR TITLE
LibWeb: Shrink generated CSSStyleProperties bindings

### DIFF
--- a/Libraries/LibWeb/CSS/CSS.cpp
+++ b/Libraries/LibWeb/CSS/CSS.cpp
@@ -76,7 +76,8 @@ WebIDL::ExceptionOr<void> register_property(JS::VM& vm, Bindings::PropertyDefini
 
     // If property set already contains an entry with name as its property name (compared codepoint-wise),
     // throw an InvalidModificationError and exit this algorithm.
-    if (property_set.contains(definition.name))
+    auto property_name = Utf16FlyString::from_utf8(definition.name);
+    if (property_set.contains(property_name))
         return WebIDL::InvalidModificationError::create(realm, "Property already registered"_utf16);
 
     auto parsing_params = CSS::Parser::ParsingParams { document };
@@ -142,7 +143,7 @@ WebIDL::ExceptionOr<void> register_property(JS::VM& vm, Bindings::PropertyDefini
     // 6. Let registered property be a struct with a property name of name, a syntax of syntax definition,
     //    an initial value of parsed initial value, and an inherit flag of inherit flag.
     CustomPropertyRegistration registered_property {
-        .property_name = definition.name,
+        .property_name = property_name,
         .syntax = definition.syntax,
         .inherit = definition.inherits,
         .initial_value = initial_value_maybe,

--- a/Libraries/LibWeb/CSS/CSS.cpp
+++ b/Libraries/LibWeb/CSS/CSS.cpp
@@ -29,7 +29,7 @@ WebIDL::ExceptionOr<String> escape(JS::VM&, StringView identifier)
 }
 
 // https://www.w3.org/TR/css-conditional-3/#dom-css-supports
-bool supports(JS::VM&, FlyString const& property_name, StringView value)
+bool supports(JS::VM&, Utf16FlyString const& property_name, StringView value)
 {
     // 1. If property is an ASCII case-insensitive match for any defined CSS property that the UA supports, or is a
     //    custom property name string, and value successfully parses according to that property’s grammar, return true.

--- a/Libraries/LibWeb/CSS/CSS.h
+++ b/Libraries/LibWeb/CSS/CSS.h
@@ -9,6 +9,7 @@
 
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Utf16FlyString.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/CSS/GeneratedCSSNumericFactoryMethods.h>
 #include <LibWeb/Export.h>
@@ -20,7 +21,7 @@ namespace Web::CSS {
 
 WEB_API WebIDL::ExceptionOr<String> escape(JS::VM&, StringView identifier);
 
-WEB_API bool supports(JS::VM&, FlyString const& property, StringView value);
+WEB_API bool supports(JS::VM&, Utf16FlyString const& property, StringView value);
 WEB_API WebIDL::ExceptionOr<bool> supports(JS::VM&, StringView condition_text);
 
 WEB_API WebIDL::ExceptionOr<void> register_property(JS::VM&, Bindings::PropertyDefinition const&);

--- a/Libraries/LibWeb/CSS/CSS.idl
+++ b/Libraries/LibWeb/CSS/CSS.idl
@@ -1,5 +1,6 @@
 // https://drafts.csswg.org/cssom-1/#cssomstring
 typedef DOMString CSSOMString;
+typedef Utf16DOMString Utf16CSSOMString;
 
 dictionary PropertyDefinition {
     required CSSOMString name;
@@ -13,7 +14,7 @@ dictionary PropertyDefinition {
 namespace CSS {
     CSSOMString escape(CSSOMString ident);
 
-    boolean supports(CSSOMString property, CSSOMString value);
+    boolean supports(Utf16CSSOMString property, CSSOMString value);
     boolean supports(CSSOMString conditionText);
 
     // https://drafts.css-houdini.org/css-properties-values-api-1/#dom-css-registerproperty

--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -139,7 +139,7 @@ WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(FlyString const& pro
     // AD-HOC: We compare names case-insensitively instead.
 
     // 3. Let value be the return value of invoking getPropertyValue() with property as argument.
-    auto value = get_property_value(property);
+    auto value = get_property_value(Utf16FlyString::from_utf8(property));
 
     // 4. Let removed be false.
     bool removed = false;
@@ -170,14 +170,20 @@ WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(FlyString const& pro
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue
-String CSSDescriptors::get_property_value(FlyString const& property) const
+String CSSDescriptors::get_property_value(Utf16FlyString const& property) const
 {
+    if (!property.is_ascii())
+        return {};
+
+    auto property_string = property.to_utf16_string();
+    auto property_name = MUST(FlyString::from_utf8(property_string.ascii_view()));
+
     // 1. If property is not a custom property, follow these substeps: ...
     // NB: These substeps only apply to shorthands, and descriptors cannot be shorthands.
 
     // 2. If property is a case-sensitive match for a property name of a CSS declaration in the declarations, then
     //    return the result of invoking serialize a CSS value of that declaration.
-    auto descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property);
+    auto descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property_name);
     if (descriptor_name_and_id.has_value()) {
         auto match = m_descriptors.first_matching([descriptor_name_and_id](Descriptor const& entry) { return entry.descriptor_name_and_id == descriptor_name_and_id; });
         if (match.has_value())

--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -63,18 +63,24 @@ bool CSSDescriptors::set_a_css_declaration(DescriptorNameAndID const& descriptor
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
-WebIDL::ExceptionOr<void> CSSDescriptors::set_property(FlyString const& property, StringView value, StringView priority)
+WebIDL::ExceptionOr<void> CSSDescriptors::set_property(Utf16FlyString const& property, StringView value, StringView priority)
 {
     // 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
     if (is_readonly())
         return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties of readonly CSSStyleDeclaration"_utf16);
+
+    if (!property.is_ascii())
+        return {};
+
+    auto property_string = property.to_utf16_string();
+    auto property_name = MUST(FlyString::from_utf8(property_string.ascii_view()));
 
     // 2. If property is not a custom property, follow these substeps:
     Optional<DescriptorNameAndID> descriptor_name_and_id;
     {
         // 1. Let property be property converted to ASCII lowercase.
         // 2. If property is not a case-sensitive match for a supported CSS property, then return.
-        descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property);
+        descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property_name);
         if (!descriptor_name_and_id.has_value())
             return {};
     }
@@ -129,21 +135,27 @@ WebIDL::ExceptionOr<void> CSSDescriptors::set_property(FlyString const& property
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
-WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(FlyString const& property)
+WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(Utf16FlyString const& property)
 {
     // 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
     if (is_readonly())
         return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties of readonly CSSStyleDeclaration"_utf16);
 
+    if (!property.is_ascii())
+        return String {};
+
+    auto property_string = property.to_utf16_string();
+    auto property_name = MUST(FlyString::from_utf8(property_string.ascii_view()));
+
     // 2. If property is not a custom property, let property be property converted to ASCII lowercase.
     // AD-HOC: We compare names case-insensitively instead.
 
     // 3. Let value be the return value of invoking getPropertyValue() with property as argument.
-    auto value = get_property_value(Utf16FlyString::from_utf8(property));
+    auto value = get_property_value(property);
 
     // 4. Let removed be false.
     bool removed = false;
-    auto descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property);
+    auto descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property_name);
 
     // 5. If property is a shorthand property, for each longhand property longhand that property maps to:
     if (descriptor_name_and_id.has_value() && is_shorthand(m_at_rule_id, *descriptor_name_and_id)) {
@@ -195,7 +207,7 @@ String CSSDescriptors::get_property_value(Utf16FlyString const& property) const
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
-StringView CSSDescriptors::get_property_priority(FlyString const&) const
+StringView CSSDescriptors::get_property_priority(Utf16FlyString const&) const
 {
     // AD-HOC: It's not valid for descriptors to be !important.
     return {};

--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -38,7 +38,7 @@ String CSSDescriptors::item(size_t index) const
     if (index >= length())
         return {};
 
-    return m_descriptors[index].descriptor_name_and_id.name().to_string();
+    return m_descriptors[index].descriptor_name_and_id.name().to_utf16_string().to_utf8_but_should_be_ported_to_utf16();
 }
 
 // https://drafts.csswg.org/cssom/#set-a-css-declaration
@@ -72,15 +72,12 @@ WebIDL::ExceptionOr<void> CSSDescriptors::set_property(Utf16FlyString const& pro
     if (!property.is_ascii())
         return {};
 
-    auto property_string = property.to_utf16_string();
-    auto property_name = MUST(FlyString::from_utf8(property_string.ascii_view()));
-
     // 2. If property is not a custom property, follow these substeps:
     Optional<DescriptorNameAndID> descriptor_name_and_id;
     {
         // 1. Let property be property converted to ASCII lowercase.
         // 2. If property is not a case-sensitive match for a supported CSS property, then return.
-        descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property_name);
+        descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property);
         if (!descriptor_name_and_id.has_value())
             return {};
     }
@@ -144,9 +141,6 @@ WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(Utf16FlyString const
     if (!property.is_ascii())
         return String {};
 
-    auto property_string = property.to_utf16_string();
-    auto property_name = MUST(FlyString::from_utf8(property_string.ascii_view()));
-
     // 2. If property is not a custom property, let property be property converted to ASCII lowercase.
     // AD-HOC: We compare names case-insensitively instead.
 
@@ -155,7 +149,7 @@ WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(Utf16FlyString const
 
     // 4. Let removed be false.
     bool removed = false;
-    auto descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property_name);
+    auto descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property);
 
     // 5. If property is a shorthand property, for each longhand property longhand that property maps to:
     if (descriptor_name_and_id.has_value() && is_shorthand(m_at_rule_id, *descriptor_name_and_id)) {
@@ -187,15 +181,12 @@ String CSSDescriptors::get_property_value(Utf16FlyString const& property) const
     if (!property.is_ascii())
         return {};
 
-    auto property_string = property.to_utf16_string();
-    auto property_name = MUST(FlyString::from_utf8(property_string.ascii_view()));
-
     // 1. If property is not a custom property, follow these substeps: ...
     // NB: These substeps only apply to shorthands, and descriptors cannot be shorthands.
 
     // 2. If property is a case-sensitive match for a property name of a CSS declaration in the declarations, then
     //    return the result of invoking serialize a CSS value of that declaration.
-    auto descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property_name);
+    auto descriptor_name_and_id = DescriptorNameAndID::from_name(m_at_rule_id, property);
     if (descriptor_name_and_id.has_value()) {
         auto match = m_descriptors.first_matching([descriptor_name_and_id](Descriptor const& entry) { return entry.descriptor_name_and_id == descriptor_name_and_id; });
         if (match.has_value())
@@ -227,6 +218,7 @@ String CSSDescriptors::serialized() const
     for (auto const& descriptor : m_descriptors) {
         // 1. Let property be declaration’s property name.
         auto property = descriptor.descriptor_name_and_id.name();
+        auto property_string = property.to_utf16_string();
 
         // 2. If property is in already serialized, continue with the steps labeled declaration loop.
         // AD-HOC: Not needed as we don't have shorthands.
@@ -239,7 +231,7 @@ String CSSDescriptors::serialized() const
         auto value = descriptor.value->to_string(SerializationMode::Normal);
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value, and the important flag set if declaration has its important flag set.
-        auto serialized_declaration = serialize_a_css_declaration(property, value, Important::No);
+        auto serialized_declaration = serialize_a_css_declaration(property_string.ascii_view(), value, Important::No);
 
         // 7. Append serialized declaration to list.
         list.append(serialized_declaration);

--- a/Libraries/LibWeb/CSS/CSSDescriptors.h
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.h
@@ -23,7 +23,7 @@ public:
     virtual String item(size_t index) const override;
     virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property, StringView value, StringView priority) override;
     virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property) override;
-    virtual String get_property_value(FlyString const& property) const override;
+    virtual String get_property_value(Utf16FlyString const& property) const override;
     virtual StringView get_property_priority(FlyString const& property) const override;
 
     Vector<Descriptor> const& descriptors() const { return m_descriptors; }

--- a/Libraries/LibWeb/CSS/CSSDescriptors.h
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.h
@@ -21,10 +21,10 @@ public:
 
     virtual size_t length() const override;
     virtual String item(size_t index) const override;
-    virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property, StringView value, StringView priority) override;
-    virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property) override;
+    virtual WebIDL::ExceptionOr<void> set_property(Utf16FlyString const& property, StringView value, StringView priority) override;
+    virtual WebIDL::ExceptionOr<String> remove_property(Utf16FlyString const& property) override;
     virtual String get_property_value(Utf16FlyString const& property) const override;
-    virtual StringView get_property_priority(FlyString const& property) const override;
+    virtual StringView get_property_priority(Utf16FlyString const& property) const override;
 
     Vector<Descriptor> const& descriptors() const { return m_descriptors; }
     RefPtr<StyleValue const> descriptor(DescriptorNameAndID const&) const;

--- a/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
@@ -39,10 +39,8 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_property(Utf16FlyString co
     if (!property.is_ascii())
         return {};
 
-    if (auto* font_face_rule = as_if<CSSFontFaceRule>(parent_rule().ptr())) {
-        auto property_string = property.to_utf16_string();
-        font_face_rule->handle_descriptor_change(MUST(FlyString::from_utf8(property_string.ascii_view())));
-    }
+    if (auto* font_face_rule = as_if<CSSFontFaceRule>(parent_rule().ptr()))
+        font_face_rule->handle_descriptor_change(property);
 
     return {};
 }

--- a/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
@@ -49,7 +49,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_ascent_override(StringView
 
 String CSSFontFaceDescriptors::ascent_override() const
 {
-    return get_property_value("ascent-override"_fly_string);
+    return get_property_value("ascent-override"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_descent_override(StringView value)
@@ -59,7 +59,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_descent_override(StringVie
 
 String CSSFontFaceDescriptors::descent_override() const
 {
-    return get_property_value("descent-override"_fly_string);
+    return get_property_value("descent-override"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_display(StringView value)
@@ -69,7 +69,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_display(StringView va
 
 String CSSFontFaceDescriptors::font_display() const
 {
-    return get_property_value("font-display"_fly_string);
+    return get_property_value("font-display"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_family(StringView value)
@@ -79,7 +79,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_family(StringView val
 
 String CSSFontFaceDescriptors::font_family() const
 {
-    return get_property_value("font-family"_fly_string);
+    return get_property_value("font-family"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_feature_settings(StringView value)
@@ -89,7 +89,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_feature_settings(Stri
 
 String CSSFontFaceDescriptors::font_feature_settings() const
 {
-    return get_property_value("font-feature-settings"_fly_string);
+    return get_property_value("font-feature-settings"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_language_override(StringView value)
@@ -99,7 +99,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_language_override(Str
 
 String CSSFontFaceDescriptors::font_language_override() const
 {
-    return get_property_value("font-language-override"_fly_string);
+    return get_property_value("font-language-override"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_named_instance(StringView value)
@@ -109,7 +109,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_named_instance(String
 
 String CSSFontFaceDescriptors::font_named_instance() const
 {
-    return get_property_value("font-named-instance"_fly_string);
+    return get_property_value("font-named-instance"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_style(StringView value)
@@ -119,7 +119,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_style(StringView valu
 
 String CSSFontFaceDescriptors::font_style() const
 {
-    return get_property_value("font-style"_fly_string);
+    return get_property_value("font-style"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_variation_settings(StringView value)
@@ -129,7 +129,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_variation_settings(St
 
 String CSSFontFaceDescriptors::font_variation_settings() const
 {
-    return get_property_value("font-variation-settings"_fly_string);
+    return get_property_value("font-variation-settings"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_weight(StringView value)
@@ -139,7 +139,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_weight(StringView val
 
 String CSSFontFaceDescriptors::font_weight() const
 {
-    return get_property_value("font-weight"_fly_string);
+    return get_property_value("font-weight"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_width(StringView value)
@@ -149,7 +149,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_width(StringView valu
 
 String CSSFontFaceDescriptors::font_width() const
 {
-    return get_property_value("font-width"_fly_string);
+    return get_property_value("font-width"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_line_gap_override(StringView value)
@@ -159,7 +159,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_line_gap_override(StringVi
 
 String CSSFontFaceDescriptors::line_gap_override() const
 {
-    return get_property_value("line-gap-override"_fly_string);
+    return get_property_value("line-gap-override"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_src(StringView value)
@@ -169,7 +169,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_src(StringView value)
 
 String CSSFontFaceDescriptors::src() const
 {
-    return get_property_value("src"_fly_string);
+    return get_property_value("src"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_unicode_range(StringView value)
@@ -179,7 +179,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_unicode_range(StringView v
 
 String CSSFontFaceDescriptors::unicode_range() const
 {
-    return get_property_value("unicode-range"_fly_string);
+    return get_property_value("unicode-range"_utf16_fly_string);
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
@@ -32,19 +32,24 @@ void CSSFontFaceDescriptors::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_property(FlyString const& property, StringView value, StringView priority)
+WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_property(Utf16FlyString const& property, StringView value, StringView priority)
 {
     TRY(Base::set_property(property, value, priority));
 
-    if (auto* font_face_rule = as_if<CSSFontFaceRule>(parent_rule().ptr()))
-        font_face_rule->handle_descriptor_change(property);
+    if (!property.is_ascii())
+        return {};
+
+    if (auto* font_face_rule = as_if<CSSFontFaceRule>(parent_rule().ptr())) {
+        auto property_string = property.to_utf16_string();
+        font_face_rule->handle_descriptor_change(MUST(FlyString::from_utf8(property_string.ascii_view())));
+    }
 
     return {};
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_ascent_override(StringView value)
 {
-    return set_property("ascent-override"_fly_string, value, ""sv);
+    return set_property("ascent-override"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::ascent_override() const
@@ -54,7 +59,7 @@ String CSSFontFaceDescriptors::ascent_override() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_descent_override(StringView value)
 {
-    return set_property("descent-override"_fly_string, value, ""sv);
+    return set_property("descent-override"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::descent_override() const
@@ -64,7 +69,7 @@ String CSSFontFaceDescriptors::descent_override() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_display(StringView value)
 {
-    return set_property("font-display"_fly_string, value, ""sv);
+    return set_property("font-display"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_display() const
@@ -74,7 +79,7 @@ String CSSFontFaceDescriptors::font_display() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_family(StringView value)
 {
-    return set_property("font-family"_fly_string, value, ""sv);
+    return set_property("font-family"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_family() const
@@ -84,7 +89,7 @@ String CSSFontFaceDescriptors::font_family() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_feature_settings(StringView value)
 {
-    return set_property("font-feature-settings"_fly_string, value, ""sv);
+    return set_property("font-feature-settings"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_feature_settings() const
@@ -94,7 +99,7 @@ String CSSFontFaceDescriptors::font_feature_settings() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_language_override(StringView value)
 {
-    return set_property("font-language-override"_fly_string, value, ""sv);
+    return set_property("font-language-override"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_language_override() const
@@ -104,7 +109,7 @@ String CSSFontFaceDescriptors::font_language_override() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_named_instance(StringView value)
 {
-    return set_property("font-named-instance"_fly_string, value, ""sv);
+    return set_property("font-named-instance"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_named_instance() const
@@ -114,7 +119,7 @@ String CSSFontFaceDescriptors::font_named_instance() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_style(StringView value)
 {
-    return set_property("font-style"_fly_string, value, ""sv);
+    return set_property("font-style"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_style() const
@@ -124,7 +129,7 @@ String CSSFontFaceDescriptors::font_style() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_variation_settings(StringView value)
 {
-    return set_property("font-variation-settings"_fly_string, value, ""sv);
+    return set_property("font-variation-settings"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_variation_settings() const
@@ -134,7 +139,7 @@ String CSSFontFaceDescriptors::font_variation_settings() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_weight(StringView value)
 {
-    return set_property("font-weight"_fly_string, value, ""sv);
+    return set_property("font-weight"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_weight() const
@@ -144,7 +149,7 @@ String CSSFontFaceDescriptors::font_weight() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_width(StringView value)
 {
-    return set_property("font-width"_fly_string, value, ""sv);
+    return set_property("font-width"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_width() const
@@ -154,7 +159,7 @@ String CSSFontFaceDescriptors::font_width() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_line_gap_override(StringView value)
 {
-    return set_property("line-gap-override"_fly_string, value, ""sv);
+    return set_property("line-gap-override"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::line_gap_override() const
@@ -164,7 +169,7 @@ String CSSFontFaceDescriptors::line_gap_override() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_src(StringView value)
 {
-    return set_property("src"_fly_string, value, ""sv);
+    return set_property("src"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::src() const
@@ -174,7 +179,7 @@ String CSSFontFaceDescriptors::src() const
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_unicode_range(StringView value)
 {
-    return set_property("unicode-range"_fly_string, value, ""sv);
+    return set_property("unicode-range"_utf16_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::unicode_range() const

--- a/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.h
+++ b/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.h
@@ -22,7 +22,7 @@ public:
     virtual ~CSSFontFaceDescriptors() override;
 
     virtual void initialize(JS::Realm&) override;
-    virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property, StringView value, StringView priority) override;
+    virtual WebIDL::ExceptionOr<void> set_property(Utf16FlyString const& property, StringView value, StringView priority) override;
 
     WebIDL::ExceptionOr<void> set_ascent_override(StringView value);
     String ascent_override() const;

--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -155,7 +155,7 @@ void CSSFontFaceRule::visit_edges(Visitor& visitor)
     visitor.visit(m_css_connected_font_face);
 }
 
-void CSSFontFaceRule::handle_descriptor_change(FlyString const& property)
+void CSSFontFaceRule::handle_descriptor_change(Utf16FlyString const& property)
 {
     if (!m_css_connected_font_face)
         return;
@@ -165,7 +165,7 @@ void CSSFontFaceRule::handle_descriptor_change(FlyString const& property)
         return;
     }
 
-    if (property.equals_ignoring_ascii_case("src"sv))
+    if (property.equals_ignoring_ascii_case("src"_utf16_fly_string))
         handle_src_descriptor_change();
 
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection

--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.h
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.h
@@ -32,7 +32,7 @@ public:
 
     GC::Ptr<FontFace> css_connected_font_face() const { return m_css_connected_font_face; }
     void set_css_connected_font_face(GC::Ptr<FontFace> font_face) { m_css_connected_font_face = font_face; }
-    void handle_descriptor_change(FlyString const& property);
+    void handle_descriptor_change(Utf16FlyString const& property);
     void disconnect_font_face();
 
 private:

--- a/Libraries/LibWeb/CSS/CSSFunctionDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSFunctionDescriptors.cpp
@@ -32,7 +32,7 @@ String CSSFunctionDescriptors::result() const
 // https://drafts.csswg.org/css-mixins-1/#dom-cssfunctiondescriptors-result
 WebIDL::ExceptionOr<void> CSSFunctionDescriptors::set_result(StringView value)
 {
-    return set_property("result"_string, value, ""sv);
+    return set_property("result"_utf16_fly_string, value, ""sv);
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSFunctionDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSFunctionDescriptors.cpp
@@ -26,7 +26,7 @@ void CSSFunctionDescriptors::initialize(JS::Realm& realm)
 // https://drafts.csswg.org/css-mixins-1/#dom-cssfunctiondescriptors-result
 String CSSFunctionDescriptors::result() const
 {
-    return get_property_value("result"_string);
+    return get_property_value("result"_utf16_fly_string);
 }
 
 // https://drafts.csswg.org/css-mixins-1/#dom-cssfunctiondescriptors-result

--- a/Libraries/LibWeb/CSS/CSSPageDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSPageDescriptors.cpp
@@ -38,7 +38,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin(StringView value)
 
 String CSSPageDescriptors::margin() const
 {
-    return get_property_value("margin"_fly_string);
+    return get_property_value("margin"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_top(StringView value)
@@ -48,7 +48,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_top(StringView value)
 
 String CSSPageDescriptors::margin_top() const
 {
-    return get_property_value("margin-top"_fly_string);
+    return get_property_value("margin-top"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_right(StringView value)
@@ -58,7 +58,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_right(StringView value)
 
 String CSSPageDescriptors::margin_right() const
 {
-    return get_property_value("margin-right"_fly_string);
+    return get_property_value("margin-right"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_bottom(StringView value)
@@ -68,7 +68,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_bottom(StringView value
 
 String CSSPageDescriptors::margin_bottom() const
 {
-    return get_property_value("margin-bottom"_fly_string);
+    return get_property_value("margin-bottom"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_left(StringView value)
@@ -78,7 +78,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_left(StringView value)
 
 String CSSPageDescriptors::margin_left() const
 {
-    return get_property_value("margin-left"_fly_string);
+    return get_property_value("margin-left"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_size(StringView value)
@@ -88,7 +88,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_size(StringView value)
 
 String CSSPageDescriptors::size() const
 {
-    return get_property_value("size"_fly_string);
+    return get_property_value("size"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_page_orientation(StringView value)
@@ -98,7 +98,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_page_orientation(StringView va
 
 String CSSPageDescriptors::page_orientation() const
 {
-    return get_property_value("page-orientation"_fly_string);
+    return get_property_value("page-orientation"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_marks(StringView value)
@@ -108,7 +108,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_marks(StringView value)
 
 String CSSPageDescriptors::marks() const
 {
-    return get_property_value("marks"_fly_string);
+    return get_property_value("marks"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_bleed(StringView value)
@@ -118,7 +118,7 @@ WebIDL::ExceptionOr<void> CSSPageDescriptors::set_bleed(StringView value)
 
 String CSSPageDescriptors::bleed() const
 {
-    return get_property_value("bleed"_fly_string);
+    return get_property_value("bleed"_utf16_fly_string);
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSPageDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSPageDescriptors.cpp
@@ -33,7 +33,7 @@ void CSSPageDescriptors::initialize(JS::Realm& realm)
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin(StringView value)
 {
-    return set_property("margin"_fly_string, value, ""sv);
+    return set_property("margin"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin() const
@@ -43,7 +43,7 @@ String CSSPageDescriptors::margin() const
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_top(StringView value)
 {
-    return set_property("margin-top"_fly_string, value, ""sv);
+    return set_property("margin-top"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin_top() const
@@ -53,7 +53,7 @@ String CSSPageDescriptors::margin_top() const
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_right(StringView value)
 {
-    return set_property("margin-right"_fly_string, value, ""sv);
+    return set_property("margin-right"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin_right() const
@@ -63,7 +63,7 @@ String CSSPageDescriptors::margin_right() const
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_bottom(StringView value)
 {
-    return set_property("margin-bottom"_fly_string, value, ""sv);
+    return set_property("margin-bottom"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin_bottom() const
@@ -73,7 +73,7 @@ String CSSPageDescriptors::margin_bottom() const
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_left(StringView value)
 {
-    return set_property("margin-left"_fly_string, value, ""sv);
+    return set_property("margin-left"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin_left() const
@@ -83,7 +83,7 @@ String CSSPageDescriptors::margin_left() const
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_size(StringView value)
 {
-    return set_property("size"_fly_string, value, ""sv);
+    return set_property("size"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::size() const
@@ -93,7 +93,7 @@ String CSSPageDescriptors::size() const
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_page_orientation(StringView value)
 {
-    return set_property("page-orientation"_fly_string, value, ""sv);
+    return set_property("page-orientation"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::page_orientation() const
@@ -103,7 +103,7 @@ String CSSPageDescriptors::page_orientation() const
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_marks(StringView value)
 {
-    return set_property("marks"_fly_string, value, ""sv);
+    return set_property("marks"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::marks() const
@@ -113,7 +113,7 @@ String CSSPageDescriptors::marks() const
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_bleed(StringView value)
 {
-    return set_property("bleed"_fly_string, value, ""sv);
+    return set_property("bleed"_utf16_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::bleed() const

--- a/Libraries/LibWeb/CSS/CSSPropertyRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSPropertyRule.cpp
@@ -15,12 +15,12 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSPropertyRule);
 
-GC::Ref<CSSPropertyRule> CSSPropertyRule::create(JS::Realm& realm, FlyString name, FlyString syntax, bool inherits, RefPtr<StyleValue const> initial_value)
+GC::Ref<CSSPropertyRule> CSSPropertyRule::create(JS::Realm& realm, Utf16FlyString name, FlyString syntax, bool inherits, RefPtr<StyleValue const> initial_value)
 {
     return realm.create<CSSPropertyRule>(realm, move(name), move(syntax), inherits, move(initial_value));
 }
 
-CSSPropertyRule::CSSPropertyRule(JS::Realm& realm, FlyString name, FlyString syntax, bool inherits, RefPtr<StyleValue const> initial_value)
+CSSPropertyRule::CSSPropertyRule(JS::Realm& realm, Utf16FlyString name, FlyString syntax, bool inherits, RefPtr<StyleValue const> initial_value)
     : CSSRule(realm, Type::Property)
     , m_name(move(name))
     , m_syntax(move(syntax))
@@ -64,7 +64,7 @@ String CSSPropertyRule::serialized() const
 
     // 1. The string "@property" followed by a single SPACE (U+0020).
     // 2. The result of performing serialize an identifier on the rule’s name, followed by a single SPACE (U+0020).
-    builder.appendff("@property {} ", serialize_an_identifier(name()));
+    builder.appendff("@property {} ", serialize_an_identifier(name().to_utf16_string().to_utf8_but_should_be_ported_to_utf16()));
 
     // 3. The string "{ ", i.e., a single LEFT CURLY BRACKET (U+007B), followed by a SPACE (U+0020).
     builder.append("{ "sv);

--- a/Libraries/LibWeb/CSS/CSSPropertyRule.h
+++ b/Libraries/LibWeb/CSS/CSSPropertyRule.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
-#include <AK/FlyString.h>
 #include <AK/Optional.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CustomPropertyRegistration.h>
 #include <LibWeb/Forward.h>
@@ -22,11 +22,11 @@ class CSSPropertyRule final : public CSSRule {
     GC_DECLARE_ALLOCATOR(CSSPropertyRule);
 
 public:
-    static GC::Ref<CSSPropertyRule> create(JS::Realm&, FlyString name, FlyString syntax, bool inherits, RefPtr<StyleValue const> initial_value);
+    static GC::Ref<CSSPropertyRule> create(JS::Realm&, Utf16FlyString name, FlyString syntax, bool inherits, RefPtr<StyleValue const> initial_value);
 
     virtual ~CSSPropertyRule() = default;
 
-    FlyString const& name() const { return m_name; }
+    Utf16FlyString const& name() const { return m_name; }
     FlyString const& syntax() const { return m_syntax; }
     bool inherits() const { return m_inherits; }
     Optional<String> initial_value() const;
@@ -35,13 +35,13 @@ public:
     CustomPropertyRegistration to_registration() const;
 
 private:
-    CSSPropertyRule(JS::Realm&, FlyString name, FlyString syntax, bool inherits, RefPtr<StyleValue const> initial_value);
+    CSSPropertyRule(JS::Realm&, Utf16FlyString name, FlyString syntax, bool inherits, RefPtr<StyleValue const> initial_value);
 
     virtual void initialize(JS::Realm&) override;
     virtual String serialized() const override;
     virtual void dump(StringBuilder&, int indent_levels) const override;
 
-    FlyString m_name;
+    Utf16FlyString m_name;
     FlyString m_syntax;
     bool m_inherits;
     RefPtr<StyleValue const> m_initial_value;

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -30,11 +30,11 @@ public:
     virtual size_t length() const = 0;
     virtual String item(size_t index) const = 0;
 
-    virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property_name, StringView css_text, StringView priority) = 0;
-    virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property_name) = 0;
+    virtual WebIDL::ExceptionOr<void> set_property(Utf16FlyString const& property_name, StringView css_text, StringView priority) = 0;
+    virtual WebIDL::ExceptionOr<String> remove_property(Utf16FlyString const& property_name) = 0;
 
     virtual String get_property_value(Utf16FlyString const& property_name) const = 0;
-    virtual StringView get_property_priority(FlyString const& property_name) const = 0;
+    virtual StringView get_property_priority(Utf16FlyString const& property_name) const = 0;
 
     String css_text() const;
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) = 0;

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -33,7 +33,7 @@ public:
     virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property_name, StringView css_text, StringView priority) = 0;
     virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property_name) = 0;
 
-    virtual String get_property_value(FlyString const& property_name) const = 0;
+    virtual String get_property_value(Utf16FlyString const& property_name) const = 0;
     virtual StringView get_property_priority(FlyString const& property_name) const = 0;
 
     String css_text() const;

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.idl
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.idl
@@ -6,11 +6,11 @@ interface CSSStyleDeclaration {
     readonly attribute unsigned long length;
     getter CSSOMString item(unsigned long index);
 
-    CSSOMString getPropertyValue(CSSOMString property);
-    CSSOMString getPropertyPriority(CSSOMString property);
+    CSSOMString getPropertyValue(Utf16CSSOMString property);
+    CSSOMString getPropertyPriority(Utf16CSSOMString property);
 
-    [CEReactions] undefined setProperty(CSSOMString property, [LegacyNullToEmptyString] CSSOMString value, optional [LegacyNullToEmptyString] CSSOMString priority = "");
-    [CEReactions] CSSOMString removeProperty(CSSOMString property);
+    [CEReactions] undefined setProperty(Utf16CSSOMString property, [LegacyNullToEmptyString] CSSOMString value, optional [LegacyNullToEmptyString] CSSOMString priority = "");
+    [CEReactions] CSSOMString removeProperty(Utf16CSSOMString property);
 
     readonly attribute CSSRule? parentRule;
 };

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -362,19 +362,34 @@ static RefPtr<StyleValue const> style_value_for_shadow(ShadowStyleValue::ShadowT
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue
-String CSSStyleProperties::get_property_value(FlyString const& property_name) const
+String CSSStyleProperties::get_property_value(Utf16FlyString const& property_name) const
 {
-    auto property = PropertyNameAndID::from_name(property_name);
-    if (!property.has_value())
+    if (!property_name.is_ascii())
         return {};
-    if (auto style_property = get_property_internal(property.value()); style_property.has_value()) {
-        return style_property->value->to_string(
-            is_computed() ? SerializationMode::ResolvedValue
-                          : SerializationMode::Normal);
+
+    auto property_name_string = property_name.to_utf16_string();
+    auto property_name_view = property_name_string.ascii_view();
+
+    if (auto property_id = property_id_from_string(property_name_view); property_id.has_value()) {
+        if (*property_id == PropertyID::Custom) {
+            auto custom_property_name = MUST(FlyString::from_utf8(property_name_view));
+            if (auto style_property = custom_property(custom_property_name); style_property.has_value()) {
+                return style_property->value->to_string(
+                    is_computed() ? SerializationMode::ResolvedValue
+                                  : SerializationMode::Normal);
+            }
+            return {};
+        }
+
+        if (auto style_property = get_property_internal(PropertyNameAndID::from_id(*property_id)); style_property.has_value()) {
+            return style_property->value->to_string(
+                is_computed() ? SerializationMode::ResolvedValue
+                              : SerializationMode::Normal);
+        }
     }
+
     return {};
 }
-
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
 StringView CSSStyleProperties::get_property_priority(FlyString const& property_name) const
 {
@@ -1137,7 +1152,7 @@ WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property_internal(Optiona
     if (property.has_value()) {
         // 3. Let value be the return value of invoking getPropertyValue() with property as argument.
         // FIXME: Add an overload that takes PropertyNameAndID?
-        value = get_property_value(property->name());
+        value = get_property_value(Utf16FlyString::from_utf8(property->name()));
 
         Function<bool(PropertyNameAndID const&)> remove_declaration = [&](PropertyNameAndID const& property_to_remove) {
             // 4. Let removed be false.
@@ -1186,7 +1201,7 @@ WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property(PropertyID prope
 String CSSStyleProperties::css_float() const
 {
     // The cssFloat attribute, on getting, must return the result of invoking getPropertyValue() with float as argument.
-    return get_property_value("float"_fly_string);
+    return get_property_value("float"_utf16_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSStyleProperties::set_css_float(StringView value)

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -42,7 +42,7 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSStyleProperties);
 
-GC::Ref<CSSStyleProperties> CSSStyleProperties::create(JS::Realm& realm, Vector<StyleProperty> properties, OrderedHashMap<FlyString, StyleProperty> custom_properties)
+GC::Ref<CSSStyleProperties> CSSStyleProperties::create(JS::Realm& realm, Vector<StyleProperty> properties, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties)
 {
     // https://drafts.csswg.org/cssom/#dom-cssstylerule-style
     // The style attribute must return a CSSStyleProperties object for the style rule, with the following properties:
@@ -64,10 +64,10 @@ GC::Ref<CSSStyleProperties> CSSStyleProperties::create_resolved_style(JS::Realm&
     //     parent CSS rule: Null.
     //     owner node: obj.
     // AD-HOC: Rather than instantiate with a list of decls, they're generated on demand.
-    return realm.create<CSSStyleProperties>(realm, Computed::Yes, Readonly::Yes, Vector<StyleProperty> {}, OrderedHashMap<FlyString, StyleProperty> {}, move(element_reference));
+    return realm.create<CSSStyleProperties>(realm, Computed::Yes, Readonly::Yes, Vector<StyleProperty> {}, OrderedHashMap<Utf16FlyString, StyleProperty> {}, move(element_reference));
 }
 
-GC::Ref<CSSStyleProperties> CSSStyleProperties::create_element_inline_style(DOM::AbstractElement element_reference, Vector<StyleProperty> properties, OrderedHashMap<FlyString, StyleProperty> custom_properties)
+GC::Ref<CSSStyleProperties> CSSStyleProperties::create_element_inline_style(DOM::AbstractElement element_reference, Vector<StyleProperty> properties, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties)
 {
     // https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style
     // The style attribute must return a CSS declaration block object whose readonly flag is unset, whose parent CSS
@@ -76,7 +76,7 @@ GC::Ref<CSSStyleProperties> CSSStyleProperties::create_element_inline_style(DOM:
     return realm.create<CSSStyleProperties>(realm, Computed::No, Readonly::No, convert_declarations_to_specified_order(properties), move(custom_properties), move(element_reference));
 }
 
-CSSStyleProperties::CSSStyleProperties(JS::Realm& realm, Computed computed, Readonly readonly, Vector<StyleProperty> properties, OrderedHashMap<FlyString, StyleProperty> custom_properties, Optional<DOM::AbstractElement> owner_node)
+CSSStyleProperties::CSSStyleProperties(JS::Realm& realm, Computed computed, Readonly readonly, Vector<StyleProperty> properties, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties, Optional<DOM::AbstractElement> owner_node)
     : CSSStyleDeclaration(realm, computed, readonly)
     , m_properties(move(properties))
     , m_custom_properties(move(custom_properties))
@@ -156,10 +156,8 @@ String CSSStyleProperties::item(size_t index) const
         return string_from_property_id(property_id).to_string();
     }
 
-    if (index < custom_properties_count) {
-        auto keys = m_custom_properties.keys();
-        return keys[index].to_string();
-    }
+    if (index < custom_properties_count)
+        return m_custom_properties.keys()[index].to_utf16_string().to_utf8_but_should_be_ported_to_utf16();
 
     return CSS::string_from_property_id(m_properties[index - custom_properties_count].property_id).to_string();
 }
@@ -169,7 +167,7 @@ Optional<StyleProperty> CSSStyleProperties::get_property(PropertyID property_id)
     return get_property_internal(PropertyNameAndID::from_id(property_id));
 }
 
-Optional<StyleProperty const&> CSSStyleProperties::custom_property(FlyString const& custom_property_name) const
+Optional<StyleProperty const&> CSSStyleProperties::custom_property(Utf16FlyString const& custom_property_name) const
 {
     if (is_computed()) {
         if (!owner_node().has_value())
@@ -200,17 +198,11 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(Utf16FlyString const&
     if (is_computed())
         return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()"_utf16);
 
-    if (!property_name.is_ascii())
-        return {};
-
-    auto property_name_string = property_name.to_utf16_string();
-    auto property_name_view = property_name_string.ascii_view();
-
     // 2. If property is not a custom property, follow these substeps:
     //    1. Let property be property converted to ASCII lowercase.
     //    2. If property is not a case-sensitive match for a supported CSS property, then return.
     // NB: This is handled inside PropertyNameAndID::from_string().
-    auto property = PropertyNameAndID::from_name(MUST(FlyString::from_utf8(property_name_view)));
+    auto property = PropertyNameAndID::from_name(property_name);
     if (!property.has_value())
         return {};
 
@@ -370,28 +362,9 @@ static RefPtr<StyleValue const> style_value_for_shadow(ShadowStyleValue::ShadowT
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue
 String CSSStyleProperties::get_property_value(Utf16FlyString const& property_name) const
 {
-    if (!property_name.is_ascii())
-        return {};
-
-    auto property_name_string = property_name.to_utf16_string();
-    auto property_name_view = property_name_string.ascii_view();
-
-    if (auto property_id = property_id_from_string(property_name_view); property_id.has_value()) {
-        if (*property_id == PropertyID::Custom) {
-            auto custom_property_name = MUST(FlyString::from_utf8(property_name_view));
-            if (auto style_property = custom_property(custom_property_name); style_property.has_value()) {
-                return style_property->value->to_string(
-                    is_computed() ? SerializationMode::ResolvedValue
-                                  : SerializationMode::Normal);
-            }
-            return {};
-        }
-
-        if (auto style_property = get_property_internal(PropertyNameAndID::from_id(*property_id)); style_property.has_value()) {
-            return style_property->value->to_string(
-                is_computed() ? SerializationMode::ResolvedValue
-                              : SerializationMode::Normal);
-        }
+    if (auto property = PropertyNameAndID::from_name(property_name); property.has_value()) {
+        if (auto style_property = get_property_internal(*property); style_property.has_value())
+            return style_property->value->to_string(is_computed() ? SerializationMode::ResolvedValue : SerializationMode::Normal);
     }
 
     return {};
@@ -399,22 +372,16 @@ String CSSStyleProperties::get_property_value(Utf16FlyString const& property_nam
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
 StringView CSSStyleProperties::get_property_priority(Utf16FlyString const& property_name) const
 {
-    if (!property_name.is_ascii())
+    auto property = PropertyNameAndID::from_name(property_name);
+    if (!property.has_value())
         return {};
-
-    auto property_name_string = property_name.to_utf16_string();
-    auto property_name_view = property_name_string.ascii_view();
-
-    auto property_id = property_id_from_string(property_name_view);
-    if (!property_id.has_value())
-        return {};
-    if (property_id.value() == PropertyID::Custom) {
-        auto maybe_custom_property = custom_property(MUST(FlyString::from_utf8(property_name_view)));
+    if (property->is_custom_property()) {
+        auto maybe_custom_property = custom_property(property_name);
         if (!maybe_custom_property.has_value())
             return {};
         return maybe_custom_property.value().important == Important::Yes ? "important"sv : ""sv;
     }
-    auto maybe_property = get_property(property_id.value());
+    auto maybe_property = get_property(property->id());
     if (!maybe_property.has_value())
         return {};
     return maybe_property->important == Important::Yes ? "important"sv : ""sv;
@@ -1145,11 +1112,7 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
 WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property(Utf16FlyString const& property_name)
 {
-    if (!property_name.is_ascii())
-        return remove_property_internal({});
-
-    auto property_name_string = property_name.to_utf16_string();
-    return remove_property_internal(PropertyNameAndID::from_name(MUST(FlyString::from_utf8(property_name_string.ascii_view()))));
+    return remove_property_internal(PropertyNameAndID::from_name(property_name));
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
@@ -1168,7 +1131,7 @@ WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property_internal(Optiona
     if (property.has_value()) {
         // 3. Let value be the return value of invoking getPropertyValue() with property as argument.
         // FIXME: Add an overload that takes PropertyNameAndID?
-        value = get_property_value(Utf16FlyString::from_utf8(property->name()));
+        value = get_property_value(property->name());
 
         Function<bool(PropertyNameAndID const&)> remove_declaration = [&](PropertyNameAndID const& property_to_remove) {
             // 4. Let removed be false.
@@ -1273,7 +1236,8 @@ String CSSStyleProperties::serialized() const
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value,
         //    and the important flag set if declaration has its important flag set.
         // NB: We have to inline this here as the actual implementation does not accept custom properties.
-        String serialized_declaration = serialize_a_css_declaration(property, value, declaration.value.important);
+        auto property_string = property.to_utf16_string().to_utf8_but_should_be_ported_to_utf16();
+        String serialized_declaration = serialize_a_css_declaration(property_string, value, declaration.value.important);
 
         // 7. Append serialized declaration to list.
         list.append(move(serialized_declaration));
@@ -1609,7 +1573,7 @@ void CSSStyleProperties::empty_the_declarations()
     m_custom_properties.clear();
 }
 
-void CSSStyleProperties::set_the_declarations(Vector<StyleProperty> properties, OrderedHashMap<FlyString, StyleProperty> custom_properties)
+void CSSStyleProperties::set_the_declarations(Vector<StyleProperty> properties, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties)
 {
     m_properties = convert_declarations_to_specified_order(properties);
     m_custom_properties = move(custom_properties);

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -194,17 +194,23 @@ Optional<StyleProperty const&> CSSStyleProperties::custom_property(FlyString con
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
-WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(FlyString const& property_name, StringView value, StringView priority)
+WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(Utf16FlyString const& property_name, StringView value, StringView priority)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
     if (is_computed())
         return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()"_utf16);
 
+    if (!property_name.is_ascii())
+        return {};
+
+    auto property_name_string = property_name.to_utf16_string();
+    auto property_name_view = property_name_string.ascii_view();
+
     // 2. If property is not a custom property, follow these substeps:
     //    1. Let property be property converted to ASCII lowercase.
     //    2. If property is not a case-sensitive match for a supported CSS property, then return.
     // NB: This is handled inside PropertyNameAndID::from_string().
-    auto property = PropertyNameAndID::from_name(property_name);
+    auto property = PropertyNameAndID::from_name(MUST(FlyString::from_utf8(property_name_view)));
     if (!property.has_value())
         return {};
 
@@ -391,13 +397,19 @@ String CSSStyleProperties::get_property_value(Utf16FlyString const& property_nam
     return {};
 }
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
-StringView CSSStyleProperties::get_property_priority(FlyString const& property_name) const
+StringView CSSStyleProperties::get_property_priority(Utf16FlyString const& property_name) const
 {
-    auto property_id = property_id_from_string(property_name);
+    if (!property_name.is_ascii())
+        return {};
+
+    auto property_name_string = property_name.to_utf16_string();
+    auto property_name_view = property_name_string.ascii_view();
+
+    auto property_id = property_id_from_string(property_name_view);
     if (!property_id.has_value())
         return {};
     if (property_id.value() == PropertyID::Custom) {
-        auto maybe_custom_property = custom_property(property_name);
+        auto maybe_custom_property = custom_property(MUST(FlyString::from_utf8(property_name_view)));
         if (!maybe_custom_property.has_value())
             return {};
         return maybe_custom_property.value().important == Important::Yes ? "important"sv : ""sv;
@@ -1131,9 +1143,13 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
-WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property(FlyString const& property_name)
+WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property(Utf16FlyString const& property_name)
 {
-    return remove_property_internal(PropertyNameAndID::from_name(property_name));
+    if (!property_name.is_ascii())
+        return remove_property_internal({});
+
+    auto property_name_string = property_name.to_utf16_string();
+    return remove_property_internal(PropertyNameAndID::from_name(MUST(FlyString::from_utf8(property_name_string.ascii_view()))));
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
@@ -1208,7 +1224,7 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_css_float(StringView value)
 {
     // On setting, the attribute must invoke setProperty() with float as first argument, as second argument the given value,
     // and no third argument. Any exceptions thrown must be re-thrown.
-    return set_property("float"_fly_string, value, ""sv);
+    return set_property("float"_utf16_fly_string, value, ""sv);
 }
 
 // https://www.w3.org/TR/cssom/#serialize-a-css-declaration-block

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -39,11 +39,11 @@ public:
     WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority = ""sv);
     WebIDL::ExceptionOr<String> remove_property(PropertyID);
 
-    virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property_name, StringView css_text, StringView priority) override;
-    virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property_name) override;
+    virtual WebIDL::ExceptionOr<void> set_property(Utf16FlyString const& property_name, StringView css_text, StringView priority) override;
+    virtual WebIDL::ExceptionOr<String> remove_property(Utf16FlyString const& property_name) override;
 
     virtual String get_property_value(Utf16FlyString const& property_name) const override;
-    virtual StringView get_property_priority(FlyString const& property_name) const override;
+    virtual StringView get_property_priority(Utf16FlyString const& property_name) const override;
 
     Vector<StyleProperty> const& properties() const { return m_properties; }
     OrderedHashMap<FlyString, StyleProperty> const& custom_properties() const { return m_custom_properties; }

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -42,7 +42,7 @@ public:
     virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property_name, StringView css_text, StringView priority) override;
     virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property_name) override;
 
-    virtual String get_property_value(FlyString const& property_name) const override;
+    virtual String get_property_value(Utf16FlyString const& property_name) const override;
     virtual StringView get_property_priority(FlyString const& property_name) const override;
 
     Vector<StyleProperty> const& properties() const { return m_properties; }

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -16,8 +16,7 @@ namespace Web::CSS {
 
 // https://drafts.csswg.org/cssom/#cssstyleproperties
 class WEB_API CSSStyleProperties
-    : public CSSStyleDeclaration
-    , public Bindings::GeneratedCSSStyleProperties {
+    : public CSSStyleDeclaration {
     WEB_PLATFORM_OBJECT(CSSStyleProperties, CSSStyleDeclaration);
     GC_DECLARE_ALLOCATOR(CSSStyleProperties);
 
@@ -66,9 +65,6 @@ public:
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) override;
 
     void set_declarations_from_text(StringView);
-
-    // ^Bindings::GeneratedCSSStyleProperties
-    virtual CSSStyleProperties& generated_style_properties_to_css_style_properties() override { return *this; }
 
 private:
     CSSStyleProperties(JS::Realm&, Computed, Readonly, Vector<StyleProperty> properties, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties, Optional<DOM::AbstractElement>);

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -22,10 +22,10 @@ class WEB_API CSSStyleProperties
     GC_DECLARE_ALLOCATOR(CSSStyleProperties);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSStyleProperties> create(JS::Realm&, Vector<StyleProperty>, OrderedHashMap<FlyString, StyleProperty> custom_properties);
+    [[nodiscard]] static GC::Ref<CSSStyleProperties> create(JS::Realm&, Vector<StyleProperty>, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties);
 
     [[nodiscard]] static GC::Ref<CSSStyleProperties> create_resolved_style(JS::Realm&, Optional<DOM::AbstractElement>);
-    [[nodiscard]] static GC::Ref<CSSStyleProperties> create_element_inline_style(DOM::AbstractElement, Vector<StyleProperty>, OrderedHashMap<FlyString, StyleProperty> custom_properties);
+    [[nodiscard]] static GC::Ref<CSSStyleProperties> create_element_inline_style(DOM::AbstractElement, Vector<StyleProperty>, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties);
 
     virtual ~CSSStyleProperties() override = default;
     virtual void initialize(JS::Realm&) override;
@@ -34,7 +34,7 @@ public:
     virtual String item(size_t index) const override;
 
     Optional<StyleProperty> get_property(PropertyID) const;
-    Optional<StyleProperty const&> custom_property(FlyString const& custom_property_name) const;
+    Optional<StyleProperty const&> custom_property(Utf16FlyString const& custom_property_name) const;
 
     WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority = ""sv);
     WebIDL::ExceptionOr<String> remove_property(PropertyID);
@@ -46,7 +46,7 @@ public:
     virtual StringView get_property_priority(Utf16FlyString const& property_name) const override;
 
     Vector<StyleProperty> const& properties() const { return m_properties; }
-    OrderedHashMap<FlyString, StyleProperty> const& custom_properties() const { return m_custom_properties; }
+    OrderedHashMap<Utf16FlyString, StyleProperty> const& custom_properties() const { return m_custom_properties; }
 
     size_t custom_property_count() const { return m_custom_properties.size(); }
 
@@ -71,7 +71,7 @@ public:
     virtual CSSStyleProperties& generated_style_properties_to_css_style_properties() override { return *this; }
 
 private:
-    CSSStyleProperties(JS::Realm&, Computed, Readonly, Vector<StyleProperty> properties, OrderedHashMap<FlyString, StyleProperty> custom_properties, Optional<DOM::AbstractElement>);
+    CSSStyleProperties(JS::Realm&, Computed, Readonly, Vector<StyleProperty> properties, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties, Optional<DOM::AbstractElement>);
     static Vector<StyleProperty> convert_declarations_to_specified_order(Vector<StyleProperty>&);
 
     virtual size_t external_memory_size() const override;
@@ -84,12 +84,12 @@ private:
 
     bool set_a_css_declaration(PropertyID, NonnullRefPtr<StyleValue const>, Important);
     void empty_the_declarations();
-    void set_the_declarations(Vector<StyleProperty> properties, OrderedHashMap<FlyString, StyleProperty> custom_properties);
+    void set_the_declarations(Vector<StyleProperty> properties, OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties);
 
     void invalidate_owners(DOM::StyleInvalidationReason);
 
     Vector<StyleProperty> m_properties;
-    OrderedHashMap<FlyString, StyleProperty> m_custom_properties;
+    OrderedHashMap<Utf16FlyString, StyleProperty> m_custom_properties;
 };
 
 }

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -17,7 +17,7 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSStyleValue);
 
-GC::Ref<CSSStyleValue> CSSStyleValue::create(JS::Realm& realm, FlyString associated_property, NonnullRefPtr<StyleValue const> source_value)
+GC::Ref<CSSStyleValue> CSSStyleValue::create(JS::Realm& realm, Utf16FlyString associated_property, NonnullRefPtr<StyleValue const> source_value)
 {
     return realm.create<CSSStyleValue>(realm, move(associated_property), move(source_value));
 }
@@ -33,7 +33,7 @@ CSSStyleValue::CSSStyleValue(JS::Realm& realm, NonnullRefPtr<StyleValue const> s
 {
 }
 
-CSSStyleValue::CSSStyleValue(JS::Realm& realm, FlyString associated_property, NonnullRefPtr<StyleValue const> source_value)
+CSSStyleValue::CSSStyleValue(JS::Realm& realm, Utf16FlyString associated_property, NonnullRefPtr<StyleValue const> source_value)
     : PlatformObject(realm)
     , m_associated_property(move(associated_property))
     , m_source_value(move(source_value))
@@ -49,7 +49,7 @@ void CSSStyleValue::initialize(JS::Realm& realm)
 CSSStyleValue::~CSSStyleValue() = default;
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-parse
-WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> CSSStyleValue::parse(JS::VM& vm, FlyString const& property, String css_text)
+WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> CSSStyleValue::parse(JS::VM& vm, Utf16FlyString const& property, String css_text)
 {
     // The parse(property, cssText) method, when invoked, must parse a CSSStyleValue with property property, cssText
     // cssText, and parseMultiple set to false, and return the result.
@@ -60,7 +60,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> CSSStyleValue::parse(JS::VM& vm, Fly
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-parseall
-WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> CSSStyleValue::parse_all(JS::VM& vm, FlyString const& property, String css_text)
+WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> CSSStyleValue::parse_all(JS::VM& vm, Utf16FlyString const& property, String css_text)
 {
     // The parseAll(property, cssText) method, when invoked, must parse a CSSStyleValue with property property, cssText
     // cssText, and parseMultiple set to true, and return the result.
@@ -71,7 +71,7 @@ WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> CSSStyleValue::parse
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#parse-a-cssstylevalue
-WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, GC::RootVector<GC::Ref<CSSStyleValue>>>> CSSStyleValue::parse_a_css_style_value(JS::VM& vm, FlyString property_name, String css_text, ParseMultiple parse_multiple)
+WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, GC::RootVector<GC::Ref<CSSStyleValue>>>> CSSStyleValue::parse_a_css_style_value(JS::VM& vm, Utf16FlyString property_name, String css_text, ParseMultiple parse_multiple)
 {
     // 1. If property is not a custom property name string, set property to property ASCII lowercased.
     // 2. If property is not a valid CSS property, throw a TypeError.

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/FlyString.h>
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 
 namespace Web::CSS {
@@ -17,23 +17,23 @@ class CSSStyleValue : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(CSSStyleValue);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSStyleValue> create(JS::Realm&, FlyString associated_property, NonnullRefPtr<StyleValue const>);
+    [[nodiscard]] static GC::Ref<CSSStyleValue> create(JS::Realm&, Utf16FlyString associated_property, NonnullRefPtr<StyleValue const>);
 
     virtual ~CSSStyleValue() override;
 
     virtual void initialize(JS::Realm&) override;
 
-    Optional<FlyString> const& associated_property() const { return m_associated_property; }
+    Optional<Utf16FlyString> const& associated_property() const { return m_associated_property; }
     RefPtr<StyleValue const> const& source_value() const { return m_source_value; }
 
-    static WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> parse(JS::VM&, FlyString const& property, String css_text);
-    static WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> parse_all(JS::VM&, FlyString const& property, String css_text);
+    static WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> parse(JS::VM&, Utf16FlyString const& property, String css_text);
+    static WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> parse_all(JS::VM&, Utf16FlyString const& property, String css_text);
 
     enum class ParseMultiple : u8 {
         No,
         Yes,
     };
-    static WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, GC::RootVector<GC::Ref<CSSStyleValue>>>> parse_a_css_style_value(JS::VM&, FlyString property, String css_text, ParseMultiple);
+    static WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, GC::RootVector<GC::Ref<CSSStyleValue>>>> parse_a_css_style_value(JS::VM&, Utf16FlyString property, String css_text, ParseMultiple);
 
     virtual WebIDL::ExceptionOr<String> to_string() const;
 
@@ -49,10 +49,10 @@ protected:
     explicit CSSStyleValue(JS::Realm&, NonnullRefPtr<StyleValue const> source_value);
 
 private:
-    explicit CSSStyleValue(JS::Realm&, FlyString associated_property, NonnullRefPtr<StyleValue const> source_value);
+    explicit CSSStyleValue(JS::Realm&, Utf16FlyString associated_property, NonnullRefPtr<StyleValue const> source_value);
 
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-associatedproperty-slot
-    Optional<FlyString> m_associated_property;
+    Optional<Utf16FlyString> m_associated_property;
 
     RefPtr<StyleValue const> m_source_value;
 };

--- a/Libraries/LibWeb/CSS/CSSStyleValue.idl
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.idl
@@ -2,6 +2,6 @@
 [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
 interface CSSStyleValue {
     stringifier;
-    [Exposed=Window] static CSSStyleValue parse(USVString property, USVString cssText);
-    [Exposed=Window] static sequence<CSSStyleValue> parseAll(USVString property, USVString cssText);
+    [Exposed=Window] static CSSStyleValue parse(Utf16USVString property, USVString cssText);
+    [Exposed=Window] static sequence<CSSStyleValue> parseAll(Utf16USVString property, USVString cssText);
 };

--- a/Libraries/LibWeb/CSS/CustomPropertyData.cpp
+++ b/Libraries/LibWeb/CSS/CustomPropertyData.cpp
@@ -13,7 +13,7 @@ namespace Web::CSS {
 static constexpr u8 max_ancestor_count = 32;
 static constexpr size_t absorb_threshold = 8;
 
-CustomPropertyData::CustomPropertyData(OrderedHashMap<FlyString, StyleProperty> own_values, RefPtr<CustomPropertyData const> parent, u8 ancestor_count)
+CustomPropertyData::CustomPropertyData(OrderedHashMap<Utf16FlyString, StyleProperty> own_values, RefPtr<CustomPropertyData const> parent, u8 ancestor_count)
     : m_own_values(move(own_values))
     , m_parent(move(parent))
     , m_ancestor_count(ancestor_count)
@@ -21,7 +21,7 @@ CustomPropertyData::CustomPropertyData(OrderedHashMap<FlyString, StyleProperty> 
 }
 
 NonnullRefPtr<CustomPropertyData> CustomPropertyData::create(
-    OrderedHashMap<FlyString, StyleProperty> own_values,
+    OrderedHashMap<Utf16FlyString, StyleProperty> own_values,
     RefPtr<CustomPropertyData const> parent)
 {
     if (!parent)
@@ -29,7 +29,7 @@ NonnullRefPtr<CustomPropertyData> CustomPropertyData::create(
 
     // If parent chain is too deep, flatten by copying all ancestor values into own.
     if (parent->m_ancestor_count >= max_ancestor_count - 1) {
-        parent->for_each_property([&](FlyString const& name, StyleProperty const& property) {
+        parent->for_each_property([&](Utf16FlyString const& name, StyleProperty const& property) {
             own_values.ensure(name, [&] { return property; });
         });
         return adopt_ref(*new CustomPropertyData(move(own_values), nullptr, 0));
@@ -48,7 +48,7 @@ NonnullRefPtr<CustomPropertyData> CustomPropertyData::create(
     return adopt_ref(*new CustomPropertyData(move(own_values), move(parent), ancestor_count));
 }
 
-StyleProperty const* CustomPropertyData::get(FlyString const& name) const
+StyleProperty const* CustomPropertyData::get(Utf16FlyString const& name) const
 {
     if (auto it = m_own_values.find(name); it != m_own_values.end())
         return &it->value;
@@ -71,7 +71,7 @@ RefPtr<CustomPropertyData const> CustomPropertyData::inheritable(DOM::Document c
     if (m_parent)
         inheritable_parent = m_parent->inheritable(document);
 
-    OrderedHashMap<FlyString, StyleProperty> inheritable_own_values;
+    OrderedHashMap<Utf16FlyString, StyleProperty> inheritable_own_values;
     bool filtered_any_own_values = false;
     for (auto const& [name, property] : m_own_values) {
         auto registration = document.get_registered_custom_property(name);
@@ -104,9 +104,9 @@ RefPtr<CustomPropertyData const> CustomPropertyData::inheritable(DOM::Document c
     return m_cached_inheritable_data;
 }
 
-void CustomPropertyData::for_each_property(Function<void(FlyString const&, StyleProperty const&)> callback) const
+void CustomPropertyData::for_each_property(Function<void(Utf16FlyString const&, StyleProperty const&)> callback) const
 {
-    HashTable<FlyString> seen;
+    HashTable<Utf16FlyString> seen;
     for (auto const* node = this; node; node = node->m_parent.ptr()) {
         for (auto const& [name, property] : node->m_own_values) {
             if (seen.set(name) == HashSetResult::KeptExistingEntry)

--- a/Libraries/LibWeb/CSS/CustomPropertyData.h
+++ b/Libraries/LibWeb/CSS/CustomPropertyData.h
@@ -23,24 +23,24 @@ namespace Web::CSS {
 class WEB_API CustomPropertyData : public RefCounted<CustomPropertyData> {
 public:
     static NonnullRefPtr<CustomPropertyData> create(
-        OrderedHashMap<FlyString, StyleProperty> own_values,
+        OrderedHashMap<Utf16FlyString, StyleProperty> own_values,
         RefPtr<CustomPropertyData const> parent);
 
-    StyleProperty const* get(FlyString const& name) const;
+    StyleProperty const* get(Utf16FlyString const& name) const;
     RefPtr<CustomPropertyData const> inheritable(DOM::Document const&) const;
 
-    OrderedHashMap<FlyString, StyleProperty> const& own_values() const { return m_own_values; }
+    OrderedHashMap<Utf16FlyString, StyleProperty> const& own_values() const { return m_own_values; }
 
-    void for_each_property(Function<void(FlyString const&, StyleProperty const&)> callback) const;
+    void for_each_property(Function<void(Utf16FlyString const&, StyleProperty const&)> callback) const;
 
     RefPtr<CustomPropertyData const> parent() const { return m_parent; }
 
     bool is_empty() const;
 
 private:
-    CustomPropertyData(OrderedHashMap<FlyString, StyleProperty> own_values, RefPtr<CustomPropertyData const> parent, u8 ancestor_count);
+    CustomPropertyData(OrderedHashMap<Utf16FlyString, StyleProperty> own_values, RefPtr<CustomPropertyData const> parent, u8 ancestor_count);
 
-    OrderedHashMap<FlyString, StyleProperty> m_own_values;
+    OrderedHashMap<Utf16FlyString, StyleProperty> m_own_values;
     RefPtr<CustomPropertyData const> m_parent;
     u8 m_ancestor_count { 0 };
     mutable FlatPtr m_cached_inheritable_document_identity { NumericLimits<FlatPtr>::max() };

--- a/Libraries/LibWeb/CSS/CustomPropertyRegistration.h
+++ b/Libraries/LibWeb/CSS/CustomPropertyRegistration.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/FlyString.h>
 #include <AK/RefPtr.h>
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 #include <LibWeb/Forward.h>
 
@@ -18,7 +18,7 @@ namespace Web::CSS {
 // like a real property. It’s a struct consisting of:
 struct CustomPropertyRegistration {
     // - a property name (a custom property name string)
-    FlyString property_name;
+    Utf16FlyString property_name;
 
     // - a syntax (a syntax string)
     String syntax;

--- a/Libraries/LibWeb/CSS/DescriptorNameAndID.h
+++ b/Libraries/LibWeb/CSS/DescriptorNameAndID.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/CSS/DescriptorID.h>
 #include <LibWeb/CSS/PropertyName.h>
 #include <LibWeb/CSS/Serialize.h>
@@ -14,15 +15,19 @@ namespace Web::CSS {
 
 class DescriptorNameAndID {
 public:
-    static Optional<DescriptorNameAndID> from_name(AtRuleID at_rule_id, FlyString name)
+    static Optional<DescriptorNameAndID> from_name(AtRuleID at_rule_id, Utf16FlyString name)
     {
         if (is_a_custom_property_name_string(name))
             return DescriptorNameAndID(move(name), DescriptorID::Custom);
 
-        if (auto descriptor_id = descriptor_id_from_string(at_rule_id, name); descriptor_id.has_value()) {
+        if (!name.is_ascii())
+            return {};
+
+        auto name_string = name.to_utf16_string();
+        if (auto descriptor_id = descriptor_id_from_string(at_rule_id, name_string.ascii_view()); descriptor_id.has_value()) {
             // NB: We use the serialized ID as the name here instead of the input name to ensure that legacy alias
             //     mapping is reflected
-            return DescriptorNameAndID(CSS::to_string(descriptor_id.value()), descriptor_id.value());
+            return DescriptorNameAndID(Utf16FlyString::from_utf8(CSS::to_string(descriptor_id.value())), descriptor_id.value());
         }
 
         return {};
@@ -31,12 +36,12 @@ public:
     static DescriptorNameAndID from_id(DescriptorID descriptor_id)
     {
         VERIFY(descriptor_id != DescriptorID::Custom);
-        return DescriptorNameAndID(CSS::to_string(descriptor_id), descriptor_id);
+        return DescriptorNameAndID(Utf16FlyString::from_utf8(CSS::to_string(descriptor_id)), descriptor_id);
     }
 
     DescriptorID id() const { return m_id; }
 
-    FlyString const& name() const
+    Utf16FlyString const& name() const
     {
         return m_name;
     }
@@ -47,13 +52,13 @@ public:
     }
 
 private:
-    DescriptorNameAndID(FlyString name, DescriptorID id)
+    DescriptorNameAndID(Utf16FlyString name, DescriptorID id)
         : m_name(move(name))
         , m_id(id)
     {
     }
 
-    FlyString m_name;
+    Utf16FlyString m_name;
     DescriptorID m_id;
 };
 

--- a/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.cpp
@@ -387,7 +387,7 @@ static Vector<ComponentValue> replace_an_inherit_function(DOM::AbstractElement& 
     //    does not contain the guaranteed-invalid value, return that inherited value.
     if (name_token.is(Token::Type::Ident) && is_a_custom_property_name_string(name_token.token().ident()) && first_argument_tokens.is_empty()) {
         if (auto element_to_inherit_style_from = element.element_to_inherit_style_from(); element_to_inherit_style_from.has_value()) {
-            if (auto const& inherited_value = element_to_inherit_style_from->get_custom_property(name_token.token().ident())) {
+            if (auto const& inherited_value = element_to_inherit_style_from->get_custom_property(Utf16FlyString::from_utf8(name_token.token().ident()))) {
                 auto inherited_value_tokens = inherited_value->tokenize();
                 if (!contains_guaranteed_invalid_value(inherited_value_tokens))
                     return inherited_value_tokens;
@@ -430,7 +430,7 @@ static Vector<ComponentValue> replace_a_var_function(DOM::AbstractElement& eleme
     } else {
         // Look up the value of the custom property
         auto& custom_property_name = name_token.token().ident();
-        auto custom_property_value = StyleComputer::compute_value_of_custom_property(element, custom_property_name, guarded_contexts);
+        auto custom_property_value = StyleComputer::compute_value_of_custom_property(element, Utf16FlyString::from_utf8(custom_property_name), guarded_contexts);
         result = custom_property_value->tokenize();
     }
 

--- a/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
@@ -22,12 +22,19 @@
 
 namespace Web::CSS::Parser {
 
+static FlyString descriptor_name_to_fly_string(DescriptorNameAndID const& descriptor_name_and_id)
+{
+    auto descriptor_name = descriptor_name_and_id.name().to_utf16_string();
+    auto descriptor_name_utf8 = descriptor_name.to_utf8_but_should_be_ported_to_utf16();
+    return MUST(FlyString::from_utf8(descriptor_name_utf8.bytes_as_string_view()));
+}
+
 Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_descriptor_value(AtRuleID at_rule_id, DescriptorNameAndID const& descriptor_name_and_id, TokenStream<ComponentValue>& tokens)
 {
     if (!at_rule_supports_descriptor(at_rule_id, descriptor_name_and_id.id())) {
         ErrorReporter::the().report(UnknownPropertyError {
             .rule_name = to_string(at_rule_id),
-            .property_name = descriptor_name_and_id.name(),
+            .property_name = descriptor_name_to_fly_string(descriptor_name_and_id),
         });
         return ParseError::SyntaxError;
     }
@@ -60,8 +67,10 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_descriptor_v
         // NB: Since we are not in a property value context we only allow ASFs if they are explicitly allowed in
         //     Descriptors.json
         if (!metadata.allow_arbitrary_substitution_functions) {
+            auto descriptor_name = descriptor_name_to_fly_string(descriptor_name_and_id);
+            auto value_type = MUST(String::formatted("{}/{}", to_string(at_rule_id), descriptor_name));
             ErrorReporter::the().report(InvalidValueError {
-                .value_type = MUST(String::formatted("{}/{}", to_string(at_rule_id), descriptor_name_and_id.name())),
+                .value_type = MUST(FlyString::from_utf8(value_type.bytes_as_string_view())),
                 .value_string = tokens.dump_string(),
                 .description = "ASFs are not supported in this descriptor"_string,
             });
@@ -423,7 +432,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_descriptor_v
 
     ErrorReporter::the().report(InvalidPropertyError {
         .rule_name = to_string(at_rule_id),
-        .property_name = descriptor_name_and_id.name(),
+        .property_name = descriptor_name_to_fly_string(descriptor_name_and_id),
         .value_string = tokens.dump_string(),
         .description = "Failed to parse."_string,
     });
@@ -433,7 +442,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_descriptor_v
 
 Optional<Descriptor> Parser::convert_to_descriptor(AtRuleID at_rule_id, Declaration const& declaration)
 {
-    auto descriptor_name_and_id = DescriptorNameAndID::from_name(at_rule_id, declaration.name);
+    auto descriptor_name_and_id = DescriptorNameAndID::from_name(at_rule_id, Utf16FlyString::from_utf8(declaration.name));
     if (!descriptor_name_and_id.has_value())
         return {};
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1971,8 +1971,10 @@ Optional<StylePropertyAndName> Parser::convert_to_style_property(Declaration con
     auto value = parse_css_value(property->id(), value_token_stream, declaration.original_value_text);
     if (value.is_error()) {
         if (value.error() == ParseError::SyntaxError) {
+            auto property_name = property->name().to_utf16_string();
+            auto property_name_utf8 = property_name.to_utf8_but_should_be_ported_to_utf16();
             ErrorReporter::the().report(InvalidPropertyError {
-                .property_name = property->name(),
+                .property_name = MUST(FlyString::from_utf8(property_name_utf8.bytes_as_string_view())),
                 .value_string = value_token_stream.dump_string(),
                 .description = "Failed to parse."_string,
             });

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1663,7 +1663,7 @@ Vector<DevToolsStyleDeclaration> Parser::parse_as_devtools_property_declaration_
     for (auto const& rule_or_list : declarations_and_at_rules) {
         if (auto* rule_declarations = rule_or_list.get_pointer<Vector<Declaration>>()) {
             for (auto const& declaration : *rule_declarations) {
-                auto property = PropertyNameAndID::from_name(declaration.name);
+                auto property = PropertyNameAndID::from_name(Utf16FlyString::from_utf8(declaration.name));
 
                 StringBuilder value_builder;
                 for (auto const& value : declaration.value)
@@ -1765,7 +1765,7 @@ bool Parser::is_valid_in_the_current_context(Declaration const& declaration) con
         // The <declaration-list> inside of <keyframe-block> accepts any CSS property except those defined in this
         // specification, but does accept the animation-timing-function property and interprets it specially
         // NB: animation-composition is defined in CSS Animations Level 2, so it is not excluded by this rule.
-        auto property = PropertyNameAndID::from_name(declaration.name);
+        auto property = PropertyNameAndID::from_name(Utf16FlyString::from_utf8(declaration.name));
         if (!property.has_value())
             return true;
         switch (property->id()) {
@@ -1957,7 +1957,7 @@ GC::Ref<CSSStyleProperties> Parser::convert_to_style_declaration(Vector<Declarat
 
 Optional<StylePropertyAndName> Parser::convert_to_style_property(Declaration const& declaration)
 {
-    auto property = PropertyNameAndID::from_name(declaration.name);
+    auto property = PropertyNameAndID::from_name(Utf16FlyString::from_utf8(declaration.name));
 
     if (!property.has_value()) {
         if (has_ignored_vendor_prefix(declaration.name)) {

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -132,7 +132,7 @@ public:
 
     struct PropertiesAndCustomProperties {
         Vector<StyleProperty> properties;
-        OrderedHashMap<FlyString, StyleProperty> custom_properties;
+        OrderedHashMap<Utf16FlyString, StyleProperty> custom_properties;
     };
     PropertiesAndCustomProperties parse_as_property_declaration_block();
     Vector<DevToolsStyleDeclaration> parse_as_devtools_property_declaration_block();

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -944,7 +944,7 @@ GC::Ptr<CSSPropertyRule> Parser::convert_to_property_rule(AtRule const& rule)
         return {};
     }
 
-    auto const& name = name_token.ident();
+    auto name = Utf16FlyString::from_utf8(name_token.ident());
 
     Optional<FlyString> syntax_maybe;
     Optional<bool> inherits_maybe;
@@ -1016,7 +1016,7 @@ GC::Ptr<CSSPropertyRule> Parser::convert_to_property_rule(AtRule const& rule)
         }
     }
 
-    return CSSPropertyRule::create(realm(), name, syntax_maybe.value(), inherits_maybe.value(), move(initial_value_maybe));
+    return CSSPropertyRule::create(realm(), move(name), syntax_maybe.value(), inherits_maybe.value(), move(initial_value_maybe));
 }
 
 // https://drafts.csswg.org/css-cascade-6/#scope-atrule

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -5599,7 +5599,7 @@ NonnullRefPtr<StyleValue const> Parser::resolve_unresolved_style_value(DOM::Abst
 
     // 1. Substitute arbitrary substitution functions in prop’s value, given «"property", prop’s name» as the
     //    substitution context. Let result be the returned component value sequence.
-    auto result = substitute_arbitrary_substitution_functions(element, guarded_contexts, unresolved.values(), SubstitutionContext { SubstitutionContext::DependencyType::Property, property.name().to_string() });
+    auto result = substitute_arbitrary_substitution_functions(element, guarded_contexts, unresolved.values(), SubstitutionContext { SubstitutionContext::DependencyType::Property, property.to_string() });
 
     // 2. If result contains the guaranteed-invalid value, prop is invalid at computed-value time; return.
     if (contains_guaranteed_invalid_value(result))

--- a/Libraries/LibWeb/CSS/PropertyName.h
+++ b/Libraries/LibWeb/CSS/PropertyName.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/StringView.h>
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/CSS/PropertyID.h>
 
 namespace Web::CSS {
@@ -26,12 +27,29 @@ inline bool is_a_custom_property_name_string(StringView string)
     return string.starts_with("--"sv) && !is_invalid_custom_property_name_string(string);
 }
 
+inline bool is_a_custom_property_name_string(Utf16FlyString const& string)
+{
+    return string.length_in_code_units() > 2
+        && string.code_unit_at(0) == '-'
+        && string.code_unit_at(1) == '-';
+}
+
 // https://drafts.css-houdini.org/css-typed-om-1/#valid-css-property
 inline bool is_a_valid_css_property(StringView string)
 {
     // A string is a valid CSS property if it is a custom property name string, or is a CSS property name recognized by
     // the user agent.
     return is_a_custom_property_name_string(string) || property_id_from_string(string).has_value();
+}
+
+inline bool is_a_valid_css_property(Utf16FlyString const& string)
+{
+    if (is_a_custom_property_name_string(string))
+        return true;
+    if (!string.is_ascii())
+        return false;
+    auto string_data = string.to_utf16_string();
+    return property_id_from_string(string_data.ascii_view()).has_value();
 }
 
 }

--- a/Libraries/LibWeb/CSS/PropertyNameAndID.h
+++ b/Libraries/LibWeb/CSS/PropertyNameAndID.h
@@ -30,11 +30,6 @@ public:
         return {};
     }
 
-    static Optional<PropertyNameAndID> from_name(FlyString const& name)
-    {
-        return from_name(Utf16FlyString::from_utf8(name));
-    }
-
     static PropertyNameAndID from_id(PropertyID property_id)
     {
         VERIFY(property_id != PropertyID::Custom);

--- a/Libraries/LibWeb/CSS/PropertyNameAndID.h
+++ b/Libraries/LibWeb/CSS/PropertyNameAndID.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/FlyString.h>
 #include <AK/Optional.h>
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/CSS/PropertyName.h>
 #include <LibWeb/CSS/Serialize.h>
 
@@ -15,15 +15,24 @@ namespace Web::CSS {
 
 class WEB_API PropertyNameAndID {
 public:
-    static Optional<PropertyNameAndID> from_name(FlyString name)
+    static Optional<PropertyNameAndID> from_name(Utf16FlyString name)
     {
         if (is_a_custom_property_name_string(name))
             return PropertyNameAndID(move(name), PropertyID::Custom);
 
-        if (auto property_id = property_id_from_string(name); property_id.has_value())
-            return PropertyNameAndID(string_from_property_id(property_id.value()), property_id.value());
+        if (!name.is_ascii())
+            return {};
+
+        auto name_string = name.to_utf16_string();
+        if (auto property_id = property_id_from_string(name_string.ascii_view()); property_id.has_value())
+            return PropertyNameAndID(Utf16FlyString::from_utf8(string_from_property_id(property_id.value())), property_id.value());
 
         return {};
+    }
+
+    static Optional<PropertyNameAndID> from_name(FlyString const& name)
+    {
+        return from_name(Utf16FlyString::from_utf8(name));
     }
 
     static PropertyNameAndID from_id(PropertyID property_id)
@@ -35,26 +44,26 @@ public:
     bool is_custom_property() const { return m_property_id == PropertyID::Custom; }
     PropertyID id() const { return m_property_id; }
 
-    FlyString const& name() const
+    Utf16FlyString const& name() const
     {
         if (!m_name.has_value())
-            m_name = string_from_property_id(m_property_id);
+            m_name = Utf16FlyString::from_utf8(string_from_property_id(m_property_id));
         return m_name.value();
     }
 
     String to_string() const
     {
-        return serialize_an_identifier(name());
+        return serialize_an_identifier(name().to_utf16_string().to_utf8_but_should_be_ported_to_utf16());
     }
 
 private:
-    PropertyNameAndID(Optional<FlyString> name, PropertyID id)
+    PropertyNameAndID(Optional<Utf16FlyString> name, PropertyID id)
         : m_name(move(name))
         , m_property_id(id)
     {
     }
 
-    mutable Optional<FlyString> m_name;
+    mutable Optional<Utf16FlyString> m_name;
     PropertyID m_property_id;
 };
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1588,7 +1588,7 @@ static JsonArray serialize_devtools_style_declarations(DOM::Document const& docu
     for (auto const& declaration : declarations) {
         bool inherits = declaration.is_custom_property
             ? custom_property_inherits(document, Utf16FlyString::from_utf8(declaration.name))
-            : PropertyNameAndID::from_name(declaration.name)
+            : PropertyNameAndID::from_name(Utf16FlyString::from_utf8(declaration.name))
                   .map([](auto const& property) { return !property.is_custom_property() && is_inherited_property(property.id()); })
                   .value_or(false);
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -714,7 +714,7 @@ void StyleComputer::cascade_declarations(
     }
 }
 
-static void cascade_custom_properties(DOM::AbstractElement abstract_element, Vector<StyleComputer::ScopedMatchingRule> const& matching_rules, OrderedHashMap<FlyString, StyleProperty>& custom_properties, Important important, bool include_inline_style)
+static void cascade_custom_properties(DOM::AbstractElement abstract_element, Vector<StyleComputer::ScopedMatchingRule> const& matching_rules, OrderedHashMap<Utf16FlyString, StyleProperty>& custom_properties, Important important, bool include_inline_style)
 {
     size_t needed_capacity = 0;
     for (auto const& matching_rule : matching_rules)
@@ -1501,7 +1501,7 @@ StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::Abstr
     return matching_rule_set;
 }
 
-static bool custom_property_inherits(DOM::Document const& document, FlyString const& name)
+static bool custom_property_inherits(DOM::Document const& document, Utf16FlyString const& name)
 {
     // A custom property inherits unless it has been registered with an explicit `inherits: false`.
     auto registration = document.get_registered_custom_property(name);
@@ -1573,7 +1573,7 @@ static JsonArray serialize_devtools_style_declarations(DOM::Document const& docu
 
     for (auto const& custom_property : declaration.custom_properties())
         serialize_property(
-            custom_property.key.to_string(),
+            custom_property.key.to_utf16_string().to_utf8_but_should_be_ported_to_utf16(),
             custom_property.value,
             IsCustomProperty::Yes,
             custom_property_inherits(document, custom_property.key) ? Inherits::Yes : Inherits::No);
@@ -1587,7 +1587,7 @@ static JsonArray serialize_devtools_style_declarations(DOM::Document const& docu
 
     for (auto const& declaration : declarations) {
         bool inherits = declaration.is_custom_property
-            ? custom_property_inherits(document, declaration.name)
+            ? custom_property_inherits(document, Utf16FlyString::from_utf8(declaration.name))
             : PropertyNameAndID::from_name(declaration.name)
                   .map([](auto const& property) { return !property.is_custom_property() && is_inherited_property(property.id()); })
                   .value_or(false);
@@ -2561,7 +2561,7 @@ RefPtr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractElemen
 
     // Resolve all the CSS custom properties ("variables") for this element:
     if (!abstract_element.pseudo_element().has_value() || pseudo_element_supports_property(*abstract_element.pseudo_element(), PropertyID::Custom)) {
-        OrderedHashMap<FlyString, StyleProperty> cascaded_all;
+        OrderedHashMap<Utf16FlyString, StyleProperty> cascaded_all;
 
         auto element_context_shadow_root = as_if<DOM::ShadowRoot>(abstract_element.element().root());
         auto cascade_inline_style = [&](Important important) {
@@ -2590,7 +2590,7 @@ RefPtr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractElemen
         // Build own_values with only properties that differ from the parent.
         // We build a fresh map instead of removing from cascaded_all,
         // because removing entries doesn't shrink the bucket array.
-        OrderedHashMap<FlyString, StyleProperty> cascaded_own;
+        OrderedHashMap<Utf16FlyString, StyleProperty> cascaded_own;
         for (auto& [name, property] : cascaded_all) {
             if (parent_data) {
                 auto const* parent_property = parent_data->get(name);
@@ -2640,7 +2640,7 @@ RefPtr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractElemen
     if (did_change_custom_properties.has_value()) {
         auto new_custom_property_data = abstract_element.custom_property_data();
         if (old_custom_property_data.ptr() != new_custom_property_data.ptr()) {
-            static NeverDestroyed<OrderedHashMap<FlyString, StyleProperty>> empty_own_values;
+            static NeverDestroyed<OrderedHashMap<Utf16FlyString, StyleProperty>> empty_own_values;
             auto const& old_own = old_custom_property_data ? old_custom_property_data->own_values() : *empty_own_values;
             auto const& new_own = new_custom_property_data ? new_custom_property_data->own_values() : *empty_own_values;
             if (old_own != new_own)
@@ -3002,7 +3002,7 @@ static Optional<SimplifiedSelectorForBucketing> is_roundabout_selector_bucketabl
     return {};
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(DOM::AbstractElement abstract_element, FlyString const& name, Optional<Parser::GuardedSubstitutionContexts&> guarded_contexts)
+NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(DOM::AbstractElement abstract_element, Utf16FlyString const& name, Optional<Parser::GuardedSubstitutionContexts&> guarded_contexts)
 {
     // https://drafts.csswg.org/css-variables/#propdef-
     // The computed value of a custom property is its specified value with any arbitrary-substitution functions replaced.
@@ -3064,7 +3064,7 @@ void StyleComputer::compute_custom_properties(ComputedProperties&, DOM::Abstract
     if (inherit_from.has_value())
         parent_data = inheritable_custom_property_data(*inherit_from);
 
-    OrderedHashMap<FlyString, StyleProperty> resolved_own;
+    OrderedHashMap<Utf16FlyString, StyleProperty> resolved_own;
     for (auto const& [name, style_property] : data->own_values()) {
         auto resolved_value = compute_value_of_custom_property(abstract_element, name);
         if (parent_data) {

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -136,7 +136,7 @@ public:
 
     [[nodiscard]] inline bool should_reject_with_ancestor_filter(Selector const&) const;
 
-    static NonnullRefPtr<StyleValue const> compute_value_of_custom_property(DOM::AbstractElement, FlyString const& custom_property, Optional<Parser::GuardedSubstitutionContexts&> = {});
+    static NonnullRefPtr<StyleValue const> compute_value_of_custom_property(DOM::AbstractElement, Utf16FlyString const& custom_property, Optional<Parser::GuardedSubstitutionContexts&> = {});
 
     static NonnullRefPtr<StyleValue const> compute_value_of_property(PropertyID, NonnullRefPtr<StyleValue const> const& specified_value, Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value, ComputationContext const&, double device_pixels_per_css_pixel);
     static NonnullRefPtr<StyleValue const> compute_animation_name(NonnullRefPtr<StyleValue const> const& absolutized_value);

--- a/Libraries/LibWeb/CSS/StyleProperty.h
+++ b/Libraries/LibWeb/CSS/StyleProperty.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/FlyString.h>
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -28,7 +28,7 @@ struct WEB_API StyleProperty {
 
 struct StylePropertyAndName {
     StyleProperty property;
-    FlyString name {};
+    Utf16FlyString name {};
 };
 
 }

--- a/Libraries/LibWeb/CSS/StylePropertyMap.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.cpp
@@ -116,7 +116,7 @@ static WebIDL::ExceptionOr<NonnullRefPtr<StyleValue const>> normalize_overflow_c
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-set
-WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
+WebIDL::ExceptionOr<void> StylePropertyMap::set(Utf16FlyString property_name, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
 {
     // The set(property, ...values) method, when called on a StylePropertyMap this, must perform the following steps:
 
@@ -221,7 +221,7 @@ WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, Readonl
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-append
-WebIDL::ExceptionOr<void> StylePropertyMap::append(FlyString property_name, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
+WebIDL::ExceptionOr<void> StylePropertyMap::append(Utf16FlyString property_name, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
 {
     // The append(property, ...values) method, when called on a StylePropertyMap this, must perform the following steps:
 
@@ -289,7 +289,7 @@ WebIDL::ExceptionOr<void> StylePropertyMap::append(FlyString property_name, Read
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-delete
-WebIDL::ExceptionOr<void> StylePropertyMap::delete_(FlyString property)
+WebIDL::ExceptionOr<void> StylePropertyMap::delete_(Utf16FlyString property)
 {
     // The delete(property) method, when called on a StylePropertyMap this, must perform the following steps:
 
@@ -302,7 +302,7 @@ WebIDL::ExceptionOr<void> StylePropertyMap::delete_(FlyString property)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, MUST(String::formatted("'{}' is not a valid CSS property", property)) };
 
     // 3. If this’s [[declarations]] internal slot contains property, remove it.
-    TRY(declarations().remove_property(Utf16FlyString::from_utf8(property)));
+    TRY(declarations().remove_property(property));
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/StylePropertyMap.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.cpp
@@ -47,7 +47,7 @@ void StylePropertyMap::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-static bool any_have_non_matching_associated_property(FlyString const& property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
+static bool any_have_non_matching_associated_property(Utf16FlyString const& property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
 {
     return any_of(values, [&property](Variant<GC::Ref<CSSStyleValue>, String> const& value) {
         if (auto* style_value = value.get_pointer<GC::Ref<CSSStyleValue>>()) {
@@ -150,7 +150,7 @@ WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, Readonl
 
     // 7. If props[property] exists, remove it.
     // FIXME: Avoid converting to string and back.
-    TRY(props.remove_property(Utf16FlyString::from_utf8(property->name())));
+    TRY(props.remove_property(property->name()));
 
     // 8. Let values to set be an empty list.
     StyleValueVector values_to_set;

--- a/Libraries/LibWeb/CSS/StylePropertyMap.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.cpp
@@ -150,7 +150,7 @@ WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, Readonl
 
     // 7. If props[property] exists, remove it.
     // FIXME: Avoid converting to string and back.
-    TRY(props.remove_property(property->name()));
+    TRY(props.remove_property(Utf16FlyString::from_utf8(property->name())));
 
     // 8. Let values to set be an empty list.
     StyleValueVector values_to_set;
@@ -302,7 +302,7 @@ WebIDL::ExceptionOr<void> StylePropertyMap::delete_(FlyString property)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, MUST(String::formatted("'{}' is not a valid CSS property", property)) };
 
     // 3. If this’s [[declarations]] internal slot contains property, remove it.
-    TRY(declarations().remove_property(property));
+    TRY(declarations().remove_property(Utf16FlyString::from_utf8(property)));
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/StylePropertyMap.h
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.h
@@ -20,9 +20,9 @@ public:
 
     virtual ~StylePropertyMap() override;
 
-    WebIDL::ExceptionOr<void> set(FlyString property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values);
-    WebIDL::ExceptionOr<void> append(FlyString property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values);
-    WebIDL::ExceptionOr<void> delete_(FlyString property);
+    WebIDL::ExceptionOr<void> set(Utf16FlyString property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values);
+    WebIDL::ExceptionOr<void> append(Utf16FlyString property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values);
+    WebIDL::ExceptionOr<void> delete_(Utf16FlyString property);
     WebIDL::ExceptionOr<void> clear();
 
 private:

--- a/Libraries/LibWeb/CSS/StylePropertyMap.idl
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.idl
@@ -1,9 +1,9 @@
 // https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymap
 [Exposed=Window]
 interface StylePropertyMap : StylePropertyMapReadOnly {
-    undefined set(USVString property, (CSSStyleValue or USVString)... values);
-    undefined append(USVString property, (CSSStyleValue or USVString)... values);
-    undefined delete(USVString property);
+    undefined set(Utf16USVString property, (CSSStyleValue or USVString)... values);
+    undefined append(Utf16USVString property, (CSSStyleValue or USVString)... values);
+    undefined delete(Utf16USVString property);
     undefined clear();
 };
 

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
@@ -48,7 +48,7 @@ void StylePropertyMapReadOnly::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
-WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> StylePropertyMapReadOnly::get(String property_name)
+WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> StylePropertyMapReadOnly::get(Utf16FlyString property_name)
 {
     // The get(property) method, when called on a StylePropertyMapReadOnly this, must perform the following steps:
 
@@ -72,7 +72,7 @@ WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> StylePropertyMapRead
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
-WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> StylePropertyMapReadOnly::get_all(String property_name)
+WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> StylePropertyMapReadOnly::get_all(Utf16FlyString property_name)
 {
     // The getAll(property) method, when called on a StylePropertyMap this, must perform the following steps:
 
@@ -100,7 +100,7 @@ WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> StylePropertyMapRead
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has
-WebIDL::ExceptionOr<bool> StylePropertyMapReadOnly::has(String property_name)
+WebIDL::ExceptionOr<bool> StylePropertyMapReadOnly::has(Utf16FlyString property_name)
 {
     // The has(property) method, when called on a StylePropertyMapReadOnly this, must perform the following steps:
 

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
@@ -151,9 +151,9 @@ WebIDL::UnsignedLong StylePropertyMapReadOnly::size() const
 
             // Some custom properties set on the element might also be in the registered custom properties set, so we
             // want the size of the union of the two sets.
-            HashTable<FlyString> custom_properties;
+            HashTable<Utf16FlyString> custom_properties;
             if (auto data = element.custom_property_data()) {
-                data->for_each_property([&](FlyString const& name, CSS::StyleProperty const&) {
+                data->for_each_property([&](Utf16FlyString const& name, CSS::StyleProperty const&) {
                     custom_properties.set(name);
                 });
             }

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.h
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.h
@@ -23,9 +23,9 @@ public:
 
     virtual ~StylePropertyMapReadOnly() override;
 
-    WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> get(String property);
-    WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> get_all(String property);
-    WebIDL::ExceptionOr<bool> has(String property);
+    WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> get(Utf16FlyString property);
+    WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> get_all(Utf16FlyString property);
+    WebIDL::ExceptionOr<bool> has(Utf16FlyString property);
     WebIDL::UnsignedLong size() const;
 
 protected:

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.idl
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.idl
@@ -2,9 +2,9 @@
 [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
 interface StylePropertyMapReadOnly {
     // FIXME: iterable<USVString, sequence<CSSStyleValue>>;
-    (undefined or CSSStyleValue) get(USVString property);
-    sequence<CSSStyleValue> getAll(USVString property);
-    boolean has(USVString property);
+    (undefined or CSSStyleValue) get(Utf16USVString property);
+    sequence<CSSStyleValue> getAll(Utf16USVString property);
+    boolean has(Utf16USVString property);
     readonly attribute unsigned long size;
 };
 

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
@@ -11,7 +11,7 @@
 namespace Web::CSS {
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-stylevalue
-GC::Ref<CSSStyleValue> AbstractImageStyleValue::reify(JS::Realm& realm, FlyString const&) const
+GC::Ref<CSSStyleValue> AbstractImageStyleValue::reify(JS::Realm& realm, Utf16FlyString const&) const
 {
     // AD-HOC: There's no spec description of how to reify as a CSSImageValue.
     return CSSImageValue::create(realm, *this);

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -40,7 +40,7 @@ public:
 
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const { return {}; }
 
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
 };
 
 // And now, some gradient related things. Maybe these should live somewhere else.

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -3206,7 +3206,7 @@ String CalculatedStyleValue::dump() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-math-expression
-GC::Ref<CSSStyleValue> CalculatedStyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
+GC::Ref<CSSStyleValue> CalculatedStyleValue::reify(JS::Realm& realm, Utf16FlyString const& associated_property) const
 {
     // NB: This spec algorithm isn't really implementable here - it's incomplete, and assumes we don't already have a
     //     calculation tree. So we have a per-node method instead.

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -115,7 +115,7 @@ public:
 
     String dump() const;
 
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
 
 private:
     explicit CalculatedStyleValue(NonnullRefPtr<CalculationNode const> calculation, NumericType resolved_type, CalculationContext context)

--- a/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.cpp
@@ -16,7 +16,7 @@ Vector<Parser::ComponentValue> CustomIdentStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-ident
-GC::Ref<CSSStyleValue> CustomIdentStyleValue::reify(JS::Realm& realm, FlyString const&) const
+GC::Ref<CSSStyleValue> CustomIdentStyleValue::reify(JS::Realm& realm, Utf16FlyString const&) const
 {
     // 1. Return a new CSSKeywordValue with its value internal slot set to the serialization of ident.
     return CSSKeywordValue::create(realm, m_custom_ident);

--- a/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
@@ -25,7 +25,7 @@ public:
 
     virtual void serialize(StringBuilder& builder, SerializationMode) const override { builder.append(serialize_an_identifier(m_custom_ident.to_string())); }
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm& realm, FlyString const&) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm& realm, Utf16FlyString const&) const override;
 
     bool properties_equal(CustomIdentStyleValue const& other) const { return m_custom_ident == other.m_custom_ident; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/DimensionStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/DimensionStyleValue.cpp
@@ -17,7 +17,7 @@ Vector<Parser::ComponentValue> DimensionStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value
-GC::Ref<CSSStyleValue> DimensionStyleValue::reify(JS::Realm& realm, FlyString const&) const
+GC::Ref<CSSStyleValue> DimensionStyleValue::reify(JS::Realm& realm, Utf16FlyString const&) const
 {
     // NB: Steps 1 and 2 don't apply here.
     // 3. Return a new CSSUnitValue with its value internal slot set to the numeric value of num, and its unit internal

--- a/Libraries/LibWeb/CSS/StyleValues/DimensionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/DimensionStyleValue.h
@@ -20,7 +20,7 @@ public:
     virtual double raw_value() const = 0;
     virtual FlyString unit_name() const = 0;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
 
 protected:
     explicit DimensionStyleValue(Type type)

--- a/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.cpp
@@ -15,7 +15,7 @@ ValueComparingNonnullRefPtr<DisplayStyleValue const> DisplayStyleValue::create(D
     return adopt_ref(*new (nothrow) DisplayStyleValue(display));
 }
 
-GC::Ref<CSSStyleValue> DisplayStyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
+GC::Ref<CSSStyleValue> DisplayStyleValue::reify(JS::Realm& realm, Utf16FlyString const& associated_property) const
 {
     if (auto keyword = m_display.to_keyword(); keyword.has_value())
         return CSSKeywordValue::create(realm, FlyString::from_utf8_without_validation(string_from_keyword(keyword.value()).bytes()));

--- a/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.h
@@ -22,7 +22,7 @@ public:
     Display display() const { return m_display; }
 
     bool properties_equal(DisplayStyleValue const& other) const { return m_display == other.m_display; }
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
 
     virtual bool is_computationally_independent() const override { return true; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
@@ -27,12 +27,12 @@ GC::Ref<CSSStyleValue> IntegerStyleValue::reify(JS::Realm& realm, Utf16FlyString
     // NB: Step 1 doesn't apply here.
     // 2. If num is the unitless value 0 and num is a <dimension>, return a new CSSUnitValue with its value internal
     //    slot set to 0, and its unit internal slot set to "px".
-    if (m_value == 0) {
+    if (m_value == 0 && associated_property.is_ascii()) {
         // NB: Determine whether the associated property expects 0 to be a <length>.
         // FIXME: Do this for registered custom properties.
         auto associated_property_string = associated_property.to_utf16_string();
         if (auto property_id = property_id_from_string(associated_property_string.ascii_view()); property_id.has_value()
-            && property_id != PropertyID::Custom
+            && *property_id != PropertyID::Custom
             && property_accepts_type(*property_id, ValueType::Length)) {
             return CSSUnitValue::create(realm, 0, "px"_fly_string);
         }

--- a/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
@@ -22,7 +22,7 @@ Vector<Parser::ComponentValue> IntegerStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value
-GC::Ref<CSSStyleValue> IntegerStyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
+GC::Ref<CSSStyleValue> IntegerStyleValue::reify(JS::Realm& realm, Utf16FlyString const& associated_property) const
 {
     // NB: Step 1 doesn't apply here.
     // 2. If num is the unitless value 0 and num is a <dimension>, return a new CSSUnitValue with its value internal
@@ -30,7 +30,8 @@ GC::Ref<CSSStyleValue> IntegerStyleValue::reify(JS::Realm& realm, FlyString cons
     if (m_value == 0) {
         // NB: Determine whether the associated property expects 0 to be a <length>.
         // FIXME: Do this for registered custom properties.
-        if (auto property_id = property_id_from_string(associated_property); property_id.has_value()
+        auto associated_property_string = associated_property.to_utf16_string();
+        if (auto property_id = property_id_from_string(associated_property_string.ascii_view()); property_id.has_value()
             && property_id != PropertyID::Custom
             && property_accepts_type(*property_id, ValueType::Length)) {
             return CSSUnitValue::create(realm, 0, "px"_fly_string);

--- a/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
@@ -21,7 +21,7 @@ public:
 
     virtual void serialize(StringBuilder&, SerializationMode) const override;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
 
     bool equals(StyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
@@ -204,7 +204,7 @@ Vector<Parser::ComponentValue> KeywordStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-ident
-GC::Ref<CSSStyleValue> KeywordStyleValue::reify(JS::Realm& realm, FlyString const&) const
+GC::Ref<CSSStyleValue> KeywordStyleValue::reify(JS::Realm& realm, Utf16FlyString const&) const
 {
     // 1. Return a new CSSKeywordValue with its value internal slot set to the serialization of ident.
     return CSSKeywordValue::create(realm, FlyString::from_utf8_without_validation(string_from_keyword(m_keyword).bytes()));

--- a/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.h
@@ -53,7 +53,7 @@ public:
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
     virtual void serialize(StringBuilder&, SerializationMode) const override;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
 
     bool properties_equal(KeywordStyleValue const& other) const { return m_keyword == other.m_keyword; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
@@ -27,7 +27,7 @@ Vector<Parser::ComponentValue> NumberStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value
-GC::Ref<CSSStyleValue> NumberStyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
+GC::Ref<CSSStyleValue> NumberStyleValue::reify(JS::Realm& realm, Utf16FlyString const& associated_property) const
 {
     // NB: Step 1 doesn't apply here.
     // 2. If num is the unitless value 0 and num is a <dimension>, return a new CSSUnitValue with its value internal
@@ -35,7 +35,8 @@ GC::Ref<CSSStyleValue> NumberStyleValue::reify(JS::Realm& realm, FlyString const
     if (m_value == 0) {
         // NB: Determine whether the associated property expects 0 to be a <length>.
         // FIXME: Do this for registered custom properties.
-        if (auto property_id = property_id_from_string(associated_property); property_id.has_value()
+        auto associated_property_string = associated_property.to_utf16_string();
+        if (auto property_id = property_id_from_string(associated_property_string.ascii_view()); property_id.has_value()
             && property_id != PropertyID::Custom
             && property_accepts_type(*property_id, ValueType::Length)) {
             return CSSUnitValue::create(realm, 0, "px"_fly_string);

--- a/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
@@ -32,12 +32,12 @@ GC::Ref<CSSStyleValue> NumberStyleValue::reify(JS::Realm& realm, Utf16FlyString 
     // NB: Step 1 doesn't apply here.
     // 2. If num is the unitless value 0 and num is a <dimension>, return a new CSSUnitValue with its value internal
     //    slot set to 0, and its unit internal slot set to "px".
-    if (m_value == 0) {
+    if (m_value == 0 && associated_property.is_ascii()) {
         // NB: Determine whether the associated property expects 0 to be a <length>.
         // FIXME: Do this for registered custom properties.
         auto associated_property_string = associated_property.to_utf16_string();
         if (auto property_id = property_id_from_string(associated_property_string.ascii_view()); property_id.has_value()
-            && property_id != PropertyID::Custom
+            && *property_id != PropertyID::Custom
             && property_accepts_type(*property_id, ValueType::Length)) {
             return CSSUnitValue::create(realm, 0, "px"_fly_string);
         }

--- a/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
@@ -24,7 +24,7 @@ public:
 
     virtual void serialize(StringBuilder&, SerializationMode) const override;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
 
     bool equals(StyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/OpacityValueStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/OpacityValueStyleValue.cpp
@@ -35,7 +35,7 @@ ValueComparingNonnullRefPtr<StyleValue const> OpacityValueStyleValue::absolutize
     return OpacityValueStyleValue::create(NumberStyleValue::create(clamped_number_value));
 }
 
-GC::Ref<CSSStyleValue> OpacityValueStyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
+GC::Ref<CSSStyleValue> OpacityValueStyleValue::reify(JS::Realm& realm, Utf16FlyString const& associated_property) const
 {
     return m_value->reify(realm, associated_property);
 }

--- a/Libraries/LibWeb/CSS/StyleValues/OpacityValueStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/OpacityValueStyleValue.h
@@ -26,7 +26,7 @@ public:
 
     double resolved() const { return m_value->as_number().number(); }
 
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm& realm, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm& realm, Utf16FlyString const& associated_property) const override;
 
     bool properties_equal(OpacityValueStyleValue const& other) const { return m_value == other.m_value; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -166,7 +166,7 @@ Vector<Parser::ComponentValue> StyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-as-a-cssstylevalue
-GC::Ref<CSSStyleValue> StyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
+GC::Ref<CSSStyleValue> StyleValue::reify(JS::Realm& realm, Utf16FlyString const& associated_property) const
 {
     // 1. Return a new CSSStyleValue object representing value whose [[associatedProperty]] internal slot is set to property.
     return CSSStyleValue::create(realm, associated_property, *this);

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -169,7 +169,7 @@ public:
     String to_string(SerializationMode) const;
     virtual void serialize(StringBuilder&, SerializationMode) const = 0;
     virtual Vector<Parser::ComponentValue> tokenize() const;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const;
     virtual StyleValueVector subdivide_into_iterations(PropertyNameAndID const&) const;
 
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) { }

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
@@ -121,7 +121,7 @@ static GC::Ptr<CSSStyleValue> reify_a_transform_list(JS::Realm& realm, StyleValu
     return CSSTransformValue::create(realm, move(transform_components));
 }
 
-GC::Ref<CSSStyleValue> StyleValueList::reify(JS::Realm& realm, FlyString const& associated_property) const
+GC::Ref<CSSStyleValue> StyleValueList::reify(JS::Realm& realm, Utf16FlyString const& associated_property) const
 {
     // NB: <transform-list> is a StyleValueList that contains TransformStyleValues. If that's what we are, follow the
     //     steps for reifying that.

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
@@ -39,7 +39,7 @@ public:
 
     virtual void serialize(StringBuilder&, SerializationMode) const override;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
     virtual StyleValueVector subdivide_into_iterations(PropertyNameAndID const&) const override;
 
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
@@ -216,7 +216,7 @@ static GC::Ref<CSSUnparsedValue> reify_a_list_of_component_values(JS::Realm& rea
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-list-of-component-values
-GC::Ref<CSSStyleValue> UnresolvedStyleValue::reify(JS::Realm& realm, FlyString const&) const
+GC::Ref<CSSStyleValue> UnresolvedStyleValue::reify(JS::Realm& realm, Utf16FlyString const&) const
 {
     auto component_values = values();
     return reify_a_list_of_component_values(realm, component_values);

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
@@ -38,7 +38,7 @@ public:
 
     virtual bool equals(StyleValue const& other) const override;
 
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, Utf16FlyString const& associated_property) const override;
 
     virtual bool is_computationally_independent() const override { VERIFY_NOT_REACHED(); }
 

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -173,7 +173,7 @@ void AbstractElement::set_custom_property_data(RefPtr<CSS::CustomPropertyData co
     m_element->set_custom_property_data(m_pseudo_element, move(data));
 }
 
-RefPtr<CSS::StyleValue const> AbstractElement::get_custom_property(FlyString const& name) const
+RefPtr<CSS::StyleValue const> AbstractElement::get_custom_property(Utf16FlyString const& name) const
 {
     auto data = custom_property_data();
     if (!data)

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -51,7 +51,7 @@ public:
 
     void set_custom_property_data(RefPtr<CSS::CustomPropertyData const>);
     [[nodiscard]] RefPtr<CSS::CustomPropertyData const> custom_property_data() const;
-    RefPtr<CSS::StyleValue const> get_custom_property(FlyString const& name) const;
+    RefPtr<CSS::StyleValue const> get_custom_property(Utf16FlyString const& name) const;
 
     bool has_non_empty_counters_set() const;
     Optional<CSS::CountersSet const&> counters_set() const;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -9198,7 +9198,7 @@ Optional<Vector<CSS::Parser::ComponentValue>> Document::environment_variable_val
     VERIFY_NOT_REACHED();
 }
 
-HashMap<FlyString, CSS::CustomPropertyRegistration>& Document::registered_property_set()
+HashMap<Utf16FlyString, CSS::CustomPropertyRegistration>& Document::registered_property_set()
 {
     return m_registered_property_set;
 }
@@ -9221,7 +9221,7 @@ GC::Ref<DOM::Node> Document::create_ns_resolver(GC::Ref<DOM::Node> node_resolver
 }
 
 // https://drafts.css-houdini.org/css-properties-values-api/#determining-registration
-Optional<CSS::CustomPropertyRegistration const&> Document::get_registered_custom_property(FlyString const& name) const
+Optional<CSS::CustomPropertyRegistration const&> Document::get_registered_custom_property(Utf16FlyString const& name) const
 {
     // If the Document’s [[registeredPropertySet]] slot contains a record with the custom property’s name, the
     // registration is that record.
@@ -9237,7 +9237,7 @@ Optional<CSS::CustomPropertyRegistration const&> Document::get_registered_custom
     return {};
 }
 
-NonnullRefPtr<CSS::StyleValue const> Document::custom_property_initial_value(FlyString const& name) const
+NonnullRefPtr<CSS::StyleValue const> Document::custom_property_initial_value(Utf16FlyString const& name) const
 {
     auto maybe_custom_property = get_registered_custom_property(name);
     if (maybe_custom_property.has_value()) {
@@ -9263,7 +9263,7 @@ void Document::did_change_custom_property_registrations()
 
 void Document::build_registered_properties_cache()
 {
-    HashMap<FlyString, CSS::CustomPropertyRegistration> cached_registered_properties_from_css_property_rules;
+    HashMap<Utf16FlyString, CSS::CustomPropertyRegistration> cached_registered_properties_from_css_property_rules;
     for_each_active_css_style_sheet([&](CSS::CSSStyleSheet const& style_sheet) {
         style_sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSS::CSSRule const& rule) {
             if (auto* property_rule = as_if<CSS::CSSPropertyRule>(rule))

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1122,9 +1122,9 @@ public:
     Optional<Vector<CSS::Parser::ComponentValue>> environment_variable_value(CSS::EnvironmentVariable, Span<i32> indices = {}) const;
 
     // https://www.w3.org/TR/css-properties-values-api-1/#dom-window-registeredpropertyset-slot
-    HashMap<FlyString, CSS::CustomPropertyRegistration>& registered_property_set();
-    Optional<CSS::CustomPropertyRegistration const&> get_registered_custom_property(FlyString const& name) const;
-    NonnullRefPtr<CSS::StyleValue const> custom_property_initial_value(FlyString const& name) const;
+    HashMap<Utf16FlyString, CSS::CustomPropertyRegistration>& registered_property_set();
+    Optional<CSS::CustomPropertyRegistration const&> get_registered_custom_property(Utf16FlyString const& name) const;
+    NonnullRefPtr<CSS::StyleValue const> custom_property_initial_value(Utf16FlyString const& name) const;
     size_t custom_property_registration_generation() const { return m_custom_property_registration_generation; }
     void did_change_custom_property_registrations();
 
@@ -1606,8 +1606,8 @@ private:
     GC::Ref<CSS::Invalidation::StyleInvalidator> m_style_invalidator;
 
     // https://www.w3.org/TR/css-properties-values-api-1/#dom-window-registeredpropertyset-slot
-    HashMap<FlyString, CSS::CustomPropertyRegistration> m_registered_property_set;
-    HashMap<FlyString, CSS::CustomPropertyRegistration> m_cached_registered_properties_from_css_property_rules;
+    HashMap<Utf16FlyString, CSS::CustomPropertyRegistration> m_registered_property_set;
+    HashMap<Utf16FlyString, CSS::CustomPropertyRegistration> m_cached_registered_properties_from_css_property_rules;
     size_t m_custom_property_registration_generation { 0 };
 
     CSS::StyleScope m_style_scope;

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -2144,9 +2144,11 @@ bool is_indentation_element(GC::Ref<DOM::Node> node)
     return is<HTML::HTMLDivElement>(element)
         && element.has_attribute(HTML::AttributeNames::style)
         && inline_style
-        && (!inline_style->margin().is_empty() || !inline_style->margin_top().is_empty()
-            || !inline_style->margin_right().is_empty() || !inline_style->margin_bottom().is_empty()
-            || !inline_style->margin_left().is_empty());
+        && (!inline_style->get_property_value("margin"_utf16_fly_string).is_empty()
+            || !inline_style->get_property_value("margin-top"_utf16_fly_string).is_empty()
+            || !inline_style->get_property_value("margin-right"_utf16_fly_string).is_empty()
+            || !inline_style->get_property_value("margin-bottom"_utf16_fly_string).is_empty()
+            || !inline_style->get_property_value("margin-left"_utf16_fly_string).is_empty());
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#inline-node
@@ -2490,7 +2492,7 @@ bool is_simple_modifiable_element(GC::Ref<DOM::Node> node)
     if (html_element.local_name().is_one_of(HTML::TagNames::a, HTML::TagNames::font, HTML::TagNames::s,
             HTML::TagNames::span, HTML::TagNames::strike, HTML::TagNames::u)
         && inline_style->has_property(CSS::PropertyID::TextDecoration)) {
-        auto text_decoration = inline_style->text_decoration();
+        auto text_decoration = inline_style->get_property_value("text-decoration"_utf16_fly_string);
         if (first_is_one_of(text_decoration,
                 string_from_keyword(CSS::Keyword::LineThrough),
                 string_from_keyword(CSS::Keyword::Underline),
@@ -3889,7 +3891,7 @@ Optional<Utf16String> specified_command_value(GC::Ref<DOM::Element> element, Fly
     //     that it sets property to.
     // FIXME: Use property_in_style_attribute once it supports shorthands.
     if (auto inline_style = element->inline_style()) {
-        auto value = inline_style->get_property_value(string_from_property_id(property.value()));
+        auto value = inline_style->get_property_value(Utf16FlyString::from_utf8(string_from_property_id(property.value())));
         if (!value.is_empty())
             return Utf16String::from_utf8_without_validation(value);
     }

--- a/Meta/Generators/generate_libweb_css_style_properties.py
+++ b/Meta/Generators/generate_libweb_css_style_properties.py
@@ -86,7 +86,7 @@ WebIDL::ExceptionOr<void> GeneratedCSSStyleProperties::set_{name_acceptable_cpp}
 
 String GeneratedCSSStyleProperties::{name_acceptable_cpp}() const
 {{
-    return generated_style_properties_to_css_style_properties().get_property_value("{name}"_fly_string);
+    return generated_style_properties_to_css_style_properties().get_property_value("{name}"_utf16_fly_string);
 }}
 """)
 

--- a/Meta/Generators/generate_libweb_css_style_properties.py
+++ b/Meta/Generators/generate_libweb_css_style_properties.py
@@ -81,7 +81,7 @@ namespace Web::Bindings {
         out.write(f"""
 WebIDL::ExceptionOr<void> GeneratedCSSStyleProperties::set_{name_acceptable_cpp}(StringView value)
 {{
-    return generated_style_properties_to_css_style_properties().set_property("{name}"_fly_string, value, ""sv);
+    return generated_style_properties_to_css_style_properties().set_property("{name}"_utf16_fly_string, value, ""sv);
 }}
 
 String GeneratedCSSStyleProperties::{name_acceptable_cpp}() const

--- a/Meta/Generators/generate_libweb_css_style_properties.py
+++ b/Meta/Generators/generate_libweb_css_style_properties.py
@@ -14,9 +14,6 @@ from typing import TextIO
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from Utils.utils import make_name_acceptable_cpp
-from Utils.utils import snake_casify
-
 
 def css_property_to_idl_attribute(property_name: str, lowercase_first: bool = False) -> str:
     # https://drafts.csswg.org/cssom/#css-property-to-idl-attribute
@@ -38,29 +35,13 @@ def write_header_file(out: TextIO, properties: dict) -> None:
     out.write("""
 #pragma once
 
-#include <AK/String.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Bindings {
 
 class GeneratedCSSStyleProperties {
 public:
-""")
-
-    for name in properties:
-        name_acceptable_cpp = make_name_acceptable_cpp(snake_casify(name, trim_leading_underscores=True))
-        out.write(f"""
-    WebIDL::ExceptionOr<void> set_{name_acceptable_cpp}(StringView value);
-    String {name_acceptable_cpp}() const;
-""")
-
-    out.write("""
-protected:
-    GeneratedCSSStyleProperties() = default;
-    virtual ~GeneratedCSSStyleProperties() = default;
-
-    virtual CSS::CSSStyleProperties& generated_style_properties_to_css_style_properties() = 0;
-    CSS::CSSStyleProperties const& generated_style_properties_to_css_style_properties() const { return const_cast<GeneratedCSSStyleProperties&>(*this).generated_style_properties_to_css_style_properties(); }
+    static void initialize(JS::Realm&, JS::Object&);
 }; // class GeneratedCSSStyleProperties
 
 } // namespace Web::Bindings
@@ -69,28 +50,121 @@ protected:
 
 def write_implementation_file(out: TextIO, properties: dict) -> None:
     out.write("""
-#include <LibWeb/CSS/CSSStyleProperties.h>
+#include <AK/Array.h>
+#include <LibJS/Runtime/NativeFunction.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PrimitiveString.h>
+#include <LibJS/Runtime/ValueInlines.h>
+#include <LibWeb/Bindings/ExceptionOrUtils.h>
+#include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/GeneratedCSSStyleProperties.h>
+#include <LibWeb/CSS/CSSStyleProperties.h>
+#include <LibWeb/HTML/Scripting/SimilarOriginWindowAgent.h>
+#include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Bindings {
+
+namespace {
+
+JS::ThrowCompletionOr<CSS::CSSStyleProperties*> impl_from(JS::VM& vm, JS::Value value)
+{
+    if (auto impl = value.as_if<CSS::CSSStyleProperties>())
+        return impl.ptr();
+    return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "CSSStyleProperties");
+}
+
+JS::ThrowCompletionOr<CSS::CSSStyleProperties*> impl_from(JS::VM& vm)
+{
+    auto this_value = vm.this_value();
+    if (this_value.is_nullish())
+        this_value = &vm.current_realm()->global_object();
+    return impl_from(vm, this_value);
+}
+
+GC::Ref<JS::NativeFunction> create_getter(JS::Realm& realm, Utf16FlyString const& attribute_name, Utf16FlyString property_name)
+{
+    auto getter = [property_name = move(property_name)](JS::VM& vm) -> JS::ThrowCompletionOr<JS::Value> {
+        auto* idl_object = TRY(impl_from(vm));
+
+        auto result = TRY(throw_dom_exception_if_needed(vm, [&] {
+            return idl_object->get_property_value(property_name);
+        }));
+        return JS::PrimitiveString::create(vm, result);
+    };
+
+    return JS::NativeFunction::create(realm, move(getter), 0, JS::PropertyKey { attribute_name }, &realm, "get"sv);
+}
+
+GC::Ref<JS::NativeFunction> create_setter(JS::Realm& realm, Utf16FlyString const& attribute_name, Utf16FlyString property_name)
+{
+    auto setter = [property_name = move(property_name)](JS::VM& vm) -> JS::ThrowCompletionOr<JS::Value> {
+        auto* idl_object = TRY(impl_from(vm));
+
+        auto value = vm.argument(0);
+        String idl_value;
+        if (!value.is_null())
+            idl_value = TRY(WebIDL::to_string(vm, value));
+
+        auto original_steps = [&]() -> JS::ThrowCompletionOr<JS::Value> {
+            TRY(throw_dom_exception_if_needed(vm, [&] {
+                return idl_object->set_property(property_name, idl_value, ""sv);
+            }));
+            return JS::js_undefined();
+        };
+
+        // For [CEReactions]: https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions
+        auto& reactions_stack = HTML::relevant_similar_origin_window_agent(*idl_object).custom_element_reactions_stack;
+        reactions_stack.element_queue_stack.append({});
+
+        auto value_or_exception = original_steps();
+
+        auto queue = reactions_stack.element_queue_stack.take_last();
+        Bindings::invoke_custom_element_reactions(queue);
+
+        if (value_or_exception.is_error())
+            return value_or_exception.release_error();
+        return value_or_exception.release_value();
+    };
+
+    return JS::NativeFunction::create(realm, move(setter), 1, JS::PropertyKey { attribute_name }, &realm, "set"sv);
+}
+
+}
+
+void GeneratedCSSStyleProperties::initialize(JS::Realm& realm, JS::Object& object)
+{
+    [[maybe_unused]] u8 default_attributes = JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable;
+
+    struct Property {
+        StringView attribute_name;
+        StringView property_name;
+    };
+
+    static constexpr auto properties = Array {
 """)
 
     for name in properties:
-        name_acceptable_cpp = make_name_acceptable_cpp(snake_casify(name, trim_leading_underscores=True))
-        out.write(f"""
-WebIDL::ExceptionOr<void> GeneratedCSSStyleProperties::set_{name_acceptable_cpp}(StringView value)
-{{
-    return generated_style_properties_to_css_style_properties().set_property("{name}"_utf16_fly_string, value, ""sv);
-}}
-
-String GeneratedCSSStyleProperties::{name_acceptable_cpp}() const
-{{
-    return generated_style_properties_to_css_style_properties().get_property_value("{name}"_utf16_fly_string);
-}}
-""")
+        out.write(f'        Property {{ "{css_property_to_idl_attribute(name)}"sv, "{name}"sv }},\n')
+        if name.startswith("-webkit-"):
+            out.write(
+                f'        Property {{ "{css_property_to_idl_attribute(name, lowercase_first=True)}"sv, "{name}"sv }},\n'
+            )
+        if "-" in name:
+            out.write(f'        Property {{ "{name}"sv, "{name}"sv }},\n')
 
     out.write("""
+    };
+
+    for (auto property : properties) {
+        auto attribute_name = Utf16FlyString::from_utf8(property.attribute_name);
+        auto property_name = Utf16FlyString::from_utf8(property.property_name);
+        auto native_getter = create_getter(realm, attribute_name, property_name);
+        auto native_setter = create_setter(realm, attribute_name, property_name);
+        object.define_direct_accessor(attribute_name, native_getter, native_setter, default_attributes);
+    }
+}
+
 } // namespace Web::Bindings
 """)
 
@@ -98,33 +172,6 @@ String GeneratedCSSStyleProperties::{name_acceptable_cpp}() const
 def write_idl_file(out: TextIO, properties: dict) -> None:
     out.write("""
 interface mixin GeneratedCSSStyleProperties {
-""")
-
-    for name in properties:
-        snake_case_name = snake_casify(name, trim_leading_underscores=True)
-        name_acceptable_cpp = make_name_acceptable_cpp(snake_case_name)
-
-        # https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-camel-cased-attribute
-        name_camelcase = css_property_to_idl_attribute(name)
-        out.write(f"""
-    [CEReactions, LegacyNullToEmptyString, AttributeCallbackName={snake_case_name}_regular, ImplementedAs={name_acceptable_cpp}] attribute CSSOMString {name_camelcase};
-""")
-
-        # For each CSS property property that is a supported CSS property and that begins with the string -webkit-,
-        # the following partial interface applies where webkit-cased attribute is obtained by running the CSS property
-        # to IDL attribute algorithm for property, with the lowercase first flag set.
-        if name.startswith("-webkit-"):
-            name_webkit = css_property_to_idl_attribute(name, lowercase_first=True)
-            out.write(f"""
-    [CEReactions, LegacyNullToEmptyString, AttributeCallbackName={snake_case_name}_webkit, ImplementedAs={name_acceptable_cpp}] attribute CSSOMString {name_webkit};
-""")
-
-        # For each CSS property property that is a supported CSS property, except for properties that have no
-        # "-" (U+002D) in the property name, the following partial interface applies where dashed attribute is
-        # property.
-        if "-" in name:
-            out.write(f"""
-    [CEReactions, LegacyNullToEmptyString, AttributeCallbackName={snake_case_name}_dashed, ImplementedAs={name_acceptable_cpp}] attribute CSSOMString {name};
 """)
 
     out.write("""

--- a/Meta/Generators/libweb_bindings/attributes.py
+++ b/Meta/Generators/libweb_bindings/attributes.py
@@ -124,15 +124,18 @@ def define_the_attributes(
         # 1. If attr is not exposed in realm, then continue.
         # NB: This is done at the end of this function.
 
+        # 6. Let id be attr’s identifier.
+        definition.write(f'    auto {cpp_name}_id = "{attribute.name}"_utf16_fly_string;\n')
+
         # 2. Let getter be the result of creating an attribute getter given attr, definition, and realm.
         if "LegacyUnforgeable" in attribute.extended_attributes:
             includes.add("LibWeb/Bindings/Intrinsics.h")
             definition.write(
-                f'    auto {native_getter_name} = host_defined_intrinsics(realm).ensure_web_unforgeable_function("{interface.namespaced_name}"_utf16_fly_string, "{attribute.name}"_utf16_fly_string, {getter_name}, UnforgeableKey::Type::Getter);\n'
+                f'    auto {native_getter_name} = host_defined_intrinsics(realm).ensure_web_unforgeable_function("{interface.namespaced_name}"_utf16_fly_string, {cpp_name}_id, {getter_name}, UnforgeableKey::Type::Getter);\n'
             )
         else:
             definition.write(
-                f'    auto {native_getter_name} = JS::NativeFunction::create(realm, {getter_name}, 0, "{attribute.name}"_utf16_fly_string, &realm, "get"sv);\n'
+                f'    auto {native_getter_name} = JS::NativeFunction::create(realm, {getter_name}, 0, {cpp_name}_id, &realm, "get"sv);\n'
             )
 
         # 3. Let setter be the result of creating an attribute setter given attr, definition, and realm.
@@ -143,11 +146,11 @@ def define_the_attributes(
             if "LegacyUnforgeable" in attribute.extended_attributes:
                 includes.add("LibWeb/Bindings/Intrinsics.h")
                 definition.write(
-                    f'    auto {native_setter_name} = host_defined_intrinsics(realm).ensure_web_unforgeable_function("{interface.namespaced_name}"_utf16_fly_string, "{attribute.name}"_utf16_fly_string, {setter_name}, UnforgeableKey::Type::Setter);\n'
+                    f'    auto {native_setter_name} = host_defined_intrinsics(realm).ensure_web_unforgeable_function("{interface.namespaced_name}"_utf16_fly_string, {cpp_name}_id, {setter_name}, UnforgeableKey::Type::Setter);\n'
                 )
             else:
                 definition.write(
-                    f'    auto {native_setter_name} = JS::NativeFunction::create(realm, {setter_name}, 1, "{attribute.name}"_utf16_fly_string, &realm, "set"sv);\n'
+                    f'    auto {native_setter_name} = JS::NativeFunction::create(realm, {setter_name}, 1, {cpp_name}_id, &realm, "set"sv);\n'
                 )
         definition.write(
             f"""
@@ -155,9 +158,6 @@ def define_the_attributes(
     auto {cpp_name}_attributes = default_attributes;
 
     // 5. Let desc be the PropertyDescriptor{{[[Get]]: getter, [[Set]]: setter, [[Enumerable]]: true, [[Configurable]]: configurable}}.
-
-    // 6. Let id be attr’s identifier.
-    auto {cpp_name}_id = "{attribute.name}"_utf16_fly_string;
 
     // 7. Perform ! DefinePropertyOrThrow(target, id, desc).
     object.define_direct_accessor({cpp_name}_id, {native_getter_name}, {native_setter_name}, {cpp_name}_attributes);

--- a/Meta/Generators/libweb_bindings/interfaces.py
+++ b/Meta/Generators/libweb_bindings/interfaces.py
@@ -227,6 +227,9 @@ void {interface.prototype_class}::initialize(JS::Realm& realm)
         global_mixins.write_global_mixin_implementation(out, context, includes, interface)
         return
     attributes.define_the_regular_attributes(out, includes, interface)
+    if interface.name == "CSSStyleProperties":
+        includes.add("LibWeb/CSS/GeneratedCSSStyleProperties.h")
+        out.write("    GeneratedCSSStyleProperties::initialize(realm, object);\n")
     operations.define_the_regular_operations(out, includes, interface)
     operations.define_the_stringifier(out, includes, interface)
     named_and_indexed_properties.define_the_indexed_property_getter(out, includes, interface)
@@ -241,7 +244,7 @@ void {interface.prototype_class}::initialize(JS::Realm& realm)
     constants.define_the_constants(out, context, includes, interface)
     operations.define_unscopable_members(out, includes, interface)
     out.write(
-        f'    object.define_direct_property(vm.well_known_symbol_to_string_tag(), JS::PrimitiveString::create(vm, "{interface.namespaced_name}"_string), JS::Attribute::Configurable);'
+        f'    object.define_direct_property(vm.well_known_symbol_to_string_tag(), JS::PrimitiveString::create(vm, "{interface.namespaced_name}"_string), JS::Attribute::Configurable);\n'
     )
     if interface_requires_custom_prototype(interface):
         out.write("    Base::initialize(realm);\n")

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -408,7 +408,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
                 dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), style.property(static_cast<Web::CSS::PropertyID>(i)).to_string(Web::CSS::SerializationMode::Normal));
             }
             if (custom_property_data) {
-                custom_property_data->for_each_property([](FlyString const& name, Web::CSS::StyleProperty const& property) {
+                custom_property_data->for_each_property([](Utf16FlyString const& name, Web::CSS::StyleProperty const& property) {
                     dbgln("|  {} = {}", name, property.value->to_string(Web::CSS::SerializationMode::Normal));
                 });
             }
@@ -594,8 +594,8 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
 
         // FIXME: Custom properties are not yet included in ComputedProperties, so add them manually.
         if (auto custom_property_data = element.custom_property_data(pseudo_element)) {
-            custom_property_data->for_each_property([&](FlyString const& name, Web::CSS::StyleProperty const& value) {
-                serialized.set(name, value.value->to_string(Web::CSS::SerializationMode::Normal));
+            custom_property_data->for_each_property([&](Utf16FlyString const& name, Web::CSS::StyleProperty const& value) {
+                serialized.set(name.to_utf16_string().to_utf8_but_should_be_ported_to_utf16(), value.value->to_string(Web::CSS::SerializationMode::Normal));
             });
         }
 

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -1411,7 +1411,7 @@ Messages::WebDriverClient::GetElementCssValueResponse WebDriverConnection::get_e
             document->update_style();
 
             // computed value of parameter URL variables["property name"] from element's style declarations.
-            if (auto property = Web::CSS::PropertyNameAndID::from_name(name); property.has_value()) {
+            if (auto property = Web::CSS::PropertyNameAndID::from_name(Utf16FlyString::from_utf8(name)); property.has_value()) {
                 if (property->is_custom_property()) {
                     if (auto data = element->custom_property_data({}); data) {
                         if (auto const* style_property = data->get(property->name()))

--- a/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-custom-properties.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-custom-properties.txt
@@ -2,3 +2,15 @@ style.getPropertyValue(--redcolor)=red
 style.getPropertyPriority(--redcolor)=
 rgb(255, 0, 0)
 rgba(0, 0, 0, 0)
+style.getPropertyValue(--é)=green
+style.cssText=--é: green;
+blue
+rgb(0, 0, 255)
+
+rgb(0, 128, 0)
+computedStyleMap(--é-number)=0
+computedStyleMap(--é-number).unit=number
+computedStyleMap(--é-number).value=0
+computedStyleMap(--é-integer)=0
+computedStyleMap(--é-integer).unit=number
+computedStyleMap(--é-integer).value=0

--- a/Tests/LibWeb/Text/expected/css/font-face-serialization.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-serialization.txt
@@ -5,3 +5,4 @@
 @font-face { font-family: "c2"; font-stretch: 50%; }
 @font-face { font-family: "c3"; font-stretch: extra-condensed; }
 @font-face { font-family: "c4"; font-stretch: 50%; }
+@font-face { font-family: "d1"; }

--- a/Tests/LibWeb/Text/input/css/CSSStyleDeclaration-custom-properties.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleDeclaration-custom-properties.html
@@ -20,5 +20,47 @@
 
         div.style.removeProperty("--redcolor");
         println(getComputedStyle(nested).backgroundColor);
+
+        div.style.setProperty("--é", "green");
+        println(`style.getPropertyValue(--é)=${div.style.getPropertyValue("--é")}`);
+        println(`style.cssText=${div.style.cssText}`);
+
+        const style = document.createElement("style");
+        style.textContent = "#non-ascii-custom-property { --é: blue; color: var(--é); }";
+        document.head.appendChild(style);
+
+        const styled = document.createElement("div");
+        styled.id = "non-ascii-custom-property";
+        document.body.appendChild(styled);
+
+        println(getComputedStyle(styled).getPropertyValue("--é"));
+        println(getComputedStyle(styled).color);
+
+        const invalidStyle = document.createElement("style");
+        invalidStyle.textContent = "#invalid-non-ascii-custom-property { --é-invalid: var(); color: green; }";
+        document.head.appendChild(invalidStyle);
+
+        const invalid = document.createElement("div");
+        invalid.id = "invalid-non-ascii-custom-property";
+        document.body.appendChild(invalid);
+
+        println(getComputedStyle(invalid).getPropertyValue("--é-invalid"));
+        println(getComputedStyle(invalid).color);
+
+        CSS.registerProperty({ name: "--é-number", syntax: "<number>", initialValue: "0", inherits: false });
+        CSS.registerProperty({ name: "--é-integer", syntax: "<integer>", initialValue: "0", inherits: false });
+
+        const typed = document.createElement("div");
+        document.body.appendChild(typed);
+
+        let typedNumber = typed.computedStyleMap().get("--é-number");
+        println(`computedStyleMap(--é-number)=${typedNumber}`);
+        println(`computedStyleMap(--é-number).unit=${typedNumber.unit}`);
+        println(`computedStyleMap(--é-number).value=${typedNumber.value}`);
+
+        let typedInteger = typed.computedStyleMap().get("--é-integer");
+        println(`computedStyleMap(--é-integer)=${typedInteger}`);
+        println(`computedStyleMap(--é-integer).unit=${typedInteger.unit}`);
+        println(`computedStyleMap(--é-integer).value=${typedInteger.value}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/font-face-serialization.html
+++ b/Tests/LibWeb/Text/input/css/font-face-serialization.html
@@ -18,6 +18,9 @@
             // - font-stretch is a legacy alias for font-width
             "@font-face { font-family: 'c3'; font-stretch: extra-condensed; }",
             "@font-face { font-family: 'c4'; font-stretch: 50%; }",
+
+            // Non-ASCII custom-property-like names are invalid @font-face descriptors.
+            "@font-face { font-family: 'd1'; --é: 1; }",
         ];
         for (let testCase of testCases) {
             let style = document.createElement("style");


### PR DESCRIPTION
This ports CSS property-name plumbing that can observe custom properties from FlyString to Utf16FlyString, while preserving the CSSOM IDL spelling with a temporary Utf16CSSOMString typedef for UTF-16-backed property-name parameters.

It also compacts generated CSSStyleProperties bindings by installing native accessors from a generated property table instead of emitting one C++ getter/setter pair per property. This reduces the LibWeb binary size by ~17 MB, improving both our build time and runtime memory footprint :)