### PR TITLE
LibWeb: Scale `image-set()` natural size by the selected resolution

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -30,7 +30,7 @@ ImageSetStyleValue::ImageSetStyleValue(Vector<Option> options)
 {
 }
 
-AbstractImageStyleValue const* ImageSetStyleValue::select_image(double device_pixels_per_css_pixel) const
+ImageSetStyleValue::Option const* ImageSetStyleValue::select_option(double device_pixels_per_css_pixel) const
 {
     ImageSetStyleValue::Option const* best_below_or_equal = nullptr;
     Optional<double> best_below_or_equal_resolution;
@@ -58,10 +58,8 @@ AbstractImageStyleValue const* ImageSetStyleValue::select_image(double device_pi
     }
 
     if (best_above)
-        return best_above->image.ptr();
-    if (best_below_or_equal)
-        return best_below_or_equal->image.ptr();
-    return nullptr;
+        return best_above;
+    return best_below_or_equal;
 }
 
 void ImageSetStyleValue::serialize(StringBuilder& builder, SerializationMode mode) const
@@ -118,24 +116,32 @@ bool ImageSetStyleValue::is_computationally_independent() const
 void ImageSetStyleValue::load_any_resources(DOM::Document& document)
 {
     auto dpr = document.page().client().device_pixels_per_css_pixel();
-    if (auto const* image = select_image(dpr); image && image != m_selected_image)
-        m_selected_image = image;
+    if (auto const* option = select_option(dpr)) {
+        m_selected_image = option->image.ptr();
+        m_selected_resolution = Resolution::from_style_value(option->resolution).to_dots_per_pixel();
+    }
     if (m_selected_image)
         const_cast<AbstractImageStyleValue&>(*m_selected_image).load_any_resources(document);
 }
 
 Optional<CSSPixels> ImageSetStyleValue::natural_width(DOM::Document const& document) const
 {
-    if (m_selected_image)
-        return m_selected_image->natural_width(document);
-    return {};
+    if (!m_selected_image)
+        return {};
+    auto natural_width = m_selected_image->natural_width(document);
+    if (!natural_width.has_value())
+        return {};
+    return CSSPixels { natural_width->to_double() / m_selected_resolution };
 }
 
 Optional<CSSPixels> ImageSetStyleValue::natural_height(DOM::Document const& document) const
 {
-    if (m_selected_image)
-        return m_selected_image->natural_height(document);
-    return {};
+    if (!m_selected_image)
+        return {};
+    auto natural_height = m_selected_image->natural_height(document);
+    if (!natural_height.has_value())
+        return {};
+    return CSSPixels { natural_height->to_double() / m_selected_resolution };
 }
 
 Optional<CSSPixelFraction> ImageSetStyleValue::natural_aspect_ratio(DOM::Document const& document) const

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
@@ -49,10 +49,11 @@ private:
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
 
-    AbstractImageStyleValue const* select_image(double device_pixels_per_css_pixel) const;
+    Option const* select_option(double device_pixels_per_css_pixel) const;
 
     Vector<Option> m_options;
     mutable AbstractImageStyleValue const* m_selected_image { nullptr };
+    mutable double m_selected_resolution { 1 };
 };
 
 }

--- a/Tests/LibWeb/Ref/expected/css-image-set-natural-size-ref.html
+++ b/Tests/LibWeb/Ref/expected/css-image-set-natural-size-ref.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<style>
+    html,
+    body {
+        margin: 0;
+    }
+
+    .box {
+        width: 100px;
+        height: 100px;
+        background-image: url("../data/smiley.png");
+        background-repeat: no-repeat;
+        background-size: 25px 25px;
+    }
+</style>
+<div class="box"></div>

--- a/Tests/LibWeb/Ref/input/css-image-set-natural-size.html
+++ b/Tests/LibWeb/Ref/input/css-image-set-natural-size.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<link rel="match" href="../expected/css-image-set-natural-size-ref.html" />
+<style>
+    html,
+    body {
+        margin: 0;
+    }
+
+    .box {
+        width: 100px;
+        height: 100px;
+        /* smiley.png is 50x50 pixels. The 2x resolution descriptor halves its natural size to 25x25 CSS pixels. */
+        background-image: image-set(url("../data/smiley.png") 2x);
+        background-repeat: no-repeat;
+    }
+</style>
+<div class="box"></div>


### PR DESCRIPTION
The <resolution> of the chosen image-set() option overrides the image's natural resolution, so the image-set()'s natural dimensions are the selected image's pixel dimensions divided by that resolution.

This issue manifested on https://tonsky.me/, where the custom cursor rendered at twice its intended size.