### PR TITLE
LibWeb: Allocate layout and painting objects with mimalloc

### DIFF
--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -134,6 +134,12 @@ static mi_heap_t* heap_for_partition(HeapPartition partition)
     case HeapPartition::JSObjectStorage:
         static mi_heap_t* js_object_storage_heap = mi_heap_new();
         return js_object_storage_heap;
+    case HeapPartition::Layout:
+        static mi_heap_t* layout_heap = mi_heap_new();
+        return layout_heap;
+    case HeapPartition::Painting:
+        static mi_heap_t* painting_heap = mi_heap_new();
+        return painting_heap;
     case HeapPartition::String:
         static thread_local mi_heap_t* string_heap = mi_heap_new();
         return string_heap;

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Checked.h>
 #include <new>
 #include <stdlib.h>
@@ -15,6 +16,8 @@ enum class HeapPartition {
     General,
     ArrayBuffer,
     JSObjectStorage,
+    Layout,
+    Painting,
     String,
 };
 
@@ -76,3 +79,29 @@ inline void* kmalloc_array(AK::Checked<size_t> a, AK::Checked<size_t> b, AK::Che
     VERIFY(!size.has_overflow());
     return kmalloc(size.value());
 }
+
+#define AK_ALLOC_WITH_KMALLOC_PARTITION(partition)                         \
+public:                                                                    \
+    static void* operator new(size_t size)                                 \
+    {                                                                      \
+        auto* ptr = ak_kmalloc(partition, size);                           \
+        VERIFY(ptr);                                                       \
+        return ptr;                                                        \
+    }                                                                      \
+                                                                           \
+    static void* operator new(size_t size, std::nothrow_t const&) noexcept \
+    {                                                                      \
+        return ak_kmalloc(partition, size);                                \
+    }                                                                      \
+                                                                           \
+    static void operator delete(void* ptr) noexcept                        \
+    {                                                                      \
+        ak_kfree(ptr);                                                     \
+    }                                                                      \
+                                                                           \
+    static void operator delete(void* ptr, std::nothrow_t const&) noexcept \
+    {                                                                      \
+        ak_kfree(ptr);                                                     \
+    }
+
+#define AK_ALLOC_WITH_KMALLOC AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::General)

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -19,6 +19,7 @@
 #include <AK/ValueComparingRefPtr.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
+#include <AK/kmalloc.h>
 #include <LibGfx/Color.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibURL/URL.h>
@@ -117,6 +118,8 @@ struct ColorResolutionContext {
 
 class WEB_API StyleValue : public RefCounted<StyleValue> {
 public:
+    AK_ALLOC_WITH_KMALLOC;
+
     virtual ~StyleValue() = default;
 
     enum class Type {

--- a/Libraries/LibWeb/Layout/FlexLayoutData.h
+++ b/Libraries/LibWeb/Layout/FlexLayoutData.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <AK/kmalloc.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
@@ -54,6 +55,8 @@ struct FlexLayoutLine {
 };
 
 struct FlexLayoutData {
+    AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
+
     CSS::AlignContent align_content { CSS::AlignContent::Normal };
     CSS::AlignItems align_items { CSS::AlignItems::Normal };
     CSS::FlexDirection flex_direction { CSS::FlexDirection::Row };

--- a/Libraries/LibWeb/Layout/GridLayoutData.h
+++ b/Libraries/LibWeb/Layout/GridLayoutData.h
@@ -8,6 +8,7 @@
 
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <AK/kmalloc.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
@@ -62,6 +63,8 @@ struct GridLayoutFragment {
 };
 
 struct GridLayoutData {
+    AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
+
     CSS::Direction direction { CSS::Direction::Ltr };
     CSS::WritingMode writing_mode { CSS::WritingMode::HorizontalTb };
     bool is_subgrid { false };

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -8,6 +8,7 @@
 
 #include <AK/HashTable.h>
 #include <AK/OwnPtr.h>
+#include <AK/kmalloc.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/Point.h>
 #include <LibWeb/Layout/Box.h>
@@ -67,6 +68,8 @@ class PagedStore {
     static constexpr u32 PageMask = PageSize - 1;
 
     struct Page {
+        AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
+
         Optional<T> entries[PageSize] {};
     };
 
@@ -121,6 +124,8 @@ private:
 };
 
 struct LayoutState {
+    AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
+
     struct UsedValues {
         UsedValues() = default;
         UsedValues(UsedValues&&) = default;
@@ -331,6 +336,8 @@ struct LayoutState {
         CSSPixels border_bottom_collapsed() const { return use_collapsing_borders_model() ? round(border_bottom / 2) : border_bottom; }
 
         struct RareData {
+            AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
+
             RareData() = default;
             RareData(RareData const& other)
                 : floating_descendants(other.floating_descendants)

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -14,6 +14,7 @@
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
+#include <AK/kmalloc.h>
 #include <LibGC/Cell.h>
 #include <LibGC/Weak.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
@@ -53,6 +54,8 @@ class WEB_API Node
     , public RefCountedTreeNode<Node> {
 
 public:
+    AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
+
     using Base = RefCountedTreeNode<Node>;
 
     virtual ~Node();

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -9,6 +9,7 @@
 #include <AK/RefCounted.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
+#include <AK/kmalloc.h>
 #include <LibGC/Ptr.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/Display.h>
@@ -38,6 +39,8 @@ class WEB_API Paintable
     , public RefCountedTreeNode<Paintable> {
 
 public:
+    AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Painting);
+
     virtual ~Paintable();
 
     virtual StringView class_name() const { return "Paintable"sv; }

--- a/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Libraries/LibWeb/Painting/StackingContext.h
@@ -12,6 +12,7 @@
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
+#include <AK/kmalloc.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Painting/Paintable.h>
 
@@ -23,6 +24,8 @@ class WEB_API StackingContext final
     friend class ViewportPaintable;
 
 public:
+    AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Painting);
+
     static NonnullRefPtr<StackingContext> create(PaintableBox&, RefPtr<StackingContext> parent, size_t index_in_tree_order);
 
     RefPtr<StackingContext> parent() { return m_parent.strong_ref(); }


### PR DESCRIPTION
Add class-local allocation macros for operator new/delete through AK's malloc helpers. The macros can optionally choose a HeapPartition. Add Layout and Painting partitions, plus basic partition stats helpers.

Use the new partitions for LibWeb layout and painting object hierarchies and layout-state side data.