### PR TITLE
Meta: Force vcpkg system binaries on arm64 Linux as well as riscv64

### DIFF
--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -307,10 +307,13 @@ def configure_build_env(platform: Platform, preset: str, jobs: Optional[str] = N
     if jobs:
         os.environ["VCPKG_MAX_CONCURRENCY"] = jobs
 
-    if platform.host_architecture == HostArchitecture.riscv64:
-        # vcpkg refuses to build ports on riscv64 and other less common architectures without this flag.
-        # With it set vcpkg will use the system provided CMake and Ninja binaries but will still download,
-        # build and use its own pinned versions of gn, meson and pkg-config.
+    needs_system_binaries = platform.host_architecture == HostArchitecture.riscv64 or (
+        platform.host_system == HostSystem.Linux and platform.host_architecture == HostArchitecture.AArch64
+    )
+    if needs_system_binaries:
+        # vcpkg does not ship prebuilt tool binaries for riscv64 or arm64 Linux and refuses to build
+        # ports on these hosts without this flag. With it set vcpkg uses the system provided CMake and
+        # Ninja binaries but still downloads, builds and uses its own pinned gn, meson and pkg-config.
         os.environ["VCPKG_FORCE_SYSTEM_BINARIES"] = "1"
 
     if "XDG_CACHE_HOME" not in os.environ:


### PR DESCRIPTION
**Problem:** Building on arm64 Linux via `Meta/ladybird.py` fails during vcpkg bootstrap with _“CMake was unable to find a build program corresponding to Ninja”_ unless `VCPKG_FORCE_SYSTEM_BINARIES=1` is set by hand.

**Cause:** vcpkg ships no prebuilt tool binaries for arm64 Linux — so it has to be told to use the system CMake and Ninja. CI and the devcontainer already set the variable for arm64, but `ladybird.py` only auto-set it for riscv64 — leaving the documented build path broken on arm64 Linux.

**Fix:** Also set `VCPKG_FORCE_SYSTEM_BINARIES` on AArch64 Linux hosts — matching the condition CI already uses.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/2417
