### PR TITLE
LibWeb: Prevent the session history step from moving backwards

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2888,7 +2888,9 @@ void finalize_a_cross_document_navigation(GC::Ref<Navigable> navigable, HistoryH
         traversable->clear_the_forward_session_history();
 
         // 2. Set targetStep to traversable's current session history step + 1.
-        target_step = traversable->current_session_history_step() + 1;
+        // AD-HOC: Claim the step instead — so a step claimed by an apply-history-step run still in flight can't be
+        //         handed out twice. See https://github.com/whatwg/html/issues/12576.
+        target_step = traversable->claim_next_session_history_step();
 
         // 3. Set historyEntry's step to targetStep.
         history_entry->set_step(target_step);

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -695,7 +695,8 @@ public:
         Navigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
         GC::Ptr<DOM::Document> pending_document,
         GC::Ref<OnApplyHistoryStepComplete> on_complete)
-        : m_traversable(traversable)
+        : m_generation(++traversable->m_apply_history_step_generation_counter)
+        , m_traversable(traversable)
         , m_step(step)
         , m_target_step(target_step)
         , m_source_snapshot_params(source_snapshot_params)
@@ -802,6 +803,7 @@ private:
     void complete();
 
     Phase m_phase { Phase::WaitingForDocumentPopulation };
+    u64 m_generation { 0 };
     GC::Ref<TraversableNavigable> m_traversable;
     int m_step;
     int m_target_step;
@@ -945,7 +947,13 @@ void ApplyHistoryStepState::start()
                     // FIXME: Add ever populated check, and fix the bug where top level traversable's step is not updated when a child navigable navigates
                     // - "push": Assert: targetEntry's step is displayedEntry's step + 1 and targetEntry's document state's ever populated is false.
                     VERIFY(target_entry != displayed_entry);
-                    VERIFY(target_entry->step().get<int>() > displayed_entry->step().get<int>());
+                    // AD-HOC: A same-document navigation's entry becomes the navigable's active session history entry
+                    //         when the navigation starts — before the queued synchronous step assigns its step number.
+                    //         A run for a load arriving in that window observes the still-pending step; the relation
+                    //         below is only checkable once both steps are assigned.
+                    //         See https://github.com/whatwg/html/issues/12576.
+                    if (displayed_entry->step() != SessionHistoryEntry::Pending::Tag)
+                        VERIFY(target_entry->step().get<int>() > displayed_entry->step().get<int>());
                     break;
                 }
             }
@@ -1421,37 +1429,48 @@ void ApplyHistoryStepState::complete()
     m_phase = Phase::Completed;
     m_timeout->stop();
 
-    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-the-used-step
-    // NB: targetStep was computed before the asynchronous portions of applying the history step. If a child
-    //     navigable was removed while those steps were running, that step can stop being used. Normalize again
-    //     before storing it as the traversable's current session history step.
-    m_target_step = m_traversable->get_the_used_step(m_target_step);
+    // AD-HOC: Commit the target step only if no newer apply history step has committed one. A synchronous navigation
+    //         jumping the queue while this step was paused has a newer target step; moving the current step back past
+    //         it would let the next push assign a step number that an existing entry already holds.
+    //         See https://github.com/whatwg/html/issues/12576.
+    if (m_generation > m_traversable->m_committed_apply_history_step_generation) {
+        m_traversable->m_committed_apply_history_step_generation = m_generation;
 
-    // 20. Set traversable's current session history step to targetStep.
-    m_traversable->m_current_session_history_step = m_target_step;
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-the-used-step
+        // NB: targetStep was computed before the asynchronous portions of applying the history step. If a child
+        //     navigable was removed while those steps were running, that step can stop being used. Normalize again
+        //     before storing it as the current session history step; keep it in a local so the claimed step retired
+        //     below still matches what the navigation claimed, not the re-normalized value.
+        auto const used_target_step = m_traversable->get_the_used_step(m_target_step);
 
-    // AD-HOC: Report the updated session history descriptors to the UI-process mirror.
-    if (m_traversable->page().client().should_report_session_history_updates()) {
-        auto save_active_entry_persisted_state = TraversableNavigable::SaveActiveEntryPersistedState::Yes;
-        // NB: During history traversal, the active entry can point at the target
-        //     entry before the active document's queued history-step update has
-        //     restored the target entry's persisted state. Do not overwrite that
-        //     target entry with the document's pre-restoration viewport offset.
-        if (m_navigation_type == Bindings::NavigationType::Traverse) {
-            auto document = m_traversable->active_document();
-            auto active_entry = m_traversable->active_session_history_entry();
-            if (document && active_entry && document->latest_entry() != active_entry)
-                save_active_entry_persisted_state = TraversableNavigable::SaveActiveEntryPersistedState::No;
+        // 20. Set traversable's current session history step to targetStep.
+        m_traversable->m_current_session_history_step = used_target_step;
+
+        // AD-HOC: Report the updated session history descriptors to the UI-process mirror.
+        if (m_traversable->page().client().should_report_session_history_updates()) {
+            auto save_active_entry_persisted_state = TraversableNavigable::SaveActiveEntryPersistedState::Yes;
+            // NB: During history traversal, the active entry can point at the target
+            //     entry before the active document's queued history-step update has
+            //     restored the target entry's persisted state. Do not overwrite that
+            //     target entry with the document's pre-restoration viewport offset.
+            if (m_navigation_type == Bindings::NavigationType::Traverse) {
+                auto document = m_traversable->active_document();
+                auto active_entry = m_traversable->active_session_history_entry();
+                if (document && active_entry && document->latest_entry() != active_entry)
+                    save_active_entry_persisted_state = TraversableNavigable::SaveActiveEntryPersistedState::No;
+            }
+            auto session_history_snapshot = m_traversable->create_session_history_snapshot(save_active_entry_persisted_state);
+            m_traversable->page().client().page_did_update_session_history(session_history_snapshot.top_level_session_history_entries, session_history_snapshot.used_session_history_steps, session_history_snapshot.current_used_step_index);
         }
-        auto session_history_snapshot = m_traversable->create_session_history_snapshot(save_active_entry_persisted_state);
-        m_traversable->page().client().page_did_update_session_history(session_history_snapshot.top_level_session_history_entries, session_history_snapshot.used_session_history_steps, session_history_snapshot.current_used_step_index);
+
+        VERIFY(m_traversable->m_session_history_entries.size() > 0);
+        auto back_enabled = m_traversable->can_go_back();
+        auto forward_enabled = m_traversable->can_go_forward();
+        m_traversable->page().client().page_did_update_navigation_buttons_state(back_enabled, forward_enabled);
+        m_traversable->page().client().page_did_change_url(m_traversable->current_session_history_entry()->url());
     }
 
-    VERIFY(m_traversable->m_session_history_entries.size() > 0);
-    auto back_enabled = m_traversable->can_go_back();
-    auto forward_enabled = m_traversable->can_go_forward();
-    m_traversable->page().client().page_did_update_navigation_buttons_state(back_enabled, forward_enabled);
-    m_traversable->page().client().page_did_change_url(m_traversable->current_session_history_entry()->url());
+    m_traversable->retire_claimed_session_history_step(m_target_step);
 
     // Clear state BEFORE on_complete, because on_complete may resolve a promise
     // that triggers the next session history traversal queue entry.
@@ -1462,6 +1481,21 @@ void ApplyHistoryStepState::complete()
     // 21. Return "applied".
     if (m_on_complete)
         m_on_complete->function()(HistoryStepResult::Applied);
+}
+
+int TraversableNavigable::claim_next_session_history_step()
+{
+    int step = m_current_session_history_step;
+    for (auto claimed : m_outstanding_claimed_session_history_steps)
+        step = max(step, claimed);
+    ++step;
+    m_outstanding_claimed_session_history_steps.append(step);
+    return step;
+}
+
+void TraversableNavigable::retire_claimed_session_history_step(int step)
+{
+    m_outstanding_claimed_session_history_steps.remove_first_matching([step](int claimed) { return claimed == step; });
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
@@ -1890,6 +1924,13 @@ void TraversableNavigable::clear_the_forward_session_history()
     // 2. Let step be the navigable's current session history step.
     auto step = current_session_history_step();
 
+    // AD-HOC: An apply-history-step run can still be in flight with a claimed step above the current step; its entry is
+    //         not forward history that traversing away abandoned — it's the entry the in-flight run is about to make
+    //         current. Removing it would leave that run applying a step with no entry.
+    //         See https://github.com/whatwg/html/issues/12576.
+    for (auto claimed : m_outstanding_claimed_session_history_steps)
+        step = max(step, claimed);
+
     // 3. Let entryLists be the ordered set « navigable's session history entries ».
     Vector<Vector<NonnullRefPtr<SessionHistoryEntry>>&> entry_lists;
     entry_lists.append(session_history_entries());
@@ -2254,7 +2295,9 @@ void finalize_a_same_document_navigation(GC::Ref<TraversableNavigable> traversab
         traversable->clear_the_forward_session_history();
 
         // 2. Set targetStep to traversable's current session history step + 1.
-        target_step = traversable->current_session_history_step() + 1;
+        // AD-HOC: Claim the step instead — so a step claimed by an apply-history-step run still in flight can't be
+        //         handed out twice. See https://github.com/whatwg/html/issues/12576.
+        target_step = traversable->claim_next_session_history_step();
 
         // 3. Set targetEntry's step to targetStep.
         target_entry->set_step(*target_step);

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -44,6 +44,13 @@ public:
     virtual bool is_top_level_traversable() const override;
 
     int current_session_history_step() const { return m_current_session_history_step; }
+
+    // Claims the step number for a new push-type session history entry. Claims are tracked separately from the current
+    // step: the current step only advances when an apply-history-step run commits — and several runs can have claimed
+    // steps in flight at once. So, computing a new step from the current step alone can hand out a step number that an
+    // existing entry already holds. A claim is retired when the run that applies it completes.
+    [[nodiscard]] int claim_next_session_history_step();
+    void retire_claimed_session_history_step(int step);
     Vector<NonnullRefPtr<SessionHistoryEntry>>& session_history_entries() { return m_session_history_entries; }
     Vector<NonnullRefPtr<SessionHistoryEntry>> const& session_history_entries() const { return m_session_history_entries; }
     struct SessionHistorySnapshot {
@@ -186,6 +193,30 @@ private:
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#tn-current-session-history-step
     int m_current_session_history_step { 0 };
+
+    // Concurrent apply-history-step runs share the step numbering below. Runs are serialized through the session
+    // history traversal queue — but a synchronous navigation can jump the queue while another run is paused (see the
+    // sync navigations jump queue in the spec). So, a nested run mutates this state while an outer run is mid-flight.
+    // The spec describes that concurrency but not the necessary bookkeeping it ends up requiring in implementations.
+    // See https://github.com/whatwg/html/issues/12576.
+    //
+    // Four invariants keep the numbering coherent under that nesting:
+    //
+    //  - uniqueness: a new step number is claimed past every claimed-but-uncommitted step — never just current step + 1
+    //    (claim_next_session_history_step);
+    //
+    //  - ordering: a run commits its target step only if no newer run has committed first — so the current step can't
+    //    move backwards past a newer run's commit (ApplyHistoryStepState::complete);
+    //
+    //  - integrity: clearing the forward session history spares entries whose steps are claimed by runs still in flight
+    //    (clear_the_forward_session_history);
+    //
+    //  - initialization: step numbers are only compared once assigned; a pushed entry is the active session history
+    //    entry before its queued synchronous step assigns its step number (the Push assertion in
+    //    ApplyHistoryStepState::start).
+    u64 m_apply_history_step_generation_counter { 0 };
+    u64 m_committed_apply_history_step_generation { 0 };
+    Vector<int> m_outstanding_claimed_session_history_steps;
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#tn-session-history-entries
     Vector<NonnullRefPtr<SessionHistoryEntry>> m_session_history_entries;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/JsonObject.h>
 #include <AK/NumericLimits.h>
+#include <LibCore/EventLoop.h>
 #include <LibCore/TimeZone.h>
 #include <LibGfx/Cursor.h>
 #include <LibHTTP/HSTS/ParsedHSTSPolicy.h>
@@ -438,6 +439,17 @@ void Internals::spoof_current_url(String const& url_string)
     window.associated_document().set_url(url.value());
     window.associated_document().set_origin(origin);
     HTML::relevant_settings_object(window.associated_document()).creation_url = url.release_value();
+}
+
+void Internals::load_url(String const& url_string)
+{
+    auto url = DOMURL::parse(url_string);
+
+    VERIFY(url.has_value());
+
+    Core::deferred_invoke([page = GC::make_root(page()), url = url.release_value()] {
+        page->load(url);
+    });
 }
 
 GC::Ref<InternalAnimationTimeline> Internals::create_internal_animation_timeline()

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -74,6 +74,7 @@ public:
     WebIDL::ExceptionOr<bool> dispatch_user_activated_event(DOM::EventTarget&, DOM::Event& event);
 
     void spoof_current_url(String const& url);
+    void load_url(String const& url);
 
     GC::Ref<InternalAnimationTimeline> create_internal_animation_timeline();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -63,6 +63,10 @@ interface Internals {
     boolean dispatchUserActivatedEvent(EventTarget target, Event event);
     undefined spoofCurrentURL(USVString url);
 
+    // Loads a URL in the top-level traversable — deferred so it starts outside the calling task and can land between
+    // session-history traversal-queue steps, as can one requested by ConnectionFromClient::load_url in the UI process.
+    undefined loadURL(USVString url);
+
     InternalAnimationTimeline createInternalAnimationTimeline();
 
     undefined simulateDragStart(double x, double y, DOMString mimeType, DOMString contents);

--- a/Tests/LibWeb/Text/expected/HTML/load-during-session-history-push-drain.txt
+++ b/Tests/LibWeb/Text/expected/HTML/load-during-session-history-push-drain.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/expected/HTML/load-during-session-history-push-flood.txt
+++ b/Tests/LibWeb/Text/expected/HTML/load-during-session-history-push-flood.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/load-during-session-history-push-drain.html
+++ b/Tests/LibWeb/Text/input/HTML/load-during-session-history-push-drain.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    asyncTest(done => {
+        if (location.search.includes("loaded")) {
+            println("PASS (didn't crash)");
+            done();
+            return;
+        }
+        document.body.appendChild(document.createElement("iframe"));
+        history.pushState({}, "", "#pushed");
+        const next = new URL(location.href);
+        next.search = "?loaded";
+        next.hash = "";
+        internals.loadURL(next.href);
+    });
+</script>
+</body>

--- a/Tests/LibWeb/Text/input/HTML/load-during-session-history-push-flood.html
+++ b/Tests/LibWeb/Text/input/HTML/load-during-session-history-push-flood.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<!-- A stream of same-document pushStates keeps claimed-but-uncommitted steps in flight while the page is loaded again
+     in the same way a request from the UI process loads it. The load used to race the in-flight push machinery in three
+     ways: (1) it could read the pushed entry's still-pending step, (2) it could claim a step number an in-flight push
+     already held, (3) and clearing the forward session history could remove the in-flight push's entry out from under
+     its apply-history-step run. The reloaded page signals completion. The races need the load to land inside another
+     run's window — so this reproduces most readily on slow builds (e.g., Sanitizer builds). -->
+<body>
+<script>
+    asyncTest(done => {
+        if (location.search.includes("loaded")) {
+            println("PASS (didn't crash)");
+            done();
+            return;
+        }
+        let round = 0;
+        (function pump() {
+            if (round++ >= 60)
+                return;
+            for (let i = 0; i < 5; i++)
+                history.pushState({ i }, "", "#s" + round + "-" + i);
+            setTimeout(pump);
+        })();
+        const next = new URL(location.href);
+        next.search = "?loaded";
+        next.hash = "";
+        setTimeout(() => internals.loadURL(next.href), 8);
+    });
+</script>
+</body>


### PR DESCRIPTION
**Problem:** Crash in `ApplyHistoryStepState::start()` during same-document `pushState` while session-history bookkeeping for a newly-created child navigable is still in flight, and the page is then loaded again by the UI process. This has been intermittently taking down unrelated tests in CI; test-web reuses the WebContent process — so the next test’s load can arrive while the previous page’s history work is still draining.

**Cause:** A sync same-document navigation may jump the session history traversal queue while another apply-history-step run is paused — and racing runs then corrupt the step numbering. The nested run commits its target step and advances the traversable’s current session history step; when the paused outer run later completes, it unconditionally writes its own, older target step — moving the current step backwards, after which the next Push-type navigation computes a step number that an existing entry already holds. A push’s finalize also computes its step from the current step while another push’s claimed step is still uncommitted — handing the same number out twice. And a run for an arriving load can read the active session history entry after a `pushState` has installed it but before the queued synchronous step assigns its step number — tripping the pending-step assert — while clearing the forward session history could remove the in-flight push’s entry out from under its run.

See https://github.com/whatwg/html/issues/12576; the root cause is a bug in the spec — which other engines have already implemented around.

**Fix:** Number apply-history-step runs, and let runs commit a target step only if no newer run has committed it — so a stale run can no longer move the current step backwards. Track claimed-but-uncommitted steps on the traversable, compute new step numbers past them, and keep clearing the forward session history from removing their entries. And skip the pushed-step assert while the displayed entry’s step is still pending.

The first commit here adds `internals.loadURL()`, which starts a load the way a request from the UI process arrives — deferred, outside the calling task — so the regression tests can reproduce these crashes deterministically.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/10028
