### PR TITLE
CI: Switch macOS runners to macos-26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             build_preset: 'Sanitizer'
             toolchain: 'Clang'
             clang_plugins: false
-            runner_labels: '["macos-15", "self-hosted"]'
+            runner_labels: '["macos-26", "self-hosted"]'
             container: 'null'
 
           - os_name: 'Linux'

--- a/.github/workflows/js-and-wasm-artifacts.yml
+++ b/.github/workflows/js-and-wasm-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
             arch: 'arm64'
             toolchain: 'Clang'
             package_type: 'macOS-arm64'
-            runner_labels: '["macos-15", "self-hosted"]'
+            runner_labels: '["macos-26", "self-hosted"]'
             container: 'null'
 
           - os_name: 'Linux'

--- a/.github/workflows/js-and-wasm-benchmarks.yml
+++ b/.github/workflows/js-and-wasm-benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
           - os_name: 'macOS'
             arch: 'arm64'
             package_type: 'macOS-arm64'
-            runner_labels: '["macos-15", "js-benchmarks", "self-hosted"]'
+            runner_labels: '["macos-26", "js-benchmarks", "self-hosted"]'
             container: 'null'
 
     permissions:

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -40,7 +40,7 @@ jobs:
             build_preset: 'Distribution'
             toolchain: 'Clang'
             clang_plugins: false
-            runner_labels: '["macos-15", "self-hosted"]'
+            runner_labels: '["macos-26", "self-hosted"]'
             container: 'null'
 
           - os_name: 'Linux'

--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - os_name: 'macOS'
             arch: 'arm64'
-            runner_labels: '["macos-15", "web-benchmarks", "self-hosted"]'
+            runner_labels: '["macos-26", "web-benchmarks", "self-hosted"]'
             container: 'null'
 
     permissions:


### PR DESCRIPTION
All our self-hosted runners have been updated.