### PR TITLE
UI/Qt: Tint missing find-in-page results

### DIFF
--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -650,14 +650,18 @@ QToolBar#LadybirdBookmarksBar QToolButton:checked {{
 QString find_in_page_style_sheet(QPalette const& palette)
 {
     auto background = style_sheet_color(chrome_background(palette));
-    auto surface = style_sheet_color(chrome_surface(palette));
+    auto surface_color = chrome_surface(palette);
+    auto surface = style_sheet_color(surface_color);
     auto hover = style_sheet_color(chrome_control_surface_hover(palette));
     auto pressed = style_sheet_color(chrome_control_surface_pressed(palette));
     auto border = style_sheet_color(chrome_border(palette));
-    auto control_border = style_sheet_color(chrome_control_border(palette));
+    auto control_border_color = chrome_control_border(palette);
+    auto control_border = style_sheet_color(control_border_color);
     auto accent = style_sheet_color(chrome_accent(palette));
     auto text = style_sheet_color(chrome_text(palette));
     auto muted = style_sheet_color(chrome_muted_text(palette));
+    auto no_results_background = style_sheet_color(mix(surface_color, chrome_destructive_hover(), is_dark(palette) ? 0.34 : 0.18));
+    auto no_results_border = style_sheet_color(mix(control_border_color, chrome_destructive_hover(), is_dark(palette) ? 0.72 : 0.58));
 
     return qformatted(R"(
 QWidget#LadybirdFindInPageBar {{
@@ -677,6 +681,11 @@ QWidget#LadybirdFindInPageBar QLineEdit {{
 
 QWidget#LadybirdFindInPageBar QLineEdit:focus {{
     border-color: {6};
+}}
+
+QWidget#LadybirdFindInPageBar QLineEdit[noResults="true"] {{
+    background: {9};
+    border-color: {10};
 }}
 
 QWidget#LadybirdFindInPageBar QPushButton {{
@@ -702,7 +711,7 @@ QWidget#LadybirdFindInPageBar QLabel {{
     color: {8};
 }}
 )",
-        background, surface, hover, pressed, border, control_border, accent, text, muted);
+        background, surface, hover, pressed, border, control_border, accent, text, muted, no_results_background, no_results_border);
 }
 
 QString devtools_banner_style_sheet(QPalette const& palette)

--- a/UI/Qt/FindInPageWidget.cpp
+++ b/UI/Qt/FindInPageWidget.cpp
@@ -12,8 +12,22 @@
 
 #include <QEvent>
 #include <QKeyEvent>
+#include <QStyle>
 
 namespace Ladybird {
+
+static constexpr auto FIND_TEXT_NO_RESULTS_PROPERTY = "noResults";
+
+static void set_dynamic_property_if_needed(QWidget& widget, char const* property, bool value)
+{
+    if (widget.property(property).toBool() == value)
+        return;
+
+    widget.setProperty(property, value);
+    widget.style()->unpolish(&widget);
+    widget.style()->polish(&widget);
+    widget.update();
+}
 
 FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     : QWidget(static_cast<QWidget*>(tab), Qt::Widget)
@@ -118,6 +132,9 @@ void FindInPageWidget::update_chrome_style()
 void FindInPageWidget::find_text_changed()
 {
     auto query = ak_string_from_qstring(m_find_text->text());
+    if (query.is_empty())
+        set_dynamic_property_if_needed(*m_find_text, FIND_TEXT_NO_RESULTS_PROPERTY, false);
+
     auto case_sensitive = m_match_case->isChecked() ? CaseSensitivity::CaseSensitive : CaseSensitivity::CaseInsensitive;
     m_content_view->find_in_page(query, case_sensitive);
 }
@@ -165,6 +182,8 @@ void FindInPageWidget::hideEvent(QHideEvent*)
 void FindInPageWidget::update_result_label(size_t current_match_index, Optional<size_t> const& total_match_count)
 {
     if (total_match_count.has_value()) {
+        set_dynamic_property_if_needed(*m_find_text, FIND_TEXT_NO_RESULTS_PROPERTY, total_match_count.value() == 0);
+
         auto label_text = "Phrase not found"_string;
         if (total_match_count.value() > 0)
             label_text = MUST(String::formatted("{} of {} matches", current_match_index + 1, total_match_count.value()));
@@ -172,6 +191,7 @@ void FindInPageWidget::update_result_label(size_t current_match_index, Optional<
         m_result_label->setText(qstring_from_ak_string(label_text));
         m_result_label->setVisible(true);
     } else {
+        set_dynamic_property_if_needed(*m_find_text, FIND_TEXT_NO_RESULTS_PROPERTY, false);
         m_result_label->setVisible(false);
     }
 }


### PR DESCRIPTION
Mark the search field with a dynamic property when a find-in-page query has zero matches, and let the chrome stylesheet show a red-tinted background. Clear the state immediately for empty searches.