### PR TITLE
LibMedia+LibWeb: Consolidate sink state tracking for buffering/seeking/ending

### DIFF
--- a/Libraries/LibMedia/CMakeLists.txt
+++ b/Libraries/LibMedia/CMakeLists.txt
@@ -21,6 +21,8 @@ set(SOURCES
     GenericTimeProvider.cpp
     IncrementallyPopulatedStream.cpp
     PlaybackManager.cpp
+    PlaybackStates/BufferingStateHandler.cpp
+    PlaybackStates/PlayingStateHandler.cpp
     PlaybackStates/StartingStateHandler.cpp
     PlaybackStates/PausedStateHandler.cpp
     PlaybackStates/PlaybackStateHandler.cpp

--- a/Libraries/LibMedia/PipelineStatus.h
+++ b/Libraries/LibMedia/PipelineStatus.h
@@ -63,12 +63,12 @@ constexpr PipelineStatus select_combined_pipeline_status(PipelineStatus a, Pipel
         return PipelineStatus::Error;
     if (a == PipelineStatus::Blocked || b == PipelineStatus::Blocked)
         return PipelineStatus::Blocked;
+    if (a == PipelineStatus::Pending || b == PipelineStatus::Pending)
+        return PipelineStatus::Pending;
     if (a == PipelineStatus::HaveData || b == PipelineStatus::HaveData)
         return PipelineStatus::HaveData;
     if (a == PipelineStatus::MovedPosition || b == PipelineStatus::MovedPosition)
         return PipelineStatus::MovedPosition;
-    if (a == PipelineStatus::Pending || b == PipelineStatus::Pending)
-        return PipelineStatus::Pending;
     return PipelineStatus::EndOfStream;
 }
 

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -401,8 +401,6 @@ void PlaybackManager::pause()
 
 void PlaybackManager::seek(AK::Duration timestamp, SeekMode mode)
 {
-    if (!m_is_in_error_state && current_time() == timestamp)
-        return;
     m_handler->seek(timestamp, mode);
     m_is_in_error_state = false;
 }

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -251,33 +251,46 @@ AK::Duration PlaybackManager::current_time() const
 
 void PlaybackManager::on_audio_sink_state_changed(PipelineStatus status)
 {
-    m_audio_buffering = status == PipelineStatus::Blocked;
-    update_buffering_state();
-    m_handler->on_audio_sink_state_changed(status);
+    m_audio_sink_status = status;
+    update_pipeline_state();
 }
 
 void PlaybackManager::on_video_sink_state_changed(Track const& track, PipelineStatus status)
 {
-    if (status == PipelineStatus::Blocked) {
-        if (m_video_tracks_buffering.set(track) == HashSetResult::InsertedNewEntry)
-            update_buffering_state();
-    } else {
-        if (m_video_tracks_buffering.remove(track))
-            update_buffering_state();
-    }
-    m_handler->on_video_sink_state_changed(track, status);
+    auto& track_data = get_video_data_for_track(track);
+    track_data.sink_status = status;
+    update_pipeline_state();
 }
 
-void PlaybackManager::update_buffering_state()
+PipelineStatus PlaybackManager::combined_pipeline_status() const
 {
-    auto is_buffering = m_audio_buffering || !m_video_tracks_buffering.is_empty();
-    if (is_buffering == m_was_buffering)
-        return;
-    m_was_buffering = is_buffering;
-    if (is_buffering)
-        m_handler->enter_buffering();
-    else
-        m_handler->exit_buffering();
+    auto status = PipelineStatus::EndOfStream;
+
+    if (m_audio_sink != nullptr)
+        status = select_combined_pipeline_status(status, m_audio_sink_status);
+
+    for (auto const& track_data : m_video_track_datas) {
+        if (track_data.display == nullptr)
+            continue;
+        status = select_combined_pipeline_status(status, track_data.sink_status);
+    }
+
+    return status;
+}
+
+void PlaybackManager::update_pipeline_state()
+{
+    m_handler->on_pipeline_status_changed(combined_pipeline_status());
+}
+
+void PlaybackManager::reset_pipeline_state()
+{
+    for (auto& track_data : m_video_track_datas) {
+        if (track_data.display == nullptr)
+            continue;
+        track_data.sink_status = PipelineStatus::Pending;
+    }
+    m_audio_sink_status = m_audio_sink != nullptr ? PipelineStatus::Pending : PipelineStatus::HaveData;
 }
 
 void PlaybackManager::check_for_duration_change(AK::Duration duration)
@@ -317,7 +330,6 @@ void PlaybackManager::set_time_provider(NonnullRefPtr<MediaTimeProvider> const& 
 
 void PlaybackManager::disable_audio()
 {
-    m_audio_buffering = false;
     m_audio_mixer = nullptr;
     m_audio_time_stretch_processor = nullptr;
     m_audio_sink = nullptr;
@@ -329,6 +341,7 @@ NonnullRefPtr<DisplayingVideoSink> PlaybackManager::get_or_create_the_displaying
 {
     auto& track_data = get_video_data_for_track(track);
     if (track_data.display == nullptr) {
+        track_data.sink_status = PipelineStatus::HaveData;
         auto display = MUST(Media::DisplayingVideoSink::try_create(m_time_provider,
             [self = weak(), track](PipelineStatus status) {
                 if (!self)
@@ -337,6 +350,7 @@ NonnullRefPtr<DisplayingVideoSink> PlaybackManager::get_or_create_the_displaying
             }));
         MUST(display->connect_input(track_data.producer));
         track_data.display = move(display);
+        update_pipeline_state();
     }
     return *track_data.display;
 }
@@ -347,29 +361,34 @@ void PlaybackManager::remove_the_displaying_video_sink_for_track(Track const& tr
     VERIFY(track_data.display);
     track_data.display->disconnect_input(track_data.producer);
     track_data.display = nullptr;
-    on_video_sink_state_changed(track, PipelineStatus::EndOfStream);
+    track_data.sink_status = PipelineStatus::HaveData;
+    update_pipeline_state();
 }
 
 void PlaybackManager::enable_an_audio_track(Track const& track)
 {
     auto& track_data = get_audio_data_for_track(track);
     VERIFY(!track_data.enabled);
+    m_audio_sink_status = PipelineStatus::HaveData;
     if (m_audio_mixer) {
         m_audio_mixer->seek(current_time());
         MUST(m_audio_mixer->connect_input(track_data.producer));
     }
     track_data.enabled = true;
+    update_pipeline_state();
 }
 
 void PlaybackManager::disable_an_audio_track(Track const& track)
 {
     auto& track_data = get_audio_data_for_track(track);
     VERIFY(track_data.enabled);
+    m_audio_sink_status = PipelineStatus::HaveData;
     if (m_audio_mixer) {
         m_audio_mixer->seek(current_time());
         m_audio_mixer->disconnect_input(track_data.producer);
     }
     track_data.enabled = false;
+    update_pipeline_state();
 }
 
 bool PlaybackManager::track_is_enabled(Track const& track) const
@@ -401,8 +420,10 @@ void PlaybackManager::pause()
 
 void PlaybackManager::seek(AK::Duration timestamp, SeekMode mode)
 {
+    reset_pipeline_state();
     m_handler->seek(timestamp, mode);
     m_is_in_error_state = false;
+    update_pipeline_state();
 }
 
 bool PlaybackManager::is_playing()

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -243,6 +243,12 @@ void PlaybackManager::set_up_producers()
     }
 }
 
+AK::Duration PlaybackManager::current_time() const
+{
+    auto time = m_handler->current_time();
+    return min(time, duration());
+}
+
 void PlaybackManager::on_audio_sink_state_changed(PipelineStatus status)
 {
     m_audio_buffering = status == PipelineStatus::Blocked;

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -106,6 +106,7 @@ private:
         Track track;
         NonnullRefPtr<DecodedVideoProducer> producer;
         RefPtr<DisplayingVideoSink> display;
+        PipelineStatus sink_status { PipelineStatus::HaveData };
     };
     using VideoTrackDatas = Vector<VideoTrackData, EXPECTED_VIDEO_TRACK_COUNT>;
 
@@ -126,7 +127,9 @@ private:
     void set_up_producers();
     void on_audio_sink_state_changed(PipelineStatus);
     void on_video_sink_state_changed(Track const&, PipelineStatus);
-    void update_buffering_state();
+    void update_pipeline_state();
+    void reset_pipeline_state();
+    PipelineStatus combined_pipeline_status() const;
     void check_for_duration_change(AK::Duration);
     void dispatch_error(DecoderError&&);
 
@@ -182,9 +185,7 @@ private:
     AK::Duration m_duration;
     Optional<AK::UnixDateTime> m_start_time_realtime;
 
-    bool m_audio_buffering { false };
-    HashTable<Track> m_video_tracks_buffering;
-    bool m_was_buffering { false };
+    PipelineStatus m_audio_sink_status { PipelineStatus::HaveData };
 
     bool m_is_in_error_state { false };
 };

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -55,7 +55,7 @@ public:
 
     AK::Duration duration() const { return m_duration; }
     void set_duration(AK::Duration duration) { m_duration = duration; }
-    AK::Duration current_time() const { return min(m_time_provider->current_time(), duration()); }
+    AK::Duration current_time() const;
 
     Optional<AK::UnixDateTime> start_time_realtime() const { return m_start_time_realtime; }
 

--- a/Libraries/LibMedia/PlaybackStates/BufferingStateHandler.cpp
+++ b/Libraries/LibMedia/PlaybackStates/BufferingStateHandler.cpp
@@ -7,11 +7,17 @@
 #include "BufferingStateHandler.h"
 
 #include <LibMedia/PlaybackManager.h>
+#include <LibMedia/PlaybackStates/EndedStateHandler.h>
 
 namespace Media {
 
 void BufferingStateHandler::on_pipeline_status_changed(PipelineStatus status)
 {
+    if (status == PipelineStatus::EndOfStream) {
+        manager().replace_state_handler<EndedStateHandler>();
+        return;
+    }
+
     if (status != PipelineStatus::Blocked)
         resume();
 }

--- a/Libraries/LibMedia/PlaybackStates/BufferingStateHandler.cpp
+++ b/Libraries/LibMedia/PlaybackStates/BufferingStateHandler.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025-2026, Gregory Bertilson <gregory@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "BufferingStateHandler.h"
+
+#include <LibMedia/PlaybackManager.h>
+
+namespace Media {
+
+void BufferingStateHandler::on_pipeline_status_changed(PipelineStatus status)
+{
+    if (status != PipelineStatus::Blocked)
+        resume();
+}
+
+}

--- a/Libraries/LibMedia/PlaybackStates/BufferingStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/BufferingStateHandler.h
@@ -30,14 +30,7 @@ public:
         return AvailableData::Current;
     }
 
-    virtual void enter_buffering() override
-    {
-    }
-
-    virtual void exit_buffering() override
-    {
-        resume();
-    }
+    virtual void on_pipeline_status_changed(PipelineStatus) override;
 };
 
 }

--- a/Libraries/LibMedia/PlaybackStates/EndedStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/EndedStateHandler.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibMedia/PlaybackManager.h>
+
+namespace Media {
+
+class EndedStateHandler final : public PlaybackStateHandler {
+public:
+    EndedStateHandler(PlaybackManager& manager)
+        : PlaybackStateHandler(manager)
+    {
+    }
+    virtual ~EndedStateHandler() override = default;
+
+    virtual void on_enter() override
+    {
+        manager().m_time_provider->pause();
+    }
+    virtual void on_exit() override { }
+
+    virtual AK::Duration current_time() const override
+    {
+        return manager().duration();
+    }
+
+    virtual void play() override { }
+    virtual void pause() override { }
+
+    virtual bool is_playing() override
+    {
+        return false;
+    }
+    virtual PlaybackState state() override
+    {
+        return PlaybackState::Ended;
+    }
+    virtual AvailableData available_data() override
+    {
+        return AvailableData::Current;
+    }
+
+    virtual void on_pipeline_status_changed(PipelineStatus) override { }
+};
+
+}

--- a/Libraries/LibMedia/PlaybackStates/Forward.h
+++ b/Libraries/LibMedia/PlaybackStates/Forward.h
@@ -15,7 +15,8 @@
     X(PlayingStateHandler)                   \
     X(PausedStateHandler)                    \
     X(ResumingStateHandler)                  \
-    X(SeekingStateHandler)
+    X(SeekingStateHandler)                   \
+    X(EndedStateHandler)
 
 namespace Media {
 

--- a/Libraries/LibMedia/PlaybackStates/PausedStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/PausedStateHandler.h
@@ -37,9 +37,6 @@ public:
     {
         return AvailableData::Future;
     }
-
-    virtual void enter_buffering() override { }
-    virtual void exit_buffering() override { }
 };
 
 }

--- a/Libraries/LibMedia/PlaybackStates/PlaybackState.h
+++ b/Libraries/LibMedia/PlaybackStates/PlaybackState.h
@@ -17,6 +17,7 @@ enum class PlaybackState : u8 {
     Playing,
     Paused,
     Seeking,
+    Ended,
 };
 
 constexpr StringView playback_state_to_string(PlaybackState state)
@@ -32,6 +33,8 @@ constexpr StringView playback_state_to_string(PlaybackState state)
         return "Paused"sv;
     case PlaybackState::Seeking:
         return "Seeking"sv;
+    case PlaybackState::Ended:
+        return "Ended"sv;
     }
     return "Invalid"sv;
 }

--- a/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.cpp
+++ b/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibMedia/PlaybackManager.h>
+#include <LibMedia/PlaybackStates/EndedStateHandler.h>
 #include <LibMedia/PlaybackStates/SeekingStateHandler.h>
 
 #include "PlaybackStateHandler.h"
@@ -23,7 +24,8 @@ void PlaybackStateHandler::seek(AK::Duration timestamp, SeekMode mode)
 
 void PlaybackStateHandler::on_pipeline_status_changed(PipelineStatus status)
 {
-    (void)status;
+    if (status == PipelineStatus::EndOfStream)
+        manager().replace_state_handler<EndedStateHandler>();
 }
 
 }

--- a/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.cpp
+++ b/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.cpp
@@ -21,4 +21,9 @@ void PlaybackStateHandler::seek(AK::Duration timestamp, SeekMode mode)
     manager().replace_state_handler<SeekingStateHandler>(manager().is_playing(), timestamp, mode);
 }
 
+void PlaybackStateHandler::on_pipeline_status_changed(PipelineStatus status)
+{
+    (void)status;
+}
+
 }

--- a/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.cpp
+++ b/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.cpp
@@ -11,6 +11,11 @@
 
 namespace Media {
 
+AK::Duration PlaybackStateHandler::current_time() const
+{
+    return manager().m_time_provider->current_time();
+}
+
 void PlaybackStateHandler::seek(AK::Duration timestamp, SeekMode mode)
 {
     manager().replace_state_handler<SeekingStateHandler>(manager().is_playing(), timestamp, mode);

--- a/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.h
@@ -37,11 +37,7 @@ public:
     virtual PlaybackState state() = 0;
     virtual AvailableData available_data() = 0;
 
-    virtual void enter_buffering() = 0;
-    virtual void exit_buffering() = 0;
-
-    virtual void on_audio_sink_state_changed(PipelineStatus) { }
-    virtual void on_video_sink_state_changed(Track const&, PipelineStatus) { }
+    virtual void on_pipeline_status_changed(PipelineStatus);
 
 protected:
     PlaybackManager& manager() const { return m_manager; }

--- a/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/PlaybackStateHandler.h
@@ -26,6 +26,8 @@ public:
     virtual void on_enter() = 0;
     virtual void on_exit() = 0;
 
+    virtual AK::Duration current_time() const;
+
     virtual void start() { }
     virtual void play() = 0;
     virtual void pause() = 0;

--- a/Libraries/LibMedia/PlaybackStates/PlayingStateHandler.cpp
+++ b/Libraries/LibMedia/PlaybackStates/PlayingStateHandler.cpp
@@ -8,6 +8,7 @@
 
 #include <LibMedia/PlaybackManager.h>
 #include <LibMedia/PlaybackStates/BufferingStateHandler.h>
+#include <LibMedia/PlaybackStates/EndedStateHandler.h>
 #include <LibMedia/PlaybackStates/PausedStateHandler.h>
 
 namespace Media {
@@ -19,8 +20,13 @@ void PlayingStateHandler::pause()
 
 void PlayingStateHandler::on_pipeline_status_changed(PipelineStatus status)
 {
-    if (status == PipelineStatus::Blocked)
+    if (status == PipelineStatus::Blocked) {
         manager().replace_state_handler<BufferingStateHandler>(true);
+        return;
+    }
+
+    if (status == PipelineStatus::EndOfStream)
+        manager().replace_state_handler<EndedStateHandler>();
 }
 
 }

--- a/Libraries/LibMedia/PlaybackStates/PlayingStateHandler.cpp
+++ b/Libraries/LibMedia/PlaybackStates/PlayingStateHandler.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025-2026, Gregory Bertilson <gregory@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PlayingStateHandler.h"
+
+#include <LibMedia/PlaybackManager.h>
+#include <LibMedia/PlaybackStates/BufferingStateHandler.h>
+#include <LibMedia/PlaybackStates/PausedStateHandler.h>
+
+namespace Media {
+
+void PlayingStateHandler::pause()
+{
+    manager().replace_state_handler<PausedStateHandler>();
+}
+
+void PlayingStateHandler::on_pipeline_status_changed(PipelineStatus status)
+{
+    if (status == PipelineStatus::Blocked)
+        manager().replace_state_handler<BufferingStateHandler>(true);
+}
+
+}

--- a/Libraries/LibMedia/PlaybackStates/PlayingStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/PlayingStateHandler.h
@@ -7,9 +7,7 @@
 #pragma once
 
 #include <LibMedia/PlaybackManager.h>
-#include <LibMedia/PlaybackStates/BufferingStateHandler.h>
 #include <LibMedia/PlaybackStates/Forward.h>
-#include <LibMedia/PlaybackStates/PausedStateHandler.h>
 
 namespace Media {
 
@@ -31,10 +29,7 @@ public:
     }
 
     virtual void play() override { }
-    virtual void pause() override
-    {
-        manager().replace_state_handler<PausedStateHandler>();
-    }
+    virtual void pause() override;
 
     virtual bool is_playing() override
     {
@@ -49,11 +44,7 @@ public:
         return AvailableData::Future;
     }
 
-    virtual void enter_buffering() override
-    {
-        manager().replace_state_handler<BufferingStateHandler>(true);
-    }
-    virtual void exit_buffering() override { }
+    virtual void on_pipeline_status_changed(PipelineStatus) override;
 };
 
 }

--- a/Libraries/LibMedia/PlaybackStates/SeekingStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/SeekingStateHandler.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/HashTable.h>
 #include <AK/Time.h>
 #include <LibMedia/PipelineStatus.h>
 #include <LibMedia/PlaybackManager.h>
@@ -36,11 +35,7 @@ public:
         begin_seek();
     }
 
-    virtual void on_exit() override
-    {
-        VERIFY(m_video_seeks_pending.is_empty());
-        VERIFY(!m_audio_seek_pending);
-    }
+    virtual void on_exit() override { }
 
     virtual AK::Duration current_time() const override { return m_chosen_timestamp; }
 
@@ -60,23 +55,12 @@ public:
         return AvailableData::Current;
     }
 
-    virtual void enter_buffering() override { }
-    virtual void exit_buffering() override { }
-
-    virtual void on_audio_sink_state_changed(PipelineStatus status) override
+    virtual void on_pipeline_status_changed(PipelineStatus status) override
     {
         if (!resolves_seek(status))
             return;
-        m_audio_seek_pending = false;
-        possibly_complete_seek();
-    }
 
-    virtual void on_video_sink_state_changed(Track const& track, PipelineStatus status) override
-    {
-        if (!resolves_seek(status))
-            return;
-        m_video_seeks_pending.remove(track);
-        possibly_complete_seek();
+        resume();
     }
 
 private:
@@ -98,40 +82,22 @@ private:
     void begin_seek()
     {
         m_chosen_timestamp = choose_timestamp();
-        m_video_seeks_pending.clear();
-        m_audio_seek_pending = false;
 
         for (auto& video_track_data : manager().m_video_track_datas) {
             if (video_track_data.display == nullptr)
                 continue;
-            m_video_seeks_pending.set(video_track_data.track);
             video_track_data.display->seek(m_chosen_timestamp);
         }
 
-        if (manager().m_audio_sink) {
-            m_audio_seek_pending = true;
+        if (manager().m_audio_sink)
             manager().m_audio_sink->seek(m_chosen_timestamp);
-        } else {
+        else
             manager().m_time_provider->seek(m_chosen_timestamp);
-        }
-
-        possibly_complete_seek();
-    }
-
-    void possibly_complete_seek()
-    {
-        if (m_audio_seek_pending)
-            return;
-        if (!m_video_seeks_pending.is_empty())
-            return;
-        resume();
     }
 
     AK::Duration m_target_timestamp;
     SeekMode m_mode { SeekMode::Accurate };
     AK::Duration m_chosen_timestamp { AK::Duration::zero() };
-    HashTable<Track> m_video_seeks_pending;
-    bool m_audio_seek_pending { false };
 };
 
 }

--- a/Libraries/LibMedia/PlaybackStates/SeekingStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/SeekingStateHandler.h
@@ -42,6 +42,8 @@ public:
         VERIFY(!m_audio_seek_pending);
     }
 
+    virtual AK::Duration current_time() const override { return m_chosen_timestamp; }
+
     virtual void seek(AK::Duration timestamp, SeekMode mode) override
     {
         m_target_timestamp = timestamp;

--- a/Libraries/LibMedia/PlaybackStates/SeekingStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/SeekingStateHandler.h
@@ -60,6 +60,11 @@ public:
         if (!resolves_seek(status))
             return;
 
+        if (status == PipelineStatus::EndOfStream) {
+            PlaybackStateHandler::on_pipeline_status_changed(status);
+            return;
+        }
+
         resume();
     }
 

--- a/Libraries/LibMedia/PlaybackStates/StartingStateHandler.cpp
+++ b/Libraries/LibMedia/PlaybackStates/StartingStateHandler.cpp
@@ -7,7 +7,6 @@
 #include "StartingStateHandler.h"
 
 #include <LibMedia/PlaybackManager.h>
-#include <LibMedia/PlaybackStates/BufferingStateHandler.h>
 
 namespace Media {
 
@@ -15,13 +14,15 @@ void StartingStateHandler::start()
 {
     m_started = true;
 
-    if (!manager().m_audio_buffering && manager().m_video_tracks_buffering.is_empty())
+    if (!m_pipeline_blocked)
         resume();
 }
 
-void StartingStateHandler::exit_buffering()
+void StartingStateHandler::on_pipeline_status_changed(PipelineStatus status)
 {
-    if (m_started)
+    m_pipeline_blocked = status == PipelineStatus::Blocked;
+
+    if (m_started && !m_pipeline_blocked)
         resume();
 }
 

--- a/Libraries/LibMedia/PlaybackStates/StartingStateHandler.h
+++ b/Libraries/LibMedia/PlaybackStates/StartingStateHandler.h
@@ -29,11 +29,11 @@ public:
         return AvailableData::None;
     }
 
-    virtual void enter_buffering() override { }
-    virtual void exit_buffering() override;
+    virtual void on_pipeline_status_changed(PipelineStatus) override;
 
 private:
     bool m_started { false };
+    bool m_pipeline_blocked { false };
 };
 
 }

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -519,26 +519,16 @@ void DecodedAudioProducer::ThreadData::push_data_and_decode_a_block()
     VERIFY(m_decoder);
 
     auto set_halting_status_and_wait_for_seek = [this](PipelineStatus status, Optional<DecoderError> error) {
-        {
-            auto locker = take_lock();
-            enter_halting_state(status, move(error));
-        }
+        auto locker = take_lock();
+        enter_halting_state(status, move(error));
 
         dbgln_if(PLAYBACK_MANAGER_DEBUG, "Decoded Audio Producer: Reached a halting pull status, waiting for a seek to start decoding again...");
         while (true) {
-            {
-                auto locker = take_lock();
-                if (m_current_halting_status == PipelineStatus::Pending)
-                    return;
-            }
-            if (handle_seek())
-                break;
-            {
-                auto locker = take_lock();
-                m_wait_condition.wait();
-                if (should_thread_exit_while_locked())
-                    return;
-            }
+            if (m_seek_id != m_last_processed_seek_id)
+                return;
+            m_wait_condition.wait();
+            if (should_thread_exit_while_locked())
+                return;
         }
     };
 

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -533,6 +533,12 @@ void DecodedAudioProducer::ThreadData::push_data_and_decode_a_block()
         }
     };
 
+    // If a prior seek encountered a decoding error, stop here to ensure that the pipeline state stays Error.
+    if (m_current_halting_status != PipelineStatus::Pending) {
+        set_halting_status_and_wait_for_seek(m_current_halting_status, {});
+        return;
+    }
+
     auto sample_result = m_demuxer->get_next_sample_for_track(m_track);
     if (sample_result.is_error()) {
         if (sample_result.error().category() == DecoderErrorCategory::EndOfStream) {

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -420,15 +420,17 @@ bool DecodedAudioProducer::ThreadData::handle_seek()
     if (m_last_processed_seek_id == seek_id)
         return false;
 
+    AK::Duration timestamp;
+    bool moved_position = false;
+
     auto handle_error = [&](DecoderError&& error) {
         auto locker = take_lock();
         m_queue.clear();
         enter_halting_state(PipelineStatus::Error, move(error));
         m_last_processed_seek_id = seek_id;
+        if (moved_position)
+            m_moved_position_pending = true;
     };
-
-    AK::Duration timestamp;
-    bool moved_position = false;
 
     while (true) {
         {

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -267,7 +267,6 @@ void DecodedAudioProducer::ThreadData::seek(AK::Duration timestamp)
     note_consumer_activity_while_locked();
     m_seek_id++;
     m_seek_timestamp = timestamp;
-    m_current_halting_status = PipelineStatus::Pending;
     m_downstream_needs_wake = true;
     m_demuxer->set_blocking_reads_aborted_for_track(m_track);
     wake();
@@ -405,8 +404,8 @@ DecoderErrorOr<void> DecodedAudioProducer::ThreadData::retrieve_next_block(Audio
 void DecodedAudioProducer::ThreadData::resolve_seek(u32 seek_id, bool moved_position)
 {
     m_last_processed_seek_id = seek_id;
-    VERIFY(m_current_halting_status != PipelineStatus::HaveData);
     if (moved_position) {
+        m_current_halting_status = PipelineStatus::Pending;
         m_moved_position_pending = true;
         m_queue.clear();
     }
@@ -426,10 +425,12 @@ bool DecodedAudioProducer::ThreadData::handle_seek()
     auto handle_error = [&](DecoderError&& error) {
         auto locker = take_lock();
         m_queue.clear();
+        if (moved_position) {
+            m_current_halting_status = PipelineStatus::Pending;
+            m_moved_position_pending = true;
+        }
         enter_halting_state(PipelineStatus::Error, move(error));
         m_last_processed_seek_id = seek_id;
-        if (moved_position)
-            m_moved_position_pending = true;
     };
 
     while (true) {

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -527,6 +527,12 @@ void DecodedVideoProducer::ThreadData::push_data_and_decode_some_frames()
         }
     };
 
+    // If a prior seek encountered a decoding error, stop here to ensure that the pipeline state stays Error.
+    if (m_current_halting_status != PipelineStatus::Pending) {
+        set_halting_status_and_wait_for_seek(m_current_halting_status, {});
+        return;
+    }
+
     auto sample_result = m_demuxer->get_next_sample_for_track(m_track);
     if (sample_result.is_error()) {
         if (sample_result.error().category() == DecoderErrorCategory::EndOfStream) {

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -258,7 +258,6 @@ void DecodedVideoProducer::ThreadData::seek(AK::Duration timestamp)
 {
     auto locker = take_lock();
     note_consumer_activity_while_locked();
-    m_current_halting_status = PipelineStatus::Pending;
     m_downstream_needs_wake = true;
 
     if (timestamp >= m_earliest_available_timestamp && timestamp < m_latest_available_timestamp) {
@@ -391,8 +390,8 @@ void DecodedVideoProducer::ThreadData::dispatch_error(DecoderError&& error)
 void DecodedVideoProducer::ThreadData::resolve_seek(u32 seek_id, bool moved_position)
 {
     m_last_processed_seek_id = seek_id;
-    VERIFY(m_current_halting_status != PipelineStatus::HaveData);
     if (moved_position) {
+        m_current_halting_status = PipelineStatus::Pending;
         m_moved_position_pending = true;
         m_queue.clear();
     }
@@ -412,10 +411,12 @@ bool DecodedVideoProducer::ThreadData::handle_seek()
     auto handle_error = [&](DecoderError&& error) {
         auto locker = take_lock();
         m_queue.clear();
+        if (moved_position) {
+            m_current_halting_status = PipelineStatus::Pending;
+            m_moved_position_pending = true;
+        }
         enter_halting_state(PipelineStatus::Error, move(error));
         m_last_processed_seek_id = seek_id;
-        if (moved_position)
-            m_moved_position_pending = true;
     };
 
     while (true) {

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -513,26 +513,16 @@ void DecodedVideoProducer::ThreadData::push_data_and_decode_some_frames()
     //        before this functionality can exist.
 
     auto set_halting_status_and_wait_for_seek = [this](PipelineStatus status, Optional<DecoderError> error) {
-        {
-            auto locker = take_lock();
-            enter_halting_state(status, move(error));
-        }
+        auto locker = take_lock();
+        enter_halting_state(status, move(error));
 
         dbgln_if(PLAYBACK_MANAGER_DEBUG, "Decoded Video Producer: Reached a halting pull status, waiting for a seek to start decoding again...");
         while (true) {
-            {
-                auto locker = take_lock();
-                if (m_current_halting_status == PipelineStatus::Pending)
-                    return;
-            }
-            if (handle_seek())
-                break;
-            {
-                auto locker = take_lock();
-                m_wait_condition.wait();
-                if (should_thread_exit_while_locked())
-                    return;
-            }
+            if (m_seek_id != m_last_processed_seek_id)
+                return;
+            m_wait_condition.wait();
+            if (should_thread_exit_while_locked())
+                return;
         }
     };
 

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -406,15 +406,17 @@ bool DecodedVideoProducer::ThreadData::handle_seek()
     if (m_last_processed_seek_id == seek_id)
         return false;
 
+    AK::Duration timestamp;
+    bool moved_position = false;
+
     auto handle_error = [&](DecoderError&& error) {
         auto locker = take_lock();
         m_queue.clear();
         enter_halting_state(PipelineStatus::Error, move(error));
         m_last_processed_seek_id = seek_id;
+        if (moved_position)
+            m_moved_position_pending = true;
     };
-
-    AK::Duration timestamp;
-    bool moved_position = false;
 
     while (true) {
         {

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -390,7 +390,6 @@ void AudioPlaybackSink::OutputThreadData::dispatch_state_if_changed(PipelineStat
         return;
     m_last_dispatched_status = status;
     m_main_thread_event_loop.deferred_invoke([self = NonnullRefPtr(*this), status, seek_id] {
-        Sync::MutexLocker locker { self->m_output_mutex };
         if (self->m_seek_id != seek_id)
             return;
         if (self->m_on_state_changed)

--- a/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
+++ b/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
@@ -155,7 +155,9 @@ DisplayingVideoSinkUpdateResult DisplayingVideoSink::update()
 
     // Dispatch the new state with a deferred invoke to avoid reentrancy. This prevents a seek from resolving while
     // an update is being processed.
-    Core::deferred_invoke([self = NonnullRefPtr(*this), last_status] {
+    Core::deferred_invoke([self = NonnullRefPtr(*this), last_status, seek_id = m_seek_id] {
+        if (seek_id != self->m_seek_id)
+            return;
         self->dispatch_state_if_changed(last_status);
     });
 

--- a/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
+++ b/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
@@ -57,6 +57,8 @@ ErrorOr<void> DisplayingVideoSink::connect_input(NonnullRefPtr<VideoProducer> co
         consume_moved_position_signals(status);
         if (!resolves_seek(status))
             return;
+        if (m_current_frame != nullptr && m_seek_status == SeekStatus::None)
+            status = PipelineStatus::HaveData;
         dispatch_state_if_changed(status);
     });
     input->seek(m_time_provider->current_time());
@@ -151,6 +153,16 @@ DisplayingVideoSinkUpdateResult DisplayingVideoSink::update()
             break;
         m_current_frame = m_next_frame.release_nonnull();
         result = DisplayingVideoSinkUpdateResult::NewFrameAvailable;
+    }
+
+    if (m_current_frame != nullptr && m_seek_status == SeekStatus::None) {
+        AK::Duration current_frame_end;
+        if (is_terminal(last_status))
+            current_frame_end = m_current_frame->timestamp() + m_current_frame->duration();
+        else
+            current_frame_end = conservative_frame_end(*m_current_frame);
+        if (current_time <= current_frame_end)
+            last_status = PipelineStatus::HaveData;
     }
 
     // Dispatch the new state with a deferred invoke to avoid reentrancy. This prevents a seek from resolving while

--- a/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -56,7 +56,7 @@ void AudioTrack::set_enabled(bool enabled)
     // Whenever an audio track in an AudioTrackList that was disabled is enabled, and whenever one that was enabled
     // is disabled, the user agent must queue a media element task given the media element to fire an event named
     // change at the AudioTrackList object.
-    media_element().queue_a_media_element_task([audio_track_list = m_audio_track_list]() {
+    media_element().queue_a_media_element_task([audio_track_list = m_audio_track_list](HTMLMediaElement&) {
         audio_track_list->dispatch_event(DOM::Event::create(audio_track_list->realm(), HTML::EventNames::change));
     });
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -467,6 +467,15 @@ void HTMLMediaElement::set_current_playback_position(double playback_position)
 
     upon_has_ended_playback_possibly_changed();
     update_natural_dimensions();
+
+    // AD-HOC: Run the SourceBuffer monitoring algorithm to update readyState based on buffered data relative to
+    //         the current playback position. This satisfies the periodic buffer monitoring in MSE:
+    //         https://w3c.github.io/media-source/#buffer-monitoring
+    //         This is queued as a task to ensure that any tasks queued to fire events based on prior ready state
+    //         changes occur before it is changed again.
+    queue_a_media_element_task(GC::weak_callback(*this, [](auto& self) {
+        self.update_ready_state();
+    }));
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-duration
@@ -2821,11 +2830,6 @@ void HTMLMediaElement::time_marches_on(TimeMarchesOnReason reason)
             queue_a_media_element_task([this]() {
                 dispatch_time_update_event();
             });
-
-            // AD-HOC: Run the SourceBuffer monitoring algorithm to update readyState based on buffered data relative to
-            //         the current playback position. This satisfies the periodic buffer monitoring in MSE:
-            //         https://w3c.github.io/media-source/#buffer-monitoring
-            update_ready_state();
         }
     }
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -459,11 +459,6 @@ void HTMLMediaElement::set_current_playback_position(double playback_position)
 
     time_marches_on();
 
-    // NOTE: Invoking the following steps is not listed in the spec. Rather, the spec just describes the scenario in
-    //       which these steps should be invoked, which is when we've reached the end of the media playback.
-    if (m_current_playback_position == m_duration)
-        reached_end_of_media_playback();
-
     upon_has_ended_playback_possibly_changed();
     update_natural_dimensions();
 
@@ -2043,6 +2038,8 @@ void HTMLMediaElement::forget_media_resource_specific_tracks()
     // of text tracks all the media-resource-specific text tracks, then empty the media element's audioTracks attribute's AudioTrackList object, then
     // empty the media element's videoTracks attribute's VideoTrackList object. No events (in particular, no removetrack events) are fired as part of
     // this; the error and emptied events, fired by the algorithms that invoke this one, can be used instead.
+    if (m_playback_manager)
+        m_playback_manager->on_playback_state_change = nullptr;
     m_audio_tracks->remove_all_tracks();
     m_video_tracks->remove_all_tracks();
     m_playback_manager.clear();
@@ -2269,6 +2266,10 @@ void HTMLMediaElement::on_playback_manager_state_change()
     auto state = m_playback_manager->state();
     if (seeking() && state != Media::PlaybackState::Seeking)
         finish_seeking_element();
+    if (state == Media::PlaybackState::Ended && !m_error) {
+        set_current_playback_position(m_duration);
+        reached_end_of_media_playback();
+    }
 
     // NB: Queue the readyState update as a task so that it will never run before the durationchange and loadedmetadata
     //     events are fired. This ensures that readyState has a deterministic value in those events.
@@ -2699,10 +2700,13 @@ bool HTMLMediaElement::has_ended_playback() const
     if (m_ready_state < ReadyState::HaveMetadata)
         return false;
 
+    VERIFY(m_playback_manager != nullptr);
     // Either:
     if (
         // The current playback position is the end of the media resource, and
-        m_current_playback_position == m_duration &&
+        // NB: This is represented by the playback manager's Ended state, which is only entered once the pipeline has
+        //     consumed all real media data.
+        m_playback_manager->state() == Media::PlaybackState::Ended &&
 
         // The direction of playback is forwards, and
         direction_of_playback() == PlaybackDirection::Forwards &&

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -149,15 +149,14 @@ void HTMLMediaElement::adjust_computed_style(CSS::ComputedProperties& style)
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task
-void HTMLMediaElement::queue_a_media_element_task(Function<void()> steps)
+void HTMLMediaElement::queue_a_media_element_task(Function<void(HTMLMediaElement&)> steps)
 {
     // To queue a media element task with a media element element and a series of steps steps, queue an element task on the media element's
     // media element event task source given element and steps.
-    queue_an_element_task(media_element_event_task_source(), [element = GC::Weak { *this }, steps = move(steps)]() mutable {
-        auto self = element.ptr();
-        if (!self || !self->document().is_fully_active())
+    queue_an_element_task(media_element_event_task_source(), [self = GC::Ref(*this), steps = move(steps)]() mutable {
+        if (!self->document().is_fully_active())
             return;
-        steps();
+        steps(*self);
     });
 }
 
@@ -473,9 +472,9 @@ void HTMLMediaElement::set_current_playback_position(double playback_position)
     //         https://w3c.github.io/media-source/#buffer-monitoring
     //         This is queued as a task to ensure that any tasks queued to fire events based on prior ready state
     //         changes occur before it is changed again.
-    queue_a_media_element_task(GC::weak_callback(*this, [](auto& self) {
+    queue_a_media_element_task([](HTMLMediaElement& self) {
         self.update_ready_state();
-    }));
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-duration
@@ -518,8 +517,8 @@ void HTMLMediaElement::set_duration(double duration)
     // is not fired when the duration is reset as part of loading a new media resource.) If the duration is changed such that the current playback position
     // ends up being greater than the time of the end of the media resource, then the user agent must also seek to the time of the end of the media resource.
     if (!isnan(duration)) {
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::durationchange));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::durationchange));
         });
 
         if (m_current_playback_position > duration)
@@ -614,8 +613,8 @@ void HTMLMediaElement::volume_or_muted_attribute_changed()
     // Whenever either of the values that would be returned by the volume and muted IDL attributes change, the user
     // agent must queue a media element task given the media element to fire an event named volumechange at the media
     // element.
-    queue_a_media_element_task([this] {
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::volumechange));
+    queue_a_media_element_task([](HTMLMediaElement& self) {
+        self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::volumechange));
     });
 
     // FIXME: Then, if the media element is not allowed to play, the user agent must run the internal pause steps for the media element.
@@ -680,12 +679,12 @@ GC::Ref<TextTrack> HTMLMediaElement::add_text_track(Bindings::TextTrackKind kind
     // 5. Queue a media element task given the media element to fire an event named addtrack at the media element's
     //    textTracks attribute's TextTrackList object, using TrackEvent, with the track attribute initialized to the new
     //    text track's TextTrack object.
-    queue_a_media_element_task([this, text_track] {
+    queue_a_media_element_task([text_track](HTMLMediaElement& self) {
         Bindings::TrackEventInit event_init {};
         event_init.track = text_track;
 
-        auto event = TrackEvent::create(this->realm(), HTML::EventNames::addtrack, move(event_init));
-        m_text_tracks->dispatch_event(event);
+        auto event = TrackEvent::create(self.realm(), HTML::EventNames::addtrack, move(event_init));
+        self.m_text_tracks->dispatch_event(event);
     });
 
     // 6. Return the new TextTrack object.
@@ -715,16 +714,16 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
     // 5. If the media element's networkState is set to NETWORK_LOADING or NETWORK_IDLE, queue a media element task given the media element to
     //    fire an event named abort at the media element.
     if (m_network_state == NetworkState::Loading || m_network_state == NetworkState::Idle) {
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::abort));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::abort));
         });
     }
 
     // 6. If the media element's networkState is not set to NETWORK_EMPTY, then:
     if (m_network_state != NetworkState::Empty) {
         // 1. Queue a media element task given the media element to fire an event named emptied at the media element.
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::emptied));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::emptied));
         });
 
         // 2. If a fetching process is in progress for the media element, the user agent should stop it.
@@ -762,8 +761,8 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
 
             // If this changed the official playback position, then queue a media element task given the media element to fire an
             // event named timeupdate at the media element.
-            queue_a_media_element_task([this] {
-                dispatch_time_update_event();
+            queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.dispatch_time_update_event();
             });
         }
 
@@ -864,7 +863,7 @@ private:
     void failed_with_elements()
     {
         // 9. Failed with elements: Queue a media element task given the media element to fire an event named error at candidate.
-        m_media_element->queue_a_media_element_task([this]() {
+        m_media_element->queue_a_media_element_task([this](HTMLMediaElement&) {
             m_candidate->dispatch_event(DOM::Event::create(m_candidate->realm(), HTML::EventNames::error));
 
             // 10. Await a stable state. The synchronous section consists of all the remaining steps of this algorithm until
@@ -919,7 +918,7 @@ private:
 
         // 19. ⌛ Queue a media element task given the media element to set the element's delaying-the-load-event flag
         //     to false. This stops delaying the load event.
-        m_media_element->queue_a_media_element_task([this]() {
+        m_media_element->queue_a_media_element_task([this](HTMLMediaElement&) {
             m_media_element->m_delaying_the_load_event.clear();
         });
 
@@ -986,72 +985,72 @@ void HTMLMediaElement::select_resource()
     // 4. Await a stable state, allowing the task that invoked this algorithm to continue. The synchronous section consists of all the remaining
     // steps of this algorithm until the algorithm says the synchronous section has ended. (Steps in synchronous sections are marked with ⌛.)
 
-    queue_a_media_element_task([this, &realm]() {
+    queue_a_media_element_task([&realm](HTMLMediaElement& self) {
         // FIXME: 5. ⌛ If the media element's blocked-on-parser flag is false, then populate the list of pending text tracks.
 
         Optional<SelectMode> mode;
         GC::Ptr<HTMLSourceElement> candidate;
 
         // 6. ⌛ If the media element has an assigned media provider object, then let mode be object.
-        if (!assigned_media_provider_object().has<Empty>()) {
+        if (!self.assigned_media_provider_object().has<Empty>()) {
             mode = SelectMode::Object;
         }
         // ⌛ Otherwise, if the media element has no assigned media provider object but has a src attribute, then let mode be attribute.
-        else if (has_attribute(HTML::AttributeNames::src)) {
+        else if (self.has_attribute(HTML::AttributeNames::src)) {
             mode = SelectMode::Attribute;
         }
         // ⌛ Otherwise, if the media element does not have an assigned media provider object and does not have a src attribute, but does have
         // a source element child, then let mode be children and let candidate be the first such source element child in tree order.
-        else if (auto* source_element = first_child_of_type<HTMLSourceElement>()) {
+        else if (auto* source_element = self.first_child_of_type<HTMLSourceElement>()) {
             mode = SelectMode::Children;
             candidate = source_element;
         }
         // ⌛ Otherwise the media element has no assigned media provider object and has neither a src attribute nor a source element child:
         else {
             // 1. ⌛ Set the networkState to NETWORK_EMPTY.
-            m_network_state = NetworkState::Empty;
+            self.m_network_state = NetworkState::Empty;
 
             // 2. ⌛ Set the element's delaying-the-load-event flag to false. This stops delaying the load event.
-            m_delaying_the_load_event.clear();
+            self.m_delaying_the_load_event.clear();
 
             // 3. End the synchronous section and return.
             return;
         }
 
         // 7. ⌛ Set the media element's networkState to NETWORK_LOADING.
-        m_network_state = NetworkState::Loading;
+        self.m_network_state = NetworkState::Loading;
 
         // 8. ⌛ Queue a media element task given the media element to fire an event named loadstart at the media element.
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::loadstart));
+        self.queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::loadstart));
         });
 
         // 9. Run the appropriate steps from the following list:
         switch (*mode) {
         // -> If mode is object
         case SelectMode::Object: {
-            auto failed_with_media_provider = [this](auto error_message) {
+            auto failed_with_media_provider = GC::weak_callback(self, [](HTMLMediaElement& self, auto error_message) {
                 // 4. Failed with media provider: Reaching this step indicates that the media resource failed to load. Take pending play promises and queue
                 //    a media element task given the media element to run the dedicated media source failure steps with the result.
-                queue_a_media_element_task([this, error_message = move(error_message)]() mutable {
-                    auto promises = take_pending_play_promises();
-                    handle_media_source_failure(promises, move(error_message));
+                self.queue_a_media_element_task([error_message = move(error_message)](HTMLMediaElement& self) mutable {
+                    auto promises = self.take_pending_play_promises();
+                    self.handle_media_source_failure(promises, move(error_message));
                 });
 
                 // 5. Wait for the task queued by the previous step to have executed.
                 // AD-HOC: All calls to the failure steps immediately return, so we do not actually need to wait here.
-            };
+            });
 
             // 1. ⌛ Set the currentSrc attribute to the empty string.
-            m_current_src = {};
+            self.m_current_src = {};
 
             // 2. End the synchronous section, continuing the remaining steps in parallel.
 
             // 3. Run the resource fetch algorithm with the assigned media provider object. If that algorithm returns without aborting this one,
             //    then the load failed.
-            VERIFY(!assigned_media_provider_object().has<Empty>());
-            queue_a_media_element_task([this, failed_with_media_provider = move(failed_with_media_provider)]() mutable {
-                load_local_resource(assigned_media_provider_object(), move(failed_with_media_provider));
+            VERIFY(!self.assigned_media_provider_object().has<Empty>());
+            self.queue_a_media_element_task([failed_with_media_provider = move(failed_with_media_provider)](HTMLMediaElement& self) mutable {
+                self.load_local_resource(self.assigned_media_provider_object(), move(failed_with_media_provider));
             });
 
             // 6. Return. The element won't attempt to load another resource until this algorithm is triggered again.
@@ -1060,20 +1059,20 @@ void HTMLMediaElement::select_resource()
 
         // -> If mode is attribute
         case SelectMode::Attribute: {
-            auto failed_with_attribute = [this](auto error_message) {
+            auto failed_with_attribute = GC::weak_callback(self, [](HTMLMediaElement& self, auto error_message) {
                 // 6. Failed with attribute: Reaching this step indicates that the media resource failed to load or that the given URL could not be parsed. Take
                 //    pending play promises and queue a media element task given the media element to run the dedicated media source failure steps with the result.
-                queue_a_media_element_task([this, error_message = move(error_message)]() mutable {
-                    auto promises = take_pending_play_promises();
-                    handle_media_source_failure(promises, move(error_message));
+                self.queue_a_media_element_task([error_message = move(error_message)](HTMLMediaElement& self) mutable {
+                    auto promises = self.take_pending_play_promises();
+                    self.handle_media_source_failure(promises, move(error_message));
                 });
 
                 // 7. Wait for the task queued by the previous step to have executed.
                 // AD-HOC: All calls to the failure steps immediately return, so we do not actually need to wait here.
-            };
+            });
 
             // 1. ⌛ If the src attribute's value is the empty string, then end the synchronous section, and jump down to the failed with attribute step below.
-            auto source = get_attribute_value(HTML::AttributeNames::src);
+            auto source = self.get_attribute_value(HTML::AttributeNames::src);
             if (source.is_empty()) {
                 failed_with_attribute("The 'src' attribute is empty"_string);
                 return;
@@ -1081,19 +1080,19 @@ void HTMLMediaElement::select_resource()
 
             // 2. ⌛ Let urlRecord be the result of encoding-parsing a URL given the src attribute's value,
             //    relative to the media element's node document when the src attribute was last changed.
-            auto url_record = document().encoding_parse_url(source);
+            auto url_record = self.document().encoding_parse_url(source);
 
             // 3. ⌛ If urlRecord is not failure, then set the currentSrc attribute to the result of applying the URL serializer to urlRecord.
             if (url_record.has_value())
-                m_current_src = url_record->serialize();
+                self.m_current_src = url_record->serialize();
 
             // 4. End the synchronous section, continuing the remaining steps in parallel.
 
             // 5. If urlRecord was obtained successfully, run the resource fetch algorithm with urlRecord. If that algorithm returns without aborting this one,
             //    then the load failed.
-            queue_a_media_element_task([this, url_record = move(url_record), failed_with_attribute = move(failed_with_attribute)]() mutable {
+            self.queue_a_media_element_task([url_record = move(url_record), failed_with_attribute = move(failed_with_attribute)](HTMLMediaElement& self) mutable {
                 if (url_record.has_value()) {
-                    load_url_resource(*url_record, move(failed_with_attribute));
+                    self.load_url_resource(*url_record, move(failed_with_attribute));
                     return;
                 }
             });
@@ -1126,8 +1125,8 @@ void HTMLMediaElement::select_resource()
             // NOTE: We do not bother with maintaining this pointer. We inspect the DOM tree on the fly, rather than dealing
             //       with the headache of auto-updating this pointer as the DOM changes.
 
-            m_source_element_selector = realm.create<SourceElementSelector>(*this, *candidate);
-            m_source_element_selector->process_candidate();
+            self.m_source_element_selector = realm.create<SourceElementSelector>(self, *candidate);
+            self.m_source_element_selector->process_candidate();
 
             break;
         }
@@ -1321,8 +1320,8 @@ void HTMLMediaElement::load_remote_resource(ByteRange const& byte_range)
                 fetch_data->stream->add_chunk_at(fetch_data->offset, media_data.bytes());
                 fetch_data->offset += media_data.size();
 
-                weak_self->queue_a_media_element_task([self = weak_self.as_nonnull()] {
-                    self->process_media_data(FetchingStatus::Ongoing);
+                weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
+                    self.process_media_data(FetchingStatus::Ongoing);
                 });
             });
 
@@ -1337,8 +1336,8 @@ void HTMLMediaElement::load_remote_resource(ByteRange const& byte_range)
                     return;
 
                 weak_self->m_remote_fetch_data->stream->close();
-                weak_self->queue_a_media_element_task([self = weak_self.as_nonnull()] {
-                    self->process_media_data(FetchingStatus::Complete);
+                weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
+                    self.process_media_data(FetchingStatus::Complete);
                 });
             });
 
@@ -1352,8 +1351,8 @@ void HTMLMediaElement::load_remote_resource(ByteRange const& byte_range)
                     return;
 
                 weak_self->m_remote_fetch_data->stream->close();
-                weak_self->queue_a_media_element_task([self = weak_self.as_nonnull()] {
-                    self->process_media_data(FetchingStatus::Interrupted);
+                weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
+                    self.process_media_data(FetchingStatus::Interrupted);
                 });
             });
 
@@ -1834,18 +1833,16 @@ void HTMLMediaElement::set_up_playback_manager_for_remote()
 
         // NB: Queue a task for this so that we don't destroy the PlaybackManager within one of its callbacks when we
         //     call forget_media_resource_specific_tracks().
-        self.queue_a_media_element_task([self = GC::Weak(self), error = move(error), playback_manager_ptr = move(playback_manager_ptr)] {
-            if (!self)
+        self.queue_a_media_element_task([error = move(error), playback_manager_ptr = move(playback_manager_ptr)](HTMLMediaElement& self) {
+            if (self.m_error)
                 return;
-            if (self->m_error)
-                return;
-            if (playback_manager_ptr != self->m_playback_manager.ptr())
+            if (playback_manager_ptr != self.m_playback_manager.ptr())
                 return;
 
             // 1. The user agent should cancel the fetching process.
-            VERIFY(self->m_remote_fetch_data);
-            auto failure_callback = move(self->m_remote_fetch_data->failure_callback);
-            self->cancel_the_fetching_process();
+            VERIFY(self.m_remote_fetch_data);
+            auto failure_callback = move(self.m_remote_fetch_data->failure_callback);
+            self.cancel_the_fetching_process();
 
             // 2. Abort this subalgorithm, returning to the resource selection algorithm.
             failure_callback(MUST(String::from_utf8(error.description())));
@@ -1856,14 +1853,12 @@ void HTMLMediaElement::set_up_playback_manager_for_remote()
     m_playback_manager->on_error = GC::weak_callback(*this, [](auto& self, Media::DecoderError&& error) {
         auto const* playback_manager_ptr = self.m_playback_manager.ptr();
 
-        self.queue_a_media_element_task([self = GC::Weak(self), error = move(error), playback_manager_ptr = move(playback_manager_ptr)] {
-            if (!self)
+        self.queue_a_media_element_task([error = move(error), playback_manager_ptr = move(playback_manager_ptr)](HTMLMediaElement& self) {
+            if (self.m_error)
                 return;
-            if (self->m_error)
+            if (playback_manager_ptr != self.m_playback_manager.ptr())
                 return;
-            if (playback_manager_ptr != self->m_playback_manager.ptr())
-                return;
-            self->set_decoder_error(MUST(String::from_utf8(error.description())));
+            self.set_decoder_error(MUST(String::from_utf8(error.description())));
         });
     });
 
@@ -1926,10 +1921,8 @@ void HTMLMediaElement::set_up_playback_manager_for_local()
 
     // -> If the media data is corrupted
     m_playback_manager->on_error = GC::weak_callback(*this, [](auto& self, Media::DecoderError&& error) {
-        self.queue_a_media_element_task([self = GC::Weak(self), error = move(error)] {
-            if (!self)
-                return;
-            self->set_decoder_error(MUST(String::from_utf8(error.description())));
+        self.queue_a_media_element_task([error = move(error)](HTMLMediaElement& self) {
+            self.set_decoder_error(MUST(String::from_utf8(error.description())));
         });
     });
 
@@ -1956,20 +1949,20 @@ void HTMLMediaElement::process_media_data(FetchingStatus fetching_status)
     } else if (fetching_status == FetchingStatus::Ongoing) {
         // If the user agent ever discards any media data and then needs to resume the network activity to obtain it
         // again, then it must queue a media element task given the media element to set the networkState to NETWORK_LOADING.
-        queue_a_media_element_task(GC::weak_callback(*this, [](auto& self) {
+        queue_a_media_element_task([](HTMLMediaElement& self) {
             self.m_network_state = NetworkState::Loading;
-        }));
+        });
 
         // While the load is not suspended (see below), every 350ms (±200ms) or for every byte received, whichever is
         // least frequent, queue a media element task given the media element to:
         auto now = MonotonicTime::now();
         if (!m_last_progress_event_time.has_value() || now - m_last_progress_event_time.value() > AK::Duration::from_milliseconds(350)) {
             m_last_progress_event_time = now;
-            queue_a_media_element_task(GC::weak_callback(*this, [](auto& self) {
+            queue_a_media_element_task([](HTMLMediaElement& self) {
                 // FIXME: 1. Set the element's is currently stalled to false.
                 // 2. Fire an event named progress at the element.
                 self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::progress));
-            }));
+            });
 
             update_ready_state();
         }
@@ -2083,8 +2076,8 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
     // -> If the previous ready state was HAVE_NOTHING, and the new ready state is HAVE_METADATA
     if (old_ready_state == ReadyState::HaveNothing && ready_state == ReadyState::HaveMetadata) {
         // Queue a media element task given the media element to fire an event named loadedmetadata at the element.
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::loadedmetadata));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::loadedmetadata));
         });
 
         return;
@@ -2097,8 +2090,8 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
         if (m_first_data_load_event_since_load_start) {
             m_first_data_load_event_since_load_start = false;
 
-            queue_a_media_element_task([this] {
-                dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::loadeddata));
+            queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::loadeddata));
             });
         }
 
@@ -2124,8 +2117,8 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
     // -> If the previous ready state was HAVE_CURRENT_DATA or less, and the new ready state is HAVE_FUTURE_DATA
     if (old_ready_state <= ReadyState::HaveCurrentData && ready_state == ReadyState::HaveFutureData) {
         // The user agent must queue a media element task given the media element to fire an event named canplay at the element.
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplay));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::canplay));
         });
 
         // If the element's paused attribute is false, the user agent must notify about playing for the element.
@@ -2140,8 +2133,8 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
         // If the previous ready state was HAVE_CURRENT_DATA or less, the user agent must queue a media element task given the media element to fire an event
         // named canplay at the element, and, if the element's paused attribute is false, notify about playing for the element.
         if (old_ready_state <= ReadyState::HaveCurrentData) {
-            queue_a_media_element_task([this] {
-                dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplay));
+            queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::canplay));
             });
 
             if (!paused())
@@ -2149,8 +2142,8 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
         }
 
         // The user agent must queue a media element task given the media element to fire an event named canplaythrough at the element.
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::canplaythrough));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::canplaythrough));
         });
 
         // If the element is not eligible for autoplay, then the user agent must abort these substeps.
@@ -2169,8 +2162,8 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
             }
 
             // Queue a media element task given the element to fire an event named play at the element.
-            queue_a_media_element_task([this]() {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::play));
+            queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::play));
             });
 
             // Notify about playing for the element.
@@ -2279,10 +2272,10 @@ void HTMLMediaElement::on_playback_manager_state_change()
 
     // NB: Queue the readyState update as a task so that it will never run before the durationchange and loadedmetadata
     //     events are fired. This ensures that readyState has a deterministic value in those events.
-    queue_a_media_element_task(GC::weak_callback(*this, [](auto& self) {
+    queue_a_media_element_task([](HTMLMediaElement& self) {
         if (self.m_ready_state >= ReadyState::HaveMetadata)
             self.update_ready_state();
-    }));
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#internal-play-steps
@@ -2310,15 +2303,15 @@ void HTMLMediaElement::play_element()
         }
 
         // 3. Queue a media element task given the media element to fire an event named play at the element.
-        queue_a_media_element_task([this]() {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::play));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::play));
         });
 
         // 4. If the media element's readyState attribute has the value HAVE_NOTHING, HAVE_METADATA, or HAVE_CURRENT_DATA,
         //    queue a media element task given the media element to fire an event named waiting at the element.
         if (m_ready_state == ReadyState::HaveNothing || m_ready_state == ReadyState::HaveMetadata || m_ready_state == ReadyState::HaveCurrentData) {
-            queue_a_media_element_task([this]() {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::waiting));
+            queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::waiting));
             });
         }
         //    Otherwise, the media element's readyState attribute has the value HAVE_FUTURE_DATA or HAVE_ENOUGH_DATA:
@@ -2341,8 +2334,8 @@ void HTMLMediaElement::play_element()
     else if (m_ready_state == ReadyState::HaveFutureData || m_ready_state == ReadyState::HaveEnoughData) {
         auto promises = take_pending_play_promises();
 
-        queue_a_media_element_task([this, promises = move(promises)]() {
-            resolve_pending_play_promises(promises);
+        queue_a_media_element_task([promises = move(promises)](HTMLMediaElement& self) {
+            self.resolve_pending_play_promises(promises);
         });
     }
 
@@ -2365,17 +2358,17 @@ void HTMLMediaElement::pause_element()
         auto promises = take_pending_play_promises();
 
         // 3. Queue a media element task given the media element and the following steps:
-        queue_a_media_element_task([this, promises = move(promises)]() {
-            auto& realm = this->realm();
+        queue_a_media_element_task([promises = move(promises)](HTMLMediaElement& self) {
+            auto& realm = self.realm();
 
             // 1. Fire an event named timeupdate at the element.
-            dispatch_time_update_event();
+            self.dispatch_time_update_event();
 
             // 2. Fire an event named pause at the element.
-            dispatch_event(DOM::Event::create(realm, HTML::EventNames::pause));
+            self.dispatch_event(DOM::Event::create(realm, HTML::EventNames::pause));
 
             // 3. Reject pending play promises with promises and an "AbortError" DOMException.
-            reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback was paused"_utf16);
+            self.reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback was paused"_utf16);
         });
 
         // 4. Set the official playback position to the current playback position.
@@ -2476,8 +2469,8 @@ void HTMLMediaElement::seek_element(double playback_position, MediaSeekMode seek
     }
 
     // 10. Queue a media element task given the media element to fire an event named seeking at the element.
-    queue_a_media_element_task([this]() {
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::seeking));
+    queue_a_media_element_task([](HTMLMediaElement& self) {
+        self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::seeking));
     });
 
     // 11. Set the current playback position to the new playback position.
@@ -2504,8 +2497,8 @@ void HTMLMediaElement::seek_element(double playback_position, MediaSeekMode seek
         //     Awaiting a stable state seems to require a task to be queued anyway, and we use media element tasks to cancel
         //     ongoing operations when load_element() is called.
         //     See: https://github.com/whatwg/html/issues/2882#issuecomment-1108531815
-        queue_a_media_element_task([this]() {
-            finish_seeking_element();
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.finish_seeking_element();
         });
     }
 }
@@ -2525,13 +2518,13 @@ void HTMLMediaElement::finish_seeking_element()
     time_marches_on(TimeMarchesOnReason::Other);
 
     // 16. ⌛ Queue a media element task given the media element to fire an event named timeupdate at the element.
-    queue_a_media_element_task([this]() {
-        dispatch_time_update_event();
+    queue_a_media_element_task([](HTMLMediaElement& self) {
+        self.dispatch_time_update_event();
     });
 
     // 17. ⌛ Queue a media element task given the media element to fire an event named seeked at the element.
-    queue_a_media_element_task([this]() {
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::seeked));
+    queue_a_media_element_task([](HTMLMediaElement& self) {
+        self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::seeked));
     });
 }
 
@@ -2542,12 +2535,12 @@ void HTMLMediaElement::notify_about_playing()
     auto promises = take_pending_play_promises();
 
     // 2. Queue a media element task given the element and the following steps:
-    queue_a_media_element_task([this, promises = move(promises)]() {
+    queue_a_media_element_task([promises = move(promises)](HTMLMediaElement& self) {
         // 1. Fire an event named playing at the element.
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::playing));
+        self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::playing));
 
         // 2. Resolve pending play promises with promises.
-        resolve_pending_play_promises(promises);
+        self.resolve_pending_play_promises(promises);
     });
 
     if (m_playback_manager)
@@ -2599,8 +2592,8 @@ void HTMLMediaElement::set_default_playback_rate(double new_value)
     // When the defaultPlaybackRate or playbackRate attributes change value (either by being set by script or by being changed directly by the user agent, e.g. in response to user
     // control), the user agent must queue a media element task given the media element to fire an event named ratechange at the media element.
     if (m_default_playback_rate != new_value) {
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::ratechange));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::ratechange));
         });
     }
 
@@ -2620,8 +2613,8 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::set_playback_rate(double new_value)
     // When the defaultPlaybackRate or playbackRate attributes change value (either by being set by script or by being changed directly by the user agent, e.g. in response to user
     // control), the user agent must queue a media element task given the media element to fire an event named ratechange at the media element.
     if (m_playback_rate != new_value) {
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::ratechange));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::ratechange));
         });
     }
 
@@ -2764,25 +2757,25 @@ void HTMLMediaElement::reached_end_of_media_playback()
     // 2. As defined above, the ended IDL attribute starts returning true once the event loop returns to step 1.
 
     // 3. Queue a media element task given the media element and the following steps:
-    queue_a_media_element_task([this]() mutable {
+    queue_a_media_element_task([](HTMLMediaElement& self) {
         // 1. Fire an event named timeupdate at the media element.
-        dispatch_time_update_event();
+        self.dispatch_time_update_event();
 
         // 2. If the media element has ended playback, the direction of playback is forwards, and paused is false, then:
-        if (has_ended_playback() && direction_of_playback() == PlaybackDirection::Forwards && !paused()) {
+        if (self.has_ended_playback() && self.direction_of_playback() == PlaybackDirection::Forwards && !self.paused()) {
             // 1. Set the paused attribute to true.
-            set_paused(true);
+            self.set_paused(true);
 
             // 2. Fire an event named pause at the media element.
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::pause));
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::pause));
 
             // 3. Take pending play promises and reject pending play promises with the result and an "AbortError" DOMException.
-            auto promises = take_pending_play_promises();
-            reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback has ended"_utf16);
+            auto promises = self.take_pending_play_promises();
+            self.reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback has ended"_utf16);
         }
 
         // 3. Fire an event named ended at the media element.
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::ended));
+        self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::ended));
     });
 }
 
@@ -2827,8 +2820,8 @@ void HTMLMediaElement::time_marches_on(TimeMarchesOnReason reason)
         }
 
         if (dispatch_event) {
-            queue_a_media_element_task([this]() {
-                dispatch_time_update_event();
+            queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.dispatch_time_update_event();
             });
         }
     }

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -53,7 +53,7 @@ public:
     virtual void adjust_computed_style(CSS::ComputedProperties& style) override;
 
     // NOTE: The function is wrapped in a GC::HeapFunction immediately.
-    void queue_a_media_element_task(Function<void()>);
+    void queue_a_media_element_task(Function<void(HTMLMediaElement&)>);
 
     void cancel_the_fetching_process();
 

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -106,8 +106,8 @@ void HTMLVideoElement::set_intrinsic_video_dimensions(Optional<Gfx::Size<u32>> d
     //         dimensions are not available. This matches other browsers.
     if (dimensions.has_value()) {
         // the user agent must queue a media element task given the media element to fire an event named resize at the media element.
-        queue_a_media_element_task([this] {
-            dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::resize));
+        queue_a_media_element_task([](HTMLMediaElement& self) {
+            self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::resize));
         });
     }
 

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -228,20 +228,20 @@ void MediaControls::set_up_event_listeners()
     }
 
     // Timeline scrubbing
-    static constexpr auto compute_timeline_position = [](UIEvents::MouseEvent const& event, DOM::Element& timeline_element, double duration) -> Optional<double> {
+    static constexpr auto compute_timeline_progress = [](UIEvents::MouseEvent const& event, DOM::Element& timeline_element, double duration) -> Optional<double> {
         if (isnan(duration) || duration == 0.0)
             return {};
         auto rect = timeline_element.get_bounding_client_rect();
-        auto fraction = clamp((event.client_x() - rect.left().to_double()) / rect.width().to_double(), 0.0, 1.0);
-        return fraction * duration;
+        return clamp((event.client_x() - rect.left().to_double()) / rect.width().to_double(), 0.0, 1.0);
     };
 
     add_event_listener(realm, *m_dom->timeline_element, UIEvents::EventNames::mousedown, [this](UIEvents::MouseEvent const& event) {
         VERIFY(m_media_element);
         VERIFY(m_dom->timeline_element);
 
-        auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
-        if (!position.has_value())
+        auto duration = m_media_element->duration();
+        auto progress = compute_timeline_progress(event, *m_dom->timeline_element, duration);
+        if (!progress.has_value())
             return false;
 
         m_scrubbing_timeline = Scrubbing::WhilePaused;
@@ -250,7 +250,9 @@ void MediaControls::set_up_event_listeners()
             m_scrubbing_timeline = Scrubbing::WhilePlaying;
         }
 
-        set_current_time(*position);
+        set_current_time(*progress * duration);
+        set_timeline_progress(*progress);
+        set_timestamp(*progress * duration, duration);
 
         auto& realm = m_media_element->realm();
         auto& window = as<HTML::Window>(realm.global_object());
@@ -259,11 +261,14 @@ void MediaControls::set_up_event_listeners()
             VERIFY(m_media_element);
             VERIFY(m_dom->timeline_element);
 
-            auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
-            if (!position.has_value())
+            auto duration = m_media_element->duration();
+            auto progress = compute_timeline_progress(event, *m_dom->timeline_element, duration);
+            if (!progress.has_value())
                 return false;
 
-            set_current_time(*position);
+            set_current_time(*progress * duration);
+            set_timeline_progress(*progress);
+            set_timestamp(*progress * duration, duration);
             return true;
         });
 
@@ -274,9 +279,10 @@ void MediaControls::set_up_event_listeners()
             auto was_playing = m_scrubbing_timeline == Scrubbing::WhilePlaying;
             m_scrubbing_timeline = Scrubbing::No;
 
-            auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
-            if (position.has_value())
-                set_current_time(*position);
+            auto duration = m_media_element->duration();
+            auto progress = compute_timeline_progress(event, *m_dom->timeline_element, duration);
+            if (progress.has_value())
+                set_current_time(*progress * duration);
 
             if (was_playing) {
                 if (m_media_element->ended()) {
@@ -500,24 +506,24 @@ void MediaControls::update_play_pause_icon()
     MUST(m_dom->play_pause_icon->class_list()->toggle(s_playing_class, !paused));
 }
 
+static String format_percent(double value)
+{
+    return MUST(String::formatted("{}%", value * 100));
+}
+
 void MediaControls::update_timeline()
 {
     VERIFY(m_media_element);
     VERIFY(m_dom->timeline_track);
     VERIFY(m_dom->timeline_fill);
 
-    auto format_percent = [](double value) {
-        return MUST(String::formatted("{}%", value * 100));
-    };
-
     auto duration = m_media_element->duration();
-    double progress = 0.0;
-    if (!isnan(duration) && duration > 0.0)
-        progress = (m_media_element->current_time() / duration);
 
-    if (m_last_timeline_progress != progress) {
-        MUST(m_dom->timeline_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, format_percent(progress)));
-        m_last_timeline_progress = progress;
+    if (m_scrubbing_timeline == Scrubbing::No) {
+        double progress = 0.0;
+        if (!isnan(duration) && duration > 0.0)
+            progress = (m_media_element->current_time() / duration);
+        set_timeline_progress(progress);
     }
 
     auto buffered = m_media_element->buffered();
@@ -557,6 +563,17 @@ void MediaControls::update_timeline()
     }
 }
 
+void MediaControls::set_timeline_progress(double progress)
+{
+    VERIFY(m_dom->timeline_fill);
+
+    if (m_last_timeline_progress == progress)
+        return;
+
+    MUST(m_dom->timeline_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, format_percent(progress)));
+    m_last_timeline_progress = progress;
+}
+
 void MediaControls::request_timeline_update()
 {
     if (m_request_animation_frame_id != 0)
@@ -572,13 +589,25 @@ void MediaControls::request_timeline_update()
 void MediaControls::update_timestamp()
 {
     VERIFY(m_media_element);
+    double time = static_cast<double>(m_last_timestamp_time);
+    if (m_scrubbing_timeline == Scrubbing::No)
+        time = m_media_element->current_time();
+    set_timestamp(time, m_media_element->duration());
+}
+
+void MediaControls::set_timestamp(double time, double duration)
+{
     VERIFY(m_dom->timestamp_element);
 
-    auto current = human_readable_digital_time(round_to<i64>(m_media_element->current_time()));
-    auto duration = m_media_element->duration();
-    auto total = human_readable_digital_time(isnan(duration) ? 0 : round_to<i64>(duration));
+    auto rounded_time = round_to<i64>(time);
+    auto rounded_duration = isnan(duration) ? 0 : round_to<i64>(duration);
 
-    MUST(m_dom->timestamp_element->set_text_content(Utf16String::formatted("{} / {}", current, total)));
+    if (rounded_time == m_last_timestamp_time && rounded_duration == m_last_timestamp_duration)
+        return;
+    m_last_timestamp_time = rounded_time;
+    m_last_timestamp_duration = rounded_duration;
+
+    MUST(m_dom->timestamp_element->set_text_content(Utf16String::formatted("{} / {}", human_readable_digital_time(rounded_time), human_readable_digital_time(rounded_duration))));
 }
 
 void MediaControls::update_volume_and_mute_indicator()
@@ -591,12 +620,10 @@ void MediaControls::update_volume_and_mute_indicator()
     auto has_audio = m_media_element->audio_tracks()->length() > 0;
     auto muted = !has_audio || m_media_element->muted();
 
-    if (muted) {
+    if (muted)
         MUST(m_dom->volume_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, "0"sv));
-    } else {
-        auto percentage = volume * 100.0;
-        MUST(m_dom->volume_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", percentage))));
-    }
+    else
+        MUST(m_dom->volume_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, format_percent(volume)));
 
     auto new_volume_icon_state = [&] {
         if (volume > 0.5)

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -176,6 +176,10 @@ void MediaControls::set_up_event_listeners()
         update_timestamp();
         return true;
     });
+    add_event_listener(realm, media_element, HTML::EventNames::progress, [this] {
+        update_timeline();
+        return true;
+    });
     add_event_listener(realm, media_element, HTML::EventNames::durationchange, [this] {
         update_timeline();
         update_timestamp();

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -26,6 +26,7 @@
 #include <LibWeb/UIEvents/KeyboardEvent.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 #include <LibWeb/WebIDL/CallbackType.h>
+#include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::HTML {
 
@@ -281,9 +282,9 @@ void MediaControls::set_up_event_listeners()
                 if (m_media_element->ended()) {
                     auto loop = m_media_element->has_attribute(HTML::AttributeNames::loop);
                     if (loop)
-                        m_media_element->play();
+                        play();
                 } else {
-                    m_media_element->play();
+                    play();
                 }
             }
 
@@ -440,12 +441,17 @@ void MediaControls::set_up_event_listeners()
     request_timeline_update();
 }
 
+void MediaControls::play()
+{
+    WebIDL::mark_promise_as_handled(m_media_element->play());
+}
+
 void MediaControls::toggle_playback()
 {
     if (m_scrubbing_timeline != Scrubbing::No)
         return;
     if (m_media_element->paused())
-        m_media_element->play();
+        play();
     else
         m_media_element->pause();
     show_controls();

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -57,7 +57,9 @@ private:
 
     void update_play_pause_icon();
     void update_timeline();
+    void set_timeline_progress(double);
     void update_timestamp();
+    void set_timestamp(double time, double duration);
     void request_timeline_update();
     void update_volume_and_mute_indicator();
     void update_fullscreen_icon();
@@ -102,6 +104,8 @@ private:
     MuteIconState m_mute_icon_state { MuteIconState::Empty };
 
     double m_last_timeline_progress { 0.0 };
+    i64 m_last_timestamp_time { -1 };
+    i64 m_last_timestamp_duration { -1 };
 
     struct BufferedRange {
         GC::Weak<DOM::Element> element;

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -48,6 +48,7 @@ private:
     void remove_event_listeners();
     void set_up_event_listeners();
 
+    void play();
     void toggle_playback();
     void set_current_time(double);
     void set_volume(double);

--- a/Libraries/LibWeb/HTML/VideoTrack.cpp
+++ b/Libraries/LibWeb/HTML/VideoTrack.cpp
@@ -63,7 +63,7 @@ void VideoTrack::set_selected(bool selected)
     // VideoTrackList is unselected without a new track being selected in its stead, the user agent must queue a media element
     // task given the media element to fire an event named change at the VideoTrackList object. This task must be queued before
     // the task that fires the resize event, if any.
-    media_element().queue_a_media_element_task([video_track_list = m_video_track_list]() {
+    media_element().queue_a_media_element_task([video_track_list = m_video_track_list](HTMLMediaElement&) {
         video_track_list->dispatch_event(DOM::Event::create(video_track_list->realm(), HTML::EventNames::change));
     });
 

--- a/Tests/LibWeb/Text/expected/HTML/HTMLVideoElement-resize-event-during-playback.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLVideoElement-resize-event-during-playback.txt
@@ -8,5 +8,5 @@ resize: videoWidth=320 videoHeight=240
 seeked: videoWidth=320 videoHeight=240
 --- seek to end ---
 resize: videoWidth=640 videoHeight=480
-ended: videoWidth=640 videoHeight=480
 seeked: videoWidth=640 videoHeight=480
+ended: videoWidth=640 videoHeight=480

--- a/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-resize-event-during-playback.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-resize-event-during-playback.html
@@ -26,8 +26,10 @@
         await new Promise(resolve => video.addEventListener("seeked", resolve, { once: true }));
 
         println("--- seek to end ---");
+        const sawEnded = new Promise(resolve => video.addEventListener("ended", resolve, { once: true }));
+        const sawSeeked = new Promise(resolve => video.addEventListener("seeked", resolve, { once: true }));
         video.currentTime = video.duration;
-        await new Promise(resolve => video.addEventListener("seeked", resolve, { once: true }));
+        await Promise.all([sawEnded, sawSeeked]);
 
         done();
     });


### PR DESCRIPTION
See individual commits, there are some bug fixes mixed in that were relevant to the changes and the testing they involved.

tl;dr: `PlaybackManager` now uses the same status combination function that `AudioMixer` does to determine the output state. That state is then dispatched to the state handlers to allow them to determine if they should transition states.
- `BufferingStateHandler` exits when the status is not `Blocked`, removing the need for the buffering-specific tracking in the manager.
- `SeekingStateHandler` exits when the status changes to one indicating the seek can resolve, instead of listening for sink state changes and tracking those internally.
- `EndedStateHandler` is new, and all other states will transition into this one if the pipeline status indicates that all sinks are at EOS.

