### PR TITLE
Tests: Attempt to unskip some MacOS IPC related tests

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -160,6 +160,14 @@ Text/input/wpt-import/workers/nested_worker_sync_xhr.worker.html
 Text/input/wpt-import/workers/nested_worker_terminate_from_document.html
 Text/input/wpt-import/encoding/legacy-mb-schinese/gb18030/gb18030-decoder.any.worker.html
 Text/input/wpt-import/WebCryptoAPI/historical.any.worker.html
+Text/input/Worker/Worker-close-after-postMessage.html
+Text/input/Worker/Worker-crypto.html
+Text/input/Worker/Worker-echo.html
+Text/input/Worker/Worker-importScripts.html
+Text/input/Worker/Worker-location.html
+Text/input/Worker/Worker-module.html
+Text/input/Worker/Worker-performance.html
+Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
 
 ; CORS fetch failures.
 ; Fails in other browsers too when loaded from file://.
@@ -297,11 +305,7 @@ Text/input/wpt-import/png/cicp-chunk.html
 Text/input/wpt-import/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.animated.gif.html
 
 [Skipped]
-; Consistently hang on macOS, see #1306
-Text/input/HTML/cross-origin-window-properties.html
-Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
-Text/input/HTML/MessagePort-MessageEvents-should-be-trusted.html
-Text/input/wpt-import/hr-time/timeOrigin.html
+; Test seems broken
 Text/input/window-scrollTo.html
 
 ; Flaky on CI
@@ -318,17 +322,6 @@ Crash/wpt-import/editing/crashtests/designMode-caret-change.html
 
 ; Times out on CI - https://github.com/LadybirdBrowser/ladybird/issues/7790
 Text/input/device-pixel-ratio-media-query.html
-
-; Worker tests are flaky on CI
-Text/input/Worker/Worker-blob.html
-Text/input/Worker/Worker-close-after-postMessage.html
-Text/input/Worker/Worker-crypto.html
-Text/input/Worker/Worker-echo.html
-Text/input/Worker/Worker-importScripts.html
-Text/input/Worker/Worker-location.html
-Text/input/Worker/Worker-module.html
-Text/input/Worker/Worker-performance.html
-Text/input/Worker/Worker-postMessage-transfer.html
 
 ; WPT ref-tests that currently fail
 Ref/input/wpt-import/css/CSS2/floats/float-nowrap-3.html


### PR DESCRIPTION
We have since fixed a lot of issues with this implementation, and have had other worker tests enabled without issue. Let's hope that the flake issues with these tests have now been fixed.

Fixes: https://github.com/LadybirdBrowser/ladybird/issues/1306