### PR TITLE
AK: Make Badge accept multiple types, including subclasses

### DIFF
--- a/AK/Badge.h
+++ b/AK/Badge.h
@@ -8,8 +8,17 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/Platform.h>
+#include <AK/StdLibExtraDetails.h>
 
 namespace AK {
+
+namespace Detail {
+
+template<typename AuthorizedType, typename BadgeType>
+inline constexpr bool IsBadgeType = IsSame<AuthorizedType, BadgeType>
+    || IsBaseOf<AuthorizedType, BadgeType>;
+
+}
 
 template<typename...>
 class Badge;
@@ -21,6 +30,14 @@ class Badge<T> {
 
 public:
     using Type = T;
+
+    // Friendship is not inherited, so derived classes mint Badge<Derived> and
+    // convert it to Badge<Base>.
+    template<typename U>
+    requires(IsBaseOf<T, U> && !IsSame<T, U>)
+    constexpr Badge(Badge<U> const&)
+    {
+    }
 
 private:
     friend T;
@@ -34,6 +51,13 @@ class Badge<T, U> {
     AK_MAKE_NONCOPYABLE(Badge);
     AK_MAKE_NONMOVABLE(Badge);
 
+public:
+    template<typename V>
+    requires(Detail::IsBadgeType<T, V> || Detail::IsBadgeType<U, V>)
+    constexpr Badge(Badge<V> const&)
+    {
+    }
+
 private:
     friend T;
     friend U;
@@ -44,6 +68,14 @@ template<typename T, typename U, typename V>
 class Badge<T, U, V> {
     AK_MAKE_NONCOPYABLE(Badge);
     AK_MAKE_NONMOVABLE(Badge);
+
+public:
+    template<typename W>
+    requires(Detail::IsBadgeType<T, W> || Detail::IsBadgeType<U, W>
+        || Detail::IsBadgeType<V, W>)
+    constexpr Badge(Badge<W> const&)
+    {
+    }
 
 private:
     friend T;
@@ -57,6 +89,14 @@ class Badge<T, U, V, W> {
     AK_MAKE_NONCOPYABLE(Badge);
     AK_MAKE_NONMOVABLE(Badge);
 
+public:
+    template<typename X>
+    requires(Detail::IsBadgeType<T, X> || Detail::IsBadgeType<U, X>
+        || Detail::IsBadgeType<V, X> || Detail::IsBadgeType<W, X>)
+    constexpr Badge(Badge<X> const&)
+    {
+    }
+
 private:
     friend T;
     friend U;
@@ -69,6 +109,15 @@ template<typename T, typename U, typename V, typename W, typename X>
 class Badge<T, U, V, W, X> {
     AK_MAKE_NONCOPYABLE(Badge);
     AK_MAKE_NONMOVABLE(Badge);
+
+public:
+    template<typename Y>
+    requires(Detail::IsBadgeType<T, Y> || Detail::IsBadgeType<U, Y>
+        || Detail::IsBadgeType<V, Y> || Detail::IsBadgeType<W, Y>
+        || Detail::IsBadgeType<X, Y>)
+    constexpr Badge(Badge<Y> const&)
+    {
+    }
 
 private:
     friend T;

--- a/AK/Badge.h
+++ b/AK/Badge.h
@@ -11,8 +11,11 @@
 
 namespace AK {
 
+template<typename...>
+class Badge;
+
 template<typename T>
-class Badge {
+class Badge<T> {
     AK_MAKE_NONCOPYABLE(Badge);
     AK_MAKE_NONMOVABLE(Badge);
 
@@ -21,6 +24,58 @@ public:
 
 private:
     friend T;
+    constexpr Badge() = default;
+};
+
+// FIXME: These overloads are all because compiler support for `friend Ts...;` is limited.
+//        Once compilers can do that, we should only need a single variadic template.
+template<typename T, typename U>
+class Badge<T, U> {
+    AK_MAKE_NONCOPYABLE(Badge);
+    AK_MAKE_NONMOVABLE(Badge);
+
+private:
+    friend T;
+    friend U;
+    constexpr Badge() = default;
+};
+
+template<typename T, typename U, typename V>
+class Badge<T, U, V> {
+    AK_MAKE_NONCOPYABLE(Badge);
+    AK_MAKE_NONMOVABLE(Badge);
+
+private:
+    friend T;
+    friend U;
+    friend V;
+    constexpr Badge() = default;
+};
+
+template<typename T, typename U, typename V, typename W>
+class Badge<T, U, V, W> {
+    AK_MAKE_NONCOPYABLE(Badge);
+    AK_MAKE_NONMOVABLE(Badge);
+
+private:
+    friend T;
+    friend U;
+    friend V;
+    friend W;
+    constexpr Badge() = default;
+};
+
+template<typename T, typename U, typename V, typename W, typename X>
+class Badge<T, U, V, W, X> {
+    AK_MAKE_NONCOPYABLE(Badge);
+    AK_MAKE_NONMOVABLE(Badge);
+
+private:
+    friend T;
+    friend U;
+    friend V;
+    friend W;
+    friend X;
     constexpr Badge() = default;
 };
 

--- a/AK/BufferedStream.h
+++ b/AK/BufferedStream.h
@@ -14,8 +14,6 @@
 namespace AK {
 
 template<typename T>
-concept StreamLike = IsBaseOf<Stream, T>;
-template<typename T>
 concept SeekableStreamLike = IsBaseOf<SeekableStream, T>;
 
 template<typename T>
@@ -24,8 +22,7 @@ class BufferedHelper {
     AK_MAKE_DEFAULT_MOVABLE(BufferedHelper);
 
 public:
-    template<StreamLike U>
-    BufferedHelper(Badge<U>, NonnullOwnPtr<T> stream, CircularBuffer buffer)
+    BufferedHelper(Badge<Stream>, NonnullOwnPtr<T> stream, CircularBuffer buffer)
         : m_stream(move(stream))
         , m_buffer(move(buffer))
     {

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -112,7 +112,7 @@ class HashMap;
 template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>>
 using OrderedHashMap = HashMap<K, V, KeyTraits, ValueTraits, true>;
 
-template<typename T>
+template<typename... Ts>
 class Badge;
 
 template<typename T>

--- a/AK/StringBase.h
+++ b/AK/StringBase.h
@@ -84,17 +84,13 @@ public:
 
     [[nodiscard]] bool operator==(StringBase const&) const;
 
-    [[nodiscard]] ALWAYS_INLINE constexpr FlatPtr raw(Badge<FlyString>) const { return bit_cast<FlatPtr>(m_impl); }
-    [[nodiscard]] ALWAYS_INLINE constexpr FlatPtr raw(Badge<String>) const { return bit_cast<FlatPtr>(m_impl); }
-
-    template<typename Func>
-    ALWAYS_INLINE ErrorOr<void> replace_with_new_string(Badge<StringView>, size_t byte_count, Func&& callback)
+    [[nodiscard]] ALWAYS_INLINE constexpr FlatPtr raw(Badge<FlyString, String>) const
     {
-        return replace_with_new_string(byte_count, forward<Func>(callback));
+        return bit_cast<FlatPtr>(m_impl);
     }
 
     template<typename Func>
-    ALWAYS_INLINE ErrorOr<void> replace_with_new_string(Badge<Utf16View>, size_t byte_count, Func&& callback)
+    ALWAYS_INLINE ErrorOr<void> replace_with_new_string(Badge<StringView, Utf16View>, size_t byte_count, Func&& callback)
     {
         return replace_with_new_string(byte_count, forward<Func>(callback));
     }

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -113,8 +113,10 @@ public:
         return {};
     }
 
-    Optional<Buffer::OutlineBuffer> leak_buffer_for_string_construction(Badge<Detail::StringData>) { return leak_buffer_for_string_construction(); }
-    Optional<Buffer::OutlineBuffer> leak_buffer_for_string_construction(Badge<Detail::Utf16StringData>) { return leak_buffer_for_string_construction(); }
+    Optional<Buffer::OutlineBuffer> leak_buffer_for_string_construction(Badge<Detail::StringData, Detail::Utf16StringData>)
+    {
+        return leak_buffer_for_string_construction();
+    }
 
 private:
     void initialize_buffer(Mode, size_t capacity);

--- a/Libraries/LibCore/Socket.h
+++ b/Libraries/LibCore/Socket.h
@@ -120,9 +120,7 @@ class CORE_API PosixSocketHelper {
     AK_MAKE_NONCOPYABLE(PosixSocketHelper);
 
 public:
-    template<typename T>
-    PosixSocketHelper(Badge<T>)
-    requires(IsBaseOf<Socket, T>)
+    PosixSocketHelper(Badge<Socket>)
     {
     }
 

--- a/Libraries/LibWeb/CSS/Parser/Token.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Token.cpp
@@ -418,13 +418,7 @@ StringView Token::bracket_mirror_string() const
     return ""sv;
 }
 
-void Token::set_position_range(Badge<Tokenizer>, SourcePosition start, SourcePosition end)
-{
-    m_start_position = start;
-    m_end_position = end;
-}
-
-void Token::set_position_range(Badge<RustTokenizer>, SourcePosition start, SourcePosition end)
+void Token::set_position_range(Badge<Tokenizer, RustTokenizer>, SourcePosition start, SourcePosition end)
 {
     m_start_position = start;
     m_end_position = end;

--- a/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Libraries/LibWeb/CSS/Parser/Token.h
@@ -182,8 +182,7 @@ public:
     String const& original_source_text() const { return m_original_source_text; }
     SourcePosition const& start_position() const { return m_start_position; }
     SourcePosition const& end_position() const { return m_end_position; }
-    void set_position_range(Badge<Tokenizer>, SourcePosition start, SourcePosition end);
-    void set_position_range(Badge<RustTokenizer>, SourcePosition start, SourcePosition end);
+    void set_position_range(Badge<Tokenizer, RustTokenizer>, SourcePosition start, SourcePosition end);
 
     bool operator==(Token const& other) const
     {

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -989,8 +989,7 @@ public:
     GC::Ptr<HTML::Navigable> navigable() const;
     void set_navigable(GC::Ptr<HTML::Navigable>);
 
-    template<OneOf<Node, Painting::Paintable, HTML::Navigable, CSS::VisualViewport, Web::EventHandler> T>
-    void set_needs_repaint(Badge<T>, InvalidateDisplayList should_invalidate_display_list = InvalidateDisplayList::Yes)
+    void set_needs_repaint(Badge<Node, Painting::Paintable, HTML::Navigable, CSS::VisualViewport, Web::EventHandler>, InvalidateDisplayList should_invalidate_display_list = InvalidateDisplayList::Yes)
     {
         set_needs_repaint(should_invalidate_display_list);
     }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -388,8 +388,7 @@ public:
     Layout::NodeWithStyle* pseudo_element_unsafe_layout_node(CSS::PseudoElement) const;
 
     bool has_synthetic_pseudo_elements() const;
-    template<OneOf<Layout::TreeBuilder, Document, Node> T>
-    void clear_synthetic_pseudo_element_layout_nodes(Badge<T>) { clear_synthetic_pseudo_element_layout_nodes(); }
+    void clear_synthetic_pseudo_element_layout_nodes(Badge<Layout::TreeBuilder, Node>) { clear_synthetic_pseudo_element_layout_nodes(); }
 
     void serialize_children_as_json(JsonObjectSerializer<StringBuilder>&) const;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1527,12 +1527,7 @@ WebIDL::ExceptionOr<GC::Ref<Node>> Node::clone_node_binding(bool subtree)
     return clone_node(nullptr, subtree);
 }
 
-void Node::set_document(Badge<Document>, Document& document)
-{
-    set_document(document);
-}
-
-void Node::set_document(Badge<NamedNodeMap>, Document& document)
+void Node::set_document(Badge<Document, NamedNodeMap>, Document& document)
 {
     set_document(document);
 }

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -378,8 +378,7 @@ public:
     CSS::StyleScope const& style_scope() const { return const_cast<Node*>(this)->style_scope(); }
     void for_each_style_scope_which_may_observe_the_node(Function<void(CSS::StyleScope&)> const&);
 
-    void set_document(Badge<Document>, Document&);
-    void set_document(Badge<NamedNodeMap>, Document&);
+    void set_document(Badge<Document, NamedNodeMap>, Document&);
 
     virtual EventTarget* get_parent(Event const&) override;
 

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -29,17 +29,13 @@ public:
     bool is_ready_to_be_parser_executed() const { return m_ready_to_be_parser_executed; }
     bool failed_to_load() const { return m_failed_to_load; }
 
-    template<OneOf<XMLDocumentBuilder, HTMLParser> T>
-    void set_parser_document(Badge<T>, DOM::Document& document) { m_parser_document = &document; }
+    void set_parser_document(Badge<XMLDocumentBuilder, HTMLParser>, DOM::Document& document) { m_parser_document = &document; }
 
-    template<OneOf<XMLDocumentBuilder, HTMLParser> T>
-    void set_force_async(Badge<T>, bool b) { m_force_async = b; }
+    void set_force_async(Badge<XMLDocumentBuilder, HTMLParser>, bool b) { m_force_async = b; }
 
-    template<OneOf<XMLDocumentBuilder, HTMLParser> T>
-    void set_already_started(Badge<T>, bool b) { m_already_started = b; }
+    void set_already_started(Badge<XMLDocumentBuilder, HTMLParser>, bool b) { m_already_started = b; }
 
-    template<OneOf<XMLDocumentBuilder, HTMLParser> T>
-    void prepare_script(Badge<T>) { prepare_script(); }
+    void prepare_script(Badge<XMLDocumentBuilder, HTMLParser>) { prepare_script(); }
 
     void execute_script();
 

--- a/Tests/AK/TestBadge.cpp
+++ b/Tests/AK/TestBadge.cpp
@@ -36,6 +36,16 @@ struct MultipleBadgeUserE {
 struct UnrelatedBadgeUser {
 };
 
+struct BaseBadgeUser {
+    static void call_base_badge();
+    static void call_multi_base_badge();
+};
+
+struct DerivedBadgeUser : BaseBadgeUser {
+    static void call_base_badge();
+    static void call_multi_base_badge();
+};
+
 static void accepts_two_argument_badge(Badge<MultipleBadgeUserA, MultipleBadgeUserB>)
 {
 }
@@ -49,6 +59,14 @@ static void accepts_four_argument_badge(Badge<MultipleBadgeUserA, MultipleBadgeU
 }
 
 static void accepts_five_argument_badge(Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD, MultipleBadgeUserE>)
+{
+}
+
+static void accepts_base_badge(Badge<BaseBadgeUser>)
+{
+}
+
+static void accepts_multi_base_badge(Badge<BaseBadgeUser, MultipleBadgeUserB>)
 {
 }
 
@@ -92,6 +110,26 @@ void MultipleBadgeUserE::call_five_argument_badge()
     accepts_five_argument_badge({});
 }
 
+void BaseBadgeUser::call_base_badge()
+{
+    accepts_base_badge({});
+}
+
+void BaseBadgeUser::call_multi_base_badge()
+{
+    accepts_multi_base_badge({});
+}
+
+void DerivedBadgeUser::call_base_badge()
+{
+    accepts_base_badge(Badge<DerivedBadgeUser> {});
+}
+
+void DerivedBadgeUser::call_multi_base_badge()
+{
+    accepts_multi_base_badge(Badge<DerivedBadgeUser> {});
+}
+
 }
 
 TEST_CASE(should_provide_underlying_type)
@@ -104,10 +142,12 @@ TEST_CASE(should_allow_multiple_underlying_types)
     static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB>>);
     static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC>>);
     static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD>>);
-    static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB>, Badge<MultipleBadgeUserA>>);
     static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD, MultipleBadgeUserE>>);
-    static_assert(!IsConstructible<
+    static_assert(IsConstructible<
         Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD, MultipleBadgeUserE>,
+        Badge<MultipleBadgeUserA> const&>);
+    static_assert(IsConstructible<
+        Badge<MultipleBadgeUserA, MultipleBadgeUserB>,
         Badge<MultipleBadgeUserA> const&>);
     static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB>, Badge<UnrelatedBadgeUser>>);
 
@@ -119,4 +159,34 @@ TEST_CASE(should_allow_multiple_underlying_types)
     MultipleBadgeUserC::call_three_argument_badge();
     MultipleBadgeUserD::call_four_argument_badge();
     MultipleBadgeUserE::call_five_argument_badge();
+}
+
+TEST_CASE(should_allow_derived_types_to_create_base_badges)
+{
+    static_assert(IsConstructible<
+        Badge<BaseBadgeUser>,
+        Badge<DerivedBadgeUser> const&>);
+    static_assert(IsConstructible<
+        Badge<BaseBadgeUser, MultipleBadgeUserB>,
+        Badge<BaseBadgeUser> const&>);
+    static_assert(IsConstructible<
+        Badge<BaseBadgeUser, MultipleBadgeUserB>,
+        Badge<DerivedBadgeUser> const&>);
+    static_assert(IsConstructible<
+        Badge<BaseBadgeUser, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD, MultipleBadgeUserE>,
+        Badge<DerivedBadgeUser> const&>);
+    static_assert(!IsConstructible<
+        Badge<DerivedBadgeUser>,
+        Badge<BaseBadgeUser> const&>);
+    static_assert(!IsConstructible<
+        Badge<BaseBadgeUser>,
+        Badge<BaseBadgeUser, MultipleBadgeUserB> const&>);
+    static_assert(!IsConstructible<
+        Badge<BaseBadgeUser>,
+        Badge<UnrelatedBadgeUser> const&>);
+
+    BaseBadgeUser::call_base_badge();
+    BaseBadgeUser::call_multi_base_badge();
+    DerivedBadgeUser::call_base_badge();
+    DerivedBadgeUser::call_multi_base_badge();
 }

--- a/Tests/AK/TestBadge.cpp
+++ b/Tests/AK/TestBadge.cpp
@@ -8,7 +8,115 @@
 
 #include <AK/Badge.h>
 
+namespace {
+
+struct MultipleBadgeUserA {
+    static void call_two_argument_badge();
+    static void call_three_argument_badge();
+    static void call_four_argument_badge();
+    static void call_five_argument_badge();
+};
+
+struct MultipleBadgeUserB {
+    static void call_two_argument_badge();
+};
+
+struct MultipleBadgeUserC {
+    static void call_three_argument_badge();
+};
+
+struct MultipleBadgeUserD {
+    static void call_four_argument_badge();
+};
+
+struct MultipleBadgeUserE {
+    static void call_five_argument_badge();
+};
+
+struct UnrelatedBadgeUser {
+};
+
+static void accepts_two_argument_badge(Badge<MultipleBadgeUserA, MultipleBadgeUserB>)
+{
+}
+
+static void accepts_three_argument_badge(Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC>)
+{
+}
+
+static void accepts_four_argument_badge(Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD>)
+{
+}
+
+static void accepts_five_argument_badge(Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD, MultipleBadgeUserE>)
+{
+}
+
+void MultipleBadgeUserA::call_two_argument_badge()
+{
+    accepts_two_argument_badge({});
+}
+
+void MultipleBadgeUserA::call_three_argument_badge()
+{
+    accepts_three_argument_badge({});
+}
+
+void MultipleBadgeUserA::call_four_argument_badge()
+{
+    accepts_four_argument_badge({});
+}
+
+void MultipleBadgeUserA::call_five_argument_badge()
+{
+    accepts_five_argument_badge({});
+}
+
+void MultipleBadgeUserB::call_two_argument_badge()
+{
+    accepts_two_argument_badge({});
+}
+
+void MultipleBadgeUserC::call_three_argument_badge()
+{
+    accepts_three_argument_badge({});
+}
+
+void MultipleBadgeUserD::call_four_argument_badge()
+{
+    accepts_four_argument_badge({});
+}
+
+void MultipleBadgeUserE::call_five_argument_badge()
+{
+    accepts_five_argument_badge({});
+}
+
+}
+
 TEST_CASE(should_provide_underlying_type)
 {
     static_assert(IsSame<int, Badge<int>::Type>);
+}
+
+TEST_CASE(should_allow_multiple_underlying_types)
+{
+    static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB>>);
+    static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC>>);
+    static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD>>);
+    static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB>, Badge<MultipleBadgeUserA>>);
+    static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD, MultipleBadgeUserE>>);
+    static_assert(!IsConstructible<
+        Badge<MultipleBadgeUserA, MultipleBadgeUserB, MultipleBadgeUserC, MultipleBadgeUserD, MultipleBadgeUserE>,
+        Badge<MultipleBadgeUserA> const&>);
+    static_assert(!IsConstructible<Badge<MultipleBadgeUserA, MultipleBadgeUserB>, Badge<UnrelatedBadgeUser>>);
+
+    MultipleBadgeUserA::call_two_argument_badge();
+    MultipleBadgeUserA::call_three_argument_badge();
+    MultipleBadgeUserA::call_four_argument_badge();
+    MultipleBadgeUserA::call_five_argument_badge();
+    MultipleBadgeUserB::call_two_argument_badge();
+    MultipleBadgeUserC::call_three_argument_badge();
+    MultipleBadgeUserD::call_four_argument_badge();
+    MultipleBadgeUserE::call_five_argument_badge();
 }


### PR DESCRIPTION
There are several places where we really wanted to let multiple classes create a Badge, but we couldn't, and so had to jump through hoops to make it work. This PR makes that work, which simplifies those users.

It's a bit verbose currently because [P2893R3 (variadic `friend`)](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2893r3.html) is a C++26 feature and isn't available yet. But once it is, we should be able to drop all the boilerplate for declaring 2,3,4,5-type Badges and just have a single variadic template.