### PR TITLE
LibWeb/CSS: Retain length precision in PercentageOr<T>

### DIFF
--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -118,8 +118,7 @@ public:
                 return t;
             },
             [&](Percentage const& percentage) {
-                // FIXME: This doesn't necessarily round correctly
-                return Length::make_px(CSSPixels(percentage.value() * reference_value) / 100);
+                return Length::make_px(CSSPixels::truncated_value_for(reference_value.to_double() * percentage.as_fraction()));
             },
             [&](NonnullRefPtr<CalculatedStyleValue const> const& calculated) {
                 return T::resolve_calculated(calculated, layout_node, reference_value);

--- a/Libraries/LibWeb/PixelUnits.h
+++ b/Libraries/LibWeb/PixelUnits.h
@@ -59,6 +59,12 @@ class CSSPixelFraction;
 /// CSSPixels: A position or length in CSS "reference pixels", independent of zoom or screen DPI.
 /// See https://www.w3.org/TR/css-values-3/#reference-pixel
 class WEB_API CSSPixels {
+    enum class ValueRounding : u8 {
+        Nearest,
+        Floor,
+        Truncate,
+    };
+
 public:
     static constexpr i32 fractional_bits = 6;
     static constexpr i32 fixed_point_denominator = 1 << fractional_bits;
@@ -92,24 +98,19 @@ public:
     template<FloatingPoint F>
     static CSSPixels nearest_value_for(F value)
     {
-        i32 raw_value = 0;
-        if (!isnan(value))
-            raw_value = AK::clamp_to<int>(value * fixed_point_denominator);
-        // Note: The resolution of CSSPixels is 0.015625, so care must be taken when converting
-        // floats/doubles to CSSPixels as small values (such as scale factors) can underflow to zero,
-        // or otherwise produce inaccurate results (when scaled back up).
-        if (raw_value == 0 && value != 0)
-            dbgln_if(LIBWEB_CSS_DEBUG, "CSSPixels: Conversion from float or double underflowed to zero");
-        return from_raw(raw_value);
+        return value_for<ValueRounding::Nearest>(value);
     }
 
     template<FloatingPoint F>
     static CSSPixels floored_value_for(F value)
     {
-        i32 raw_value = 0;
-        if (!isnan(value))
-            raw_value = AK::clamp_to<int>(floor(value * fixed_point_denominator));
-        return from_raw(raw_value);
+        return value_for<ValueRounding::Floor>(value);
+    }
+
+    template<FloatingPoint F>
+    static CSSPixels truncated_value_for(F value)
+    {
+        return value_for<ValueRounding::Truncate>(value);
     }
 
     template<Unsigned U>
@@ -274,6 +275,30 @@ public:
     }
 
 private:
+    template<ValueRounding rounding, FloatingPoint F>
+    static CSSPixels value_for(F value)
+    {
+        if (isnan(value))
+            return {};
+
+        auto scaled_value = value * fixed_point_denominator;
+        if constexpr (rounding == ValueRounding::Floor)
+            scaled_value = floor(scaled_value);
+        else if constexpr (rounding == ValueRounding::Truncate)
+            scaled_value = trunc(scaled_value);
+        auto raw_value = AK::clamp_to<int>(scaled_value);
+
+        if constexpr (LIBWEB_CSS_DEBUG) {
+            // Note: The resolution of CSSPixels is 0.015625, so care must be taken when converting floats/doubles to
+            // CSSPixels as small values (such as scale factors) can underflow to zero, or otherwise produce inaccurate
+            // results (when scaled back up).
+            if (raw_value == 0 && value != 0)
+                dbgln("CSSPixels: Conversion from float or double underflowed to zero");
+        }
+
+        return from_raw(raw_value);
+    }
+
     i32 m_value { 0 };
 };
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/large-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/large-percentage-width.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
+      BlockContainer <div.parent> at [8,8] [0+0+0 4753650 0+0+-4752866] [0+0+0 20 0+0+0] children: not-inline
+        BlockContainer <div.child> at [8,8] [0+0+0 4753650 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,28] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 4753658x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x20]
+      PaintableWithLines (BlockContainer<DIV>.parent) [8,8 4753650x20]
+        PaintableWithLines (BlockContainer<DIV>.child) [8,8 4753650x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,28 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x36] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/large-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/large-percentage-width.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+.parent {
+    width: 4753650px;
+    height: 20px;
+}
+.child {
+    width: 100%;
+    height: 10px;
+}
+</style>
+<div class="parent"><div class="child"></div></div>

--- a/Tests/LibWeb/TestCSSPixels.cpp
+++ b/Tests/LibWeb/TestCSSPixels.cpp
@@ -89,6 +89,20 @@ TEST_CASE(to_int)
     EXPECT_EQ(b.to_int(), 12);
 }
 
+TEST_CASE(float_conversion)
+{
+    auto value = 620.0 * .333333;
+    EXPECT_EQ(CSSPixels::nearest_value_for(value), CSSPixels::from_raw(13227));
+    EXPECT_EQ(CSSPixels::floored_value_for(value), CSSPixels::from_raw(13226));
+    EXPECT_EQ(CSSPixels::truncated_value_for(value), CSSPixels::from_raw(13226));
+
+    EXPECT_EQ(CSSPixels::floored_value_for(-value), CSSPixels::from_raw(-13227));
+    EXPECT_EQ(CSSPixels::truncated_value_for(-value), CSSPixels::from_raw(-13226));
+
+    EXPECT_EQ(CSSPixels::truncated_value_for(INFINITY), CSSPixels::max());
+    EXPECT_EQ(CSSPixels::truncated_value_for(-INFINITY), CSSPixels::min());
+}
+
 TEST_CASE(comparison1)
 {
     EXPECT_EQ(CSSPixels(1) < CSSPixels(2), true);


### PR DESCRIPTION
Instead of operating within the (saturating) CSSPixels constraints, calculate the expected value using a floating point calculation first and then create the CSSPixels value.

Fixes the initial score in [Lyra's CSS clicker](https://lyra.horse/css-clicker/):

| Before | After |
|--|--|
| <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/cce916d9-9f60-4a8b-9a40-0535f389a22a" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/d524c8c3-625a-476a-ae11-9616ea395229" /> |
