### PR TITLE
LibWeb: Preserve implemented overloads with FIXME siblings

### DIFF
--- a/Meta/Generators/libweb_bindings/operations.py
+++ b/Meta/Generators/libweb_bindings/operations.py
@@ -97,8 +97,11 @@ def define_the_regular_operations(
     if unforgeable:
         return
 
+    implemented_operation_names = overload_resolution.operation_overload_sets(interface).keys()
     for operation in interface.regular_operations:
         if "FIXME" not in operation.extended_attributes:
+            continue
+        if operation.name in implemented_operation_names:
             continue
         out.write(
             f"""    object.define_direct_property("{operation.name}"_utf16_fly_string, JS::js_undefined(), default_attributes | JS::Attribute::Unimplemented);

--- a/Tests/LibWeb/Text/expected/canvas/webgl-create-canvas.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-create-canvas.txt
@@ -1,5 +1,6 @@
 FIXME: This test relies on having a GPU backend enabled, which it is not in run-tests mode :(
 context instanceof WebGLRenderingContext: false
 context is null: true
+typeof WebGL2RenderingContext.prototype.texImage2D: function
 context2 instanceof WebGL2RenderingContext: false
 context2 is null: true

--- a/Tests/LibWeb/Text/input/canvas/webgl-create-canvas.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-create-canvas.html
@@ -11,6 +11,7 @@
 
         let canvas2 = document.createElement("canvas");
         let context2 = canvas2.getContext("webgl2");
+        println(`typeof WebGL2RenderingContext.prototype.texImage2D: ${typeof WebGL2RenderingContext.prototype.texImage2D}`);
         println(`context2 instanceof WebGL2RenderingContext: ${context2 instanceof WebGL2RenderingContext}`);
         println(`context2 is null: ${context2 === null}`);
     });


### PR DESCRIPTION
Do not emit an unimplemented prototype property for an operation name when at least one overload with that name is implemented. The overload resolver already filters FIXME overloads out of the native overload set, so defining an unimplemented property afterwards replaces the working function with undefined.

This lets WebGL2RenderingContext.texImage2D keep its implemented WebGL1 and typed-array overloads even though the PBO-offset overload remains marked FIXME.