### PR TITLE
LibSandbox: Return ENOENT for `getcwd()` instead of trapping

### DIFF
--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -1167,6 +1167,15 @@ void SeccompPolicy::allow_common_runtime()
     allow_process_metadata();
     allow_prctl();
     allow_exit();
+    deny_current_directory_queries();
+}
+
+void SeccompPolicy::deny_current_directory_queries()
+{
+#ifdef __NR_getcwd
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getcwd, 0, 1));
+    append(SECCOMP_ERRNO(ENOENT));
+#endif
 }
 
 void SeccompPolicy::allow_prctl()

--- a/Libraries/LibSandbox/Seccomp.h
+++ b/Libraries/LibSandbox/Seccomp.h
@@ -17,6 +17,7 @@ public:
     SeccompPolicy();
 
     void deny_readonly_filesystem_probes();
+    void deny_current_directory_queries();
     void allow_readonly_file_opens();
     void allow_filesystem_metadata_queries();
     void allow_filesystem_writes();


### PR DESCRIPTION
Previously, passing a certificate using `--certificate` that had a relative path would  cause a sandbox violation on the first https connection.

Tested with: `Meta/ladybird.py run --enable-sandbox -C Tests/LibWeb/WPT/wpt/tools/certs/cacert.pem https://example.com`.