### PR TITLE
LibWeb: Record abspos inline static positions as line-box markers

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -242,7 +242,12 @@ void InlineFormattingContext::apply_justification_to_fragments(CSS::TextJustify 
 
         if (fragment.is_justifiable_whitespace()
             && fragment.inline_length() != justified_space_width) {
-            running_diff += justified_space_width - fragment.inline_length();
+            auto diff = justified_space_width - fragment.inline_length();
+            running_diff += diff;
+            for (auto& marker : line_box.static_position_markers()) {
+                if (marker.inline_offset > fragment.inline_offset())
+                    marker.inline_offset += diff;
+            }
             fragment.set_inline_length(justified_space_width);
         }
     }
@@ -339,6 +344,7 @@ void InlineFormattingContext::apply_text_overflow_ellipsis(Vector<LineBox>& line
                 fragments[j].set_fully_truncated(true);
 
             line_box.m_inline_length = available_width;
+            line_box.clamp_static_position_markers_to_inline_length();
             break;
         }
     }
@@ -418,7 +424,7 @@ void InlineFormattingContext::generate_line_boxes()
         }
         case InlineLevelIterator::Item::Type::AbsolutelyPositionedElement:
             if (auto const* box = as_if<Box>(*item.node)) {
-                // Calculation of static position for absolute boxes is delayed until trailing whitespaces are removed.
+                line_builder.append_static_position_marker(*box);
                 absolute_boxes.append(box);
             }
             break;
@@ -484,8 +490,6 @@ void InlineFormattingContext::generate_line_boxes()
 
     apply_text_overflow_ellipsis(line_boxes);
 
-    line_builder.remove_last_line_if_empty();
-
     auto const& containing_block = this->containing_block();
     auto text_align = containing_block.computed_values().text_align();
     auto text_justify = containing_block.computed_values().text_justify();
@@ -508,14 +512,35 @@ void InlineFormattingContext::generate_line_boxes()
     }
 
     line_builder.update_last_line();
-    m_containing_block_used_values.set_inline_end_static_position_rect(calculate_inline_end_static_position_rect());
 
     if (m_layout_mode == LayoutMode::Normal) {
-        for (auto* box : absolute_boxes) {
+        for (auto const* box : absolute_boxes) {
+            StaticPositionRect static_position_rect;
+            bool found_static_position_marker = false;
+            for (auto const& line_box : line_boxes) {
+                for (auto const& marker : line_box.static_position_markers()) {
+                    if (marker.box != box)
+                        continue;
+
+                    if (box->display_before_box_type_transformation().is_block_outside()) {
+                        auto block_position = line_box.fragments().is_empty() ? marker.offset().y() : line_box.bottom();
+                        static_position_rect.rect = { { 0, block_position }, { 0, 0 } };
+                    } else {
+                        static_position_rect.rect = { marker.offset(), { 0, 0 } };
+                    }
+                    found_static_position_marker = true;
+                    break;
+                }
+                if (found_static_position_marker)
+                    break;
+            }
             auto& box_state = m_state.get_mutable(*box);
-            box_state.set_static_position_rect(calculate_static_position_rect(*box));
+            box_state.set_static_position_rect(static_position_rect);
         }
     }
+
+    line_builder.remove_last_line_if_empty();
+    m_containing_block_used_values.set_inline_end_static_position_rect(calculate_inline_end_static_position_rect());
 }
 
 bool InlineFormattingContext::any_floats_intrude_at_block_offset(CSSPixels block_offset) const
@@ -562,48 +587,6 @@ CSSPixels InlineFormattingContext::vertical_float_clearance() const
 void InlineFormattingContext::set_vertical_float_clearance(CSSPixels vertical_float_clearance)
 {
     m_vertical_float_clearance = vertical_float_clearance;
-}
-
-StaticPositionRect InlineFormattingContext::calculate_static_position_rect(Box const& box) const
-{
-    VERIFY(box.parent());
-    VERIFY(box.parent()->children_are_inline());
-
-    CSSPixelPoint position;
-
-    // We're calculating the position for an absolutely positioned box in an IFC.
-    // Walk backwards through previous siblings to find the most recent one with a line box fragment.
-    LineBoxFragment const* last_fragment = nullptr;
-    for (auto sibling = box.previous_sibling(); sibling && !last_fragment; sibling = sibling->previous_sibling()) {
-        for (auto const& line_box : m_containing_block_used_values.line_boxes) {
-            for (auto const& fragment : line_box.fragments()) {
-                if (&fragment.layout_node() == sibling.ptr())
-                    last_fragment = &fragment;
-            }
-        }
-    }
-
-    // We need to position the box...
-    // ...below the last fragment, if the display-outside value (before box type transformation) is block.
-    // ...at the top right corner of the last fragment otherwise.
-    auto is_block_outside = box.display_before_box_type_transformation().is_block_outside();
-    if (last_fragment) {
-        if (is_block_outside) {
-            // Display-outside value is block => position below
-            position.set_x(0);
-            position.set_y(last_fragment->offset().y() + last_fragment->height());
-        } else {
-            // Display-outside value is not block => position to the right
-            position.set_x(last_fragment->offset().x() + last_fragment->width());
-            position.set_y(last_fragment->offset().y());
-        }
-    } else if (!is_block_outside) {
-        // No preceding sibling has a line box fragment (e.g. only floats and collapsed whitespace precede this box).
-        // For inline-level elements, the static position must account for float intrusion into the line box.
-        position.set_x(leftmost_inline_offset_at(0));
-    }
-
-    return { .rect = { position, { 0, 0 } } };
 }
 
 StaticPositionRect InlineFormattingContext::calculate_inline_end_static_position_rect() const

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -26,7 +26,6 @@ public:
     virtual void run(AvailableSpace const&) override;
     virtual CSSPixels automatic_content_height() const override;
     virtual CSSPixels automatic_content_width() const override;
-    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     void dimension_box_on_line(Box const&, LayoutMode);
 

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -60,6 +60,24 @@ void LineBox::add_fragment(Node const& layout_node, size_t start, size_t length,
     m_block_length = max(m_block_length, content_height + border_box_top + border_box_bottom);
 }
 
+void LineBox::add_static_position_marker(Box const& box)
+{
+    m_static_position_markers.append(StaticPositionMarker {
+        .box = &box,
+        .inline_offset = m_inline_length,
+        .block_offset = 0,
+        .writing_mode = m_writing_mode,
+    });
+}
+
+void LineBox::clamp_static_position_markers_to_inline_length()
+{
+    for (auto& marker : m_static_position_markers) {
+        if (marker.inline_offset > m_inline_length)
+            marker.inline_offset = m_inline_length;
+    }
+}
+
 CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespace should_remove)
 {
     auto should_trim = [](LineBoxFragment* fragment) {
@@ -92,6 +110,7 @@ CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespac
         if (should_remove == RemoveTrailingWhitespace::Yes) {
             m_inline_length -= last_fragment->inline_length();
             m_fragments.remove(fragment_index);
+            clamp_static_position_markers_to_inline_length();
         }
     }
 
@@ -118,6 +137,7 @@ CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespac
             --last_fragment->m_length_in_code_units;
             last_fragment->set_inline_length(last_fragment->inline_length() - last_character_width);
             m_inline_length -= last_character_width;
+            clamp_static_position_markers_to_inline_length();
         }
     }
 

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -11,8 +11,24 @@
 
 namespace Web::Layout {
 
+class Box;
+
 class LineBox {
 public:
+    struct StaticPositionMarker {
+        Box const* box { nullptr };
+        CSSPixels inline_offset { 0 };
+        CSSPixels block_offset { 0 };
+        CSS::WritingMode writing_mode { CSS::WritingMode::HorizontalTb };
+
+        CSSPixelPoint offset() const
+        {
+            if (writing_mode != CSS::WritingMode::HorizontalTb)
+                return { block_offset, inline_offset };
+            return { inline_offset, block_offset };
+        }
+    };
+
     LineBox(CSS::Direction direction, CSS::WritingMode writing_mode)
         : m_direction(direction)
         , m_writing_mode(writing_mode)
@@ -28,12 +44,16 @@ public:
     CSSPixels baseline() const { return m_baseline; }
 
     void add_fragment(Node const& layout_node, size_t start, size_t length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run = {});
+    void add_static_position_marker(Box const&);
 
     Vector<LineBoxFragment> const& fragments() const { return m_fragments; }
     Vector<LineBoxFragment>& fragments() { return m_fragments; }
+    Vector<StaticPositionMarker> const& static_position_markers() const { return m_static_position_markers; }
+    Vector<StaticPositionMarker>& static_position_markers() { return m_static_position_markers; }
 
     CSSPixels get_trailing_whitespace_width() const;
     void trim_trailing_whitespace();
+    void clamp_static_position_markers_to_inline_length();
 
     bool is_empty_or_ends_in_whitespace() const;
     bool is_empty() const { return m_fragments.is_empty() && !m_has_break; }
@@ -54,6 +74,7 @@ private:
     CSSPixels calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespace);
 
     Vector<LineBoxFragment> m_fragments;
+    Vector<StaticPositionMarker> m_static_position_markers;
     CSSPixels m_inline_length { 0 };
     CSSPixels m_block_length { 0 };
     CSSPixels m_bottom { 0 };

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -125,6 +125,11 @@ void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_
     m_max_height_on_current_line = max(m_max_height_on_current_line, line_box.block_length());
 }
 
+void LineBuilder::append_static_position_marker(Box const& box)
+{
+    ensure_last_line_box().add_static_position_marker(box);
+}
+
 CSSPixels LineBuilder::y_for_float_to_be_inserted_here(Box const& box)
 {
     auto const& box_state = m_layout_state.get(box);
@@ -416,6 +421,14 @@ void LineBuilder::update_last_line()
 
         uppermost_box_top = min(uppermost_box_top, top_of_inline_box);
         lowermost_box_bottom = max(lowermost_box_bottom, bottom_of_inline_box);
+    }
+
+    auto marker_inline_offset = line_box.fragments().is_empty()
+        ? max(inline_offset_top, inline_offset_bottom)
+        : inline_offset;
+    for (auto& marker : line_box.static_position_markers()) {
+        marker.inline_offset += marker_inline_offset;
+        marker.block_offset += block_offset + m_current_block_offset;
     }
 
     // 3. The line box height is the distance between the uppermost box top and the lowermost box bottom.

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -25,6 +25,7 @@ public:
     void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
     void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun>);
+    void append_static_position_marker(Box const&);
 
     // Returns whether a line break occurred.
     bool break_if_needed(CSSPixels next_item_width)

--- a/Tests/LibWeb/Text/expected/css/abspos-inline-static-position-in-pre.txt
+++ b/Tests/LibWeb/Text/expected/css/abspos-inline-static-position-in-pre.txt
@@ -1,0 +1,4 @@
+one: 0,0
+two: 0,20
+three: 0,40
+right-one: 50,0

--- a/Tests/LibWeb/Text/input/css/abspos-inline-static-position-in-pre.html
+++ b/Tests/LibWeb/Text/input/css/abspos-inline-static-position-in-pre.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+#container {
+    font: 10px/20px Ahem;
+    position: relative;
+    white-space: pre;
+}
+
+#right-container {
+    font: 10px/20px Ahem;
+    position: relative;
+    text-align: right;
+    white-space: pre;
+    width: 100px;
+}
+
+.a {
+    position: absolute;
+}
+</style>
+<div id="container"><span class="a" id="one">1</span>  fo<span>o</span>
+<span class="a" id="two">2</span>  fo<span>o</span>
+<span class="a" id="three">3</span>  fo<span>o</span></div>
+<div id="right-container"><span class="a" id="right-one">1</span>  fo<span>o</span></div>
+<script>
+promiseTest(async () => {
+    await document.fonts.ready;
+    await animationFrame();
+
+    const containerRect = document.getElementById("container").getBoundingClientRect();
+
+    for (const id of ["one", "two", "three"]) {
+        const rect = document.getElementById(id).getBoundingClientRect();
+        println(`${id}: ${Math.round(rect.x - containerRect.x)},${Math.round(rect.y - containerRect.y)}`);
+    }
+
+    const rightContainerRect = document.getElementById("right-container").getBoundingClientRect();
+    const rightRect = document.getElementById("right-one").getBoundingClientRect();
+    println(`right-one: ${Math.round(rightRect.x - rightContainerRect.x)},${Math.round(rightRect.y - rightContainerRect.y)}`);
+});
+</script>


### PR DESCRIPTION
The static position of an absolutely positioned inline child is the in-flow insertion point on the line where it appears. Previously this was reconstructed after layout by walking previous siblings for a line-box fragment. That lookup could match a fragment from an earlier line and collapse multiple abspos children onto the same position, especially in white-space preserving content.

Instead, drop a zero-width static-position marker into the line box at the insertion point when each abspos child is encountered. The marker is carried through normal line post-processing, including float intrusion, ext-align, justification, trailing-whitespace trimming and ellipsis, so the final static position is resolved from the line itself.

Resolve marker-only trailing lines before removing them, so they can provide static position without contributing line height.

Fixes: #1952 

Before:

<img width="1494" height="944" alt="image" src="https://github.com/user-attachments/assets/cc78fc26-097a-411c-9f19-5257d0d4865a" />

After:

<img width="1494" height="944" alt="image" src="https://github.com/user-attachments/assets/9e2119bd-d57f-44dd-8853-7e5ebf27ecbb" />
