### PR TITLE
LibWeb: Skip meta http-equiv processing outside a document tree

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -122,6 +122,9 @@ void HTMLMetaElement::inserted()
     // When a meta element is inserted into the document, if its http-equiv attribute is present and represents one of
     // the above states, then the user agent must run the algorithm appropriate for that state, as described in the
     // following list:
+    if (!in_a_document_tree())
+        return;
+
     auto http_equiv = http_equiv_state();
     if (http_equiv.has_value()) {
         switch (http_equiv.value()) {

--- a/Tests/LibWeb/Crash/HTML/meta-content-language-without-document-element.html
+++ b/Tests/LibWeb/Crash/HTML/meta-content-language-without-document-element.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<script>
+const documentElement = document.documentElement;
+documentElement.remove();
+
+const head = document.createElement("head");
+const meta = document.createElement("meta");
+meta.setAttribute("http-equiv", "content-language");
+meta.setAttribute("content", "en");
+head.append(meta);
+
+document.append(documentElement);
+</script>


### PR DESCRIPTION
The pragma directives specification steps should only run when a meta element is inserted into the document, meaning it is in a document tree after the insertion steps have run. We previously ran the pragma algorithms for any insertion, so inserting a meta element with `http-equiv=content-language` into a detached subtree dereferenced a null document element.

Fixes #10005