### PR TITLE
Tests: Wait for mirrored history before UI traversal

### DIFF
--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -3915,15 +3915,28 @@ return [location.href, window.canceledTraverseCount];
                 + "\n".join(log)
             )
 
-        expect_current_top_level_history_url(
+        def browser_ui_traverse_setup_is_mirrored(snapshot):
+            ui_history = snapshot["ui"]
+            if (
+                not ui_history["webContentHistoryMatchesUI"]
+                or ui_history["waitingToSeedWebContent"]
+                or ui_history["waitingForWebContentSeedAck"]
+                or ui_history["ignoringWebContentUpdatesUntilSeed"]
+                or ui_history["reseedAfterCurrentHistoryLoad"]
+                or ui_history["pendingWebContentHistoryStepAfterFallbackLoad"] is not None
+                or ui_history["pendingSessionHistoryNavigation"] is not None
+                or ui_history["pendingSessionHistoryTraversal"] is not None
+                or comparable_history(ui_history) != comparable_history(snapshot["webContent"])
+            ):
+                return False
+            return history_current_entry(ui_history)["url"] == url_scroll_cancel_current
+
+        history_before_browser_ui_traverse = wait_for_session_history(
             webdriver_port,
             session_id,
             "before browser UI traverse with navigate cancel handler",
-            url_scroll_cancel_current,
+            browser_ui_traverse_setup_is_mirrored,
             log,
-        )
-        history_before_browser_ui_traverse = expect_web_content_session_history_matches_ui(
-            webdriver_port, session_id, "before browser UI traverse with navigate cancel handler", log
         )
         if history_before_browser_ui_traverse["ui"]["currentUsedStepIndex"] == 0:
             raise AssertionError(


### PR DESCRIPTION
Wait for the WebDriver session history test to observe the UI-process mirror after a same-document pushState setup before it starts testing a browser UI history traversal.

The script-visible URL changes before the asynchronous session history snapshot reaches the UI process, especially in sanitizer CI. The test already needs the UI and WebContent histories to match at this point, so wait for that condition directly instead of sampling the mirror at once.