### PR TITLE
LibWeb: Restore context after culled display list effects

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -264,10 +264,13 @@ void DisplayListPlayer::execute_impl(
             return false;
         };
 
-        while (applied_depth > common_ancestor_depth) {
-            restore({});
-            applied_depth--;
-        }
+        auto restore_to_depth = [&](size_t target_depth) {
+            while (applied_depth > target_depth) {
+                restore({});
+                --applied_depth;
+            }
+        };
+        restore_to_depth(common_ancestor_depth);
 
         auto result = SwitchResult::Switched;
         for_each_node_from_common_ancestor_to_target(
@@ -289,6 +292,8 @@ void DisplayListPlayer::execute_impl(
         if (result == SwitchResult::Switched) {
             applied_context_index = target_index;
             has_applied_context = true;
+        } else {
+            restore_to_depth(common_ancestor_depth);
         }
         return result;
     };

--- a/Tests/LibWeb/Ref/expected/effect-culling-restores-previous-context-ref.html
+++ b/Tests/LibWeb/Ref/expected/effect-culling-restores-previous-context-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<style>
+header {
+    position: relative;
+    z-index: 1;
+}
+
+header h1 {
+    background: red;
+}
+
+.later-context {
+    position: relative;
+    left: -80%;
+}
+
+.later-context span {
+    position: absolute;
+    width: 3em;
+    height: 2em;
+    overflow: hidden;
+    background: green;
+}
+
+.effect {
+    display: none;
+}
+</style>
+<header><h1>Heading</h1></header>
+<section class="later-context"><ul><li><a><span><div class="effect"></div></span></a></li></ul></section>

--- a/Tests/LibWeb/Ref/input/effect-culling-restores-previous-context.html
+++ b/Tests/LibWeb/Ref/input/effect-culling-restores-previous-context.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/effect-culling-restores-previous-context-ref.html">
+<style>
+header {
+    position: relative;
+    z-index: 1;
+}
+
+header h1 {
+    background: red;
+}
+
+.later-context {
+    position: relative;
+    left: -80%;
+}
+
+.later-context span {
+    position: absolute;
+    width: 3em;
+    height: 2em;
+    overflow: hidden;
+    background: green;
+}
+
+.effect {
+    position: absolute;
+    left: -77px;
+    top: -58px;
+    width: 200px;
+    height: 200px;
+    opacity: 0.75;
+    background: blue;
+}
+</style>
+<header><h1>Heading</h1></header>
+<section class="later-context"><ul><li><a><span><div class="effect"></div></span></a></li></ul></section>


### PR DESCRIPTION
Effect culling can stop a visual context switch after applying some ancestor contexts. The player left those contexts on the painter stack even though the target command was skipped.

Restore the painter stack back to the common ancestor when effect culling aborts the switch.

Fixes the logo and background on the homepage of https://cssday.nl:

| Before | After |
|--|--|
| <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/7a090466-b5d3-4932-99c1-c137dac2e54d" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/2ccc46be-1a56-4c5d-b973-e95f3925e617" /> |
