### PR TITLE
Prepare 2D canvas command replay for compositor rasterization

### DIFF
--- a/Libraries/LibGfx/AffineTransform.cpp
+++ b/Libraries/LibGfx/AffineTransform.cpp
@@ -9,6 +9,8 @@
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Quad.h>
 #include <LibGfx/Rect.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 
 namespace Gfx {
 
@@ -256,6 +258,34 @@ Matrix<4, float> AffineTransform::to_matrix() const
         0.f, 0.f, 1.f, 0.f,
         0.f, 0.f, 0.f, 1.f
     };
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::AffineTransform const& transform)
+{
+    TRY(encoder.encode(transform.a()));
+    TRY(encoder.encode(transform.b()));
+    TRY(encoder.encode(transform.c()));
+    TRY(encoder.encode(transform.d()));
+    TRY(encoder.encode(transform.e()));
+    TRY(encoder.encode(transform.f()));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::AffineTransform> decode(Decoder& decoder)
+{
+    auto a = TRY(decoder.decode<float>());
+    auto b = TRY(decoder.decode<float>());
+    auto c = TRY(decoder.decode<float>());
+    auto d = TRY(decoder.decode<float>());
+    auto e = TRY(decoder.decode<float>());
+    auto f = TRY(decoder.decode<float>());
+    return Gfx::AffineTransform { a, b, c, d, e, f };
 }
 
 }

--- a/Libraries/LibGfx/AffineTransform.h
+++ b/Libraries/LibGfx/AffineTransform.h
@@ -11,6 +11,7 @@
 #include <AK/Forward.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Matrix.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -99,3 +100,13 @@ struct AK::Formatter<Gfx::AffineTransform> : Formatter<FormatString> {
         return Formatter<FormatString>::format(builder, "[{} {} {} {} {} {}]"sv, value.a(), value.b(), value.c(), value.d(), value.e(), value.f());
     }
 };
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::AffineTransform const&);
+
+template<>
+ErrorOr<Gfx::AffineTransform> decode(Decoder&);
+
+}

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     BitmapSequence.cpp
     CMYKBitmap.cpp
     CanvasCommandList.cpp
+    CanvasCommandPlayer.cpp
     Color.cpp
     ColorConversion.cpp
     ColorSpace.cpp

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     BitmapExport.cpp
     BitmapSequence.cpp
     CMYKBitmap.cpp
+    CanvasCommandList.cpp
     Color.cpp
     ColorConversion.cpp
     ColorSpace.cpp
@@ -21,7 +22,9 @@ set(SOURCES
     Font/WOFF2/Loader.cpp
     FontCascadeList.cpp
     GradientPainting.cpp
+    Gradients.cpp
     Matrix4x4.cpp
+    DecodedImageFrame.cpp
     ImageFormats/BMPWriter.cpp
     ImageFormats/JPEGWriter.cpp
     ImageFormats/PNGWriter.cpp

--- a/Libraries/LibGfx/CanvasCommandList.cpp
+++ b/Libraries/LibGfx/CanvasCommandList.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/TypeCasts.h>
+#include <LibGfx/CanvasCommandList.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace Gfx {
+
+CanvasPaintStyle to_canvas_paint_style(PaintStyle const& paint_style)
+{
+    if (auto const* solid_color = as_if<SolidColorPaintStyle>(paint_style))
+        return solid_color->color();
+
+    if (auto const* linear_gradient = as_if<CanvasLinearGradientPaintStyle>(paint_style)) {
+        return CanvasLinearGradient {
+            .start_point = linear_gradient->start_point(),
+            .end_point = linear_gradient->end_point(),
+            .color_stops = Vector<ColorStop> { linear_gradient->color_stops() },
+            .repeat_length = linear_gradient->repeat_length(),
+        };
+    }
+
+    if (auto const* radial_gradient = as_if<CanvasRadialGradientPaintStyle>(paint_style)) {
+        return CanvasRadialGradient {
+            .start_center = radial_gradient->start_center(),
+            .start_radius = radial_gradient->start_radius(),
+            .end_center = radial_gradient->end_center(),
+            .end_radius = radial_gradient->end_radius(),
+            .color_stops = Vector<ColorStop> { radial_gradient->color_stops() },
+            .repeat_length = radial_gradient->repeat_length(),
+        };
+    }
+
+    if (auto const* conic_gradient = as_if<CanvasConicGradientPaintStyle>(paint_style)) {
+        return CanvasConicGradient {
+            .center = conic_gradient->center(),
+            .start_angle = conic_gradient->start_angle(),
+            .color_stops = Vector<ColorStop> { conic_gradient->color_stops() },
+            .repeat_length = conic_gradient->repeat_length(),
+        };
+    }
+
+    if (auto const* pattern = as_if<CanvasPatternPaintStyle>(paint_style)) {
+        return CanvasPatternStyle {
+            .image = pattern->image(),
+            .repetition = pattern->repetition(),
+            .transform = pattern->transform(),
+        };
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasLinearGradient const& gradient)
+{
+    TRY(encoder.encode(gradient.start_point));
+    TRY(encoder.encode(gradient.end_point));
+    TRY(encoder.encode(gradient.color_stops));
+    TRY(encoder.encode(gradient.repeat_length));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasLinearGradient> decode(Decoder& decoder)
+{
+    return Gfx::CanvasLinearGradient {
+        .start_point = TRY(decoder.decode<Gfx::FloatPoint>()),
+        .end_point = TRY(decoder.decode<Gfx::FloatPoint>()),
+        .color_stops = TRY(decoder.decode<Vector<Gfx::ColorStop>>()),
+        .repeat_length = TRY(decoder.decode<Optional<float>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasRadialGradient const& gradient)
+{
+    TRY(encoder.encode(gradient.start_center));
+    TRY(encoder.encode(gradient.start_radius));
+    TRY(encoder.encode(gradient.end_center));
+    TRY(encoder.encode(gradient.end_radius));
+    TRY(encoder.encode(gradient.color_stops));
+    TRY(encoder.encode(gradient.repeat_length));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasRadialGradient> decode(Decoder& decoder)
+{
+    return Gfx::CanvasRadialGradient {
+        .start_center = TRY(decoder.decode<Gfx::FloatPoint>()),
+        .start_radius = TRY(decoder.decode<float>()),
+        .end_center = TRY(decoder.decode<Gfx::FloatPoint>()),
+        .end_radius = TRY(decoder.decode<float>()),
+        .color_stops = TRY(decoder.decode<Vector<Gfx::ColorStop>>()),
+        .repeat_length = TRY(decoder.decode<Optional<float>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasConicGradient const& gradient)
+{
+    TRY(encoder.encode(gradient.center));
+    TRY(encoder.encode(gradient.start_angle));
+    TRY(encoder.encode(gradient.color_stops));
+    TRY(encoder.encode(gradient.repeat_length));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasConicGradient> decode(Decoder& decoder)
+{
+    return Gfx::CanvasConicGradient {
+        .center = TRY(decoder.decode<Gfx::FloatPoint>()),
+        .start_angle = TRY(decoder.decode<float>()),
+        .color_stops = TRY(decoder.decode<Vector<Gfx::ColorStop>>()),
+        .repeat_length = TRY(decoder.decode<Optional<float>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasPatternStyle const& pattern)
+{
+    TRY(encoder.encode(pattern.image));
+    TRY(encoder.encode(pattern.repetition));
+    TRY(encoder.encode(pattern.transform));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasPatternStyle> decode(Decoder& decoder)
+{
+    return Gfx::CanvasPatternStyle {
+        .image = TRY(decoder.decode<Optional<Gfx::DecodedImageFrame>>()),
+        .repetition = TRY(decoder.decode<Gfx::CanvasPatternPaintStyle::Repetition>()),
+        .transform = TRY(decoder.decode<Optional<Gfx::AffineTransform>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasCommands::ClearRect const& command)
+{
+    TRY(encoder.encode(command.rect));
+    TRY(encoder.encode(command.color));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::ClearRect> decode(Decoder& decoder)
+{
+    return Gfx::CanvasCommands::ClearRect {
+        .rect = TRY(decoder.decode<Gfx::FloatRect>()),
+        .color = TRY(decoder.decode<Gfx::Color>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasCommands::FillRect const& command)
+{
+    TRY(encoder.encode(command.rect));
+    TRY(encoder.encode(command.color));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::FillRect> decode(Decoder& decoder)
+{
+    return Gfx::CanvasCommands::FillRect {
+        .rect = TRY(decoder.decode<Gfx::FloatRect>()),
+        .color = TRY(decoder.decode<Gfx::Color>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasCommands::DrawBitmap const& command)
+{
+    TRY(encoder.encode(command.frame));
+    TRY(encoder.encode(command.dst_rect));
+    TRY(encoder.encode(command.src_rect));
+    TRY(encoder.encode(command.scaling_mode));
+    TRY(encoder.encode(command.filter));
+    TRY(encoder.encode(command.global_alpha));
+    TRY(encoder.encode(command.compositing_and_blending_operator));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::DrawBitmap> decode(Decoder& decoder)
+{
+    return Gfx::CanvasCommands::DrawBitmap {
+        .frame = TRY(decoder.decode<Gfx::DecodedImageFrame>()),
+        .dst_rect = TRY(decoder.decode<Gfx::FloatRect>()),
+        .src_rect = TRY(decoder.decode<Gfx::IntRect>()),
+        .scaling_mode = TRY(decoder.decode<Gfx::ScalingMode>()),
+        .filter = TRY(decoder.decode<Optional<Gfx::Filter>>()),
+        .global_alpha = TRY(decoder.decode<float>()),
+        .compositing_and_blending_operator = TRY(decoder.decode<Gfx::CompositingAndBlendingOperator>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasCommands::FillPath const& command)
+{
+    TRY(encoder.encode(command.path));
+    TRY(encoder.encode(command.style));
+    TRY(encoder.encode(command.winding_rule));
+    TRY(encoder.encode(command.blur_radius));
+    TRY(encoder.encode(command.filter));
+    TRY(encoder.encode(command.global_alpha));
+    TRY(encoder.encode(command.compositing_and_blending_operator));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::FillPath> decode(Decoder& decoder)
+{
+    return Gfx::CanvasCommands::FillPath {
+        .path = TRY(decoder.decode<Gfx::Path>()),
+        .style = TRY(decoder.decode<Gfx::CanvasPaintStyle>()),
+        .winding_rule = TRY(decoder.decode<Gfx::WindingRule>()),
+        .blur_radius = TRY(decoder.decode<float>()),
+        .filter = TRY(decoder.decode<Optional<Gfx::Filter>>()),
+        .global_alpha = TRY(decoder.decode<float>()),
+        .compositing_and_blending_operator = TRY(decoder.decode<Gfx::CompositingAndBlendingOperator>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasCommands::StrokePath const& command)
+{
+    TRY(encoder.encode(command.path));
+    TRY(encoder.encode(command.style));
+    TRY(encoder.encode(command.thickness));
+    TRY(encoder.encode(command.cap_style));
+    TRY(encoder.encode(command.join_style));
+    TRY(encoder.encode(command.miter_limit));
+    TRY(encoder.encode(command.dash_array));
+    TRY(encoder.encode(command.dash_offset));
+    TRY(encoder.encode(command.blur_radius));
+    TRY(encoder.encode(command.filter));
+    TRY(encoder.encode(command.global_alpha));
+    TRY(encoder.encode(command.compositing_and_blending_operator));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::StrokePath> decode(Decoder& decoder)
+{
+    return Gfx::CanvasCommands::StrokePath {
+        .path = TRY(decoder.decode<Gfx::Path>()),
+        .style = TRY(decoder.decode<Gfx::CanvasPaintStyle>()),
+        .thickness = TRY(decoder.decode<float>()),
+        .cap_style = TRY(decoder.decode<Gfx::Path::CapStyle>()),
+        .join_style = TRY(decoder.decode<Gfx::Path::JoinStyle>()),
+        .miter_limit = TRY(decoder.decode<float>()),
+        .dash_array = TRY(decoder.decode<Vector<float>>()),
+        .dash_offset = TRY(decoder.decode<float>()),
+        .blur_radius = TRY(decoder.decode<float>()),
+        .filter = TRY(decoder.decode<Optional<Gfx::Filter>>()),
+        .global_alpha = TRY(decoder.decode<float>()),
+        .compositing_and_blending_operator = TRY(decoder.decode<Gfx::CompositingAndBlendingOperator>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasCommands::SetTransform const& command)
+{
+    TRY(encoder.encode(command.transform));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::SetTransform> decode(Decoder& decoder)
+{
+    return Gfx::CanvasCommands::SetTransform {
+        .transform = TRY(decoder.decode<Gfx::AffineTransform>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::Save const&)
+{
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::Save> decode(Decoder&)
+{
+    return Gfx::CanvasCommands::Save {};
+}
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::Restore const&)
+{
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::Restore> decode(Decoder&)
+{
+    return Gfx::CanvasCommands::Restore {};
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasCommands::ClipPath const& command)
+{
+    TRY(encoder.encode(command.path));
+    TRY(encoder.encode(command.winding_rule));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::ClipPath> decode(Decoder& decoder)
+{
+    return Gfx::CanvasCommands::ClipPath {
+        .path = TRY(decoder.decode<Gfx::Path>()),
+        .winding_rule = TRY(decoder.decode<Gfx::WindingRule>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::Reset const&)
+{
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommands::Reset> decode(Decoder&)
+{
+    return Gfx::CanvasCommands::Reset {};
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CanvasCommandList const& command_list)
+{
+    TRY(encoder.encode(command_list.commands()));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CanvasCommandList> decode(Decoder& decoder)
+{
+    return Gfx::CanvasCommandList { TRY(decoder.decode<Vector<Gfx::CanvasCommand>>()) };
+}
+
+}

--- a/Libraries/LibGfx/CanvasCommandList.h
+++ b/Libraries/LibGfx/CanvasCommandList.h
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibGfx/AffineTransform.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/CompositingAndBlendingOperator.h>
+#include <LibGfx/DecodedImageFrame.h>
+#include <LibGfx/Filter.h>
+#include <LibGfx/Gradients.h>
+#include <LibGfx/PaintStyle.h>
+#include <LibGfx/Path.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/ScalingMode.h>
+#include <LibGfx/Size.h>
+#include <LibGfx/WindingRule.h>
+#include <LibIPC/Forward.h>
+
+namespace Gfx {
+
+struct CanvasLinearGradient {
+    FloatPoint start_point;
+    FloatPoint end_point;
+    Vector<ColorStop> color_stops;
+    Optional<float> repeat_length;
+};
+
+struct CanvasRadialGradient {
+    FloatPoint start_center;
+    float start_radius { 0 };
+    FloatPoint end_center;
+    float end_radius { 0 };
+    Vector<ColorStop> color_stops;
+    Optional<float> repeat_length;
+};
+
+struct CanvasConicGradient {
+    FloatPoint center;
+    float start_angle { 0 };
+    Vector<ColorStop> color_stops;
+    Optional<float> repeat_length;
+};
+
+struct CanvasPatternStyle {
+    Optional<DecodedImageFrame> image;
+    CanvasPatternPaintStyle::Repetition repetition { CanvasPatternPaintStyle::Repetition::Repeat };
+    Optional<AffineTransform> transform;
+};
+
+using CanvasPaintStyle = Variant<Color, CanvasLinearGradient, CanvasRadialGradient, CanvasConicGradient, CanvasPatternStyle>;
+
+namespace CanvasCommands {
+
+struct ClearRect {
+    FloatRect rect;
+    Color color;
+};
+
+struct FillRect {
+    FloatRect rect;
+    Color color;
+};
+
+struct DrawBitmap {
+    DecodedImageFrame frame;
+    FloatRect dst_rect;
+    IntRect src_rect;
+    ScalingMode scaling_mode { ScalingMode::NearestNeighbor };
+    Optional<Filter> filter;
+    float global_alpha { 1 };
+    CompositingAndBlendingOperator compositing_and_blending_operator { CompositingAndBlendingOperator::SourceOver };
+};
+
+struct FillPath {
+    Path path;
+    CanvasPaintStyle style;
+    WindingRule winding_rule { WindingRule::Nonzero };
+    float blur_radius { 0 };
+    Optional<Filter> filter;
+    float global_alpha { 1 };
+    CompositingAndBlendingOperator compositing_and_blending_operator { CompositingAndBlendingOperator::SourceOver };
+};
+
+struct StrokePath {
+    Path path;
+    CanvasPaintStyle style;
+    float thickness { 1 };
+    Path::CapStyle cap_style { Path::CapStyle::Butt };
+    Path::JoinStyle join_style { Path::JoinStyle::Miter };
+    float miter_limit { 10 };
+    Vector<float> dash_array;
+    float dash_offset { 0 };
+    float blur_radius { 0 };
+    Optional<Filter> filter;
+    float global_alpha { 1 };
+    CompositingAndBlendingOperator compositing_and_blending_operator { CompositingAndBlendingOperator::SourceOver };
+};
+
+struct SetTransform {
+    AffineTransform transform;
+};
+
+struct Save { };
+
+struct Restore { };
+
+struct ClipPath {
+    Path path;
+    WindingRule winding_rule { WindingRule::Nonzero };
+};
+
+struct Reset { };
+
+}
+
+using CanvasCommand = Variant<
+    CanvasCommands::ClearRect,
+    CanvasCommands::FillRect,
+    CanvasCommands::DrawBitmap,
+    CanvasCommands::FillPath,
+    CanvasCommands::StrokePath,
+    CanvasCommands::SetTransform,
+    CanvasCommands::Save,
+    CanvasCommands::Restore,
+    CanvasCommands::ClipPath,
+    CanvasCommands::Reset>;
+
+class CanvasCommandList {
+public:
+    CanvasCommandList() = default;
+    explicit CanvasCommandList(Vector<CanvasCommand> commands)
+        : m_commands(move(commands))
+    {
+    }
+
+    void append(CanvasCommand&& command) { m_commands.append(move(command)); }
+
+    bool is_empty() const { return m_commands.is_empty(); }
+    size_t size() const { return m_commands.size(); }
+
+    Vector<CanvasCommand> const& commands() const { return m_commands; }
+
+private:
+    Vector<CanvasCommand> m_commands;
+};
+
+CanvasPaintStyle to_canvas_paint_style(PaintStyle const&);
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasLinearGradient const&);
+template<>
+ErrorOr<Gfx::CanvasLinearGradient> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasRadialGradient const&);
+template<>
+ErrorOr<Gfx::CanvasRadialGradient> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasConicGradient const&);
+template<>
+ErrorOr<Gfx::CanvasConicGradient> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasPatternStyle const&);
+template<>
+ErrorOr<Gfx::CanvasPatternStyle> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::ClearRect const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::ClearRect> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::FillRect const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::FillRect> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::DrawBitmap const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::DrawBitmap> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::FillPath const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::FillPath> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::StrokePath const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::StrokePath> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::SetTransform const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::SetTransform> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::Save const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::Save> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::Restore const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::Restore> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::ClipPath const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::ClipPath> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommands::Reset const&);
+template<>
+ErrorOr<Gfx::CanvasCommands::Reset> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CanvasCommandList const&);
+template<>
+ErrorOr<Gfx::CanvasCommandList> decode(Decoder&);
+
+}

--- a/Libraries/LibGfx/CanvasCommandPlayer.cpp
+++ b/Libraries/LibGfx/CanvasCommandPlayer.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/CanvasCommandPlayer.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/PainterSkia.h>
+#include <LibGfx/PaintingSurface.h>
+
+namespace Gfx {
+
+CanvasCommandPlayer::CanvasCommandPlayer(RefPtr<SkiaBackendContext> skia_backend_context, IntSize size, BitmapFormat format, AlphaType alpha_type)
+    : m_surface(PaintingSurface::create_with_size(size, format, alpha_type, move(skia_backend_context)))
+    , m_painter(make<PainterSkia>(*m_surface))
+{
+}
+
+CanvasCommandPlayer::~CanvasCommandPlayer() = default;
+
+NonnullRefPtr<PaintingSurface> CanvasCommandPlayer::surface() const
+{
+    return m_surface;
+}
+
+void CanvasCommandPlayer::clear(Color color)
+{
+    m_painter->clear_rect({ {}, m_surface->size().to_type<float>() }, color);
+}
+
+void CanvasCommandPlayer::play(CanvasCommandList const& command_list)
+{
+    for (auto const& command : command_list.commands())
+        command.visit([&](auto const& command) { play_command(command); });
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::ClearRect const& command)
+{
+    m_painter->clear_rect(command.rect, command.color);
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::FillRect const& command)
+{
+    m_painter->fill_rect(command.rect, command.color);
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::DrawBitmap const& command)
+{
+    m_painter->draw_bitmap(command.dst_rect, command.frame, command.src_rect, command.scaling_mode, command.filter, command.global_alpha, command.compositing_and_blending_operator);
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::FillPath const& command)
+{
+    // Shadows are recorded as blurred solid-color fills; everything else goes through the general paint-style overload.
+    if (command.blur_radius > 0 && command.style.has<Color>()) {
+        m_painter->fill_path(command.path, command.style.get<Color>(), command.winding_rule, command.blur_radius, command.compositing_and_blending_operator);
+        return;
+    }
+
+    m_painter->fill_path(command.path, resolve_paint_style(command.style), command.filter, command.global_alpha, command.compositing_and_blending_operator, command.winding_rule);
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::StrokePath const& command)
+{
+    if (command.blur_radius > 0 && command.style.has<Color>()) {
+        m_painter->stroke_path(command.path, command.style.get<Color>(), command.thickness, command.blur_radius, command.compositing_and_blending_operator, command.cap_style, command.join_style, command.miter_limit, command.dash_array, command.dash_offset);
+        return;
+    }
+
+    m_painter->stroke_path(command.path, resolve_paint_style(command.style), command.filter, command.thickness, command.global_alpha, command.compositing_and_blending_operator, command.cap_style, command.join_style, command.miter_limit, command.dash_array, command.dash_offset);
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::SetTransform const& command)
+{
+    m_painter->set_transform(command.transform);
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::Save const&)
+{
+    m_painter->save();
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::Restore const&)
+{
+    m_painter->restore();
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::ClipPath const& command)
+{
+    m_painter->clip(command.path, command.winding_rule);
+}
+
+void CanvasCommandPlayer::play_command(CanvasCommands::Reset const&)
+{
+    m_painter->reset();
+}
+
+NonnullRefPtr<PaintStyle> CanvasCommandPlayer::resolve_paint_style(CanvasPaintStyle const& style) const
+{
+    auto with_color_stops = [](auto paint_style, auto const& gradient) -> NonnullRefPtr<PaintStyle> {
+        paint_style->set_color_stops(Vector<ColorStop> { gradient.color_stops });
+        if (gradient.repeat_length.has_value())
+            paint_style->set_repeat_length(*gradient.repeat_length);
+        return paint_style;
+    };
+
+    return style.visit(
+        [](Color const& color) -> NonnullRefPtr<PaintStyle> {
+            return MUST(SolidColorPaintStyle::create(color));
+        },
+        [&](CanvasLinearGradient const& gradient) -> NonnullRefPtr<PaintStyle> {
+            return with_color_stops(MUST(CanvasLinearGradientPaintStyle::create(gradient.start_point, gradient.end_point)), gradient);
+        },
+        [&](CanvasRadialGradient const& gradient) -> NonnullRefPtr<PaintStyle> {
+            return with_color_stops(MUST(CanvasRadialGradientPaintStyle::create(gradient.start_center, gradient.start_radius, gradient.end_center, gradient.end_radius)), gradient);
+        },
+        [&](CanvasConicGradient const& gradient) -> NonnullRefPtr<PaintStyle> {
+            return with_color_stops(MUST(CanvasConicGradientPaintStyle::create(gradient.center, gradient.start_angle)), gradient);
+        },
+        [&](CanvasPatternStyle const& pattern) -> NonnullRefPtr<PaintStyle> {
+            auto paint_style = MUST(CanvasPatternPaintStyle::create(pattern.image, pattern.repetition));
+            if (pattern.transform.has_value())
+                paint_style->set_transform(*pattern.transform);
+            return paint_style;
+        });
+}
+
+}

--- a/Libraries/LibGfx/CanvasCommandPlayer.cpp
+++ b/Libraries/LibGfx/CanvasCommandPlayer.cpp
@@ -37,6 +37,11 @@ void CanvasCommandPlayer::play(CanvasCommandList const& command_list)
         command.visit([&](auto const& command) { play_command(command); });
 }
 
+void CanvasCommandPlayer::prune_caches()
+{
+    m_painter->prune_caches();
+}
+
 void CanvasCommandPlayer::play_command(CanvasCommands::ClearRect const& command)
 {
     m_painter->clear_rect(command.rect, command.color);

--- a/Libraries/LibGfx/CanvasCommandPlayer.h
+++ b/Libraries/LibGfx/CanvasCommandPlayer.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefPtr.h>
+#include <LibGfx/CanvasCommandList.h>
+#include <LibGfx/Forward.h>
+
+namespace Gfx {
+
+class CanvasCommandPlayer {
+    AK_MAKE_NONCOPYABLE(CanvasCommandPlayer);
+    AK_MAKE_NONMOVABLE(CanvasCommandPlayer);
+
+public:
+    CanvasCommandPlayer(RefPtr<SkiaBackendContext>, IntSize, BitmapFormat, AlphaType);
+    ~CanvasCommandPlayer();
+
+    NonnullRefPtr<PaintingSurface> surface() const;
+
+    void clear(Color);
+
+    void play(CanvasCommandList const&);
+
+private:
+    void play_command(CanvasCommands::ClearRect const&);
+    void play_command(CanvasCommands::FillRect const&);
+    void play_command(CanvasCommands::DrawBitmap const&);
+    void play_command(CanvasCommands::FillPath const&);
+    void play_command(CanvasCommands::StrokePath const&);
+    void play_command(CanvasCommands::SetTransform const&);
+    void play_command(CanvasCommands::Save const&);
+    void play_command(CanvasCommands::Restore const&);
+    void play_command(CanvasCommands::ClipPath const&);
+    void play_command(CanvasCommands::Reset const&);
+
+    NonnullRefPtr<PaintStyle> resolve_paint_style(CanvasPaintStyle const&) const;
+
+    NonnullRefPtr<PaintingSurface> m_surface;
+    NonnullOwnPtr<PainterSkia> m_painter;
+};
+
+}

--- a/Libraries/LibGfx/CanvasCommandPlayer.h
+++ b/Libraries/LibGfx/CanvasCommandPlayer.h
@@ -29,6 +29,8 @@ public:
 
     void play(CanvasCommandList const&);
 
+    void prune_caches();
+
 private:
     void play_command(CanvasCommands::ClearRect const&);
     void play_command(CanvasCommands::FillRect const&);

--- a/Libraries/LibGfx/DecodedImageFrame.cpp
+++ b/Libraries/LibGfx/DecodedImageFrame.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/DecodedImageFrame.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::DecodedImageFrame const& frame)
+{
+    auto bitmap = frame.bitmap().to_shareable_bitmap();
+    TRY(encoder.encode(bitmap));
+    TRY(encoder.encode(frame.color_space()));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::DecodedImageFrame> decode(Decoder& decoder)
+{
+    auto bitmap = TRY(decoder.decode<Gfx::ShareableBitmap>());
+    auto color_space = TRY(decoder.decode<Gfx::ColorSpace>());
+    return Gfx::DecodedImageFrame { *bitmap.bitmap(), move(color_space) };
+}
+
+}

--- a/Libraries/LibGfx/DecodedImageFrame.h
+++ b/Libraries/LibGfx/DecodedImageFrame.h
@@ -13,6 +13,7 @@
 #include <LibGfx/ColorSpace.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -65,5 +66,15 @@ private:
     NonnullRefPtr<Bitmap const> m_bitmap;
     ColorSpace m_color_space;
 };
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::DecodedImageFrame const&);
+
+template<>
+ErrorOr<Gfx::DecodedImageFrame> decode(Decoder&);
 
 }

--- a/Libraries/LibGfx/Forward.h
+++ b/Libraries/LibGfx/Forward.h
@@ -10,6 +10,7 @@ namespace Gfx {
 
 class Bitmap;
 class CMYKBitmap;
+class CanvasCommandList;
 class ColorSpace;
 class DecodedImageFrame;
 class Color;

--- a/Libraries/LibGfx/Forward.h
+++ b/Libraries/LibGfx/Forward.h
@@ -11,6 +11,7 @@ namespace Gfx {
 class Bitmap;
 class CMYKBitmap;
 class CanvasCommandList;
+class CanvasCommandPlayer;
 class ColorSpace;
 class DecodedImageFrame;
 class Color;
@@ -22,6 +23,7 @@ class ImageDecoder;
 struct FontPixelMetrics;
 
 class Painter;
+class PainterSkia;
 class PaintingSurface;
 class Palette;
 class YUVData;

--- a/Libraries/LibGfx/Gradients.cpp
+++ b/Libraries/LibGfx/Gradients.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Gradients.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::ColorStop const& color_stop)
+{
+    TRY(encoder.encode(color_stop.color));
+    TRY(encoder.encode(color_stop.position));
+    TRY(encoder.encode(color_stop.transition_hint));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::ColorStop> decode(Decoder& decoder)
+{
+    auto color = TRY(decoder.decode<Gfx::Color>());
+    auto position = TRY(decoder.decode<float>());
+    auto transition_hint = TRY(decoder.decode<Optional<float>>());
+    return Gfx::ColorStop { color, position, transition_hint };
+}
+
+}

--- a/Libraries/LibGfx/Gradients.h
+++ b/Libraries/LibGfx/Gradients.h
@@ -9,6 +9,7 @@
 #include <AK/Math.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Size.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -43,5 +44,15 @@ inline float calculate_gradient_length(Size<T> gradient_size, float gradient_ang
     AK::sincos(angle, sin_angle, cos_angle);
     return calculate_gradient_length(gradient_size, sin_angle, cos_angle);
 }
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::ColorStop const&);
+
+template<>
+ErrorOr<Gfx::ColorStop> decode(Decoder&);
 
 }

--- a/Libraries/LibGfx/Painter.h
+++ b/Libraries/LibGfx/Painter.h
@@ -7,13 +7,11 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Optional.h>
 #include <LibGfx/CompositingAndBlendingOperator.h>
 #include <LibGfx/Filter.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/PaintStyle.h>
-#include <LibGfx/Path.h>
 #include <LibGfx/ScalingMode.h>
-#include <LibGfx/WindingRule.h>
 
 namespace Gfx {
 
@@ -27,25 +25,6 @@ public:
     virtual void fill_rect(Gfx::FloatRect const&, Gfx::Color) = 0;
 
     virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::DecodedImageFrame const& source, Gfx::IntRect const& src_rect, Gfx::ScalingMode, Optional<Gfx::Filter> filters, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
-
-    virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness) = 0;
-    virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle, Gfx::Path::JoinStyle, float miter_limit, Vector<float> const& dash_array, float dash_offset) = 0;
-    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
-    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const&, Gfx::Path::JoinStyle const&, float miter_limit, Vector<float> const&, float dash_offset) = 0;
-
-    virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule) = 0;
-    virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
-    virtual void fill_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::WindingRule) = 0;
-
-    virtual void set_transform(Gfx::AffineTransform const&) = 0;
-
-    virtual void save() = 0;
-    virtual void restore() = 0;
-
-    virtual void clip(Gfx::Path const&, Gfx::WindingRule) = 0;
-
-    virtual void reset() = 0;
-    virtual void prune_caches() { }
 };
 
 }

--- a/Libraries/LibGfx/PainterSkia.cpp
+++ b/Libraries/LibGfx/PainterSkia.cpp
@@ -218,22 +218,6 @@ void PainterSkia::set_transform(Gfx::AffineTransform const& transform)
     canvas.setMatrix(matrix);
 }
 
-void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::Color color, float thickness)
-{
-    // Skia treats zero thickness as a special case and will draw a hairline, while we want to draw nothing.
-    if (thickness <= 0)
-        return;
-
-    SkPaint paint;
-    paint.setAntiAlias(true);
-    paint.setStyle(SkPaint::kStroke_Style);
-    paint.setStrokeWidth(thickness);
-    paint.setColor(to_skia_color(color));
-    auto sk_path = to_skia_path(path);
-    auto& canvas = impl().painting_surface->canvas();
-    canvas.drawPath(sk_path, paint);
-}
-
 void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::Color color, float thickness, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle cap_style, Gfx::Path::JoinStyle join_style, float miter_limit, Vector<float> const& dash_array, float dash_offset)
 {
     // Skia treats zero thickness as a special case and will draw a hairline, while we want to draw nothing.
@@ -256,24 +240,6 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::Color color, float thi
     canvas.drawPath(sk_path, paint);
 }
 
-void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& paint_style, Optional<Gfx::Filter> filter, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)
-{
-    // Skia treats zero thickness as a special case and will draw a hairline, while we want to draw nothing.
-    if (thickness <= 0)
-        return;
-
-    auto sk_path = to_skia_path(path);
-    auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
-    paint.setAntiAlias(true);
-    float alpha = paint.getAlphaf();
-    paint.setAlphaf(alpha * global_alpha);
-    paint.setStyle(SkPaint::Style::kStroke_Style);
-    paint.setStrokeWidth(thickness);
-    paint.setBlender(to_skia_blender(compositing_and_blending_operator));
-    auto& canvas = impl().painting_surface->canvas();
-    canvas.drawPath(sk_path, paint);
-}
-
 void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& paint_style, Optional<Gfx::Filter> filter, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const& cap_style, Gfx::Path::JoinStyle const& join_style, float miter_limit, Vector<float> const& dash_array, float dash_offset)
 {
     // Skia treats zero thickness as a special case and will draw a hairline, while we want to draw nothing.
@@ -292,17 +258,6 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& pain
     paint.setStrokeMiter(miter_limit);
     paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), dash_offset));
     paint.setBlender(to_skia_blender(compositing_and_blending_operator));
-    auto& canvas = impl().painting_surface->canvas();
-    canvas.drawPath(sk_path, paint);
-}
-
-void PainterSkia::fill_path(Gfx::Path const& path, Gfx::Color color, Gfx::WindingRule winding_rule)
-{
-    SkPaint paint;
-    paint.setAntiAlias(true);
-    paint.setColor(to_skia_color(color));
-    auto sk_path = to_skia_path(path);
-    sk_path.setFillType(to_skia_path_fill_type(winding_rule));
     auto& canvas = impl().painting_surface->canvas();
     canvas.drawPath(sk_path, paint);
 }

--- a/Libraries/LibGfx/PainterSkia.h
+++ b/Libraries/LibGfx/PainterSkia.h
@@ -8,8 +8,11 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <LibGfx/CompositingAndBlendingOperator.h>
+#include <LibGfx/PaintStyle.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/PaintingSurface.h>
+#include <LibGfx/Path.h>
+#include <LibGfx/WindingRule.h>
 
 namespace Gfx {
 
@@ -21,19 +24,16 @@ public:
     virtual void clear_rect(Gfx::FloatRect const&, Color) override;
     virtual void fill_rect(Gfx::FloatRect const&, Color) override;
     virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::DecodedImageFrame const& source, Gfx::IntRect const& src_rect, Gfx::ScalingMode, Optional<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
-    virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness) override;
-    virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle, Gfx::Path::JoinStyle, float miter_limit, Vector<float> const& dash_array, float dash_offset) override;
-    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
-    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const&, Gfx::Path::JoinStyle const&, float miter_limit, Vector<float> const&, float dash_offset) override;
-    virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule) override;
-    virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
-    virtual void fill_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::WindingRule) override;
-    virtual void set_transform(Gfx::AffineTransform const&) override;
-    virtual void save() override;
-    virtual void restore() override;
-    virtual void clip(Gfx::Path const&, Gfx::WindingRule) override;
-    virtual void reset() override;
-    virtual void prune_caches() override;
+    void stroke_path(Gfx::Path const&, Gfx::Color, float thickness, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle, Gfx::Path::JoinStyle, float miter_limit, Vector<float> const& dash_array, float dash_offset);
+    void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const&, Gfx::Path::JoinStyle const&, float miter_limit, Vector<float> const&, float dash_offset);
+    void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator);
+    void fill_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::WindingRule);
+    void set_transform(Gfx::AffineTransform const&);
+    void save();
+    void restore();
+    void clip(Gfx::Path const&, Gfx::WindingRule);
+    void reset();
+    void prune_caches();
 
 private:
     struct Impl;

--- a/Libraries/LibGfx/Rect.cpp
+++ b/Libraries/LibGfx/Rect.cpp
@@ -43,6 +43,26 @@ ErrorOr<Gfx::IntRect> decode(Decoder& decoder)
     return Gfx::IntRect { point, size };
 }
 
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::FloatRect const& rect)
+{
+    TRY(encoder.encode(rect.x()));
+    TRY(encoder.encode(rect.y()));
+    TRY(encoder.encode(rect.width()));
+    TRY(encoder.encode(rect.height()));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::FloatRect> decode(Decoder& decoder)
+{
+    auto x = TRY(decoder.decode<float>());
+    auto y = TRY(decoder.decode<float>());
+    auto width = TRY(decoder.decode<float>());
+    auto height = TRY(decoder.decode<float>());
+    return Gfx::FloatRect { x, y, width, height };
+}
+
 }
 
 template class Gfx::Rect<int>;

--- a/Libraries/LibGfx/Rect.h
+++ b/Libraries/LibGfx/Rect.h
@@ -620,4 +620,10 @@ ErrorOr<void> encode(Encoder&, Gfx::IntRect const&);
 template<>
 ErrorOr<Gfx::IntRect> decode(Decoder&);
 
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::FloatRect const&);
+
+template<>
+ErrorOr<Gfx::FloatRect> decode(Decoder&);
+
 }

--- a/Libraries/LibGfx/VectorGraphic.cpp
+++ b/Libraries/LibGfx/VectorGraphic.cpp
@@ -13,7 +13,7 @@ namespace Gfx {
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> VectorGraphic::bitmap(IntSize size, AffineTransform transform) const
 {
     auto bitmap = TRY(Bitmap::create(Gfx::BitmapFormat::BGRA8888, size));
-    auto painter = PainterSkia::create(bitmap);
+    auto painter = make<PainterSkia>(PaintingSurface::wrap_bitmap(bitmap));
 
     // Apply the transform then center within destination rectangle (this ignores any translation from the transform):
     // This allows you to easily rotate or flip the image before painting.

--- a/Libraries/LibGfx/VectorGraphic.h
+++ b/Libraries/LibGfx/VectorGraphic.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <AK/RefCounted.h>
+#include <LibGfx/AffineTransform.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Size.h>
 
 namespace Gfx {
@@ -16,7 +16,7 @@ namespace Gfx {
 class VectorGraphic : public RefCounted<VectorGraphic> {
 public:
     virtual IntSize intrinsic_size() const = 0;
-    virtual void draw(Painter&) const = 0;
+    virtual void draw(PainterSkia&) const = 0;
 
     IntSize size() const { return intrinsic_size(); }
     IntRect rect() const { return { {}, size() }; }

--- a/Libraries/LibWeb/HTML/Canvas/AbstractCanvasMixin.h
+++ b/Libraries/LibWeb/HTML/Canvas/AbstractCanvasMixin.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/CanvasCommandList.h>
 #include <LibWeb/HTML/Canvas/DrawingState.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
 #include <LibWeb/HTML/OffscreenCanvas.h>
@@ -20,7 +21,7 @@ protected:
     virtual DrawingState const& drawing_state() const = 0;
     virtual JS::Realm& my_realm() = 0;
     virtual Gfx::Path& mutable_path() = 0;
-    virtual Gfx::Painter* painter() = 0;
+    virtual Gfx::CanvasCommandList* canvas_command_list() = 0;
     virtual CSS::ComputationContext computation_context_for_drawing_state() const = 0;
     Optional<Color> parse_a_css_color_value(StringView const& value) const;
 };

--- a/Libraries/LibWeb/HTML/Canvas/CanvasState.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasState.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/Painter.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/StyleValues/ShorthandStyleValue.h>
@@ -22,8 +21,8 @@ void CanvasState::save()
     // The save() method steps are to push a copy of the current drawing state onto the drawing state stack.
     m_drawing_state_stack.append(m_drawing_state);
 
-    if (auto* painter = this->painter())
-        painter->save();
+    if (auto* canvas_command_list = this->canvas_command_list())
+        canvas_command_list->append(Gfx::CanvasCommands::Save {});
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-restore
@@ -34,8 +33,8 @@ void CanvasState::restore()
         return;
     m_drawing_state = m_drawing_state_stack.take_last();
 
-    if (auto* painter = this->painter())
-        painter->restore();
+    if (auto* canvas_command_list = this->canvas_command_list())
+        canvas_command_list->append(Gfx::CanvasCommands::Restore {});
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-reset

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTransform.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTransform.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <AK/Debug.h>
-#include <LibGfx/Painter.h>
 #include <LibWeb/Bindings/DOMMatrixReadOnly.h>
 #include <LibWeb/Geometry/DOMMatrix.h>
 #include <LibWeb/HTML/Canvas/AbstractCanvasMixin.h>
@@ -126,8 +125,8 @@ public:
 
     void flush_transform()
     {
-        if (auto* painter = this->painter())
-            painter->set_transform(drawing_state().transform);
+        if (auto* canvas_command_list = this->canvas_command_list())
+            canvas_command_list->append(Gfx::CanvasCommands::SetTransform { .transform = drawing_state().transform });
     }
 
 protected:

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -13,9 +13,12 @@
 #include <AK/NumericLimits.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/CanvasCommandList.h>
+#include <LibGfx/CanvasCommandPlayer.h>
 #include <LibGfx/CompositingAndBlendingOperator.h>
 #include <LibGfx/DecodedImageFrame.h>
-#include <LibGfx/PainterSkia.h>
+#include <LibGfx/Painter.h>
+#include <LibGfx/PaintingSurface.h>
 #include <LibGfx/Rect.h>
 #include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/TypedArray.h>
@@ -82,10 +85,10 @@ void CanvasRenderingContext2D::visit_edges(Cell::Visitor& visitor)
 size_t CanvasRenderingContext2D::external_memory_size() const
 {
     auto size = Base::external_memory_size();
-    if (!m_surface)
+    if (!m_player)
         return size;
 
-    auto surface_size = m_surface->size();
+    auto surface_size = m_player->surface()->size();
     if (surface_size.is_empty())
         return size;
 
@@ -130,9 +133,9 @@ void CanvasRenderingContext2D::clear_rect(float x, float y, float width, float h
     if (!isfinite(x) || !isfinite(y) || !isfinite(width) || !isfinite(height))
         return;
 
-    if (auto* painter = this->painter()) {
+    if (auto* canvas_command_list = this->canvas_command_list()) {
         auto rect = Gfx::FloatRect(x, y, width, height);
-        painter->clear_rect(rect, clear_color());
+        canvas_command_list->append(Gfx::CanvasCommands::ClearRect { .rect = rect, .color = clear_color() });
         did_draw(rect);
     }
 }
@@ -210,8 +213,16 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::draw_image_internal(CanvasIm
         scaling_mode = Gfx::ScalingMode::BilinearMipmap;
     }
 
-    if (auto* painter = this->painter()) {
-        painter->draw_bitmap(destination_rect, *frame, source_rect.to_rounded<int>(), scaling_mode, drawing_state().filter, drawing_state().global_alpha, drawing_state().current_compositing_and_blending_operator);
+    if (auto* canvas_command_list = this->canvas_command_list()) {
+        canvas_command_list->append(Gfx::CanvasCommands::DrawBitmap {
+            .frame = *frame,
+            .dst_rect = destination_rect,
+            .src_rect = source_rect.to_rounded<int>(),
+            .scaling_mode = scaling_mode,
+            .filter = drawing_state().filter,
+            .global_alpha = drawing_state().global_alpha,
+            .compositing_and_blending_operator = drawing_state().current_compositing_and_blending_operator,
+        });
         did_draw(destination_rect);
     }
 
@@ -229,15 +240,28 @@ void CanvasRenderingContext2D::did_draw(Gfx::FloatRect const&)
     m_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 
-Gfx::Painter* CanvasRenderingContext2D::painter()
+Gfx::CanvasCommandList* CanvasRenderingContext2D::canvas_command_list()
 {
     allocate_painting_surface_if_needed();
-    auto surface = m_element->surface();
-    if (!m_painter && surface) {
-        m_element->set_needs_repaint();
-        m_painter = make<Gfx::PainterSkia>(*m_element->surface());
-    }
-    return m_painter.ptr();
+    if (!m_player)
+        return nullptr;
+    return &m_commands;
+}
+
+RefPtr<Gfx::PaintingSurface> CanvasRenderingContext2D::surface()
+{
+    if (!m_player)
+        return nullptr;
+    flush_recorded_commands();
+    return m_player->surface();
+}
+
+void CanvasRenderingContext2D::flush_recorded_commands()
+{
+    if (m_commands.is_empty())
+        return;
+    auto commands = move(m_commands);
+    m_player->play(commands);
 }
 
 void CanvasRenderingContext2D::set_size(Gfx::IntSize const& size)
@@ -245,19 +269,21 @@ void CanvasRenderingContext2D::set_size(Gfx::IntSize const& size)
     if (m_size == size)
         return;
     m_size = size;
-    m_surface = nullptr;
-    m_painter = nullptr;
+    m_commands = {};
+    m_player = nullptr;
 }
 
 void CanvasRenderingContext2D::present()
 {
-    if (m_painter)
-        m_painter->prune_caches();
+    if (!m_player)
+        return;
+    flush_recorded_commands();
+    m_player->prune_caches();
 }
 
 void CanvasRenderingContext2D::allocate_painting_surface_if_needed()
 {
-    if (m_surface || m_size.is_empty())
+    if (m_player || m_size.is_empty())
         return;
 
     // FIXME: implement context attribute .color_space
@@ -267,16 +293,15 @@ void CanvasRenderingContext2D::allocate_painting_surface_if_needed()
 
     auto color_type = m_context_attributes.alpha ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
 
-    m_surface = Gfx::PaintingSurface::create_with_size(m_element->bitmap_size_for_canvas(), color_type, Gfx::AlphaType::Premultiplied);
-    m_painter = nullptr;
+    auto surface_size = m_element->bitmap_size_for_canvas();
+    m_player = make<Gfx::CanvasCommandPlayer>(nullptr, surface_size, color_type, Gfx::AlphaType::Premultiplied);
+    m_element->set_needs_repaint();
 
     // https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-settings:concept-canvas-alpha
     // Thus, the bitmap of such a context starts off as opaque black instead of transparent black;
     // AD-HOC: Skia provides us with a full transparent surface by default; only clear the surface if alpha is disabled.
-    if (!m_context_attributes.alpha) {
-        auto* painter = this->painter();
-        painter->clear_rect(m_surface->rect().to_type<float>(), clear_color());
-    }
+    if (!m_context_attributes.alpha)
+        m_player->clear(clear_color());
 }
 
 Gfx::Path CanvasRenderingContext2D::text_path(Utf16String const& text, float x, float y, Optional<double> max_width)
@@ -432,10 +457,10 @@ Gfx::Color CanvasRenderingContext2D::clear_color() const
     return m_context_attributes.alpha ? Gfx::Color::Transparent : Gfx::Color::Black;
 }
 
-void CanvasRenderingContext2D::stroke_internal(Gfx::Path const& path)
+void CanvasRenderingContext2D::stroke_internal(Gfx::Path path)
 {
-    auto* painter = this->painter();
-    if (!painter)
+    auto* canvas_command_list = this->canvas_command_list();
+    if (!canvas_command_list)
         return;
 
     auto& state = drawing_state();
@@ -453,19 +478,32 @@ void CanvasRenderingContext2D::stroke_internal(Gfx::Path const& path)
         dash_array.append(static_cast<float>(dash));
     }
     paint_shadow_for_stroke_internal(path, line_cap, line_join, dash_array);
-    painter->stroke_path(path, paint_style, state.filter, state.line_width, state.global_alpha, state.current_compositing_and_blending_operator, line_cap, line_join, state.miter_limit, dash_array, state.line_dash_offset);
+    auto bounding_box = path.bounding_box();
+    canvas_command_list->append(Gfx::CanvasCommands::StrokePath {
+        .path = move(path),
+        .style = Gfx::to_canvas_paint_style(*paint_style),
+        .thickness = state.line_width,
+        .cap_style = line_cap,
+        .join_style = line_join,
+        .miter_limit = state.miter_limit,
+        .dash_array = move(dash_array),
+        .dash_offset = state.line_dash_offset,
+        .filter = state.filter,
+        .global_alpha = state.global_alpha,
+        .compositing_and_blending_operator = state.current_compositing_and_blending_operator,
+    });
 
-    did_draw(path.bounding_box());
+    did_draw(bounding_box);
 }
 
 void CanvasRenderingContext2D::stroke()
 {
-    stroke_internal(path());
+    stroke_internal(path().clone());
 }
 
 void CanvasRenderingContext2D::stroke(Path2D const& path)
 {
-    stroke_internal(path.path());
+    stroke_internal(path.path().clone());
 }
 
 static Gfx::WindingRule parse_fill_rule(StringView fill_rule)
@@ -478,10 +516,10 @@ static Gfx::WindingRule parse_fill_rule(StringView fill_rule)
     return Gfx::WindingRule::Nonzero;
 }
 
-void CanvasRenderingContext2D::fill_internal(Gfx::Path const& path, Gfx::WindingRule winding_rule)
+void CanvasRenderingContext2D::fill_internal(Gfx::Path path, Gfx::WindingRule winding_rule)
 {
-    auto* painter = this->painter();
-    if (!painter)
+    auto* canvas_command_list = this->canvas_command_list();
+    if (!canvas_command_list)
         return;
 
     auto& state = this->drawing_state();
@@ -491,19 +529,27 @@ void CanvasRenderingContext2D::fill_internal(Gfx::Path const& path, Gfx::Winding
 
     paint_shadow_for_fill_internal(path, winding_rule);
 
-    painter->fill_path(path, paint_style, state.filter, state.global_alpha, state.current_compositing_and_blending_operator, winding_rule);
+    auto bounding_box = path.bounding_box();
+    canvas_command_list->append(Gfx::CanvasCommands::FillPath {
+        .path = move(path),
+        .style = Gfx::to_canvas_paint_style(*paint_style),
+        .winding_rule = winding_rule,
+        .filter = state.filter,
+        .global_alpha = state.global_alpha,
+        .compositing_and_blending_operator = state.current_compositing_and_blending_operator,
+    });
 
-    did_draw(path.bounding_box());
+    did_draw(bounding_box);
 }
 
 void CanvasRenderingContext2D::fill(StringView fill_rule)
 {
-    fill_internal(path(), parse_fill_rule(fill_rule));
+    fill_internal(path().clone(), parse_fill_rule(fill_rule));
 }
 
 void CanvasRenderingContext2D::fill(Path2D& path, StringView fill_rule)
 {
-    fill_internal(path.path(), parse_fill_rule(fill_rule));
+    fill_internal(path.path().clone(), parse_fill_rule(fill_rule));
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createimagedata
@@ -598,8 +644,8 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::put_image_data(ImageData& im
 {
     // The putImageData(imageData, dx, dy) method steps are to put pixels from an ImageData onto a bitmap,
     // given imageData, this's output bitmap, dx, dy, 0, 0, imageData's width, and imageData's height.
-    if (auto* painter = this->painter())
-        TRY(put_pixels_from_an_image_data_onto_a_bitmap(image_data, *painter, dx, dy, 0, 0, image_data.width(), image_data.height()));
+    if (auto* canvas_command_list = this->canvas_command_list())
+        TRY(put_pixels_from_an_image_data_onto_a_bitmap(image_data, *canvas_command_list, dx, dy, 0, 0, image_data.width(), image_data.height()));
 
     return {};
 }
@@ -610,14 +656,14 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::put_image_data(ImageData& im
     // The putImageData(imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight) method steps are to put pixels
     // from an ImageData onto a bitmap, given imageData, this's output bitmap, dx, dy, dirtyX, dirtyY, dirtyWidth, and
     // dirtyHeight.
-    if (auto* painter = this->painter())
-        TRY(put_pixels_from_an_image_data_onto_a_bitmap(image_data, *painter, x, y, dirty_x, dirty_y, dirty_width, dirty_height));
+    if (auto* canvas_command_list = this->canvas_command_list())
+        TRY(put_pixels_from_an_image_data_onto_a_bitmap(image_data, *canvas_command_list, x, y, dirty_x, dirty_y, dirty_width, dirty_height));
 
     return {};
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-context2d-putimagedata-common
-WebIDL::ExceptionOr<void> CanvasRenderingContext2D::put_pixels_from_an_image_data_onto_a_bitmap(ImageData& image_data, Gfx::Painter& painter, float dx, float dy, float dirty_x, float dirty_y, float dirty_width, float dirty_height)
+WebIDL::ExceptionOr<void> CanvasRenderingContext2D::put_pixels_from_an_image_data_onto_a_bitmap(ImageData& image_data, Gfx::CanvasCommandList& canvas_command_list, float dx, float dy, float dirty_x, float dirty_y, float dirty_width, float dirty_height)
 {
     // 1. Let buffer be imageData's data attribute value's [[ViewedArrayBuffer]] internal slot.
     auto* buffer = image_data.data()->viewed_array_buffer();
@@ -672,17 +718,24 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::put_pixels_from_an_image_dat
     //    imageData data structure's bitmap, converted from imageData's colorSpace to the color space of bitmap using
     //    'relative-colorimetric' rendering intent.
     auto dst_rect = Gfx::FloatRect { dx + dirty_x, dy + dirty_y, dirty_width, dirty_height };
-    painter.save();
-    painter.set_transform({});
-    painter.draw_bitmap(
-        dst_rect,
-        Gfx::DecodedImageFrame { image_data.bitmap(), Gfx::AlphaType::Unpremultiplied },
-        Gfx::IntRect { dirty_x, dirty_y, dirty_width, dirty_height },
-        Gfx::ScalingMode::NearestNeighbor,
-        {},
-        1.0f,
-        Gfx::CompositingAndBlendingOperator::SourceOver);
-    painter.restore();
+    // NOTE: The ImageData buffer is mutable from script and the recorded draw is only
+    //       serialized at flush time, so snapshot the dirty pixels at call time. The
+    //       snapshot is shareable so that flushing to the Compositor passes the pixels
+    //       by file descriptor instead of copying them again.
+    auto source_rect = Gfx::IntRect { dirty_x, dirty_y, dirty_width, dirty_height };
+    auto const& source_bitmap = image_data.bitmap();
+    auto bitmap_snapshot = MUST(Gfx::Bitmap::create_shareable(source_bitmap.format(), source_bitmap.alpha_type(), source_rect.size()));
+    for (int y = 0; y < source_rect.height(); ++y)
+        __builtin_memcpy(bitmap_snapshot->scanline(y), source_bitmap.scanline(source_rect.y() + y) + source_rect.x(), static_cast<size_t>(source_rect.width()) * sizeof(Gfx::RawPixel));
+    canvas_command_list.append(Gfx::CanvasCommands::Save {});
+    canvas_command_list.append(Gfx::CanvasCommands::SetTransform { .transform = {} });
+    canvas_command_list.append(Gfx::CanvasCommands::DrawBitmap {
+        .frame = Gfx::DecodedImageFrame { *bitmap_snapshot, Gfx::AlphaType::Unpremultiplied },
+        .dst_rect = dst_rect,
+        .src_rect = bitmap_snapshot->rect(),
+        .filter = {},
+    });
+    canvas_command_list.append(Gfx::CanvasCommands::Restore {});
 
     did_draw(dst_rect);
 
@@ -696,7 +749,7 @@ void CanvasRenderingContext2D::reset_to_default_state()
 
     // 1. Clear canvas's bitmap to transparent black.
     if (surface) {
-        painter()->clear_rect(surface->rect().to_type<float>(), clear_color());
+        canvas_command_list()->append(Gfx::CanvasCommands::ClearRect { .rect = surface->rect().to_type<float>(), .color = clear_color() });
     }
 
     // 2. Empty the list of subpaths in context's current default path.
@@ -709,7 +762,7 @@ void CanvasRenderingContext2D::reset_to_default_state()
     reset_drawing_state();
 
     if (surface) {
-        painter()->reset();
+        canvas_command_list()->append(Gfx::CanvasCommands::Reset {});
         did_draw(surface->rect().to_type<float>());
     }
 }
@@ -855,11 +908,11 @@ CanvasRenderingContext2D::PreparedText CanvasRenderingContext2D::prepare_text(Ut
 
 void CanvasRenderingContext2D::clip_internal(Gfx::Path& path, Gfx::WindingRule winding_rule)
 {
-    auto* painter = this->painter();
-    if (!painter)
+    auto* canvas_command_list = this->canvas_command_list();
+    if (!canvas_command_list)
         return;
 
-    painter->clip(path, winding_rule);
+    canvas_command_list->append(Gfx::CanvasCommands::ClipPath { .path = path.clone(), .winding_rule = winding_rule });
 }
 
 void CanvasRenderingContext2D::clip(StringView fill_rule)
@@ -1152,8 +1205,8 @@ void CanvasRenderingContext2D::set_shadow_color(String color)
 }
 void CanvasRenderingContext2D::paint_shadow_for_fill_internal(Gfx::Path const& path, Gfx::WindingRule winding_rule)
 {
-    auto* painter = this->painter();
-    if (!painter)
+    auto* canvas_command_list = this->canvas_command_list();
+    if (!canvas_command_list)
         return;
 
     auto& state = this->drawing_state();
@@ -1170,23 +1223,30 @@ void CanvasRenderingContext2D::paint_shadow_for_fill_internal(Gfx::Path const& p
     if (alpha == 0.0f)
         return;
 
-    painter->save();
+    canvas_command_list->append(Gfx::CanvasCommands::Save {});
 
     Gfx::AffineTransform transform;
     transform.translate(state.shadow_offset_x, state.shadow_offset_y);
     transform.multiply(state.transform);
-    painter->set_transform(transform);
-    painter->fill_path(path, state.shadow_color.with_opacity(alpha), winding_rule, state.shadow_blur, state.current_compositing_and_blending_operator);
+    canvas_command_list->append(Gfx::CanvasCommands::SetTransform { .transform = transform });
+    canvas_command_list->append(Gfx::CanvasCommands::FillPath {
+        .path = path.clone(),
+        .style = state.shadow_color.with_opacity(alpha),
+        .winding_rule = winding_rule,
+        .blur_radius = state.shadow_blur,
+        .filter = state.filter,
+        .compositing_and_blending_operator = state.current_compositing_and_blending_operator,
+    });
 
-    painter->restore();
+    canvas_command_list->append(Gfx::CanvasCommands::Restore {});
 
     did_draw(path.bounding_box());
 }
 
 void CanvasRenderingContext2D::paint_shadow_for_stroke_internal(Gfx::Path const& path, Gfx::Path::CapStyle line_cap, Gfx::Path::JoinStyle line_join, Vector<float> const& dash_array)
 {
-    auto* painter = this->painter();
-    if (!painter)
+    auto* canvas_command_list = this->canvas_command_list();
+    if (!canvas_command_list)
         return;
 
     auto& state = drawing_state();
@@ -1204,15 +1264,27 @@ void CanvasRenderingContext2D::paint_shadow_for_stroke_internal(Gfx::Path const&
     if (alpha == 0.0f)
         return;
 
-    painter->save();
+    canvas_command_list->append(Gfx::CanvasCommands::Save {});
 
     Gfx::AffineTransform transform;
     transform.translate(state.shadow_offset_x, state.shadow_offset_y);
     transform.multiply(state.transform);
-    painter->set_transform(transform);
-    painter->stroke_path(path, state.shadow_color.with_opacity(alpha), state.line_width, state.shadow_blur, state.current_compositing_and_blending_operator, line_cap, line_join, state.miter_limit, dash_array, state.line_dash_offset);
+    canvas_command_list->append(Gfx::CanvasCommands::SetTransform { .transform = transform });
+    canvas_command_list->append(Gfx::CanvasCommands::StrokePath {
+        .path = path.clone(),
+        .style = state.shadow_color.with_opacity(alpha),
+        .thickness = state.line_width,
+        .cap_style = line_cap,
+        .join_style = line_join,
+        .miter_limit = state.miter_limit,
+        .dash_array = dash_array,
+        .dash_offset = state.line_dash_offset,
+        .blur_radius = state.shadow_blur,
+        .filter = state.filter,
+        .compositing_and_blending_operator = state.current_compositing_and_blending_operator,
+    });
 
-    painter->restore();
+    canvas_command_list->append(Gfx::CanvasCommands::Restore {});
 
     did_draw(path.bounding_box());
 }

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <AK/String.h>
+#include <LibGfx/CanvasCommandList.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/TextLayout.h>
 #include <LibWeb/Bindings/PlatformObject.h>
@@ -81,7 +81,7 @@ public:
     virtual WebIDL::ExceptionOr<GC::Ptr<ImageData>> get_image_data(int x, int y, int width, int height, Optional<Bindings::ImageDataSettings> const& settings = {}) const override;
     virtual WebIDL::ExceptionOr<void> put_image_data(ImageData&, float x, float y) override;
     virtual WebIDL::ExceptionOr<void> put_image_data(ImageData&, float x, float y, float dirty_x, float dirty_y, float dirty_width, float dirty_height) override;
-    WebIDL::ExceptionOr<void> put_pixels_from_an_image_data_onto_a_bitmap(ImageData&, Gfx::Painter&, float dx, float dy, float dirty_x, float dirty_y, float dirty_width, float dirty_height);
+    WebIDL::ExceptionOr<void> put_pixels_from_an_image_data_onto_a_bitmap(ImageData&, Gfx::CanvasCommandList&, float dx, float dy, float dirty_x, float dirty_y, float dirty_width, float dirty_height);
 
     virtual void reset_to_default_state() override;
 
@@ -123,11 +123,11 @@ public:
     void set_size(Gfx::IntSize const&);
     void present();
 
-    RefPtr<Gfx::PaintingSurface> surface() { return m_surface; }
+    RefPtr<Gfx::PaintingSurface> surface();
     void allocate_painting_surface_if_needed();
 
 protected:
-    [[nodiscard]] Gfx::Painter* painter() override;
+    [[nodiscard]] Gfx::CanvasCommandList* canvas_command_list() override;
     Variant<GC::Ref<HTMLCanvasElement>, GC::Ref<OffscreenCanvas>> canvas_element() override { return m_element; }
     Variant<GC::Ref<HTMLCanvasElement>, GC::Ref<OffscreenCanvas>> canvas_element() const override { return m_element; }
     JS::Realm& my_realm() override { return realm(); }
@@ -159,20 +159,23 @@ private:
 
     Gfx::Color clear_color() const;
 
-    void stroke_internal(Gfx::Path const&);
-    void fill_internal(Gfx::Path const&, Gfx::WindingRule);
+    void stroke_internal(Gfx::Path);
+    void fill_internal(Gfx::Path, Gfx::WindingRule);
     void clip_internal(Gfx::Path&, Gfx::WindingRule);
     void paint_shadow_for_fill_internal(Gfx::Path const&, Gfx::WindingRule);
     void paint_shadow_for_stroke_internal(Gfx::Path const&, Gfx::Path::CapStyle, Gfx::Path::JoinStyle, Vector<float> const&);
 
+    void flush_recorded_commands();
+
     GC::Ref<HTMLCanvasElement> m_element;
-    OwnPtr<Gfx::Painter> m_painter;
+
+    Gfx::CanvasCommandList m_commands;
+    OwnPtr<Gfx::CanvasCommandPlayer> m_player;
 
     // https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-origin-clean
     bool m_origin_clean { true };
 
     Gfx::IntSize m_size;
-    RefPtr<Gfx::PaintingSurface> m_surface;
     Bindings::CanvasRenderingContext2DSettings m_context_attributes;
 };
 

--- a/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.cpp
@@ -322,9 +322,9 @@ void OffscreenCanvasRenderingContext2D::set_global_composite_operation(String)
     dbgln("(STUBBED) OffscreenCanvasRenderingContext2D::set_global_composite_operation()");
 }
 
-[[nodiscard]] Gfx::Painter* OffscreenCanvasRenderingContext2D::painter()
+[[nodiscard]] Gfx::CanvasCommandList* OffscreenCanvasRenderingContext2D::canvas_command_list()
 {
-    dbgln("(STUBBED) OffscreenCanvasRenderingContext2D::painter()");
+    dbgln("(STUBBED) OffscreenCanvasRenderingContext2D::canvas_command_list()");
     return nullptr;
 }
 

--- a/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.h
@@ -11,7 +11,6 @@
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/DOM/EventTarget.h>
@@ -125,7 +124,7 @@ public:
     void set_size(Gfx::IntSize const&);
 
 protected:
-    [[nodiscard]] Gfx::Painter* painter() override;
+    [[nodiscard]] Gfx::CanvasCommandList* canvas_command_list() override;
     Variant<GC::Ref<HTMLCanvasElement>, GC::Ref<OffscreenCanvas>> canvas_element() override { return m_canvas; }
     Variant<GC::Ref<HTMLCanvasElement>, GC::Ref<OffscreenCanvas>> canvas_element() const override { return m_canvas; }
     JS::Realm& my_realm() override { return realm(); }

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -182,48 +182,48 @@ void DisplayListPlayer::execute_impl(
         [&](VisualContextIndex, AccumulatedVisualContextNode const& node) {
             node.data.visit(
                 [&](EffectsData const& effects) {
-                    apply_effects({
-                                      .opacity = effects.opacity,
-                                      .compositing_and_blending_operator = effects.blend_mode,
-                                      .has_filter = effects.gfx_filter.has_value(),
-                                      .filter_data = {},
-                                  },
+                    play_command(ApplyEffects {
+                                     .opacity = effects.opacity,
+                                     .compositing_and_blending_operator = effects.blend_mode,
+                                     .has_filter = effects.gfx_filter.has_value(),
+                                     .filter_data = {},
+                                 },
                         effects.gfx_filter.has_value() ? &effects.gfx_filter.value() : nullptr);
                 },
                 [&](PerspectiveData const& perspective) {
-                    save({});
+                    play_command(Save {});
                     apply_transform({ 0, 0 }, perspective.matrix);
                 },
                 [&](ScrollData const& scroll) {
-                    save({});
+                    play_command(Save {});
                     auto offset = scroll_state.device_offset_for_index(scroll.scroll_frame_index);
                     if (!offset.is_zero())
-                        translate({ .delta = offset.to_type<int>() });
+                        play_command(Translate { .delta = offset.to_type<int>() });
                 },
                 [&](ScrollCompensation const& compensation) {
-                    save({});
+                    play_command(Save {});
                     auto offset = scroll_state.device_offset_for_index(compensation.scroll_frame_index);
                     if (!offset.is_zero())
-                        translate({ .delta = (-offset).to_type<int>() });
+                        play_command(Translate { .delta = (-offset).to_type<int>() });
                 },
                 [&](TransformData const& transform) {
-                    save({});
+                    play_command(Save {});
                     apply_transform(transform.origin, transform.matrix);
                 },
                 [&](ClipData const& clip) {
-                    save({});
+                    play_command(Save {});
                     if (clip.corner_radii.has_any_radius()) {
-                        add_rounded_rect_clip({
+                        play_command(AddRoundedRectClip {
                             .corner_radii = clip.corner_radii,
                             .border_rect = clip.rect.to_type<int>(),
                             .corner_clip = Gfx::CornerClip::Outside,
                         });
                     } else {
-                        add_clip_rect({ .rect = clip.rect.to_type<int>() });
+                        play_command(AddClipRect { .rect = clip.rect.to_type<int>() });
                     }
                 },
                 [&](ClipPathData const& clip_path) {
-                    save({});
+                    play_command(Save {});
                     add_clip_path(clip_path.path);
                 });
         };
@@ -266,7 +266,7 @@ void DisplayListPlayer::execute_impl(
 
         auto restore_to_depth = [&](size_t target_depth) {
             while (applied_depth > target_depth) {
-                restore({});
+                play_command(Restore {});
                 --applied_depth;
             }
         };
@@ -314,9 +314,9 @@ void DisplayListPlayer::execute_impl(
             // so replace it with one to avoid doing unnecessary work.
             if (header.is_clip) {
                 if (header.type == DisplayListCommandType::AddClipRect)
-                    add_clip_rect(read_display_list_command_payload<AddClipRect>(payload));
+                    play_command(read_display_list_command_payload<AddClipRect>(payload));
                 else
-                    add_clip_rect({ bounding_rect.release_value() });
+                    play_command(AddClipRect { bounding_rect.release_value() });
             }
             return;
         }
@@ -338,7 +338,7 @@ void DisplayListPlayer::execute_impl(
 #define DISPATCH_DISPLAY_LIST_COMMAND(command_type, player_method)                    \
     case DisplayListCommandType::command_type:                                        \
         dispatch_command.template operator()<command_type>([&](auto const& command) { \
-            player_method(command);                                                   \
+            play_command(command);                                                    \
         });                                                                           \
         break;
             ENUMERATE_DISPLAY_LIST_COMMANDS(DISPATCH_DISPLAY_LIST_COMMAND)
@@ -347,7 +347,7 @@ void DisplayListPlayer::execute_impl(
     });
 
     while (applied_depth > 0) {
-        restore({});
+        play_command(Restore {});
         applied_depth--;
     }
 }

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -60,42 +60,11 @@ protected:
     void execute_nested_display_list(DisplayList const&, AccumulatedVisualContextTree const&, ScrollStateSnapshot const&, ReadonlyBytes command_bytes);
 
 private:
-    virtual void draw_glyph_run(DrawGlyphRun const&) = 0;
-    virtual void fill_rect(FillRect const&) = 0;
-    virtual void draw_scaled_decoded_image_frame(DrawScaledDecodedImageFrame const&) = 0;
-    virtual void draw_repeated_decoded_image_frame(DrawRepeatedDecodedImageFrame const&) = 0;
-    virtual void draw_compositor_surface(DrawCompositorSurface const&) = 0;
-    virtual void draw_video_frame(DrawVideoFrame const&) = 0;
-    virtual void save(Save const&) = 0;
-    virtual void save_layer(SaveLayer const&) = 0;
-    virtual void restore(Restore const&) = 0;
-    virtual void translate(Translate const&) = 0;
-    virtual void add_clip_rect(AddClipRect const&) = 0;
-    virtual void paint_linear_gradient(PaintLinearGradient const&) = 0;
-    virtual void paint_radial_gradient(PaintRadialGradient const&) = 0;
-    virtual void paint_conic_gradient(PaintConicGradient const&) = 0;
-    virtual void paint_outer_box_shadow(PaintOuterBoxShadow const&) = 0;
-    virtual void paint_inner_box_shadow(PaintInnerBoxShadow const&) = 0;
-    virtual void paint_text_shadow(PaintTextShadow const&) = 0;
-    virtual void fill_rect_with_rounded_corners(FillRectWithRoundedCorners const&) = 0;
-    virtual void fill_path(FillPath const&) = 0;
-    virtual void stroke_path(StrokePath const&) = 0;
-    virtual void draw_ellipse(DrawEllipse const&) = 0;
-    virtual void fill_ellipse(FillEllipse const&) = 0;
-    virtual void draw_line(DrawLine const&) = 0;
-    virtual void apply_backdrop_filter(ApplyBackdropFilter const&) = 0;
-    virtual void draw_rect(DrawRect const&) = 0;
-    virtual void add_rounded_rect_clip(AddRoundedRectClip const&) = 0;
-    virtual void paint_nested_display_list(PaintNestedDisplayList const&) = 0;
-    virtual void compositor_scroll_node(CompositorScrollNode const&) = 0;
-    virtual void compositor_sticky_area(CompositorStickyArea const&) = 0;
-    virtual void compositor_wheel_hit_test_target(CompositorWheelHitTestTarget const&) = 0;
-    virtual void compositor_wheel_hit_test_target_with_corner_radii(CompositorWheelHitTestTargetWithCornerRadii const&) = 0;
-    virtual void compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&) = 0;
-    virtual void compositor_viewport_scrollbar(CompositorViewportScrollbar const&) = 0;
-    virtual void compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&) = 0;
-    virtual void paint_scrollbar(PaintScrollBar const&) = 0;
-    virtual void apply_effects(ApplyEffects const&, Gfx::Filter const* = nullptr) = 0;
+#define DECLARE_PLAY_COMMAND(command_type, player_method) \
+    virtual void play_command(command_type const&) = 0;
+    ENUMERATE_DISPLAY_LIST_COMMANDS(DECLARE_PLAY_COMMAND)
+#undef DECLARE_PLAY_COMMAND
+    virtual void play_command(ApplyEffects const&, Gfx::Filter const*) = 0;
     virtual void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
 

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -155,7 +155,7 @@ void DisplayListPlayerSkia::paint_scrollbar(Gfx::PaintingSurface& surface, Paint
     paint_scrollbar_into_surface(surface, command);
 }
 
-void DisplayListPlayerSkia::draw_glyph_run(DrawGlyphRun const& command)
+void DisplayListPlayerSkia::play_command(DrawGlyphRun const& command)
 {
     auto const& font = resource_storage().font(command.font_id);
     auto glyphs = inline_objects<DisplayListGlyph>(command.glyphs);
@@ -197,7 +197,7 @@ void DisplayListPlayerSkia::draw_glyph_run(DrawGlyphRun const& command)
     }
 }
 
-void DisplayListPlayerSkia::fill_rect(FillRect const& command)
+void DisplayListPlayerSkia::play_command(FillRect const& command)
 {
     auto const& rect = command.rect;
     auto& canvas = surface().canvas();
@@ -207,7 +207,7 @@ void DisplayListPlayerSkia::fill_rect(FillRect const& command)
     canvas.drawRect(to_skia_rect(rect), paint);
 }
 
-void DisplayListPlayerSkia::draw_compositor_surface(DrawCompositorSurface const& command)
+void DisplayListPlayerSkia::play_command(DrawCompositorSurface const& command)
 {
     auto frame = resource_storage().compositor_surface(command.surface_id);
     if (!frame.has_value())
@@ -225,7 +225,7 @@ void DisplayListPlayerSkia::draw_compositor_surface(DrawCompositorSurface const&
     canvas.drawImageRect(image.get(), src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
 }
 
-void DisplayListPlayerSkia::draw_video_frame(DrawVideoFrame const& command)
+void DisplayListPlayerSkia::play_command(DrawVideoFrame const& command)
 {
     auto frame = resource_storage().video_frame(command.video_frame_id);
     if (!frame)
@@ -268,7 +268,7 @@ void DisplayListPlayerSkia::draw_video_frame(DrawVideoFrame const& command)
     canvas.drawImageRect(image.get(), src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
 }
 
-void DisplayListPlayerSkia::draw_scaled_decoded_image_frame(DrawScaledDecodedImageFrame const& command)
+void DisplayListPlayerSkia::play_command(DrawScaledDecodedImageFrame const& command)
 {
     auto const& frame = resource_storage().image_frame(command.frame_id);
     auto image = m_image_cache.image_for_frame(frame);
@@ -285,7 +285,7 @@ void DisplayListPlayerSkia::draw_scaled_decoded_image_frame(DrawScaledDecodedIma
     canvas.restore();
 }
 
-void DisplayListPlayerSkia::draw_repeated_decoded_image_frame(DrawRepeatedDecodedImageFrame const& command)
+void DisplayListPlayerSkia::play_command(DrawRepeatedDecodedImageFrame const& command)
 {
     auto const& frame = resource_storage().image_frame(command.frame_id);
     auto image = m_image_cache.image_for_frame(frame);
@@ -310,32 +310,32 @@ void DisplayListPlayerSkia::draw_repeated_decoded_image_frame(DrawRepeatedDecode
     canvas.drawPaint(paint);
 }
 
-void DisplayListPlayerSkia::add_clip_rect(AddClipRect const& command)
+void DisplayListPlayerSkia::play_command(AddClipRect const& command)
 {
     auto& canvas = surface().canvas();
     auto const& rect = command.rect;
     canvas.clipRect(to_skia_rect(rect), true);
 }
 
-void DisplayListPlayerSkia::save(Save const&)
+void DisplayListPlayerSkia::play_command(Save const&)
 {
     auto& canvas = surface().canvas();
     canvas.save();
 }
 
-void DisplayListPlayerSkia::save_layer(SaveLayer const&)
+void DisplayListPlayerSkia::play_command(SaveLayer const&)
 {
     auto& canvas = surface().canvas();
     canvas.saveLayer(nullptr, nullptr);
 }
 
-void DisplayListPlayerSkia::restore(Restore const&)
+void DisplayListPlayerSkia::play_command(Restore const&)
 {
     auto& canvas = surface().canvas();
     canvas.restore();
 }
 
-void DisplayListPlayerSkia::translate(Translate const& command)
+void DisplayListPlayerSkia::play_command(Translate const& command)
 {
     auto& canvas = surface().canvas();
     canvas.translate(command.delta.x(), command.delta.y());
@@ -435,7 +435,7 @@ static Vector<SkColor4f> to_skia_gradient_colors(ReadonlySpan<Color> color_stop_
     return colors;
 }
 
-void DisplayListPlayerSkia::paint_linear_gradient(PaintLinearGradient const& command)
+void DisplayListPlayerSkia::play_command(PaintLinearGradient const& command)
 {
     auto color_stop_colors = gradient_colors(command.color_stops);
     auto color_stop_positions = gradient_positions(command.color_stops);
@@ -465,7 +465,7 @@ void DisplayListPlayerSkia::paint_linear_gradient(PaintLinearGradient const& com
     surface().canvas().drawRect(to_skia_rect(rect), paint);
 }
 
-void DisplayListPlayerSkia::paint_outer_box_shadow(PaintOuterBoxShadow const& command)
+void DisplayListPlayerSkia::play_command(PaintOuterBoxShadow const& command)
 {
     auto content_rrect = to_skia_rrect(command.device_content_rect, command.content_corner_radii);
 
@@ -481,7 +481,7 @@ void DisplayListPlayerSkia::paint_outer_box_shadow(PaintOuterBoxShadow const& co
     canvas.restore();
 }
 
-void DisplayListPlayerSkia::paint_inner_box_shadow(PaintInnerBoxShadow const& command)
+void DisplayListPlayerSkia::play_command(PaintInnerBoxShadow const& command)
 {
     auto outer_rect = to_skia_rrect(command.outer_shadow_rect, command.content_corner_radii);
     auto inner_rect = to_skia_rrect(command.inner_shadow_rect, command.inner_shadow_corner_radii);
@@ -507,14 +507,14 @@ void DisplayListPlayerSkia::paint_inner_box_shadow(PaintInnerBoxShadow const& co
     canvas.restore();
 }
 
-void DisplayListPlayerSkia::paint_text_shadow(PaintTextShadow const& command)
+void DisplayListPlayerSkia::play_command(PaintTextShadow const& command)
 {
     auto& canvas = surface().canvas();
     auto blur_image_filter = SkImageFilters::Blur(command.blur_radius / 2, command.blur_radius / 2, nullptr);
     SkPaint blur_paint;
     blur_paint.setImageFilter(blur_image_filter);
     canvas.saveLayer(SkCanvas::SaveLayerRec(nullptr, &blur_paint, nullptr, 0));
-    draw_glyph_run({ .font_id = command.font_id,
+    play_command(DrawGlyphRun { .font_id = command.font_id,
         .glyphs = command.glyphs,
         .rect = command.text_rect,
         .glyph_bounding_rect = command.shadow_bounding_rect,
@@ -524,7 +524,7 @@ void DisplayListPlayerSkia::paint_text_shadow(PaintTextShadow const& command)
     canvas.restore();
 }
 
-void DisplayListPlayerSkia::fill_rect_with_rounded_corners(FillRectWithRoundedCorners const& command)
+void DisplayListPlayerSkia::play_command(FillRectWithRoundedCorners const& command)
 {
     auto const& rect = command.rect;
 
@@ -653,7 +653,7 @@ Gfx::Path DisplayListPlayerSkia::path_from_data(DisplayListDataSpan path_data) c
     return Gfx::Path::from_serialized_bytes(bytes);
 }
 
-void DisplayListPlayerSkia::fill_path(FillPath const& command)
+void DisplayListPlayerSkia::play_command(FillPath const& command)
 {
     auto path = Gfx::to_skia_path(path_from_data(command.path_data));
     path.setFillType(to_skia_path_fill_type(command.winding_rule));
@@ -669,7 +669,7 @@ void DisplayListPlayerSkia::fill_path(FillPath const& command)
     surface().canvas().drawPath(path, paint);
 }
 
-void DisplayListPlayerSkia::stroke_path(StrokePath const& command)
+void DisplayListPlayerSkia::play_command(StrokePath const& command)
 {
     auto path = Gfx::to_skia_path(path_from_data(command.path_data));
     SkPaint paint;
@@ -690,7 +690,7 @@ void DisplayListPlayerSkia::stroke_path(StrokePath const& command)
     surface().canvas().drawPath(path, paint);
 }
 
-void DisplayListPlayerSkia::draw_ellipse(DrawEllipse const& command)
+void DisplayListPlayerSkia::play_command(DrawEllipse const& command)
 {
     auto const& rect = command.rect;
     auto& canvas = surface().canvas();
@@ -702,7 +702,7 @@ void DisplayListPlayerSkia::draw_ellipse(DrawEllipse const& command)
     canvas.drawOval(to_skia_rect(rect), paint);
 }
 
-void DisplayListPlayerSkia::fill_ellipse(FillEllipse const& command)
+void DisplayListPlayerSkia::play_command(FillEllipse const& command)
 {
     auto const& rect = command.rect;
     auto& canvas = surface().canvas();
@@ -712,7 +712,7 @@ void DisplayListPlayerSkia::fill_ellipse(FillEllipse const& command)
     canvas.drawOval(to_skia_rect(rect), paint);
 }
 
-void DisplayListPlayerSkia::draw_line(DrawLine const& command)
+void DisplayListPlayerSkia::play_command(DrawLine const& command)
 {
     auto from = to_skia_point(command.from);
     auto to = to_skia_point(command.to);
@@ -759,7 +759,7 @@ void DisplayListPlayerSkia::draw_line(DrawLine const& command)
     canvas.drawLine(from, to, paint);
 }
 
-void DisplayListPlayerSkia::apply_backdrop_filter(ApplyBackdropFilter const& command)
+void DisplayListPlayerSkia::play_command(ApplyBackdropFilter const& command)
 {
     auto& canvas = surface().canvas();
 
@@ -778,7 +778,7 @@ void DisplayListPlayerSkia::apply_backdrop_filter(ApplyBackdropFilter const& com
     }
 }
 
-void DisplayListPlayerSkia::draw_rect(DrawRect const& command)
+void DisplayListPlayerSkia::play_command(DrawRect const& command)
 {
     auto const& rect = command.rect;
     auto& canvas = surface().canvas();
@@ -790,7 +790,7 @@ void DisplayListPlayerSkia::draw_rect(DrawRect const& command)
     canvas.drawRect(to_skia_rect(rect), paint);
 }
 
-void DisplayListPlayerSkia::paint_radial_gradient(PaintRadialGradient const& command)
+void DisplayListPlayerSkia::play_command(PaintRadialGradient const& command)
 {
     auto color_stop_colors = gradient_colors(command.color_stops);
     auto color_stop_positions = gradient_positions(command.color_stops);
@@ -822,7 +822,7 @@ void DisplayListPlayerSkia::paint_radial_gradient(PaintRadialGradient const& com
     surface().canvas().drawRect(to_skia_rect(rect), paint);
 }
 
-void DisplayListPlayerSkia::paint_conic_gradient(PaintConicGradient const& command)
+void DisplayListPlayerSkia::play_command(PaintConicGradient const& command)
 {
     auto color_stop_colors = gradient_colors(command.color_stops);
     auto color_stop_positions = gradient_positions(command.color_stops);
@@ -846,7 +846,7 @@ void DisplayListPlayerSkia::paint_conic_gradient(PaintConicGradient const& comma
     surface().canvas().drawRect(to_skia_rect(rect), paint);
 }
 
-void DisplayListPlayerSkia::add_rounded_rect_clip(AddRoundedRectClip const& command)
+void DisplayListPlayerSkia::play_command(AddRoundedRectClip const& command)
 {
     auto rounded_rect = to_skia_rrect(command.border_rect, command.corner_radii);
     auto& canvas = surface().canvas();
@@ -854,7 +854,7 @@ void DisplayListPlayerSkia::add_rounded_rect_clip(AddRoundedRectClip const& comm
     canvas.clipRRect(rounded_rect, clip_op, true);
 }
 
-void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList const& command)
+void DisplayListPlayerSkia::play_command(PaintNestedDisplayList const& command)
 {
     auto& canvas = surface().canvas();
     canvas.save();
@@ -870,40 +870,45 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
     canvas.restore();
 }
 
-void DisplayListPlayerSkia::compositor_scroll_node(CompositorScrollNode const&)
+void DisplayListPlayerSkia::play_command(CompositorScrollNode const&)
 {
 }
 
-void DisplayListPlayerSkia::compositor_sticky_area(CompositorStickyArea const&)
+void DisplayListPlayerSkia::play_command(CompositorStickyArea const&)
 {
 }
 
-void DisplayListPlayerSkia::compositor_wheel_hit_test_target(CompositorWheelHitTestTarget const&)
+void DisplayListPlayerSkia::play_command(CompositorWheelHitTestTarget const&)
 {
 }
 
-void DisplayListPlayerSkia::compositor_wheel_hit_test_target_with_corner_radii(CompositorWheelHitTestTargetWithCornerRadii const&)
+void DisplayListPlayerSkia::play_command(CompositorWheelHitTestTargetWithCornerRadii const&)
 {
 }
 
-void DisplayListPlayerSkia::compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&)
+void DisplayListPlayerSkia::play_command(CompositorMainThreadWheelEventRegion const&)
 {
 }
 
-void DisplayListPlayerSkia::compositor_viewport_scrollbar(CompositorViewportScrollbar const&)
+void DisplayListPlayerSkia::play_command(CompositorViewportScrollbar const&)
 {
 }
 
-void DisplayListPlayerSkia::compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&)
+void DisplayListPlayerSkia::play_command(CompositorBlockingWheelEventRegion const&)
 {
 }
 
-void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)
+void DisplayListPlayerSkia::play_command(PaintScrollBar const& command)
 {
     paint_scrollbar_into_surface(surface(), command);
 }
 
-void DisplayListPlayerSkia::apply_effects(ApplyEffects const& command, Gfx::Filter const* filter)
+void DisplayListPlayerSkia::play_command(ApplyEffects const& command)
+{
+    play_command(command, nullptr);
+}
+
+void DisplayListPlayerSkia::play_command(ApplyEffects const& command, Gfx::Filter const* filter)
 {
     auto& canvas = surface().canvas();
     SkPaint paint;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -28,42 +28,11 @@ public:
     void paint_scrollbar(Gfx::PaintingSurface&, PaintScrollBar const&);
 
 private:
-    void draw_glyph_run(DrawGlyphRun const&) override;
-    void fill_rect(FillRect const&) override;
-    void draw_scaled_decoded_image_frame(DrawScaledDecodedImageFrame const&) override;
-    void draw_repeated_decoded_image_frame(DrawRepeatedDecodedImageFrame const&) override;
-    void draw_compositor_surface(DrawCompositorSurface const&) override;
-    void draw_video_frame(DrawVideoFrame const&) override;
-    void add_clip_rect(AddClipRect const&) override;
-    void save(Save const&) override;
-    void save_layer(SaveLayer const&) override;
-    void restore(Restore const&) override;
-    void translate(Translate const&) override;
-    void paint_linear_gradient(PaintLinearGradient const&) override;
-    void paint_outer_box_shadow(PaintOuterBoxShadow const&) override;
-    void paint_inner_box_shadow(PaintInnerBoxShadow const&) override;
-    void paint_text_shadow(PaintTextShadow const&) override;
-    void fill_rect_with_rounded_corners(FillRectWithRoundedCorners const&) override;
-    void fill_path(FillPath const&) override;
-    void stroke_path(StrokePath const&) override;
-    void draw_ellipse(DrawEllipse const&) override;
-    void fill_ellipse(FillEllipse const&) override;
-    void draw_line(DrawLine const&) override;
-    void apply_backdrop_filter(ApplyBackdropFilter const&) override;
-    void draw_rect(DrawRect const&) override;
-    void paint_radial_gradient(PaintRadialGradient const&) override;
-    void paint_conic_gradient(PaintConicGradient const&) override;
-    void add_rounded_rect_clip(AddRoundedRectClip const&) override;
-    void compositor_scroll_node(CompositorScrollNode const&) override;
-    void compositor_sticky_area(CompositorStickyArea const&) override;
-    void compositor_wheel_hit_test_target(CompositorWheelHitTestTarget const&) override;
-    void compositor_wheel_hit_test_target_with_corner_radii(CompositorWheelHitTestTargetWithCornerRadii const&) override;
-    void compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&) override;
-    void compositor_viewport_scrollbar(CompositorViewportScrollbar const&) override;
-    void compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&) override;
-    void paint_scrollbar(PaintScrollBar const&) override;
-    void paint_nested_display_list(PaintNestedDisplayList const&) override;
-    void apply_effects(ApplyEffects const&, Gfx::Filter const*) override;
+#define DECLARE_PLAY_COMMAND(command_type, player_method) \
+    void play_command(command_type const&) override;
+    ENUMERATE_DISPLAY_LIST_COMMANDS(DECLARE_PLAY_COMMAND)
+#undef DECLARE_PLAY_COMMAND
+    void play_command(ApplyEffects const&, Gfx::Filter const*) override;
     void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 const&) override;
 
     void add_clip_path(Gfx::Path const&) override;


### PR DESCRIPTION
Instead of having CanvasRenderingContext2D paint directly into a WebContent-owned surface, canvas drawing now records LibGfx canvas commands and replays them through a CanvasCommandPlayer. Playback still happens locally with this changes, but the API shape now matches the future compositor-process path: WebContent produces a mutation stream, and the surface owner replays it.