### PR TITLE
Compositor+WebContent: Initialize WebContent transport peer pid

### DIFF
--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -13,6 +13,8 @@
 
 endpoint CompositorWebContentServer
 {
+    init_transport(int peer_pid) => (int compositor_pid)
+
     set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode) =|
     destroy_context(Web::Compositor::CompositorContextId context_id) =|
 

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <Compositor/ConnectionFromWebContent.h>
+#include <LibCore/System.h>
 #include <LibWeb/Page/InputEvent.h>
 
 namespace Compositor {
@@ -26,6 +27,15 @@ void ConnectionFromWebContent::die()
 void ConnectionFromWebContent::notify_compositor_lost()
 {
     async_did_lose_compositor();
+}
+
+Messages::CompositorWebContentServer::InitTransportResponse ConnectionFromWebContent::init_transport([[maybe_unused]] int peer_pid)
+{
+#ifdef AK_OS_WINDOWS
+    m_transport->set_peer_pid(peer_pid);
+    return Core::System::getpid();
+#endif
+    VERIFY_NOT_REACHED();
 }
 
 void ConnectionFromWebContent::request_rendering_update()

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -31,6 +31,7 @@ private:
 
     virtual void die() override;
 
+    virtual Messages::CompositorWebContentServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode) override;
     virtual void destroy_context(Web::Compositor::CompositorContextId) override;
     virtual void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::AccumulatedVisualContextTree, Web::Painting::DisplayListResourceTransaction, Web::Painting::ScrollStateSnapshot) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -201,6 +201,14 @@ void ConnectionFromClient::connect_to_compositor_process(IPC::TransportHandle ha
     m_compositor_connection->on_mouse_event = [this](u64 page_id, Web::MouseEvent event) {
         mouse_event(page_id, move(event));
     };
+
+#ifdef AK_OS_WINDOWS
+    // Perform Windows peer PID handshake before any other IPC
+    if constexpr (requires { m_compositor_connection->transport().set_peer_pid(0); }) {
+        auto response = m_compositor_connection->send_sync<Messages::CompositorWebContentServer::InitTransport>(Core::System::getpid());
+        m_compositor_connection->transport().set_peer_pid(response->compositor_pid());
+    }
+#endif
 }
 
 void ConnectionFromClient::compositor_process_reconnected()


### PR DESCRIPTION
A WebContent display-list update can send compositor resource attachments over the WebContent-to-compositor transport. On Windows, serializing an attachment requires the destination process id, but this secondary transport never exchanged peer pids before the first message.

That left TransportSocketWindows with m_peer_pid == -1 and hit the serialize_attachments() verification when WebContent tried to send the first attachment-bearing compositor update. Add InitTransport to this endpoint and run it immediately after WebContent creates the compositor connection, before any other IPC uses the channel.