### PR TITLE
LibWeb: Track SVG use elements in a document list

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -206,6 +206,7 @@
 #include <LibWeb/SVG/SVGScriptElement.h>
 #include <LibWeb/SVG/SVGStyleElement.h>
 #include <LibWeb/SVG/SVGTitleElement.h>
+#include <LibWeb/SVG/SVGUseElement.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/TrustedTypes/RequireTrustedTypesForDirective.h>
 #include <LibWeb/TrustedTypes/TrustedTypePolicy.h>
@@ -4873,6 +4874,16 @@ void Document::unregister_document_observer(Badge<DocumentObserver>, DocumentObs
 {
     bool was_removed = m_document_observers.remove(document_observer);
     VERIFY(was_removed);
+}
+
+void Document::register_svg_use_element(Badge<SVG::SVGUseElement>, SVG::SVGUseElement& use_element)
+{
+    m_svg_use_elements.append(use_element);
+}
+
+void Document::unregister_svg_use_element(Badge<SVG::SVGUseElement>, SVG::SVGUseElement& use_element)
+{
+    m_svg_use_elements.remove(use_element);
 }
 
 void Document::increment_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -53,6 +53,7 @@
 #include <LibWeb/Painting/GridInspectorOverlay.h>
 #include <LibWeb/Painting/HitTestResult.h>
 #include <LibWeb/ResizeObserver/ResizeObserver.h>
+#include <LibWeb/SVG/SVGUseElement.h>
 #include <LibWeb/TrustedTypes/InjectionSink.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -659,6 +660,10 @@ public:
 
     void register_document_observer(Badge<DocumentObserver>, DocumentObserver&);
     void unregister_document_observer(Badge<DocumentObserver>, DocumentObserver&);
+
+    void register_svg_use_element(Badge<SVG::SVGUseElement>, SVG::SVGUseElement&);
+    void unregister_svg_use_element(Badge<SVG::SVGUseElement>, SVG::SVGUseElement&);
+    SVG::SVGUseElement::DocumentUseElementList& svg_use_elements() { return m_svg_use_elements; }
 
     template<typename Callback>
     void for_each_node_iterator(Callback callback)
@@ -1373,6 +1378,11 @@ private:
     // It's responsibility of object that requires DocumentObserver to keep it alive.
     HashTable<GC::RawRef<DocumentObserver>> m_document_observers;
     Vector<GC::Ref<DocumentObserver>> m_document_observers_being_notified;
+
+    // Every SVG use element connected to this document's node tree, maintained by SVGUseElement on insertion and
+    // removal. This lets SVG elements notify interested use elements about mutations without traversing the entire
+    // document. Not visited: registered elements are connected and thus kept alive by the tree.
+    SVG::SVGUseElement::DocumentUseElementList m_svg_use_elements;
 
     // https://html.spec.whatwg.org/multipage/dom.html#is-initial-about:blank
     bool m_is_initial_about_blank { false };

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -266,6 +266,10 @@ GC::Ptr<Element> ParentNode::get_element_by_id(FlyString const& id) const
             auto const& shadow_root = static_cast<ShadowRoot const&>(*this);
             return shadow_root.element_by_id().get(id, shadow_root);
         }
+        // The document element's inclusive subtree contains every element in the document, so the document's cache
+        // gives the same answer as walking our subtree.
+        if (auto const& document = this->document(); document.document_element() == this)
+            return document.element_by_id().get(id, document);
     }
 
     GC::Ptr<Element> found_element;

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -235,7 +235,7 @@ void SVGElement::update_use_elements_that_reference_this()
     if (is<SVGUseElement>(this)
         // If this element is in a shadow root, it already represents a clone and is not itself referenced.
         || is<DOM::ShadowRoot>(this->root())
-        // If this does not have an id it cannot be referenced, no point in searching the entire DOM tree.
+        // If this does not have an id it cannot be referenced, no point in notifying use elements.
         || !id().has_value()
         // An unconnected node cannot have valid references.
         // This also prevents searches for elements that are in the process of being constructed - as clones.
@@ -244,13 +244,12 @@ void SVGElement::update_use_elements_that_reference_this()
         return;
     }
 
-    document().for_each_in_subtree_of_type<SVGUseElement>([this](SVGUseElement& use_element) {
+    for (auto& use_element : document().svg_use_elements()) {
         if (document().is_completely_loaded())
             use_element.svg_element_changed(*this);
         else
             use_element.svg_element_changed_before_document_complete(*this);
-        return TraversalDecision::Continue;
-    });
+    }
 }
 
 void SVGElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
@@ -278,10 +277,15 @@ void SVGElement::remove_from_use_element_that_reference_this()
         return;
     }
 
-    document().for_each_in_subtree_of_type<SVGUseElement>([this](SVGUseElement& use_element) {
+    for (auto& use_element : document().svg_use_elements()) {
+        // Use elements that are part of the same subtree removal may still be registered, since removal hooks run
+        // after the subtree has been detached. They are no longer reachable from the document and should not be
+        // notified. NB: This must check the tree structure, not Node::is_connected(), because the connected flag of
+        // nodes later in tree order has not been updated yet when we get here.
+        if (!use_element.root().is_document())
+            continue;
         use_element.svg_element_removed(*this);
-        return TraversalDecision::Continue;
-    });
+    }
 }
 
 void SVGElement::adjust_computed_style(CSS::ComputedProperties& computed_properties)

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -74,6 +74,75 @@ void SVGUseElement::adopted_from(DOM::Document& old_document)
         m_load_event_delayer.emplace(document());
 }
 
+void SVGUseElement::inserted()
+{
+    Base::inserted();
+
+    // Only use elements in the document's node tree react to changes of the elements they reference, mirroring the
+    // document-wide traversal this registry replaced. A use element inside a shadow tree is itself part of a clone.
+    if (!root().is_document())
+        return;
+
+    register_for_referenced_element_changes();
+
+    // The insertion that connected us may have inserted our referenced element along with us, with its insertion
+    // steps running before ours, i.e. before we were registered to be notified about changes to it. If our shadow
+    // tree has not been populated yet, try resolving the reference again.
+    // NB: While the document is still loading, the document-completely-loaded hook repopulates empty shadow trees,
+    //     so there is nothing to do here in that case.
+    if (!instance_root() && document().is_completely_loaded()
+        && m_href.has_value() && m_href->fragment().has_value() && is_referenced_element_same_document()) {
+        clone_element_tree_as_our_shadow_tree(referenced_element());
+    }
+}
+
+void SVGUseElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
+{
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
+
+    if (old_root.is_document())
+        unregister_for_referenced_element_changes();
+}
+
+void SVGUseElement::moved_from(IsSubtreeRoot is_subtree_root, GC::Ptr<Node> old_ancestor)
+{
+    Base::moved_from(is_subtree_root, old_ancestor);
+
+    if (!old_ancestor)
+        return;
+
+    auto was_in_document_tree = old_ancestor->root().is_document();
+    auto is_in_document_tree = root().is_document();
+    if (was_in_document_tree == is_in_document_tree)
+        return;
+
+    if (was_in_document_tree) {
+        unregister_for_referenced_element_changes();
+        return;
+    }
+
+    register_for_referenced_element_changes();
+
+    if (!instance_root() && document().is_completely_loaded()
+        && m_href.has_value() && m_href->fragment().has_value() && is_referenced_element_same_document()) {
+        clone_element_tree_as_our_shadow_tree(referenced_element());
+    }
+}
+
+void SVGUseElement::register_for_referenced_element_changes()
+{
+    if (m_list_node.is_in_list())
+        return;
+    document().register_svg_use_element({}, *this);
+}
+
+void SVGUseElement::unregister_for_referenced_element_changes()
+{
+    if (!m_list_node.is_in_list())
+        return;
+    document().unregister_svg_use_element({}, *this);
+}
+
 void SVGUseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/IntrusiveList.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/DOM/DocumentObserver.h>
 #include <LibWeb/SVG/SVGAnimatedLength.h>
@@ -46,6 +47,9 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void adopted_from(DOM::Document&) override;
+    virtual void inserted() override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
+    virtual void moved_from(IsSubtreeRoot, GC::Ptr<Node> old_ancestor) override;
 
     virtual bool is_svg_use_element() const override { return true; }
 
@@ -64,6 +68,8 @@ private:
     bool is_valid_reference_element(Element const& reference_element) const;
     bool would_create_circular_reference(Element const& target) const;
     bool would_create_circular_reference_impl(Element const& target, GC::HeapHashTable<GC::Ref<Element const>>& visited) const;
+    void register_for_referenced_element_changes();
+    void unregister_for_referenced_element_changes();
 
     Optional<float> m_x;
     Optional<float> m_y;
@@ -74,6 +80,11 @@ private:
     GC::Ptr<DOM::DocumentObserver> m_document_observer;
     GC::Ptr<HTML::SharedResourceRequest> m_resource_request;
     Optional<DOM::DocumentLoadEventDelayer> m_load_event_delayer;
+
+    IntrusiveListNode<SVGUseElement> m_list_node;
+
+public:
+    using DocumentUseElementList = IntrusiveList<&SVGUseElement::m_list_node>;
 };
 
 }

--- a/Tests/LibWeb/Text/expected/SVG/use-element-inserted-together-with-referenced-element.txt
+++ b/Tests/LibWeb/Text/expected/SVG/use-element-inserted-together-with-referenced-element.txt
@@ -1,0 +1,2 @@
+Referenced element before use: has instance root: true
+Use before referenced element: has instance root: true

--- a/Tests/LibWeb/Text/expected/SVG/use-element-moveBefore-registry.txt
+++ b/Tests/LibWeb/Text/expected/SVG/use-element-moveBefore-registry.txt
@@ -1,0 +1,2 @@
+Use moved into shadow tree kept old fill: red
+Use moved into document tree updated fill: green

--- a/Tests/LibWeb/Text/input/SVG/use-element-inserted-together-with-referenced-element.html
+++ b/Tests/LibWeb/Text/input/SVG/use-element-inserted-together-with-referenced-element.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        const SVG_NS = "http://www.w3.org/2000/svg";
+
+        // Build a detached subtree that contains both a use element and the element it
+        // references. Since the referenced element is not connected yet, the reference
+        // cannot resolve at construction time.
+        function makeSubtree(id, order) {
+            const svg = document.createElementNS(SVG_NS, "svg");
+            svg.style.display = "none";
+            const symbol = document.createElementNS(SVG_NS, "symbol");
+            symbol.id = id;
+            const rect = document.createElementNS(SVG_NS, "rect");
+            rect.setAttribute("width", "10");
+            rect.setAttribute("height", "10");
+            symbol.appendChild(rect);
+            const use = document.createElementNS(SVG_NS, "use");
+            use.setAttribute("href", `#${id}`);
+            if (order === "use-first")
+                svg.append(use, symbol);
+            else
+                svg.append(symbol, use);
+            return { svg, use };
+        }
+
+        window.addEventListener("load", () => {
+            setTimeout(() => {
+                // Inserting the subtree must resolve the reference no matter which of the
+                // two elements has its insertion steps run first.
+                let { svg, use } = makeSubtree("targetBeforeUse", "target-first");
+                document.body.appendChild(svg);
+                println(`Referenced element before use: has instance root: ${!!use.instanceRoot}`);
+
+                ({ svg, use } = makeSubtree("useBeforeTarget", "use-first"));
+                document.body.appendChild(svg);
+                println(`Use before referenced element: has instance root: ${!!use.instanceRoot}`);
+
+                done();
+            }, 0);
+        }, { once: true });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/SVG/use-element-moveBefore-registry.html
+++ b/Tests/LibWeb/Text/input/SVG/use-element-moveBefore-registry.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        const SVG_NS = "http://www.w3.org/2000/svg";
+
+        function createSVGElement(localName) {
+            return document.createElementNS(SVG_NS, localName);
+        }
+
+        function createReferencedUse(id, fill) {
+            const svg = createSVGElement("svg");
+            svg.style.display = "none";
+
+            const source = createSVGElement("rect");
+            source.id = id;
+            source.setAttribute("width", "10");
+            source.setAttribute("height", "10");
+            source.setAttribute("fill", fill);
+
+            const use = createSVGElement("use");
+            use.setAttribute("href", `#${id}`);
+
+            svg.append(source, use);
+            document.body.appendChild(svg);
+            return { source, svg, use };
+        }
+
+        window.addEventListener("load", () => {
+            setTimeout(() => {
+                {
+                    const { source, use } = createReferencedUse("moveOutSource", "red");
+                    const host = document.createElement("div");
+                    document.body.appendChild(host);
+                    host.attachShadow({ mode: "open" });
+
+                    host.shadowRoot.moveBefore(use, null);
+                    source.setAttribute("fill", "green");
+
+                    println(`Use moved into shadow tree kept old fill: ${use.instanceRoot.getAttribute("fill")}`);
+                }
+
+                {
+                    const { source, svg, use } = createReferencedUse("moveInSource", "red");
+                    const host = document.createElement("div");
+                    document.body.appendChild(host);
+                    host.attachShadow({ mode: "open" });
+
+                    host.shadowRoot.appendChild(use);
+                    svg.moveBefore(use, null);
+                    source.setAttribute("fill", "green");
+
+                    println(`Use moved into document tree updated fill: ${use.instanceRoot.getAttribute("fill")}`);
+                }
+
+                done();
+            }, 0);
+        }, { once: true });
+    });
+</script>


### PR DESCRIPTION
This replaces document-wide SVG scans for `<use>` invalidation with a per-document intrusive list of connected `SVGUseElement`s. This avoids repeatedly walking large SVG documents when SVG elements are inserted, removed, or changed.

The change also handles the edge cases needed to keep the list correct:

- re-resolves `<use>` elements inserted together with their referenced element
- updates list membership for `moveBefore()` across document and shadow roots
- skips stale registered `<use>` entries during subtree removal

Adds text coverage for subtree insertion order and `moveBefore()` document/shadow-root moves.

This shaves 1 second off of the https://chatgpt.com/ load time on my Linux machine.