### PR TITLE
LibWeb+LibWakeLock: Keep the screen on while video is playing

### DIFF
--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(LibURL)
 add_subdirectory(LibUnicode)
 add_subdirectory(LibWasm)
 add_subdirectory(LibWebSocket)
+add_subdirectory(LibWakeLock)
 add_subdirectory(LibXML)
 
 if (ENABLE_GUI_TARGETS)

--- a/Libraries/LibWakeLock/CMakeLists.txt
+++ b/Libraries/LibWakeLock/CMakeLists.txt
@@ -1,0 +1,15 @@
+if (APPLE)
+    set(SOURCES
+        DisplaySleepInhibitorIOKit.cpp
+    )
+else()
+    set(SOURCES
+        DisplaySleepInhibitorNoOp.cpp
+    )
+endif()
+
+ladybird_lib(LibWakeLock wakelock)
+
+if (APPLE)
+    target_link_libraries(LibWakeLock PRIVATE "-framework CoreFoundation" "-framework IOKit")
+endif()

--- a/Libraries/LibWakeLock/DisplaySleepInhibitor.h
+++ b/Libraries/LibWakeLock/DisplaySleepInhibitor.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/OwnPtr.h>
+#include <AK/StringView.h>
+
+namespace WakeLock {
+
+namespace Detail {
+
+struct DisplaySleepInhibitorImpl;
+
+}
+
+class DisplaySleepInhibitor {
+public:
+    static ErrorOr<DisplaySleepInhibitor> create(StringView reason);
+
+    DisplaySleepInhibitor(DisplaySleepInhibitor const&) = delete;
+    DisplaySleepInhibitor& operator=(DisplaySleepInhibitor const&) = delete;
+
+    DisplaySleepInhibitor(DisplaySleepInhibitor&&);
+    DisplaySleepInhibitor& operator=(DisplaySleepInhibitor&&);
+
+    ~DisplaySleepInhibitor();
+
+private:
+    explicit DisplaySleepInhibitor(NonnullOwnPtr<Detail::DisplaySleepInhibitorImpl>);
+
+    OwnPtr<Detail::DisplaySleepInhibitorImpl> m_impl;
+};
+
+}

--- a/Libraries/LibWakeLock/DisplaySleepInhibitorIOKit.cpp
+++ b/Libraries/LibWakeLock/DisplaySleepInhibitorIOKit.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWakeLock/DisplaySleepInhibitor.h>
+
+#include <AK/StdLibExtras.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/pwr_mgt/IOPMLib.h>
+
+namespace WakeLock {
+
+namespace Detail {
+
+struct DisplaySleepInhibitorImpl {
+    explicit DisplaySleepInhibitorImpl(IOPMAssertionID assertion_id)
+        : assertion_id(assertion_id)
+    {
+    }
+
+    ~DisplaySleepInhibitorImpl()
+    {
+        IOPMAssertionRelease(assertion_id);
+    }
+
+    IOPMAssertionID assertion_id { 0 };
+};
+
+}
+
+ErrorOr<DisplaySleepInhibitor> DisplaySleepInhibitor::create(StringView reason)
+{
+    auto const* reason_string = CFStringCreateWithBytes(nullptr, reinterpret_cast<u8 const*>(reason.characters_without_null_termination()), reason.length(), kCFStringEncodingUTF8, false);
+    if (!reason_string)
+        return Error::from_string_literal("Failed to create display sleep inhibition reason");
+
+    IOPMAssertionID assertion_id = 0;
+    auto result = IOPMAssertionCreateWithName(kIOPMAssertPreventUserIdleDisplaySleep, kIOPMAssertionLevelOn, reason_string, &assertion_id);
+    CFRelease(reason_string);
+    if (result != kIOReturnSuccess)
+        return Error::from_string_literal("Failed to inhibit display sleep");
+
+    return DisplaySleepInhibitor { make<Detail::DisplaySleepInhibitorImpl>(assertion_id) };
+}
+
+DisplaySleepInhibitor::DisplaySleepInhibitor(NonnullOwnPtr<Detail::DisplaySleepInhibitorImpl> impl)
+    : m_impl(move(impl))
+{
+}
+
+DisplaySleepInhibitor::DisplaySleepInhibitor(DisplaySleepInhibitor&&) = default;
+
+DisplaySleepInhibitor& DisplaySleepInhibitor::operator=(DisplaySleepInhibitor&&) = default;
+
+DisplaySleepInhibitor::~DisplaySleepInhibitor() = default;
+
+}

--- a/Libraries/LibWakeLock/DisplaySleepInhibitorNoOp.cpp
+++ b/Libraries/LibWakeLock/DisplaySleepInhibitorNoOp.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWakeLock/DisplaySleepInhibitor.h>
+
+#include <AK/StdLibExtras.h>
+
+namespace WakeLock {
+
+namespace Detail {
+
+struct DisplaySleepInhibitorImpl {
+};
+
+}
+
+ErrorOr<DisplaySleepInhibitor> DisplaySleepInhibitor::create(StringView)
+{
+    return DisplaySleepInhibitor { make<Detail::DisplaySleepInhibitorImpl>() };
+}
+
+DisplaySleepInhibitor::DisplaySleepInhibitor(NonnullOwnPtr<Detail::DisplaySleepInhibitorImpl> impl)
+    : m_impl(move(impl))
+{
+}
+
+DisplaySleepInhibitor::DisplaySleepInhibitor(DisplaySleepInhibitor&&) = default;
+
+DisplaySleepInhibitor& DisplaySleepInhibitor::operator=(DisplaySleepInhibitor&&) = default;
+
+DisplaySleepInhibitor::~DisplaySleepInhibitor() = default;
+
+}

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -870,6 +870,7 @@ set(SOURCES
     Page/InputEvent.cpp
     Page/MiddleButtonScrollHandler.cpp
     Page/Page.cpp
+    Page/ScreenWakeLockHandle.cpp
     Painting/AccumulatedVisualContext.cpp
     Painting/BackgroundPainting.cpp
     Painting/Blending.cpp

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -53,6 +53,7 @@
 #include <LibWeb/MediaSourceExtensions/MediaSource.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/WebIDL/Promise.h>
@@ -126,6 +127,8 @@ void HTMLMediaElement::finalize()
 {
     Base::finalize();
 
+    m_screen_wake_lock.clear();
+
     // Tear down the controls eagerly so the Core::Timer they own (and the
     // closures it captures) cannot fire during the window between this GC
     // and our sweep, when our GC::Weak references to shadow tree nodes are
@@ -182,6 +185,8 @@ void HTMLMediaElement::visit_edges(Cell::Visitor& visitor)
         });
     if (m_controls.has_value())
         m_controls->visit_edges(visitor);
+    if (m_screen_wake_lock.has_value())
+        m_screen_wake_lock->visit_edges(visitor);
 }
 
 void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
@@ -264,6 +269,11 @@ void HTMLMediaElement::adopted_from(DOM::Document& old_document)
 
     if (m_delaying_the_load_event.has_value())
         m_delaying_the_load_event.emplace(document());
+
+    if (m_screen_wake_lock.has_value()) {
+        m_screen_wake_lock.clear();
+        update_screen_wake_lock();
+    }
 }
 
 void HTMLMediaElement::cancel_the_fetching_process()
@@ -1521,6 +1531,29 @@ Optional<String> HTMLMediaElement::verify_response_or_get_failure_reason(GC::Ref
     return {};
 }
 
+bool HTMLMediaElement::should_hold_screen_wake_lock() const
+{
+    if (!is<HTMLVideoElement>(*this))
+        return false;
+    if (m_video_tracks->selected_index() < 0)
+        return false;
+    if (!m_audio_tracks->has_enabled_track())
+        return false;
+
+    return potentially_playing();
+}
+
+void HTMLMediaElement::update_screen_wake_lock()
+{
+    if (should_hold_screen_wake_lock()) {
+        if (!m_screen_wake_lock.has_value())
+            m_screen_wake_lock.emplace(document().page());
+        return;
+    }
+
+    m_screen_wake_lock.clear();
+}
+
 void HTMLMediaElement::restart_fetch_at_offset(u64 offset)
 {
     VERIFY(m_remote_fetch_data);
@@ -1550,6 +1583,8 @@ void HTMLMediaElement::set_audio_track_enabled(Badge<AudioTrack>, GC::Ptr<HTML::
         m_playback_manager->enable_an_audio_track(audio_track->track_in_playback_manager());
     else
         m_playback_manager->disable_an_audio_track(audio_track->track_in_playback_manager());
+
+    update_screen_wake_lock();
 }
 
 Painting::VideoFrameResourceId HTMLMediaElement::ensure_video_frame_resource_id()
@@ -1612,6 +1647,8 @@ void HTMLMediaElement::set_selected_video_track(Badge<VideoTrack>, GC::Ptr<HTML:
 
     if (previous_track)
         m_playback_manager->remove_the_displaying_video_sink_for_track(previous_track->track_in_playback_manager());
+
+    update_screen_wake_lock();
 }
 
 void HTMLMediaElement::update_video_frame_and_timeline()
@@ -2052,6 +2089,7 @@ void HTMLMediaElement::forget_media_resource_specific_tracks()
     m_video_tracks->remove_all_tracks();
     m_playback_manager.clear();
     clear_compositor_video_frame();
+    update_screen_wake_lock();
 
     // NB: At this point, we no longer have any selected tracks to derive the video dimensions from.
     update_intrinsic_video_dimensions();
@@ -2068,6 +2106,7 @@ void HTMLMediaElement::set_ready_state(ReadyState ready_state)
 
     ScopeGuard guard { [&] {
         upon_has_ended_playback_possibly_changed();
+        update_screen_wake_lock();
         update_natural_dimensions();
         set_needs_style_update(true);
     } };
@@ -2557,6 +2596,8 @@ void HTMLMediaElement::notify_about_playing()
 
     if (m_audio_tracks->has_enabled_track())
         document().page().client().page_did_change_audio_play_state(AudioPlayState::Playing);
+
+    update_screen_wake_lock();
 }
 
 void HTMLMediaElement::set_show_poster(bool show_poster)
@@ -2585,6 +2626,8 @@ void HTMLMediaElement::set_paused(bool paused)
             document().page().client().page_did_change_audio_play_state(AudioPlayState::Paused);
     }
 
+    update_screen_wake_lock();
+
     update_natural_dimensions();
     set_needs_repaint();
     set_needs_style_update(true);
@@ -2592,7 +2635,12 @@ void HTMLMediaElement::set_paused(bool paused)
 
 void HTMLMediaElement::set_ended(bool ended)
 {
+    if (m_ended == ended)
+        return;
+
     m_ended = ended;
+
+    update_screen_wake_lock();
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-defaultplaybackrate

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/EventLoop/Task.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/MediaControls.h>
+#include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWeb/Painting/DisplayListResourceIds.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/WebIDL/DOMException.h>
@@ -195,7 +196,6 @@ private:
     friend SourceElementSelector;
 
     struct RemoteFetchData;
-
     virtual bool is_html_media_element() const final { return true; }
 
     struct EntireResource { };
@@ -218,6 +218,8 @@ private:
     void load_local_resource(MediaProviderObject const&, ESCAPING Function<void(String)> failure_callback);
 
     Optional<String> verify_response_or_get_failure_reason(GC::Ref<Fetch::Infrastructure::Response>, ByteRange const&);
+    bool should_hold_screen_wake_lock() const;
+    void update_screen_wake_lock();
 
     void restart_fetch_at_offset(u64 offset);
 
@@ -383,6 +385,7 @@ private:
     OwnPtr<Media::PlaybackManager> m_playback_manager;
     GC::Ptr<VideoTrack> m_selected_video_track;
     RefPtr<Media::DisplayingVideoSink> m_selected_video_track_sink;
+    Optional<ScreenWakeLockHandle> m_screen_wake_lock;
 
     bool m_loop_was_specified_when_reaching_end_of_media_resource { false };
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -640,6 +640,11 @@ bool Internals::needs_repaint()
     return page().top_level_traversable()->needs_repaint();
 }
 
+bool Internals::screen_wake_lock_active()
+{
+    return page().is_screen_wake_lock_active();
+}
+
 String Internals::dump_display_list()
 {
     return window().associated_document().dump_display_list();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -106,6 +106,7 @@ public:
     void set_device_pixel_ratio(double ratio);
 
     bool headless();
+    bool screen_wake_lock_active();
 
     bool needs_repaint();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -95,6 +95,7 @@ interface Internals {
     undefined setDevicePixelRatio(double ratio);
 
     readonly attribute boolean headless;
+    readonly attribute boolean screenWakeLockActive;
 
     readonly attribute boolean needsRepaint;
 

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -51,6 +51,19 @@ Page::Page(GC::Ref<PageClient> client)
 
 Page::~Page() = default;
 
+void Page::acquire_screen_wake_lock()
+{
+    if (m_active_screen_wake_lock_count++ == 0)
+        client().page_did_change_screen_wake_lock_state(ScreenWakeLockState::Acquired);
+}
+
+void Page::release_screen_wake_lock()
+{
+    VERIFY(m_active_screen_wake_lock_count > 0);
+    if (--m_active_screen_wake_lock_count == 0)
+        client().page_did_change_screen_wake_lock_state(ScreenWakeLockState::Released);
+}
+
 bool Page::has_compositor_host() const
 {
     return m_client->compositor_host();

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -810,9 +810,12 @@ void Page::toggle_media_controls_state()
         media_element->set_attribute_value(HTML::AttributeNames::controls, String {});
 }
 
-void Page::toggle_page_mute_state()
+void Page::set_page_mute_state(HTML::MuteState mute_state)
 {
-    m_mute_state = HTML::invert_mute_state(m_mute_state);
+    if (m_mute_state == mute_state)
+        return;
+
+    m_mute_state = mute_state;
 
     for_each_media_element([&](auto& media_element) {
         media_element.page_mute_state_changed({});

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -258,7 +258,7 @@ public:
     void toggle_media_controls_state();
 
     HTML::MuteState page_mute_state() const { return m_mute_state; }
-    void toggle_page_mute_state();
+    void set_page_mute_state(HTML::MuteState);
 
     Optional<String> const& user_style() const { return m_user_style_sheet_source; }
     void set_user_style(String source);

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -57,6 +57,7 @@
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/Painting/ChromeMetrics.h>
 #include <LibWeb/PixelUnits.h>
@@ -84,6 +85,9 @@ public:
 
     PageClient& client() { return m_client; }
     PageClient const& client() const { return m_client; }
+    void acquire_screen_wake_lock();
+    void release_screen_wake_lock();
+    bool is_screen_wake_lock_active() const { return m_active_screen_wake_lock_count > 0; }
     bool has_compositor_host() const;
     void ensure_compositor_host();
     Compositor::CompositorHost& compositor_host();
@@ -370,6 +374,7 @@ private:
     Optional<UniqueNodeID> m_media_context_menu_element_id;
 
     Web::HTML::MuteState m_mute_state { Web::HTML::MuteState::Unmuted };
+    size_t m_active_screen_wake_lock_count { 0 };
 
     Optional<String> m_user_style_sheet_source;
 
@@ -599,6 +604,7 @@ public:
     virtual void page_did_update_primary_selection(String const&) { }
 
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
+    virtual void page_did_change_screen_wake_lock_state(ScreenWakeLockState) { }
 
     virtual void page_did_start_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] URL::URL const& url, [[maybe_unused]] ByteString const& method, [[maybe_unused]] Vector<HTTP::Header> const& request_headers, [[maybe_unused]] ReadonlyBytes request_body, [[maybe_unused]] Optional<String> initiator_type) { }
     virtual void page_did_receive_network_response_headers([[maybe_unused]] u64 request_id, [[maybe_unused]] u32 status_code, [[maybe_unused]] Optional<String> reason_phrase, [[maybe_unused]] Vector<HTTP::Header> const& response_headers) { }

--- a/Libraries/LibWeb/Page/ScreenWakeLockHandle.cpp
+++ b/Libraries/LibWeb/Page/ScreenWakeLockHandle.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Page/Page.h>
+#include <LibWeb/Page/ScreenWakeLockHandle.h>
+
+namespace Web {
+
+ScreenWakeLockHandle::ScreenWakeLockHandle(Page& page)
+    : m_page(page)
+{
+    m_page->acquire_screen_wake_lock();
+}
+
+ScreenWakeLockHandle::~ScreenWakeLockHandle()
+{
+    m_page->release_screen_wake_lock();
+}
+
+void ScreenWakeLockHandle::visit_edges(JS::Cell::Visitor& visitor)
+{
+    visitor.visit(m_page);
+}
+
+}

--- a/Libraries/LibWeb/Page/ScreenWakeLockHandle.h
+++ b/Libraries/LibWeb/Page/ScreenWakeLockHandle.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <LibGC/Root.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibWeb/Forward.h>
+
+namespace Web {
+
+enum class ScreenWakeLockState {
+    Released,
+    Acquired,
+};
+
+class ScreenWakeLockHandle {
+    AK_MAKE_NONCOPYABLE(ScreenWakeLockHandle);
+    AK_MAKE_NONMOVABLE(ScreenWakeLockHandle);
+
+public:
+    explicit ScreenWakeLockHandle(Page&);
+    ~ScreenWakeLockHandle();
+
+    void visit_edges(JS::Cell::Visitor&);
+
+private:
+    GC::Ref<Page> m_page;
+};
+
+}

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1159,6 +1159,22 @@ void ViewImplementation::reset_page_media_state()
 
     if (should_notify_audio_play_state_changed && on_audio_play_state_changed)
         on_audio_play_state_changed(m_audio_play_state);
+
+    if (m_screen_wake_lock_state != Web::ScreenWakeLockState::Released) {
+        m_screen_wake_lock_state = Web::ScreenWakeLockState::Released;
+        if (on_screen_wake_lock_state_changed)
+            on_screen_wake_lock_state_changed(m_screen_wake_lock_state);
+    }
+}
+
+void ViewImplementation::did_change_screen_wake_lock_state(Badge<WebContentClient>, Web::ScreenWakeLockState wake_lock_state)
+{
+    if (m_screen_wake_lock_state == wake_lock_state)
+        return;
+
+    m_screen_wake_lock_state = wake_lock_state;
+    if (on_screen_wake_lock_state_changed)
+        on_screen_wake_lock_state_changed(m_screen_wake_lock_state);
 }
 
 static Optional<size_t> current_top_level_history_entry_index_for_step(Vector<Web::HTML::SessionHistoryEntryDescriptor> const&, Optional<i32> current_step);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -161,6 +161,8 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
         m_client_state.client->unregister_view(m_client_state.page_index);
     }
 
+    reset_page_media_state();
+
     initialize_client();
     VERIFY(m_client_state.client);
 
@@ -1120,7 +1122,7 @@ void ViewImplementation::retrieved_clipboard_entries(u64 request_id, ReadonlySpa
 void ViewImplementation::toggle_page_mute_state()
 {
     m_mute_state = Web::HTML::invert_mute_state(m_mute_state);
-    client().async_toggle_page_mute_state(page_id());
+    client().async_set_page_mute_state(page_id(), m_mute_state);
 }
 
 void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState play_state)
@@ -1150,12 +1152,10 @@ void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, We
 void ViewImplementation::reset_page_media_state()
 {
     auto const should_notify_audio_play_state_changed = m_audio_play_state != Web::HTML::AudioPlayState::Paused
-        || m_number_of_elements_playing_audio != 0
-        || m_mute_state != Web::HTML::MuteState::Unmuted;
+        || m_number_of_elements_playing_audio != 0;
 
     m_audio_play_state = Web::HTML::AudioPlayState::Paused;
     m_number_of_elements_playing_audio = 0;
-    m_mute_state = Web::HTML::MuteState::Unmuted;
 
     if (should_notify_audio_play_state_changed && on_audio_play_state_changed)
         on_audio_play_state_changed(m_audio_play_state);
@@ -1323,6 +1323,8 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
     Application::the().update_compositor_viewport(compositor_context_id, viewport_size().to_type<int>());
     client().async_set_document_cookie_version_buffer(m_client_state.page_index, m_document_cookie_version_buffer);
+
+    client().async_set_page_mute_state(m_client_state.page_index, m_mute_state);
 
     if (auto webdriver_endpoint = Application::browser_options().webdriver_endpoint; webdriver_endpoint.has_value())
         client().async_connect_to_webdriver(m_client_state.page_index, *webdriver_endpoint);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -41,6 +41,7 @@
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/WebDriver/Response.h>
 #include <LibWebView/BookmarkStore.h>
@@ -251,6 +252,8 @@ public:
 
     void did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState);
     Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
+    void did_change_screen_wake_lock_state(Badge<WebContentClient>, Web::ScreenWakeLockState);
+    Web::ScreenWakeLockState screen_wake_lock_state() const { return m_screen_wake_lock_state; }
 
     void did_update_session_history(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index);
     void did_update_session_history_for_testing(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index);
@@ -363,6 +366,7 @@ public:
     Function<void(Gfx::Color)> on_theme_color_change;
     Function<void(Gfx::Color)> on_page_background_color_change;
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;
+    Function<void(Web::ScreenWakeLockState)> on_screen_wake_lock_state_changed;
     Function<void()> on_web_content_crashed;
     Function<void()> on_web_content_process_change_for_cross_site_navigation;
 
@@ -551,6 +555,7 @@ protected:
 
     Web::HTML::AudioPlayState m_audio_play_state { Web::HTML::AudioPlayState::Paused };
     size_t m_number_of_elements_playing_audio { 0 };
+    Web::ScreenWakeLockState m_screen_wake_lock_state { Web::ScreenWakeLockState::Released };
 
     Web::HTML::MuteState m_mute_state { Web::HTML::MuteState::Unmuted };
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1772,6 +1772,12 @@ void WebContentClient::did_change_audio_play_state(u64 page_id, Web::HTML::Audio
         view->did_change_audio_play_state({}, play_state);
 }
 
+void WebContentClient::did_change_screen_wake_lock_state(u64 page_id, Web::ScreenWakeLockState wake_lock_state)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_change_screen_wake_lock_state({}, wake_lock_state);
+}
+
 void WebContentClient::did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -37,6 +37,7 @@
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
 #include <LibWeb/Page/EventResult.h>
+#include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/Forward.h>
@@ -242,6 +243,7 @@ private:
     virtual void did_request_primary_paste(u64 page_id) override;
     virtual void did_update_primary_selection(u64 page_id, String) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
+    virtual void did_change_screen_wake_lock_state(u64 page_id, Web::ScreenWakeLockState) override;
     virtual void did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index) override;
     virtual Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse did_request_ui_process_session_history_for_testing(u64 page_id) override;
     virtual Messages::WebContentClient::DidRequestSiteIsolationProcessTreeForTestingResponse did_request_site_isolation_process_tree_for_testing(u64 page_id) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2396,10 +2396,10 @@ void ConnectionFromClient::toggle_media_controls_state(u64 page_id)
         page->page().toggle_media_controls_state();
 }
 
-void ConnectionFromClient::toggle_page_mute_state(u64 page_id)
+void ConnectionFromClient::set_page_mute_state(u64 page_id, Web::HTML::MuteState mute_state)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().toggle_page_mute_state();
+        page->page().set_page_mute_state(mute_state);
 }
 
 void ConnectionFromClient::set_user_style(u64 page_id, String source)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -191,7 +191,7 @@ private:
     virtual void toggle_media_fullscreen_state(u64 page_id) override;
     virtual void toggle_media_controls_state(u64 page_id) override;
 
-    virtual void toggle_page_mute_state(u64 page_id) override;
+    virtual void set_page_mute_state(u64 page_id, Web::HTML::MuteState mute_state) override;
 
     virtual void set_user_style(u64 page_id, String) override;
 

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1182,6 +1182,11 @@ void PageClient::page_did_change_audio_play_state(Web::HTML::AudioPlayState play
     client().async_did_change_audio_play_state(m_id, play_state);
 }
 
+void PageClient::page_did_change_screen_wake_lock_state(Web::ScreenWakeLockState wake_lock_state)
+{
+    client().async_did_change_screen_wake_lock_state(m_id, wake_lock_state);
+}
+
 Web::HTML::WorkerAgentId PageClient::start_worker_agent(Web::HTML::WorkerAgentStartRequest&& request)
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::StartWorkerAgent>(m_id, move(request));

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -258,6 +258,7 @@ private:
     virtual void page_did_request_primary_paste() override;
     virtual void page_did_update_primary_selection(String const&) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
+    virtual void page_did_change_screen_wake_lock_state(Web::ScreenWakeLockState) override;
     virtual Web::HTML::WorkerAgentId start_worker_agent(Web::HTML::WorkerAgentStartRequest&&) override;
     virtual void close_worker_agent(Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken) override;
     virtual void page_did_mutate_dom(FlyString const& type, Web::DOM::Node const& target, Web::DOM::NodeList& added_nodes, Web::DOM::NodeList& removed_nodes, GC::Ptr<Web::DOM::Node> previous_sibling, GC::Ptr<Web::DOM::Node> next_sibling, Optional<String> const& attribute_name) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -30,6 +30,7 @@
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWeb/WebDriver/Response.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/ConsoleOutput.h>
@@ -178,6 +179,7 @@ endpoint WebContentClient
     did_reset_session_history_for_testing(u64 page_id) =|
 
     did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state) =|
+    did_change_screen_wake_lock_state(u64 page_id, Web::ScreenWakeLockState wake_lock_state) =|
 
     did_execute_js_console_input(u64 page_id, JsonValue result) =|
     did_output_js_console_message(u64 page_id, WebView::ConsoleOutput console_output) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -12,6 +12,7 @@
 #include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/AutoplayPolicy.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
@@ -184,7 +185,7 @@ endpoint WebContentServer
     toggle_media_fullscreen_state(u64 page_id) =|
     toggle_media_controls_state(u64 page_id) =|
 
-    toggle_page_mute_state(u64 page_id) =|
+    set_page_mute_state(u64 page_id, Web::HTML::MuteState mute_state) =|
 
     set_user_style(u64 page_id, String source) =|
 

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-screen-wake-lock.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-screen-wake-lock.txt
@@ -1,0 +1,10 @@
+initial: screenWakeLockActive=false
+loaded metadata: screenWakeLockActive=false
+playing: screenWakeLockActive=true
+paused: screenWakeLockActive=false
+playing again: screenWakeLockActive=true
+audio track disabled: screenWakeLockActive=false
+audio track re-enabled: screenWakeLockActive=true
+video track disabled: screenWakeLockActive=false
+video track re-enabled: screenWakeLockActive=true
+src cleared and loaded: screenWakeLockActive=false

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-screen-wake-lock.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-screen-wake-lock.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<video id="video"></video>
+<script>
+    const video = document.getElementById("video");
+
+    function logState(label) {
+        println(`${label}: screenWakeLockActive=${internals.screenWakeLockActive}`);
+    }
+
+    function waitForEvent(target, name) {
+        return new Promise(resolve => target.addEventListener(name, resolve, { once: true }));
+    }
+
+    asyncTest(async done => {
+        logState("initial");
+
+        video.src = "../../../Assets/test-webm.webm";
+        await waitForEvent(video, "loadedmetadata");
+        logState("loaded metadata");
+
+        const sawPlaying = waitForEvent(video, "playing");
+        await video.play();
+        await sawPlaying;
+        logState("playing");
+
+        video.pause();
+        logState("paused");
+
+        const sawPlayingAgain = waitForEvent(video, "playing");
+        await video.play();
+        await sawPlayingAgain;
+        logState("playing again");
+
+        video.audioTracks[0].enabled = false;
+        logState("audio track disabled");
+
+        video.audioTracks[0].enabled = true;
+        logState("audio track re-enabled");
+
+        video.videoTracks[0].selected = false;
+        logState("video track disabled");
+
+        video.videoTracks[0].selected = true;
+        logState("video track re-enabled");
+
+        video.removeAttribute("src");
+        video.load();
+        logState("src cleared and loaded");
+
+        done();
+    });
+</script>

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -7,6 +7,7 @@
 #include <AK/Optional.h>
 #include <Interface/LadybirdWebViewBridge.h>
 #include <LibURL/URL.h>
+#include <LibWakeLock/DisplaySleepInhibitor.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/Utilities.h>
@@ -91,6 +92,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 @interface LadybirdWebView () <NSDraggingDestination>
 {
     OwnPtr<Ladybird::WebViewBridge> m_web_view_bridge;
+    Optional<WakeLock::DisplaySleepInhibitor> m_screen_display_sleep_inhibitor;
 
     Optional<HideCursor> m_hidden_cursor;
 
@@ -964,6 +966,25 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
             return;
         }
         [self.observer onAudioPlayStateChange:play_state];
+    };
+
+    m_web_view_bridge->on_screen_wake_lock_state_changed = [weak_self](auto wake_lock_state) {
+        LadybirdWebView* self = weak_self;
+        if (self == nil) {
+            return;
+        }
+
+        switch (wake_lock_state) {
+        case Web::ScreenWakeLockState::Released:
+            self->m_screen_display_sleep_inhibitor.clear();
+            break;
+        case Web::ScreenWakeLockState::Acquired:
+            if (self->m_screen_display_sleep_inhibitor.has_value())
+                break;
+            if (auto inhibitor = WakeLock::DisplaySleepInhibitor::create("Ladybird Content"sv); !inhibitor.is_error())
+                self->m_screen_display_sleep_inhibitor = inhibitor.release_value();
+            break;
+        }
     };
 }
 

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -59,7 +59,7 @@ else()
     set(LADYBIRD_TARGET ladybird PRIVATE)
 endif()
 
-set(LADYBIRD_LIBS AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebView LibRequests LibSync LibURL)
+set(LADYBIRD_LIBS AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebView LibRequests LibSync LibURL LibWakeLock)
 target_link_libraries(${LADYBIRD_TARGET} PRIVATE ${LADYBIRD_LIBS})
 target_link_libraries(${LADYBIRD_TARGET} PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -8,6 +8,7 @@
 
 #include <LibCore/EventLoop.h>
 #include <LibURL/URL.h>
+#include <LibWakeLock/DisplaySleepInhibitor.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/DownloadPresentation.h>
@@ -962,6 +963,10 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         emit audio_play_state_changed(tab_index(), play_state);
     };
 
+    view().on_screen_wake_lock_state_changed = [this](auto wake_lock_state) {
+        set_screen_wake_lock_state(wake_lock_state);
+    };
+
     auto* duplicate_tab_action = new QAction("&Duplicate Tab", this);
     QObject::connect(duplicate_tab_action, &QAction::triggered, this, [this]() {
         m_window->new_tab_from_url(view().url(), Web::HTML::ActivateTab::Yes);
@@ -1229,6 +1234,21 @@ void Tab::open_file()
 int Tab::tab_index()
 {
     return m_window->tab_index(this);
+}
+
+void Tab::set_screen_wake_lock_state(Web::ScreenWakeLockState wake_lock_state)
+{
+    switch (wake_lock_state) {
+    case Web::ScreenWakeLockState::Released:
+        m_screen_display_sleep_inhibitor.clear();
+        break;
+    case Web::ScreenWakeLockState::Acquired:
+        if (m_screen_display_sleep_inhibitor.has_value())
+            break;
+        if (auto inhibitor = WakeLock::DisplaySleepInhibitor::create("Ladybird Content"sv); !inhibitor.is_error())
+            m_screen_display_sleep_inhibitor = inhibitor.release_value();
+        break;
+    }
 }
 
 void Tab::resizeEvent(QResizeEvent* event)

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+#include <LibWakeLock/DisplaySleepInhibitor.h>
 #include <LibWeb/HTML/AudioPlayState.h>
+#include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWebView/FileDownloader.h>
 #include <LibWebView/Settings.h>
 #include <UI/Qt/BookmarksBar.h>
@@ -129,6 +132,7 @@ private:
     void set_loading(bool);
     void update_tab_icon();
     int tab_index();
+    void set_screen_wake_lock_state(Web::ScreenWakeLockState);
 
     virtual void download_added(WebView::FileDownloader::Download const&) override;
     virtual void download_updated(WebView::FileDownloader::Download const&) override;
@@ -154,6 +158,7 @@ private:
     LocationEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
     FindInPageWidget* m_find_in_page { nullptr };
+    Optional<WakeLock::DisplaySleepInhibitor> m_screen_display_sleep_inhibitor;
     BrowserWindow* m_window { nullptr };
     QString m_title;
     HyperlinkLabel* m_hover_label { nullptr };


### PR DESCRIPTION
This uses a new library to implement the wake locking, since it requires linking in libraries that would be unused for any other functionality in LibCore. The library is currently a no-op on any platforms other than macOS.

The media element checks whether it should have a wakelock at points where it may change, and then emplaces or removes a LibWeb RAII wrapper for the Page methods for taking/releasing the lock. The Page tracks the number of wakes held, and when it goes to or from zero, it notifies the UI that it needs to change.

Currently, this is only for screen locking. We could potentially do sleep locking as well, to allow audio playback to continue while idle.

For testing, the Internals object exposes a function to check whether the wake lock is held.