### PR TITLE
Meta: Remove setting `XDG_CACHE_HOME` from ladybird.py

### DIFF
--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -316,11 +316,6 @@ def configure_build_env(platform: Platform, preset: str, jobs: Optional[str] = N
         # Ninja binaries but still downloads, builds and uses its own pinned gn, meson and pkg-config.
         os.environ["VCPKG_FORCE_SYSTEM_BINARIES"] = "1"
 
-    if "XDG_CACHE_HOME" not in os.environ:
-        # vcpkg requires this variable to set and in some cases like the Android build environment it might
-        # not be present, so we need to ensure that it is set
-        os.environ["XDG_CACHE_HOME"] = str(ladybird_source_dir / "Build" / "caches")
-
     return ladybird_source_dir, build_preset_dir
 
 


### PR DESCRIPTION
This was added in 61c9e819bb788a022f78013c1499e58b5d4917e1 for the Android build. But on environments like macOS where `XDG_CACHE_HOME` is not set, it's forcing things like the HTTP disk cache and ccache to live under the Build directory instead of their proper homes in ~/Library/Caches. If this environment is needed for the Android build, we should come up with some other solution when that becomes a priority.