### PR TITLE
LibWeb: Transfer the load delayer when a media element is adopted

### DIFF
--- a/Libraries/LibWeb/DOM/StyleElementBase.h
+++ b/Libraries/LibWeb/DOM/StyleElementBase.h
@@ -43,6 +43,12 @@ public:
 
     void visit_style_element_edges(JS::Cell::Visitor&);
 
+    void retarget_style_load_event_delayer(Document& new_document)
+    {
+        if (m_document_load_event_delayer.has_value())
+            m_document_load_event_delayer.emplace(new_document);
+    }
+
     virtual Element& as_element() = 0;
     virtual Element const& as_element() const = 0;
 

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -202,6 +202,9 @@ void HTMLImageElement::adopted_from(DOM::Document& old_document)
         if (auto callback = m_document_observer->document_became_active())
             callback->function()();
     }
+
+    if (m_load_event_delayer.has_value())
+        m_load_event_delayer.emplace(document());
 }
 
 void HTMLImageElement::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -124,6 +124,14 @@ void HTMLInputElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_resource_request);
 }
 
+void HTMLInputElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    if (m_load_event_delayer.has_value())
+        m_load_event_delayer.emplace(document());
+}
+
 void HTMLInputElement::set_being_activated(bool activated)
 {
     Base::set_being_activated(activated);

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -299,6 +299,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 
     Optional<double> convert_time_string_to_number(StringView input) const;
     Optional<double> convert_string_to_number(StringView input) const;

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -67,6 +67,14 @@ void HTMLLinkElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_sizes);
 }
 
+void HTMLLinkElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    if (m_document_load_event_delayer.has_value())
+        m_document_load_event_delayer.emplace(document());
+}
+
 void HTMLLinkElement::inserted()
 {
     HTMLElement::inserted();

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -140,6 +140,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 
     // ^DOM::Node
     virtual bool is_html_link_element() const override { return true; }

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -258,6 +258,14 @@ void HTMLMediaElement::removed_from(IsSubtreeRoot is_subtree_root, DOM::Node* ol
     pause_element();
 }
 
+void HTMLMediaElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    if (m_delaying_the_load_event.has_value())
+        m_delaying_the_load_event.emplace(document());
+}
+
 void HTMLMediaElement::cancel_the_fetching_process()
 {
     m_current_fetch_generation++;

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -188,6 +188,7 @@ protected:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual void removed_from(IsSubtreeRoot, DOM::Node* old_ancestor, DOM::Node& old_root) override;
+    virtual void adopted_from(DOM::Document&) override;
     virtual void children_changed(ChildrenChangedMetadata const& metadata) override;
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -84,6 +84,16 @@ void HTMLObjectElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_observer);
 }
 
+void HTMLObjectElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    for (auto& delayer : m_document_load_event_delayer_for_object_representation_task)
+        delayer = DOM::DocumentLoadEventDelayer { document() };
+    for (auto& delayer : m_document_load_event_delayer_for_resource_load)
+        delayer = DOM::DocumentLoadEventDelayer { document() };
+}
+
 void HTMLObjectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&)
 {
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -51,6 +51,7 @@ public:
     }
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 
 private:
     HTMLObjectElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -56,6 +56,14 @@ void HTMLScriptElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_preparation_time_document);
 }
 
+void HTMLScriptElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    if (m_document_load_event_delayer.has_value())
+        m_document_load_event_delayer.emplace(document());
+}
+
 void HTMLScriptElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -89,6 +89,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -32,6 +32,13 @@ void HTMLStyleElement::visit_edges(Cell::Visitor& visitor)
     visit_style_element_edges(visitor);
 }
 
+void HTMLStyleElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    retarget_style_load_event_delayer(document());
+}
+
 void HTMLStyleElement::children_changed(ChildrenChangedMetadata const& metadata)
 {
     Base::children_changed(metadata);

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -43,6 +43,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -59,6 +59,14 @@ void HTMLVideoElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
+void HTMLVideoElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    if (m_load_event_delayer.has_value())
+        m_load_event_delayer.emplace(document());
+}
+
 void HTMLVideoElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -68,6 +68,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void finalize() override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -49,6 +49,14 @@ void SVGImageElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_resource_request);
 }
 
+void SVGImageElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    if (m_load_event_delayer.has_value())
+        m_load_event_delayer.emplace(document());
+}
+
 void SVGImageElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -51,6 +51,7 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 
     void process_the_url(Optional<String> const& href);
     void fetch_the_document(URL::URL const& url);

--- a/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -41,6 +41,14 @@ void SVGScriptElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_script);
 }
 
+void SVGScriptElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    if (m_document_load_event_delayer.has_value())
+        m_document_load_event_delayer.emplace(document());
+}
+
 void SVGScriptElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/SVG/SVGScriptElement.h
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.h
@@ -45,6 +45,7 @@ private:
     virtual bool is_svg_script_element() const final { return true; }
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 
     void finish_external_script_fetch(URL::URL const& script_url, ReadonlyBytes body);
     void execute_script();

--- a/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -30,6 +30,13 @@ void SVGStyleElement::visit_edges(Cell::Visitor& visitor)
     visit_style_element_edges(visitor);
 }
 
+void SVGStyleElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    retarget_style_load_event_delayer(document());
+}
+
 void SVGStyleElement::children_changed(ChildrenChangedMetadata const& metadata)
 {
     Base::children_changed(metadata);

--- a/Libraries/LibWeb/SVG/SVGStyleElement.h
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.h
@@ -38,6 +38,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -66,6 +66,14 @@ void SVGUseElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_resource_request);
 }
 
+void SVGUseElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+
+    if (m_load_event_delayer.has_value())
+        m_load_event_delayer.emplace(document());
+}
+
 void SVGUseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -45,6 +45,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void adopted_from(DOM::Document&) override;
 
     virtual bool is_svg_use_element() const override { return true; }
 


### PR DESCRIPTION
Otherwise, the load event will block the original document until GC runs. This makes the run time of media-load-task-after-adoption.html not depend on the GC idle timeout.