### PR TITLE
LibWeb: Keep child navigable history updates coherent

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -254,6 +254,35 @@ HashTable<GC::RawRef<Navigable>>& all_navigables()
     return *set;
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-session-history-entries
+static Vector<NonnullRefPtr<SessionHistoryEntry>>* get_session_history_entries_if_present(TraversableNavigable& traversable, Navigable const& navigable)
+{
+    // 4. Let docStates be an empty ordered set of document states.
+    Vector<RefPtr<DocumentState>> doc_states;
+
+    // 5. For each entry of traversable's session history entries, append entry's document state to docStates.
+    for (auto& entry : traversable.session_history_entries())
+        doc_states.append(entry->document_state());
+
+    // 6. For each docState of docStates:
+    for (size_t i = 0; i < doc_states.size(); ++i) {
+        auto doc_state = doc_states[i];
+
+        // 1. For each nestedHistory of docState's nested histories:
+        for (auto& nested_history : doc_state->nested_histories()) {
+            // 1. If nestedHistory's id equals navigable's id, return nestedHistory's entries.
+            if (nested_history.id == navigable.id())
+                return &nested_history.entries;
+
+            // 2. For each entry of nestedHistory's entries, append entry's document state to docStates.
+            for (auto& entry : nested_history.entries)
+                doc_states.append(entry->document_state());
+        }
+    }
+
+    return nullptr;
+}
+
 // https://html.spec.whatwg.org/multipage/document-sequences.html#child-navigable
 Vector<GC::Root<Navigable>> Navigable::child_navigables() const
 {
@@ -936,28 +965,8 @@ Vector<NonnullRefPtr<SessionHistoryEntry>>& Navigable::get_session_history_entri
     if (this == traversable)
         return traversable->session_history_entries();
 
-    // 4. Let docStates be an empty ordered set of document states.
-    Vector<RefPtr<DocumentState>> doc_states;
-
-    // 5. For each entry of traversable's session history entries, append entry's document state to docStates.
-    for (auto& entry : traversable->session_history_entries())
-        doc_states.append(entry->document_state());
-
-    // 6. For each docState of docStates:
-    for (size_t i = 0; i < doc_states.size(); ++i) {
-        auto doc_state = doc_states[i];
-
-        // 1. For each nestedHistory of docState's nested histories:
-        for (auto& nested_history : doc_state->nested_histories()) {
-            // 1. If nestedHistory's id equals navigable's id, return nestedHistory's entries.
-            if (nested_history.id == id())
-                return nested_history.entries;
-
-            // 2. For each entry of nestedHistory's entries, append entry's document state to docStates.
-            for (auto& entry : nested_history.entries)
-                doc_states.append(entry->document_state());
-        }
-    }
+    if (auto* entries = get_session_history_entries_if_present(*traversable, *this))
+        return *entries;
 
     VERIFY_NOT_REACHED();
 }
@@ -2855,7 +2864,23 @@ void finalize_a_cross_document_navigation(GC::Ref<Navigable> navigable, HistoryH
     int target_step;
 
     // 8. Let targetEntries be the result of getting session history entries for navigable.
-    auto& target_entries = navigable->get_session_history_entries();
+    Vector<NonnullRefPtr<SessionHistoryEntry>>* target_entries_pointer = nullptr;
+    if (navigable.ptr() == traversable.ptr()) {
+        target_entries_pointer = &traversable->session_history_entries();
+    } else {
+        target_entries_pointer = get_session_history_entries_if_present(*traversable, navigable);
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-session-history-entries
+        // AD-HOC: The spec asserts that a nested history list is found. A queued child-frame commit can run
+        //         after the iframe has been removed, when there is no remaining list to update. Chromium,
+        //         WebKit, and Gecko bind child-frame commits to the live frame, so a removed frame's late
+        //         commit has no observable session history effect.
+        if (!target_entries_pointer) {
+            navigable->clear_navigation_load_event_guard();
+            on_complete->function()(HistoryStepResult::Applied);
+            return;
+        }
+    }
+    auto& target_entries = *target_entries_pointer;
 
     // 9. If entryToReplace is null, then:
     if (entry_to_replace == nullptr) {
@@ -2872,10 +2897,45 @@ void finalize_a_cross_document_navigation(GC::Ref<Navigable> navigable, HistoryH
         target_entries.append(history_entry);
     } else {
         // 1. Replace entryToReplace with historyEntry in targetEntries.
-        *(target_entries.find(*entry_to_replace)) = history_entry;
+        auto entry_to_replace_iterator = target_entries.find(*entry_to_replace);
+        if (entry_to_replace_iterator == target_entries.end()) {
+            if (!navigable->active_document()->is_initial_about_blank()) {
+                // AD-HOC: A non-initial document whose entryToReplace is no longer in targetEntries is the same
+                //         stale child-frame commit case as above.
+                navigable->clear_navigation_load_event_guard();
+                on_complete->function()(HistoryStepResult::Applied);
+                return;
+            }
 
-        // 2. Set historyEntry's step to entryToReplace's step.
-        history_entry->set_step(entry_to_replace->step());
+            // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-child-navigable
+            // https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-cross-document-navigation
+            // AD-HOC: Initial about:blank's first real navigation is a replacement. If a synchronous
+            //         same-document history update swapped out the original entry object before the queued
+            //         cross-document commit runs, replace the remaining initial child entry instead.
+            Optional<size_t> entry_to_replace_index;
+            for (size_t i = 0; i < target_entries.size(); ++i) {
+                if (target_entries[i]->step() == entry_to_replace->step()) {
+                    entry_to_replace_index = i;
+                    break;
+                }
+            }
+            if (!entry_to_replace_index.has_value() && target_entries.size() == 1)
+                entry_to_replace_index = 0;
+            if (!entry_to_replace_index.has_value()) {
+                navigable->clear_navigation_load_event_guard();
+                on_complete->function()(HistoryStepResult::Applied);
+                return;
+            }
+
+            auto replacement_entry = target_entries[*entry_to_replace_index];
+            target_entries[*entry_to_replace_index] = history_entry;
+            history_entry->set_step(replacement_entry->step());
+        } else {
+            *entry_to_replace_iterator = history_entry;
+
+            // 2. Set historyEntry's step to entryToReplace's step.
+            history_entry->set_step(entry_to_replace->step());
+        }
 
         // 3. If historyEntry's document state's origin is same origin with entryToReplace's document state's origin,
         //    then set historyEntry's navigation API key to entryToReplace's navigation API key.

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -839,32 +839,23 @@ void ApplyHistoryStepState::start()
     // 8. For each navigable of changingNavigables:
     auto changing_navigables = m_traversable->get_all_navigables_whose_current_session_history_entry_will_change_or_reload(m_target_step);
     for (auto& navigable : changing_navigables) {
-        // AD-HOC: For a synchronous (same-document) application of a history step, skip a navigable that has just
-        //         been claimed by a fresh ongoing navigation. Apply the history step would otherwise transition the
-        //         navigable's ongoing navigation through "traversal" and back to null, which informs the navigation
-        //         API about aborting (cancelling the in-flight navigation's navigate event) and then trips the
-        //         "ongoing navigation is no longer navigationId" bail-out in navigate's deferred steps, leaving the
-        //         in-flight navigation stranded.
-        //
-        //         The race shows up when a click capture handler calls history.replaceState and the link's
-        //         cross-document activation behavior runs in the same task: the replaceState's queued sync step
-        //         finalizes after the link nav has already entered begin_navigation, and wipes its id. Real-world
-        //         example: Shopify storefronts running hCaptcha (which hooks click and replaceStates to the current
-        //         URL for analytics). The page silently never moves.
-        //
-        //         No major engine reproduces this. Chromium runs sync same-document nav entirely in-task and never
-        //         enters a parallel traversal queue, WebKit doesn't track navigation IDs at all, and Gecko routes
-        //         sync replaceState directly through history without entering SetOngoingNavigation. The strictly
-        //         correct long-term fix is to bypass the traversal queue for sync same-document navigations to
-        //         match Chromium; until then, skipping the transient when the navigable is already mid-navigation
-        //         matches the observable behavior of all three.
-        //
-        //         Cross-document and traversal applications still process every changing navigable: the "traversal"
-        //         transition there is not transient. It precedes an actual document switch that takes ownership.
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-same-document-navigation
+        // AD-HOC: The spec queues same-document history updates because they happen synchronously, outside the
+        //         traversal queue, and must later resolve races with the current history step. If another navigation
+        //         has already claimed the navigable by the time this queued reconciliation runs, leave that navigation
+        //         ID alone. This matches the observable behavior of Chromium, WebKit, and Gecko: a same-document
+        //         history update does not cancel a later cross-document navigation from the same task.
         if (m_synchronous_navigation == TraversableNavigable::SynchronousNavigation::Yes
             && navigable->ongoing_navigation().has<String>()) {
             continue;
         }
+
+        // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-child-navigable
+        // NB: The creation/destruction update is the bookkeeping step after the child's nested history has been
+        //     attached to its parent document state. If the container's requested navigation has already started, it
+        //     owns the ongoing navigation ID and eventual document activation.
+        if (!m_navigation_type.has_value() && navigable->ongoing_navigation().has<String>())
+            continue;
 
         // 1. Let targetEntry be the result of getting the target history entry given navigable and targetStep.
         auto target_entry = navigable->get_the_target_history_entry(m_target_step);
@@ -1157,7 +1148,7 @@ void ApplyHistoryStepState::process_continuations()
             continue;
         }
 
-        VERIFY(m_target_step == m_traversable->get_the_used_step(m_step));
+        m_target_step = m_traversable->get_the_used_step(m_step);
 
         // 7. Let (scriptHistoryLength, scriptHistoryIndex) be the result of getting the history object length and index given traversable and targetStep.
         auto history_object_length_and_index = m_traversable->get_the_history_object_length_and_index(m_target_step);
@@ -1271,7 +1262,7 @@ void ApplyHistoryStepState::process_continuations()
 
 void ApplyHistoryStepState::enter_waiting_for_non_changing_jobs()
 {
-    VERIFY(m_target_step == m_traversable->get_the_used_step(m_step));
+    m_target_step = m_traversable->get_the_used_step(m_step);
 
     // 17. Let (scriptHistoryLength, scriptHistoryIndex) be the result of getting the history object length and index given traversable and targetStep.
     auto length_and_index = m_traversable->get_the_history_object_length_and_index(m_target_step);
@@ -1398,11 +1389,20 @@ TraversableNavigable::SessionHistorySnapshot TraversableNavigable::create_sessio
     auto used_history_steps = get_all_used_history_steps();
     Vector<i32> used_session_history_steps;
     used_session_history_steps.ensure_capacity(used_history_steps.size());
+    auto current_session_history_step_for_snapshot = current_session_history_step();
+    if (!used_history_steps.contains_slow(current_session_history_step_for_snapshot)) {
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-the-used-step
+        // NB: The UI process snapshot needs a current item from the used-steps list. While the
+        //     creation/destruction update is reconciling removed child navigables, the traversable's current
+        //     session history step can be a hole. Use the same greatest-used-step <= current step rule here only;
+        //     traversal and back/forward decisions still use the spec's current-step-in-allSteps assertions.
+        current_session_history_step_for_snapshot = get_the_used_step(current_session_history_step_for_snapshot);
+    }
     Optional<size_t> current_used_step_index;
     for (size_t i = 0; i < used_history_steps.size(); ++i) {
         auto step = used_history_steps[i];
         used_session_history_steps.unchecked_append(static_cast<i32>(step));
-        if (step == current_session_history_step())
+        if (step == current_session_history_step_for_snapshot)
             current_used_step_index = i;
     }
     VERIFY(current_used_step_index.has_value());
@@ -1420,6 +1420,12 @@ void ApplyHistoryStepState::complete()
         return;
     m_phase = Phase::Completed;
     m_timeout->stop();
+
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-the-used-step
+    // NB: targetStep was computed before the asynchronous portions of applying the history step. If a child
+    //     navigable was removed while those steps were running, that step can stop being used. Normalize again
+    //     before storing it as the traversable's current session history step.
+    m_target_step = m_traversable->get_the_used_step(m_target_step);
 
     // 20. Set traversable's current session history step to targetStep.
     m_traversable->m_current_session_history_step = m_target_step;

--- a/Tests/LibWeb/Crash/HTML/iframe-pushstate-before-nested-history-snapshot.html
+++ b/Tests/LibWeb/Crash/HTML/iframe-pushstate-before-nested-history-snapshot.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<iframe id="frame"></iframe>
+<script>
+frame.onload = () => {
+    frame.contentWindow.history.pushState({}, "", "#child");
+};
+frame.srcdoc = "<!doctype html><body>child</body>";
+</script>

--- a/Tests/LibWeb/Text/expected/navigation/iframe-pushstate-before-nested-history-ready.txt
+++ b/Tests/LibWeb/Text/expected/navigation/iframe-pushstate-before-nested-history-ready.txt
@@ -1,0 +1,2 @@
+#child
+queue drained

--- a/Tests/LibWeb/Text/expected/navigation/iframe-remove-and-recreate-after-initial-navigation.txt
+++ b/Tests/LibWeb/Text/expected/navigation/iframe-remove-and-recreate-after-initial-navigation.txt
@@ -1,0 +1,2 @@
+first loaded
+second loaded

--- a/Tests/LibWeb/Text/input/navigation/iframe-pushstate-before-nested-history-ready.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-pushstate-before-nested-history-ready.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<body></body>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+
+        document.body.append(iframe);
+        iframe.contentWindow.history.pushState({}, "", "about:blank#child");
+
+        await internals.flushSessionHistoryTraversalQueue();
+        println(iframe.contentWindow.location.hash);
+        println("queue drained");
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/iframe-remove-and-recreate-after-initial-navigation.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-remove-and-recreate-after-initial-navigation.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<body></body>
+<script src="../include.js"></script>
+<script>
+    function loadFrame(url) {
+        return new Promise(resolve => {
+            const iframe = document.createElement("iframe");
+            iframe.onload = () => resolve(iframe);
+            document.body.insertBefore(iframe, document.body.firstChild);
+            iframe.src = url;
+        });
+    }
+
+    asyncTest(async done => {
+        history.pushState({ section: "running" }, "", "#running");
+
+        const first = await loadFrame("about:blank");
+        println("first loaded");
+        first.contentWindow.history.pushState({}, "", "about:blank#first");
+        first.remove();
+        await internals.flushSessionHistoryTraversalQueue();
+
+        await loadFrame("about:blank");
+        println("second loaded");
+        done();
+    });
+</script>


### PR DESCRIPTION
Normalize the target step again at the end of applying a history step, since iframe removal can leave the originally computed target step unused before the asynchronous application finishes. Let the UI history snapshot use the same used-step mapping when it serializes a current item for the UI process.

Handle late child-frame navigation commits whose original nested history entry disappeared before finalization. Removed iframes have no live nested history list to update, and initial about:blank still needs its first real navigation to replace the remaining initial child entry.

Add coverage for iframe pushState before nested history readiness and for removing and recreating an iframe after an initial same-document history update.