### PR TITLE
LibWeb/Bindings: Preserve object EventHandler assignments

### DIFF
--- a/Meta/Generators/libweb_bindings/to_idl_value.py
+++ b/Meta/Generators/libweb_bindings/to_idl_value.py
@@ -19,7 +19,6 @@ from Generators.libweb_bindings.cpp_types import add_include_for_string_cpp_type
 from Generators.libweb_bindings.cpp_types import converter_function_name
 from Generators.libweb_bindings.cpp_types import cpp_empty_value
 from Generators.libweb_bindings.cpp_types import cpp_name
-from Generators.libweb_bindings.cpp_types import cpp_null_value
 from Generators.libweb_bindings.cpp_types import cpp_type
 from Generators.libweb_bindings.cpp_types import cpp_type_for_idl_type
 from Generators.libweb_bindings.cpp_types import cpp_type_for_idl_type_details
@@ -676,9 +675,6 @@ def callback_function_to_idl_value(
     includes.add("LibWeb/HTML/Scripting/Environments.h")
     includes.add("LibWeb/WebIDL/CallbackType.h")
 
-    # https://webidl.spec.whatwg.org/#js-callback-function
-    # 1. If the result of calling IsCallable(V) is false and the conversion to an IDL value is not being performed due to V being assigned to an attribute whose type is a nullable callback function that is annotated with [LegacyTreatNonObjectAsNull], then throw a TypeError.
-    # 2. Return the IDL callback function type value that represents a reference to the same object that V represents, with the incumbent settings object as the callback context.
     operation_returns_promise = (
         "WebIDL::OperationReturnsPromise::Yes"
         if callback_function.return_type.name.split("<", 1)[0] == "Promise"
@@ -687,23 +683,25 @@ def callback_function_to_idl_value(
 
     legacy_treat_non_object_as_null = "LegacyTreatNonObjectAsNull" in callback_function.extended_attributes
     return_cpp_type = "GC::Ptr<WebIDL::CallbackType>" if legacy_treat_non_object_as_null else return_cpp_type
-    if legacy_treat_non_object_as_null:
-        callable_check = f"""                    if (!{value_name}.is_function())
-                        return nullptr;
-"""
-    else:
-        callable_check = f"""                    // 1. If the result of calling IsCallable(V) is false and the conversion to an IDL value is not being performed due to V being assigned to an attribute whose type is a nullable callback function that is annotated with [LegacyTreatNonObjectAsNull], then throw a TypeError.
-                    if (!{value_name}.is_function())
-                        return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAFunction, {value_name});
+
+    conversion = f"""[&]() -> JS::ThrowCompletionOr<{return_cpp_type}> {{
 """
 
-    return f"""[&]() -> JS::ThrowCompletionOr<{return_cpp_type}> {{
-{callable_check}
-                    return vm.heap().allocate<WebIDL::CallbackType>(
-                        {value_name}.as_object(),
-                        HTML::incumbent_realm(),
-                        {operation_returns_promise});
-                    }}()"""
+    # 1. If the result of calling IsCallable(V) is false and the conversion to an IDL value is not being
+    #    performed due to V being assigned to an attribute whose type is a nullable callback function that
+    #    is annotated with [LegacyTreatNonObjectAsNull], then throw a TypeError.
+    if not legacy_treat_non_object_as_null:
+        conversion += f"""
+        if (!{value_name}.is_function())
+            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAFunction, {value_name});
+"""
+
+    # 2. Return the IDL callback function type value that represents a reference to the same object that V
+    #    represents, with the incumbent settings object as the callback context.
+    conversion += f"""
+        return vm.heap().allocate<WebIDL::CallbackType>({value_name}.as_object(),  HTML::incumbent_realm(), {operation_returns_promise});
+    }}()"""
+    return conversion
 
 
 # 3.2.20. Nullable types — T?, https://webidl.spec.whatwg.org/#js-nullable-type
@@ -716,23 +714,63 @@ def nullable_to_idl_value(
     includes: GeneratedIncludes,
     context: GenerationContext,
 ) -> str:
-    # 1. If V is not an Object, and the conversion to an IDL value is being performed due to V being assigned to an attribute whose type is a nullable callback function that is annotated with [LegacyTreatNonObjectAsNull], then return the IDL nullable type T? value null.
-    # 2. Otherwise, if V is undefined, and T includes undefined, return the unique undefined value.
-    # 3. Otherwise, if V is null or undefined, then return the IDL nullable type T? value null.
-    # 4. Otherwise, return the result of converting V using the rules for the inner IDL type T.
     inner_type = idl_type.clone_with_nullable(False)
+    cpp_type = cpp_type_for_idl_type_details(
+        idl_type,
+        context,
+        extended_attributes=extended_attributes,
+    )
+    conversion = f"""[&]() -> JS::ThrowCompletionOr<{return_cpp_type}> {{
+        {cpp_type.name} value;
+"""
+
+    # 1. If V is not an Object, and the conversion to an IDL value is being performed due to V being assigned to an
+    #    attribute whose type is a nullable callback function that is annotated with [LegacyTreatNonObjectAsNull],
+    #    then return the IDL nullable type T? value null.
+    callback_function = context.callback_function(inner_type)
+    legacy_treat_non_object_as_null = (
+        callback_function is not None and "LegacyTreatNonObjectAsNull" in callback_function.extended_attributes
+    )
+    if legacy_treat_non_object_as_null:
+        conversion += f"        if ({value_name}.is_object()) {{\n"
+
     inner_conversion = to_idl_value_from_type(
         inner_type, identifier, extended_attributes, value_name, includes, context
     )
-    null_value = cpp_null_value(idl_type, context)
     inner_return = (
         f"TRY({inner_conversion})" if idl_value_conversion_is_throwing(inner_type, context) else inner_conversion
     )
-    return f"""[&]() -> JS::ThrowCompletionOr<{return_cpp_type}> {{
-        if ({value_name}.is_nullish())
-            return {null_value};
-        return {inner_return};
-    }}()"""
+    inner_type_includes_undefined = inner_type.includes_undefined()
+
+    # 2. Otherwise, if V is undefined, and T includes undefined, return the unique undefined value.
+    if inner_type_includes_undefined:
+        conversion += f"""
+        if ({value_name}.is_undefined()) {{
+            value = Empty {{}};
+        }}
+"""
+        # 3. Otherwise, if V is null or undefined, then return the IDL nullable type T? value null.
+        conversion += f"""
+        else if (!{value_name}.is_nullish()) {{
+"""
+    else:
+        # 3. Otherwise, if V is null or undefined, then return the IDL nullable type T? value null.
+        conversion += f"""
+        if (!{value_name}.is_nullish()) {{
+"""
+
+    # 4. Otherwise, return the result of converting V using the rules for the inner IDL type T.
+    conversion += f"""
+            value = {inner_return};
+        }}
+"""
+
+    if legacy_treat_non_object_as_null:
+        conversion += "        }\n"
+
+    conversion += """        return value;
+    }()"""
+    return conversion
 
 
 # 3.2.21. Sequences — sequence<T>, https://webidl.spec.whatwg.org/#js-sequence

--- a/Tests/LibWeb/Text/expected/wpt-import/workers/constructors/SharedWorker/setting-port-members.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/workers/constructors/SharedWorker/setting-port-members.txt
@@ -2,12 +2,11 @@ Harness status: OK
 
 Found 7 tests
 
-6 Pass
-1 Fail
+7 Pass
 Pass	postMessage
 Pass	start
 Pass	close
-Fail	onmessage
+Pass	onmessage
 Pass	addEventListener
 Pass	removeEventListener
 Pass	despatchEvent

--- a/Tests/LibWeb/Text/expected/wpt-import/workers/constructors/SharedWorker/setting-port-members.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/workers/constructors/SharedWorker/setting-port-members.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 7 tests
+
+6 Pass
+1 Fail
+Pass	postMessage
+Pass	start
+Pass	close
+Fail	onmessage
+Pass	addEventListener
+Pass	removeEventListener
+Pass	despatchEvent

--- a/Tests/LibWeb/Text/input/wpt-import/workers/constructors/SharedWorker/#', '
+++ b/Tests/LibWeb/Text/input/wpt-import/workers/constructors/SharedWorker/#', '
@@ -1,0 +1,44 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width">
+<title>Directory listing for /workers/constructors/SharedWorker/</title>
+<h1>Directory listing for /workers/constructors/SharedWorker/</h1>
+<ul>
+<li class="dir"><a href="/workers/constructors/">..</a></li>
+<li class="file"><a href="1">1</a> (<a href="1.headers">.headers</a>)</li>
+<li class="file"><a href="Infinity">Infinity</a> (<a href="Infinity.headers">.headers</a>)</li>
+<li class="file"><a href="Infinity-arguments.html">Infinity-arguments.html</a></li>
+<li class="file"><a href="NaN">NaN</a> (<a href="NaN.headers">.headers</a>)</li>
+<li class="file"><a href="NaN-arguments.html">NaN-arguments.html</a></li>
+<li class="file"><a href="SharedWorker-constructor.html">SharedWorker-constructor.html</a></li>
+<li class="file"><a href="URLMismatchError.htm">URLMismatchError.htm</a></li>
+<li class="file"><a href="WEB_FEATURES.yml">WEB_FEATURES.yml</a></li>
+<li class="file"><a href="connect-event.html">connect-event.html</a></li>
+<li class="file"><a href="connect-event.js">connect-event.js</a></li>
+<li class="file"><a href="dummy-name.html">dummy-name.html</a></li>
+<li class="file"><a href="dummy-shared-worker.html">dummy-shared-worker.html</a></li>
+<li class="file"><a href="dummy-shared-worker.js">dummy-shared-worker.js</a></li>
+<li class="file"><a href="empty-name.html">empty-name.html</a></li>
+<li class="file"><a href="empty.js">empty.js</a></li>
+<li class="file"><a href="global-members.html">global-members.html</a></li>
+<li class="file"><a href="global-members.js">global-members.js</a></li>
+<li class="file"><a href="interface-objects.html">interface-objects.html</a></li>
+<li class="file"><a href="interface-objects.js">interface-objects.js</a></li>
+<li class="file"><a href="name.html">name.html</a></li>
+<li class="file"><a href="name.js">name.js</a></li>
+<li class="file"><a href="no-arguments-ctor.html">no-arguments-ctor.html</a></li>
+<li class="file"><a href="null">null</a> (<a href="null.headers">.headers</a>)</li>
+<li class="file"><a href="null-arguments.html">null-arguments.html</a></li>
+<li class="file"><a href="number-arguments.html">number-arguments.html</a></li>
+<li class="file"><a href="port-onmessage.html">port-onmessage.html</a></li>
+<li class="file"><a href="port-onmessage.js">port-onmessage.js</a></li>
+<li class="file"><a href="port-properties.html">port-properties.html</a></li>
+<li class="file"><a href="port-readonly.html">port-readonly.html</a></li>
+<li class="file"><a href="same-origin.html">same-origin.html</a></li>
+<li class="file"><a href="setting-port-members.html">setting-port-members.html</a></li>
+<li class="file"><a href="shared-worker.js">shared-worker.js</a></li>
+<li class="file"><a href="undefined">undefined</a> (<a href="undefined.headers">.headers</a>)</li>
+<li class="file"><a href="undefined-arguments.html">undefined-arguments.html</a></li>
+<li class="file"><a href="unexpected-global-properties.html">unexpected-global-properties.html</a></li>
+<li class="file"><a href="unexpected-global-properties.js">unexpected-global-properties.js</a></li>
+<li class="file"><a href="unresolvable-url.html">unresolvable-url.html</a></li>
+</ul>

--- a/Tests/LibWeb/Text/input/wpt-import/workers/constructors/SharedWorker/setting-port-members.html
+++ b/Tests/LibWeb/Text/input/wpt-import/workers/constructors/SharedWorker/setting-port-members.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<title>setting members of worker.port</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+setup(() => {
+  window.worker = new SharedWorker('#', '');
+});
+test(() => {
+  worker.port.postMessage = 1;
+  assert_equals(worker.port.postMessage, 1);
+}, 'postMessage');
+test(() => {
+  worker.port.start = 1;
+  assert_equals(worker.port.start, 1);
+}, 'start');
+test(() => {
+  worker.port.close = 1;
+  assert_equals(worker.port.close, 1);
+}, 'close');
+test(() => {
+  const f = () => {};
+  worker.port.onmessage = f;
+  assert_equals(worker.port.onmessage, f, '() => {}');
+  worker.port.onmessage = 1;
+  assert_equals(worker.port.onmessage, null, '1');
+  worker.port.onmessage = f;
+  worker.port.onmessage = ';';
+  assert_equals(worker.port.onmessage, null, '";"');
+  worker.port.onmessage = f;
+  const handler = {handleEvent:() => {}};
+  worker.port.onmessage = handler;
+  assert_equals(worker.port.onmessage, handler, '{handleEvent:() => {}}');
+  worker.port.onmessage = f;
+  worker.port.onmessage = null;
+  assert_equals(worker.port.onmessage, null, 'null');
+  worker.port.onmessage = f;
+  worker.port.onmessage = undefined;
+  assert_equals(worker.port.onmessage, null, 'undefined');
+}, 'onmessage');
+test(() => {
+  worker.port.addEventListener = 1;
+  assert_equals(worker.port.addEventListener, 1);
+}, 'addEventListener');
+test(() => {
+  worker.port.removeEventListener = 1;
+  assert_equals(worker.port.removeEventListener, 1);
+}, 'removeEventListener');
+test(() => {
+  worker.port.despatchEvent = 1;
+  assert_equals(worker.port.despatchEvent, 1);
+}, 'despatchEvent');
+</script>


### PR DESCRIPTION
EventHandler attributes are nullable callback function attributes with
[LegacyTreatNonObjectAsNull]. Assigning a non-object value should
produce null, but assigning an object value should preserve that object
as the callback value, even when the object is not callable.

Previously, object values such as `{ handleEvent() {} }` could pass the
nullable conversion and then be converted to null by the inner callback
function conversion. This made MessagePort.onmessage in the fixed test
return null after such an assignment.

Handle the non-object-to-null rule in nullable conversion, and let the
legacy callback conversion wrap object values without rejecting them for
not being callable.

Fixes a regression in the python port of the IDL generator.