### PR TITLE
LibWeb: Always treat [Replaceable] attributes as having setters 

### DIFF
--- a/Meta/Generators/libweb_bindings/attributes.py
+++ b/Meta/Generators/libweb_bindings/attributes.py
@@ -22,12 +22,12 @@ from Utils.webidl_parser import IDLType
 from Utils.webidl_parser import Interface
 
 
-def attribute_has_setter(attribute: Attribute, include_replaceable: bool = False) -> bool:
+def attribute_has_setter(attribute: Attribute) -> bool:
     return (
         not attribute.readonly
         or "LegacyLenientSetter" in attribute.extended_attributes
         or "PutForwards" in attribute.extended_attributes
-        or (include_replaceable and "Replaceable" in attribute.extended_attributes)
+        or "Replaceable" in attribute.extended_attributes
     )
 
 
@@ -73,7 +73,6 @@ def define_the_regular_attributes(
     out: TextIO,
     includes: GeneratedIncludes,
     interface: Interface,
-    include_replaceable_setters: bool = False,
 ) -> None:
     # 1. Let attributes be the list of regular attributes that are members of definition.
     attributes = [
@@ -84,21 +83,20 @@ def define_the_regular_attributes(
     attributes = [attribute for attribute in attributes if "LegacyUnforgeable" not in attribute.extended_attributes]
 
     # 3. Define the attributes attributes of definition on target given realm.
-    define_the_attributes(out, includes, attributes, interface, include_replaceable_setters)
+    define_the_attributes(out, includes, attributes, interface)
 
 
 def define_the_unforgeable_attributes(
     out: TextIO,
     includes: GeneratedIncludes,
     interface: Interface,
-    include_replaceable_setters: bool = False,
 ) -> None:
     attributes = [
         attribute
         for attribute in interface.regular_attributes
         if "FIXME" not in attribute.extended_attributes and "LegacyUnforgeable" in attribute.extended_attributes
     ]
-    define_the_attributes(out, includes, attributes, interface, include_replaceable_setters)
+    define_the_attributes(out, includes, attributes, interface)
 
 
 def define_the_attributes(
@@ -106,7 +104,6 @@ def define_the_attributes(
     includes: GeneratedIncludes,
     attributes: list[Attribute],
     interface: Interface,
-    include_replaceable_setters: bool = False,
 ) -> None:
     if not attributes:
         return
@@ -139,7 +136,7 @@ def define_the_attributes(
             )
 
         # 3. Let setter be the result of creating an attribute setter given attr, definition, and realm.
-        if not attribute_has_setter(attribute, include_replaceable=include_replaceable_setters):
+        if not attribute_has_setter(attribute):
             # NB: the algorithm to create an attribute setter returns undefined if attr is read only.
             definition.write(f"    GC::Ptr<JS::NativeFunction> {native_setter_name};\n")
         else:

--- a/Meta/Generators/libweb_bindings/global_mixins.py
+++ b/Meta/Generators/libweb_bindings/global_mixins.py
@@ -44,7 +44,7 @@ private:
         if getter_callback not in declared_callbacks:
             declared_callbacks.add(getter_callback)
             out.write(f"    JS_DECLARE_NATIVE_FUNCTION({getter_callback});\n")
-        if attribute_has_setter(attribute, include_replaceable=True):
+        if attribute_has_setter(attribute):
             setter_callback = attribute_setter_callback_name(attribute)
             if setter_callback not in declared_callbacks:
                 declared_callbacks.add(setter_callback)
@@ -91,7 +91,7 @@ void {interface.name}GlobalMixin::initialize(JS::Realm& realm, [[maybe_unused]] 
     object.set_prototype(&ensure_web_prototype<{interface.prototype_class}>(realm, "{interface.namespaced_name}"_fly_string));
 """
     )
-    define_the_regular_attributes(out, includes, interface, include_replaceable_setters=True)
+    define_the_regular_attributes(out, includes, interface)
     define_the_regular_operations(out, includes, interface)
     define_the_stringifier(out, includes, interface)
     define_the_constants(out, context, includes, interface)
@@ -104,7 +104,7 @@ void {interface.name}GlobalMixin::define_unforgeable_attributes(JS::Realm& realm
     [[maybe_unused]] u8 default_attributes = JS::Attribute::Enumerable;
 """
     )
-    define_the_unforgeable_attributes(out, includes, interface, include_replaceable_setters=True)
+    define_the_unforgeable_attributes(out, includes, interface)
     define_the_regular_operations(out, includes, interface, unforgeable=True)
     define_the_stringifier(out, includes, interface, unforgeable=True)
     out.write(
@@ -121,7 +121,7 @@ void {interface.name}GlobalMixin::define_unforgeable_attributes(JS::Realm& realm
         if getter_callback not in defined_callbacks:
             defined_callbacks.add(getter_callback)
             write_attribute_getter(out, context, includes, interface, attribute, f"{interface.name}GlobalMixin")
-        if attribute_has_setter(attribute, include_replaceable=True):
+        if attribute_has_setter(attribute):
             setter_callback = attribute_setter_callback_name(attribute)
             if setter_callback not in defined_callbacks:
                 defined_callbacks.add(setter_callback)

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -151,6 +151,7 @@ Text/input/wpt-import/html/canvas/element/manual/imagebitmap/createImageBitmap-i
 
 ; Unable to fetch from inside of the Worker due to MixedContent
 ; Fails in other browsers too when loaded from file://.
+Text/input/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.html
 Text/input/wpt-import/workers/nested_worker.worker.html
 Text/input/wpt-import/workers/nested_worker_close_from_parent_worker.html
 Text/input/wpt-import/workers/nested_worker_close_self.worker.html

--- a/Tests/LibWeb/Text/expected/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 6 tests
+
+4 Pass
+2 Fail
+Pass	Global object's getter throws when called on incompatible object
+Fail	Global object's setter throws when called on incompatible object
+Pass	Global object's operation throws when called on incompatible object
+Pass	Global object's getter works when called on null / undefined
+Fail	Global object's setter works when called on null / undefined
+Pass	Global object's operation works when called on null / undefined

--- a/Tests/LibWeb/Text/expected/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-4 Pass
-2 Fail
+6 Pass
 Pass	Global object's getter throws when called on incompatible object
-Fail	Global object's setter throws when called on incompatible object
+Pass	Global object's setter throws when called on incompatible object
 Pass	Global object's operation throws when called on incompatible object
 Pass	Global object's getter works when called on null / undefined
-Fail	Global object's setter works when called on null / undefined
+Pass	Global object's setter works when called on null / undefined
 Pass	Global object's operation works when called on null / undefined

--- a/Tests/LibWeb/Text/input/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+fetch_tests_from_worker(new Worker("../../webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.js"));
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.js
+++ b/Tests/LibWeb/Text/input/wpt-import/webidl/ecmascript-binding/global-object-implicit-this-value.any.worker.js
@@ -1,0 +1,10 @@
+
+self.GLOBAL = {
+  isWindow: function() { return false; },
+  isWorker: function() { return true; },
+  isShadowRealm: function() { return false; },
+};
+importScripts("/resources/testharness.js");
+
+importScripts("/webidl/ecmascript-binding/global-object-implicit-this-value.any.js");
+done();


### PR DESCRIPTION
[Replaceable] readonly attributes still need JS accessor setters for
replacement and receiver checks. Remove the include_replaceable opt-in
so the binding generator handles them consistently.