### PR TITLE
Tests: Make JSON.stringify deep serialization test more consistent

### DIFF
--- a/Tests/LibJS/Runtime/builtins/JSON/JSON.stringify.js
+++ b/Tests/LibJS/Runtime/builtins/JSON/JSON.stringify.js
@@ -152,7 +152,7 @@ describe("errors", () => {
     test("should not crash when serializing deeply nested structures", () => {
         const deepArray = [];
         let current = deepArray;
-        for (let i = 0; i < 100_000; i++) {
+        for (let i = 0; i < 1_000_000; i++) {
             current[0] = [];
             current = current[0];
         }
@@ -163,7 +163,7 @@ describe("errors", () => {
 
         const deepObject = {};
         current = deepObject;
-        for (let i = 0; i < 100_000; i++) {
+        for (let i = 0; i < 1_000_000; i++) {
             current.x = {};
             current = current.x;
         }


### PR DESCRIPTION
This test verifies that we throw an exception instead of overflowing the stack, but some machines have a large enough stack that this wouldn't fill it. Raise the value by 10x, which does now throw an exception for me.