### PR TITLE
LibWeb: Hit testing improvements for SVG paths

### DIFF
--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -204,6 +204,27 @@ void HitTestDisplayList::append_box(PaintableBox const& paintable_box, Paintable
     add_item_to_caret_items(item_index);
 }
 
+void HitTestDisplayList::append_svg_path(Paintable& target, Gfx::Path path, Gfx::WindingRule winding_rule, CSSPixelRect bounding_box, VisualContextIndex visual_context_index)
+{
+    auto item_index = m_items.size();
+    m_items.append({
+        .kind = ItemKind::SvgPath,
+        .paintable = target,
+        .chrome_widget = {},
+        .text_fragment = nullptr,
+        .rect = bounding_box,
+        .caret_rect = {},
+        .caret_line_index = {},
+        .caret_line_rect = {},
+        .block_container_margin_rect = {},
+        .visual_context_index = visual_context_index,
+        .border_radii = {},
+        .path = move(path),
+        .winding_rule = winding_rule,
+    });
+    add_item_to_spatial_index(item_index);
+}
+
 void HitTestDisplayList::append_text_fragment(PaintableFragment const& fragment, VisualContextIndex visual_context_index)
 {
     auto fragment_paintable = fragment.layout_node().first_paintable();
@@ -329,6 +350,7 @@ bool HitTestDisplayList::item_can_produce_caret_position(Item const& item) const
             && item.paintable->dom_node()->parent()
             && (item.paintable->layout_node().is_atomic_inline() || item.paintable->layout_node().is_replaced_box());
     }
+    case ItemKind::SvgPath:
     case ItemKind::ChromeWidget:
         return false;
     }
@@ -400,6 +422,8 @@ bool HitTestDisplayList::item_contains(Item const& item, CSSPixelPoint local_poi
     switch (item.kind) {
     case ItemKind::Box:
         return item.rect.contains(local_point) && item.border_radii.contains(local_point, item.rect);
+    case ItemKind::SvgPath:
+        return item.rect.contains(local_point) && item.path->contains(local_point.to_type<float>(), item.winding_rule);
     case ItemKind::TextFragment:
         return item.rect.contains(local_point);
     case ItemKind::EmptyEditable:
@@ -414,6 +438,7 @@ DOM::Node const* HitTestDisplayList::item_dom_node(Item const& item) const
 {
     switch (item.kind) {
     case ItemKind::Box:
+    case ItemKind::SvgPath:
     case ItemKind::EmptyEditable:
     case ItemKind::ChromeWidget:
         return item.paintable->dom_node();
@@ -442,6 +467,7 @@ HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSS
 {
     switch (item.kind) {
     case ItemKind::Box:
+    case ItemKind::SvgPath:
         return HitTestResult { .paintable = item.paintable };
     case ItemKind::TextFragment:
         VERIFY(item.text_fragment);
@@ -523,6 +549,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
             .debug_rect = item.caret_rect,
         };
     }
+    case ItemKind::SvgPath:
     case ItemKind::ChromeWidget:
         return {};
     }

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -10,6 +10,8 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
+#include <LibGfx/Path.h>
+#include <LibGfx/WindingRule.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/BorderRadiiData.h>
 #include <LibWeb/Painting/Paintable.h>
@@ -35,6 +37,7 @@ public:
     static NonnullRefPtr<HitTestDisplayList> create(u64 visual_context_tree_version);
 
     void append_box(PaintableBox const&, Paintable& target, CSSPixelRect, VisualContextIndex, BorderRadiiData);
+    void append_svg_path(Paintable& target, Gfx::Path, Gfx::WindingRule, CSSPixelRect bounding_box, VisualContextIndex);
     void append_text_fragment(PaintableFragment const&, VisualContextIndex);
     void append_empty_editable(PaintableWithLines const&, CSSPixelRect, VisualContextIndex);
     void append_chrome_widget(PaintableBox const&, ChromeWidget&, VisualContextIndex);
@@ -49,6 +52,7 @@ private:
 
     enum class ItemKind : u8 {
         Box,
+        SvgPath,
         TextFragment,
         EmptyEditable,
         ChromeWidget,
@@ -66,6 +70,8 @@ private:
         Optional<CSSPixelRect> block_container_margin_rect;
         VisualContextIndex visual_context_index;
         BorderRadiiData border_radii;
+        Optional<Gfx::Path> path {};
+        Gfx::WindingRule winding_rule { Gfx::WindingRule::Nonzero };
     };
 
     struct SpatialIndex {

--- a/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -228,12 +228,19 @@ void SVGPathPaintable::record_hit_test_items(DisplayListRecordingContext& contex
     if (computed_values().visibility() != CSS::Visibility::Visible || !visible_for_hit_testing())
         return;
 
+    auto& graphics_element = dom_node();
+
+    // FIXME: Hit test the stroked region of paths without a fill, rather than treating them as non-hittable.
+    if (!graphics_element.fill_color().has_value())
+        return;
+
     auto transformed_path = computed_path()->copy_transformed(computed_transforms().svg_to_css_pixels_transform());
     auto bounding_box = transformed_path.bounding_box().to_type<CSSPixels>();
     if (bounding_box.is_empty())
         return;
 
-    hit_test_display_list->append_box(*this, const_cast<SVGPathPaintable&>(*this), bounding_box, accumulated_visual_context_index(), {});
+    auto winding_rule = to_gfx_winding_rule(graphics_element.fill_rule().value_or(SVG::FillRule::Nonzero));
+    hit_test_display_list->append_svg_path(const_cast<SVGPathPaintable&>(*this), move(transformed_path), winding_rule, bounding_box, accumulated_visual_context_index());
 }
 
 }

--- a/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -234,7 +234,12 @@ void SVGPathPaintable::record_hit_test_items(DisplayListRecordingContext& contex
     if (!graphics_element.fill_color().has_value())
         return;
 
+    auto const* svg_node = layout_box().first_ancestor_of_type<Layout::SVGSVGBox>();
+    if (!svg_node || !svg_node->paintable_box())
+        return;
+
     auto transformed_path = computed_path()->copy_transformed(computed_transforms().svg_to_css_pixels_transform());
+    transformed_path.offset(svg_node->paintable_box()->absolute_rect().location().to_type<float>());
     auto bounding_box = transformed_path.bounding_box().to_type<CSSPixels>();
     if (bounding_box.is_empty())
         return;

--- a/Tests/LibWeb/Text/expected/hit_testing/svg-fill-geometry.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/svg-fill-geometry.txt
@@ -1,0 +1,3 @@
+inside triangle fill: triangle
+triangle bounding box corner outside fill: svg
+inside unfilled rect: svg

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/elementsFromPoint.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/elementsFromPoint.txt
@@ -2,14 +2,14 @@ Harness status: OK
 
 Found 9 tests
 
-7 Pass
-2 Fail
+8 Pass
+1 Fail
 Pass	Negative co-ordinates
 Pass	co-ordinates larger than the viewport
 Pass	co-ordinates larger than the viewport from in iframe
 Pass	Return first element that is the target for hit testing
 Pass	First element to get mouse events with pointer-events css
 Pass	SVG element at x,y
-Fail	transformed element at x,y
+Pass	transformed element at x,y
 Pass	no hit target at x,y
 Fail	No viewport available

--- a/Tests/LibWeb/Text/input/hit_testing/svg-fill-geometry.html
+++ b/Tests/LibWeb/Text/input/hit_testing/svg-fill-geometry.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+</style>
+<svg id="svg" width="300" height="120">
+    <path id="triangle" d="M 220 10 L 290 110 L 150 110 Z" fill="blue"></path>
+      <rect id="hollow" x="10" y="10" width="60" height="60" fill="none" stroke="black"></rect>
+</svg>
+<script>
+    test(() => {
+        function idAt(x, y) {
+            const element = document.elementFromPoint(x, y);
+            return element ? (element.id || element.tagName.toLowerCase()) : "null";
+        }
+        println("inside triangle fill: " + idAt(220, 95));
+        println("triangle bounding box corner outside fill: " + idAt(160, 20));
+        println("inside unfilled rect: " + idAt(40, 40));
+    });
+</script>


### PR DESCRIPTION
See individual commits for details.

These changes allow the tooltip on the GitHub pulse page to appear.

From https://github.com/LadybirdBrowser/ladybird/pulse:
<img width="461" height="227" alt="image" src="https://github.com/user-attachments/assets/21510790-ac8f-4d71-bd4a-68865264f8ec" />
