### PR TITLE
LibWeb: Allow transforms to apply to pseudo elements

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1214,12 +1214,10 @@ bool Node::is_transformable() const
 {
     // A transformable element is an element in one of these categories:
     auto const* dom_node = this->dom_node();
-    if (!dom_node)
-        return false;
 
     // * all SVG paint server elements, the clipPath element and SVG renderable elements with the exception
     //   of any descendant element of text content elements [SVG2].
-    if (is<SVG::SVGElement>(*dom_node)) {
+    if (is<SVG::SVGElement>(dom_node)) {
         // Paint servers and clipPath are always transformable.
         if (is<SVG::SVGGradientElement>(*dom_node) || is<SVG::SVGPatternElement>(*dom_node) || is<SVG::SVGClipPathElement>(*dom_node))
             return true;
@@ -1236,7 +1234,8 @@ bool Node::is_transformable() const
 
     // * all elements whose layout is governed by the CSS box model except for non-replaced inline boxes,
     //   table-column boxes, and table-column-group boxes [CSS2].
-    if (is<DOM::Element>(*dom_node) && is_box()) {
+    bool is_element_or_pseudo_element = is<DOM::Element>(dom_node) || is_generated_for_pseudo_element();
+    if (is_element_or_pseudo_element && is_box()) {
         auto display = this->display();
         if (display.is_table_column() || display.is_table_column_group())
             return false;

--- a/Tests/LibWeb/Layout/expected/pdf-viewer.txt
+++ b/Tests/LibWeb/Layout/expected/pdf-viewer.txt
@@ -520,7 +520,7 @@ SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
     SC for BlockContainer<DIV>.endOfContent [233.5,175 333x0] [children: 0] (z-index: 0), has_transform
     SC for BlockContainer<SPAN> [316.75,64.9375 121.046875x23.328125] [children: 0] (z-index: 1), has_transform
   SC for BlockContainer<DIV>.toolbar [0,0 800x32] [children: 14] (z-index: 2)
-   SC for BlockContainer(anonymous) [15,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [15,8 16x16] [children: 0] (z-index: auto), has_transform
    SC for BlockContainer(anonymous) [75,8 16x16] [children: 0] (z-index: auto)
    SC for Box<BUTTON>#previous.toolbarButton [98,2 28x28] [children: 1] (z-index: auto)
     SC for BlockContainer(anonymous) [104,8 16x16] [children: 0] (z-index: auto)
@@ -535,4 +535,4 @@ SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
    SC for BlockContainer(anonymous) [678,8 16x16] [children: 0] (z-index: auto)
    SC for BlockContainer(anonymous) [713,8 16x16] [children: 0] (z-index: auto)
    SC for BlockContainer(anonymous) [742,8 16x16] [children: 0] (z-index: auto)
-   SC for BlockContainer(anonymous) [777,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [777,8 16x16] [children: 0] (z-index: auto), has_transform

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-generated-001-notref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-generated-001-notref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <style>
+      div {
+        float: left;
+      }
+      div::before {
+        float: left;
+        content: 'abc';
+      }
+    </style>
+  </head>
+  <body>
+    <div>def</div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-generated-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-generated-001-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <style>
+      div {
+        float: left;
+      }
+      div:first-child {
+        transform: rotate(180deg);
+      }
+    </style>
+  </head>
+  <body>
+    <div>abc</div>
+    <div>def</div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-generated-002-notref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-generated-002-notref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <style>
+      span::before {
+        display: block;
+        content: 'abc';
+      }
+    </style>
+  </head>
+  <body>
+    <span>def</span>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-generated-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-generated-002-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <style>
+      div {
+        transform: rotate(180deg);
+        transform-origin: left;
+      }
+    </style>
+  </head>
+  <body>
+    <div>abc</div>
+    <span>def</span>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform-generated-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform-generated-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Generated Content (block)</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+    <meta name="assert" content="Transforms need to work on boxes of generated
+    content just as on any other boxes.  This file tests a generated block
+    box.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-generated-001-ref.html">
+    <link rel="mismatch" href="../../../../expected/wpt-import/css/css-transforms/transform-generated-001-notref.html">
+    <style>
+      div {
+        float: left;
+      }
+      div::before {
+        transform: rotate(180deg);
+        float: left;
+        content: 'abc';
+      }
+    </style>
+  </head>
+  <body>
+    <div>def</div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform-generated-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform-generated-002.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Generated Content (inline)</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+    <meta name="assert" content="Transforms need to work on boxes of generated
+    content just as on any other boxes.  This file tests a generated inline
+    box.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-generated-002-ref.html">
+    <link rel="mismatch" href="../../../../expected/wpt-import/css/css-transforms/transform-generated-002-notref.html">
+    <style>
+      span::before {
+        transform: rotate(180deg);
+        transform-origin: left;
+        display: block;
+        content: 'abc';
+      }
+    </style>
+  </head>
+  <body>
+    <span>def</span>
+  </body>
+</html>


### PR DESCRIPTION
Previously `is_transformable()` didn't take pseudo elements into account.

This improves the navbar on https://rightmove.co.uk, which previously displayed box artifacts under each heading (these are supposed to be transformed into an arrow shape when each heading is hovered):

Before:
<img width="1376" height="68" alt="image" src="https://github.com/user-attachments/assets/b8b9aa37-0011-4336-913c-804f0b5eac33" />


After
<img width="1376" height="68" alt="image" src="https://github.com/user-attachments/assets/f31b2241-9f05-436a-af6c-ca171a35981d" />