### PR TITLE
Route all GL calls through generated GLFunctions

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1226,6 +1226,8 @@ generate_css_implementation()
 
 generate_html_implementation()
 
+generate_webgl_implementation()
+
 set(GENERATED_SOURCES
     ARIA/AriaRoles.cpp
     CSS/DefaultStyleSheetSource.cpp
@@ -1252,6 +1254,7 @@ set(GENERATED_SOURCES
     Worker/WebWorkerServerEndpoint.h
     HTML/MediaControlsDOM.cpp
     HTML/Parser/NamedCharacterReferences.cpp
+    WebGL/GLFunctions.cpp
 )
 
 ladybird_lib(LibWeb web EXPLICIT_SYMBOL_EXPORT)

--- a/Libraries/LibWeb/WebGL/Extensions/ANGLEInstancedArrays.cpp
+++ b/Libraries/LibWeb/WebGL/Extensions/ANGLEInstancedArrays.cpp
@@ -11,7 +11,6 @@
 #include <LibWeb/WebGL/OpenGLContext.h>
 #include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 
-#define GL_GLEXT_PROTOTYPES 1
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
@@ -33,19 +32,19 @@ ANGLEInstancedArrays::ANGLEInstancedArrays(JS::Realm& realm, GC::Ref<WebGLRender
 void ANGLEInstancedArrays::vertex_attrib_divisor_angle(GLuint index, GLuint divisor)
 {
     m_context->context().make_current();
-    glVertexAttribDivisorANGLE(index, divisor);
+    m_context->context().vertex_attrib_divisor_angle(index, divisor);
 }
 
 void ANGLEInstancedArrays::draw_arrays_instanced_angle(GLenum mode, GLint first, GLsizei count, GLsizei primcount)
 {
     m_context->context().make_current();
-    glDrawArraysInstancedANGLE(mode, first, count, primcount);
+    m_context->context().draw_arrays_instanced_angle(mode, first, count, primcount);
 }
 
 void ANGLEInstancedArrays::draw_elements_instanced_angle(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount)
 {
     m_context->context().make_current();
-    glDrawElementsInstancedANGLE(mode, count, type, reinterpret_cast<void*>(offset), primcount);
+    m_context->context().draw_elements_instanced_angle(mode, count, type, reinterpret_cast<void*>(offset), primcount);
 }
 
 void ANGLEInstancedArrays::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/WebGL/Extensions/OESVertexArrayObject.cpp
+++ b/Libraries/LibWeb/WebGL/Extensions/OESVertexArrayObject.cpp
@@ -12,7 +12,6 @@
 #include <LibWeb/WebGL/OpenGLContext.h>
 #include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 
-#define GL_GLEXT_PROTOTYPES 1
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
@@ -36,7 +35,7 @@ GC::Ref<WebGLVertexArrayObjectOES> OESVertexArrayObject::create_vertex_array_oes
     m_context->context().make_current();
 
     GLuint handle = 0;
-    glGenVertexArraysOES(1, &handle);
+    m_context->context().gen_vertex_arrays_oes(1, &handle);
     return WebGLVertexArrayObjectOES::create(realm(), m_context, handle);
 }
 
@@ -54,7 +53,7 @@ void OESVertexArrayObject::delete_vertex_array_oes(GC::Ptr<WebGLVertexArrayObjec
         vertex_array_handle = handle_or_error.release_value();
     }
 
-    glDeleteVertexArraysOES(1, &vertex_array_handle);
+    m_context->context().delete_vertex_arrays_oes(1, &vertex_array_handle);
 }
 
 bool OESVertexArrayObject::is_vertex_array_oes(GC::Ptr<WebGLVertexArrayObjectOES> array_object)
@@ -70,7 +69,7 @@ bool OESVertexArrayObject::is_vertex_array_oes(GC::Ptr<WebGLVertexArrayObjectOES
         vertex_array_handle = handle_or_error.release_value();
     }
 
-    return glIsVertexArrayOES(vertex_array_handle) == GL_TRUE;
+    return m_context->context().is_vertex_array_oes(vertex_array_handle) == GL_TRUE;
 }
 
 void OESVertexArrayObject::bind_vertex_array_oes(GC::Ptr<WebGLVertexArrayObjectOES> array_object)
@@ -87,7 +86,7 @@ void OESVertexArrayObject::bind_vertex_array_oes(GC::Ptr<WebGLVertexArrayObjectO
         vertex_array_handle = handle_or_error.release_value();
     }
 
-    glBindVertexArrayOES(vertex_array_handle);
+    m_context->context().bind_vertex_array_oes(vertex_array_handle);
 }
 
 void OESVertexArrayObject::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/WebGL/Extensions/WebGLDrawBuffers.cpp
+++ b/Libraries/LibWeb/WebGL/Extensions/WebGLDrawBuffers.cpp
@@ -11,7 +11,6 @@
 #include <LibWeb/WebGL/OpenGLContext.h>
 #include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 
-#define GL_GLEXT_PROTOTYPES 1
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
@@ -33,7 +32,7 @@ WebGLDrawBuffers::WebGLDrawBuffers(JS::Realm& realm, GC::Ref<WebGLRenderingConte
 void WebGLDrawBuffers::draw_buffers_webgl(Vector<GLenum> buffers)
 {
     m_context->context().make_current();
-    glDrawBuffersEXT(buffers.size(), buffers.data());
+    m_context->context().draw_buffers_ext(buffers.size(), buffers.data());
 }
 
 void WebGLDrawBuffers::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/WebGL/GLFunctions.json
+++ b/Libraries/LibWeb/WebGL/GLFunctions.json
@@ -1,0 +1,4239 @@
+[
+    {
+        "name": "glActiveTexture",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "texture"
+            }
+        ]
+    },
+    {
+        "name": "glAttachShader",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLuint",
+                "name": "shader"
+            }
+        ]
+    },
+    {
+        "name": "glBeginQuery",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLuint",
+                "name": "id"
+            }
+        ]
+    },
+    {
+        "name": "glBeginTransformFeedback",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "primitiveMode"
+            }
+        ]
+    },
+    {
+        "name": "glBindAttribLocation",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLchar const*",
+                "name": "name"
+            }
+        ]
+    },
+    {
+        "name": "glBindBuffer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLuint",
+                "name": "buffer"
+            }
+        ]
+    },
+    {
+        "name": "glBindBufferBase",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLuint",
+                "name": "buffer"
+            }
+        ]
+    },
+    {
+        "name": "glBindBufferRange",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLuint",
+                "name": "buffer"
+            },
+            {
+                "type": "GLintptr",
+                "name": "offset"
+            },
+            {
+                "type": "GLsizeiptr",
+                "name": "size"
+            }
+        ]
+    },
+    {
+        "name": "glBindFramebuffer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLuint",
+                "name": "framebuffer"
+            }
+        ]
+    },
+    {
+        "name": "glBindRenderbuffer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLuint",
+                "name": "renderbuffer"
+            }
+        ]
+    },
+    {
+        "name": "glBindSampler",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "unit"
+            },
+            {
+                "type": "GLuint",
+                "name": "sampler"
+            }
+        ]
+    },
+    {
+        "name": "glBindTexture",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLuint",
+                "name": "texture"
+            }
+        ]
+    },
+    {
+        "name": "glBindTransformFeedback",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLuint",
+                "name": "id"
+            }
+        ]
+    },
+    {
+        "name": "glBindVertexArray",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "array"
+            }
+        ]
+    },
+    {
+        "name": "glBindVertexArrayOES",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "array"
+            }
+        ]
+    },
+    {
+        "name": "glBlendColor",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLfloat",
+                "name": "red"
+            },
+            {
+                "type": "GLfloat",
+                "name": "green"
+            },
+            {
+                "type": "GLfloat",
+                "name": "blue"
+            },
+            {
+                "type": "GLfloat",
+                "name": "alpha"
+            }
+        ]
+    },
+    {
+        "name": "glBlendEquation",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            }
+        ]
+    },
+    {
+        "name": "glBlendEquationSeparate",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "modeRGB"
+            },
+            {
+                "type": "GLenum",
+                "name": "modeAlpha"
+            }
+        ]
+    },
+    {
+        "name": "glBlendFunc",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "sfactor"
+            },
+            {
+                "type": "GLenum",
+                "name": "dfactor"
+            }
+        ]
+    },
+    {
+        "name": "glBlendFuncSeparate",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "sfactorRGB"
+            },
+            {
+                "type": "GLenum",
+                "name": "dfactorRGB"
+            },
+            {
+                "type": "GLenum",
+                "name": "sfactorAlpha"
+            },
+            {
+                "type": "GLenum",
+                "name": "dfactorAlpha"
+            }
+        ]
+    },
+    {
+        "name": "glBlitFramebuffer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "srcX0"
+            },
+            {
+                "type": "GLint",
+                "name": "srcY0"
+            },
+            {
+                "type": "GLint",
+                "name": "srcX1"
+            },
+            {
+                "type": "GLint",
+                "name": "srcY1"
+            },
+            {
+                "type": "GLint",
+                "name": "dstX0"
+            },
+            {
+                "type": "GLint",
+                "name": "dstY0"
+            },
+            {
+                "type": "GLint",
+                "name": "dstX1"
+            },
+            {
+                "type": "GLint",
+                "name": "dstY1"
+            },
+            {
+                "type": "GLbitfield",
+                "name": "mask"
+            },
+            {
+                "type": "GLenum",
+                "name": "filter"
+            }
+        ]
+    },
+    {
+        "name": "glBufferData",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLsizeiptr",
+                "name": "size"
+            },
+            {
+                "type": "void const*",
+                "name": "data"
+            },
+            {
+                "type": "GLenum",
+                "name": "usage"
+            }
+        ]
+    },
+    {
+        "name": "glBufferSubData",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLintptr",
+                "name": "offset"
+            },
+            {
+                "type": "GLsizeiptr",
+                "name": "size"
+            },
+            {
+                "type": "void const*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glCheckFramebufferStatus",
+        "return": "GLenum",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            }
+        ]
+    },
+    {
+        "name": "glClear",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLbitfield",
+                "name": "mask"
+            }
+        ]
+    },
+    {
+        "name": "glClearBufferfi",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "buffer"
+            },
+            {
+                "type": "GLint",
+                "name": "drawbuffer"
+            },
+            {
+                "type": "GLfloat",
+                "name": "depth"
+            },
+            {
+                "type": "GLint",
+                "name": "stencil"
+            }
+        ]
+    },
+    {
+        "name": "glClearBufferfv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "buffer"
+            },
+            {
+                "type": "GLint",
+                "name": "drawbuffer"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glClearBufferiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "buffer"
+            },
+            {
+                "type": "GLint",
+                "name": "drawbuffer"
+            },
+            {
+                "type": "GLint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glClearBufferuiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "buffer"
+            },
+            {
+                "type": "GLint",
+                "name": "drawbuffer"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glClearColor",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLfloat",
+                "name": "red"
+            },
+            {
+                "type": "GLfloat",
+                "name": "green"
+            },
+            {
+                "type": "GLfloat",
+                "name": "blue"
+            },
+            {
+                "type": "GLfloat",
+                "name": "alpha"
+            }
+        ]
+    },
+    {
+        "name": "glClearDepthf",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLfloat",
+                "name": "d"
+            }
+        ]
+    },
+    {
+        "name": "glClearStencil",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "s"
+            }
+        ]
+    },
+    {
+        "name": "glClientWaitSync",
+        "return": "GLenum",
+        "args": [
+            {
+                "type": "GLsync",
+                "name": "sync"
+            },
+            {
+                "type": "GLbitfield",
+                "name": "flags"
+            },
+            {
+                "type": "GLuint64",
+                "name": "timeout"
+            }
+        ]
+    },
+    {
+        "name": "glColorMask",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLboolean",
+                "name": "red"
+            },
+            {
+                "type": "GLboolean",
+                "name": "green"
+            },
+            {
+                "type": "GLboolean",
+                "name": "blue"
+            },
+            {
+                "type": "GLboolean",
+                "name": "alpha"
+            }
+        ]
+    },
+    {
+        "name": "glCompileShader",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "shader"
+            }
+        ]
+    },
+    {
+        "name": "glCompressedTexImage2DRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLenum",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLint",
+                "name": "border"
+            },
+            {
+                "type": "GLsizei",
+                "name": "imageSize"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "void const*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glCompressedTexImage3DRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLenum",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLsizei",
+                "name": "depth"
+            },
+            {
+                "type": "GLint",
+                "name": "border"
+            },
+            {
+                "type": "GLsizei",
+                "name": "imageSize"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "void const*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glCompressedTexSubImage2DRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLint",
+                "name": "xoffset"
+            },
+            {
+                "type": "GLint",
+                "name": "yoffset"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLenum",
+                "name": "format"
+            },
+            {
+                "type": "GLsizei",
+                "name": "imageSize"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "void const*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glCompressedTexSubImage3DRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLint",
+                "name": "xoffset"
+            },
+            {
+                "type": "GLint",
+                "name": "yoffset"
+            },
+            {
+                "type": "GLint",
+                "name": "zoffset"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLsizei",
+                "name": "depth"
+            },
+            {
+                "type": "GLenum",
+                "name": "format"
+            },
+            {
+                "type": "GLsizei",
+                "name": "imageSize"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "void const*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glCopyBufferSubData",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "readTarget"
+            },
+            {
+                "type": "GLenum",
+                "name": "writeTarget"
+            },
+            {
+                "type": "GLintptr",
+                "name": "readOffset"
+            },
+            {
+                "type": "GLintptr",
+                "name": "writeOffset"
+            },
+            {
+                "type": "GLsizeiptr",
+                "name": "size"
+            }
+        ]
+    },
+    {
+        "name": "glCopyTexImage2D",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLenum",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLint",
+                "name": "x"
+            },
+            {
+                "type": "GLint",
+                "name": "y"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLint",
+                "name": "border"
+            }
+        ]
+    },
+    {
+        "name": "glCopyTexSubImage2D",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLint",
+                "name": "xoffset"
+            },
+            {
+                "type": "GLint",
+                "name": "yoffset"
+            },
+            {
+                "type": "GLint",
+                "name": "x"
+            },
+            {
+                "type": "GLint",
+                "name": "y"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            }
+        ]
+    },
+    {
+        "name": "glCreateProgram",
+        "return": "GLuint",
+        "args": []
+    },
+    {
+        "name": "glCreateShader",
+        "return": "GLuint",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "type"
+            }
+        ]
+    },
+    {
+        "name": "glCullFace",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteBuffers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "buffers"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteFramebuffers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "framebuffers"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteProgram",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteQueries",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "ids"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteRenderbuffers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "renderbuffers"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteSamplers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "samplers"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteShader",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "shader"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteSync",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsync",
+                "name": "sync"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteTextures",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "textures"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteTransformFeedbacks",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "ids"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteVertexArrays",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "arrays"
+            }
+        ]
+    },
+    {
+        "name": "glDeleteVertexArraysOES",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "arrays"
+            }
+        ]
+    },
+    {
+        "name": "glDepthFunc",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "func"
+            }
+        ]
+    },
+    {
+        "name": "glDepthMask",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLboolean",
+                "name": "flag"
+            }
+        ]
+    },
+    {
+        "name": "glDepthRangef",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLfloat",
+                "name": "n"
+            },
+            {
+                "type": "GLfloat",
+                "name": "f"
+            }
+        ]
+    },
+    {
+        "name": "glDetachShader",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLuint",
+                "name": "shader"
+            }
+        ]
+    },
+    {
+        "name": "glDisable",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "cap"
+            }
+        ]
+    },
+    {
+        "name": "glDisableVertexAttribArray",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            }
+        ]
+    },
+    {
+        "name": "glDrawArrays",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            },
+            {
+                "type": "GLint",
+                "name": "first"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            }
+        ]
+    },
+    {
+        "name": "glDrawArraysInstanced",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            },
+            {
+                "type": "GLint",
+                "name": "first"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLsizei",
+                "name": "instancecount"
+            }
+        ]
+    },
+    {
+        "name": "glDrawArraysInstancedANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            },
+            {
+                "type": "GLint",
+                "name": "first"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLsizei",
+                "name": "primcount"
+            }
+        ]
+    },
+    {
+        "name": "glDrawBuffers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLenum const*",
+                "name": "bufs"
+            }
+        ]
+    },
+    {
+        "name": "glDrawBuffersEXT",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLenum const*",
+                "name": "bufs"
+            }
+        ]
+    },
+    {
+        "name": "glDrawElements",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "void const*",
+                "name": "indices"
+            }
+        ]
+    },
+    {
+        "name": "glDrawElementsInstanced",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "void const*",
+                "name": "indices"
+            },
+            {
+                "type": "GLsizei",
+                "name": "instancecount"
+            }
+        ]
+    },
+    {
+        "name": "glDrawElementsInstancedANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "void const*",
+                "name": "indices"
+            },
+            {
+                "type": "GLsizei",
+                "name": "primcount"
+            }
+        ]
+    },
+    {
+        "name": "glDrawRangeElements",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            },
+            {
+                "type": "GLuint",
+                "name": "start"
+            },
+            {
+                "type": "GLuint",
+                "name": "end"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "void const*",
+                "name": "indices"
+            }
+        ]
+    },
+    {
+        "name": "glEnable",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "cap"
+            }
+        ]
+    },
+    {
+        "name": "glEnableVertexAttribArray",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            }
+        ]
+    },
+    {
+        "name": "glEndQuery",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            }
+        ]
+    },
+    {
+        "name": "glEndTransformFeedback",
+        "return": "void",
+        "args": []
+    },
+    {
+        "name": "glFenceSync",
+        "return": "GLsync",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "condition"
+            },
+            {
+                "type": "GLbitfield",
+                "name": "flags"
+            }
+        ]
+    },
+    {
+        "name": "glFinish",
+        "return": "void",
+        "args": []
+    },
+    {
+        "name": "glFlush",
+        "return": "void",
+        "args": []
+    },
+    {
+        "name": "glFramebufferRenderbuffer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "attachment"
+            },
+            {
+                "type": "GLenum",
+                "name": "renderbuffertarget"
+            },
+            {
+                "type": "GLuint",
+                "name": "renderbuffer"
+            }
+        ]
+    },
+    {
+        "name": "glFramebufferTexture2D",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "attachment"
+            },
+            {
+                "type": "GLenum",
+                "name": "textarget"
+            },
+            {
+                "type": "GLuint",
+                "name": "texture"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            }
+        ]
+    },
+    {
+        "name": "glFramebufferTextureLayer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "attachment"
+            },
+            {
+                "type": "GLuint",
+                "name": "texture"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLint",
+                "name": "layer"
+            }
+        ]
+    },
+    {
+        "name": "glFrontFace",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "mode"
+            }
+        ]
+    },
+    {
+        "name": "glGenBuffers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint*",
+                "name": "buffers"
+            }
+        ]
+    },
+    {
+        "name": "glGenFramebuffers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint*",
+                "name": "framebuffers"
+            }
+        ]
+    },
+    {
+        "name": "glGenQueries",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint*",
+                "name": "ids"
+            }
+        ]
+    },
+    {
+        "name": "glGenRenderbuffers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint*",
+                "name": "renderbuffers"
+            }
+        ]
+    },
+    {
+        "name": "glGenSamplers",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLuint*",
+                "name": "samplers"
+            }
+        ]
+    },
+    {
+        "name": "glGenTextures",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint*",
+                "name": "textures"
+            }
+        ]
+    },
+    {
+        "name": "glGenTransformFeedbacks",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint*",
+                "name": "ids"
+            }
+        ]
+    },
+    {
+        "name": "glGenVertexArrays",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint*",
+                "name": "arrays"
+            }
+        ]
+    },
+    {
+        "name": "glGenVertexArraysOES",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsizei",
+                "name": "n"
+            },
+            {
+                "type": "GLuint*",
+                "name": "arrays"
+            }
+        ]
+    },
+    {
+        "name": "glGenerateMipmap",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            }
+        ]
+    },
+    {
+        "name": "glGetActiveAttrib",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "size"
+            },
+            {
+                "type": "GLenum*",
+                "name": "type"
+            },
+            {
+                "type": "GLchar*",
+                "name": "name"
+            }
+        ]
+    },
+    {
+        "name": "glGetActiveUniform",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "size"
+            },
+            {
+                "type": "GLenum*",
+                "name": "type"
+            },
+            {
+                "type": "GLchar*",
+                "name": "name"
+            }
+        ]
+    },
+    {
+        "name": "glGetActiveUniformBlockName",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLuint",
+                "name": "uniformBlockIndex"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLchar*",
+                "name": "uniformBlockName"
+            }
+        ]
+    },
+    {
+        "name": "glGetActiveUniformBlockivRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLuint",
+                "name": "uniformBlockIndex"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetActiveUniformsiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLsizei",
+                "name": "uniformCount"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "uniformIndices"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetAttribLocation",
+        "return": "GLint",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLchar const*",
+                "name": "name"
+            }
+        ]
+    },
+    {
+        "name": "glGetBooleanvRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLboolean*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glGetBufferParameterivRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetError",
+        "return": "GLenum",
+        "args": []
+    },
+    {
+        "name": "glGetFloatvRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLfloat*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glGetInteger64vRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint64*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glGetIntegervRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "data"
+            }
+        ]
+    },
+    {
+        "name": "glGetInternalformativRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetProgramInfoLog",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLchar*",
+                "name": "infoLog"
+            }
+        ]
+    },
+    {
+        "name": "glGetProgramiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetProgramivRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetQueryObjectuivRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "id"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLuint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetRenderbufferParameterivRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetShaderInfoLog",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "shader"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLchar*",
+                "name": "infoLog"
+            }
+        ]
+    },
+    {
+        "name": "glGetShaderPrecisionFormat",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "shadertype"
+            },
+            {
+                "type": "GLenum",
+                "name": "precisiontype"
+            },
+            {
+                "type": "GLint*",
+                "name": "range"
+            },
+            {
+                "type": "GLint*",
+                "name": "precision"
+            }
+        ]
+    },
+    {
+        "name": "glGetShaderSource",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "shader"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLchar*",
+                "name": "source"
+            }
+        ]
+    },
+    {
+        "name": "glGetShaderiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "shader"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetShaderivRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "shader"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetString",
+        "return": "GLubyte const*",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "name"
+            }
+        ]
+    },
+    {
+        "name": "glGetSynciv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsync",
+                "name": "sync"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "values"
+            }
+        ]
+    },
+    {
+        "name": "glGetTexParameterfvRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLfloat*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetTexParameterivRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetUniformBlockIndex",
+        "return": "GLuint",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLchar const*",
+                "name": "uniformBlockName"
+            }
+        ]
+    },
+    {
+        "name": "glGetUniformIndices",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLsizei",
+                "name": "uniformCount"
+            },
+            {
+                "type": "GLchar const* const*",
+                "name": "uniformNames"
+            },
+            {
+                "type": "GLuint*",
+                "name": "uniformIndices"
+            }
+        ]
+    },
+    {
+        "name": "glGetUniformLocation",
+        "return": "GLint",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLchar const*",
+                "name": "name"
+            }
+        ]
+    },
+    {
+        "name": "glGetVertexAttribPointervRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "void**",
+                "name": "pointer"
+            }
+        ]
+    },
+    {
+        "name": "glGetVertexAttribfvRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLfloat*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glGetVertexAttribivRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLint*",
+                "name": "params"
+            }
+        ]
+    },
+    {
+        "name": "glHint",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "mode"
+            }
+        ]
+    },
+    {
+        "name": "glInvalidateFramebuffer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLsizei",
+                "name": "numAttachments"
+            },
+            {
+                "type": "GLenum const*",
+                "name": "attachments"
+            }
+        ]
+    },
+    {
+        "name": "glInvalidateSubFramebuffer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLsizei",
+                "name": "numAttachments"
+            },
+            {
+                "type": "GLenum const*",
+                "name": "attachments"
+            },
+            {
+                "type": "GLint",
+                "name": "x"
+            },
+            {
+                "type": "GLint",
+                "name": "y"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            }
+        ]
+    },
+    {
+        "name": "glIsBuffer",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "buffer"
+            }
+        ]
+    },
+    {
+        "name": "glIsEnabled",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "cap"
+            }
+        ]
+    },
+    {
+        "name": "glIsFramebuffer",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "framebuffer"
+            }
+        ]
+    },
+    {
+        "name": "glIsProgram",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            }
+        ]
+    },
+    {
+        "name": "glIsRenderbuffer",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "renderbuffer"
+            }
+        ]
+    },
+    {
+        "name": "glIsShader",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "shader"
+            }
+        ]
+    },
+    {
+        "name": "glIsTexture",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "texture"
+            }
+        ]
+    },
+    {
+        "name": "glIsVertexArray",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "array"
+            }
+        ]
+    },
+    {
+        "name": "glIsVertexArrayOES",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "array"
+            }
+        ]
+    },
+    {
+        "name": "glLineWidth",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLfloat",
+                "name": "width"
+            }
+        ]
+    },
+    {
+        "name": "glLinkProgram",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            }
+        ]
+    },
+    {
+        "name": "glMapBufferRange",
+        "return": "void*",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLintptr",
+                "name": "offset"
+            },
+            {
+                "type": "GLsizeiptr",
+                "name": "length"
+            },
+            {
+                "type": "GLbitfield",
+                "name": "access"
+            }
+        ]
+    },
+    {
+        "name": "glPauseTransformFeedback",
+        "return": "void",
+        "args": []
+    },
+    {
+        "name": "glPixelStorei",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLint",
+                "name": "param"
+            }
+        ]
+    },
+    {
+        "name": "glPolygonOffset",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLfloat",
+                "name": "factor"
+            },
+            {
+                "type": "GLfloat",
+                "name": "units"
+            }
+        ]
+    },
+    {
+        "name": "glReadBuffer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "src"
+            }
+        ]
+    },
+    {
+        "name": "glReadPixelsRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "x"
+            },
+            {
+                "type": "GLint",
+                "name": "y"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLenum",
+                "name": "format"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "length"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "columns"
+            },
+            {
+                "type": "GLsizei*",
+                "name": "rows"
+            },
+            {
+                "type": "void*",
+                "name": "pixels"
+            }
+        ]
+    },
+    {
+        "name": "glRenderbufferStorage",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            }
+        ]
+    },
+    {
+        "name": "glRenderbufferStorageMultisample",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLsizei",
+                "name": "samples"
+            },
+            {
+                "type": "GLenum",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            }
+        ]
+    },
+    {
+        "name": "glResumeTransformFeedback",
+        "return": "void",
+        "args": []
+    },
+    {
+        "name": "glSampleCoverage",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLfloat",
+                "name": "value"
+            },
+            {
+                "type": "GLboolean",
+                "name": "invert"
+            }
+        ]
+    },
+    {
+        "name": "glSamplerParameterf",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "sampler"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLfloat",
+                "name": "param"
+            }
+        ]
+    },
+    {
+        "name": "glSamplerParameteri",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "sampler"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLint",
+                "name": "param"
+            }
+        ]
+    },
+    {
+        "name": "glScissor",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "x"
+            },
+            {
+                "type": "GLint",
+                "name": "y"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            }
+        ]
+    },
+    {
+        "name": "glShaderSource",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "shader"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLchar const* const*",
+                "name": "string"
+            },
+            {
+                "type": "GLint const*",
+                "name": "length"
+            }
+        ]
+    },
+    {
+        "name": "glStencilFunc",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "func"
+            },
+            {
+                "type": "GLint",
+                "name": "ref"
+            },
+            {
+                "type": "GLuint",
+                "name": "mask"
+            }
+        ]
+    },
+    {
+        "name": "glStencilFuncSeparate",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "face"
+            },
+            {
+                "type": "GLenum",
+                "name": "func"
+            },
+            {
+                "type": "GLint",
+                "name": "ref"
+            },
+            {
+                "type": "GLuint",
+                "name": "mask"
+            }
+        ]
+    },
+    {
+        "name": "glStencilMask",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "mask"
+            }
+        ]
+    },
+    {
+        "name": "glStencilMaskSeparate",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "face"
+            },
+            {
+                "type": "GLuint",
+                "name": "mask"
+            }
+        ]
+    },
+    {
+        "name": "glStencilOp",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "fail"
+            },
+            {
+                "type": "GLenum",
+                "name": "zfail"
+            },
+            {
+                "type": "GLenum",
+                "name": "zpass"
+            }
+        ]
+    },
+    {
+        "name": "glStencilOpSeparate",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "face"
+            },
+            {
+                "type": "GLenum",
+                "name": "sfail"
+            },
+            {
+                "type": "GLenum",
+                "name": "dpfail"
+            },
+            {
+                "type": "GLenum",
+                "name": "dppass"
+            }
+        ]
+    },
+    {
+        "name": "glTexImage2DRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLint",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLint",
+                "name": "border"
+            },
+            {
+                "type": "GLenum",
+                "name": "format"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "void const*",
+                "name": "pixels"
+            }
+        ]
+    },
+    {
+        "name": "glTexImage3DRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLint",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLsizei",
+                "name": "depth"
+            },
+            {
+                "type": "GLint",
+                "name": "border"
+            },
+            {
+                "type": "GLenum",
+                "name": "format"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "void const*",
+                "name": "pixels"
+            }
+        ]
+    },
+    {
+        "name": "glTexParameterf",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLfloat",
+                "name": "param"
+            }
+        ]
+    },
+    {
+        "name": "glTexParameteri",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLenum",
+                "name": "pname"
+            },
+            {
+                "type": "GLint",
+                "name": "param"
+            }
+        ]
+    },
+    {
+        "name": "glTexStorage2D",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLsizei",
+                "name": "levels"
+            },
+            {
+                "type": "GLenum",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            }
+        ]
+    },
+    {
+        "name": "glTexStorage3D",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLsizei",
+                "name": "levels"
+            },
+            {
+                "type": "GLenum",
+                "name": "internalformat"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLsizei",
+                "name": "depth"
+            }
+        ]
+    },
+    {
+        "name": "glTexSubImage2DRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLint",
+                "name": "xoffset"
+            },
+            {
+                "type": "GLint",
+                "name": "yoffset"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLenum",
+                "name": "format"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "void const*",
+                "name": "pixels"
+            }
+        ]
+    },
+    {
+        "name": "glTexSubImage3DRobustANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            },
+            {
+                "type": "GLint",
+                "name": "level"
+            },
+            {
+                "type": "GLint",
+                "name": "xoffset"
+            },
+            {
+                "type": "GLint",
+                "name": "yoffset"
+            },
+            {
+                "type": "GLint",
+                "name": "zoffset"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            },
+            {
+                "type": "GLsizei",
+                "name": "depth"
+            },
+            {
+                "type": "GLenum",
+                "name": "format"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "GLsizei",
+                "name": "bufSize"
+            },
+            {
+                "type": "void const*",
+                "name": "pixels"
+            }
+        ]
+    },
+    {
+        "name": "glTransformFeedbackVaryings",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLchar const* const*",
+                "name": "varyings"
+            },
+            {
+                "type": "GLenum",
+                "name": "bufferMode"
+            }
+        ]
+    },
+    {
+        "name": "glUniform1f",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v0"
+            }
+        ]
+    },
+    {
+        "name": "glUniform1fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform1i",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLint",
+                "name": "v0"
+            }
+        ]
+    },
+    {
+        "name": "glUniform1iv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform1ui",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLuint",
+                "name": "v0"
+            }
+        ]
+    },
+    {
+        "name": "glUniform1uiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform2f",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v0"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v1"
+            }
+        ]
+    },
+    {
+        "name": "glUniform2fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform2i",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLint",
+                "name": "v0"
+            },
+            {
+                "type": "GLint",
+                "name": "v1"
+            }
+        ]
+    },
+    {
+        "name": "glUniform2iv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform2ui",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLuint",
+                "name": "v0"
+            },
+            {
+                "type": "GLuint",
+                "name": "v1"
+            }
+        ]
+    },
+    {
+        "name": "glUniform2uiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform3f",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v0"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v1"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v2"
+            }
+        ]
+    },
+    {
+        "name": "glUniform3fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform3i",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLint",
+                "name": "v0"
+            },
+            {
+                "type": "GLint",
+                "name": "v1"
+            },
+            {
+                "type": "GLint",
+                "name": "v2"
+            }
+        ]
+    },
+    {
+        "name": "glUniform3iv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform3ui",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLuint",
+                "name": "v0"
+            },
+            {
+                "type": "GLuint",
+                "name": "v1"
+            },
+            {
+                "type": "GLuint",
+                "name": "v2"
+            }
+        ]
+    },
+    {
+        "name": "glUniform3uiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform4f",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v0"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v1"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v2"
+            },
+            {
+                "type": "GLfloat",
+                "name": "v3"
+            }
+        ]
+    },
+    {
+        "name": "glUniform4fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform4i",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLint",
+                "name": "v0"
+            },
+            {
+                "type": "GLint",
+                "name": "v1"
+            },
+            {
+                "type": "GLint",
+                "name": "v2"
+            },
+            {
+                "type": "GLint",
+                "name": "v3"
+            }
+        ]
+    },
+    {
+        "name": "glUniform4iv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniform4ui",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLuint",
+                "name": "v0"
+            },
+            {
+                "type": "GLuint",
+                "name": "v1"
+            },
+            {
+                "type": "GLuint",
+                "name": "v2"
+            },
+            {
+                "type": "GLuint",
+                "name": "v3"
+            }
+        ]
+    },
+    {
+        "name": "glUniform4uiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformBlockBinding",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            },
+            {
+                "type": "GLuint",
+                "name": "uniformBlockIndex"
+            },
+            {
+                "type": "GLuint",
+                "name": "uniformBlockBinding"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix2fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix2x3fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix2x4fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix3fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix3x2fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix3x4fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix4fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix4x2fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUniformMatrix4x3fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "location"
+            },
+            {
+                "type": "GLsizei",
+                "name": "count"
+            },
+            {
+                "type": "GLboolean",
+                "name": "transpose"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "value"
+            }
+        ]
+    },
+    {
+        "name": "glUnmapBuffer",
+        "return": "GLboolean",
+        "args": [
+            {
+                "type": "GLenum",
+                "name": "target"
+            }
+        ]
+    },
+    {
+        "name": "glUseProgram",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            }
+        ]
+    },
+    {
+        "name": "glValidateProgram",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "program"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttrib1f",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLfloat",
+                "name": "x"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttrib1fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "v"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttrib2f",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLfloat",
+                "name": "x"
+            },
+            {
+                "type": "GLfloat",
+                "name": "y"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttrib2fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "v"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttrib3f",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLfloat",
+                "name": "x"
+            },
+            {
+                "type": "GLfloat",
+                "name": "y"
+            },
+            {
+                "type": "GLfloat",
+                "name": "z"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttrib3fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "v"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttrib4f",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLfloat",
+                "name": "x"
+            },
+            {
+                "type": "GLfloat",
+                "name": "y"
+            },
+            {
+                "type": "GLfloat",
+                "name": "z"
+            },
+            {
+                "type": "GLfloat",
+                "name": "w"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttrib4fv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLfloat const*",
+                "name": "v"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttribDivisor",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLuint",
+                "name": "divisor"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttribDivisorANGLE",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLuint",
+                "name": "divisor"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttribI4i",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLint",
+                "name": "x"
+            },
+            {
+                "type": "GLint",
+                "name": "y"
+            },
+            {
+                "type": "GLint",
+                "name": "z"
+            },
+            {
+                "type": "GLint",
+                "name": "w"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttribI4iv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLint const*",
+                "name": "v"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttribI4ui",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLuint",
+                "name": "x"
+            },
+            {
+                "type": "GLuint",
+                "name": "y"
+            },
+            {
+                "type": "GLuint",
+                "name": "z"
+            },
+            {
+                "type": "GLuint",
+                "name": "w"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttribI4uiv",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLuint const*",
+                "name": "v"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttribIPointer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLint",
+                "name": "size"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "GLsizei",
+                "name": "stride"
+            },
+            {
+                "type": "void const*",
+                "name": "pointer"
+            }
+        ]
+    },
+    {
+        "name": "glVertexAttribPointer",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLuint",
+                "name": "index"
+            },
+            {
+                "type": "GLint",
+                "name": "size"
+            },
+            {
+                "type": "GLenum",
+                "name": "type"
+            },
+            {
+                "type": "GLboolean",
+                "name": "normalized"
+            },
+            {
+                "type": "GLsizei",
+                "name": "stride"
+            },
+            {
+                "type": "void const*",
+                "name": "pointer"
+            }
+        ]
+    },
+    {
+        "name": "glViewport",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLint",
+                "name": "x"
+            },
+            {
+                "type": "GLint",
+                "name": "y"
+            },
+            {
+                "type": "GLsizei",
+                "name": "width"
+            },
+            {
+                "type": "GLsizei",
+                "name": "height"
+            }
+        ]
+    },
+    {
+        "name": "glWaitSync",
+        "return": "void",
+        "args": [
+            {
+                "type": "GLsync",
+                "name": "sync"
+            },
+            {
+                "type": "GLbitfield",
+                "name": "flags"
+            },
+            {
+                "type": "GLuint64",
+                "name": "timeout"
+            }
+        ]
+    }
+]

--- a/Libraries/LibWeb/WebGL/OpenGLContext.cpp
+++ b/Libraries/LibWeb/WebGL/OpenGLContext.cpp
@@ -4,6 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+// Define GL_GLEXT_PROTOTYPES before OpenGLContext.h pulls in the GL headers without it.
+#define GL_GLEXT_PROTOTYPES 1
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+extern "C" {
+#include <GLES2/gl2ext_angle.h>
+}
+#include <GLES3/gl3.h>
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#define EGL_EGLEXT_PROTOTYPES 1
+extern "C" {
+#include <EGL/eglext_angle.h>
+}
+
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
@@ -13,20 +29,6 @@
 #    include <LibGfx/VulkanImage.h>
 #endif
 #include <LibWeb/WebGL/OpenGLContext.h>
-
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
-#define EGL_EGLEXT_PROTOTYPES 1
-extern "C" {
-#include <EGL/eglext_angle.h>
-}
-#define GL_GLEXT_PROTOTYPES 1
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
-extern "C" {
-#include <GLES2/gl2ext_angle.h>
-}
-#include <GLES3/gl3.h>
 
 // Enable WebGL if we're on MacOS and can use Metal or if we can use shareable Vulkan images
 #if defined(AK_OS_MACOS) || defined(USE_VULKAN_DMABUF_IMAGES)

--- a/Libraries/LibWeb/WebGL/OpenGLContext.h
+++ b/Libraries/LibWeb/WebGL/OpenGLContext.h
@@ -13,10 +13,11 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Size.h>
 #include <LibWeb/Export.h>
+#include <LibWeb/WebGL/GLFunctions.h>
 
 namespace Web::WebGL {
 
-class WEB_API OpenGLContext {
+class WEB_API OpenGLContext : public GLFunctions {
 public:
     enum class WebGLVersion {
         WebGL1,

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
@@ -7,8 +7,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#define GL_GLEXT_PROTOTYPES 1
-
 #include <GLES3/gl3.h>
 extern "C" {
 #include <GLES2/gl2ext.h>
@@ -46,7 +44,7 @@ WebGL2RenderingContextImpl::WebGL2RenderingContextImpl(JS::Realm& realm, Nonnull
 void WebGL2RenderingContextImpl::copy_buffer_sub_data(WebIDL::UnsignedLong read_target, WebIDL::UnsignedLong write_target, WebIDL::LongLong read_offset, WebIDL::LongLong write_offset, WebIDL::LongLong size)
 {
     m_context->make_current();
-    glCopyBufferSubData(read_target, write_target, read_offset, write_offset, size);
+    m_context->copy_buffer_sub_data(read_target, write_target, read_offset, write_offset, size);
 }
 
 // https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.3
@@ -92,13 +90,13 @@ void WebGL2RenderingContextImpl::get_buffer_sub_data(WebIDL::UnsignedLong target
     // If copyLength is greater than zero, copy copyLength typed elements (each of size elementSize) from buf into
     // dstBuffer, reading buf starting at byte index srcByteOffset and writing into dstBuffer starting at element
     // index dstOffset.
-    auto* buffer_data = glMapBufferRange(target, src_byte_offset, copy_bytes, GL_MAP_READ_BIT);
+    auto* buffer_data = m_context->map_buffer_range(target, src_byte_offset, copy_bytes, GL_MAP_READ_BIT);
     if (!buffer_data)
         return;
 
     dst_buffer.write({ buffer_data, copy_bytes }, dst_offset_in_bytes);
 
-    glUnmapBuffer(target);
+    m_context->unmap_buffer(target);
 }
 
 void WebGL2RenderingContextImpl::blit_framebuffer(WebIDL::Long src_x0, WebIDL::Long src_y0, WebIDL::Long src_x1, WebIDL::Long src_y1, WebIDL::Long dst_x0, WebIDL::Long dst_y0, WebIDL::Long dst_x1, WebIDL::Long dst_y1, WebIDL::UnsignedLong mask, WebIDL::UnsignedLong filter)
@@ -106,7 +104,7 @@ void WebGL2RenderingContextImpl::blit_framebuffer(WebIDL::Long src_x0, WebIDL::L
     m_context->make_current();
     m_context->notify_content_will_change();
     needs_to_present();
-    glBlitFramebuffer(src_x0, src_y0, src_x1, src_y1, dst_x0, dst_y0, dst_x1, dst_y1, mask, filter);
+    m_context->blit_framebuffer(src_x0, src_y0, src_x1, src_y1, dst_x0, dst_y0, dst_x1, dst_y1, mask, filter);
 }
 
 void WebGL2RenderingContextImpl::framebuffer_texture_layer(WebIDL::UnsignedLong target, WebIDL::UnsignedLong attachment, GC::Ptr<WebGLTexture> texture, WebIDL::Long level, WebIDL::Long layer)
@@ -123,7 +121,7 @@ void WebGL2RenderingContextImpl::framebuffer_texture_layer(WebIDL::UnsignedLong 
         texture_handle = handle_or_error.release_value();
     }
 
-    glFramebufferTextureLayer(target, attachment, texture_handle, level, layer);
+    m_context->framebuffer_texture_layer(target, attachment, texture_handle, level, layer);
 }
 
 void WebGL2RenderingContextImpl::invalidate_framebuffer(WebIDL::UnsignedLong target, Vector<WebIDL::UnsignedLong> attachments)
@@ -131,7 +129,7 @@ void WebGL2RenderingContextImpl::invalidate_framebuffer(WebIDL::UnsignedLong tar
     m_context->make_current();
     m_context->notify_content_will_change();
 
-    glInvalidateFramebuffer(target, attachments.size(), attachments.data());
+    m_context->invalidate_framebuffer(target, attachments.size(), attachments.data());
     needs_to_present();
 }
 
@@ -140,14 +138,14 @@ void WebGL2RenderingContextImpl::invalidate_sub_framebuffer(WebIDL::UnsignedLong
     m_context->make_current();
     m_context->notify_content_will_change();
 
-    glInvalidateSubFramebuffer(target, attachments.size(), attachments.data(), x, y, width, height);
+    m_context->invalidate_sub_framebuffer(target, attachments.size(), attachments.data(), x, y, width, height);
     needs_to_present();
 }
 
 void WebGL2RenderingContextImpl::read_buffer(WebIDL::UnsignedLong src)
 {
     m_context->make_current();
-    glReadBuffer(src);
+    m_context->read_buffer(src);
 }
 
 JS::Value WebGL2RenderingContextImpl::get_internalformat_parameter(WebIDL::UnsignedLong target, WebIDL::UnsignedLong internalformat, WebIDL::UnsignedLong pname)
@@ -157,10 +155,10 @@ JS::Value WebGL2RenderingContextImpl::get_internalformat_parameter(WebIDL::Unsig
     switch (pname) {
     case GL_SAMPLES: {
         GLint num_sample_counts { 0 };
-        glGetInternalformativRobustANGLE(target, internalformat, GL_NUM_SAMPLE_COUNTS, 1, nullptr, &num_sample_counts);
+        m_context->get_internalformativ_robust_angle(target, internalformat, GL_NUM_SAMPLE_COUNTS, 1, nullptr, &num_sample_counts);
         size_t buffer_size = num_sample_counts * sizeof(GLint);
         auto samples_buffer = MUST(ByteBuffer::create_zeroed(buffer_size));
-        glGetInternalformativRobustANGLE(target, internalformat, GL_SAMPLES, buffer_size, nullptr, reinterpret_cast<GLint*>(samples_buffer.data()));
+        m_context->get_internalformativ_robust_angle(target, internalformat, GL_SAMPLES, buffer_size, nullptr, reinterpret_cast<GLint*>(samples_buffer.data()));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(samples_buffer));
         return JS::Int32Array::create(realm(), num_sample_counts, array_buffer);
     }
@@ -174,20 +172,20 @@ JS::Value WebGL2RenderingContextImpl::get_internalformat_parameter(WebIDL::Unsig
 void WebGL2RenderingContextImpl::renderbuffer_storage_multisample(WebIDL::UnsignedLong target, WebIDL::Long samples, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height)
 {
     m_context->make_current();
-    glRenderbufferStorageMultisample(target, samples, internalformat, width, height);
+    m_context->renderbuffer_storage_multisample(target, samples, internalformat, width, height);
 }
 
 void WebGL2RenderingContextImpl::tex_storage2d(WebIDL::UnsignedLong target, WebIDL::Long levels, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height)
 {
     m_context->make_current();
 
-    glTexStorage2D(target, levels, internalformat, width, height);
+    m_context->tex_storage2d(target, levels, internalformat, width, height);
 }
 
 void WebGL2RenderingContextImpl::tex_storage3d(WebIDL::UnsignedLong target, WebIDL::Long levels, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long depth)
 {
     m_context->make_current();
-    glTexStorage3D(target, levels, internalformat, width, height, depth);
+    m_context->tex_storage3d(target, levels, internalformat, width, height, depth);
 }
 
 void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long depth, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant src_data)
@@ -199,7 +197,7 @@ void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL
         src_data_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0), GL_INVALID_OPERATION);
     }
 
-    glTexImage3DRobustANGLE(target, level, internalformat, width, height, depth, border, format, type, src_data_span.size(), src_data_span.data());
+    m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, src_data_span.size(), src_data_span.data());
 }
 
 void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long depth, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset)
@@ -208,7 +206,7 @@ void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL
 
     auto src_data_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset), GL_INVALID_OPERATION);
 
-    glTexImage3DRobustANGLE(target, level, internalformat, width, height, depth, border, format, type, src_data_span.size(), src_data_span.data());
+    m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, src_data_span.size(), src_data_span.data());
 }
 
 void WebGL2RenderingContextImpl::tex_sub_image3d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long zoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::Long depth, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant src_data, WebIDL::UnsignedLongLong src_offset)
@@ -220,7 +218,7 @@ void WebGL2RenderingContextImpl::tex_sub_image3d(WebIDL::UnsignedLong target, We
         src_data_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data.downcast<WebIDL::ArrayBufferViewVariant>(), src_offset), GL_INVALID_OPERATION);
     }
 
-    glTexSubImage3DRobustANGLE(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, src_data_span.size(), src_data_span.data());
+    m_context->tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, src_data_span.size(), src_data_span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform1ui(GC::Ptr<WebGLUniformLocation> location, WebIDL::UnsignedLong v0)
@@ -231,7 +229,7 @@ void WebGL2RenderingContextImpl::uniform1ui(GC::Ptr<WebGLUniformLocation> locati
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform1ui(location_handle, v0);
+    m_context->uniform1ui(location_handle, v0);
 }
 
 void WebGL2RenderingContextImpl::uniform2ui(GC::Ptr<WebGLUniformLocation> location, WebIDL::UnsignedLong v0, WebIDL::UnsignedLong v1)
@@ -242,7 +240,7 @@ void WebGL2RenderingContextImpl::uniform2ui(GC::Ptr<WebGLUniformLocation> locati
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform2ui(location_handle, v0, v1);
+    m_context->uniform2ui(location_handle, v0, v1);
 }
 
 void WebGL2RenderingContextImpl::uniform3ui(GC::Ptr<WebGLUniformLocation> location, WebIDL::UnsignedLong v0, WebIDL::UnsignedLong v1, WebIDL::UnsignedLong v2)
@@ -253,7 +251,7 @@ void WebGL2RenderingContextImpl::uniform3ui(GC::Ptr<WebGLUniformLocation> locati
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform3ui(location_handle, v0, v1, v2);
+    m_context->uniform3ui(location_handle, v0, v1, v2);
 }
 
 void WebGL2RenderingContextImpl::uniform4ui(GC::Ptr<WebGLUniformLocation> location, WebIDL::UnsignedLong v0, WebIDL::UnsignedLong v1, WebIDL::UnsignedLong v2, WebIDL::UnsignedLong v3)
@@ -264,7 +262,7 @@ void WebGL2RenderingContextImpl::uniform4ui(GC::Ptr<WebGLUniformLocation> locati
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform4ui(location_handle, v0, v1, v2, v3);
+    m_context->uniform4ui(location_handle, v0, v1, v2, v3);
 }
 
 void WebGL2RenderingContextImpl::uniform1uiv(GC::Ptr<WebGLUniformLocation> location, Uint32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -277,7 +275,7 @@ void WebGL2RenderingContextImpl::uniform1uiv(GC::Ptr<WebGLUniformLocation> locat
     GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_uint32_list(values, src_offset, src_length), GL_INVALID_VALUE);
-    glUniform1uiv(location_handle, span.size(), span.data());
+    m_context->uniform1uiv(location_handle, span.size(), span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform2uiv(GC::Ptr<WebGLUniformLocation> location, Uint32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -294,7 +292,7 @@ void WebGL2RenderingContextImpl::uniform2uiv(GC::Ptr<WebGLUniformLocation> locat
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2uiv(location_handle, span.size() / 2, span.data());
+    m_context->uniform2uiv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform3uiv(GC::Ptr<WebGLUniformLocation> location, Uint32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -311,7 +309,7 @@ void WebGL2RenderingContextImpl::uniform3uiv(GC::Ptr<WebGLUniformLocation> locat
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3uiv(location_handle, span.size() / 3, span.data());
+    m_context->uniform3uiv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform4uiv(GC::Ptr<WebGLUniformLocation> location, Uint32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -328,7 +326,7 @@ void WebGL2RenderingContextImpl::uniform4uiv(GC::Ptr<WebGLUniformLocation> locat
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4uiv(location_handle, span.size() / 4, span.data());
+    m_context->uniform4uiv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix3x2fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -346,7 +344,7 @@ void WebGL2RenderingContextImpl::uniform_matrix3x2fv(GC::Ptr<WebGLUniformLocatio
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix3x2fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix3x2fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix4x2fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -364,7 +362,7 @@ void WebGL2RenderingContextImpl::uniform_matrix4x2fv(GC::Ptr<WebGLUniformLocatio
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix4x2fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix4x2fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix2x3fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -382,7 +380,7 @@ void WebGL2RenderingContextImpl::uniform_matrix2x3fv(GC::Ptr<WebGLUniformLocatio
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix2x3fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix2x3fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix4x3fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -400,7 +398,7 @@ void WebGL2RenderingContextImpl::uniform_matrix4x3fv(GC::Ptr<WebGLUniformLocatio
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix4x3fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix4x3fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix2x4fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -418,7 +416,7 @@ void WebGL2RenderingContextImpl::uniform_matrix2x4fv(GC::Ptr<WebGLUniformLocatio
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix2x4fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix2x4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix3x4fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -436,13 +434,13 @@ void WebGL2RenderingContextImpl::uniform_matrix3x4fv(GC::Ptr<WebGLUniformLocatio
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix3x4fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix3x4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::vertex_attrib_i4i(WebIDL::UnsignedLong index, WebIDL::Long x, WebIDL::Long y, WebIDL::Long z, WebIDL::Long w)
 {
     m_context->make_current();
-    glVertexAttribI4i(index, x, y, z, w);
+    m_context->vertex_attrib_i4i(index, x, y, z, w);
 }
 
 void WebGL2RenderingContextImpl::vertex_attrib_i4iv(WebIDL::UnsignedLong index, Int32List values)
@@ -453,13 +451,13 @@ void WebGL2RenderingContextImpl::vertex_attrib_i4iv(WebIDL::UnsignedLong index, 
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glVertexAttribI4iv(index, span.data());
+    m_context->vertex_attrib_i4iv(index, span.data());
 }
 
 void WebGL2RenderingContextImpl::vertex_attrib_i4ui(WebIDL::UnsignedLong index, WebIDL::UnsignedLong x, WebIDL::UnsignedLong y, WebIDL::UnsignedLong z, WebIDL::UnsignedLong w)
 {
     m_context->make_current();
-    glVertexAttribI4ui(index, x, y, z, w);
+    m_context->vertex_attrib_i4ui(index, x, y, z, w);
 }
 
 void WebGL2RenderingContextImpl::vertex_attrib_i4uiv(WebIDL::UnsignedLong index, Uint32List values)
@@ -470,20 +468,20 @@ void WebGL2RenderingContextImpl::vertex_attrib_i4uiv(WebIDL::UnsignedLong index,
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glVertexAttribI4uiv(index, span.data());
+    m_context->vertex_attrib_i4uiv(index, span.data());
 }
 
 void WebGL2RenderingContextImpl::vertex_attrib_i_pointer(WebIDL::UnsignedLong index, WebIDL::Long size, WebIDL::UnsignedLong type, WebIDL::Long stride, WebIDL::LongLong offset)
 {
     m_context->make_current();
 
-    glVertexAttribIPointer(index, size, type, stride, reinterpret_cast<void*>(offset));
+    m_context->vertex_attrib_i_pointer(index, size, type, stride, reinterpret_cast<void*>(offset));
 }
 
 void WebGL2RenderingContextImpl::vertex_attrib_divisor(WebIDL::UnsignedLong index, WebIDL::UnsignedLong divisor)
 {
     m_context->make_current();
-    glVertexAttribDivisor(index, divisor);
+    m_context->vertex_attrib_divisor(index, divisor);
 }
 
 void WebGL2RenderingContextImpl::draw_arrays_instanced(WebIDL::UnsignedLong mode, WebIDL::Long first, WebIDL::Long count, WebIDL::Long instance_count)
@@ -491,7 +489,7 @@ void WebGL2RenderingContextImpl::draw_arrays_instanced(WebIDL::UnsignedLong mode
     m_context->make_current();
     m_context->notify_content_will_change();
     needs_to_present();
-    glDrawArraysInstanced(mode, first, count, instance_count);
+    m_context->draw_arrays_instanced(mode, first, count, instance_count);
 }
 
 void WebGL2RenderingContextImpl::draw_elements_instanced(WebIDL::UnsignedLong mode, WebIDL::Long count, WebIDL::UnsignedLong type, WebIDL::LongLong offset, WebIDL::Long instance_count)
@@ -499,7 +497,7 @@ void WebGL2RenderingContextImpl::draw_elements_instanced(WebIDL::UnsignedLong mo
     m_context->make_current();
     m_context->notify_content_will_change();
 
-    glDrawElementsInstanced(mode, count, type, reinterpret_cast<void*>(offset), instance_count);
+    m_context->draw_elements_instanced(mode, count, type, reinterpret_cast<void*>(offset), instance_count);
     needs_to_present();
 }
 
@@ -508,14 +506,14 @@ void WebGL2RenderingContextImpl::draw_range_elements(WebIDL::UnsignedLong mode, 
     m_context->make_current();
     m_context->notify_content_will_change();
     needs_to_present();
-    glDrawRangeElements(mode, start, end, count, type, reinterpret_cast<void*>(offset));
+    m_context->draw_range_elements(mode, start, end, count, type, reinterpret_cast<void*>(offset));
 }
 
 void WebGL2RenderingContextImpl::draw_buffers(Vector<WebIDL::UnsignedLong> buffers)
 {
     m_context->make_current();
 
-    glDrawBuffers(buffers.size(), buffers.data());
+    m_context->draw_buffers(buffers.size(), buffers.data());
 }
 
 void WebGL2RenderingContextImpl::clear_bufferfv(WebIDL::UnsignedLong buffer, WebIDL::Long drawbuffer, Float32List values, WebIDL::UnsignedLongLong src_offset)
@@ -545,7 +543,7 @@ void WebGL2RenderingContextImpl::clear_bufferfv(WebIDL::UnsignedLong buffer, Web
         return;
     }
 
-    glClearBufferfv(buffer, drawbuffer, span.data());
+    m_context->clear_bufferfv(buffer, drawbuffer, span.data());
     needs_to_present();
 }
 
@@ -576,7 +574,7 @@ void WebGL2RenderingContextImpl::clear_bufferiv(WebIDL::UnsignedLong buffer, Web
         return;
     }
 
-    glClearBufferiv(buffer, drawbuffer, span.data());
+    m_context->clear_bufferiv(buffer, drawbuffer, span.data());
     needs_to_present();
 }
 
@@ -606,7 +604,7 @@ void WebGL2RenderingContextImpl::clear_bufferuiv(WebIDL::UnsignedLong buffer, We
         return;
     }
 
-    glClearBufferuiv(buffer, drawbuffer, span.data());
+    m_context->clear_bufferuiv(buffer, drawbuffer, span.data());
     needs_to_present();
 }
 
@@ -615,7 +613,7 @@ void WebGL2RenderingContextImpl::clear_bufferfi(WebIDL::UnsignedLong buffer, Web
     m_context->make_current();
     m_context->notify_content_will_change();
     needs_to_present();
-    glClearBufferfi(buffer, drawbuffer, depth, stencil);
+    m_context->clear_bufferfi(buffer, drawbuffer, depth, stencil);
 }
 
 GC::Ref<WebGLQuery> WebGL2RenderingContextImpl::create_query()
@@ -623,7 +621,7 @@ GC::Ref<WebGLQuery> WebGL2RenderingContextImpl::create_query()
     m_context->make_current();
 
     GLuint handle = 0;
-    glGenQueries(1, &handle);
+    m_context->gen_queries(1, &handle);
     return WebGLQuery::create(realm(), *this, handle);
 }
 
@@ -641,7 +639,7 @@ void WebGL2RenderingContextImpl::delete_query(GC::Ptr<WebGLQuery> query)
         query_handle = handle_or_error.release_value();
     }
 
-    glDeleteQueries(1, &query_handle);
+    m_context->delete_queries(1, &query_handle);
 }
 
 void WebGL2RenderingContextImpl::begin_query(WebIDL::UnsignedLong target, GC::Ref<WebGLQuery> query)
@@ -667,7 +665,7 @@ void WebGL2RenderingContextImpl::begin_query(WebIDL::UnsignedLong target, GC::Re
         break;
     }
 
-    glBeginQuery(target, query_handle);
+    m_context->begin_query(target, query_handle);
 }
 
 void WebGL2RenderingContextImpl::end_query(WebIDL::UnsignedLong target)
@@ -686,7 +684,7 @@ void WebGL2RenderingContextImpl::end_query(WebIDL::UnsignedLong target)
         break;
     }
 
-    glEndQuery(target);
+    m_context->end_query(target);
 }
 
 GC::Ptr<WebGLQuery> WebGL2RenderingContextImpl::get_query(WebIDL::UnsignedLong target, WebIDL::UnsignedLong pname)
@@ -721,7 +719,7 @@ JS::Value WebGL2RenderingContextImpl::get_query_parameter(GC::Ref<WebGLQuery> qu
     auto query_handle = handle_or_error.release_value();
 
     GLuint result { 0 };
-    glGetQueryObjectuivRobustANGLE(query_handle, pname, 1, nullptr, &result);
+    m_context->get_query_objectuiv_robust_angle(query_handle, pname, 1, nullptr, &result);
 
     switch (pname) {
     case GL_QUERY_RESULT:
@@ -738,7 +736,7 @@ GC::Ref<WebGLSampler> WebGL2RenderingContextImpl::create_sampler()
     m_context->make_current();
 
     GLuint handle = 0;
-    glGenSamplers(1, &handle);
+    m_context->gen_samplers(1, &handle);
     return WebGLSampler::create(realm(), *this, handle);
 }
 
@@ -756,7 +754,7 @@ void WebGL2RenderingContextImpl::delete_sampler(GC::Ptr<WebGLSampler> sampler)
         sampler_handle = handle_or_error.release_value();
     }
 
-    glDeleteSamplers(1, &sampler_handle);
+    m_context->delete_samplers(1, &sampler_handle);
 }
 
 void WebGL2RenderingContextImpl::bind_sampler(WebIDL::UnsignedLong unit, GC::Ptr<WebGLSampler> sampler)
@@ -772,7 +770,7 @@ void WebGL2RenderingContextImpl::bind_sampler(WebIDL::UnsignedLong unit, GC::Ptr
         }
         sampler_handle = handle_or_error.release_value();
     }
-    glBindSampler(unit, sampler_handle);
+    m_context->bind_sampler(unit, sampler_handle);
 }
 
 void WebGL2RenderingContextImpl::sampler_parameteri(GC::Ref<WebGLSampler> sampler, WebIDL::UnsignedLong pname, WebIDL::Long param)
@@ -809,7 +807,7 @@ void WebGL2RenderingContextImpl::sampler_parameteri(GC::Ref<WebGLSampler> sample
         set_error(GL_INVALID_ENUM);
         return;
     }
-    glSamplerParameteri(sampler_handle, pname, param);
+    m_context->sampler_parameteri(sampler_handle, pname, param);
 }
 
 void WebGL2RenderingContextImpl::sampler_parameterf(GC::Ref<WebGLSampler> sampler, WebIDL::UnsignedLong pname, float param)
@@ -846,14 +844,14 @@ void WebGL2RenderingContextImpl::sampler_parameterf(GC::Ref<WebGLSampler> sample
         set_error(GL_INVALID_ENUM);
         return;
     }
-    glSamplerParameterf(sampler_handle, pname, param);
+    m_context->sampler_parameterf(sampler_handle, pname, param);
 }
 
 GC::Ptr<WebGLSync> WebGL2RenderingContextImpl::fence_sync(WebIDL::UnsignedLong condition, WebIDL::UnsignedLong flags)
 {
     m_context->make_current();
 
-    GLsync handle = glFenceSync(condition, flags);
+    GLsync handle = m_context->fence_sync(condition, flags);
     return WebGLSync::create(realm(), *this, handle);
 }
 
@@ -871,7 +869,7 @@ void WebGL2RenderingContextImpl::delete_sync(GC::Ptr<WebGLSync> sync)
         sync_handle = static_cast<GLsync>(handle_or_error.release_value());
     }
 
-    glDeleteSync(sync_handle);
+    m_context->delete_sync(sync_handle);
 }
 
 WebIDL::UnsignedLong WebGL2RenderingContextImpl::client_wait_sync(GC::Ref<WebGLSync> sync, WebIDL::UnsignedLong flags, WebIDL::UnsignedLongLong timeout)
@@ -885,7 +883,7 @@ WebIDL::UnsignedLong WebGL2RenderingContextImpl::client_wait_sync(GC::Ref<WebGLS
     }
     auto sync_handle = static_cast<GLsync>(handle_or_error.release_value());
 
-    return glClientWaitSync(sync_handle, flags, timeout);
+    return m_context->client_wait_sync(sync_handle, flags, timeout);
 }
 
 void WebGL2RenderingContextImpl::wait_sync(GC::Ref<WebGLSync> sync, WebIDL::UnsignedLong flags, WebIDL::UnsignedLongLong timeout)
@@ -899,7 +897,7 @@ void WebGL2RenderingContextImpl::wait_sync(GC::Ref<WebGLSync> sync, WebIDL::Unsi
     }
     auto sync_handle = static_cast<GLsync>(handle_or_error.release_value());
 
-    glWaitSync(sync_handle, flags, timeout);
+    m_context->wait_sync(sync_handle, flags, timeout);
 }
 
 JS::Value WebGL2RenderingContextImpl::get_sync_parameter(GC::Ref<WebGLSync> sync, WebIDL::UnsignedLong pname)
@@ -914,7 +912,7 @@ JS::Value WebGL2RenderingContextImpl::get_sync_parameter(GC::Ref<WebGLSync> sync
     auto sync_handle = static_cast<GLsync>(handle_or_error.release_value());
 
     GLint result = 0;
-    glGetSynciv(sync_handle, pname, 1, nullptr, &result);
+    m_context->get_synciv(sync_handle, pname, 1, nullptr, &result);
     return JS::Value(result);
 }
 
@@ -923,7 +921,7 @@ GC::Ref<WebGLTransformFeedback> WebGL2RenderingContextImpl::create_transform_fee
     m_context->make_current();
 
     GLuint handle = 0;
-    glGenTransformFeedbacks(1, &handle);
+    m_context->gen_transform_feedbacks(1, &handle);
     return WebGLTransformFeedback::create(realm(), *this, handle);
 }
 
@@ -941,7 +939,7 @@ void WebGL2RenderingContextImpl::delete_transform_feedback(GC::Ptr<WebGLTransfor
         transform_feedback_handle = handle_or_error.release_value();
     }
 
-    glDeleteTransformFeedbacks(1, &transform_feedback_handle);
+    m_context->delete_transform_feedbacks(1, &transform_feedback_handle);
 }
 
 void WebGL2RenderingContextImpl::bind_transform_feedback(WebIDL::UnsignedLong target, GC::Ptr<WebGLTransformFeedback> transform_feedback)
@@ -958,19 +956,19 @@ void WebGL2RenderingContextImpl::bind_transform_feedback(WebIDL::UnsignedLong ta
         transform_feedback_handle = handle_or_error.release_value();
     }
 
-    glBindTransformFeedback(target, transform_feedback_handle);
+    m_context->bind_transform_feedback(target, transform_feedback_handle);
 }
 
 void WebGL2RenderingContextImpl::begin_transform_feedback(WebIDL::UnsignedLong primitive_mode)
 {
     m_context->make_current();
-    glBeginTransformFeedback(primitive_mode);
+    m_context->begin_transform_feedback(primitive_mode);
 }
 
 void WebGL2RenderingContextImpl::end_transform_feedback()
 {
     m_context->make_current();
-    glEndTransformFeedback();
+    m_context->end_transform_feedback();
 }
 
 void WebGL2RenderingContextImpl::transform_feedback_varyings(GC::Ref<WebGLProgram> program, Vector<String> const& varyings, WebIDL::UnsignedLong buffer_mode)
@@ -996,19 +994,19 @@ void WebGL2RenderingContextImpl::transform_feedback_varyings(GC::Ref<WebGLProgra
         varying_strings_characters.append(varying_string.data());
     }
 
-    glTransformFeedbackVaryings(program_handle, varying_strings_characters.size(), varying_strings_characters.data(), buffer_mode);
+    m_context->transform_feedback_varyings(program_handle, varying_strings_characters.size(), varying_strings_characters.data(), buffer_mode);
 }
 
 void WebGL2RenderingContextImpl::pause_transform_feedback()
 {
     m_context->make_current();
-    glPauseTransformFeedback();
+    m_context->pause_transform_feedback();
 }
 
 void WebGL2RenderingContextImpl::resume_transform_feedback()
 {
     m_context->make_current();
-    glResumeTransformFeedback();
+    m_context->resume_transform_feedback();
 }
 
 void WebGL2RenderingContextImpl::bind_buffer_base(WebIDL::UnsignedLong target, WebIDL::UnsignedLong index, GC::Ptr<WebGLBuffer> buffer)
@@ -1029,7 +1027,7 @@ void WebGL2RenderingContextImpl::bind_buffer_base(WebIDL::UnsignedLong target, W
             return;
         }
     }
-    glBindBufferBase(target, index, buffer_handle);
+    m_context->bind_buffer_base(target, index, buffer_handle);
 }
 
 void WebGL2RenderingContextImpl::bind_buffer_range(WebIDL::UnsignedLong target, WebIDL::UnsignedLong index, GC::Ptr<WebGLBuffer> buffer, WebIDL::LongLong offset, WebIDL::LongLong size)
@@ -1050,7 +1048,7 @@ void WebGL2RenderingContextImpl::bind_buffer_range(WebIDL::UnsignedLong target, 
             return;
         }
     }
-    glBindBufferRange(target, index, buffer_handle, offset, size);
+    m_context->bind_buffer_range(target, index, buffer_handle, offset, size);
 }
 
 Optional<Vector<WebIDL::UnsignedLong>> WebGL2RenderingContextImpl::get_uniform_indices(GC::Ref<WebGLProgram> program, Vector<String> const& uniform_names)
@@ -1079,7 +1077,7 @@ Optional<Vector<WebIDL::UnsignedLong>> WebGL2RenderingContextImpl::get_uniform_i
 
     auto result_buffer = MUST(ByteBuffer::create_zeroed(uniform_names_characters.size() * sizeof(WebIDL::UnsignedLong)));
     auto result_span = result_buffer.bytes().reinterpret<WebIDL::UnsignedLong>();
-    glGetUniformIndices(program_handle, uniform_names_characters.size(), uniform_names_characters.data(), result_span.data());
+    m_context->get_uniform_indices(program_handle, uniform_names_characters.size(), uniform_names_characters.data(), result_span.data());
     return Vector<WebIDL::UnsignedLong> { result_span };
 }
 
@@ -1096,7 +1094,7 @@ JS::Value WebGL2RenderingContextImpl::get_active_uniforms(GC::Ref<WebGLProgram> 
 
     auto params = MUST(ByteBuffer::create_zeroed(uniform_indices.size() * sizeof(GLint)));
     Span<GLint> params_span(reinterpret_cast<GLint*>(params.data()), uniform_indices.size());
-    glGetActiveUniformsiv(program_handle, uniform_indices.size(), uniform_indices.data(), pname, params_span.data());
+    m_context->get_active_uniformsiv(program_handle, uniform_indices.size(), uniform_indices.data(), pname, params_span.data());
 
     Vector<JS::Value> params_as_values;
     params_as_values.ensure_capacity(params.size());
@@ -1139,7 +1137,7 @@ WebIDL::UnsignedLong WebGL2RenderingContextImpl::get_uniform_block_index(GC::Ref
     auto program_handle = handle_or_error.release_value();
 
     auto uniform_block_name_null_terminated = null_terminated_string(uniform_block_name);
-    return glGetUniformBlockIndex(program_handle, uniform_block_name_null_terminated.data());
+    return m_context->get_uniform_block_index(program_handle, uniform_block_name_null_terminated.data());
 }
 
 JS::Value WebGL2RenderingContextImpl::get_active_uniform_block_parameter(GC::Ref<WebGLProgram> program, WebIDL::UnsignedLong uniform_block_index, WebIDL::UnsignedLong pname)
@@ -1158,22 +1156,22 @@ JS::Value WebGL2RenderingContextImpl::get_active_uniform_block_parameter(GC::Ref
     case GL_UNIFORM_BLOCK_DATA_SIZE:
     case GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS: {
         GLint result = 0;
-        glGetActiveUniformBlockivRobustANGLE(program_handle, uniform_block_index, pname, 1, nullptr, &result);
+        m_context->get_active_uniform_blockiv_robust_angle(program_handle, uniform_block_index, pname, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES: {
         GLint num_active_uniforms = 0;
-        glGetActiveUniformBlockivRobustANGLE(program_handle, uniform_block_index, GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS, sizeof(GLint), nullptr, &num_active_uniforms);
+        m_context->get_active_uniform_blockiv_robust_angle(program_handle, uniform_block_index, GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS, sizeof(GLint), nullptr, &num_active_uniforms);
         size_t buffer_size = num_active_uniforms * sizeof(GLint);
         auto active_uniform_indices_buffer = MUST(ByteBuffer::create_zeroed(buffer_size));
-        glGetActiveUniformBlockivRobustANGLE(program_handle, uniform_block_index, GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES, num_active_uniforms, nullptr, reinterpret_cast<GLint*>(active_uniform_indices_buffer.data()));
+        m_context->get_active_uniform_blockiv_robust_angle(program_handle, uniform_block_index, GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES, num_active_uniforms, nullptr, reinterpret_cast<GLint*>(active_uniform_indices_buffer.data()));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(active_uniform_indices_buffer));
         return JS::Uint32Array::create(realm(), num_active_uniforms, array_buffer);
     }
     case GL_UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER:
     case GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER: {
         GLint result = 0;
-        glGetActiveUniformBlockivRobustANGLE(program_handle, uniform_block_index, pname, 1, nullptr, &result);
+        m_context->get_active_uniform_blockiv_robust_angle(program_handle, uniform_block_index, pname, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     default:
@@ -1195,12 +1193,12 @@ Optional<String> WebGL2RenderingContextImpl::get_active_uniform_block_name(GC::R
     auto program_handle = handle_or_error.release_value();
 
     GLint uniform_block_name_length = 0;
-    glGetActiveUniformBlockivRobustANGLE(program_handle, uniform_block_index, GL_UNIFORM_BLOCK_NAME_LENGTH, 1, nullptr, &uniform_block_name_length);
+    m_context->get_active_uniform_blockiv_robust_angle(program_handle, uniform_block_index, GL_UNIFORM_BLOCK_NAME_LENGTH, 1, nullptr, &uniform_block_name_length);
     Vector<GLchar> uniform_block_name;
     uniform_block_name.resize(uniform_block_name_length);
     if (!uniform_block_name_length)
         return String {};
-    glGetActiveUniformBlockName(program_handle, uniform_block_index, uniform_block_name_length, nullptr, uniform_block_name.data());
+    m_context->get_active_uniform_block_name(program_handle, uniform_block_index, uniform_block_name_length, nullptr, uniform_block_name.data());
     return String::from_utf8_without_validation(ReadonlyBytes { uniform_block_name.data(), static_cast<size_t>(uniform_block_name_length - 1) });
 }
 
@@ -1214,7 +1212,7 @@ void WebGL2RenderingContextImpl::uniform_block_binding(GC::Ref<WebGLProgram> pro
         return;
     }
     auto program_handle = handle_or_error.release_value();
-    glUniformBlockBinding(program_handle, uniform_block_index, uniform_block_binding);
+    m_context->uniform_block_binding(program_handle, uniform_block_index, uniform_block_binding);
 }
 
 GC::Ref<WebGLVertexArrayObject> WebGL2RenderingContextImpl::create_vertex_array()
@@ -1222,7 +1220,7 @@ GC::Ref<WebGLVertexArrayObject> WebGL2RenderingContextImpl::create_vertex_array(
     m_context->make_current();
 
     GLuint handle = 0;
-    glGenVertexArrays(1, &handle);
+    m_context->gen_vertex_arrays(1, &handle);
     return WebGLVertexArrayObject::create(realm(), *this, handle);
 }
 
@@ -1240,7 +1238,7 @@ void WebGL2RenderingContextImpl::delete_vertex_array(GC::Ptr<WebGLVertexArrayObj
         vertex_array_handle = handle_or_error.release_value();
     }
 
-    glDeleteVertexArrays(1, &vertex_array_handle);
+    m_context->delete_vertex_arrays(1, &vertex_array_handle);
     if (m_current_vertex_array == vertex_array)
         m_current_vertex_array = nullptr;
 }
@@ -1258,7 +1256,7 @@ bool WebGL2RenderingContextImpl::is_vertex_array(GC::Ptr<WebGLVertexArrayObject>
         }
         vertex_array_handle = handle_or_error.release_value();
     }
-    return glIsVertexArray(vertex_array_handle);
+    return m_context->is_vertex_array(vertex_array_handle);
 }
 
 void WebGL2RenderingContextImpl::bind_vertex_array(GC::Ptr<WebGLVertexArrayObject> array)
@@ -1275,7 +1273,7 @@ void WebGL2RenderingContextImpl::bind_vertex_array(GC::Ptr<WebGLVertexArrayObjec
         array_handle = handle_or_error.release_value();
     }
 
-    glBindVertexArray(array_handle);
+    m_context->bind_vertex_array(array_handle);
     m_current_vertex_array = array;
 }
 
@@ -1289,7 +1287,7 @@ void WebGL2RenderingContextImpl::compressed_tex_image3d(WebIDL::UnsignedLong tar
     }
 
     auto pixels = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, src_length_override), GL_INVALID_VALUE);
-    glCompressedTexImage3DRobustANGLE(target, level, internalformat, width, height, depth, border, pixels.size(), pixels.size(), pixels.data());
+    m_context->compressed_tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, pixels.size(), pixels.size(), pixels.data());
 }
 
 void WebGL2RenderingContextImpl::compressed_tex_sub_image3d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long zoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::Long depth, WebIDL::UnsignedLong format, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override)
@@ -1302,7 +1300,7 @@ void WebGL2RenderingContextImpl::compressed_tex_sub_image3d(WebIDL::UnsignedLong
     }
 
     auto pixels = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, src_length_override), GL_INVALID_VALUE);
-    glCompressedTexSubImage3DRobustANGLE(target, level, xoffset, yoffset, zoffset, width, height, depth, format, pixels.size(), pixels.size(), pixels.data());
+    m_context->compressed_tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, pixels.size(), pixels.size(), pixels.data());
 }
 
 }

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
@@ -7,8 +7,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#define GL_GLEXT_PROTOTYPES 1
-
 #include <GLES3/gl3.h>
 extern "C" {
 #include <GLES2/gl2ext.h>
@@ -34,7 +32,7 @@ void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, W
 {
     m_context->make_current();
 
-    glBufferData(target, size, 0, usage);
+    m_context->buffer_data(target, size, 0, usage);
 }
 
 void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, WebIDL::NullableBufferSourceVariant src_data, WebIDL::UnsignedLong usage)
@@ -49,7 +47,7 @@ void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, W
     }
 
     auto data = MUST(get_offset_span<u8 const>(src_data.downcast<WebIDL::BufferSourceVariant>(), /* src_offset= */ 0));
-    glBufferData(target, static_cast<GLsizeiptr>(data.size()), data.data(), usage);
+    m_context->buffer_data(target, static_cast<GLsizeiptr>(data.size()), data.data(), usage);
 }
 
 void WebGL2RenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, WebIDL::BufferSource src_data)
@@ -57,7 +55,7 @@ void WebGL2RenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong targe
     m_context->make_current();
 
     auto data = MUST(get_offset_span<u8 const>(src_data, /* src_offset= */ 0));
-    glBufferSubData(target, dst_byte_offset, data.size(), data.data());
+    m_context->buffer_sub_data(target, dst_byte_offset, data.size(), data.data());
 }
 
 void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLong usage, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length)
@@ -65,7 +63,7 @@ void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, W
     m_context->make_current();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, length), GL_INVALID_VALUE);
-    glBufferData(target, span.size(), span.data(), usage);
+    m_context->buffer_data(target, span.size(), span.data(), usage);
 }
 
 void WebGL2RenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length)
@@ -73,7 +71,7 @@ void WebGL2RenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong targe
     m_context->make_current();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, length), GL_INVALID_VALUE);
-    glBufferSubData(target, dst_byte_offset, span.size(), span.data());
+    m_context->buffer_sub_data(target, dst_byte_offset, span.size(), span.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -85,7 +83,7 @@ void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, W
         pixels_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0), GL_INVALID_OPERATION);
     }
 
-    glTexImage2DRobustANGLE(target, level, internalformat, width, height, border, format, type, pixels_span.size(), pixels_span.data());
+    m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, pixels_span.size(), pixels_span.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -96,7 +94,7 @@ void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, W
     if (!maybe_converted_texture.has_value())
         return;
     auto converted_texture = maybe_converted_texture.release_value();
-    glTexImage2DRobustANGLE(target, level, internalformat, converted_texture.width, converted_texture.height, 0, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
+    m_context->tex_image2d_robust_angle(target, level, internalformat, converted_texture.width, converted_texture.height, 0, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -108,7 +106,7 @@ void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong targe
         pixels_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0), GL_INVALID_OPERATION);
     }
 
-    glTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, width, height, format, type, pixels_span.size(), pixels_span.data());
+    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, pixels_span.size(), pixels_span.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -120,7 +118,7 @@ void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong targe
     if (!maybe_converted_texture.has_value())
         return;
     auto converted_texture = maybe_converted_texture.release_value();
-    glTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, converted_texture.width, converted_texture.height, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
+    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, converted_texture.width, converted_texture.height, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -131,7 +129,7 @@ void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, W
     if (!maybe_converted_texture.has_value())
         return;
     auto converted_texture = maybe_converted_texture.release_value();
-    glTexImage2DRobustANGLE(target, level, internalformat, converted_texture.width, converted_texture.height, border, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
+    m_context->tex_image2d_robust_angle(target, level, internalformat, converted_texture.width, converted_texture.height, border, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset)
@@ -140,7 +138,7 @@ void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, W
 
     auto pixels_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset), GL_INVALID_OPERATION);
 
-    glTexImage2DRobustANGLE(target, level, internalformat, width, height, border, format, type, pixels_span.size(), pixels_span.data());
+    m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, pixels_span.size(), pixels_span.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -152,7 +150,7 @@ void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong targe
     if (!maybe_converted_texture.has_value())
         return;
     auto converted_texture = maybe_converted_texture.release_value();
-    glTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, converted_texture.width, converted_texture.height, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
+    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, converted_texture.width, converted_texture.height, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset)
@@ -161,7 +159,7 @@ void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong targe
 
     auto pixels_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset), GL_INVALID_OPERATION);
 
-    glTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, width, height, format, type, pixels_span.size(), pixels_span.data());
+    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, pixels_span.size(), pixels_span.data());
 }
 
 void WebGL2RenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override)
@@ -174,7 +172,7 @@ void WebGL2RenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLon
     }
 
     auto pixels = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, src_length_override), GL_INVALID_VALUE);
-    glCompressedTexImage2DRobustANGLE(target, level, internalformat, width, height, border, pixels.size(), pixels.size(), pixels.data());
+    m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, pixels.size(), pixels.size(), pixels.data());
 }
 
 void WebGL2RenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override)
@@ -187,7 +185,7 @@ void WebGL2RenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::Unsigne
     }
 
     auto pixels = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, src_length_override), GL_INVALID_VALUE);
-    glCompressedTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, width, height, format, pixels.size(), pixels.size(), pixels.data());
+    m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, pixels.size(), pixels.size(), pixels.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform1fv(GC::Ptr<WebGLUniformLocation> location, Float32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -200,7 +198,7 @@ void WebGL2RenderingContextOverloads::uniform1fv(GC::Ptr<WebGLUniformLocation> l
     GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(values, src_offset, src_length), GL_INVALID_VALUE);
-    glUniform1fv(location_handle, span.size(), span.data());
+    m_context->uniform1fv(location_handle, span.size(), span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform2fv(GC::Ptr<WebGLUniformLocation> location, Float32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -217,7 +215,7 @@ void WebGL2RenderingContextOverloads::uniform2fv(GC::Ptr<WebGLUniformLocation> l
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2fv(location_handle, span.size() / 2, span.data());
+    m_context->uniform2fv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform3fv(GC::Ptr<WebGLUniformLocation> location, Float32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -234,7 +232,7 @@ void WebGL2RenderingContextOverloads::uniform3fv(GC::Ptr<WebGLUniformLocation> l
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3fv(location_handle, span.size() / 3, span.data());
+    m_context->uniform3fv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform4fv(GC::Ptr<WebGLUniformLocation> location, Float32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -251,7 +249,7 @@ void WebGL2RenderingContextOverloads::uniform4fv(GC::Ptr<WebGLUniformLocation> l
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4fv(location_handle, span.size() / 4, span.data());
+    m_context->uniform4fv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform1iv(GC::Ptr<WebGLUniformLocation> location, Int32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -264,7 +262,7 @@ void WebGL2RenderingContextOverloads::uniform1iv(GC::Ptr<WebGLUniformLocation> l
     GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_int32_list(values, src_offset, src_length), GL_INVALID_VALUE);
-    glUniform1iv(location_handle, span.size(), span.data());
+    m_context->uniform1iv(location_handle, span.size(), span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform2iv(GC::Ptr<WebGLUniformLocation> location, Int32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -281,7 +279,7 @@ void WebGL2RenderingContextOverloads::uniform2iv(GC::Ptr<WebGLUniformLocation> l
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2iv(location_handle, span.size() / 2, span.data());
+    m_context->uniform2iv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform3iv(GC::Ptr<WebGLUniformLocation> location, Int32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -298,7 +296,7 @@ void WebGL2RenderingContextOverloads::uniform3iv(GC::Ptr<WebGLUniformLocation> l
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3iv(location_handle, span.size() / 3, span.data());
+    m_context->uniform3iv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform4iv(GC::Ptr<WebGLUniformLocation> location, Int32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -315,7 +313,7 @@ void WebGL2RenderingContextOverloads::uniform4iv(GC::Ptr<WebGLUniformLocation> l
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4iv(location_handle, span.size() / 4, span.data());
+    m_context->uniform4iv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform_matrix2fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -333,7 +331,7 @@ void WebGL2RenderingContextOverloads::uniform_matrix2fv(GC::Ptr<WebGLUniformLoca
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix2fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix2fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform_matrix3fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -351,7 +349,7 @@ void WebGL2RenderingContextOverloads::uniform_matrix3fv(GC::Ptr<WebGLUniformLoca
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix3fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix3fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextOverloads::uniform_matrix4fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
@@ -369,7 +367,7 @@ void WebGL2RenderingContextOverloads::uniform_matrix4fv(GC::Ptr<WebGLUniformLoca
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix4fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -382,7 +380,7 @@ void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y
     }
 
     auto span = MUST(get_offset_span<u8>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0));
-    glReadPixelsRobustANGLE(x, y, width, height, format, type, span.size(), nullptr, nullptr, nullptr, span.data());
+    m_context->read_pixels_robust_angle(x, y, width, height, format, type, span.size(), nullptr, nullptr, nullptr, span.data());
 }
 
 void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height,
@@ -395,7 +393,7 @@ void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y
         return;
     }
 
-    glReadPixelsRobustANGLE(x, y, width, height, format, type, 0, nullptr, nullptr, nullptr, reinterpret_cast<void*>(offset));
+    m_context->read_pixels_robust_angle(x, y, width, height, format, type, 0, nullptr, nullptr, nullptr, reinterpret_cast<void*>(offset));
 }
 
 }

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#define GL_GLEXT_PROTOTYPES 1
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 extern "C" {
@@ -328,7 +327,7 @@ Optional<Gfx::BitmapExportResult> WebGLRenderingContextBase::read_and_pixel_conv
 GLenum WebGLRenderingContextBase::get_error_value()
 {
     if (m_error == GL_NO_ERROR)
-        return glGetError();
+        return context().get_error();
 
     auto error = m_error;
     m_error = GL_NO_ERROR;
@@ -340,7 +339,7 @@ void WebGLRenderingContextBase::set_error(GLenum error)
     if (m_error != GL_NO_ERROR)
         return;
 
-    auto context_error = glGetError();
+    auto context_error = context().get_error();
     if (context_error != GL_NO_ERROR)
         m_error = context_error;
     else

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#define GL_GLEXT_PROTOTYPES 1
-
 #include <GLES3/gl3.h>
 extern "C" {
 #include <GLES2/gl2ext.h>
@@ -51,7 +49,7 @@ WebGLRenderingContextImpl::WebGLRenderingContextImpl(JS::Realm& realm, NonnullOw
 void WebGLRenderingContextImpl::active_texture(WebIDL::UnsignedLong texture)
 {
     m_context->make_current();
-    glActiveTexture(texture);
+    m_context->active_texture(texture);
 }
 
 void WebGLRenderingContextImpl::attach_shader(GC::Ref<WebGLProgram> program, GC::Ref<WebGLShader> shader)
@@ -91,7 +89,7 @@ void WebGLRenderingContextImpl::attach_shader(GC::Ref<WebGLProgram> program, GC:
         return;
     }
 
-    glAttachShader(program_handle, shader_handle);
+    m_context->attach_shader(program_handle, shader_handle);
 
     switch (shader->type()) {
     case GL_VERTEX_SHADER:
@@ -117,7 +115,7 @@ void WebGLRenderingContextImpl::bind_attrib_location(GC::Ref<WebGLProgram> progr
     auto program_handle = handle_or_error.release_value();
 
     auto name_null_terminated = null_terminated_string(name);
-    glBindAttribLocation(program_handle, index, name_null_terminated.data());
+    m_context->bind_attrib_location(program_handle, index, name_null_terminated.data());
 }
 
 void WebGLRenderingContextImpl::bind_buffer(WebIDL::UnsignedLong target, GC::Ptr<WebGLBuffer> buffer)
@@ -185,7 +183,7 @@ void WebGLRenderingContextImpl::bind_buffer(WebIDL::UnsignedLong target, GC::Ptr
         }
     }
 
-    glBindBuffer(target, buffer_handle);
+    m_context->bind_buffer(target, buffer_handle);
 }
 
 void WebGLRenderingContextImpl::bind_framebuffer(WebIDL::UnsignedLong target, GC::Ptr<WebGLFramebuffer> framebuffer)
@@ -202,7 +200,7 @@ void WebGLRenderingContextImpl::bind_framebuffer(WebIDL::UnsignedLong target, GC
         framebuffer_handle = handle_or_error.release_value();
     }
 
-    glBindFramebuffer(target, framebuffer ? framebuffer_handle : m_context->default_framebuffer());
+    m_context->bind_framebuffer(target, framebuffer ? framebuffer_handle : m_context->default_framebuffer());
     m_framebuffer_binding = framebuffer;
 }
 
@@ -220,7 +218,7 @@ void WebGLRenderingContextImpl::bind_renderbuffer(WebIDL::UnsignedLong target, G
         renderbuffer_handle = handle_or_error.release_value();
     }
 
-    glBindRenderbuffer(target, renderbuffer ? renderbuffer_handle : m_context->default_renderbuffer());
+    m_context->bind_renderbuffer(target, renderbuffer ? renderbuffer_handle : m_context->default_renderbuffer());
     m_renderbuffer_binding = renderbuffer;
 }
 
@@ -268,43 +266,43 @@ void WebGLRenderingContextImpl::bind_texture(WebIDL::UnsignedLong target, GC::Pt
         set_error(GL_INVALID_ENUM);
         return;
     }
-    glBindTexture(target, texture_handle);
+    m_context->bind_texture(target, texture_handle);
 }
 
 void WebGLRenderingContextImpl::blend_color(float red, float green, float blue, float alpha)
 {
     m_context->make_current();
-    glBlendColor(red, green, blue, alpha);
+    m_context->blend_color(red, green, blue, alpha);
 }
 
 void WebGLRenderingContextImpl::blend_equation(WebIDL::UnsignedLong mode)
 {
     m_context->make_current();
-    glBlendEquation(mode);
+    m_context->blend_equation(mode);
 }
 
 void WebGLRenderingContextImpl::blend_equation_separate(WebIDL::UnsignedLong mode_rgb, WebIDL::UnsignedLong mode_alpha)
 {
     m_context->make_current();
-    glBlendEquationSeparate(mode_rgb, mode_alpha);
+    m_context->blend_equation_separate(mode_rgb, mode_alpha);
 }
 
 void WebGLRenderingContextImpl::blend_func(WebIDL::UnsignedLong sfactor, WebIDL::UnsignedLong dfactor)
 {
     m_context->make_current();
-    glBlendFunc(sfactor, dfactor);
+    m_context->blend_func(sfactor, dfactor);
 }
 
 void WebGLRenderingContextImpl::blend_func_separate(WebIDL::UnsignedLong src_rgb, WebIDL::UnsignedLong dst_rgb, WebIDL::UnsignedLong src_alpha, WebIDL::UnsignedLong dst_alpha)
 {
     m_context->make_current();
-    glBlendFuncSeparate(src_rgb, dst_rgb, src_alpha, dst_alpha);
+    m_context->blend_func_separate(src_rgb, dst_rgb, src_alpha, dst_alpha);
 }
 
 WebIDL::UnsignedLong WebGLRenderingContextImpl::check_framebuffer_status(WebIDL::UnsignedLong target)
 {
     m_context->make_current();
-    return glCheckFramebufferStatus(target);
+    return m_context->check_framebuffer_status(target);
 }
 
 void WebGLRenderingContextImpl::clear(WebIDL::UnsignedLong mask)
@@ -312,31 +310,31 @@ void WebGLRenderingContextImpl::clear(WebIDL::UnsignedLong mask)
     m_context->make_current();
     m_context->notify_content_will_change();
     needs_to_present();
-    glClear(mask);
+    m_context->clear(mask);
 }
 
 void WebGLRenderingContextImpl::clear_color(float red, float green, float blue, float alpha)
 {
     m_context->make_current();
-    glClearColor(red, green, blue, alpha);
+    m_context->clear_color(red, green, blue, alpha);
 }
 
 void WebGLRenderingContextImpl::clear_depth(float depth)
 {
     m_context->make_current();
-    glClearDepthf(depth);
+    m_context->clear_depthf(depth);
 }
 
 void WebGLRenderingContextImpl::clear_stencil(WebIDL::Long s)
 {
     m_context->make_current();
-    glClearStencil(s);
+    m_context->clear_stencil(s);
 }
 
 void WebGLRenderingContextImpl::color_mask(bool red, bool green, bool blue, bool alpha)
 {
     m_context->make_current();
-    glColorMask(red, green, blue, alpha);
+    m_context->color_mask(red, green, blue, alpha);
 }
 
 void WebGLRenderingContextImpl::compile_shader(GC::Ref<WebGLShader> shader)
@@ -349,19 +347,19 @@ void WebGLRenderingContextImpl::compile_shader(GC::Ref<WebGLShader> shader)
         return;
     }
     auto shader_handle = handle_or_error.release_value();
-    glCompileShader(shader_handle);
+    m_context->compile_shader(shader_handle);
 }
 
 void WebGLRenderingContextImpl::copy_tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::UnsignedLong internalformat, WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border)
 {
     m_context->make_current();
-    glCopyTexImage2D(target, level, internalformat, x, y, width, height, border);
+    m_context->copy_tex_image2d(target, level, internalformat, x, y, width, height, border);
 }
 
 void WebGLRenderingContextImpl::copy_tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height)
 {
     m_context->make_current();
-    glCopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
+    m_context->copy_tex_sub_image2d(target, level, xoffset, yoffset, x, y, width, height);
 }
 
 GC::Ptr<WebGLBuffer> WebGLRenderingContextImpl::create_buffer()
@@ -369,7 +367,7 @@ GC::Ptr<WebGLBuffer> WebGLRenderingContextImpl::create_buffer()
     m_context->make_current();
 
     GLuint handle = 0;
-    glGenBuffers(1, &handle);
+    m_context->gen_buffers(1, &handle);
     return WebGLBuffer::create(realm(), *this, handle);
 }
 
@@ -378,14 +376,14 @@ GC::Ptr<WebGLFramebuffer> WebGLRenderingContextImpl::create_framebuffer()
     m_context->make_current();
 
     GLuint handle = 0;
-    glGenFramebuffers(1, &handle);
+    m_context->gen_framebuffers(1, &handle);
     return WebGLFramebuffer::create(realm(), *this, handle);
 }
 
 GC::Ptr<WebGLProgram> WebGLRenderingContextImpl::create_program()
 {
     m_context->make_current();
-    return WebGLProgram::create(realm(), *this, glCreateProgram());
+    return WebGLProgram::create(realm(), *this, m_context->create_program());
 }
 
 GC::Ptr<WebGLRenderbuffer> WebGLRenderingContextImpl::create_renderbuffer()
@@ -393,7 +391,7 @@ GC::Ptr<WebGLRenderbuffer> WebGLRenderingContextImpl::create_renderbuffer()
     m_context->make_current();
 
     GLuint handle = 0;
-    glGenRenderbuffers(1, &handle);
+    m_context->gen_renderbuffers(1, &handle);
     return WebGLRenderbuffer::create(realm(), *this, handle);
 }
 
@@ -407,7 +405,7 @@ GC::Ptr<WebGLShader> WebGLRenderingContextImpl::create_shader(WebIDL::UnsignedLo
         return nullptr;
     }
 
-    GLuint handle = glCreateShader(type);
+    GLuint handle = m_context->create_shader(type);
     return WebGLShader::create(realm(), *this, handle, type);
 }
 
@@ -416,14 +414,14 @@ GC::Ptr<WebGLTexture> WebGLRenderingContextImpl::create_texture()
     m_context->make_current();
 
     GLuint handle = 0;
-    glGenTextures(1, &handle);
+    m_context->gen_textures(1, &handle);
     return WebGLTexture::create(realm(), *this, handle);
 }
 
 void WebGLRenderingContextImpl::cull_face(WebIDL::UnsignedLong mode)
 {
     m_context->make_current();
-    glCullFace(mode);
+    m_context->cull_face(mode);
 }
 
 void WebGLRenderingContextImpl::delete_buffer(GC::Ptr<WebGLBuffer> buffer)
@@ -440,7 +438,7 @@ void WebGLRenderingContextImpl::delete_buffer(GC::Ptr<WebGLBuffer> buffer)
         buffer_handle = handle_or_error.release_value();
     }
 
-    glDeleteBuffers(1, &buffer_handle);
+    m_context->delete_buffers(1, &buffer_handle);
 }
 
 void WebGLRenderingContextImpl::delete_framebuffer(GC::Ptr<WebGLFramebuffer> framebuffer)
@@ -457,7 +455,7 @@ void WebGLRenderingContextImpl::delete_framebuffer(GC::Ptr<WebGLFramebuffer> fra
         framebuffer_handle = handle_or_error.release_value();
     }
 
-    glDeleteFramebuffers(1, &framebuffer_handle);
+    m_context->delete_framebuffers(1, &framebuffer_handle);
 }
 
 void WebGLRenderingContextImpl::delete_program(GC::Ptr<WebGLProgram> program)
@@ -474,7 +472,7 @@ void WebGLRenderingContextImpl::delete_program(GC::Ptr<WebGLProgram> program)
         program_handle = handle_or_error.release_value();
     }
 
-    glDeleteProgram(program_handle);
+    m_context->delete_program(program_handle);
     if (m_current_program == program)
         m_current_program = nullptr;
 }
@@ -493,7 +491,7 @@ void WebGLRenderingContextImpl::delete_renderbuffer(GC::Ptr<WebGLRenderbuffer> r
         renderbuffer_handle = handle_or_error.release_value();
     }
 
-    glDeleteRenderbuffers(1, &renderbuffer_handle);
+    m_context->delete_renderbuffers(1, &renderbuffer_handle);
 }
 
 void WebGLRenderingContextImpl::delete_shader(GC::Ptr<WebGLShader> shader)
@@ -509,7 +507,7 @@ void WebGLRenderingContextImpl::delete_shader(GC::Ptr<WebGLShader> shader)
         }
         shader_handle = handle_or_error.release_value();
     }
-    glDeleteShader(shader_handle);
+    m_context->delete_shader(shader_handle);
 }
 
 void WebGLRenderingContextImpl::delete_texture(GC::Ptr<WebGLTexture> texture)
@@ -526,7 +524,7 @@ void WebGLRenderingContextImpl::delete_texture(GC::Ptr<WebGLTexture> texture)
         texture_handle = handle_or_error.release_value();
     }
 
-    glDeleteTextures(1, &texture_handle);
+    m_context->delete_textures(1, &texture_handle);
 
     if (m_texture_binding_2d == texture)
         m_texture_binding_2d = nullptr;
@@ -541,19 +539,19 @@ void WebGLRenderingContextImpl::delete_texture(GC::Ptr<WebGLTexture> texture)
 void WebGLRenderingContextImpl::depth_func(WebIDL::UnsignedLong func)
 {
     m_context->make_current();
-    glDepthFunc(func);
+    m_context->depth_func(func);
 }
 
 void WebGLRenderingContextImpl::depth_mask(bool flag)
 {
     m_context->make_current();
-    glDepthMask(flag);
+    m_context->depth_mask(flag);
 }
 
 void WebGLRenderingContextImpl::depth_range(float z_near, float z_far)
 {
     m_context->make_current();
-    glDepthRangef(z_near, z_far);
+    m_context->depth_rangef(z_near, z_far);
 }
 
 void WebGLRenderingContextImpl::detach_shader(GC::Ref<WebGLProgram> program, GC::Ref<WebGLShader> shader)
@@ -574,7 +572,7 @@ void WebGLRenderingContextImpl::detach_shader(GC::Ref<WebGLProgram> program, GC:
     }
     auto shader_handle = handle_or_error.release_value();
 
-    glDetachShader(program_handle, shader_handle);
+    m_context->detach_shader(program_handle, shader_handle);
 
     switch (shader->type()) {
     case GL_VERTEX_SHADER:
@@ -589,13 +587,13 @@ void WebGLRenderingContextImpl::detach_shader(GC::Ref<WebGLProgram> program, GC:
 void WebGLRenderingContextImpl::disable(WebIDL::UnsignedLong cap)
 {
     m_context->make_current();
-    glDisable(cap);
+    m_context->disable(cap);
 }
 
 void WebGLRenderingContextImpl::disable_vertex_attrib_array(WebIDL::UnsignedLong index)
 {
     m_context->make_current();
-    glDisableVertexAttribArray(index);
+    m_context->disable_vertex_attrib_array(index);
 }
 
 void WebGLRenderingContextImpl::draw_arrays(WebIDL::UnsignedLong mode, WebIDL::Long first, WebIDL::Long count)
@@ -603,7 +601,7 @@ void WebGLRenderingContextImpl::draw_arrays(WebIDL::UnsignedLong mode, WebIDL::L
     m_context->make_current();
     m_context->notify_content_will_change();
     needs_to_present();
-    glDrawArrays(mode, first, count);
+    m_context->draw_arrays(mode, first, count);
 }
 
 void WebGLRenderingContextImpl::draw_elements(WebIDL::UnsignedLong mode, WebIDL::Long count, WebIDL::UnsignedLong type, WebIDL::LongLong offset)
@@ -611,32 +609,32 @@ void WebGLRenderingContextImpl::draw_elements(WebIDL::UnsignedLong mode, WebIDL:
     m_context->make_current();
     m_context->notify_content_will_change();
 
-    glDrawElements(mode, count, type, reinterpret_cast<void*>(offset));
+    m_context->draw_elements(mode, count, type, reinterpret_cast<void*>(offset));
     needs_to_present();
 }
 
 void WebGLRenderingContextImpl::enable(WebIDL::UnsignedLong cap)
 {
     m_context->make_current();
-    glEnable(cap);
+    m_context->enable(cap);
 }
 
 void WebGLRenderingContextImpl::enable_vertex_attrib_array(WebIDL::UnsignedLong index)
 {
     m_context->make_current();
-    glEnableVertexAttribArray(index);
+    m_context->enable_vertex_attrib_array(index);
 }
 
 void WebGLRenderingContextImpl::finish()
 {
     m_context->make_current();
-    glFinish();
+    m_context->finish();
 }
 
 void WebGLRenderingContextImpl::flush()
 {
     m_context->make_current();
-    glFlush();
+    m_context->flush();
 }
 
 void WebGLRenderingContextImpl::framebuffer_renderbuffer(WebIDL::UnsignedLong target, WebIDL::UnsignedLong attachment, WebIDL::UnsignedLong renderbuffertarget, GC::Ptr<WebGLRenderbuffer> renderbuffer)
@@ -652,7 +650,7 @@ void WebGLRenderingContextImpl::framebuffer_renderbuffer(WebIDL::UnsignedLong ta
         }
         renderbuffer_handle = handle_or_error.release_value();
     }
-    glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer_handle);
+    m_context->framebuffer_renderbuffer(target, attachment, renderbuffertarget, renderbuffer_handle);
 }
 
 void WebGLRenderingContextImpl::framebuffer_texture2d(WebIDL::UnsignedLong target, WebIDL::UnsignedLong attachment, WebIDL::UnsignedLong textarget, GC::Ptr<WebGLTexture> texture, WebIDL::Long level)
@@ -668,19 +666,19 @@ void WebGLRenderingContextImpl::framebuffer_texture2d(WebIDL::UnsignedLong targe
         }
         texture_handle = handle_or_error.release_value();
     }
-    glFramebufferTexture2D(target, attachment, textarget, texture_handle, level);
+    m_context->framebuffer_texture2d(target, attachment, textarget, texture_handle, level);
 }
 
 void WebGLRenderingContextImpl::front_face(WebIDL::UnsignedLong mode)
 {
     m_context->make_current();
-    glFrontFace(mode);
+    m_context->front_face(mode);
 }
 
 void WebGLRenderingContextImpl::generate_mipmap(WebIDL::UnsignedLong target)
 {
     m_context->make_current();
-    glGenerateMipmap(target);
+    m_context->generate_mipmap(target);
 }
 
 GC::Ptr<WebGLActiveInfo> WebGLRenderingContextImpl::get_active_attrib(GC::Ref<WebGLProgram> program, WebIDL::UnsignedLong index)
@@ -699,7 +697,7 @@ GC::Ptr<WebGLActiveInfo> WebGLRenderingContextImpl::get_active_attrib(GC::Ref<We
     GLsizei buf_size = 256;
     GLsizei length = 0;
     GLchar name[256];
-    glGetActiveAttrib(program_handle, index, buf_size, &length, &size, &type, name);
+    m_context->get_active_attrib(program_handle, index, buf_size, &length, &size, &type, name);
     auto readonly_bytes = ReadonlyBytes { name, static_cast<size_t>(length) };
     return WebGLActiveInfo::create(realm(), String::from_utf8_without_validation(readonly_bytes), type, size);
 }
@@ -720,7 +718,7 @@ GC::Ptr<WebGLActiveInfo> WebGLRenderingContextImpl::get_active_uniform(GC::Ref<W
     GLsizei buf_size = 256;
     GLsizei length = 0;
     GLchar name[256];
-    glGetActiveUniform(program_handle, index, buf_size, &length, &size, &type, name);
+    m_context->get_active_uniform(program_handle, index, buf_size, &length, &size, &type, name);
     auto readonly_bytes = ReadonlyBytes { name, static_cast<size_t>(length) };
     return WebGLActiveInfo::create(realm(), String::from_utf8_without_validation(readonly_bytes), type, size);
 }
@@ -761,7 +759,7 @@ WebIDL::Long WebGLRenderingContextImpl::get_attrib_location(GC::Ref<WebGLProgram
     auto program_handle = handle_or_error.release_value();
 
     auto name_null_terminated = null_terminated_string(name);
-    return glGetAttribLocation(program_handle, name_null_terminated.data());
+    return m_context->get_attrib_location(program_handle, name_null_terminated.data());
 }
 
 JS::Value WebGLRenderingContextImpl::get_buffer_parameter(WebIDL::UnsignedLong target, WebIDL::UnsignedLong pname)
@@ -770,13 +768,13 @@ JS::Value WebGLRenderingContextImpl::get_buffer_parameter(WebIDL::UnsignedLong t
     switch (pname) {
     case GL_BUFFER_SIZE: {
         GLint result { 0 };
-        glGetBufferParameterivRobustANGLE(target, GL_BUFFER_SIZE, 1, nullptr, &result);
+        m_context->get_buffer_parameteriv_robust_angle(target, GL_BUFFER_SIZE, 1, nullptr, &result);
         return JS::Value(result);
     }
 
     case GL_BUFFER_USAGE: {
         GLint result { 0 };
-        glGetBufferParameterivRobustANGLE(target, GL_BUFFER_USAGE, 1, nullptr, &result);
+        m_context->get_buffer_parameteriv_robust_angle(target, GL_BUFFER_USAGE, 1, nullptr, &result);
         return JS::Value(result);
     }
 
@@ -793,14 +791,14 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     switch (pname) {
     case GL_ACTIVE_TEXTURE: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_ACTIVE_TEXTURE, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_ACTIVE_TEXTURE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_ALIASED_LINE_WIDTH_RANGE: {
         Array<GLfloat, 2> result;
         result.fill(0);
         constexpr size_t buffer_size = 2 * sizeof(GLfloat);
-        glGetFloatvRobustANGLE(GL_ALIASED_LINE_WIDTH_RANGE, 2, nullptr, result.data());
+        m_context->get_floatv_robust_angle(GL_ALIASED_LINE_WIDTH_RANGE, 2, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
         return JS::Float32Array::create(realm(), 2, array_buffer);
@@ -809,14 +807,14 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
         Array<GLfloat, 2> result;
         result.fill(0);
         constexpr size_t buffer_size = 2 * sizeof(GLfloat);
-        glGetFloatvRobustANGLE(GL_ALIASED_POINT_SIZE_RANGE, 2, nullptr, result.data());
+        m_context->get_floatv_robust_angle(GL_ALIASED_POINT_SIZE_RANGE, 2, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
         return JS::Float32Array::create(realm(), 2, array_buffer);
     }
     case GL_ALPHA_BITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_ALPHA_BITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_ALPHA_BITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_ARRAY_BUFFER_BINDING: {
@@ -826,58 +824,58 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     }
     case GL_BLEND: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_BLEND, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_BLEND, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_BLEND_COLOR: {
         Array<GLfloat, 4> result;
         result.fill(0);
         constexpr size_t buffer_size = 4 * sizeof(GLfloat);
-        glGetFloatvRobustANGLE(GL_BLEND_COLOR, 4, nullptr, result.data());
+        m_context->get_floatv_robust_angle(GL_BLEND_COLOR, 4, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
         return JS::Float32Array::create(realm(), 4, array_buffer);
     }
     case GL_BLEND_DST_ALPHA: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_BLEND_DST_ALPHA, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_BLEND_DST_ALPHA, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_BLEND_DST_RGB: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_BLEND_DST_RGB, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_BLEND_DST_RGB, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_BLEND_EQUATION_ALPHA: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_BLEND_EQUATION_ALPHA, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_BLEND_EQUATION_ALPHA, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_BLEND_EQUATION_RGB: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_BLEND_EQUATION_RGB, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_BLEND_EQUATION_RGB, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_BLEND_SRC_ALPHA: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_BLEND_SRC_ALPHA, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_BLEND_SRC_ALPHA, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_BLEND_SRC_RGB: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_BLEND_SRC_RGB, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_BLEND_SRC_RGB, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_BLUE_BITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_BLUE_BITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_BLUE_BITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_COLOR_CLEAR_VALUE: {
         Array<GLfloat, 4> result;
         result.fill(0);
         constexpr size_t buffer_size = 4 * sizeof(GLfloat);
-        glGetFloatvRobustANGLE(GL_COLOR_CLEAR_VALUE, 4, nullptr, result.data());
+        m_context->get_floatv_robust_angle(GL_COLOR_CLEAR_VALUE, 4, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
         return JS::Float32Array::create(realm(), 4, array_buffer);
@@ -885,7 +883,7 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     case GL_COLOR_WRITEMASK: {
         Array<GLboolean, 4> result;
         result.fill(0);
-        glGetBooleanvRobustANGLE(GL_COLOR_WRITEMASK, 4, nullptr, result.data());
+        m_context->get_booleanv_robust_angle(GL_COLOR_WRITEMASK, 4, nullptr, result.data());
 
         auto sequence = TRY(JS::Array::create(realm(), 4));
         for (int i = 0; i < 4; i++) {
@@ -896,12 +894,12 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     }
     case GL_CULL_FACE: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_CULL_FACE, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_CULL_FACE, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_CULL_FACE_MODE: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_CULL_FACE_MODE, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_CULL_FACE_MODE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_CURRENT_PROGRAM: {
@@ -911,41 +909,41 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     }
     case GL_DEPTH_BITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_DEPTH_BITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_DEPTH_BITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_DEPTH_CLEAR_VALUE: {
         GLfloat result { 0.0f };
-        glGetFloatvRobustANGLE(GL_DEPTH_CLEAR_VALUE, 1, nullptr, &result);
+        m_context->get_floatv_robust_angle(GL_DEPTH_CLEAR_VALUE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_DEPTH_FUNC: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_DEPTH_FUNC, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_DEPTH_FUNC, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_DEPTH_RANGE: {
         Array<GLfloat, 2> result;
         result.fill(0);
         constexpr size_t buffer_size = 2 * sizeof(GLfloat);
-        glGetFloatvRobustANGLE(GL_DEPTH_RANGE, 2, nullptr, result.data());
+        m_context->get_floatv_robust_angle(GL_DEPTH_RANGE, 2, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
         return JS::Float32Array::create(realm(), 2, array_buffer);
     }
     case GL_DEPTH_TEST: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_DEPTH_TEST, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_DEPTH_TEST, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_DEPTH_WRITEMASK: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_DEPTH_WRITEMASK, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_DEPTH_WRITEMASK, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_DITHER: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_DITHER, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_DITHER, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_ELEMENT_ARRAY_BUFFER_BINDING: {
@@ -960,116 +958,116 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     }
     case GL_FRONT_FACE: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_FRONT_FACE, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_FRONT_FACE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_GENERATE_MIPMAP_HINT: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_GENERATE_MIPMAP_HINT, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_GENERATE_MIPMAP_HINT, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_GREEN_BITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_GREEN_BITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_GREEN_BITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_IMPLEMENTATION_COLOR_READ_FORMAT: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_IMPLEMENTATION_COLOR_READ_FORMAT, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_IMPLEMENTATION_COLOR_READ_FORMAT, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_IMPLEMENTATION_COLOR_READ_TYPE: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_IMPLEMENTATION_COLOR_READ_TYPE, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_IMPLEMENTATION_COLOR_READ_TYPE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_LINE_WIDTH: {
         GLfloat result { 0.0f };
-        glGetFloatvRobustANGLE(GL_LINE_WIDTH, 1, nullptr, &result);
+        m_context->get_floatv_robust_angle(GL_LINE_WIDTH, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_CUBE_MAP_TEXTURE_SIZE: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_CUBE_MAP_TEXTURE_SIZE, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_CUBE_MAP_TEXTURE_SIZE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_FRAGMENT_UNIFORM_VECTORS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_FRAGMENT_UNIFORM_VECTORS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_FRAGMENT_UNIFORM_VECTORS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_RENDERBUFFER_SIZE: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_RENDERBUFFER_SIZE, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_RENDERBUFFER_SIZE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_TEXTURE_IMAGE_UNITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_TEXTURE_IMAGE_UNITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_TEXTURE_IMAGE_UNITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_TEXTURE_SIZE: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_TEXTURE_SIZE, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_TEXTURE_SIZE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_VARYING_VECTORS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_VARYING_VECTORS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_VARYING_VECTORS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_VERTEX_ATTRIBS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_VERTEX_ATTRIBS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_VERTEX_ATTRIBS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_VERTEX_UNIFORM_VECTORS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_MAX_VERTEX_UNIFORM_VECTORS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_MAX_VERTEX_UNIFORM_VECTORS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_MAX_VIEWPORT_DIMS: {
         Array<GLint, 2> result;
         result.fill(0);
         constexpr size_t buffer_size = 2 * sizeof(GLint);
-        glGetIntegervRobustANGLE(GL_MAX_VIEWPORT_DIMS, 2, nullptr, result.data());
+        m_context->get_integerv_robust_angle(GL_MAX_VIEWPORT_DIMS, 2, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
         return JS::Int32Array::create(realm(), 2, array_buffer);
     }
     case GL_PACK_ALIGNMENT: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_PACK_ALIGNMENT, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_PACK_ALIGNMENT, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_POLYGON_OFFSET_FACTOR: {
         GLfloat result { 0.0f };
-        glGetFloatvRobustANGLE(GL_POLYGON_OFFSET_FACTOR, 1, nullptr, &result);
+        m_context->get_floatv_robust_angle(GL_POLYGON_OFFSET_FACTOR, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_POLYGON_OFFSET_FILL: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_POLYGON_OFFSET_FILL, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_POLYGON_OFFSET_FILL, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_POLYGON_OFFSET_UNITS: {
         GLfloat result { 0.0f };
-        glGetFloatvRobustANGLE(GL_POLYGON_OFFSET_UNITS, 1, nullptr, &result);
+        m_context->get_floatv_robust_angle(GL_POLYGON_OFFSET_UNITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_RED_BITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_RED_BITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_RED_BITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_RENDERBUFFER_BINDING: {
@@ -1078,145 +1076,145 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
         return JS::Value(m_renderbuffer_binding);
     }
     case GL_RENDERER: {
-        auto result = reinterpret_cast<char const*>(glGetString(GL_RENDERER));
+        auto result = reinterpret_cast<char const*>(m_context->get_string(GL_RENDERER));
         return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case GL_SAMPLE_ALPHA_TO_COVERAGE: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_SAMPLE_ALPHA_TO_COVERAGE, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_SAMPLE_ALPHA_TO_COVERAGE, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_SAMPLE_BUFFERS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_SAMPLE_BUFFERS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_SAMPLE_BUFFERS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_SAMPLE_COVERAGE: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_SAMPLE_COVERAGE, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_SAMPLE_COVERAGE, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_SAMPLE_COVERAGE_INVERT: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_SAMPLE_COVERAGE_INVERT, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_SAMPLE_COVERAGE_INVERT, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_SAMPLE_COVERAGE_VALUE: {
         GLfloat result { 0.0f };
-        glGetFloatvRobustANGLE(GL_SAMPLE_COVERAGE_VALUE, 1, nullptr, &result);
+        m_context->get_floatv_robust_angle(GL_SAMPLE_COVERAGE_VALUE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_SAMPLES: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_SAMPLES, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_SAMPLES, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_SCISSOR_BOX: {
         Array<GLint, 4> result;
         result.fill(0);
         constexpr size_t buffer_size = 4 * sizeof(GLint);
-        glGetIntegervRobustANGLE(GL_SCISSOR_BOX, 4, nullptr, result.data());
+        m_context->get_integerv_robust_angle(GL_SCISSOR_BOX, 4, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
         return JS::Int32Array::create(realm(), 4, array_buffer);
     }
     case GL_SCISSOR_TEST: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_SCISSOR_TEST, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_SCISSOR_TEST, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_SHADING_LANGUAGE_VERSION: {
-        auto result = reinterpret_cast<char const*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
+        auto result = reinterpret_cast<char const*>(m_context->get_string(GL_SHADING_LANGUAGE_VERSION));
         return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case GL_STENCIL_BACK_FAIL: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_BACK_FAIL, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_BACK_FAIL, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_BACK_FUNC: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_BACK_FUNC, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_BACK_FUNC, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_BACK_PASS_DEPTH_FAIL: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_BACK_PASS_DEPTH_FAIL, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_BACK_PASS_DEPTH_FAIL, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_BACK_PASS_DEPTH_PASS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_BACK_PASS_DEPTH_PASS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_BACK_PASS_DEPTH_PASS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_BACK_REF: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_BACK_REF, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_BACK_REF, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_BACK_VALUE_MASK: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_BACK_VALUE_MASK, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_BACK_VALUE_MASK, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_BACK_WRITEMASK: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_BACK_WRITEMASK, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_BACK_WRITEMASK, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_BITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_BITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_BITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_CLEAR_VALUE: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_CLEAR_VALUE, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_CLEAR_VALUE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_FAIL: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_FAIL, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_FAIL, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_FUNC: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_FUNC, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_FUNC, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_PASS_DEPTH_FAIL: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_PASS_DEPTH_FAIL, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_PASS_DEPTH_FAIL, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_PASS_DEPTH_PASS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_PASS_DEPTH_PASS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_PASS_DEPTH_PASS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_REF: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_REF, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_REF, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_TEST: {
         GLboolean result { GL_FALSE };
-        glGetBooleanvRobustANGLE(GL_STENCIL_TEST, 1, nullptr, &result);
+        m_context->get_booleanv_robust_angle(GL_STENCIL_TEST, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_STENCIL_VALUE_MASK: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_VALUE_MASK, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_VALUE_MASK, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_STENCIL_WRITEMASK: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_STENCIL_WRITEMASK, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_STENCIL_WRITEMASK, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_SUBPIXEL_BITS: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_SUBPIXEL_BITS, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_SUBPIXEL_BITS, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_TEXTURE_BINDING_2D: {
@@ -1231,22 +1229,22 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     }
     case GL_UNPACK_ALIGNMENT: {
         GLint result { 0 };
-        glGetIntegervRobustANGLE(GL_UNPACK_ALIGNMENT, 1, nullptr, &result);
+        m_context->get_integerv_robust_angle(GL_UNPACK_ALIGNMENT, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_VENDOR: {
-        auto result = reinterpret_cast<char const*>(glGetString(GL_VENDOR));
+        auto result = reinterpret_cast<char const*>(m_context->get_string(GL_VENDOR));
         return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case GL_VERSION: {
-        auto result = reinterpret_cast<char const*>(glGetString(GL_VERSION));
+        auto result = reinterpret_cast<char const*>(m_context->get_string(GL_VERSION));
         return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case GL_VIEWPORT: {
         Array<GLint, 4> result;
         result.fill(0);
         constexpr size_t buffer_size = 4 * sizeof(GLint);
-        glGetIntegervRobustANGLE(GL_VIEWPORT, 4, nullptr, result.data());
+        m_context->get_integerv_robust_angle(GL_VIEWPORT, 4, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
         return JS::Int32Array::create(realm(), 4, array_buffer);
@@ -1257,7 +1255,7 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
             set_error(GL_INVALID_ENUM);
             return JS::js_null();
         }
-        auto result = reinterpret_cast<char const*>(glGetString(GL_VENDOR));
+        auto result = reinterpret_cast<char const*>(m_context->get_string(GL_VENDOR));
         return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case UNMASKED_RENDERER_WEBGL: {
@@ -1265,14 +1263,14 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
             set_error(GL_INVALID_ENUM);
             return JS::js_null();
         }
-        auto result = reinterpret_cast<char const*>(glGetString(GL_RENDERER));
+        auto result = reinterpret_cast<char const*>(m_context->get_string(GL_RENDERER));
         return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
 
     case GL_FRAGMENT_SHADER_DERIVATIVE_HINT: { // NOTE: This has the same value as GL_FRAGMENT_SHADER_DERIVATIVE_HINT_OES
         if (extension_enabled("OES_standard_derivatives"sv) || m_context->webgl_version() == OpenGLContext::WebGLVersion::WebGL2) {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_FRAGMENT_SHADER_DERIVATIVE_HINT, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_FRAGMENT_SHADER_DERIVATIVE_HINT, 1, nullptr, &result);
             return JS::Value(result);
         }
 
@@ -1282,7 +1280,7 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     case GL_MAX_COLOR_ATTACHMENTS: { // NOTE: This has the same value as MAX_COLOR_ATTACHMENTS_WEBGL
         if (extension_enabled("WEBGL_draw_buffers"sv) || m_context->webgl_version() == OpenGLContext::WebGLVersion::WebGL2) {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_COLOR_ATTACHMENTS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_COLOR_ATTACHMENTS, 1, nullptr, &result);
             return JS::Value(result);
         }
 
@@ -1292,7 +1290,7 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     case GL_MAX_DRAW_BUFFERS: {
         if (m_context->webgl_version() == OpenGLContext::WebGLVersion::WebGL2) { // FIXME: Allow this code path for MAX_DRAW_BUFFERS_WEBGL
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_DRAW_BUFFERS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_DRAW_BUFFERS, 1, nullptr, &result);
             return JS::Value(result);
         }
 
@@ -1302,7 +1300,7 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
     case GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT: {
         if (extension_enabled("EXT_texture_filter_anisotropic"sv)) {
             GLfloat result { 0.0f };
-            glGetFloatvRobustANGLE(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, 1, nullptr, &result);
+            m_context->get_floatv_robust_angle(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, 1, nullptr, &result);
             return JS::Value(result);
         }
 
@@ -1338,147 +1336,147 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
         }
         case GL_MAX_SAMPLES: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_SAMPLES, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_SAMPLES, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_3D_TEXTURE_SIZE: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_3D_TEXTURE_SIZE, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_3D_TEXTURE_SIZE, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_ARRAY_TEXTURE_LAYERS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_ARRAY_TEXTURE_LAYERS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_ARRAY_TEXTURE_LAYERS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_VERTEX_UNIFORM_COMPONENTS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_VERTEX_UNIFORM_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_VERTEX_UNIFORM_COMPONENTS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_UNIFORM_BLOCK_SIZE: {
             GLint64 result { 0 };
-            glGetInteger64vRobustANGLE(GL_MAX_UNIFORM_BLOCK_SIZE, 1, nullptr, &result);
+            m_context->get_integer64v_robust_angle(GL_MAX_UNIFORM_BLOCK_SIZE, 1, nullptr, &result);
             return JS::Value(static_cast<double>(result));
         }
         case GL_MAX_UNIFORM_BUFFER_BINDINGS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_UNIFORM_BUFFER_BINDINGS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_UNIFORM_BUFFER_BINDINGS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_VERTEX_UNIFORM_BLOCKS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_VERTEX_UNIFORM_BLOCKS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_VERTEX_UNIFORM_BLOCKS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_FRAGMENT_INPUT_COMPONENTS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_FRAGMENT_INPUT_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_FRAGMENT_INPUT_COMPONENTS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_FRAGMENT_UNIFORM_COMPONENTS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_COMBINED_UNIFORM_BLOCKS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_COMBINED_UNIFORM_BLOCKS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_COMBINED_UNIFORM_BLOCKS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS: {
             GLint64 result { 0 };
-            glGetInteger64vRobustANGLE(GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integer64v_robust_angle(GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS, 1, nullptr, &result);
             return JS::Value(static_cast<double>(result));
         }
         case GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS: {
             GLint64 result { 0 };
-            glGetInteger64vRobustANGLE(GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integer64v_robust_angle(GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS, 1, nullptr, &result);
             return JS::Value(static_cast<double>(result));
         }
         case GL_MAX_ELEMENT_INDEX: {
             GLint64 result { 0 };
-            glGetInteger64vRobustANGLE(GL_MAX_ELEMENT_INDEX, 1, nullptr, &result);
+            m_context->get_integer64v_robust_angle(GL_MAX_ELEMENT_INDEX, 1, nullptr, &result);
             return JS::Value(static_cast<double>(result));
         }
         case GL_MAX_FRAGMENT_UNIFORM_BLOCKS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_FRAGMENT_UNIFORM_BLOCKS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_FRAGMENT_UNIFORM_BLOCKS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_VARYING_COMPONENTS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_VARYING_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_VARYING_COMPONENTS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_ELEMENTS_INDICES: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_ELEMENTS_INDICES, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_ELEMENTS_INDICES, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_ELEMENTS_VERTICES: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_ELEMENTS_VERTICES, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_ELEMENTS_VERTICES, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_TEXTURE_LOD_BIAS: {
             GLfloat result { 0.0f };
-            glGetFloatvRobustANGLE(GL_MAX_TEXTURE_LOD_BIAS, 1, nullptr, &result);
+            m_context->get_floatv_robust_angle(GL_MAX_TEXTURE_LOD_BIAS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MIN_PROGRAM_TEXEL_OFFSET: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MIN_PROGRAM_TEXEL_OFFSET, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MIN_PROGRAM_TEXEL_OFFSET, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_PROGRAM_TEXEL_OFFSET: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_PROGRAM_TEXEL_OFFSET, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_PROGRAM_TEXEL_OFFSET, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_VERTEX_OUTPUT_COMPONENTS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_MAX_VERTEX_OUTPUT_COMPONENTS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_MAX_VERTEX_OUTPUT_COMPONENTS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_MAX_SERVER_WAIT_TIMEOUT: {
             GLint64 result { 0 };
-            glGetInteger64vRobustANGLE(GL_MAX_SERVER_WAIT_TIMEOUT, 1, nullptr, &result);
+            m_context->get_integer64v_robust_angle(GL_MAX_SERVER_WAIT_TIMEOUT, 1, nullptr, &result);
             return JS::Value(static_cast<double>(result));
         }
         case GL_PACK_ROW_LENGTH: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_PACK_ROW_LENGTH, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_PACK_ROW_LENGTH, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_PACK_SKIP_ROWS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_PACK_SKIP_ROWS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_PACK_SKIP_ROWS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_PACK_SKIP_PIXELS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_PACK_SKIP_PIXELS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_PACK_SKIP_PIXELS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_PIXEL_PACK_BUFFER_BINDING: {
@@ -1498,7 +1496,7 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
         }
         case GL_TRANSFORM_FEEDBACK_ACTIVE: {
             GLboolean result { GL_FALSE };
-            glGetBooleanvRobustANGLE(GL_TRANSFORM_FEEDBACK_ACTIVE, 1, nullptr, &result);
+            m_context->get_booleanv_robust_angle(GL_TRANSFORM_FEEDBACK_ACTIVE, 1, nullptr, &result);
             return JS::Value(result == GL_TRUE);
         }
         case GL_TRANSFORM_FEEDBACK_BINDING: {
@@ -1513,17 +1511,17 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
         }
         case GL_TRANSFORM_FEEDBACK_PAUSED: {
             GLboolean result { GL_FALSE };
-            glGetBooleanvRobustANGLE(GL_TRANSFORM_FEEDBACK_PAUSED, 1, nullptr, &result);
+            m_context->get_booleanv_robust_angle(GL_TRANSFORM_FEEDBACK_PAUSED, 1, nullptr, &result);
             return JS::Value(result == GL_TRUE);
         }
         case GL_RASTERIZER_DISCARD: {
             GLboolean result { GL_FALSE };
-            glGetBooleanvRobustANGLE(GL_RASTERIZER_DISCARD, 1, nullptr, &result);
+            m_context->get_booleanv_robust_angle(GL_RASTERIZER_DISCARD, 1, nullptr, &result);
             return JS::Value(result == GL_TRUE);
         }
         case GL_SAMPLER_BINDING: {
             GLint handle { 0 };
-            glGetIntegervRobustANGLE(GL_SAMPLER_BINDING, 1, nullptr, &handle);
+            m_context->get_integerv_robust_angle(GL_SAMPLER_BINDING, 1, nullptr, &handle);
             return WebGLSampler::create(realm(), *this, handle);
         }
         case GL_UNIFORM_BUFFER_BINDING: {
@@ -1533,27 +1531,27 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
         }
         case GL_UNPACK_IMAGE_HEIGHT: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_UNPACK_IMAGE_HEIGHT, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_UNPACK_IMAGE_HEIGHT, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_UNPACK_ROW_LENGTH: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_UNPACK_ROW_LENGTH, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_UNPACK_ROW_LENGTH, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_UNPACK_SKIP_IMAGES: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_UNPACK_SKIP_IMAGES, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_UNPACK_SKIP_IMAGES, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_UNPACK_SKIP_PIXELS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_UNPACK_SKIP_PIXELS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_UNPACK_SKIP_PIXELS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_UNPACK_SKIP_ROWS: {
             GLint result { 0 };
-            glGetIntegervRobustANGLE(GL_UNPACK_SKIP_ROWS, 1, nullptr, &result);
+            m_context->get_integerv_robust_angle(GL_UNPACK_SKIP_ROWS, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_VERTEX_ARRAY_BINDING: { // FIXME: Allow this for VERTEX_ARRAY_BINDING_OES
@@ -1590,7 +1588,7 @@ JS::Value WebGLRenderingContextImpl::get_program_parameter(GC::Ref<WebGLProgram>
     auto program_handle = handle_or_error.release_value();
 
     GLint result = 0;
-    glGetProgramivRobustANGLE(program_handle, pname, 1, nullptr, &result);
+    m_context->get_programiv_robust_angle(program_handle, pname, 1, nullptr, &result);
     switch (pname) {
     case GL_ATTACHED_SHADERS:
     case GL_ACTIVE_ATTRIBUTES:
@@ -1629,12 +1627,12 @@ Optional<String> WebGLRenderingContextImpl::get_program_info_log(GC::Ref<WebGLPr
     auto program_handle = handle_or_error.release_value();
 
     GLint info_log_length = 0;
-    glGetProgramiv(program_handle, GL_INFO_LOG_LENGTH, &info_log_length);
+    m_context->get_programiv(program_handle, GL_INFO_LOG_LENGTH, &info_log_length);
     Vector<GLchar> info_log;
     info_log.resize(info_log_length);
     if (!info_log_length)
         return String {};
-    glGetProgramInfoLog(program_handle, info_log_length, nullptr, info_log.data());
+    m_context->get_program_info_log(program_handle, info_log_length, nullptr, info_log.data());
     return String::from_utf8_without_validation(ReadonlyBytes { info_log.data(), static_cast<size_t>(info_log_length - 1) });
 }
 
@@ -1654,7 +1652,7 @@ JS::Value WebGLRenderingContextImpl::get_renderbuffer_parameter(WebIDL::Unsigned
     case GL_RENDERBUFFER_SAMPLES:
     case GL_RENDERBUFFER_STENCIL_SIZE: {
         GLint result = 0;
-        glGetRenderbufferParameterivRobustANGLE(target, pname, 1, nullptr, &result);
+        m_context->get_renderbuffer_parameteriv_robust_angle(target, pname, 1, nullptr, &result);
         return JS::Value(result);
     }
     default:
@@ -1676,7 +1674,7 @@ JS::Value WebGLRenderingContextImpl::get_shader_parameter(GC::Ref<WebGLShader> s
     auto shader_handle = handle_or_error.release_value();
 
     GLint result = 0;
-    glGetShaderivRobustANGLE(shader_handle, pname, 1, nullptr, &result);
+    m_context->get_shaderiv_robust_angle(shader_handle, pname, 1, nullptr, &result);
     switch (pname) {
     case GL_SHADER_TYPE:
         return JS::Value(result);
@@ -1696,7 +1694,7 @@ GC::Ptr<WebGLShaderPrecisionFormat> WebGLRenderingContextImpl::get_shader_precis
 
     GLint range[2];
     GLint precision;
-    glGetShaderPrecisionFormat(shadertype, precisiontype, range, &precision);
+    m_context->get_shader_precision_format(shadertype, precisiontype, range, &precision);
     return WebGLShaderPrecisionFormat::create(realm(), range[0], range[1], precision);
 }
 
@@ -1712,12 +1710,12 @@ Optional<String> WebGLRenderingContextImpl::get_shader_info_log(GC::Ref<WebGLSha
     auto shader_handle = handle_or_error.release_value();
 
     GLint info_log_length = 0;
-    glGetShaderiv(shader_handle, GL_INFO_LOG_LENGTH, &info_log_length);
+    m_context->get_shaderiv(shader_handle, GL_INFO_LOG_LENGTH, &info_log_length);
     Vector<GLchar> info_log;
     info_log.resize(info_log_length);
     if (!info_log_length)
         return String {};
-    glGetShaderInfoLog(shader_handle, info_log_length, nullptr, info_log.data());
+    m_context->get_shader_info_log(shader_handle, info_log_length, nullptr, info_log.data());
     return String::from_utf8_without_validation(ReadonlyBytes { info_log.data(), static_cast<size_t>(info_log_length - 1) });
 }
 
@@ -1733,12 +1731,12 @@ Optional<String> WebGLRenderingContextImpl::get_shader_source(GC::Ref<WebGLShade
     auto shader_handle = handle_or_error.release_value();
 
     GLint shader_source_length = 0;
-    glGetShaderiv(shader_handle, GL_SHADER_SOURCE_LENGTH, &shader_source_length);
+    m_context->get_shaderiv(shader_handle, GL_SHADER_SOURCE_LENGTH, &shader_source_length);
     if (!shader_source_length)
         return String {};
 
     auto shader_source = MUST(ByteBuffer::create_uninitialized(shader_source_length));
-    glGetShaderSource(shader_handle, shader_source_length, nullptr, reinterpret_cast<GLchar*>(shader_source.data()));
+    m_context->get_shader_source(shader_handle, shader_source_length, nullptr, reinterpret_cast<GLchar*>(shader_source.data()));
     return String::from_utf8_without_validation(ReadonlyBytes { shader_source.data(), static_cast<size_t>(shader_source_length - 1) });
 }
 
@@ -1752,13 +1750,13 @@ JS::Value WebGLRenderingContextImpl::get_tex_parameter(WebIDL::UnsignedLong targ
     case GL_TEXTURE_WRAP_S:
     case GL_TEXTURE_WRAP_T: {
         GLint result { 0 };
-        glGetTexParameterivRobustANGLE(target, pname, 1, nullptr, &result);
+        m_context->get_tex_parameteriv_robust_angle(target, pname, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_TEXTURE_MAX_ANISOTROPY_EXT: {
         if (extension_enabled("EXT_texture_filter_anisotropic"sv)) {
             GLint result { 0 };
-            glGetTexParameterivRobustANGLE(target, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1, nullptr, &result);
+            m_context->get_tex_parameteriv_robust_angle(target, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1, nullptr, &result);
             return JS::Value(result);
         }
 
@@ -1776,18 +1774,18 @@ JS::Value WebGLRenderingContextImpl::get_tex_parameter(WebIDL::UnsignedLong targ
         case GL_TEXTURE_MAX_LEVEL:
         case GL_TEXTURE_WRAP_R: {
             GLint result { 0 };
-            glGetTexParameterivRobustANGLE(target, pname, 1, nullptr, &result);
+            m_context->get_tex_parameteriv_robust_angle(target, pname, 1, nullptr, &result);
             return JS::Value(result);
         }
         case GL_TEXTURE_IMMUTABLE_FORMAT: {
             GLint result { 0 };
-            glGetTexParameterivRobustANGLE(target, GL_TEXTURE_IMMUTABLE_FORMAT, 1, nullptr, &result);
+            m_context->get_tex_parameteriv_robust_angle(target, GL_TEXTURE_IMMUTABLE_FORMAT, 1, nullptr, &result);
             return JS::Value(result == GL_TRUE);
         }
         case GL_TEXTURE_MAX_LOD:
         case GL_TEXTURE_MIN_LOD: {
             GLfloat result { 0.0f };
-            glGetTexParameterfvRobustANGLE(target, GL_TEXTURE_IMMUTABLE_FORMAT, 1, nullptr, &result);
+            m_context->get_tex_parameterfv_robust_angle(target, GL_TEXTURE_IMMUTABLE_FORMAT, 1, nullptr, &result);
             return JS::Value(result == GL_TRUE);
         }
         }
@@ -1819,7 +1817,7 @@ GC::Ptr<WebGLUniformLocation> WebGLRenderingContextImpl::get_uniform_location(GC
     // "This function returns -1 if name does not correspond to an active uniform variable in program or if name starts
     //  with the reserved prefix "gl_"."
     // WebGL Spec: The return value is null if name does not correspond to an active uniform variable in the passed program.
-    auto location = glGetUniformLocation(program_handle, name_null_terminated.data());
+    auto location = m_context->get_uniform_location(program_handle, name_null_terminated.data());
     if (location == -1)
         return nullptr;
 
@@ -1832,7 +1830,7 @@ JS::Value WebGLRenderingContextImpl::get_vertex_attrib(WebIDL::UnsignedLong inde
     case GL_CURRENT_VERTEX_ATTRIB: {
         Array<GLfloat, 4> result;
         result.fill(0);
-        glGetVertexAttribfvRobustANGLE(index, GL_CURRENT_VERTEX_ATTRIB, result.size(), nullptr, result.data());
+        m_context->get_vertex_attribfv_robust_angle(index, GL_CURRENT_VERTEX_ATTRIB, result.size(), nullptr, result.data());
 
         auto byte_buffer = MUST(ByteBuffer::copy(result.span().reinterpret<u8>()));
         auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
@@ -1840,13 +1838,13 @@ JS::Value WebGLRenderingContextImpl::get_vertex_attrib(WebIDL::UnsignedLong inde
     }
     case GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING: {
         GLint handle { 0 };
-        glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING, 1, nullptr, &handle);
+        m_context->get_vertex_attribiv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING, 1, nullptr, &handle);
         return WebGLBuffer::create(realm(), *this, handle);
     }
     case GL_VERTEX_ATTRIB_ARRAY_DIVISOR: { // NOTE: This has the same value as GL_VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE
         if (extension_enabled("ANGLE_instanced_arrays"sv) || m_context->webgl_version() == OpenGLContext::WebGLVersion::WebGL2) {
             GLint result { 0 };
-            glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, 1, nullptr, &result);
+            m_context->get_vertex_attribiv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_DIVISOR, 1, nullptr, &result);
             return JS::Value(result);
         }
 
@@ -1855,13 +1853,13 @@ JS::Value WebGLRenderingContextImpl::get_vertex_attrib(WebIDL::UnsignedLong inde
     }
     case GL_VERTEX_ATTRIB_ARRAY_ENABLED: {
         GLint result { 0 };
-        glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_ENABLED, 1, nullptr, &result);
+        m_context->get_vertex_attribiv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_ENABLED, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_VERTEX_ATTRIB_ARRAY_INTEGER: {
         if (m_context->webgl_version() == OpenGLContext::WebGLVersion::WebGL2) {
             GLint result { 0 };
-            glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_INTEGER, 1, nullptr, &result);
+            m_context->get_vertex_attribiv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_INTEGER, 1, nullptr, &result);
             return JS::Value(result == GL_TRUE);
         }
 
@@ -1870,22 +1868,22 @@ JS::Value WebGLRenderingContextImpl::get_vertex_attrib(WebIDL::UnsignedLong inde
     }
     case GL_VERTEX_ATTRIB_ARRAY_NORMALIZED: {
         GLint result { 0 };
-        glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, 1, nullptr, &result);
+        m_context->get_vertex_attribiv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED, 1, nullptr, &result);
         return JS::Value(result == GL_TRUE);
     }
     case GL_VERTEX_ATTRIB_ARRAY_SIZE: {
         GLint result { 0 };
-        glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_SIZE, 1, nullptr, &result);
+        m_context->get_vertex_attribiv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_SIZE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_VERTEX_ATTRIB_ARRAY_STRIDE: {
         GLint result { 0 };
-        glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_STRIDE, 1, nullptr, &result);
+        m_context->get_vertex_attribiv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_STRIDE, 1, nullptr, &result);
         return JS::Value(result);
     }
     case GL_VERTEX_ATTRIB_ARRAY_TYPE: {
         GLint result { 0 };
-        glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_TYPE, 1, nullptr, &result);
+        m_context->get_vertex_attribiv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_TYPE, 1, nullptr, &result);
         return JS::Value(result);
     }
     default:
@@ -1903,14 +1901,14 @@ WebIDL::LongLong WebGLRenderingContextImpl::get_vertex_attrib_offset(WebIDL::Uns
     }
 
     GLintptr result { 0 };
-    glGetVertexAttribPointervRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_POINTER, 1, nullptr, reinterpret_cast<void**>(&result));
+    m_context->get_vertex_attrib_pointerv_robust_angle(index, GL_VERTEX_ATTRIB_ARRAY_POINTER, 1, nullptr, reinterpret_cast<void**>(&result));
     return result;
 }
 
 void WebGLRenderingContextImpl::hint(WebIDL::UnsignedLong target, WebIDL::UnsignedLong mode)
 {
     m_context->make_current();
-    glHint(target, mode);
+    m_context->hint(target, mode);
 }
 
 bool WebGLRenderingContextImpl::is_buffer(GC::Ptr<WebGLBuffer> buffer)
@@ -1926,13 +1924,13 @@ bool WebGLRenderingContextImpl::is_buffer(GC::Ptr<WebGLBuffer> buffer)
         }
         buffer_handle = handle_or_error.release_value();
     }
-    return glIsBuffer(buffer_handle);
+    return m_context->is_buffer(buffer_handle);
 }
 
 bool WebGLRenderingContextImpl::is_enabled(WebIDL::UnsignedLong cap)
 {
     m_context->make_current();
-    return glIsEnabled(cap);
+    return m_context->is_enabled(cap);
 }
 
 bool WebGLRenderingContextImpl::is_framebuffer(GC::Ptr<WebGLFramebuffer> framebuffer)
@@ -1948,7 +1946,7 @@ bool WebGLRenderingContextImpl::is_framebuffer(GC::Ptr<WebGLFramebuffer> framebu
         }
         framebuffer_handle = handle_or_error.release_value();
     }
-    return glIsFramebuffer(framebuffer_handle);
+    return m_context->is_framebuffer(framebuffer_handle);
 }
 
 bool WebGLRenderingContextImpl::is_program(GC::Ptr<WebGLProgram> program)
@@ -1964,7 +1962,7 @@ bool WebGLRenderingContextImpl::is_program(GC::Ptr<WebGLProgram> program)
         }
         program_handle = handle_or_error.release_value();
     }
-    return glIsProgram(program_handle);
+    return m_context->is_program(program_handle);
 }
 
 bool WebGLRenderingContextImpl::is_renderbuffer(GC::Ptr<WebGLRenderbuffer> renderbuffer)
@@ -1980,7 +1978,7 @@ bool WebGLRenderingContextImpl::is_renderbuffer(GC::Ptr<WebGLRenderbuffer> rende
         }
         renderbuffer_handle = handle_or_error.release_value();
     }
-    return glIsRenderbuffer(renderbuffer_handle);
+    return m_context->is_renderbuffer(renderbuffer_handle);
 }
 
 bool WebGLRenderingContextImpl::is_shader(GC::Ptr<WebGLShader> shader)
@@ -1996,7 +1994,7 @@ bool WebGLRenderingContextImpl::is_shader(GC::Ptr<WebGLShader> shader)
         }
         shader_handle = handle_or_error.release_value();
     }
-    return glIsShader(shader_handle);
+    return m_context->is_shader(shader_handle);
 }
 
 bool WebGLRenderingContextImpl::is_texture(GC::Ptr<WebGLTexture> texture)
@@ -2012,13 +2010,13 @@ bool WebGLRenderingContextImpl::is_texture(GC::Ptr<WebGLTexture> texture)
         }
         texture_handle = handle_or_error.release_value();
     }
-    return glIsTexture(texture_handle);
+    return m_context->is_texture(texture_handle);
 }
 
 void WebGLRenderingContextImpl::line_width(float width)
 {
     m_context->make_current();
-    glLineWidth(width);
+    m_context->line_width(width);
 }
 
 void WebGLRenderingContextImpl::link_program(GC::Ref<WebGLProgram> program)
@@ -2031,7 +2029,7 @@ void WebGLRenderingContextImpl::link_program(GC::Ref<WebGLProgram> program)
         return;
     }
     auto program_handle = handle_or_error.release_value();
-    glLinkProgram(program_handle);
+    m_context->link_program(program_handle);
 }
 
 void WebGLRenderingContextImpl::pixel_storei(WebIDL::UnsignedLong pname, WebIDL::Long param)
@@ -2050,13 +2048,13 @@ void WebGLRenderingContextImpl::pixel_storei(WebIDL::UnsignedLong pname, WebIDL:
         return;
     }
 
-    glPixelStorei(pname, param);
+    m_context->pixel_storei(pname, param);
 }
 
 void WebGLRenderingContextImpl::polygon_offset(float factor, float units)
 {
     m_context->make_current();
-    glPolygonOffset(factor, units);
+    m_context->polygon_offset(factor, units);
 }
 
 void WebGLRenderingContextImpl::renderbuffer_storage(WebIDL::UnsignedLong target, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height)
@@ -2066,19 +2064,19 @@ void WebGLRenderingContextImpl::renderbuffer_storage(WebIDL::UnsignedLong target
     if (internalformat == GL_DEPTH_STENCIL)
         internalformat = GL_DEPTH24_STENCIL8;
 
-    glRenderbufferStorage(target, internalformat, width, height);
+    m_context->renderbuffer_storage(target, internalformat, width, height);
 }
 
 void WebGLRenderingContextImpl::sample_coverage(float value, bool invert)
 {
     m_context->make_current();
-    glSampleCoverage(value, invert);
+    m_context->sample_coverage(value, invert);
 }
 
 void WebGLRenderingContextImpl::scissor(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height)
 {
     m_context->make_current();
-    glScissor(x, y, width, height);
+    m_context->scissor(x, y, width, height);
 }
 
 void WebGLRenderingContextImpl::shader_source(GC::Ref<WebGLShader> shader, String source)
@@ -2097,55 +2095,55 @@ void WebGLRenderingContextImpl::shader_source(GC::Ref<WebGLShader> shader, Strin
     strings.append(string.data());
     Vector<GLint> length;
     length.append(source.bytes().size());
-    glShaderSource(shader_handle, 1, strings.data(), length.data());
+    m_context->shader_source(shader_handle, 1, strings.data(), length.data());
 }
 
 void WebGLRenderingContextImpl::stencil_func(WebIDL::UnsignedLong func, WebIDL::Long ref, WebIDL::UnsignedLong mask)
 {
     m_context->make_current();
-    glStencilFunc(func, ref, mask);
+    m_context->stencil_func(func, ref, mask);
 }
 
 void WebGLRenderingContextImpl::stencil_func_separate(WebIDL::UnsignedLong face, WebIDL::UnsignedLong func, WebIDL::Long ref, WebIDL::UnsignedLong mask)
 {
     m_context->make_current();
-    glStencilFuncSeparate(face, func, ref, mask);
+    m_context->stencil_func_separate(face, func, ref, mask);
 }
 
 void WebGLRenderingContextImpl::stencil_mask(WebIDL::UnsignedLong mask)
 {
     m_context->make_current();
-    glStencilMask(mask);
+    m_context->stencil_mask(mask);
 }
 
 void WebGLRenderingContextImpl::stencil_mask_separate(WebIDL::UnsignedLong face, WebIDL::UnsignedLong mask)
 {
     m_context->make_current();
-    glStencilMaskSeparate(face, mask);
+    m_context->stencil_mask_separate(face, mask);
 }
 
 void WebGLRenderingContextImpl::stencil_op(WebIDL::UnsignedLong fail, WebIDL::UnsignedLong zfail, WebIDL::UnsignedLong zpass)
 {
     m_context->make_current();
-    glStencilOp(fail, zfail, zpass);
+    m_context->stencil_op(fail, zfail, zpass);
 }
 
 void WebGLRenderingContextImpl::stencil_op_separate(WebIDL::UnsignedLong face, WebIDL::UnsignedLong fail, WebIDL::UnsignedLong zfail, WebIDL::UnsignedLong zpass)
 {
     m_context->make_current();
-    glStencilOpSeparate(face, fail, zfail, zpass);
+    m_context->stencil_op_separate(face, fail, zfail, zpass);
 }
 
 void WebGLRenderingContextImpl::tex_parameterf(WebIDL::UnsignedLong target, WebIDL::UnsignedLong pname, float param)
 {
     m_context->make_current();
-    glTexParameterf(target, pname, param);
+    m_context->tex_parameterf(target, pname, param);
 }
 
 void WebGLRenderingContextImpl::tex_parameteri(WebIDL::UnsignedLong target, WebIDL::UnsignedLong pname, WebIDL::Long param)
 {
     m_context->make_current();
-    glTexParameteri(target, pname, param);
+    m_context->tex_parameteri(target, pname, param);
 }
 
 void WebGLRenderingContextImpl::uniform1f(GC::Ptr<WebGLUniformLocation> location, float x)
@@ -2156,7 +2154,7 @@ void WebGLRenderingContextImpl::uniform1f(GC::Ptr<WebGLUniformLocation> location
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform1f(location_handle, x);
+    m_context->uniform1f(location_handle, x);
 }
 
 void WebGLRenderingContextImpl::uniform2f(GC::Ptr<WebGLUniformLocation> location, float x, float y)
@@ -2167,7 +2165,7 @@ void WebGLRenderingContextImpl::uniform2f(GC::Ptr<WebGLUniformLocation> location
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform2f(location_handle, x, y);
+    m_context->uniform2f(location_handle, x, y);
 }
 
 void WebGLRenderingContextImpl::uniform3f(GC::Ptr<WebGLUniformLocation> location, float x, float y, float z)
@@ -2178,7 +2176,7 @@ void WebGLRenderingContextImpl::uniform3f(GC::Ptr<WebGLUniformLocation> location
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform3f(location_handle, x, y, z);
+    m_context->uniform3f(location_handle, x, y, z);
 }
 
 void WebGLRenderingContextImpl::uniform4f(GC::Ptr<WebGLUniformLocation> location, float x, float y, float z, float w)
@@ -2189,7 +2187,7 @@ void WebGLRenderingContextImpl::uniform4f(GC::Ptr<WebGLUniformLocation> location
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform4f(location_handle, x, y, z, w);
+    m_context->uniform4f(location_handle, x, y, z, w);
 }
 
 void WebGLRenderingContextImpl::uniform1i(GC::Ptr<WebGLUniformLocation> location, WebIDL::Long x)
@@ -2200,7 +2198,7 @@ void WebGLRenderingContextImpl::uniform1i(GC::Ptr<WebGLUniformLocation> location
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform1i(location_handle, x);
+    m_context->uniform1i(location_handle, x);
 }
 
 void WebGLRenderingContextImpl::uniform2i(GC::Ptr<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y)
@@ -2211,7 +2209,7 @@ void WebGLRenderingContextImpl::uniform2i(GC::Ptr<WebGLUniformLocation> location
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform2i(location_handle, x, y);
+    m_context->uniform2i(location_handle, x, y);
 }
 
 void WebGLRenderingContextImpl::uniform3i(GC::Ptr<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y, WebIDL::Long z)
@@ -2222,7 +2220,7 @@ void WebGLRenderingContextImpl::uniform3i(GC::Ptr<WebGLUniformLocation> location
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform3i(location_handle, x, y, z);
+    m_context->uniform3i(location_handle, x, y, z);
 }
 
 void WebGLRenderingContextImpl::uniform4i(GC::Ptr<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y, WebIDL::Long z, WebIDL::Long w)
@@ -2233,7 +2231,7 @@ void WebGLRenderingContextImpl::uniform4i(GC::Ptr<WebGLUniformLocation> location
     if (location)
         location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
-    glUniform4i(location_handle, x, y, z, w);
+    m_context->uniform4i(location_handle, x, y, z, w);
 }
 
 void WebGLRenderingContextImpl::use_program(GC::Ptr<WebGLProgram> program)
@@ -2250,7 +2248,7 @@ void WebGLRenderingContextImpl::use_program(GC::Ptr<WebGLProgram> program)
         program_handle = handle_or_error.release_value();
     }
 
-    glUseProgram(program_handle);
+    m_context->use_program(program_handle);
     m_current_program = program;
 }
 
@@ -2264,31 +2262,31 @@ void WebGLRenderingContextImpl::validate_program(GC::Ref<WebGLProgram> program)
         return;
     }
     auto program_handle = handle_or_error.release_value();
-    glValidateProgram(program_handle);
+    m_context->validate_program(program_handle);
 }
 
 void WebGLRenderingContextImpl::vertex_attrib1f(WebIDL::UnsignedLong index, float x)
 {
     m_context->make_current();
-    glVertexAttrib1f(index, x);
+    m_context->vertex_attrib1f(index, x);
 }
 
 void WebGLRenderingContextImpl::vertex_attrib2f(WebIDL::UnsignedLong index, float x, float y)
 {
     m_context->make_current();
-    glVertexAttrib2f(index, x, y);
+    m_context->vertex_attrib2f(index, x, y);
 }
 
 void WebGLRenderingContextImpl::vertex_attrib3f(WebIDL::UnsignedLong index, float x, float y, float z)
 {
     m_context->make_current();
-    glVertexAttrib3f(index, x, y, z);
+    m_context->vertex_attrib3f(index, x, y, z);
 }
 
 void WebGLRenderingContextImpl::vertex_attrib4f(WebIDL::UnsignedLong index, float x, float y, float z, float w)
 {
     m_context->make_current();
-    glVertexAttrib4f(index, x, y, z, w);
+    m_context->vertex_attrib4f(index, x, y, z, w);
 }
 
 void WebGLRenderingContextImpl::vertex_attrib1fv(WebIDL::UnsignedLong index, Float32List values)
@@ -2300,7 +2298,7 @@ void WebGLRenderingContextImpl::vertex_attrib1fv(WebIDL::UnsignedLong index, Flo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glVertexAttrib1fv(index, span.data());
+    m_context->vertex_attrib1fv(index, span.data());
 }
 
 void WebGLRenderingContextImpl::vertex_attrib2fv(WebIDL::UnsignedLong index, Float32List values)
@@ -2312,7 +2310,7 @@ void WebGLRenderingContextImpl::vertex_attrib2fv(WebIDL::UnsignedLong index, Flo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glVertexAttrib2fv(index, span.data());
+    m_context->vertex_attrib2fv(index, span.data());
 }
 
 void WebGLRenderingContextImpl::vertex_attrib3fv(WebIDL::UnsignedLong index, Float32List values)
@@ -2324,7 +2322,7 @@ void WebGLRenderingContextImpl::vertex_attrib3fv(WebIDL::UnsignedLong index, Flo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glVertexAttrib3fv(index, span.data());
+    m_context->vertex_attrib3fv(index, span.data());
 }
 
 void WebGLRenderingContextImpl::vertex_attrib4fv(WebIDL::UnsignedLong index, Float32List values)
@@ -2336,7 +2334,7 @@ void WebGLRenderingContextImpl::vertex_attrib4fv(WebIDL::UnsignedLong index, Flo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glVertexAttrib4fv(index, span.data());
+    m_context->vertex_attrib4fv(index, span.data());
 }
 
 void WebGLRenderingContextImpl::vertex_attrib_pointer(WebIDL::UnsignedLong index, WebIDL::Long size, WebIDL::UnsignedLong type, bool normalized, WebIDL::Long stride, WebIDL::LongLong offset)
@@ -2349,13 +2347,13 @@ void WebGLRenderingContextImpl::vertex_attrib_pointer(WebIDL::UnsignedLong index
         return;
     }
 
-    glVertexAttribPointer(index, size, type, normalized, stride, reinterpret_cast<void*>(offset));
+    m_context->vertex_attrib_pointer(index, size, type, normalized, stride, reinterpret_cast<void*>(offset));
 }
 
 void WebGLRenderingContextImpl::viewport(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height)
 {
     m_context->make_current();
-    glViewport(x, y, width, height);
+    m_context->viewport(x, y, width, height);
 }
 
 void WebGLRenderingContextImpl::visit_edges(JS::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#define GL_GLEXT_PROTOTYPES 1
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 extern "C" {
@@ -31,7 +30,7 @@ void WebGLRenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, We
 {
     m_context->make_current();
 
-    glBufferData(target, size, 0, usage);
+    m_context->buffer_data(target, size, 0, usage);
 }
 
 void WebGLRenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, WebIDL::NullableBufferSourceVariant data, WebIDL::UnsignedLong usage)
@@ -46,7 +45,7 @@ void WebGLRenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, We
     }
 
     auto span = MUST(get_offset_span<u8 const>(data.downcast<WebIDL::BufferSourceVariant>(), /* src_offset= */ 0));
-    glBufferData(target, static_cast<GLsizeiptr>(span.size()), span.data(), usage);
+    m_context->buffer_data(target, static_cast<GLsizeiptr>(span.size()), span.data(), usage);
 }
 
 void WebGLRenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong offset, WebIDL::BufferSource data)
@@ -54,7 +53,7 @@ void WebGLRenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target
     m_context->make_current();
 
     auto span = MUST(get_offset_span<u8 const>(data, /* src_offset= */ 0));
-    glBufferSubData(target, offset, span.size(), span.data());
+    m_context->buffer_sub_data(target, offset, span.size(), span.data());
 }
 
 void WebGLRenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::ArrayBufferView data)
@@ -67,7 +66,7 @@ void WebGLRenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLong
     }
 
     auto span = MUST(get_offset_span<u8 const>(data, /* src_offset= */ 0));
-    glCompressedTexImage2DRobustANGLE(target, level, internalformat, width, height, border, span.size(), span.size(), span.data());
+    m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, span.size(), span.size(), span.data());
 }
 
 void WebGLRenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::ArrayBufferView data)
@@ -80,7 +79,7 @@ void WebGLRenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::Unsigned
     }
 
     auto span = MUST(get_offset_span<u8 const>(data, /* src_offset= */ 0));
-    glCompressedTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, width, height, format, span.size(), span.size(), span.data());
+    m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, span.size(), span.size(), span.data());
 }
 
 void WebGLRenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -93,7 +92,7 @@ void WebGLRenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y,
     }
 
     auto span = MUST(get_offset_span<u8>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0));
-    glReadPixelsRobustANGLE(x, y, width, height, format, type, span.size(), nullptr, nullptr, nullptr, span.data());
+    m_context->read_pixels_robust_angle(x, y, width, height, format, type, span.size(), nullptr, nullptr, nullptr, span.data());
 }
 
 void WebGLRenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -102,7 +101,7 @@ void WebGLRenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, We
 
     if (!pixels.has<Empty>()) {
         auto span = MUST(get_offset_span<u8>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0));
-        glTexImage2DRobustANGLE(target, level, internalformat, width, height, border, format, type, span.size(), span.data());
+        m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, span.size(), span.data());
         return;
     }
 
@@ -161,7 +160,7 @@ void WebGLRenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, We
     }
 
     auto byte_buffer = MUST(ByteBuffer::create_zeroed(bytes.value_unchecked()));
-    glTexImage2DRobustANGLE(target, level, internalformat, width, height, border, format, type, byte_buffer.size(), byte_buffer.data());
+    m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, byte_buffer.size(), byte_buffer.data());
 }
 
 void WebGLRenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -172,7 +171,7 @@ void WebGLRenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, We
     if (!maybe_converted_texture.has_value())
         return;
     auto converted_texture = maybe_converted_texture.release_value();
-    glTexImage2DRobustANGLE(target, level, internalformat, converted_texture.width, converted_texture.height, 0, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
+    m_context->tex_image2d_robust_angle(target, level, internalformat, converted_texture.width, converted_texture.height, 0, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
 }
 
 void WebGLRenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -185,7 +184,7 @@ void WebGLRenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target
     }
 
     auto span = MUST(get_offset_span<u8>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0));
-    glTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, width, height, format, type, span.size(), span.data());
+    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, span.size(), span.data());
 }
 
 void WebGLRenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -197,7 +196,7 @@ void WebGLRenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target
     if (!maybe_converted_texture.has_value())
         return;
     auto converted_texture = maybe_converted_texture.release_value();
-    glTexSubImage2DRobustANGLE(target, level, xoffset, yoffset, converted_texture.width, converted_texture.height, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
+    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, converted_texture.width, converted_texture.height, format, type, converted_texture.buffer.size(), converted_texture.buffer.data());
 }
 
 void WebGLRenderingContextOverloads::uniform1fv(GC::Ptr<WebGLUniformLocation> location, Float32List v)
@@ -210,7 +209,7 @@ void WebGLRenderingContextOverloads::uniform1fv(GC::Ptr<WebGLUniformLocation> lo
     GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     auto span = MUST(span_from_float32_list(v, /* src_offset= */ 0));
-    glUniform1fv(location_handle, span.size(), span.data());
+    m_context->uniform1fv(location_handle, span.size(), span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform2fv(GC::Ptr<WebGLUniformLocation> location, Float32List v)
@@ -227,7 +226,7 @@ void WebGLRenderingContextOverloads::uniform2fv(GC::Ptr<WebGLUniformLocation> lo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2fv(location_handle, span.size() / 2, span.data());
+    m_context->uniform2fv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform3fv(GC::Ptr<WebGLUniformLocation> location, Float32List v)
@@ -244,7 +243,7 @@ void WebGLRenderingContextOverloads::uniform3fv(GC::Ptr<WebGLUniformLocation> lo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3fv(location_handle, span.size() / 3, span.data());
+    m_context->uniform3fv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform4fv(GC::Ptr<WebGLUniformLocation> location, Float32List v)
@@ -261,7 +260,7 @@ void WebGLRenderingContextOverloads::uniform4fv(GC::Ptr<WebGLUniformLocation> lo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4fv(location_handle, span.size() / 4, span.data());
+    m_context->uniform4fv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform1iv(GC::Ptr<WebGLUniformLocation> location, Int32List v)
@@ -274,7 +273,7 @@ void WebGLRenderingContextOverloads::uniform1iv(GC::Ptr<WebGLUniformLocation> lo
     GLuint location_handle = SET_ERROR_VALUE_IF_ERROR(location->handle(m_current_program), GL_INVALID_OPERATION);
 
     auto span = MUST(span_from_int32_list(v, /* src_offset= */ 0));
-    glUniform1iv(location_handle, span.size(), span.data());
+    m_context->uniform1iv(location_handle, span.size(), span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform2iv(GC::Ptr<WebGLUniformLocation> location, Int32List v)
@@ -291,7 +290,7 @@ void WebGLRenderingContextOverloads::uniform2iv(GC::Ptr<WebGLUniformLocation> lo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2iv(location_handle, span.size() / 2, span.data());
+    m_context->uniform2iv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform3iv(GC::Ptr<WebGLUniformLocation> location, Int32List v)
@@ -308,7 +307,7 @@ void WebGLRenderingContextOverloads::uniform3iv(GC::Ptr<WebGLUniformLocation> lo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3iv(location_handle, span.size() / 3, span.data());
+    m_context->uniform3iv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform4iv(GC::Ptr<WebGLUniformLocation> location, Int32List v)
@@ -325,7 +324,7 @@ void WebGLRenderingContextOverloads::uniform4iv(GC::Ptr<WebGLUniformLocation> lo
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4iv(location_handle, span.size() / 4, span.data());
+    m_context->uniform4iv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform_matrix2fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List value)
@@ -343,7 +342,7 @@ void WebGLRenderingContextOverloads::uniform_matrix2fv(GC::Ptr<WebGLUniformLocat
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix2fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix2fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform_matrix3fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List value)
@@ -361,7 +360,7 @@ void WebGLRenderingContextOverloads::uniform_matrix3fv(GC::Ptr<WebGLUniformLocat
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix3fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix3fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGLRenderingContextOverloads::uniform_matrix4fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List value)
@@ -379,7 +378,7 @@ void WebGLRenderingContextOverloads::uniform_matrix4fv(GC::Ptr<WebGLUniformLocat
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix4fv(location_handle, span.size() / matrix_size, transpose, span.data());
+    m_context->uniform_matrix4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 }

--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -241,6 +241,30 @@ function (generate_html_implementation)
     set(LIBWEB_ALL_GENERATED_HEADERS ${LIBWEB_ALL_GENERATED_HEADERS} PARENT_SCOPE)
 endfunction()
 
+function (generate_webgl_implementation)
+    set(LIBWEB_INPUT_FOLDER "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    invoke_py_generator(
+        "GLFunctions.cpp"
+        "generate_libweb_webgl_functions.py"
+        "${LIBWEB_INPUT_FOLDER}/WebGL/GLFunctions.json"
+        "WebGL/GLFunctions.h"
+        "WebGL/GLFunctions.cpp"
+        arguments -j "${LIBWEB_INPUT_FOLDER}/WebGL/GLFunctions.json"
+        dependencies "${LADYBIRD_SOURCE_DIR}/Meta/Generators/libweb_webgl.py"
+    )
+
+    set(WEBGL_GENERATED_HEADERS
+       "WebGL/GLFunctions.h"
+    )
+    list(TRANSFORM WEBGL_GENERATED_HEADERS PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
+    if (ENABLE_INSTALL_HEADERS)
+        install(FILES ${WEBGL_GENERATED_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibWeb/WebGL")
+    endif()
+    list(APPEND LIBWEB_ALL_GENERATED_HEADERS ${WEBGL_GENERATED_HEADERS})
+    set(LIBWEB_ALL_GENERATED_HEADERS ${LIBWEB_ALL_GENERATED_HEADERS} PARENT_SCOPE)
+endfunction()
+
 function (generate_js_bindings target)
     set(LIBWEB_INPUT_FOLDER "${CMAKE_CURRENT_SOURCE_DIR}")
     find_package(Python3 REQUIRED COMPONENTS Interpreter)

--- a/Meta/Generators/generate_libweb_webgl_functions.py
+++ b/Meta/Generators/generate_libweb_webgl_functions.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import sys
+
+from pathlib import Path
+from typing import TextIO
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from libweb_webgl import method_signature
+from libweb_webgl import run_generator
+
+# Generates Web::WebGL::GLFunctions from GLFunctions.json: one member function per GL
+# entry point used by the WebGL implementation. This is the only place in LibWeb that is
+# allowed to call GL entry points directly; everything above it goes through the methods
+# so the GL boundary stays in one generated, mechanically-verifiable layer.
+
+
+def write_header_file(out: TextIO, functions: list) -> None:
+    out.write("""#pragma once
+
+// GL type and enum definitions only -- GL_GLEXT_PROTOTYPES stays undefined here so that
+// nothing outside the generated GLFunctions implementation can call GL directly.
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+extern "C" {
+#include <GLES2/gl2ext_angle.h>
+}
+#include <GLES3/gl3.h>
+
+#include <LibWeb/Export.h>
+#include <LibWeb/WebGL/Types.h>
+
+namespace Web::WebGL {
+
+class WEB_API GLFunctions {
+public:
+""")
+
+    for function in functions:
+        out.write(f"    {method_signature(function)};\n")
+
+    out.write("""};
+
+}
+""")
+
+
+def write_implementation_file(out: TextIO, functions: list) -> None:
+    out.write("""#define GL_GLEXT_PROTOTYPES 1
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+extern "C" {
+#include <GLES2/gl2ext_angle.h>
+}
+#include <GLES3/gl3.h>
+
+#include <LibWeb/WebGL/GLFunctions.h>
+
+namespace Web::WebGL {
+""")
+
+    for function in functions:
+        forwarded_args = ", ".join(arg["name"] for arg in function["args"])
+        call = f"::{function['name']}({forwarded_args})"
+        if function["return"] != "void":
+            call = "return " + call
+        out.write(f"""
+{method_signature(function, "GLFunctions::")}
+{{
+    {call};
+}}
+""")
+
+    out.write("""
+}
+""")
+
+
+if __name__ == "__main__":
+    run_generator("Generate WebGL GL function wrappers", write_header_file, write_implementation_file)

--- a/Meta/Generators/libweb_webgl.py
+++ b/Meta/Generators/libweb_webgl.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Shared model and CLI driver for the WebGL generators: loads GLFunctions.json and
+# derives the generated method name and signature of each GL entry point.
+
+import argparse
+import json
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from Utils.utils import title_case_to_snake_case as snake_case
+
+
+def load_functions(path: str) -> list:
+    with open(path, "r", encoding="utf-8") as input_file:
+        return json.load(input_file)
+
+
+# All WebGL generators take the same -h/-c/-j arguments and emit one header and one
+# implementation file from the loaded function list.
+def run_generator(description: str, write_header_file, write_implementation_file) -> None:
+    parser = argparse.ArgumentParser(description=description, add_help=False)
+    parser.add_argument("--help", action="help", help="Show this help message and exit")
+    parser.add_argument("-h", "--header", required=True, help="Path to the header file to generate")
+    parser.add_argument("-c", "--implementation", required=True, help="Path to the implementation file to generate")
+    parser.add_argument("-j", "--json", required=True, help="Path to the JSON file to read from")
+    args = parser.parse_args()
+
+    functions = load_functions(args.json)
+
+    with open(args.header, "w", encoding="utf-8") as output_file:
+        write_header_file(output_file, functions)
+
+    with open(args.implementation, "w", encoding="utf-8") as output_file:
+        write_implementation_file(output_file, functions)
+
+
+def command_name(function: dict) -> str:
+    assert function["name"].startswith("gl")
+    return function["name"][2:]
+
+
+def method_name(function: dict) -> str:
+    return snake_case(command_name(function))
+
+
+def method_signature(function: dict, qualifier: str = "") -> str:
+    args = ", ".join(f"{arg['type']} {arg['name']}" for arg in function["args"])
+    return f"{function['return']} {qualifier}{method_name(function)}({args})"


### PR DESCRIPTION
LibWeb's WebGL implementation currently reaches ANGLE by calling glFoo() throughout the WebGL context and extension code. That ties the WebGL spec layer to the concrete GL executor. A future backend that records operations, sends them to another process, or executes them from the Compositor would otherwise need to duplicate the WebGL logic or edit every call site again.

Introduce GLFunctions as an explicit boundary between WebGL semantics and GL execution. GLFunctions.json lists the GL entry points used by the implementation, and the generator emits one forwarding method per entry point. OpenGLContext implements those methods today, so the current in-process ANGLE path keeps the same behavior while all callers go through a single replaceable interface.

That boundary is needed before canvas/WebGL rendering can move to the Compositor: the WebGL context code can keep doing validation, state tracking, and spec-visible error handling in LibWeb, while a later implementation can record the same GL calls and replay them where the canvas surface is produced. The JSON source also gives the recorder and replayer one shared description of argument shapes, avoiding two hand-written views of the GL API drifting apart.