### PR TITLE
CI: Run a WPT smoke test step on PRs

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -215,6 +215,19 @@ jobs:
             --python-executable "${{ env.pythonLocation }}/bin/python" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
+      - name: Run WPT Smoke Tests
+        if: ${{ inputs.os_name == 'Linux' && (inputs.build_preset == 'Release' || inputs.build_preset == 'Sanitizer') }}
+        timeout-minutes: 5
+        working-directory: ${{ github.workspace }}
+        run: Meta/WPT.sh run --test-list Tests/LibWeb/WPT/ci-smoke-tests.txt
+        env:
+          BUILD_LADYBIRD: 'false'
+          LADYBIRD_BINARY: ${{ github.workspace }}/Build/bin/Ladybird
+          WEBDRIVER_BINARY: ${{ github.workspace }}/Build/bin/WebDriver
+          WPT_PROCESSES: '4'
+          ASAN_OPTIONS: 'log_path=${{ github.workspace }}/Build/asan.log'
+          UBSAN_OPTIONS: 'log_path=${{ github.workspace }}/Build/ubsan.log'
+
       - name: Test
         if: ${{ inputs.build_preset == 'Sanitizer' }}
         working-directory: ${{ github.workspace }}

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -94,6 +94,7 @@ WPT_ARGS=(
 )
 IMPORT_ARGS=()
 WPT_LOG_ARGS=()
+TESTS_FROM_FILE=()
 
 ARG0=$0
 print_help() {
@@ -135,6 +136,9 @@ print_help() {
               N>1 to enable chunked mode with explicit process count
       --log PATH
           Alias for --log-raw PATH
+      --test-list PATH
+          Read tests to run from the given file, one test path per line
+              Empty lines and lines starting with '#' are ignored
       --log-(raw|unittest|xunit|html|mach|tbpl|grouped|chromium|wptreport|wptscreenshot) PATH
           Enable the given wpt log option with the given PATH
 
@@ -191,10 +195,17 @@ set_logging_flags()
 
 headless=1
 ARG=$1
-while [[ "$ARG" =~ ^(--show-window|--debug-process|--parallel-instances|(--log(-(raw|unittest|xunit|html|mach|tbpl|grouped|chromium|wptreport|wptscreenshot))?))$ ]]; do
+while [[ "$ARG" =~ ^(--show-window|--debug-process|--parallel-instances|--test-list|(--log(-(raw|unittest|xunit|html|mach|tbpl|grouped|chromium|wptreport|wptscreenshot))?))$ ]]; do
     case "$ARG" in
         --show-window)
             headless=0
+            ;;
+        --test-list)
+            [ -f "${2}" ] || die "No such test list file: '${2}'"
+            while IFS= read -r test_path; do
+                TESTS_FROM_FILE+=("$test_path")
+            done < <(grep -v -e '^#' -e '^[[:space:]]*$' "${2}")
+            shift
             ;;
         --debug-process)
             process_name="${2}"
@@ -226,7 +237,7 @@ fi
 exit_if_running_as_root "Do not run WPT.sh as root"
 
 construct_test_list() {
-    TEST_LIST=( "$@" )
+    TEST_LIST=( "$@" "${TESTS_FROM_FILE[@]}" )
 
     for i in "${!TEST_LIST[@]}"; do
         item="${TEST_LIST[i]}"

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -86,6 +86,14 @@ WPT_PROCESSES=${WPT_PROCESSES:-$(get_number_of_processing_units)}
 WPT_CERTIFICATES=(
     "tools/certs/cacert.pem"
 )
+WPT_TEST_TYPE_ARGS=(
+    "--test-types"
+    "testharness"
+    "reftest"
+    "wdspec"
+    "crashtest"
+    "test262"
+)
 WPT_ARGS=(
     "--binary=${LADYBIRD_BINARY}"
     "--webdriver-binary=${WEBDRIVER_BINARY}"
@@ -510,7 +518,7 @@ run_wpt_chunked() {
 
     echo "Preparing the venv setup..."
     base_venv="${BUILD_DIR}/wpt-prep/_venv"
-    ./wpt --venv "$base_venv" run "${WPT_ARGS[@]}" ladybird THIS_TEST_CANNOT_POSSIBLY_EXIST || true
+    ./wpt --venv "$base_venv" run "${WPT_ARGS[@]}" ladybird THIS_TEST_CANNOT_POSSIBLY_EXIST "${WPT_TEST_TYPE_ARGS[@]}" || true
 
     echo "Launching $procs chunked instances (concurrency=$concurrency each)"
     local logs=()
@@ -579,7 +587,7 @@ execute_wpt() {
             WPT_ARGS+=( "--webdriver-arg=--certificate=${certificate_path}" )
         done
         construct_test_list "${@}"
-        run_wpt_chunked "$procs" "${WPT_ARGS[@]}" "${WPT_LOG_ARGS[@]}" ladybird "${TEST_LIST[@]}"
+        run_wpt_chunked "$procs" "${WPT_ARGS[@]}" "${WPT_LOG_ARGS[@]}" ladybird "${TEST_LIST[@]}" "${WPT_TEST_TYPE_ARGS[@]}"
     popd > /dev/null
 }
 
@@ -697,7 +705,7 @@ list_tests_wpt()
     construct_test_list "${@}"
 
     pushd "${WPT_SOURCE_DIR}" > /dev/null
-        ./wpt run --list-tests ladybird "${TEST_LIST[@]}"
+        ./wpt run --list-tests ladybird "${TEST_LIST[@]}" "${WPT_TEST_TYPE_ARGS[@]}"
     popd > /dev/null
 }
 

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -32,6 +32,11 @@ fi
 sudo_and_ask() {
     local prompt
     prompt="$1"; shift
+    # Running as root is only possible when the CI environment variable is set to true.
+    if [ "$(id -u)" -eq 0 ]; then
+        "${@}"
+        return
+    fi
     if [ -z "$prompt" ]; then
         prompt="Running '${*}' as root, please enter password for %p: "
     else
@@ -234,7 +239,9 @@ if [ $headless -eq 1 ]; then
     WPT_ARGS+=( "--webdriver-arg=--headless" )
 fi
 
-exit_if_running_as_root "Do not run WPT.sh as root"
+if [ "${CI:-false}" != "true" ]; then
+    exit_if_running_as_root "Do not run WPT.sh as root"
+fi
 
 construct_test_list() {
     TEST_LIST=( "$@" "${TESTS_FROM_FILE[@]}" )

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -22,6 +22,7 @@ TMPDIR=${TMPDIR:-/tmp}
 : "${SHOW_LOGFILES:=true}"
 : "${SHOW_PROGRESS:=true}"
 : "${PARALLEL_INSTANCES:=1}"
+: "${BUILD_LADYBIRD:=true}"
 
 if "$SHOW_PROGRESS"; then
     SHOW_LOGFILES=true
@@ -115,6 +116,7 @@ print_help() {
                       Find the first commit where a given set of tests produce unexpected results.
 
     Env vars:
+      BUILD_LADYBIRD:             Whether to build Ladybird and WebDriver before running tests; true or false, default true
       EXTRA_WPT_ARGS:             Extra arguments for the wpt command, placed at the end; array, default empty
       TRY_SHOW_LOGFILES_IN_TMUX:  Whether to show split logs in tmux; true or false, default false
       SHOW_LOGFILES:              Whether to show logs at all; true or false, default true
@@ -246,6 +248,9 @@ ensure_wpt_repository() {
 }
 
 build_ladybird_and_webdriver() {
+    if ! "$BUILD_LADYBIRD"; then
+        return
+    fi
     "${LADYBIRD_SOURCE_DIR}"/Meta/ladybird.py build WebDriver
 }
 

--- a/Tests/LibWeb/WPT/ci-smoke-tests.txt
+++ b/Tests/LibWeb/WPT/ci-smoke-tests.txt
@@ -1,0 +1,33 @@
+# Web Platform Tests run by the WPT smoke test CI step. Each line is a test
+# path passed to "Meta/WPT.sh run"; every listed test is expected to pass.
+
+# testharness.js tests
+infrastructure/assumptions/ahem.html
+infrastructure/assumptions/cookie.html
+infrastructure/assumptions/html-elements.html
+infrastructure/assumptions/initial-color.html
+
+# Multi-global (.any.js) tests, including workers
+infrastructure/server/context.any.html
+infrastructure/server/context.any.sharedworker.html
+infrastructure/server/context.any.worker.html
+
+# Secure contexts
+infrastructure/server/secure-context.https.any.html
+
+# WPT server features (subdomains, WebSockets)
+infrastructure/server/wpt-server-http.sub.html
+infrastructure/server/wpt-server-websocket.sub.html
+
+# Reftests
+infrastructure/reftest/reftest_fuzzy_1.html
+infrastructure/reftest/reftest_match.html
+infrastructure/reftest/reftest_mismatch.html
+infrastructure/reftest/reftest_wait_TestRendered.html
+
+# Crash tests
+infrastructure/crashtests/example.html
+
+# testdriver.js tests
+infrastructure/testdriver/click.html
+infrastructure/testdriver/send_keys.html


### PR DESCRIPTION
Run `WPT.sh` against a set of known good tests in `Tests/LibWeb/WPT/ci-smoke-tests.txt` as a smoke test.

To support this I've added the following to `WPT.sh`:
* A `--test-list` option that pulls tests from a file, ignoring lines starting with `#`.
* A `BUILD_LADYBIRD` env var to allow skipping the build step.
* A `CI` env var that allows running as root.