### PR TITLE
Meta: Some Linux build hardening

### DIFF
--- a/Meta/CMake/compile_options.cmake
+++ b/Meta/CMake/compile_options.cmake
@@ -199,6 +199,8 @@ endif()
 
 if (LINUX)
     add_cxx_compile_definitions(_FILE_OFFSET_BITS=64)
+    add_cxx_link_option_if_supported(LINKER:-z,relro)
+    add_cxx_link_option_if_supported(LINKER:-z,now)
 endif()
 
 if (APPLE)

--- a/Meta/CMake/compile_options.cmake
+++ b/Meta/CMake/compile_options.cmake
@@ -199,6 +199,7 @@ endif()
 
 if (LINUX)
     add_cxx_compile_definitions(_FILE_OFFSET_BITS=64)
+    add_cxx_compile_options(-fstack-clash-protection)
     add_cxx_link_option_if_supported(LINKER:-z,relro)
     add_cxx_link_option_if_supported(LINKER:-z,now)
 endif()

--- a/Meta/CMake/compile_options.cmake
+++ b/Meta/CMake/compile_options.cmake
@@ -198,6 +198,7 @@ if(CMAKE_CXX_LINK_PIE_SUPPORTED)
 endif()
 
 if (LINUX)
+    add_cxx_compile_definitions(_FORTIFY_SOURCE=3)
     add_cxx_compile_definitions(_FILE_OFFSET_BITS=64)
     add_cxx_compile_options(-fstack-clash-protection)
     add_cxx_link_option_if_supported(LINKER:-z,relro)


### PR DESCRIPTION
Enable additional hardening for platform builds:

- Use full RELRO on Linux with `-z relro` and `-z now`.
- Enable `-fstack-clash-protection` on Linux.
- Define `_FORTIFY_SOURCE=3` on Linux and `_FORTIFY_SOURCE=2` on macOS.

These are low-overhead hardening defaults for browser processes and keep the new flags scoped to platforms where they are expected to be useful.
