### PR TITLE
LibWeb: Miscellaneous `ImageProvider`/`DecodedImageData` cleanup

### DIFF
--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
@@ -16,15 +16,13 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(BitmapDecodedImageData);
 
-ErrorOr<GC::Ref<BitmapDecodedImageData>> BitmapDecodedImageData::create(JS::Realm& realm, Vector<Frame>&& frames, size_t loop_count, bool animated)
+GC::Ref<BitmapDecodedImageData> BitmapDecodedImageData::create(JS::Realm& realm, Gfx::DecodedImageFrame&& frame)
 {
-    return realm.create<BitmapDecodedImageData>(move(frames), loop_count, animated);
+    return realm.create<BitmapDecodedImageData>(move(frame));
 }
 
-BitmapDecodedImageData::BitmapDecodedImageData(Vector<Frame>&& frames, size_t loop_count, bool animated)
-    : m_frames(move(frames))
-    , m_loop_count(loop_count)
-    , m_animated(animated)
+BitmapDecodedImageData::BitmapDecodedImageData(Gfx::DecodedImageFrame&& frame)
+    : m_frame(move(frame))
 {
 }
 
@@ -32,49 +30,37 @@ BitmapDecodedImageData::~BitmapDecodedImageData() = default;
 
 size_t BitmapDecodedImageData::external_memory_size() const
 {
-    size_t size = JS::vector_external_memory_size(m_frames);
-    for (auto const& frame : m_frames)
-        size = JS::saturating_add_external_memory_size(size, frame.frame.bitmap().data_size());
-    return size;
+    return m_frame.bitmap().data_size();
 }
 
-Optional<Gfx::DecodedImageFrame> BitmapDecodedImageData::frame(size_t frame_index, Gfx::IntSize) const
+Optional<Gfx::DecodedImageFrame> BitmapDecodedImageData::frame(size_t, Gfx::IntSize) const
 {
-    if (frame_index >= m_frames.size())
-        return {};
-    return m_frames[frame_index].frame;
-}
-
-int BitmapDecodedImageData::frame_duration(size_t frame_index) const
-{
-    if (frame_index >= m_frames.size())
-        return 0;
-    return m_frames[frame_index].duration;
+    return m_frame;
 }
 
 Optional<CSSPixels> BitmapDecodedImageData::intrinsic_width() const
 {
-    return m_frames.first().frame.width();
+    return m_frame.width();
 }
 
 Optional<CSSPixels> BitmapDecodedImageData::intrinsic_height() const
 {
-    return m_frames.first().frame.height();
+    return m_frame.height();
 }
 
 Optional<CSSPixelFraction> BitmapDecodedImageData::intrinsic_aspect_ratio() const
 {
-    return CSSPixels(m_frames.first().frame.width()) / CSSPixels(m_frames.first().frame.height());
+    return CSSPixels(m_frame.width()) / CSSPixels(m_frame.height());
 }
 
-Optional<Gfx::IntRect> BitmapDecodedImageData::frame_rect(size_t frame_index) const
+Optional<Gfx::IntRect> BitmapDecodedImageData::frame_rect(size_t) const
 {
-    return m_frames[frame_index].frame.rect();
+    return m_frame.rect();
 }
 
-void BitmapDecodedImageData::paint(DisplayListRecordingContext& context, size_t frame_index, Gfx::IntRect dst_rect, Gfx::ScalingMode scaling_mode) const
+void BitmapDecodedImageData::paint(DisplayListRecordingContext& context, size_t, Gfx::IntRect dst_rect, Gfx::ScalingMode scaling_mode) const
 {
-    context.display_list_recorder().draw_scaled_decoded_image_frame(dst_rect, m_frames[frame_index].frame, scaling_mode);
+    context.display_list_recorder().draw_scaled_decoded_image_frame(dst_rect, m_frame, scaling_mode);
 }
 
 }

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
@@ -17,20 +17,15 @@ class BitmapDecodedImageData final : public DecodedImageData {
     GC_DECLARE_ALLOCATOR(BitmapDecodedImageData);
 
 public:
-    struct Frame {
-        Gfx::DecodedImageFrame frame;
-        int duration { 0 };
-    };
-
-    static ErrorOr<GC::Ref<BitmapDecodedImageData>> create(JS::Realm&, Vector<Frame>&&, size_t loop_count, bool animated);
+    static GC::Ref<BitmapDecodedImageData> create(JS::Realm&, Gfx::DecodedImageFrame&& frame);
     virtual ~BitmapDecodedImageData() override;
 
     virtual Optional<Gfx::DecodedImageFrame> frame(size_t frame_index, Gfx::IntSize = {}) const override;
-    virtual int frame_duration(size_t frame_index) const override;
 
-    virtual size_t frame_count() const override { return m_frames.size(); }
-    virtual size_t loop_count() const override { return m_loop_count; }
-    virtual bool is_animated() const override { return m_animated; }
+    virtual int frame_duration(size_t) const override { return 0; }
+    virtual size_t frame_count() const override { return 1; }
+    virtual size_t loop_count() const override { return 0; }
+    virtual bool is_animated() const override { return false; }
 
     virtual Optional<CSSPixels> intrinsic_width() const override;
     virtual Optional<CSSPixels> intrinsic_height() const override;
@@ -40,13 +35,11 @@ public:
     virtual void paint(DisplayListRecordingContext&, size_t frame_index, Gfx::IntRect dst_rect, Gfx::ScalingMode scaling_mode) const override;
 
 private:
-    BitmapDecodedImageData(Vector<Frame>&&, size_t loop_count, bool animated);
+    BitmapDecodedImageData(Gfx::DecodedImageFrame&& frame);
 
     virtual size_t external_memory_size() const override;
 
-    Vector<Frame> m_frames;
-    size_t m_loop_count { 0 };
-    bool m_animated { false };
+    Gfx::DecodedImageFrame m_frame;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -310,46 +310,6 @@ void HTMLImageElement::adjust_computed_style(CSS::ComputedProperties& style)
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
 }
 
-Optional<Gfx::DecodedImageFrame> HTMLImageElement::default_image_frame_sized(Gfx::IntSize size) const
-{
-    if (auto data = m_current_request->image_data())
-        return data->frame(0, size);
-    return {};
-}
-
-bool HTMLImageElement::is_image_available() const
-{
-    return m_current_request && m_current_request->is_available();
-}
-
-Optional<CSSPixels> HTMLImageElement::intrinsic_width() const
-{
-    if (auto image_data = m_current_request->image_data())
-        return image_data->intrinsic_width();
-    return {};
-}
-
-Optional<CSSPixels> HTMLImageElement::intrinsic_height() const
-{
-    if (auto image_data = m_current_request->image_data())
-        return image_data->intrinsic_height();
-    return {};
-}
-
-Optional<CSSPixelFraction> HTMLImageElement::intrinsic_aspect_ratio() const
-{
-    if (auto image_data = m_current_request->image_data())
-        return image_data->intrinsic_aspect_ratio();
-    return {};
-}
-
-Optional<Gfx::DecodedImageFrame> HTMLImageElement::current_image_frame_sized(Gfx::IntSize size) const
-{
-    if (auto data = m_current_request->image_data())
-        return data->frame(m_current_frame_index, size);
-    return {};
-}
-
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-width
 WebIDL::UnsignedLong HTMLImageElement::width() const
 {

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -350,11 +350,6 @@ Optional<Gfx::DecodedImageFrame> HTMLImageElement::current_image_frame_sized(Gfx
     return {};
 }
 
-void HTMLImageElement::set_visible_in_viewport(bool)
-{
-    // FIXME: Loosen grip on image data when it's not visible, e.g via volatile memory.
-}
-
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-width
 WebIDL::UnsignedLong HTMLImageElement::width() const
 {

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -112,8 +112,6 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
     virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const override;
-    virtual void set_visible_in_viewport(bool) override;
-    virtual GC::Ptr<DOM::Element const> to_html_element() const override { return *this; }
     virtual GC::Ptr<DecodedImageData> decoded_image_data() const override;
 
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -49,8 +49,6 @@ public:
 
     String alt() const { return get_attribute_value(HTML::AttributeNames::alt); }
 
-    virtual Optional<Gfx::DecodedImageFrame> default_image_frame_sized(Gfx::IntSize) const override;
-
     WebIDL::UnsignedLong width() const;
     void set_width(WebIDL::UnsignedLong);
 
@@ -107,11 +105,6 @@ public:
     bool allows_auto_sizes() const;
 
     // ^Layout::ImageProvider
-    virtual bool is_image_available() const override;
-    virtual Optional<CSSPixels> intrinsic_width() const override;
-    virtual Optional<CSSPixels> intrinsic_height() const override;
-    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
-    virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const override;
     virtual GC::Ptr<DecodedImageData> decoded_image_data() const override;
 
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2347,11 +2347,6 @@ Optional<Gfx::DecodedImageFrame> HTMLInputElement::current_image_frame_sized(Gfx
     return {};
 }
 
-void HTMLInputElement::set_visible_in_viewport(bool)
-{
-    // FIXME: Loosen grip on image data when it's not visible, e.g via volatile memory.
-}
-
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
 i32 HTMLInputElement::default_tab_index_value() const
 {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2314,39 +2314,6 @@ GC::Ptr<DecodedImageData> HTMLInputElement::image_data() const
     return nullptr;
 }
 
-bool HTMLInputElement::is_image_available() const
-{
-    return image_data() != nullptr;
-}
-
-Optional<CSSPixels> HTMLInputElement::intrinsic_width() const
-{
-    if (auto image_data = this->image_data())
-        return image_data->intrinsic_width();
-    return {};
-}
-
-Optional<CSSPixels> HTMLInputElement::intrinsic_height() const
-{
-    if (auto image_data = this->image_data())
-        return image_data->intrinsic_height();
-    return {};
-}
-
-Optional<CSSPixelFraction> HTMLInputElement::intrinsic_aspect_ratio() const
-{
-    if (auto image_data = this->image_data())
-        return image_data->intrinsic_aspect_ratio();
-    return {};
-}
-
-Optional<Gfx::DecodedImageFrame> HTMLInputElement::current_image_frame_sized(Gfx::IntSize size) const
-{
-    if (auto image_data = this->image_data())
-        return image_data->frame(0, size);
-    return {};
-}
-
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
 i32 HTMLInputElement::default_tab_index_value() const
 {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -287,11 +287,6 @@ private:
     virtual bool supports_dimension_attributes() const override { return type_state() == TypeAttributeState::ImageButton; }
 
     // ^Layout::ImageProvider
-    virtual bool is_image_available() const override;
-    virtual Optional<CSSPixels> intrinsic_width() const override;
-    virtual Optional<CSSPixels> intrinsic_height() const override;
-    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
-    virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const override;
     virtual size_t current_frame_index() const override { return 0; }
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override { return image_data(); }
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -292,8 +292,6 @@ private:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
     virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const override;
-    virtual void set_visible_in_viewport(bool) override;
-    virtual GC::Ptr<DOM::Element const> to_html_element() const override { return *this; }
     virtual size_t current_frame_index() const override { return 0; }
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override { return image_data(); }
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -594,37 +594,4 @@ GC::Ptr<DecodedImageData> HTMLObjectElement::image_data() const
     return m_resource_request->image_data();
 }
 
-bool HTMLObjectElement::is_image_available() const
-{
-    return image_data() != nullptr;
-}
-
-Optional<CSSPixels> HTMLObjectElement::intrinsic_width() const
-{
-    if (auto image_data = this->image_data())
-        return image_data->intrinsic_width();
-    return {};
-}
-
-Optional<CSSPixels> HTMLObjectElement::intrinsic_height() const
-{
-    if (auto image_data = this->image_data())
-        return image_data->intrinsic_height();
-    return {};
-}
-
-Optional<CSSPixelFraction> HTMLObjectElement::intrinsic_aspect_ratio() const
-{
-    if (auto image_data = this->image_data())
-        return image_data->intrinsic_aspect_ratio();
-    return {};
-}
-
-Optional<Gfx::DecodedImageFrame> HTMLObjectElement::current_image_frame_sized(Gfx::IntSize size) const
-{
-    if (auto image_data = this->image_data())
-        return image_data->frame(0, size);
-    return {};
-}
-
 }

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -627,9 +627,4 @@ Optional<Gfx::DecodedImageFrame> HTMLObjectElement::current_image_frame_sized(Gf
     return {};
 }
 
-void HTMLObjectElement::set_visible_in_viewport(bool)
-{
-    // FIXME: Loosen grip on image data when it's not visible, e.g via volatile memory.
-}
-
 }

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -88,8 +88,6 @@ private:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
     virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const override;
-    virtual void set_visible_in_viewport(bool) override;
-    virtual GC::Ptr<DOM::Element const> to_html_element() const override { return *this; }
     virtual size_t current_frame_index() const override { return 0; }
     virtual GC::Ptr<DecodedImageData> decoded_image_data() const override { return image_data(); }
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -83,11 +83,6 @@ private:
     virtual i32 default_tab_index_value() const override;
 
     // ^Layout::ImageProvider
-    virtual bool is_image_available() const override;
-    virtual Optional<CSSPixels> intrinsic_width() const override;
-    virtual Optional<CSSPixels> intrinsic_height() const override;
-    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
-    virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const override;
     virtual size_t current_frame_index() const override { return 0; }
     virtual GC::Ptr<DecodedImageData> decoded_image_data() const override { return image_data(); }
 

--- a/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
@@ -227,15 +227,10 @@ void SharedResourceRequest::handle_successful_fetch(URL::URL const& url_string, 
                 move(result.all_durations),
                 move(initial_bitmaps));
         } else {
-            // Single-shot decode: create BitmapDecodedImageData as before.
-            Vector<BitmapDecodedImageData::Frame> frames;
-            for (auto& frame : result.frames) {
-                frames.append(BitmapDecodedImageData::Frame {
-                    .frame = Gfx::DecodedImageFrame { *frame.bitmap, result.color_space },
-                    .duration = static_cast<int>(frame.duration),
-                });
-            }
-            strong_this->m_image_data = BitmapDecodedImageData::create(strong_this->m_document->realm(), move(frames), result.loop_count, result.is_animated).release_value_but_fixme_should_propagate_errors();
+            // Non animated decode: create a single framed BitmapDecodedImageData.
+            VERIFY(result.frames.size() == 1);
+
+            strong_this->m_image_data = BitmapDecodedImageData::create(strong_this->m_document->realm(), { *result.frames[0].bitmap, result.color_space });
         }
         strong_this->m_image_data->set_is_cors_cross_origin(image_data_is_cors_cross_origin);
         strong_this->handle_successful_resource_load();

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -481,9 +481,9 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
                     //    the animation.
                     Optional<Gfx::DecodedImageFrame> decoded_frame;
                     if (has_natural_dimensions) {
-                        decoded_frame = image_element->default_image_frame_sized(Gfx::IntSize { *image_element->intrinsic_width(), *image_element->intrinsic_height() });
+                        decoded_frame = image_element->default_image_frame(Gfx::IntSize { *image_element->intrinsic_width(), *image_element->intrinsic_height() });
                     } else {
-                        decoded_frame = image_element->default_image_frame_sized(Gfx::IntSize { *options->resize_width, *options->resize_height });
+                        decoded_frame = image_element->default_image_frame(Gfx::IntSize { *options->resize_width, *options->resize_height });
                     }
                     auto cropped_bitmap_or_error = crop_to_the_source_rectangle_with_formatting(decoded_frame->bitmap(), sx, sy, sw, sh, options);
                     // AD-HOC: Reject promise with an "InvalidStateError" DOMException on allocation failure

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -461,15 +461,24 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
                 // -> img
                 // -> SVG image
                 [&](auto const& image_element) {
-                    // 1. If image's media data has no natural dimensions (e.g., it's a vector graphic with no specified content size) and options's resizeWidth or options's resizeHeight is not present, then return a promise rejected with an "InvalidStateError" DOMException.
+                    // 1. If image's media data has no natural dimensions (e.g., it's a vector graphic with no specified
+                    //    content size) and options's resizeWidth or options's resizeHeight is not present, then return
+                    //    a promise rejected with an "InvalidStateError" DOMException.
                     auto const has_natural_dimensions = image_element->intrinsic_width().has_value() && image_element->intrinsic_height().has_value();
                     if (!has_natural_dimensions && (!options.has_value() || !options->resize_width.has_value() || !options->resize_height.has_value())) {
                         WebIDL::reject_promise(realm, *p, WebIDL::InvalidStateError::create(image_bitmap->realm(), "Image data is detached"_utf16));
                         return;
                     }
 
-                    // 2. If image's media data has no natural dimensions (e.g., it's a vector graphic with no specified content size), it should be rendered to a bitmap of the size specified by the resizeWidth and the resizeHeight options.
-                    // 3. Set imageBitmap's bitmap data to a copy of image's media data, cropped to the source rectangle with formatting. If this is an animated image, imageBitmap's bitmap data must only be taken from the default image of the animation (the one that the format defines is to be used when animation is not supported or is disabled), or, if there is no such image, the first frame of the animation.
+                    // 2. If image's media data has no natural dimensions (e.g., it's a vector graphic with no specified
+                    //    content size), it should be rendered to a bitmap of the size specified by the resizeWidth and
+                    //    the resizeHeight options.
+
+                    // 3. Set imageBitmap's bitmap data to a copy of image's media data, cropped to the source rectangle
+                    //    with formatting. If this is an animated image, imageBitmap's bitmap data must only be taken
+                    //    from the default image of the animation (the one that the format defines is to be used when
+                    //    animation is not supported or is disabled), or, if there is no such image, the first frame of
+                    //    the animation.
                     Optional<Gfx::DecodedImageFrame> decoded_frame;
                     if (has_natural_dimensions) {
                         decoded_frame = image_element->default_image_frame_sized(Gfx::IntSize { *image_element->intrinsic_width(), *image_element->intrinsic_height() });

--- a/Libraries/LibWeb/Layout/ImageProvider.cpp
+++ b/Libraries/LibWeb/Layout/ImageProvider.cpp
@@ -30,11 +30,6 @@ Optional<Gfx::DecodedImageFrame> ImageProvider::current_image_frame() const
     return current_image_frame_sized(intrinsic_size().value_or({}).to_type<int>());
 }
 
-Optional<Gfx::DecodedImageFrame> ImageProvider::default_image_frame() const
-{
-    return default_image_frame_sized(intrinsic_size().value_or({}).to_type<int>());
-}
-
 Optional<Gfx::DecodedImageFrame> ImageProvider::default_image_frame_sized(Gfx::IntSize size) const
 {
     // Defer to the current image by default.

--- a/Libraries/LibWeb/Layout/ImageProvider.cpp
+++ b/Libraries/LibWeb/Layout/ImageProvider.cpp
@@ -47,22 +47,17 @@ Optional<CSSPixelSize> ImageProvider::intrinsic_size() const
     return CSSPixelSize { *width, *height };
 }
 
-Optional<Gfx::DecodedImageFrame> ImageProvider::current_image_frame() const
-{
-    return current_image_frame_sized(intrinsic_size().value_or({}).to_type<int>());
-}
-
-Optional<Gfx::DecodedImageFrame> ImageProvider::current_image_frame_sized(Gfx::IntSize size) const
+Optional<Gfx::DecodedImageFrame> ImageProvider::current_image_frame(Optional<Gfx::IntSize> size) const
 {
     if (auto const& data = decoded_image_data())
-        return data->frame(current_frame_index(), size);
+        return data->frame(current_frame_index(), size.value_or(intrinsic_size().value_or({}).to_type<int>()));
     return {};
 }
 
-Optional<Gfx::DecodedImageFrame> ImageProvider::default_image_frame_sized(Gfx::IntSize size) const
+Optional<Gfx::DecodedImageFrame> ImageProvider::default_image_frame(Optional<Gfx::IntSize> size) const
 {
     if (auto const& data = decoded_image_data())
-        return data->frame(0, size);
+        return data->frame(0, size.value_or(intrinsic_size().value_or({}).to_type<int>()));
     return {};
 }
 

--- a/Libraries/LibWeb/Layout/ImageProvider.cpp
+++ b/Libraries/LibWeb/Layout/ImageProvider.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/DecodedImageFrame.h>
+#include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/ImageProvider.h>
 
@@ -13,6 +14,27 @@ namespace Web::Layout {
 void ImageProvider::did_update_alt_text(ImageBox& layout_node)
 {
     layout_node.dom_node_did_update_alt_text({});
+}
+
+Optional<CSSPixels> ImageProvider::intrinsic_width() const
+{
+    if (auto const& data = decoded_image_data())
+        return data->intrinsic_width();
+    return {};
+}
+
+Optional<CSSPixels> ImageProvider::intrinsic_height() const
+{
+    if (auto const& data = decoded_image_data())
+        return data->intrinsic_height();
+    return {};
+}
+
+Optional<CSSPixelFraction> ImageProvider::intrinsic_aspect_ratio() const
+{
+    if (auto const& data = decoded_image_data())
+        return data->intrinsic_aspect_ratio();
+    return {};
 }
 
 Optional<CSSPixelSize> ImageProvider::intrinsic_size() const
@@ -30,10 +52,18 @@ Optional<Gfx::DecodedImageFrame> ImageProvider::current_image_frame() const
     return current_image_frame_sized(intrinsic_size().value_or({}).to_type<int>());
 }
 
+Optional<Gfx::DecodedImageFrame> ImageProvider::current_image_frame_sized(Gfx::IntSize size) const
+{
+    if (auto const& data = decoded_image_data())
+        return data->frame(current_frame_index(), size);
+    return {};
+}
+
 Optional<Gfx::DecodedImageFrame> ImageProvider::default_image_frame_sized(Gfx::IntSize size) const
 {
-    // Defer to the current image by default.
-    return current_image_frame_sized(size);
+    if (auto const& data = decoded_image_data())
+        return data->frame(0, size);
+    return {};
 }
 
 }

--- a/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Libraries/LibWeb/Layout/ImageProvider.h
@@ -33,14 +33,11 @@ public:
     virtual Optional<Gfx::DecodedImageFrame> current_image_frame() const;
     virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const = 0;
 
-    virtual Optional<Gfx::DecodedImageFrame> default_image_frame() const;
     virtual Optional<Gfx::DecodedImageFrame> default_image_frame_sized(Gfx::IntSize) const;
 
-    virtual void set_visible_in_viewport(bool) = 0;
     virtual void layout_node_was_detached() const { }
 
 protected:
-    virtual GC::Ptr<DOM::Element const> to_html_element() const = 0;
     static void did_update_alt_text(ImageBox&);
 };
 

--- a/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Libraries/LibWeb/Layout/ImageProvider.h
@@ -19,21 +19,21 @@ class ImageProvider {
 public:
     virtual ~ImageProvider() { }
 
-    virtual bool is_image_available() const = 0;
+    bool is_image_available() const { return decoded_image_data() != nullptr; }
 
     virtual size_t current_frame_index() const = 0;
 
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const = 0;
 
-    virtual Optional<CSSPixels> intrinsic_width() const = 0;
-    virtual Optional<CSSPixels> intrinsic_height() const = 0;
+    Optional<CSSPixels> intrinsic_width() const;
+    Optional<CSSPixels> intrinsic_height() const;
     Optional<CSSPixelSize> intrinsic_size() const;
-    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const = 0;
+    Optional<CSSPixelFraction> intrinsic_aspect_ratio() const;
 
-    virtual Optional<Gfx::DecodedImageFrame> current_image_frame() const;
-    virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const = 0;
+    Optional<Gfx::DecodedImageFrame> current_image_frame() const;
+    Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const;
 
-    virtual Optional<Gfx::DecodedImageFrame> default_image_frame_sized(Gfx::IntSize) const;
+    Optional<Gfx::DecodedImageFrame> default_image_frame_sized(Gfx::IntSize) const;
 
     virtual void layout_node_was_detached() const { }
 

--- a/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Libraries/LibWeb/Layout/ImageProvider.h
@@ -30,10 +30,8 @@ public:
     Optional<CSSPixelSize> intrinsic_size() const;
     Optional<CSSPixelFraction> intrinsic_aspect_ratio() const;
 
-    Optional<Gfx::DecodedImageFrame> current_image_frame() const;
-    Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const;
-
-    Optional<Gfx::DecodedImageFrame> default_image_frame_sized(Gfx::IntSize) const;
+    Optional<Gfx::DecodedImageFrame> current_image_frame(Optional<Gfx::IntSize> size = {}) const;
+    Optional<Gfx::DecodedImageFrame> default_image_frame(Optional<Gfx::IntSize> size = {}) const;
 
     virtual void layout_node_was_detached() const { }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -203,43 +203,6 @@ public:
         unregister_image_style_value_client();
     }
 
-    virtual bool is_image_available() const override
-    {
-        if (auto document = this->document())
-            return m_image->is_paintable(*document);
-        return false;
-    }
-
-    virtual Optional<CSSPixels> intrinsic_width() const override
-    {
-        if (auto document = this->document())
-            return m_image->natural_width(*document);
-        return {};
-    }
-
-    virtual Optional<CSSPixels> intrinsic_height() const override
-    {
-        if (auto document = this->document())
-            return m_image->natural_height(*document);
-        return {};
-    }
-
-    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override
-    {
-        if (auto document = this->document())
-            return m_image->natural_aspect_ratio(*document);
-        return {};
-    }
-
-    virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize size) const override
-    {
-        auto document = this->document();
-        if (!document)
-            return {};
-        auto rect = DevicePixelRect { DevicePixelPoint {}, size.to_type<DevicePixels>() };
-        return m_image->current_frame(*document, rect);
-    }
-
     virtual void layout_node_was_detached() const override
     {
         unregister_image_style_value_client();

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -240,14 +240,11 @@ public:
         return m_image->current_frame(*document, rect);
     }
 
-    virtual void set_visible_in_viewport(bool) override { }
     virtual void layout_node_was_detached() const override
     {
         unregister_image_style_value_client();
         m_layout_node = nullptr;
     }
-
-    virtual GC::Ptr<DOM::Element const> to_html_element() const override { return nullptr; }
 
     static NonnullOwnPtr<GeneratedContentImageProvider> create(DOM::Document& document, NonnullRefPtr<CSS::ImageStyleValue> image)
     {

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -306,11 +306,6 @@ Optional<Gfx::IntRect> SVGDecodedImageData::frame_rect(size_t) const
     return {};
 }
 
-RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::surface(size_t, Gfx::IntSize size) const
-{
-    return render_to_surface(size);
-}
-
 void SVGDecodedImageData::paint(DisplayListRecordingContext& context, size_t, Gfx::IntRect dst_rect, Gfx::ScalingMode) const
 {
     auto display_list = record_display_list(dst_rect.size(), context.display_list_recorder().resource_storage());

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -47,7 +47,6 @@ public:
 private:
     SVGDecodedImageData(GC::Ref<Page>, GC::Ref<SVGPageClient>, GC::Ref<DOM::Document>, GC::Ref<SVG::SVGSVGElement>);
 
-    RefPtr<Gfx::PaintingSurface> surface(size_t frame_index, Gfx::IntSize) const;
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
     Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
     void prune_cached_display_list_resources() const;

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -218,56 +218,6 @@ RefPtr<Layout::Node> SVGImageElement::create_layout_node(CSS::ComputedProperties
     return make_ref_counted<Layout::SVGImageBox>(document(), *this, style);
 }
 
-bool SVGImageElement::is_image_available() const
-{
-    return m_resource_request && m_resource_request->image_data();
-}
-
-Optional<CSSPixels> SVGImageElement::intrinsic_width() const
-{
-    if (!m_resource_request)
-        return {};
-    if (auto image_data = m_resource_request->image_data())
-        return image_data->intrinsic_width();
-    return {};
-}
-
-Optional<CSSPixels> SVGImageElement::intrinsic_height() const
-{
-    if (!m_resource_request)
-        return {};
-    if (auto image_data = m_resource_request->image_data())
-        return image_data->intrinsic_height();
-    return {};
-}
-
-Optional<CSSPixelFraction> SVGImageElement::intrinsic_aspect_ratio() const
-{
-    if (!m_resource_request)
-        return {};
-    if (auto image_data = m_resource_request->image_data())
-        return image_data->intrinsic_aspect_ratio();
-    return {};
-}
-
-Optional<Gfx::DecodedImageFrame> SVGImageElement::default_image_frame_sized(Gfx::IntSize size) const
-{
-    if (!m_resource_request)
-        return {};
-    if (auto data = m_resource_request->image_data())
-        return data->frame(0, size);
-    return {};
-}
-
-Optional<Gfx::DecodedImageFrame> SVGImageElement::current_image_frame_sized(Gfx::IntSize size) const
-{
-    if (!m_resource_request)
-        return {};
-    if (auto data = m_resource_request->image_data())
-        return data->frame(m_current_frame_index, size);
-    return {};
-}
-
 void SVGImageElement::animate()
 {
     auto image_data = m_resource_request->image_data();

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -41,8 +41,6 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
     virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const override;
-    virtual void set_visible_in_viewport(bool) override { }
-    virtual GC::Ptr<DOM::Element const> to_html_element() const override { return *this; }
     virtual size_t current_frame_index() const override { return m_current_frame_index; }
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override;
 

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -33,14 +33,7 @@ public:
 
     Gfx::FloatRect bounding_box() const;
 
-    virtual Optional<Gfx::DecodedImageFrame> default_image_frame_sized(Gfx::IntSize) const override;
-
     // ^Layout::ImageProvider
-    virtual bool is_image_available() const override;
-    virtual Optional<CSSPixels> intrinsic_width() const override;
-    virtual Optional<CSSPixels> intrinsic_height() const override;
-    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
-    virtual Optional<Gfx::DecodedImageFrame> current_image_frame_sized(Gfx::IntSize) const override;
     virtual size_t current_frame_index() const override { return m_current_frame_index; }
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override;
 


### PR DESCRIPTION
A few drive by cleanups - no functional change.