### PR TITLE
RequestServer+LibWebView: Clean up partitioned cache directories on RequestServer shutdown

### DIFF
--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -40,7 +40,7 @@ static ErrorOr<u64> compute_associated_data_size(LexicalPath const& cache_direct
     return associated_data_size;
 }
 
-static constexpr StringView cache_directory_for_mode(DiskCache::Mode mode)
+static ByteString cache_directory_for_mode(DiskCache::Mode mode)
 {
     switch (mode) {
     case DiskCache::Mode::Normal:
@@ -49,7 +49,7 @@ static constexpr StringView cache_directory_for_mode(DiskCache::Mode mode)
         // FIXME: Ideally, we could support multiple RequestServer processes using the same database by setting a
         //        reasonable busy timeout. We would also have to prevent multiple processes writing to the same cache
         //        entry file at the same time with some interprocess locking mechanism.
-        return "PartitionedCache"sv;
+        return ByteString::formatted("PartitionedCache-{}", Core::System::getpid());
     case DiskCache::Mode::Testing:
         return "TestCache"sv;
     }
@@ -59,6 +59,11 @@ static constexpr StringView cache_directory_for_mode(DiskCache::Mode mode)
 ErrorOr<DiskCache> DiskCache::create(Mode mode)
 {
     auto cache_directory = LexicalPath::join(Core::StandardPaths::cache_directory(), "Ladybird"sv, cache_directory_for_mode(mode));
+
+    // Remove any cache contents left behind by an earlier process that was assigned the same PID.
+    if (mode == DiskCache::Mode::Partitioned)
+        (void)FileSystem::remove(cache_directory.string(), FileSystem::RecursionMode::Allowed);
+
     TRY(Core::Directory::create(cache_directory, Core::Directory::CreateDirectories::Yes));
 
     auto database = mode == DiskCache::Mode::Normal
@@ -94,9 +99,16 @@ DiskCache& DiskCache::operator=(DiskCache&&) = default;
 
 DiskCache::~DiskCache()
 {
-    // Clean up cache directories in testing modes to prevent endless growth of disk usage.
-    if (m_mode != Mode::Normal)
+    // Clean up cache directories in non-persistent modes to prevent endless growth of disk usage.
+    if (m_mode == Mode::Testing)
         remove_entries_accessed_since(UnixDateTime::earliest());
+
+    if (m_mode != Mode::Partitioned)
+        return;
+
+    // NB: The cache directory is empty when this instance has been moved from.
+    if (auto const& cache_directory = m_cache_directory.string(); !cache_directory.is_empty())
+        (void)FileSystem::remove(cache_directory, FileSystem::RecursionMode::Allowed);
 }
 
 Variant<Optional<CacheEntryWriter&>, DiskCache::CacheHasOpenEntry> DiskCache::create_entry(CacheRequest& request, URL::URL const& url, StringView method, HeaderList const& request_headers, UnixDateTime request_start_time)

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -126,6 +126,7 @@ Application::~Application()
     // Explicitly delete the observers first, as the observer destructors will refer to Application::the().
     m_settings_observer.clear();
     m_bookmark_store_observer.clear();
+    shutdown_request_server();
     if (m_compositor_client)
         m_compositor_client->on_death = nullptr;
 
@@ -1113,6 +1114,34 @@ ErrorOr<void> Application::launch_request_server()
         m_settings.set_dns_settings(m_browser_options.dns_settings.value(), true);
 
     return {};
+}
+
+void Application::shutdown_request_server()
+{
+    if (!m_request_server_client)
+        return;
+
+    m_request_server_client->on_request_server_died = nullptr;
+    if (m_request_server_client->is_open())
+        m_request_server_client->async_close_server();
+
+    Vector<pid_t> request_server_pids;
+    if (m_process_manager) {
+        m_process_manager->for_each_process([&](Process& process) {
+            if (process.type() == ProcessType::RequestServer)
+                request_server_pids.append(process.pid());
+        });
+    }
+
+    for (auto request_server_pid : request_server_pids) {
+        auto request_server_process = m_process_manager->remove_process(request_server_pid);
+        if (request_server_process.has_value()) {
+            if (auto result = request_server_process->wait_for_termination(); result.is_error())
+                dbgln("Failed to wait for RequestServer process {} to exit: {}", request_server_pid, result.error());
+        }
+    }
+
+    m_request_server_client = nullptr;
 }
 
 ErrorOr<void> Application::launch_image_decoder_server()

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -51,6 +51,7 @@
 #endif
 
 #if !defined(AK_OS_WINDOWS)
+#    include <signal.h>
 #    include <sys/wait.h>
 #endif
 
@@ -126,6 +127,10 @@ Application::~Application()
     // Explicitly delete the observers first, as the observer destructors will refer to Application::the().
     m_settings_observer.clear();
     m_bookmark_store_observer.clear();
+#if !defined(AK_OS_WINDOWS)
+    if (m_termination_signal_handler.has_value())
+        Core::EventLoop::unregister_signal(*m_termination_signal_handler);
+#endif
     shutdown_request_server();
     if (m_compositor_client)
         m_compositor_client->on_death = nullptr;
@@ -534,6 +539,11 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     initialize_actions();
 
     m_event_loop = &create_platform_event_loop();
+#if !defined(AK_OS_WINDOWS)
+    m_termination_signal_handler = Core::EventLoop::register_signal(SIGTERM, [this](int) {
+        m_event_loop->quit(0);
+    });
+#endif
     TRY(launch_services());
 
     return {};

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -278,6 +278,7 @@ private:
     void recover_compositor_process();
     void crash_compositor_process();
     ErrorOr<void> launch_request_server();
+    void shutdown_request_server();
     ErrorOr<void> launch_image_decoder_server();
     ErrorOr<void> launch_devtools_server();
     ErrorOr<void> load_content_blocker_lists();

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -407,6 +407,9 @@ private:
     OwnPtr<Core::TimeZoneWatcher> m_time_zone_watcher;
 
     Core::EventLoop* m_event_loop { nullptr };
+#if !defined(AK_OS_WINDOWS)
+    Optional<int> m_termination_signal_handler;
+#endif
     OwnPtr<ProcessManager> m_process_manager;
 
     RefPtr<Action> m_reload_action;

--- a/Libraries/LibWebView/Process.h
+++ b/Libraries/LibWebView/Process.h
@@ -50,6 +50,7 @@ public:
     }
 
     pid_t pid() const { return m_process.pid(); }
+    ErrorOr<int> wait_for_termination() const { return m_process.wait_for_termination(); }
 
     ProcessOutputCapture& output_capture() { return m_output_capture; }
     ProcessOutputCapture const& output_capture() const { return m_output_capture; }

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -204,6 +204,12 @@ Messages::RequestServer::ConnectNewClientsResponse ConnectionFromClient::connect
     return handles;
 }
 
+void ConnectionFromClient::close_server()
+{
+    // FIXME: Wait for other clients to disconnect before exiting, rather than abandoning their in-flight requests.
+    Core::EventLoop::current().quit(0);
+}
+
 ErrorOr<IPC::TransportHandle> ConnectionFromClient::create_client_socket(IsPrivate is_private)
 {
     auto paired = TRY(IPC::Transport::create_paired());

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -54,6 +54,7 @@ private:
     virtual Messages::RequestServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client(IsPrivate) override;
     virtual Messages::RequestServer::ConnectNewClientsResponse connect_new_clients(size_t count, IsPrivate) override;
+    virtual void close_server() override;
 
     virtual void set_disk_cache_settings(HTTP::DiskCacheSettings) override;
 

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -16,6 +16,7 @@ endpoint RequestServer
     init_transport(int peer_pid) => (int peer_pid)
     connect_new_client(::RequestServer::IsPrivate is_private) => (IPC::TransportHandle handle)
     connect_new_clients(size_t count, ::RequestServer::IsPrivate is_private) => (Vector<IPC::TransportHandle> handles)
+    close_server() =|
 
     set_disk_cache_settings(HTTP::DiskCacheSettings disk_cache_settings) =|
 

--- a/Tests/LibHTTP/TestDiskCache.cpp
+++ b/Tests/LibHTTP/TestDiskCache.cpp
@@ -5,7 +5,11 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/LexicalPath.h>
+#include <LibCore/Directory.h>
+#include <LibCore/File.h>
 #include <LibCore/ImmutableBytes.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibHTTP/Cache/CacheRequest.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibHTTP/Cache/Utilities.h>
@@ -84,6 +88,52 @@ TEST_CASE(associated_data_round_trips_with_cache_entry)
 
     retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
     EXPECT(!retrieved_bytecode.has_value());
+}
+
+TEST_CASE(partitioned_cache_directory_is_removed_on_destruction)
+{
+    Optional<LexicalPath> cache_directory;
+
+    {
+        auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Partitioned));
+        cache_directory = disk_cache.cache_directory();
+
+        TestCacheRequest request;
+        auto url = parse_url("https://example.com/script.js"sv);
+        auto request_headers = create_cacheable_request_headers();
+        auto response_headers = create_cacheable_response_headers();
+
+        auto& writer = create_cache_entry(disk_cache, request, url, *request_headers);
+        TRY_OR_FAIL(writer.write_status_and_reason(200, "OK"_string, *request_headers, *response_headers));
+        TRY_OR_FAIL(writer.write_data("console.log('hello');"sv.bytes()));
+        TRY_OR_FAIL(writer.flush(request_headers, response_headers));
+
+        auto bytecode = TRY_OR_FAIL(ByteBuffer::copy("bytecode"sv.bytes()));
+        EXPECT(TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+        EXPECT(FileSystem::exists(cache_directory->string()));
+    }
+
+    VERIFY(cache_directory.has_value());
+    EXPECT(!FileSystem::exists(cache_directory->string()));
+}
+
+TEST_CASE(creating_partitioned_cache_removes_leftover_directory_contents)
+{
+    Optional<LexicalPath> cache_directory;
+
+    {
+        auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Partitioned));
+        cache_directory = disk_cache.cache_directory();
+    }
+
+    // Simulate a leftover directory from an earlier process that was assigned the same PID.
+    auto stale_file = cache_directory->append("stale-entry"sv);
+    TRY_OR_FAIL(Core::Directory::create(*cache_directory, Core::Directory::CreateDirectories::Yes));
+    (void)TRY_OR_FAIL(Core::File::open(stale_file.string(), Core::File::OpenMode::Write));
+
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Partitioned));
+    EXPECT(!FileSystem::exists(stale_file.string()));
+    EXPECT(FileSystem::exists(cache_directory->string()));
 }
 
 TEST_CASE(replacing_cache_entry_removes_associated_data)


### PR DESCRIPTION
We now store partitioned disk cache files in per-pid directories and ensure these directories are cleared when RequestServer shuts down.

This fixes an issue where the partitioned cache would grow unbounded. This was particularly noticeable when running a large amount of WPT tests, as each test would create duplicate `*.jsbc` cache files.