### PR TITLE
DevTools: Add localStorage and sessionStorage support

### DIFF
--- a/Libraries/LibDevTools/Actors/CookiesActor.cpp
+++ b/Libraries/LibDevTools/Actors/CookiesActor.cpp
@@ -81,26 +81,6 @@ static bool cookie_matches_requested_domain(HTTP::Cookie::Cookie const& cookie, 
     return cookie.domain == *domain;
 }
 
-static JsonObject cookie_operation_result(Optional<String> error_string)
-{
-    JsonObject response;
-    if (error_string.has_value())
-        response.set("errorString"sv, *error_string);
-    else
-        response.set("errorString"sv, JsonValue {});
-    return response;
-}
-
-static JsonObject cookie_operation_result(ErrorOr<void> result)
-{
-    JsonObject response;
-    if (result.is_error())
-        response.set("errorString"sv, result.error().string_literal());
-    else
-        response.set("errorString"sv, JsonValue {});
-    return response;
-}
-
 static String same_site_for_devtools(HTTP::Cookie::SameSite same_site)
 {
     if (same_site == HTTP::Cookie::SameSite::Default)
@@ -420,7 +400,7 @@ void CookiesActor::edit_item(Message const& message)
 
     auto new_value = string_from_devtools_value(*new_value_json);
     if (!new_value.has_value()) {
-        send_response(message, cookie_operation_result("Missing cookie value"_string));
+        send_response(message, to_storage_operation_result("Missing cookie value"_string));
         return;
     }
 
@@ -477,7 +457,7 @@ void CookiesActor::edit_item(Message const& message)
     }
 
     if (!old_cookie.has_value()) {
-        send_response(message, cookie_operation_result(Optional<String> {}));
+        send_response(message, to_storage_operation_result(Optional<String> {}));
         return;
     }
 
@@ -493,32 +473,32 @@ void CookiesActor::edit_item(Message const& message)
         edited_cookie.path = new_value.release_value();
     } else if (*field == "expires"sv) {
         if (auto error_string = set_cookie_expiry_from_devtools(edited_cookie, *new_value_json, new_value->bytes_as_string_view()); error_string.has_value()) {
-            send_response(message, cookie_operation_result(move(error_string)));
+            send_response(message, to_storage_operation_result(move(error_string)));
             return;
         }
     } else if (*field == "isSecure"sv) {
         auto value = bool_from_devtools_value(*new_value_json);
         if (!value.has_value()) {
-            send_response(message, cookie_operation_result("Cookie secure flag must be true or false"_string));
+            send_response(message, to_storage_operation_result("Cookie secure flag must be true or false"_string));
             return;
         }
         edited_cookie.secure = *value;
     } else if (*field == "isHttpOnly"sv) {
         auto value = bool_from_devtools_value(*new_value_json);
         if (!value.has_value()) {
-            send_response(message, cookie_operation_result("Cookie HTTP-only flag must be true or false"_string));
+            send_response(message, to_storage_operation_result("Cookie HTTP-only flag must be true or false"_string));
             return;
         }
         edited_cookie.http_only = *value;
     } else if (*field == "sameSite"sv) {
         edited_cookie.same_site = HTTP::Cookie::same_site_from_string(new_value->bytes_as_string_view());
     } else {
-        send_response(message, cookie_operation_result(Optional<String> {}));
+        send_response(message, to_storage_operation_result(Optional<String> {}));
         return;
     }
 
     auto result = devtools().delegate().set_cookie(tab->description(), old_cookie, move(edited_cookie));
-    send_response(message, cookie_operation_result(move(result)));
+    send_response(message, to_storage_operation_result(move(result)));
 }
 
 void CookiesActor::add_item(Message const& message)
@@ -530,14 +510,14 @@ void CookiesActor::add_item(Message const& message)
     auto storage_host = message.data.get_string("host"sv)
                             .value_or_lazy_evaluated_optional([this] { return host(); });
     if (!storage_host.has_value()) {
-        send_response(message, cookie_operation_result("No storage host is available for this page"_string));
+        send_response(message, to_storage_operation_result("No storage host is available for this page"_string));
         return;
     }
 
     auto storage_url = URL::Parser::basic_parse(*storage_host);
     auto host_name = storage_host_name(*storage_host);
     if (!storage_url.has_value() || !host_name.has_value()) {
-        send_response(message, cookie_operation_result("Cannot add a cookie for this storage host"_string));
+        send_response(message, to_storage_operation_result("Cannot add a cookie for this storage host"_string));
         return;
     }
 
@@ -560,7 +540,7 @@ void CookiesActor::add_item(Message const& message)
     cookie.host_only = true;
 
     auto result = devtools().delegate().set_cookie(tab->description(), {}, move(cookie));
-    send_response(message, cookie_operation_result(move(result)));
+    send_response(message, to_storage_operation_result(result));
 }
 
 void CookiesActor::remove_item(Message const& message)

--- a/Libraries/LibDevTools/Actors/StorageActor.cpp
+++ b/Libraries/LibDevTools/Actors/StorageActor.cpp
@@ -33,6 +33,19 @@ static JsonObject serialize_storage_item(DevToolsDelegate::StorageItem const& it
     return object;
 }
 
+static Optional<String> string_from_devtools_value(JsonValue const& value)
+{
+    if (value.is_string())
+        return value.as_string();
+    if (value.is_bool())
+        return value.as_bool() ? "true"_string : "false"_string;
+    if (value.is_number())
+        return MUST(String::formatted("{}", value.get_number_with_precision_loss<double>().release_value()));
+    if (value.is_null())
+        return {};
+    return value.serialized();
+}
+
 NonnullRefPtr<StorageActor> StorageActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, Web::StorageAPI::StorageEndpointType storage_endpoint)
 {
     return adopt_ref(*new StorageActor(devtools, move(name), move(tab), storage_endpoint));
@@ -119,6 +132,26 @@ void StorageActor::handle_message(Message const& message)
 
     if (message.type == "getStoreObjects"sv) {
         get_store_objects(message);
+        return;
+    }
+
+    if (message.type == "editItem"sv) {
+        edit_item(message);
+        return;
+    }
+
+    if (message.type == "addItem"sv) {
+        add_item(message);
+        return;
+    }
+
+    if (message.type == "removeItem"sv) {
+        remove_item(message);
+        return;
+    }
+
+    if (message.type == "removeAll"sv) {
+        remove_all(message);
         return;
     }
 
@@ -213,6 +246,163 @@ void StorageActor::send_store_objects(Message const& message, Optional<String> r
     response.set("total"sv, total);
     response.set("data"sv, move(data));
     send_response(message, move(response));
+}
+
+void StorageActor::edit_item(Message const& message)
+{
+    auto data = get_required_parameter<JsonObject>(message, "data"sv);
+    if (!data.has_value())
+        return;
+
+    auto requested_host = data->get_string("host"sv);
+    if (!requested_host.has_value()) {
+        send_missing_parameter_error(message, "host"sv);
+        return;
+    }
+
+    if (!host().has_value() || *host() != *requested_host) {
+        send_response(message, to_storage_operation_result(Error::from_string_literal("Storage host is not available")));
+        return;
+    }
+
+    auto field = data->get_string("field"sv);
+    if (!field.has_value()) {
+        send_missing_parameter_error(message, "field"sv);
+        return;
+    }
+
+    auto items = data->get_object("items"sv);
+    if (!items.has_value()) {
+        send_missing_parameter_error(message, "items"sv);
+        return;
+    }
+
+    auto key = items->get_string("name"sv);
+    if (!key.has_value()) {
+        send_missing_parameter_error(message, "items.name"sv);
+        return;
+    }
+
+    auto value_json = items->get("value"sv);
+    if (!value_json.has_value()) {
+        send_missing_parameter_error(message, "items.value"sv);
+        return;
+    }
+
+    auto value = string_from_devtools_value(*value_json);
+    if (!value.has_value()) {
+        send_response(message, to_storage_operation_result(Error::from_string_literal("Missing storage value")));
+        return;
+    }
+
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return;
+
+    if (*field == "name"sv) {
+        auto old_value_json = data->get("oldValue"sv);
+        if (!old_value_json.has_value()) {
+            send_missing_parameter_error(message, "oldValue"sv);
+            return;
+        }
+
+        auto old_key = string_from_devtools_value(*old_value_json);
+        if (!old_key.has_value()) {
+            send_response(message, to_storage_operation_result(Error::from_string_literal("Missing old storage key")));
+            return;
+        }
+
+        if (*old_key != *key) {
+            auto remove_result = devtools().delegate().remove_storage_item(tab->description(), m_storage_endpoint, *requested_host, *old_key);
+            if (remove_result.is_error()) {
+                send_response(message, to_storage_operation_result(remove_result.release_error()));
+                return;
+            }
+        }
+    }
+
+    auto result = devtools().delegate().set_storage_item(tab->description(), m_storage_endpoint, *requested_host, *key, *value);
+    if (result.is_error())
+        send_response(message, to_storage_operation_result(result.release_error()));
+    else
+        send_response(message, to_storage_operation_result(ErrorOr<void> {}));
+}
+
+void StorageActor::add_item(Message const& message)
+{
+    auto guid = get_required_parameter<String>(message, "guid"sv);
+    if (!guid.has_value())
+        return;
+
+    auto requested_host = message.data.get_string("host"sv)
+                              .value_or_lazy_evaluated_optional([this] { return host(); });
+    if (!requested_host.has_value()) {
+        send_response(message, to_storage_operation_result(Error::from_string_literal("No storage host is available for this page")));
+        return;
+    }
+
+    if (!host().has_value() || *host() != *requested_host) {
+        send_response(message, to_storage_operation_result(Error::from_string_literal("Storage host is not available")));
+        return;
+    }
+
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return;
+
+    auto result = devtools().delegate().set_storage_item(tab->description(), m_storage_endpoint, *requested_host, *guid, "value"_string);
+    if (result.is_error())
+        send_response(message, to_storage_operation_result(result.release_error()));
+    else
+        send_response(message, to_storage_operation_result(ErrorOr<void> {}));
+}
+
+void StorageActor::remove_item(Message const& message)
+{
+    auto requested_host = get_required_parameter<String>(message, "host"sv);
+    if (!requested_host.has_value())
+        return;
+
+    auto name = get_required_parameter<String>(message, "name"sv);
+    if (!name.has_value())
+        return;
+
+    if (!host().has_value() || *host() != *requested_host) {
+        send_response(message, {});
+        return;
+    }
+
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return;
+
+    auto result = devtools().delegate().remove_storage_item(tab->description(), m_storage_endpoint, *requested_host, *name);
+    if (result.is_error())
+        send_response(message, to_storage_operation_result(result.release_error()));
+    else
+        send_response(message, {});
+}
+
+void StorageActor::remove_all(Message const& message)
+{
+    auto requested_host = get_required_parameter<String>(message, "host"sv);
+    if (!requested_host.has_value())
+        return;
+
+    if (!host().has_value() || *host() != *requested_host) {
+        send_response(message, {});
+        return;
+    }
+
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return;
+
+    auto result = devtools().delegate().clear_storage(tab->description(), m_storage_endpoint, *requested_host);
+    if (result.is_error())
+        send_response(message, to_storage_operation_result(result.release_error()));
+    else
+        send_response(message, {});
 }
 
 void StorageActor::on_storage_changed(DevToolsDelegate::StorageChange change)

--- a/Libraries/LibDevTools/Actors/StorageActor.cpp
+++ b/Libraries/LibDevTools/Actors/StorageActor.cpp
@@ -43,9 +43,23 @@ StorageActor::StorageActor(DevToolsServer& devtools, String name, WeakPtr<TabAct
     , m_tab(move(tab))
     , m_storage_endpoint(storage_endpoint)
 {
+    if (auto tab = m_tab.strong_ref()) {
+        m_storage_change_listener_id = devtools.delegate().add_storage_change_listener(
+            tab->description(),
+            weak_callback(*this, [](auto& self, DevToolsDelegate::StorageChange change) {
+                self.on_storage_changed(move(change));
+            }));
+    }
 }
 
-StorageActor::~StorageActor() = default;
+StorageActor::~StorageActor()
+{
+    if (m_storage_change_listener_id == 0)
+        return;
+
+    if (auto tab = m_tab.strong_ref())
+        devtools().delegate().remove_storage_change_listener(tab->description(), m_storage_change_listener_id);
+}
 
 StringView StorageActor::resource_type() const
 {
@@ -199,6 +213,75 @@ void StorageActor::send_store_objects(Message const& message, Optional<String> r
     response.set("total"sv, total);
     response.set("data"sv, move(data));
     send_response(message, move(response));
+}
+
+void StorageActor::on_storage_changed(DevToolsDelegate::StorageChange change)
+{
+    if (change.storage_endpoint != m_storage_endpoint)
+        return;
+
+    auto storage_host = host();
+    if (!storage_host.has_value() || *storage_host != change.host)
+        return;
+
+    if (change.type == DevToolsDelegate::StorageChange::Type::Cleared) {
+        send_store_cleared(change);
+        return;
+    }
+
+    if (!change.key.has_value())
+        return;
+
+    send_store_update(change);
+}
+
+void StorageActor::send_store_update(DevToolsDelegate::StorageChange const& change)
+{
+    StringView update_type;
+    switch (change.type) {
+    case DevToolsDelegate::StorageChange::Type::Added:
+        update_type = "added"sv;
+        break;
+    case DevToolsDelegate::StorageChange::Type::Changed:
+        update_type = "changed"sv;
+        break;
+    case DevToolsDelegate::StorageChange::Type::Deleted:
+        update_type = "deleted"sv;
+        break;
+    case DevToolsDelegate::StorageChange::Type::Cleared:
+        VERIFY_NOT_REACHED();
+    }
+
+    JsonArray keys;
+    keys.must_append(*change.key);
+
+    JsonObject hosts;
+    hosts.set(change.host, move(keys));
+
+    JsonObject storage_updates;
+    storage_updates.set(resource_key(), move(hosts));
+
+    JsonObject data;
+    data.set(update_type, move(storage_updates));
+
+    JsonObject message;
+    message.set("type"sv, "storesUpdate"sv);
+    message.set("data"sv, move(data));
+    send_message(move(message));
+}
+
+void StorageActor::send_store_cleared(DevToolsDelegate::StorageChange const& change)
+{
+    JsonArray hosts;
+    hosts.must_append(change.host);
+
+    JsonObject data;
+    data.set("clearedHostsOrPaths"sv, move(hosts));
+
+    JsonObject message;
+    message.set("type"sv, "storesCleared"sv);
+    message.set("data"sv, move(data));
+    send_message(move(message));
 }
 
 }

--- a/Libraries/LibDevTools/Actors/StorageActor.cpp
+++ b/Libraries/LibDevTools/Actors/StorageActor.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/QuickSort.h>
+#include <LibDevTools/Actors/StorageActor.h>
+#include <LibDevTools/Actors/TabActor.h>
+#include <LibDevTools/DevToolsDelegate.h>
+#include <LibDevTools/DevToolsServer.h>
+#include <LibDevTools/StorageHelpers.h>
+
+namespace DevTools {
+
+static constexpr auto max_store_object_count = 50uz;
+
+static JsonObject storage_field(StringView name)
+{
+    JsonObject field;
+    field.set("name"sv, name);
+    field.set("editable"sv, true);
+    return field;
+}
+
+static JsonObject serialize_storage_item(DevToolsDelegate::StorageItem const& item)
+{
+    JsonObject object;
+    object.set("name"sv, item.name);
+    object.set("value"sv, item.value);
+    return object;
+}
+
+NonnullRefPtr<StorageActor> StorageActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, Web::StorageAPI::StorageEndpointType storage_endpoint)
+{
+    return adopt_ref(*new StorageActor(devtools, move(name), move(tab), storage_endpoint));
+}
+
+StorageActor::StorageActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, Web::StorageAPI::StorageEndpointType storage_endpoint)
+    : Actor(devtools, move(name))
+    , m_tab(move(tab))
+    , m_storage_endpoint(storage_endpoint)
+{
+}
+
+StorageActor::~StorageActor() = default;
+
+StringView StorageActor::resource_type() const
+{
+    if (m_storage_endpoint == Web::StorageAPI::StorageEndpointType::LocalStorage)
+        return "local-storage"sv;
+    VERIFY(m_storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage);
+    return "session-storage"sv;
+}
+
+StringView StorageActor::resource_key() const
+{
+    if (m_storage_endpoint == Web::StorageAPI::StorageEndpointType::LocalStorage)
+        return "localStorage"sv;
+    VERIFY(m_storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage);
+    return "sessionStorage"sv;
+}
+
+Optional<String> StorageActor::host() const
+{
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return {};
+    return storage_host_for_url(tab->description().url);
+}
+
+JsonObject StorageActor::serialize_storage() const
+{
+    JsonObject hosts;
+    if (auto storage_host = host(); storage_host.has_value())
+        hosts.set(*storage_host, JsonArray {});
+
+    JsonObject traits;
+    traits.set("supportsAddItem"sv, true);
+    traits.set("supportsRemoveAll"sv, true);
+    traits.set("supportsRemoveAllSessionCookies"sv, false);
+    traits.set("supportsRemoveItem"sv, true);
+
+    JsonObject storage;
+    storage.set("actor"sv, name());
+    if (auto tab = m_tab.strong_ref()) {
+        storage.set("browsingContextID"sv, tab->description().id);
+        storage.set("innerWindowId"sv, tab->inner_window_id());
+        storage.set("resourceId"sv, MUST(String::formatted("{}-{}", resource_key(), tab->inner_window_id())));
+    }
+    storage.set("hosts"sv, move(hosts));
+    storage.set("resourceKey"sv, resource_key());
+    storage.set("traits"sv, move(traits));
+    return storage;
+}
+
+void StorageActor::handle_message(Message const& message)
+{
+    if (message.type == "getFields"sv) {
+        get_fields(message);
+        return;
+    }
+
+    if (message.type == "getStoreObjects"sv) {
+        get_store_objects(message);
+        return;
+    }
+
+    send_unrecognized_packet_type_error(message);
+}
+
+void StorageActor::get_fields(Message const& message)
+{
+    JsonArray fields;
+    fields.must_append(storage_field("name"sv));
+    fields.must_append(storage_field("value"sv));
+
+    JsonObject response;
+    response.set("value"sv, move(fields));
+    send_response(message, move(response));
+}
+
+void StorageActor::get_store_objects(Message const& message)
+{
+    auto requested_host_ref = get_required_parameter<String>(message, "host"sv);
+    if (!requested_host_ref.has_value())
+        return;
+    String requested_host = *requested_host_ref;
+
+    auto names_value = message.data.get("names"sv);
+    Optional<JsonArray> requested_names;
+    if (names_value.has_value() && names_value->is_array())
+        requested_names = names_value->as_array();
+
+    JsonObject options;
+    auto options_value = message.data.get("options"sv);
+    if (options_value.has_value() && options_value->is_object())
+        options = options_value->as_object();
+
+    auto tab = m_tab.strong_ref();
+    if (!tab) {
+        send_store_objects(message, requested_host, move(requested_names), move(options), Vector<DevToolsDelegate::StorageItem> {});
+        return;
+    }
+
+    devtools().delegate().inspect_storage(
+        tab->description(),
+        m_storage_endpoint,
+        weak_callback(*this, [message, requested_host, requested_names, options](auto& self, ErrorOr<Vector<DevToolsDelegate::StorageItem>> storage_items) {
+            self.send_store_objects(message, requested_host, requested_names, options, move(storage_items));
+        }));
+}
+
+void StorageActor::send_store_objects(Message const& message, Optional<String> requested_host, Optional<JsonArray> requested_names, JsonObject options, ErrorOr<Vector<DevToolsDelegate::StorageItem>> storage_items_or_error)
+{
+    if (storage_items_or_error.is_error()) {
+        JsonObject response;
+        response.set("error"sv, "storageError"sv);
+        response.set("message"sv, storage_items_or_error.error().string_literal());
+        send_response(message, move(response));
+        return;
+    }
+
+    Vector<DevToolsDelegate::StorageItem> storage_items = storage_items_or_error.release_value();
+    if (!host().has_value() || !requested_host.has_value() || *host() != *requested_host)
+        storage_items.clear();
+
+    if (requested_names.has_value()) {
+        storage_items.remove_all_matching([&](auto const& item) {
+            return !requested_names->values().contains([&](auto const& value) {
+                return value.is_string() && value.as_string() == item.name;
+            });
+        });
+    }
+
+    quick_sort(storage_items, [](auto const& a, auto const& b) {
+        return a.name < b.name;
+    });
+
+    auto total = storage_items.size();
+    auto offset = options.get_integer<size_t>("offset"sv).value_or(0);
+    auto size = options.get_integer<size_t>("size"sv).value_or(max_store_object_count);
+    if (size > max_store_object_count)
+        size = max_store_object_count;
+
+    JsonArray data;
+    if (offset > total) {
+        offset = total;
+    } else {
+        auto end = min(total, offset + size);
+        for (auto i = offset; i < end; ++i)
+            data.must_append(serialize_storage_item(storage_items[i]));
+    }
+
+    JsonObject response;
+    response.set("offset"sv, offset);
+    response.set("total"sv, total);
+    response.set("data"sv, move(data));
+    send_response(message, move(response));
+}
+
+}

--- a/Libraries/LibDevTools/Actors/StorageActor.h
+++ b/Libraries/LibDevTools/Actors/StorageActor.h
@@ -25,6 +25,7 @@ public:
     StringView resource_key() const;
     Optional<String> host() const;
     JsonObject serialize_storage() const;
+    void on_storage_changed(DevToolsDelegate::StorageChange);
 
 private:
     StorageActor(DevToolsServer&, String name, WeakPtr<TabActor>, Web::StorageAPI::StorageEndpointType);
@@ -34,9 +35,12 @@ private:
     void get_fields(Message const&);
     void get_store_objects(Message const&);
     void send_store_objects(Message const&, Optional<String> requested_host, Optional<JsonArray> requested_names, JsonObject options, ErrorOr<Vector<DevToolsDelegate::StorageItem>>);
+    void send_store_update(DevToolsDelegate::StorageChange const&);
+    void send_store_cleared(DevToolsDelegate::StorageChange const&);
 
     WeakPtr<TabActor> m_tab;
     Web::StorageAPI::StorageEndpointType m_storage_endpoint;
+    u64 m_storage_change_listener_id { 0 };
 };
 
 }

--- a/Libraries/LibDevTools/Actors/StorageActor.h
+++ b/Libraries/LibDevTools/Actors/StorageActor.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonArray.h>
+#include <LibDevTools/Actor.h>
+#include <LibDevTools/DevToolsDelegate.h>
+#include <LibDevTools/Forward.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
+
+namespace DevTools {
+
+class DEVTOOLS_API StorageActor final : public Actor {
+public:
+    static constexpr auto base_name = "storage"sv;
+
+    static NonnullRefPtr<StorageActor> create(DevToolsServer&, String name, WeakPtr<TabActor>, Web::StorageAPI::StorageEndpointType);
+    virtual ~StorageActor() override;
+
+    StringView resource_type() const;
+    StringView resource_key() const;
+    Optional<String> host() const;
+    JsonObject serialize_storage() const;
+
+private:
+    StorageActor(DevToolsServer&, String name, WeakPtr<TabActor>, Web::StorageAPI::StorageEndpointType);
+
+    virtual void handle_message(Message const&) override;
+
+    void get_fields(Message const&);
+    void get_store_objects(Message const&);
+    void send_store_objects(Message const&, Optional<String> requested_host, Optional<JsonArray> requested_names, JsonObject options, ErrorOr<Vector<DevToolsDelegate::StorageItem>>);
+
+    WeakPtr<TabActor> m_tab;
+    Web::StorageAPI::StorageEndpointType m_storage_endpoint;
+};
+
+}

--- a/Libraries/LibDevTools/Actors/StorageActor.h
+++ b/Libraries/LibDevTools/Actors/StorageActor.h
@@ -34,6 +34,10 @@ private:
 
     void get_fields(Message const&);
     void get_store_objects(Message const&);
+    void edit_item(Message const&);
+    void add_item(Message const&);
+    void remove_item(Message const&);
+    void remove_all(Message const&);
     void send_store_objects(Message const&, Optional<String> requested_host, Optional<JsonArray> requested_names, JsonObject options, ErrorOr<Vector<DevToolsDelegate::StorageItem>>);
     void send_store_update(DevToolsDelegate::StorageChange const&);
     void send_store_cleared(DevToolsDelegate::StorageChange const&);

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -14,6 +14,7 @@
 #include <LibDevTools/Actors/FrameActor.h>
 #include <LibDevTools/Actors/InspectorActor.h>
 #include <LibDevTools/Actors/NetworkParentActor.h>
+#include <LibDevTools/Actors/StorageActor.h>
 #include <LibDevTools/Actors/StyleSheetsActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/TargetConfigurationActor.h>
@@ -91,11 +92,13 @@ void WatcherActor::handle_message(Message const& message)
             return;
 
         bool should_send_cookie_resources = false;
+        bool should_send_local_storage_resources = false;
+        bool should_send_session_storage_resources = false;
         if constexpr (DEVTOOLS_DEBUG) {
             for (auto const& resource_type : resource_types->values()) {
                 if (!resource_type.is_string())
                     continue;
-                if (resource_type.as_string() != "console-message"sv && resource_type.as_string() != "cookies"sv)
+                if (!first_is_one_of(resource_type.as_string(), "console-message"sv, "cookies"sv, "local-storage"sv, "session-storage"sv))
                     dbgln("Unrecognized `watchResources` resource type: '{}'", resource_type.as_string());
             }
         }
@@ -105,12 +108,22 @@ void WatcherActor::handle_message(Message const& message)
             if (resource_type.as_string() == "cookies"sv) {
                 m_is_watching_cookie_resources = true;
                 should_send_cookie_resources = true;
+            } else if (resource_type.as_string() == "local-storage"sv) {
+                m_is_watching_local_storage_resources = true;
+                should_send_local_storage_resources = true;
+            } else if (resource_type.as_string() == "session-storage"sv) {
+                m_is_watching_session_storage_resources = true;
+                should_send_session_storage_resources = true;
             }
         }
 
         send_response(message, move(response));
         if (should_send_cookie_resources)
             send_cookies_resource_available_message();
+        if (should_send_local_storage_resources)
+            send_storage_resource_available_message(local_storage_actor());
+        if (should_send_session_storage_resources)
+            send_storage_resource_available_message(session_storage_actor());
         return;
     }
 
@@ -155,13 +168,13 @@ JsonObject WatcherActor::serialize_description() const
     resources.set("jstracer-state"sv, false);
     resources.set("jstracer-trace"sv, false);
     resources.set("last-private-context-exit"sv, false);
-    resources.set("local-storage"sv, false);
+    resources.set("local-storage"sv, true);
     resources.set("network-event"sv, true);
     resources.set("network-event-stacktrace"sv, false);
     resources.set("platform-message"sv, false);
     resources.set("reflow"sv, false);
     resources.set("server-sent-event"sv, false);
-    resources.set("session-storage"sv, false);
+    resources.set("session-storage"sv, true);
     resources.set("source"sv, false);
     resources.set("stylesheet"sv, false);
     resources.set("thread-state"sv, false);
@@ -214,6 +227,10 @@ void WatcherActor::switch_frame_target(FrameActor& previous_target, String const
     target.set_pending_navigation_document_events_after_target_switch(url, title);
     if (m_is_watching_cookie_resources)
         send_cookies_resource_available_message();
+    if (m_is_watching_local_storage_resources)
+        send_storage_resource_available_message(local_storage_actor());
+    if (m_is_watching_session_storage_resources)
+        send_storage_resource_available_message(session_storage_actor());
 }
 
 void WatcherActor::send_frame_target_available_message(FrameActor& target)
@@ -257,6 +274,42 @@ void WatcherActor::send_cookies_resource_available_message()
 
     JsonArray array;
     array.must_append(move(cookie_resources));
+
+    JsonObject message;
+    message.set("type"sv, "resources-available-array"sv);
+    message.set("array"sv, move(array));
+    send_message(move(message));
+}
+
+StorageActor& WatcherActor::local_storage_actor()
+{
+    if (auto storage = m_local_storage.strong_ref())
+        return *storage;
+
+    m_local_storage = devtools().register_actor<StorageActor>(m_tab, Web::StorageAPI::StorageEndpointType::LocalStorage);
+    return *m_local_storage.strong_ref();
+}
+
+StorageActor& WatcherActor::session_storage_actor()
+{
+    if (auto storage = m_session_storage.strong_ref())
+        return *storage;
+
+    m_session_storage = devtools().register_actor<StorageActor>(m_tab, Web::StorageAPI::StorageEndpointType::SessionStorage);
+    return *m_session_storage.strong_ref();
+}
+
+void WatcherActor::send_storage_resource_available_message(StorageActor& storage)
+{
+    JsonArray resources;
+    resources.must_append(storage.serialize_storage());
+
+    JsonArray typed_resources;
+    typed_resources.must_append(storage.resource_type());
+    typed_resources.must_append(move(resources));
+
+    JsonArray array;
+    array.must_append(move(typed_resources));
 
     JsonObject message;
     message.set("type"sv, "resources-available-array"sv);

--- a/Libraries/LibDevTools/Actors/WatcherActor.h
+++ b/Libraries/LibDevTools/Actors/WatcherActor.h
@@ -33,15 +33,22 @@ private:
     void send_frame_target_destroyed_message(FrameActor&);
     CookiesActor& cookies_actor();
     void send_cookies_resource_available_message();
+    StorageActor& local_storage_actor();
+    StorageActor& session_storage_actor();
+    void send_storage_resource_available_message(StorageActor&);
 
     WeakPtr<TabActor> m_tab;
     WeakPtr<FrameActor> m_target;
     WeakPtr<CookiesActor> m_cookies;
+    WeakPtr<StorageActor> m_local_storage;
+    WeakPtr<StorageActor> m_session_storage;
     WeakPtr<TargetConfigurationActor> m_target_configuration;
     WeakPtr<ThreadConfigurationActor> m_thread_configuration;
     WeakPtr<NetworkParentActor> m_network_parent;
     bool m_is_watching_frame_targets { false };
     bool m_is_watching_cookie_resources { false };
+    bool m_is_watching_local_storage_resources { false };
+    bool m_is_watching_session_storage_resources { false };
 };
 
 }

--- a/Libraries/LibDevTools/CMakeLists.txt
+++ b/Libraries/LibDevTools/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     Actors/RootActor.cpp
     Actors/StyleRuleActor.cpp
     Actors/StyleSheetsActor.cpp
+    Actors/StorageActor.cpp
     Actors/TabActor.cpp
     Actors/TargetConfigurationActor.cpp
     Actors/ThreadActor.cpp

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -24,6 +24,7 @@
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
 
@@ -44,6 +45,14 @@ public:
     using OnHostCookieChange = Function<void(Vector<HTTP::Cookie::Cookie>)>;
     virtual void listen_for_host_cookie_changes(TabDescription const&, OnHostCookieChange) const { }
     virtual void stop_listening_for_host_cookie_changes(TabDescription const&) const { }
+
+    struct StorageItem {
+        String name;
+        String value;
+    };
+
+    using OnStorageItemsReceived = Function<void(ErrorOr<Vector<StorageItem>>)>;
+    virtual void inspect_storage(TabDescription const&, Web::StorageAPI::StorageEndpointType, OnStorageItemsReceived) const { }
 
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -54,6 +54,24 @@ public:
     using OnStorageItemsReceived = Function<void(ErrorOr<Vector<StorageItem>>)>;
     virtual void inspect_storage(TabDescription const&, Web::StorageAPI::StorageEndpointType, OnStorageItemsReceived) const { }
 
+    struct StorageChange {
+        enum class Type : u8 {
+            Added,
+            Changed,
+            Deleted,
+            Cleared,
+        };
+
+        Web::StorageAPI::StorageEndpointType storage_endpoint;
+        String host;
+        Type type;
+        Optional<String> key;
+    };
+
+    using OnStorageChange = Function<void(StorageChange)>;
+    virtual u64 add_storage_change_listener(TabDescription const&, OnStorageChange) const { return 0; }
+    virtual void remove_storage_change_listener(TabDescription const&, u64) const { }
+
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }
 

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -53,6 +53,9 @@ public:
 
     using OnStorageItemsReceived = Function<void(ErrorOr<Vector<StorageItem>>)>;
     virtual void inspect_storage(TabDescription const&, Web::StorageAPI::StorageEndpointType, OnStorageItemsReceived) const { }
+    virtual ErrorOr<Optional<String>> set_storage_item(TabDescription const&, Web::StorageAPI::StorageEndpointType, String const&, String const&, String const&) const { return Optional<String> {}; }
+    virtual ErrorOr<Optional<String>> remove_storage_item(TabDescription const&, Web::StorageAPI::StorageEndpointType, String const&, String const&) const { return Optional<String> {}; }
+    virtual ErrorOr<void> clear_storage(TabDescription const&, Web::StorageAPI::StorageEndpointType, String const&) const { return {}; }
 
     struct StorageChange {
         enum class Type : u8 {

--- a/Libraries/LibDevTools/Forward.h
+++ b/Libraries/LibDevTools/Forward.h
@@ -35,6 +35,7 @@ class ProcessActor;
 class RootActor;
 class StyleRuleActor;
 class StyleSheetsActor;
+class StorageActor;
 class TabActor;
 class TargetConfigurationActor;
 class ThreadActor;

--- a/Libraries/LibDevTools/StorageHelpers.cpp
+++ b/Libraries/LibDevTools/StorageHelpers.cpp
@@ -42,4 +42,24 @@ Optional<String> storage_host_name(String const& storage_host)
     return url->serialized_host();
 }
 
+JsonObject to_storage_operation_result(Optional<String> const& error_string)
+{
+    JsonObject response;
+    if (error_string.has_value())
+        response.set("errorString"sv, *error_string);
+    else
+        response.set("errorString"sv, JsonValue {});
+    return response;
+}
+
+JsonObject to_storage_operation_result(ErrorOr<void> const& result)
+{
+    JsonObject response;
+    if (result.is_error())
+        response.set("errorString"sv, result.error().string_literal());
+    else
+        response.set("errorString"sv, JsonValue {});
+    return response;
+}
+
 }

--- a/Libraries/LibDevTools/StorageHelpers.h
+++ b/Libraries/LibDevTools/StorageHelpers.h
@@ -10,11 +10,12 @@
 #include <AK/JsonObject.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
+#include <LibDevTools/Forward.h>
 
 namespace DevTools {
 
-Optional<String> storage_host_for_url(String const&);
-Optional<String> storage_host_name(String const&);
+DEVTOOLS_API Optional<String> storage_host_for_url(String const&);
+DEVTOOLS_API Optional<String> storage_host_name(String const&);
 
 JsonObject to_storage_operation_result(Optional<String> const& error_string);
 JsonObject to_storage_operation_result(ErrorOr<void> const& result);

--- a/Libraries/LibDevTools/StorageHelpers.h
+++ b/Libraries/LibDevTools/StorageHelpers.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Error.h>
+#include <AK/JsonObject.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 
@@ -13,5 +15,8 @@ namespace DevTools {
 
 Optional<String> storage_host_for_url(String const&);
 Optional<String> storage_host_name(String const&);
+
+JsonObject to_storage_operation_result(Optional<String> const& error_string);
+JsonObject to_storage_operation_result(ErrorOr<void> const& result);
 
 }

--- a/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Libraries/LibWeb/HTML/Storage.cpp
@@ -15,6 +15,8 @@
 #include <LibWeb/HTML/Storage.h>
 #include <LibWeb/HTML/StorageEvent.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Page/Page.h>
+#include <LibWeb/StorageAPI/StorageKey.h>
 #include <LibWeb/WebIDL/QuotaExceededError.h>
 
 namespace Web::HTML {
@@ -187,7 +189,14 @@ void Storage::broadcast(Optional<String> const& key, Optional<String> const& old
 
     // 1. Let thisDocument be storage's relevant global object's associated Document.
     auto& relevant_global = relevant_global_object(*this);
-    auto const& this_document = as<Window>(relevant_global).associated_document();
+    auto& this_document = as<Window>(relevant_global).associated_document();
+
+    if (auto storage_key = StorageAPI::obtain_a_storage_key(relevant_settings_object(*this)); storage_key.has_value()) {
+        auto storage_endpoint = type() == Type::Local
+            ? StorageAPI::StorageEndpointType::LocalStorage
+            : StorageAPI::StorageEndpointType::SessionStorage;
+        this_document.page().client().page_did_broadcast_storage_change(storage_endpoint, this_document.url().serialize(), key, old_value, new_value);
+    }
 
     // 2. Let url be the serialization of thisDocument's URL.
     auto url = this_document.url().serialize();

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -488,6 +488,7 @@ public:
     virtual void page_did_remove_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key) { }
     virtual Vector<String> page_did_request_storage_keys([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { return {}; }
     virtual void page_did_clear_storage([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { }
+    virtual void page_did_broadcast_storage_change([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& url, [[maybe_unused]] Optional<String> const& key, [[maybe_unused]] Optional<String> const& old_value, [[maybe_unused]] Optional<String> const& new_value) { }
     virtual void page_did_update_resource_count(i32) { }
     struct NewWebViewResult {
         GC::Ptr<Page> page;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1867,6 +1867,21 @@ void Application::stop_listening_for_host_cookie_changes(DevTools::TabDescriptio
         view->stop_listening_for_host_cookie_changes();
 }
 
+void Application::inspect_storage(DevTools::TabDescription const& description, Web::StorageAPI::StorageEndpointType storage_endpoint, OnStorageItemsReceived on_complete) const
+{
+    static u64 next_request_id = 0;
+
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    auto request_id = next_request_id++;
+    view->on_received_storage_items.set(request_id, move(on_complete));
+    view->inspect_storage(storage_endpoint, request_id);
+}
+
 void Application::inspect_tab(DevTools::TabDescription const& description, OnTabInspectionComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1882,6 +1882,19 @@ void Application::inspect_storage(DevTools::TabDescription const& description, W
     view->inspect_storage(storage_endpoint, request_id);
 }
 
+u64 Application::add_storage_change_listener(DevTools::TabDescription const& description, OnStorageChange on_storage_change) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        return view->add_storage_change_listener(move(on_storage_change));
+    return 0;
+}
+
+void Application::remove_storage_change_listener(DevTools::TabDescription const& description, u64 listener_id) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->remove_storage_change_listener(listener_id);
+}
+
 void Application::inspect_tab(DevTools::TabDescription const& description, OnTabInspectionComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1867,6 +1867,14 @@ void Application::stop_listening_for_host_cookie_changes(DevTools::TabDescriptio
         view->stop_listening_for_host_cookie_changes();
 }
 
+static ErrorOr<Optional<String>> storage_set_result_to_error_or_old_value(StorageSetResult result)
+{
+    if (result.has<StorageOperationError>())
+        return Error::from_string_literal("Unable to store more than the storage quota");
+
+    return result.get<Optional<String>>();
+}
+
 void Application::inspect_storage(DevTools::TabDescription const& description, Web::StorageAPI::StorageEndpointType storage_endpoint, OnStorageItemsReceived on_complete) const
 {
     static u64 next_request_id = 0;
@@ -1880,6 +1888,67 @@ void Application::inspect_storage(DevTools::TabDescription const& description, W
     auto request_id = next_request_id++;
     view->on_received_storage_items.set(request_id, move(on_complete));
     view->inspect_storage(storage_endpoint, request_id);
+}
+
+ErrorOr<Optional<String>> Application::set_storage_item(DevTools::TabDescription const& description, Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& key, String const& value) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return Error::from_string_literal("Unable to locate tab");
+
+    if (storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage) {
+        auto result = view->set_session_storage_item(key, value);
+        if (!result.has_value())
+            return Error::from_string_literal("Unable to locate session storage");
+        return TRY(storage_set_result_to_error_or_old_value(result.release_value()));
+    }
+
+    auto old_value = TRY(storage_set_result_to_error_or_old_value(Application::storage_jar().set_item(storage_endpoint, storage_key, key, value)));
+    if (!old_value.has_value()) {
+        view->notify_storage_changed({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Added, key });
+    } else if (*old_value != value) {
+        view->notify_storage_changed({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Changed, key });
+    }
+
+    return old_value;
+}
+
+ErrorOr<Optional<String>> Application::remove_storage_item(DevTools::TabDescription const& description, Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& key) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return Error::from_string_literal("Unable to locate tab");
+
+    if (storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage)
+        return view->remove_session_storage_item(key);
+
+    auto old_value = Application::storage_jar().get_item(storage_endpoint, storage_key, key);
+    if (!old_value.has_value())
+        return Optional<String> {};
+
+    Application::storage_jar().remove_item(storage_endpoint, storage_key, key);
+    view->notify_storage_changed({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Deleted, key });
+    return old_value;
+}
+
+ErrorOr<void> Application::clear_storage(DevTools::TabDescription const& description, Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return Error::from_string_literal("Unable to locate tab");
+
+    if (storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage) {
+        view->clear_session_storage();
+        return {};
+    }
+
+    auto keys = Application::storage_jar().get_all_keys(storage_endpoint, storage_key);
+    if (keys.is_empty())
+        return {};
+
+    Application::storage_jar().clear_storage_key(storage_endpoint, storage_key);
+    view->notify_storage_changed({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Cleared, {} });
+    return {};
 }
 
 u64 Application::add_storage_change_listener(DevTools::TabDescription const& description, OnStorageChange on_storage_change) const

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1547,6 +1547,7 @@ void Application::initialize_actions()
     m_debug_menu->add_action(Action::create("Dump CSS Errors"sv, ActionID::DumpCSSErrors, debug_request("dump-all-css-errors"sv)));
     m_debug_menu->add_action(Action::create("Dump Cookies"sv, ActionID::DumpCookies, [this]() { m_cookie_jar->dump_cookies(); }));
     m_debug_menu->add_action(Action::create("Dump Local Storage"sv, ActionID::DumpLocalStorage, debug_request("dump-local-storage"sv)));
+    m_debug_menu->add_action(Action::create("Dump Session Storage"sv, ActionID::DumpSessionStorage, debug_request("dump-session-storage"sv)));
     m_debug_menu->add_action(Action::create("Dump WASM Stats"sv, ActionID::DumpWasmStats, debug_request("dump-wasm-stats"sv)));
     m_debug_menu->add_action(Action::create("Dump GC graph"sv, ActionID::DumpGCGraph, [this]() {
         if (auto view = active_web_view(); view.has_value()) {

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -274,6 +274,7 @@ private:
     virtual void delete_cookies(DevTools::TabDescription const&, Vector<HTTP::Cookie::Cookie>) const override;
     virtual void listen_for_host_cookie_changes(DevTools::TabDescription const&, OnHostCookieChange) const override;
     virtual void stop_listening_for_host_cookie_changes(DevTools::TabDescription const&) const override;
+    virtual void inspect_storage(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType, OnStorageItemsReceived) const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;
     virtual void inspect_accessibility_tree(DevTools::TabDescription const&, OnAccessibilityTreeInspectionComplete) const override;
     virtual void listen_for_dom_properties(DevTools::TabDescription const&, OnDOMNodePropertiesReceived) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -275,6 +275,8 @@ private:
     virtual void listen_for_host_cookie_changes(DevTools::TabDescription const&, OnHostCookieChange) const override;
     virtual void stop_listening_for_host_cookie_changes(DevTools::TabDescription const&) const override;
     virtual void inspect_storage(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType, OnStorageItemsReceived) const override;
+    virtual u64 add_storage_change_listener(DevTools::TabDescription const&, OnStorageChange) const override;
+    virtual void remove_storage_change_listener(DevTools::TabDescription const&, u64) const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;
     virtual void inspect_accessibility_tree(DevTools::TabDescription const&, OnAccessibilityTreeInspectionComplete) const override;
     virtual void listen_for_dom_properties(DevTools::TabDescription const&, OnDOMNodePropertiesReceived) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -275,6 +275,9 @@ private:
     virtual void listen_for_host_cookie_changes(DevTools::TabDescription const&, OnHostCookieChange) const override;
     virtual void stop_listening_for_host_cookie_changes(DevTools::TabDescription const&) const override;
     virtual void inspect_storage(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType, OnStorageItemsReceived) const override;
+    virtual ErrorOr<Optional<String>> set_storage_item(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType, String const&, String const&, String const&) const override;
+    virtual ErrorOr<Optional<String>> remove_storage_item(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType, String const&, String const&) const override;
+    virtual ErrorOr<void> clear_storage(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType, String const&) const override;
     virtual u64 add_storage_change_listener(DevTools::TabDescription const&, OnStorageChange) const override;
     virtual void remove_storage_change_listener(DevTools::TabDescription const&, u64) const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -102,6 +102,7 @@ enum class ActionID {
     DumpCSSErrors,
     DumpCookies,
     DumpLocalStorage,
+    DumpSessionStorage,
     DumpGCGraph,
     DumpWasmStats,
     ShowLineBoxBorders,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -402,6 +402,24 @@ void ViewImplementation::stop_listening_for_host_cookie_changes()
     m_on_host_cookie_change = nullptr;
 }
 
+void ViewImplementation::notify_storage_changed(DevTools::DevToolsDelegate::StorageChange change)
+{
+    for (auto& listener : m_storage_change_listeners)
+        listener.value(change);
+}
+
+u64 ViewImplementation::add_storage_change_listener(DevTools::DevToolsDelegate::OnStorageChange on_storage_change)
+{
+    auto listener_id = m_next_storage_change_listener_id++;
+    m_storage_change_listeners.set(listener_id, move(on_storage_change));
+    return listener_id;
+}
+
+void ViewImplementation::remove_storage_change_listener(u64 listener_id)
+{
+    m_storage_change_listeners.remove(listener_id);
+}
+
 ErrorOr<Core::SharedVersionIndex> ViewImplementation::ensure_document_cookie_version_index(Badge<WebContentClient>, String const& domain)
 {
     return m_document_cookie_version_indices.try_ensure(domain, [&]() -> ErrorOr<Core::SharedVersionIndex> {

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -500,6 +500,21 @@ void ViewImplementation::inspect_storage(Web::StorageAPI::StorageEndpointType st
     client().async_inspect_storage(page_id(), storage_endpoint, request_id);
 }
 
+Optional<StorageSetResult> ViewImplementation::set_session_storage_item(String const& key, String const& value)
+{
+    return client().set_session_storage_item(page_id(), key, value);
+}
+
+Optional<String> ViewImplementation::remove_session_storage_item(String const& key)
+{
+    return client().remove_session_storage_item(page_id(), key);
+}
+
+bool ViewImplementation::clear_session_storage()
+{
+    return client().clear_session_storage(page_id());
+}
+
 void ViewImplementation::inspect_accessibility_tree()
 {
     client().async_inspect_accessibility_tree(page_id());

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -477,6 +477,11 @@ void ViewImplementation::inspect_dom_tree()
     client().async_inspect_dom_tree(page_id());
 }
 
+void ViewImplementation::inspect_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, u64 request_id)
+{
+    client().async_inspect_storage(page_id(), storage_endpoint, request_id);
+}
+
 void ViewImplementation::inspect_accessibility_tree()
 {
     client().async_inspect_accessibility_tree(page_id());

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -122,6 +122,7 @@ public:
     void get_source();
 
     void inspect_dom_tree();
+    void inspect_storage(Web::StorageAPI::StorageEndpointType, u64 request_id);
     void inspect_accessibility_tree();
     void get_hovered_node_id();
     void start_node_picker(DevTools::DevToolsDelegate::OnNodePickerEvent);
@@ -258,6 +259,7 @@ public:
     Function<void()> on_request_dismiss_dialog;
     Function<void(JsonObject)> on_received_dom_tree;
     Function<void(DOMNodeProperties)> on_received_dom_node_properties;
+    HashMap<u64, Function<void(ErrorOr<Vector<DevTools::DevToolsDelegate::StorageItem>>)>> on_received_storage_items;
     Function<void(JsonArray)> on_received_grid_layouts;
     Function<void(Optional<JsonObject>)> on_received_current_grid;
     Function<void(Optional<JsonObject>)> on_received_current_flexbox;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -44,6 +44,7 @@
 #include <LibWebView/Forward.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/Settings.h>
+#include <LibWebView/StorageSetResult.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace WebView {
@@ -127,6 +128,9 @@ public:
 
     void inspect_dom_tree();
     void inspect_storage(Web::StorageAPI::StorageEndpointType, u64 request_id);
+    Optional<StorageSetResult> set_session_storage_item(String const& key, String const& value);
+    Optional<String> remove_session_storage_item(String const& key);
+    bool clear_session_storage();
     void inspect_accessibility_tree();
     void get_hovered_node_id();
     void start_node_picker(DevTools::DevToolsDelegate::OnNodePickerEvent);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -111,6 +111,10 @@ public:
     ErrorOr<Core::SharedVersionIndex> ensure_document_cookie_version_index(Badge<WebContentClient>, String const&);
     Optional<Core::SharedVersion> document_cookie_version(URL::URL const&) const;
 
+    void notify_storage_changed(DevTools::DevToolsDelegate::StorageChange);
+    u64 add_storage_change_listener(DevTools::DevToolsDelegate::OnStorageChange);
+    void remove_storage_change_listener(u64 listener_id);
+
     ByteString selected_text();
     ByteString cut_selected_text();
     Optional<String> selected_text_with_whitespace_collapsed();
@@ -463,6 +467,9 @@ protected:
     Core::AnonymousBuffer m_document_cookie_version_buffer;
     HashMap<String, Core::SharedVersionIndex> m_document_cookie_version_indices;
     DevTools::DevToolsDelegate::OnHostCookieChange m_on_host_cookie_change;
+
+    HashMap<u64, DevTools::DevToolsDelegate::OnStorageChange> m_storage_change_listeners;
+    u64 m_next_storage_change_listener_id { 1 };
 
     // FIXME: Reconcile this ID with `page_id`. The latter is only unique per WebContent connection, whereas the view ID
     //        is required to be globally unique for Firefox DevTools.

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -11,6 +11,7 @@
 #include <AK/WeakPtr.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/Timer.h>
+#include <LibDevTools/StorageHelpers.h>
 #include <LibHTTP/Cookie/ParsedCookie.h>
 #include <LibIPC/Transport.h>
 #include <LibIPC/TransportHandle.h>
@@ -1014,6 +1015,32 @@ Messages::WebContentClient::DidRequestStorageKeysResponse WebContentClient::did_
 void WebContentClient::did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key)
 {
     Application::storage_jar().clear_storage_key(storage_endpoint, storage_key);
+}
+
+void WebContentClient::did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<String> key, Optional<String> old_value, Optional<String> new_value)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        auto host = DevTools::storage_host_for_url(url);
+        if (!host.has_value())
+            return;
+
+        DevTools::DevToolsDelegate::StorageChange::Type type;
+        if (!key.has_value())
+            type = DevTools::DevToolsDelegate::StorageChange::Type::Cleared;
+        else if (!old_value.has_value())
+            type = DevTools::DevToolsDelegate::StorageChange::Type::Added;
+        else if (!new_value.has_value())
+            type = DevTools::DevToolsDelegate::StorageChange::Type::Deleted;
+        else
+            type = DevTools::DevToolsDelegate::StorageChange::Type::Changed;
+
+        view->notify_storage_changed({
+            .storage_endpoint = storage_endpoint,
+            .host = host.release_value(),
+            .type = type,
+            .key = move(key),
+        });
+    }
 }
 
 void WebContentClient::did_post_broadcast_channel_message(u64, Web::HTML::BroadcastChannelMessage message)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -680,6 +680,39 @@ void WebContentClient::did_inspect_dom_tree(u64 page_id, String dom_tree)
     }
 }
 
+static ErrorOr<Vector<DevTools::DevToolsDelegate::StorageItem>> parse_storage_items(String const& storage_items)
+{
+    auto parsed_items = JsonValue::from_string(storage_items);
+    if (parsed_items.is_error())
+        return Error::from_string_literal("Unable to parse storage items");
+
+    if (!parsed_items.value().is_array())
+        return Error::from_string_literal("Expected storage items to be an array");
+
+    Vector<DevTools::DevToolsDelegate::StorageItem> items;
+    parsed_items.value().as_array().for_each([&](auto const& item) {
+        if (!item.is_object())
+            return;
+
+        auto name = item.as_object().get_string("name"sv);
+        auto value = item.as_object().get_string("value"sv);
+        if (!name.has_value() || !value.has_value())
+            return;
+
+        items.append({ name.release_value(), value.release_value() });
+    });
+    return items;
+}
+
+void WebContentClient::did_inspect_storage(u64 page_id, u64 request_id, String storage_items)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        auto handler = view->on_received_storage_items.take(request_id);
+        if (handler.has_value())
+            (*handler)(parse_storage_items(storage_items));
+    }
+}
+
 void WebContentClient::did_inspect_dom_node(u64 page_id, DOMNodeProperties properties)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -160,6 +160,7 @@ private:
     virtual void did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) override;
     virtual Messages::WebContentClient::DidRequestStorageKeysResponse did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
     virtual void did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
+    virtual void did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<String> key, Optional<String> old_value, Optional<String> new_value) override;
     virtual void did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) override;
     virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints) override;
     virtual void did_request_activate_tab(u64 page_id) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -117,6 +117,7 @@ private:
     virtual void did_request_media_context_menu(u64 page_id, Gfx::IntPoint, ByteString, unsigned, Web::Page::MediaContextMenu) override;
     virtual void did_get_source(u64 page_id, URL::URL, URL::URL, String) override;
     virtual void did_inspect_dom_tree(u64 page_id, String) override;
+    virtual void did_inspect_storage(u64 page_id, u64 request_id, String) override;
     virtual void did_inspect_dom_node(u64 page_id, DOMNodeProperties) override;
     virtual void did_inspect_grid_layouts(u64 page_id, String) override;
     virtual void did_inspect_current_grid(u64 page_id, String) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -604,6 +604,67 @@ void ConnectionFromClient::inspect_storage(u64 page_id, Web::StorageAPI::Storage
     async_did_inspect_storage(page_id, request_id, storage_items.serialized());
 }
 
+static Optional<GC::Ref<Web::HTML::Storage>> active_session_storage_for_page(PageClient& page)
+{
+    auto* document = page.page().top_level_browsing_context().active_document();
+    if (!document || !document->window())
+        return {};
+
+    auto storage_or_error = document->window()->session_storage();
+    if (storage_or_error.is_exception())
+        return {};
+
+    return storage_or_error.release_value();
+}
+
+Messages::WebContentServer::SetSessionStorageItemResponse ConnectionFromClient::set_session_storage_item(u64 page_id, String key, String value)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return Optional<WebView::StorageSetResult> {};
+
+    auto storage = active_session_storage_for_page(*page);
+    if (!storage.has_value())
+        return Optional<WebView::StorageSetResult> {};
+
+    auto old_value = (*storage)->get_item(key);
+    auto result = (*storage)->set_item(key, value);
+    if (result.is_exception())
+        return WebView::StorageSetResult { WebView::StorageOperationError::QuotaExceededError };
+
+    return WebView::StorageSetResult { move(old_value) };
+}
+
+Messages::WebContentServer::RemoveSessionStorageItemResponse ConnectionFromClient::remove_session_storage_item(u64 page_id, String key)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return Optional<String> {};
+
+    auto storage = active_session_storage_for_page(*page);
+    if (!storage.has_value())
+        return Optional<String> {};
+
+    auto old_value = (*storage)->get_item(key);
+    if (old_value.has_value())
+        (*storage)->remove_item(key);
+    return old_value;
+}
+
+Messages::WebContentServer::ClearSessionStorageResponse ConnectionFromClient::clear_session_storage(u64 page_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return false;
+
+    auto storage = active_session_storage_for_page(*page);
+    if (!storage.has_value() || (*storage)->length() == 0)
+        return false;
+
+    (*storage)->clear();
+    return true;
+}
+
 void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options_value)
 {
     auto page = this->page(page_id);

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -508,6 +508,17 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
         return;
     }
 
+    if (request == "dump-session-storage") {
+        if (auto* document = page->page().top_level_browsing_context().active_document()) {
+            auto storage_or_error = document->window()->session_storage();
+            if (storage_or_error.is_error())
+                dbgln("Failed to retrieve session storage: {}", storage_or_error.release_error());
+            else
+                storage_or_error.release_value()->dump();
+        }
+        return;
+    }
+
     if (request == "navigator-compatibility-mode") {
         Web::NavigatorCompatibilityMode compatibility_mode;
         if (argument == "chrome") {

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -558,6 +558,52 @@ void ConnectionFromClient::inspect_dom_tree(u64 page_id)
     }
 }
 
+void ConnectionFromClient::inspect_storage(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, u64 request_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value()) {
+        async_did_inspect_storage(page_id, request_id, "[]"_string);
+        return;
+    }
+
+    auto* document = page->page().top_level_browsing_context().active_document();
+    if (!document || !document->window()) {
+        async_did_inspect_storage(page_id, request_id, "[]"_string);
+        return;
+    }
+
+    Web::WebIDL::ExceptionOr<GC::Ref<Web::HTML::Storage>> storage_or_error = [&]() -> Web::WebIDL::ExceptionOr<GC::Ref<Web::HTML::Storage>> {
+        if (storage_endpoint == Web::StorageAPI::StorageEndpointType::LocalStorage)
+            return document->window()->local_storage();
+        VERIFY(storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage);
+        return document->window()->session_storage();
+    }();
+
+    if (storage_or_error.is_error()) {
+        async_did_inspect_storage(page_id, request_id, "[]"_string);
+        return;
+    }
+
+    auto storage = storage_or_error.release_value();
+    JsonArray storage_items;
+    for (auto i = 0uz; i < storage->length(); ++i) {
+        auto name = storage->key(i);
+        if (!name.has_value())
+            continue;
+
+        auto value = storage->get_item(*name);
+        if (!value.has_value())
+            continue;
+
+        JsonObject item;
+        item.set("name"sv, name.release_value());
+        item.set("value"sv, value.release_value());
+        storage_items.must_append(move(item));
+    }
+
+    async_did_inspect_storage(page_id, request_id, storage_items.serialized());
+}
+
 void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options_value)
 {
     auto page = this->page(page_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -93,6 +93,9 @@ private:
     virtual void get_source(u64 page_id) override;
     virtual void inspect_dom_tree(u64 page_id) override;
     virtual void inspect_storage(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, u64 request_id) override;
+    virtual Messages::WebContentServer::SetSessionStorageItemResponse set_session_storage_item(u64 page_id, String key, String value) override;
+    virtual Messages::WebContentServer::RemoveSessionStorageItemResponse remove_session_storage_item(u64 page_id, String key) override;
+    virtual Messages::WebContentServer::ClearSessionStorageResponse clear_session_storage(u64 page_id) override;
     virtual void inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options) override;
     virtual void inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) override;
     virtual void inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) override;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -92,6 +92,7 @@ private:
     virtual void debug_request(u64 page_id, ByteString, ByteString) override;
     virtual void get_source(u64 page_id) override;
     virtual void inspect_dom_tree(u64 page_id) override;
+    virtual void inspect_storage(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, u64 request_id) override;
     virtual void inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options) override;
     virtual void inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) override;
     virtual void inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -697,6 +697,11 @@ void PageClient::page_did_clear_storage(Web::StorageAPI::StorageEndpointType sto
     }
 }
 
+void PageClient::page_did_broadcast_storage_change(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& url, Optional<String> const& key, Optional<String> const& old_value, Optional<String> const& new_value)
+{
+    client().async_did_change_storage_item(m_id, storage_endpoint, url, key, old_value, new_value);
+}
+
 void PageClient::page_did_post_broadcast_channel_message(Web::HTML::BroadcastChannelMessage const& message)
 {
     client().async_did_post_broadcast_channel_message(m_id, message);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -186,6 +186,7 @@ private:
     virtual void page_did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key) override;
     virtual Vector<String> page_did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
     virtual void page_did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
+    virtual void page_did_broadcast_storage_change(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& url, Optional<String> const& key, Optional<String> const& old_value, Optional<String> const& new_value) override;
     virtual void page_did_update_resource_count(i32) override;
     virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Web::HTML::TokenizedFeature::NoOpener) override;
     virtual void page_did_request_activate_tab() override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -67,6 +67,7 @@ endpoint WebContentClient
     did_get_source(u64 page_id, URL::URL url, URL::URL base_url, String source) =|
 
     did_inspect_dom_tree(u64 page_id, String dom_tree) =|
+    did_inspect_storage(u64 page_id, u64 request_id, String storage_items) =|
     did_inspect_dom_node(u64 page_id, WebView::DOMNodeProperties properties) =|
     did_inspect_grid_layouts(u64 page_id, String grid_layouts) =|
     did_inspect_current_grid(u64 page_id, String grid_layout) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -105,6 +105,7 @@ endpoint WebContentClient
     did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) => ()
     did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => (Vector<String> keys)
     did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => ()
+    did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<String> key, Optional<String> old_value, Optional<String> new_value) =|
     did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) =|
 
     did_update_resource_count(u64 page_id, i32 count_waiting) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -16,6 +16,7 @@
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWebView/Attribute.h>
@@ -58,6 +59,7 @@ endpoint WebContentServer
     debug_request(u64 page_id, ByteString request, ByteString argument) =|
     get_source(u64 page_id) =|
     inspect_dom_tree(u64 page_id) =|
+    inspect_storage(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, u64 request_id) =|
     inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options) =|
     inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) =|
     inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -23,6 +23,7 @@
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/Settings.h>
+#include <LibWebView/StorageSetResult.h>
 
 endpoint WebContentServer
 {
@@ -60,6 +61,9 @@ endpoint WebContentServer
     get_source(u64 page_id) =|
     inspect_dom_tree(u64 page_id) =|
     inspect_storage(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, u64 request_id) =|
+    set_session_storage_item(u64 page_id, String key, String value) => (Optional<WebView::StorageSetResult> result)
+    remove_session_storage_item(u64 page_id, String key) => (Optional<String> old_value)
+    clear_session_storage(u64 page_id) => (bool did_clear)
     inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element, JsonValue options) =|
     inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) =|
     inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) =|

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -547,7 +547,7 @@ class TestDevToolsDelegate final : public DevTools::DevToolsDelegate {
 public:
     virtual Vector<DevTools::TabDescription> tab_list() const override
     {
-        return { { .id = 1, .title = "Fixture page"_string, .url = "https://example.test/"_string } };
+        return { { .id = 1, .title = "Fixture page"_string, .url = tab_url } };
     }
 
     virtual Vector<DevTools::CSSProperty> css_property_list() const override
@@ -663,6 +663,20 @@ public:
 
         VERIFY(storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage);
         callback(fixture_session_storage_items);
+    }
+
+    virtual u64 add_storage_change_listener(DevTools::TabDescription const&, OnStorageChange callback) const override
+    {
+        auto listener_id = next_storage_change_listener_id++;
+        storage_change_listeners.set(listener_id, move(callback));
+        ++add_storage_change_listener_call_count;
+        return listener_id;
+    }
+
+    virtual void remove_storage_change_listener(DevTools::TabDescription const&, u64 listener_id) const override
+    {
+        storage_change_listeners.remove(listener_id);
+        ++remove_storage_change_listener_call_count;
     }
 
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete callback) const override
@@ -1064,6 +1078,12 @@ public:
         on_host_cookie_change(move(cookies));
     }
 
+    void emit_storage_change(DevToolsDelegate::StorageChange change) const
+    {
+        for (auto& listener : storage_change_listeners)
+            listener.value(change);
+    }
+
     mutable Function<void(WebView::DOMNodeProperties)> on_dom_node_properties;
     mutable Function<void(WebView::Mutation)> on_dom_mutation;
     mutable Function<void(Web::CSS::StyleSheetIdentifier const&, String)> on_style_sheet_source;
@@ -1074,6 +1094,8 @@ public:
     mutable Function<void(DevToolsDelegate::NetworkRequestCompleteData)> on_network_request_finished;
     mutable Function<void(DevToolsDelegate::NodePickerEvent)> on_node_picker_event;
     mutable Function<void(Vector<HTTP::Cookie::Cookie>)> on_host_cookie_change;
+    mutable HashMap<u64, Function<void(DevToolsDelegate::StorageChange)>> storage_change_listeners;
+    String tab_url { "https://example.test/"_string };
 
     struct NavigationListener {
         Function<void(String)> on_navigation_started;
@@ -1093,6 +1115,9 @@ public:
     mutable size_t listen_for_cookie_changes_call_count { 0 };
     mutable size_t stop_listening_for_cookie_changes_call_count { 0 };
     mutable size_t inspect_storage_call_count { 0 };
+    mutable size_t add_storage_change_listener_call_count { 0 };
+    mutable size_t remove_storage_change_listener_call_count { 0 };
+    mutable u64 next_storage_change_listener_id { 1 };
     mutable size_t inspect_accessibility_tree_call_count { 0 };
     mutable size_t listen_for_dom_properties_call_count { 0 };
     mutable size_t stop_listening_for_dom_properties_call_count { 0 };
@@ -1302,9 +1327,10 @@ struct TestSession {
     OwnPtr<ProtocolClient> client;
 };
 
-static NonnullOwnPtr<TestSession> create_session()
+static NonnullOwnPtr<TestSession> create_session(StringView tab_url = "https://example.test/"sv)
 {
     auto session = make<TestSession>();
+    session->delegate.tab_url = MUST(String::from_utf8(tab_url));
     session->server = MUST(DevTools::DevToolsServer::create(session->delegate, 0));
     session->client = ProtocolClient::connect(session->loop, *session->server);
     return session;
@@ -1462,6 +1488,15 @@ static JsonArray get_cookie_update_keys(JsonObject const& stores_update, StringV
     return stores_update.get_object("data"sv)
         ->get_object(update_type)
         ->get_object("cookies"sv)
+        ->get_array(host)
+        .release_value();
+}
+
+static JsonArray get_storage_update_keys(JsonObject const& stores_update, StringView update_type, StringView resource_key, StringView host = "https://example.test"sv)
+{
+    return stores_update.get_object("data"sv)
+        ->get_object(update_type)
+        ->get_object(resource_key)
         ->get_array(host)
         .release_value();
 }
@@ -1852,6 +1887,104 @@ TEST_CASE(storage_web_storage_store_objects)
     objects = get_storage_store_objects(client, session_storage_actor, "https://other.test"sv);
     EXPECT_EQ(objects.get_integer<size_t>("total"sv).value(), 0u);
     EXPECT(objects.get_array("data"sv)->is_empty());
+}
+
+TEST_CASE(storage_web_storage_change_events)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto local_storage_actor = get_storage_actor(client, "local-storage"sv);
+    EXPECT_EQ(session->delegate.add_storage_change_listener_call_count, 1u);
+
+    session->delegate.emit_storage_change({
+        .storage_endpoint = Web::StorageAPI::StorageEndpointType::LocalStorage,
+        .host = "https://example.test"_string,
+        .type = DevTools::DevToolsDelegate::StorageChange::Type::Added,
+        .key = "alpha"_string,
+    });
+    auto stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    EXPECT_EQ(stores_update.get_string("from"sv).value(), local_storage_actor);
+    auto added_keys = get_storage_update_keys(stores_update, "added"sv, "localStorage"sv);
+    EXPECT_EQ(added_keys.size(), 1u);
+    EXPECT_EQ(added_keys.at(0).as_string(), "alpha"sv);
+
+    session->delegate.emit_storage_change({
+        .storage_endpoint = Web::StorageAPI::StorageEndpointType::LocalStorage,
+        .host = "https://example.test"_string,
+        .type = DevTools::DevToolsDelegate::StorageChange::Type::Changed,
+        .key = "alpha"_string,
+    });
+    stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    auto changed_keys = get_storage_update_keys(stores_update, "changed"sv, "localStorage"sv);
+    EXPECT_EQ(changed_keys.size(), 1u);
+    EXPECT_EQ(changed_keys.at(0).as_string(), "alpha"sv);
+
+    session->delegate.emit_storage_change({
+        .storage_endpoint = Web::StorageAPI::StorageEndpointType::LocalStorage,
+        .host = "https://example.test"_string,
+        .type = DevTools::DevToolsDelegate::StorageChange::Type::Deleted,
+        .key = "alpha"_string,
+    });
+    stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    auto deleted_keys = get_storage_update_keys(stores_update, "deleted"sv, "localStorage"sv);
+    EXPECT_EQ(deleted_keys.size(), 1u);
+    EXPECT_EQ(deleted_keys.at(0).as_string(), "alpha"sv);
+
+    session->delegate.emit_storage_change({
+        .storage_endpoint = Web::StorageAPI::StorageEndpointType::LocalStorage,
+        .host = "https://example.test"_string,
+        .type = DevTools::DevToolsDelegate::StorageChange::Type::Cleared,
+        .key = {},
+    });
+    auto stores_cleared = read_packet_with_type(client, "storesCleared"sv);
+    EXPECT_EQ(stores_cleared.get_string("from"sv).value(), local_storage_actor);
+    auto cleared_hosts = stores_cleared.get_object("data"sv)->get_array("clearedHostsOrPaths"sv).release_value();
+    EXPECT_EQ(cleared_hosts.size(), 1u);
+    EXPECT_EQ(cleared_hosts.at(0).as_string(), "https://example.test"sv);
+
+    auto session_storage_actor = get_storage_actor(client, "session-storage"sv);
+    EXPECT_EQ(session->delegate.add_storage_change_listener_call_count, 2u);
+    session->delegate.emit_storage_change({
+        .storage_endpoint = Web::StorageAPI::StorageEndpointType::SessionStorage,
+        .host = "https://example.test"_string,
+        .type = DevTools::DevToolsDelegate::StorageChange::Type::Added,
+        .key = "session-key"_string,
+    });
+    stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    EXPECT_EQ(stores_update.get_string("from"sv).value(), session_storage_actor);
+    added_keys = get_storage_update_keys(stores_update, "added"sv, "sessionStorage"sv);
+    EXPECT_EQ(added_keys.size(), 1u);
+    EXPECT_EQ(added_keys.at(0).as_string(), "session-key"sv);
+}
+
+TEST_CASE(storage_web_storage_change_events_for_file_urls)
+{
+    auto session = create_session("file:///tmp/devtools-storage.html"sv);
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto local_storage_actor = get_storage_actor(client, "local-storage"sv);
+
+    session->delegate.emit_storage_change({
+        .storage_endpoint = Web::StorageAPI::StorageEndpointType::LocalStorage,
+        .host = "file:///tmp/other.html"_string,
+        .type = DevTools::DevToolsDelegate::StorageChange::Type::Added,
+        .key = "other"_string,
+    });
+    session->delegate.emit_storage_change({
+        .storage_endpoint = Web::StorageAPI::StorageEndpointType::LocalStorage,
+        .host = "file:///tmp/devtools-storage.html"_string,
+        .type = DevTools::DevToolsDelegate::StorageChange::Type::Added,
+        .key = "alpha"_string,
+    });
+
+    auto stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    EXPECT_EQ(stores_update.get_string("from"sv).value(), local_storage_actor);
+    auto added_keys = get_storage_update_keys(stores_update, "added"sv, "localStorage"sv, "file:///tmp/devtools-storage.html"sv);
+    EXPECT_EQ(added_keys.size(), 1u);
+    EXPECT_EQ(added_keys.at(0).as_string(), "alpha"sv);
 }
 
 TEST_CASE(storage_cookie_store_objects)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -656,13 +656,65 @@ public:
     virtual void inspect_storage(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType storage_endpoint, OnStorageItemsReceived callback) const override
     {
         ++inspect_storage_call_count;
-        if (storage_endpoint == Web::StorageAPI::StorageEndpointType::LocalStorage) {
-            callback(fixture_local_storage_items);
-            return;
+        callback(storage_items_for_endpoint(storage_endpoint));
+    }
+
+    virtual ErrorOr<Optional<String>> set_storage_item(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& key, String const& value) const override
+    {
+        ++set_storage_item_call_count;
+        if (fail_set_storage_item)
+            return Error::from_string_literal("Unable to set storage item");
+
+        auto& storage_items = storage_items_for_endpoint(storage_endpoint);
+        for (auto& item : storage_items) {
+            if (item.name != key)
+                continue;
+
+            auto old_value = item.value;
+            item.value = value;
+            if (old_value != value)
+                emit_storage_change({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Changed, key });
+            return old_value;
         }
 
-        VERIFY(storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage);
-        callback(fixture_session_storage_items);
+        storage_items.append({ key, value });
+        emit_storage_change({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Added, key });
+        return Optional<String> {};
+    }
+
+    virtual ErrorOr<Optional<String>> remove_storage_item(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& key) const override
+    {
+        ++remove_storage_item_call_count;
+        if (fail_remove_storage_item)
+            return Error::from_string_literal("Unable to remove storage item");
+
+        auto& storage_items = storage_items_for_endpoint(storage_endpoint);
+        for (auto i = 0uz; i < storage_items.size(); ++i) {
+            if (storage_items[i].name != key)
+                continue;
+
+            auto old_value = storage_items[i].value;
+            storage_items.remove(i);
+            emit_storage_change({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Deleted, key });
+            return old_value;
+        }
+
+        return Optional<String> {};
+    }
+
+    virtual ErrorOr<void> clear_storage(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) const override
+    {
+        ++clear_storage_call_count;
+        if (fail_clear_storage)
+            return Error::from_string_literal("Unable to clear storage");
+
+        auto& storage_items = storage_items_for_endpoint(storage_endpoint);
+        if (storage_items.is_empty())
+            return {};
+
+        storage_items.clear();
+        emit_storage_change({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Cleared, {} });
+        return {};
     }
 
     virtual u64 add_storage_change_listener(DevTools::TabDescription const&, OnStorageChange callback) const override
@@ -1084,6 +1136,15 @@ public:
             listener.value(change);
     }
 
+    Vector<DevTools::DevToolsDelegate::StorageItem>& storage_items_for_endpoint(Web::StorageAPI::StorageEndpointType storage_endpoint) const
+    {
+        if (storage_endpoint == Web::StorageAPI::StorageEndpointType::LocalStorage)
+            return fixture_local_storage_items;
+
+        VERIFY(storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage);
+        return fixture_session_storage_items;
+    }
+
     mutable Function<void(WebView::DOMNodeProperties)> on_dom_node_properties;
     mutable Function<void(WebView::Mutation)> on_dom_mutation;
     mutable Function<void(Web::CSS::StyleSheetIdentifier const&, String)> on_style_sheet_source;
@@ -1115,9 +1176,15 @@ public:
     mutable size_t listen_for_cookie_changes_call_count { 0 };
     mutable size_t stop_listening_for_cookie_changes_call_count { 0 };
     mutable size_t inspect_storage_call_count { 0 };
+    mutable size_t set_storage_item_call_count { 0 };
+    mutable size_t remove_storage_item_call_count { 0 };
+    mutable size_t clear_storage_call_count { 0 };
     mutable size_t add_storage_change_listener_call_count { 0 };
     mutable size_t remove_storage_change_listener_call_count { 0 };
     mutable u64 next_storage_change_listener_id { 1 };
+    mutable bool fail_set_storage_item { false };
+    mutable bool fail_remove_storage_item { false };
+    mutable bool fail_clear_storage { false };
     mutable size_t inspect_accessibility_tree_call_count { 0 };
     mutable size_t listen_for_dom_properties_call_count { 0 };
     mutable size_t stop_listening_for_dom_properties_call_count { 0 };
@@ -1260,6 +1327,7 @@ private:
             || *type == "pickerNodePicked"sv
             || *type == "pickerNodePreviewed"sv
             || *type == "tabListChanged"sv
+            || *type == "storesCleared"sv
             || *type == "storesUpdate"sv
             || *type == "target-available-form"sv
             || *type == "target-destroyed-form"sv;
@@ -1499,6 +1567,58 @@ static JsonArray get_storage_update_keys(JsonObject const& stores_update, String
         ->get_object(resource_key)
         ->get_array(host)
         .release_value();
+}
+
+static JsonObject make_storage_edit_items(StringView name, StringView value)
+{
+    JsonObject items;
+    items.set("name"sv, name);
+    items.set("value"sv, value);
+    return items;
+}
+
+static JsonObject edit_storage_item(ProtocolClient& client, StringView storage_actor, StringView field, JsonValue old_value, StringView name, StringView value)
+{
+    JsonObject data;
+    data.set("host"sv, "https://example.test"sv);
+    data.set("field"sv, field);
+    data.set("oldValue"sv, move(old_value));
+    data.set("items"sv, make_storage_edit_items(name, value));
+
+    JsonObject request;
+    request.set("to"sv, storage_actor);
+    request.set("type"sv, "editItem"sv);
+    request.set("data"sv, move(data));
+    return client.request(move(request));
+}
+
+static JsonObject add_storage_item(ProtocolClient& client, StringView storage_actor, StringView name)
+{
+    JsonObject request;
+    request.set("to"sv, storage_actor);
+    request.set("type"sv, "addItem"sv);
+    request.set("guid"sv, name);
+    request.set("host"sv, "https://example.test"sv);
+    return client.request(move(request));
+}
+
+static JsonObject remove_storage_item(ProtocolClient& client, StringView storage_actor, StringView name)
+{
+    JsonObject request;
+    request.set("to"sv, storage_actor);
+    request.set("type"sv, "removeItem"sv);
+    request.set("host"sv, "https://example.test"sv);
+    request.set("name"sv, name);
+    return client.request(move(request));
+}
+
+static JsonObject remove_all_storage_items(ProtocolClient& client, StringView storage_actor)
+{
+    JsonObject request;
+    request.set("to"sv, storage_actor);
+    request.set("type"sv, "removeAll"sv);
+    request.set("host"sv, "https://example.test"sv);
+    return client.request(move(request));
 }
 
 static JsonObject make_cookie_edit_items(HTTP::Cookie::Cookie const& cookie)
@@ -1985,6 +2105,121 @@ TEST_CASE(storage_web_storage_change_events_for_file_urls)
     auto added_keys = get_storage_update_keys(stores_update, "added"sv, "localStorage"sv, "file:///tmp/devtools-storage.html"sv);
     EXPECT_EQ(added_keys.size(), 1u);
     EXPECT_EQ(added_keys.at(0).as_string(), "alpha"sv);
+}
+
+TEST_CASE(storage_web_storage_add_edit_and_remove_items)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto local_storage_actor = get_storage_actor(client, "local-storage"sv);
+
+    auto response = add_storage_item(client, local_storage_actor, "devtools-key"sv);
+    EXPECT(response.get("errorString"sv).value().is_null());
+    EXPECT_EQ(session->delegate.set_storage_item_call_count, 1u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items.size(), 1u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items[0].name, "devtools-key"sv);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items[0].value, "value"sv);
+
+    auto stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    auto added_keys = get_storage_update_keys(stores_update, "added"sv, "localStorage"sv);
+    EXPECT_EQ(added_keys.size(), 1u);
+    EXPECT_EQ(added_keys.at(0).as_string(), "devtools-key"sv);
+
+    response = edit_storage_item(client, local_storage_actor, "value"sv, "value"_string, "devtools-key"sv, "updated-value"sv);
+    EXPECT(response.get("errorString"sv).value().is_null());
+    EXPECT_EQ(session->delegate.set_storage_item_call_count, 2u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items.size(), 1u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items[0].name, "devtools-key"sv);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items[0].value, "updated-value"sv);
+
+    stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    auto changed_keys = get_storage_update_keys(stores_update, "changed"sv, "localStorage"sv);
+    EXPECT_EQ(changed_keys.size(), 1u);
+    EXPECT_EQ(changed_keys.at(0).as_string(), "devtools-key"sv);
+
+    response = edit_storage_item(client, local_storage_actor, "name"sv, "devtools-key"_string, "renamed-key"sv, "updated-value"sv);
+    EXPECT(response.get("errorString"sv).value().is_null());
+    EXPECT_EQ(session->delegate.remove_storage_item_call_count, 1u);
+    EXPECT_EQ(session->delegate.set_storage_item_call_count, 3u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items.size(), 1u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items[0].name, "renamed-key"sv);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items[0].value, "updated-value"sv);
+
+    stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    auto deleted_keys = get_storage_update_keys(stores_update, "deleted"sv, "localStorage"sv);
+    EXPECT_EQ(deleted_keys.size(), 1u);
+    EXPECT_EQ(deleted_keys.at(0).as_string(), "devtools-key"sv);
+    stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    added_keys = get_storage_update_keys(stores_update, "added"sv, "localStorage"sv);
+    EXPECT_EQ(added_keys.size(), 1u);
+    EXPECT_EQ(added_keys.at(0).as_string(), "renamed-key"sv);
+
+    response = remove_storage_item(client, local_storage_actor, "renamed-key"sv);
+    EXPECT_EQ(response.get_string("from"sv).value(), local_storage_actor);
+    EXPECT_EQ(session->delegate.remove_storage_item_call_count, 2u);
+    EXPECT(session->delegate.fixture_local_storage_items.is_empty());
+
+    stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    deleted_keys = get_storage_update_keys(stores_update, "deleted"sv, "localStorage"sv);
+    EXPECT_EQ(deleted_keys.size(), 1u);
+    EXPECT_EQ(deleted_keys.at(0).as_string(), "renamed-key"sv);
+
+    session->delegate.fixture_local_storage_items.append({ "first"_string, "one"_string });
+    session->delegate.fixture_local_storage_items.append({ "second"_string, "two"_string });
+    response = remove_all_storage_items(client, local_storage_actor);
+    EXPECT_EQ(response.get_string("from"sv).value(), local_storage_actor);
+    EXPECT_EQ(session->delegate.clear_storage_call_count, 1u);
+    EXPECT(session->delegate.fixture_local_storage_items.is_empty());
+
+    auto stores_cleared = read_packet_with_type(client, "storesCleared"sv);
+    EXPECT_EQ(stores_cleared.get_string("from"sv).value(), local_storage_actor);
+    auto cleared_hosts = stores_cleared.get_object("data"sv)->get_array("clearedHostsOrPaths"sv).release_value();
+    EXPECT_EQ(cleared_hosts.size(), 1u);
+    EXPECT_EQ(cleared_hosts.at(0).as_string(), "https://example.test"sv);
+
+    auto session_storage_actor = get_storage_actor(client, "session-storage"sv);
+    response = add_storage_item(client, session_storage_actor, "session-key"sv);
+    EXPECT(response.get("errorString"sv).value().is_null());
+    EXPECT_EQ(session->delegate.fixture_session_storage_items.size(), 1u);
+    EXPECT_EQ(session->delegate.fixture_session_storage_items[0].name, "session-key"sv);
+    EXPECT_EQ(session->delegate.fixture_session_storage_items[0].value, "value"sv);
+
+    stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    added_keys = get_storage_update_keys(stores_update, "added"sv, "sessionStorage"sv);
+    EXPECT_EQ(added_keys.size(), 1u);
+    EXPECT_EQ(added_keys.at(0).as_string(), "session-key"sv);
+}
+
+TEST_CASE(storage_web_storage_mutation_errors)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto local_storage_actor = get_storage_actor(client, "local-storage"sv);
+    session->delegate.fixture_local_storage_items.append({ "devtools-key"_string, "value"_string });
+
+    session->delegate.fail_remove_storage_item = true;
+    auto response = edit_storage_item(client, local_storage_actor, "name"sv, "devtools-key"_string, "renamed-key"sv, "value"sv);
+    EXPECT_EQ(response.get_string("errorString"sv).value(), "Unable to remove storage item"sv);
+    EXPECT_EQ(session->delegate.remove_storage_item_call_count, 1u);
+    EXPECT_EQ(session->delegate.set_storage_item_call_count, 0u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items.size(), 1u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items[0].name, "devtools-key"sv);
+
+    response = remove_storage_item(client, local_storage_actor, "devtools-key"sv);
+    EXPECT_EQ(response.get_string("errorString"sv).value(), "Unable to remove storage item"sv);
+    EXPECT_EQ(session->delegate.remove_storage_item_call_count, 2u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items.size(), 1u);
+
+    session->delegate.fail_remove_storage_item = false;
+    session->delegate.fail_clear_storage = true;
+    response = remove_all_storage_items(client, local_storage_actor);
+    EXPECT_EQ(response.get_string("errorString"sv).value(), "Unable to clear storage"sv);
+    EXPECT_EQ(session->delegate.clear_storage_call_count, 1u);
+    EXPECT_EQ(session->delegate.fixture_local_storage_items.size(), 1u);
 }
 
 TEST_CASE(storage_cookie_store_objects)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -653,6 +653,18 @@ public:
         on_host_cookie_change = nullptr;
     }
 
+    virtual void inspect_storage(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType storage_endpoint, OnStorageItemsReceived callback) const override
+    {
+        ++inspect_storage_call_count;
+        if (storage_endpoint == Web::StorageAPI::StorageEndpointType::LocalStorage) {
+            callback(fixture_local_storage_items);
+            return;
+        }
+
+        VERIFY(storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage);
+        callback(fixture_session_storage_items);
+    }
+
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete callback) const override
     {
         ++inspect_tab_call_count;
@@ -1071,6 +1083,8 @@ public:
 
     mutable bool use_navigation_dom_tree { false };
     mutable Vector<HTTP::Cookie::Cookie> fixture_cookies;
+    mutable Vector<DevTools::DevToolsDelegate::StorageItem> fixture_local_storage_items;
+    mutable Vector<DevTools::DevToolsDelegate::StorageItem> fixture_session_storage_items;
 
     mutable size_t inspect_tab_call_count { 0 };
     mutable size_t cookies_call_count { 0 };
@@ -1078,6 +1092,7 @@ public:
     mutable size_t delete_cookies_call_count { 0 };
     mutable size_t listen_for_cookie_changes_call_count { 0 };
     mutable size_t stop_listening_for_cookie_changes_call_count { 0 };
+    mutable size_t inspect_storage_call_count { 0 };
     mutable size_t inspect_accessibility_tree_call_count { 0 };
     mutable size_t listen_for_dom_properties_call_count { 0 };
     mutable size_t stop_listening_for_dom_properties_call_count { 0 };
@@ -1412,6 +1427,36 @@ static JsonObject get_cookie_store_objects(ProtocolClient& client, StringView co
     return client.request(move(get_store_objects));
 }
 
+static String get_storage_actor(ProtocolClient& client, StringView resource_type)
+{
+    auto tab_actor = actor_from(get_tab(client), "actor"sv);
+    auto watcher_actor = actor_from(client.request(tab_actor, "getWatcher"sv), "actor"sv);
+
+    JsonObject watch_resources;
+    watch_resources.set("to"sv, watcher_actor);
+    watch_resources.set("type"sv, "watchResources"sv);
+    JsonArray resource_types;
+    resource_types.must_append(resource_type);
+    watch_resources.set("resourceTypes"sv, move(resource_types));
+    EXPECT_EQ(client.request(move(watch_resources)).get_string("from"sv).value(), watcher_actor);
+
+    return actor_from(read_resource(client, resource_type), "actor"sv);
+}
+
+static JsonObject get_storage_store_objects(ProtocolClient& client, StringView storage_actor, StringView host = "https://example.test"sv, Optional<JsonArray> names = {})
+{
+    JsonObject get_store_objects;
+    get_store_objects.set("to"sv, storage_actor);
+    get_store_objects.set("type"sv, "getStoreObjects"sv);
+    get_store_objects.set("host"sv, host);
+    if (names.has_value())
+        get_store_objects.set("names"sv, names.release_value());
+    else
+        get_store_objects.set("names"sv, JsonValue {});
+    get_store_objects.set("options"sv, JsonObject {});
+    return client.request(move(get_store_objects));
+}
+
 static JsonArray get_cookie_update_keys(JsonObject const& stores_update, StringView update_type, StringView host = "https://example.test"sv)
 {
     return stores_update.get_object("data"sv)
@@ -1698,6 +1743,113 @@ TEST_CASE(storage_cookie_resource)
     get_store_objects.set("options"sv, move(options));
     auto objects = client.request(move(get_store_objects));
     EXPECT_EQ(objects.get_integer<size_t>("offset"sv).value(), 0u);
+    EXPECT_EQ(objects.get_integer<size_t>("total"sv).value(), 0u);
+    EXPECT(objects.get_array("data"sv)->is_empty());
+}
+
+TEST_CASE(storage_web_storage_resources)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto tab_actor = actor_from(get_tab(client), "actor"sv);
+    auto watcher_response = client.request(tab_actor, "getWatcher"sv);
+    auto watcher_actor = actor_from(watcher_response, "actor"sv);
+    auto resources = watcher_response.get_object("traits"sv)->get_object("resources"sv).release_value();
+    EXPECT(resources.get_bool("local-storage"sv).value());
+    EXPECT(resources.get_bool("session-storage"sv).value());
+
+    JsonObject watch_resources;
+    watch_resources.set("to"sv, watcher_actor);
+    watch_resources.set("type"sv, "watchResources"sv);
+    JsonArray resource_types;
+    resource_types.must_append("local-storage"sv);
+    resource_types.must_append("session-storage"sv);
+    watch_resources.set("resourceTypes"sv, move(resource_types));
+    EXPECT_EQ(client.request(move(watch_resources)).get_string("from"sv).value(), watcher_actor);
+
+    auto local_storage_resource = read_resource(client, "local-storage"sv);
+    EXPECT_EQ(local_storage_resource.get_string("resourceKey"sv).value(), "localStorage"sv);
+    EXPECT_EQ(local_storage_resource.get_integer<u64>("browsingContextID"sv).value(), 1u);
+    EXPECT_EQ(local_storage_resource.get_integer<u64>("innerWindowId"sv).value(), 1u);
+    EXPECT_EQ(local_storage_resource.get_string("resourceId"sv).value(), "localStorage-1"sv);
+    EXPECT(local_storage_resource.get_object("hosts"sv)->has_array("https://example.test"sv));
+    auto local_traits = local_storage_resource.get_object("traits"sv).release_value();
+    EXPECT(local_traits.get_bool("supportsAddItem"sv).value());
+    EXPECT(local_traits.get_bool("supportsRemoveAll"sv).value());
+    EXPECT(!local_traits.get_bool("supportsRemoveAllSessionCookies"sv).value());
+    EXPECT(local_traits.get_bool("supportsRemoveItem"sv).value());
+
+    auto local_storage_actor = actor_from(local_storage_resource, "actor"sv);
+    auto fields = client.request(local_storage_actor, "getFields"sv).get_array("value"sv).release_value();
+    EXPECT_EQ(fields.size(), 2u);
+    EXPECT_EQ(fields.at(0).as_object().get_string("name"sv).value(), "name"sv);
+    EXPECT(fields.at(0).as_object().get_bool("editable"sv).value());
+    EXPECT_EQ(fields.at(1).as_object().get_string("name"sv).value(), "value"sv);
+    EXPECT(fields.at(1).as_object().get_bool("editable"sv).value());
+
+    auto session_storage_resource = read_resource(client, "session-storage"sv);
+    EXPECT_EQ(session_storage_resource.get_string("resourceKey"sv).value(), "sessionStorage"sv);
+    EXPECT_EQ(session_storage_resource.get_string("resourceId"sv).value(), "sessionStorage-1"sv);
+    EXPECT(session_storage_resource.get_object("hosts"sv)->has_array("https://example.test"sv));
+}
+
+TEST_CASE(storage_web_storage_store_objects)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    session->delegate.fixture_local_storage_items.append({ "beta"_string, "two"_string });
+    session->delegate.fixture_local_storage_items.append({ "alpha"_string, "one"_string });
+    session->delegate.fixture_session_storage_items.append({ "session-key"_string, "session-value"_string });
+
+    auto local_storage_actor = get_storage_actor(client, "local-storage"sv);
+    auto objects = get_storage_store_objects(client, local_storage_actor);
+    EXPECT_EQ(session->delegate.inspect_storage_call_count, 1u);
+    EXPECT_EQ(objects.get_integer<size_t>("offset"sv).value(), 0u);
+    EXPECT_EQ(objects.get_integer<size_t>("total"sv).value(), 2u);
+
+    auto data = objects.get_array("data"sv).release_value();
+    EXPECT_EQ(data.size(), 2u);
+    EXPECT_EQ(data.at(0).as_object().get_string("name"sv).value(), "alpha"sv);
+    EXPECT_EQ(data.at(0).as_object().get_string("value"sv).value(), "one"sv);
+    EXPECT_EQ(data.at(1).as_object().get_string("name"sv).value(), "beta"sv);
+    EXPECT_EQ(data.at(1).as_object().get_string("value"sv).value(), "two"sv);
+
+    JsonArray names;
+    names.must_append("beta"sv);
+    auto filtered_objects = get_storage_store_objects(client, local_storage_actor, "https://example.test"sv, move(names));
+    EXPECT_EQ(filtered_objects.get_integer<size_t>("total"sv).value(), 1u);
+    auto filtered_data = filtered_objects.get_array("data"sv).release_value();
+    EXPECT_EQ(filtered_data.size(), 1u);
+    EXPECT_EQ(filtered_data.at(0).as_object().get_string("name"sv).value(), "beta"sv);
+
+    JsonObject paginated_request;
+    paginated_request.set("to"sv, local_storage_actor);
+    paginated_request.set("type"sv, "getStoreObjects"sv);
+    paginated_request.set("host"sv, "https://example.test"sv);
+    paginated_request.set("names"sv, JsonValue {});
+    JsonObject options;
+    options.set("offset"sv, 1);
+    options.set("size"sv, 1);
+    paginated_request.set("options"sv, move(options));
+    auto paginated_objects = client.request(move(paginated_request));
+    EXPECT_EQ(paginated_objects.get_integer<size_t>("offset"sv).value(), 1u);
+    EXPECT_EQ(paginated_objects.get_integer<size_t>("total"sv).value(), 2u);
+    auto paginated_data = paginated_objects.get_array("data"sv).release_value();
+    EXPECT_EQ(paginated_data.size(), 1u);
+    EXPECT_EQ(paginated_data.at(0).as_object().get_string("name"sv).value(), "beta"sv);
+
+    auto session_storage_actor = get_storage_actor(client, "session-storage"sv);
+    objects = get_storage_store_objects(client, session_storage_actor);
+    EXPECT_EQ(objects.get_integer<size_t>("total"sv).value(), 1u);
+    data = objects.get_array("data"sv).release_value();
+    EXPECT_EQ(data.at(0).as_object().get_string("name"sv).value(), "session-key"sv);
+    EXPECT_EQ(data.at(0).as_object().get_string("value"sv).value(), "session-value"sv);
+
+    objects = get_storage_store_objects(client, session_storage_actor, "https://other.test"sv);
     EXPECT_EQ(objects.get_integer<size_t>("total"sv).value(), 0u);
     EXPECT(objects.get_array("data"sv)->is_empty());
 }


### PR DESCRIPTION
Similar to the cookies support really, just with the web storage API things.

Comes with a bonus commit to add a "dump session storage" debug menu option, because we didn't have that and I needed it to verify that the session storage modifications were working.