### PR TITLE
LibDatabase: Add a versioned schema migration runner and adopt it for the existing stores

### DIFF
--- a/Libraries/LibDatabase/Database.cpp
+++ b/Libraries/LibDatabase/Database.cpp
@@ -109,6 +109,14 @@ ErrorOr<StatementID> Database::prepare_statement(StringView statement)
 
 void Database::execute_statement_internal(StatementID statement_id, OnResult on_result)
 {
+    if (auto result = try_execute_statement_internal(statement_id, move(on_result)); result.is_error()) [[unlikely]] {
+        warnln("\033[31;1mDatabase error\033[0m: {}: {}", result.error(), sqlite3_errmsg(m_database));
+        VERIFY_NOT_REACHED();
+    }
+}
+
+ErrorOr<void> Database::try_execute_statement_internal(StatementID statement_id, OnResult on_result)
+{
     auto* statement = prepared_statement(statement_id);
 
     while (true) {
@@ -116,8 +124,8 @@ void Database::execute_statement_internal(StatementID statement_id, OnResult on_
 
         switch (result) {
         case SQLITE_DONE:
-            SQL_MUST(sqlite3_reset(statement));
-            return;
+            SQL_TRY(sqlite3_reset(statement));
+            return {};
 
         case SQLITE_ROW:
             if (on_result)
@@ -125,8 +133,9 @@ void Database::execute_statement_internal(StatementID statement_id, OnResult on_
             continue;
 
         default:
-            SQL_MUST(result);
-            return;
+            // Reset so the failed statement does not stay active and block a later COMMIT or ROLLBACK.
+            sqlite3_reset(statement);
+            return Error::from_string_view(sql_error(result));
         }
     }
 }
@@ -140,27 +149,43 @@ int Database::bound_parameter_count(StatementID statement_id)
 template<typename ValueType>
 void Database::apply_placeholder(StatementID statement_id, int index, ValueType const& value)
 {
-    auto* statement = prepared_statement(statement_id);
-
-    if constexpr (IsSame<ValueType, String>) {
-        StringView string { value };
-        SQL_MUST(sqlite3_bind_text(statement, index, string.characters_without_null_termination(), static_cast<int>(string.length()), SQLITE_TRANSIENT));
-    } else if constexpr (IsSame<ValueType, ByteString>) {
-        SQL_MUST(sqlite3_bind_blob(statement, index, value.characters(), static_cast<int>(value.length()), SQLITE_TRANSIENT));
-    } else if constexpr (IsSame<ValueType, UnixDateTime>) {
-        apply_placeholder(statement_id, index, value.offset_to_epoch().to_milliseconds());
-    } else if constexpr (IsIntegral<ValueType>) {
-        if constexpr (sizeof(ValueType) <= sizeof(int))
-            SQL_MUST(sqlite3_bind_int(statement, index, static_cast<int>(value)));
-        else
-            SQL_MUST(sqlite3_bind_int64(statement, index, static_cast<sqlite3_int64>(value)));
-    } else {
-        static_assert(DependentFalse<ValueType>);
+    if (auto result = try_apply_placeholder(statement_id, index, value); result.is_error()) [[unlikely]] {
+        warnln("\033[31;1mDatabase error\033[0m: {}: {}", result.error(), sqlite3_errmsg(m_database));
+        VERIFY_NOT_REACHED();
     }
 }
 
 #define __ENUMERATE_TYPE(type) \
     template DATABASE_API void Database::apply_placeholder(StatementID, int, type const&);
+ENUMERATE_SQL_TYPES
+#undef __ENUMERATE_TYPE
+
+template<typename ValueType>
+ErrorOr<void> Database::try_apply_placeholder(StatementID statement_id, int index, ValueType const& value)
+{
+    auto* statement = prepared_statement(statement_id);
+
+    if constexpr (IsSame<ValueType, String>) {
+        StringView string { value };
+        SQL_TRY(sqlite3_bind_text(statement, index, string.characters_without_null_termination(), static_cast<int>(string.length()), SQLITE_TRANSIENT));
+    } else if constexpr (IsSame<ValueType, ByteString>) {
+        SQL_TRY(sqlite3_bind_blob(statement, index, value.characters(), static_cast<int>(value.length()), SQLITE_TRANSIENT));
+    } else if constexpr (IsSame<ValueType, UnixDateTime>) {
+        TRY(try_apply_placeholder(statement_id, index, value.offset_to_epoch().to_milliseconds()));
+    } else if constexpr (IsIntegral<ValueType>) {
+        if constexpr (sizeof(ValueType) <= sizeof(int))
+            SQL_TRY(sqlite3_bind_int(statement, index, static_cast<int>(value)));
+        else
+            SQL_TRY(sqlite3_bind_int64(statement, index, static_cast<sqlite3_int64>(value)));
+    } else {
+        static_assert(DependentFalse<ValueType>);
+    }
+
+    return {};
+}
+
+#define __ENUMERATE_TYPE(type) \
+    template DATABASE_API ErrorOr<void> Database::try_apply_placeholder(StatementID, int, type const&);
 ENUMERATE_SQL_TYPES
 #undef __ENUMERATE_TYPE
 
@@ -195,6 +220,119 @@ ValueType Database::result_column(StatementID statement_id, int column)
 ENUMERATE_SQL_TYPES
 #undef __ENUMERATE_TYPE
 
+ErrorOr<void> Database::execute_raw(ByteString const& sql)
+{
+    SQL_TRY(sqlite3_exec(m_database, sql.characters(), nullptr, nullptr, nullptr));
+    return {};
+}
+
+ErrorOr<void> Database::Transaction::begin()
+{
+    TRY(m_database.execute_raw("BEGIN IMMEDIATE;"));
+    m_active = true;
+    return {};
+}
+
+Database::Transaction::~Transaction()
+{
+    if (!m_active)
+        return;
+    if (auto result = m_database.execute_raw("ROLLBACK;"); result.is_error())
+        warnln("\033[31;1mDatabase error\033[0m: Unable to roll back transaction: {}", result.error());
+}
+
+ErrorOr<void> Database::Transaction::commit()
+{
+    VERIFY(m_active);
+    TRY(m_database.execute_raw("COMMIT;"));
+    m_active = false;
+    return {};
+}
+
+ErrorOr<MigrationOutcome> Database::migrate(StringView store_name, ReadonlySpan<Migration> migrations, MigrationMode mode)
+{
+    VERIFY(!migrations.is_empty());
+    VERIFY(migrations.first().version >= 1);
+    for (size_t i = 1; i < migrations.size(); ++i)
+        VERIFY(migrations[i].version > migrations[i - 1].version);
+
+    auto store = TRY(String::from_utf8(store_name));
+    auto latest_version = migrations.last().version;
+
+    // Fast path: only reads, so a database from a newer version of Ladybird is left untouched.
+    if (auto recorded = TRY(schema_version(store_name)); recorded.has_value()) {
+        if (*recorded > latest_version)
+            return MigrationOutcome::DatabaseTooNew;
+        if (*recorded == latest_version)
+            return MigrationOutcome::Success;
+    }
+
+    Transaction transaction { *this };
+    TRY(transaction.begin());
+
+    TRY(execute_raw("CREATE TABLE IF NOT EXISTS SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"));
+
+    // Re-read under the write lock; a concurrent process may have migrated since the fast path.
+    auto recorded = TRY(schema_version(store_name));
+    if (recorded.has_value()) {
+        if (*recorded > latest_version)
+            return MigrationOutcome::DatabaseTooNew;
+
+        if (*recorded == latest_version) {
+            if (mode == MigrationMode::CheckOnly)
+                return MigrationOutcome::Success;
+
+            TRY(transaction.commit());
+            return MigrationOutcome::Success;
+        }
+    }
+
+    auto current_version = recorded.value_or(0);
+
+    if (mode == MigrationMode::CheckOnly)
+        return MigrationOutcome::Success;
+
+    for (auto const& migration : migrations) {
+        if (migration.version <= current_version)
+            continue;
+
+        if (!migration.sql.is_empty())
+            TRY(execute_raw(migration.sql));
+
+        if (migration.backfill)
+            TRY(migration.backfill(*this));
+    }
+
+    auto update_version = TRY(prepare_statement("INSERT INTO SchemaVersions (store, version) VALUES (?, ?) ON CONFLICT(store) DO UPDATE SET version = excluded.version;"sv));
+    TRY(try_execute_statement(update_version, {}, store, latest_version));
+
+    TRY(transaction.commit());
+    return MigrationOutcome::Success;
+}
+
+ErrorOr<bool> Database::table_exists(StringView table)
+{
+    if (!m_table_exists_statement.has_value())
+        m_table_exists_statement = TRY(prepare_statement("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?;"sv));
+
+    bool exists = false;
+    TRY(try_execute_statement(*m_table_exists_statement, [&](auto) { exists = true; }, TRY(String::from_utf8(table))));
+    return exists;
+}
+
+ErrorOr<Optional<u32>> Database::schema_version(StringView store)
+{
+    if (!TRY(table_exists("SchemaVersions"sv)))
+        return OptionalNone {};
+
+    if (!m_schema_version_statement.has_value())
+        m_schema_version_statement = TRY(prepare_statement("SELECT version FROM SchemaVersions WHERE store = ?;"sv));
+
+    Optional<u32> version;
+    TRY(try_execute_statement(*m_schema_version_statement, [&](auto statement_id) { version = result_column<u32>(statement_id, 0); }, TRY(String::from_utf8(store))));
+    return version;
+}
+
 ErrorOr<void> Database::set_journal_mode_pragma(JournalMode journal_mode)
 {
     auto journal_mode_string = [&]() {
@@ -216,7 +354,7 @@ ErrorOr<void> Database::set_journal_mode_pragma(JournalMode journal_mode)
     }();
 
     auto pragma = ByteString::formatted("PRAGMA journal_mode={};", journal_mode_string);
-    SQL_TRY(sqlite3_exec(m_database, pragma.characters(), nullptr, nullptr, nullptr));
+    TRY(execute_raw(pragma));
 
     return {};
 }
@@ -238,7 +376,7 @@ ErrorOr<void> Database::set_synchronous_pragma(Synchronous synchronous)
     }();
 
     auto pragma = ByteString::formatted("PRAGMA synchronous={};", synchronous_string);
-    SQL_TRY(sqlite3_exec(m_database, pragma.characters(), nullptr, nullptr, nullptr));
+    TRY(execute_raw(pragma));
 
     return {};
 }

--- a/Libraries/LibDatabase/Database.h
+++ b/Libraries/LibDatabase/Database.h
@@ -11,7 +11,9 @@
 #include <AK/Function.h>
 #include <AK/LexicalPath.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
 #include <AK/RefCounted.h>
+#include <AK/Span.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibDatabase/Forward.h>
@@ -20,6 +22,17 @@ struct sqlite3;
 struct sqlite3_stmt;
 
 namespace Database {
+
+struct Migration {
+    u32 version { 0 };
+
+    // Executed first. May contain multiple statements.
+    ByteString sql {};
+
+    // Optional, runs after `sql`. Use this to bind placeholder values. Use
+    // try_execute_statement to allow a failure to roll the migration transaction back.
+    Function<ErrorOr<void>(Database&)> backfill {};
+};
 
 class DATABASE_API Database : public RefCounted<Database> {
 public:
@@ -52,6 +65,46 @@ public:
     template<typename ValueType>
     ValueType result_column(StatementID, int column);
 
+    ErrorOr<void> execute_raw(ByteString const& sql);
+
+    // Error-returning sibling of execute_statement, for callers that must handle failures
+    // (e.g. migration backfills, which roll the migration transaction back) instead of
+    // aborting the process.
+    template<typename... PlaceholderValues>
+    ErrorOr<void> try_execute_statement(StatementID statement_id, OnResult on_result, PlaceholderValues&&... placeholder_values)
+    {
+        if constexpr (sizeof...(PlaceholderValues) > 0) {
+            int index = 1;
+            Optional<Error> bind_error;
+
+            auto bind = [&](auto const& value) {
+                if (bind_error.has_value())
+                    return;
+                if (auto result = try_apply_placeholder(statement_id, index++, value); result.is_error())
+                    bind_error = result.release_error();
+            };
+            (bind(forward<PlaceholderValues>(placeholder_values)), ...);
+
+            if (bind_error.has_value())
+                return bind_error.release_value();
+        }
+
+        VERIFY(bound_parameter_count(statement_id) == sizeof...(PlaceholderValues));
+        return try_execute_statement_internal(statement_id, move(on_result));
+    }
+
+    // Brings the named store's schema to the latest version by replaying, in order, every
+    // migration newer than the version recorded for it in the SchemaVersions table. Shipped
+    // migration text is immutable; schema changes append a new version. Baseline (first)
+    // migrations use CREATE ... IF NOT EXISTS so pre-versioning databases adopt them as a
+    // no-op; later migrations must not.
+    ErrorOr<MigrationOutcome> migrate(StringView store_name, ReadonlySpan<Migration> migrations, MigrationMode = MigrationMode::Apply);
+
+    ErrorOr<bool> table_exists(StringView table);
+
+    // The version recorded for the store in SchemaVersions, or empty if it has none yet.
+    ErrorOr<Optional<u32>> schema_version(StringView store);
+
     // https://www.sqlite.org/pragma.html#pragma_journal_mode
     enum class JournalMode {
         Delete,
@@ -77,11 +130,36 @@ private:
     Database(sqlite3*, Optional<LexicalPath> database_path);
 
     void execute_statement_internal(StatementID, OnResult);
+    ErrorOr<void> try_execute_statement_internal(StatementID, OnResult);
 
     int bound_parameter_count(StatementID);
 
     template<typename ValueType>
     void apply_placeholder(StatementID statement_id, int index, ValueType const& value);
+
+    template<typename ValueType>
+    ErrorOr<void> try_apply_placeholder(StatementID statement_id, int index, ValueType const& value);
+
+    class Transaction {
+    public:
+        explicit Transaction(Database& database)
+            : m_database(database)
+        {
+        }
+        ~Transaction();
+
+        Transaction(Transaction&&) = delete;
+        Transaction(Transaction const&) = delete;
+        Transaction& operator=(Transaction&&) = delete;
+        Transaction& operator=(Transaction const&) = delete;
+
+        ErrorOr<void> begin();
+        ErrorOr<void> commit();
+
+    private:
+        Database& m_database;
+        bool m_active { false };
+    };
 
     ALWAYS_INLINE sqlite3_stmt* prepared_statement(StatementID statement_id)
     {
@@ -92,6 +170,8 @@ private:
     Optional<LexicalPath> m_database_path;
     sqlite3* m_database { nullptr };
     Vector<sqlite3_stmt*> m_prepared_statements;
+    Optional<StatementID> m_table_exists_statement;
+    Optional<StatementID> m_schema_version_statement;
 };
 
 }

--- a/Libraries/LibDatabase/Forward.h
+++ b/Libraries/LibDatabase/Forward.h
@@ -15,4 +15,14 @@ class Database;
 
 using StatementID = size_t;
 
+enum class MigrationOutcome : u8 {
+    Success,        // The store's schema is now at the latest known version.
+    DatabaseTooNew, // The recorded version is newer than this build understands; the database was left untouched.
+};
+
+enum class MigrationMode : u8 {
+    Apply,     // Run pending migrations and record the new version.
+    CheckOnly, // Determine the outcome, then roll back unconditionally without committing anything.
+};
+
 }

--- a/Libraries/LibHTTP/Cache/CacheIndex.cpp
+++ b/Libraries/LibHTTP/Cache/CacheIndex.cpp
@@ -155,7 +155,7 @@ ErrorOr<CacheIndex> CacheIndex::create(Database::Database& database, LexicalPath
 #endif
 
     Statements statements {};
-    statements.insert_entry = TRY(database.prepare_statement("INSERT OR REPLACE INTO CacheIndex VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"sv));
+    statements.insert_entry = TRY(database.prepare_statement("INSERT OR REPLACE INTO CacheIndex (cache_key, vary_key, url, request_headers, response_headers, data_size, associated_data_size, request_time, response_time, last_access_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"sv));
     statements.remove_entry = TRY(database.prepare_statement(R"#(
         DELETE FROM CacheIndex
         WHERE cache_key = ? AND vary_key = ?
@@ -166,7 +166,7 @@ ErrorOr<CacheIndex> CacheIndex::create(Database::Database& database, LexicalPath
         WHERE last_access_time >= ?
         RETURNING cache_key, vary_key, data_size + associated_data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers);
     )#"sv));
-    statements.select_entries = TRY(database.prepare_statement("SELECT * FROM CacheIndex WHERE cache_key = ?;"sv));
+    statements.select_entries = TRY(database.prepare_statement("SELECT vary_key, url, request_headers, response_headers, data_size, associated_data_size, request_time, response_time, last_access_time FROM CacheIndex WHERE cache_key = ?;"sv));
     statements.update_response_headers = TRY(database.prepare_statement("UPDATE CacheIndex SET response_headers = ? WHERE cache_key = ? AND vary_key = ?;"sv));
     statements.update_associated_data_size = TRY(database.prepare_statement("UPDATE CacheIndex SET associated_data_size = ? WHERE cache_key = ? AND vary_key = ?;"sv));
     statements.update_last_access_time = TRY(database.prepare_statement("UPDATE CacheIndex SET last_access_time = ? WHERE cache_key = ? AND vary_key = ?;"sv));
@@ -387,7 +387,7 @@ Optional<CacheIndex::Entry const&> CacheIndex::find_entry(u64 cache_key, HeaderL
         m_database->execute_statement(
             m_statements.select_entries,
             [&](auto statement_id) {
-                int column = 1; // Skip the cache_key column.
+                int column = 0;
 
                 auto vary_key = m_database->result_column<u64>(statement_id, column++);
                 auto url = m_database->result_column<String>(statement_id, column++);

--- a/Libraries/LibHTTP/Cache/CacheIndex.cpp
+++ b/Libraries/LibHTTP/Cache/CacheIndex.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/Debug.h>
+#include <AK/StdLibExtras.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/Directory.h>
 #include <LibFileSystem/FileSystem.h>
@@ -14,7 +16,7 @@
 
 namespace HTTP {
 
-static constexpr u32 CACHE_METADATA_KEY = 12389u;
+static constexpr u32 INDEX_SCHEMA_BASELINE_VERSION = 1u;
 
 static ByteString serialize_headers(HeaderList const& headers)
 {
@@ -98,58 +100,37 @@ static void log_orphaned_disk_cache_entries(Database::Database& database)
 
 #endif
 
+// The index schema version is independent of CACHE_VERSION: index-only schema changes append
+// a migration here without invalidating the cache entries on disk. Entry files embed
+// CACHE_VERSION in their headers and are validated when read, so an entry format break must
+// append a migration that deletes the index rows referencing the now-unreadable entries.
+static_assert(CACHE_VERSION == 7, "Bumping CACHE_VERSION requires appending a CacheIndex migration that deletes the index rows referencing the old entry format");
+
+ErrorOr<Database::MigrationOutcome> CacheIndex::migrate_schema(Database::Database& database, Database::MigrationMode mode)
+{
+    Array<Database::Migration, 1> migrations { {
+        { .version = INDEX_SCHEMA_BASELINE_VERSION, .sql = R"#(
+            CREATE TABLE IF NOT EXISTS CacheIndex (
+                cache_key INTEGER,
+                vary_key INTEGER,
+                url TEXT,
+                request_headers BLOB,
+                response_headers BLOB,
+                data_size INTEGER,
+                associated_data_size INTEGER,
+                request_time INTEGER,
+                response_time INTEGER,
+                last_access_time INTEGER,
+                PRIMARY KEY(cache_key, vary_key)
+            );
+        )#"sv },
+    } };
+
+    return database.migrate("CacheIndex"sv, migrations, mode);
+}
+
 ErrorOr<CacheIndex> CacheIndex::create(Database::Database& database, LexicalPath const& cache_directory)
 {
-    auto create_cache_metadata_table = TRY(database.prepare_statement(R"#(
-        CREATE TABLE IF NOT EXISTS CacheMetadata (
-            metadata_key INTEGER,
-            version INTEGER,
-            PRIMARY KEY(metadata_key)
-        );
-    )#"sv));
-    database.execute_statement(create_cache_metadata_table, {});
-
-    auto read_cache_version = TRY(database.prepare_statement("SELECT version FROM CacheMetadata WHERE metadata_key = ?;"sv));
-    auto cache_version = 0u;
-
-    database.execute_statement(
-        read_cache_version,
-        [&](auto statement_id) { cache_version = database.result_column<u32>(statement_id, 0); },
-        CACHE_METADATA_KEY);
-
-    if (cache_version != CACHE_VERSION) {
-        if (cache_version != 0)
-            dbgln_if(HTTP_DISK_CACHE_DEBUG, "\033[36m[disk]\033[0m \033[31;1mDisk cache version mismatch:\033[0m stored version = {}, new version = {}", cache_version, CACHE_VERSION);
-
-        // FIXME: We should more elegantly handle minor changes, i.e. use ALTER TABLE to add fields to CacheIndex.
-        auto delete_cache_index_table = TRY(database.prepare_statement("DROP TABLE IF EXISTS CacheIndex;"sv));
-        database.execute_statement(delete_cache_index_table, {});
-
-        auto set_cache_version = TRY(database.prepare_statement("INSERT OR REPLACE INTO CacheMetadata VALUES (?, ?);"sv));
-        database.execute_statement(set_cache_version, {}, CACHE_METADATA_KEY, CACHE_VERSION);
-
-        for_each_cache_entry_file(database, [&](LexicalPath const& cache_entry) {
-            (void)FileSystem::remove(cache_entry.string(), FileSystem::RecursionMode::Disallowed);
-        });
-    }
-
-    auto create_cache_index_table = TRY(database.prepare_statement(R"#(
-        CREATE TABLE IF NOT EXISTS CacheIndex (
-            cache_key INTEGER,
-            vary_key INTEGER,
-            url TEXT,
-            request_headers BLOB,
-            response_headers BLOB,
-            data_size INTEGER,
-            associated_data_size INTEGER,
-            request_time INTEGER,
-            response_time INTEGER,
-            last_access_time INTEGER,
-            PRIMARY KEY(cache_key, vary_key)
-        );
-    )#"sv));
-    database.execute_statement(create_cache_index_table, {});
-
 #if HTTP_DISK_CACHE_DEBUG
     log_orphaned_disk_cache_entries(database);
 #endif

--- a/Libraries/LibHTTP/Cache/CacheIndex.h
+++ b/Libraries/LibHTTP/Cache/CacheIndex.h
@@ -42,6 +42,8 @@ class CacheIndex {
     };
 
 public:
+    static ErrorOr<Database::MigrationOutcome> migrate_schema(Database::Database&, Database::MigrationMode = Database::MigrationMode::Apply);
+
     static ErrorOr<CacheIndex> create(Database::Database&, LexicalPath const& cache_directory);
 
     ErrorOr<void> create_entry(u64 cache_key, u64 vary_key, String url, NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers, u64 data_size, UnixDateTime request_time, UnixDateTime response_time);

--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -65,6 +65,15 @@ ErrorOr<DiskCache> DiskCache::create(Mode mode)
         ? TRY(Database::Database::create(cache_directory.string(), INDEX_DATABASE))
         : TRY(Database::Database::create_memory_backed());
 
+    if (TRY(CacheIndex::migrate_schema(*database)) == Database::MigrationOutcome::DatabaseTooNew) {
+        // Entry file names are derived from the cache key, so writing into the existing cache
+        // directory without its index would corrupt entries the newer build's index refers to.
+        // Partitioned mode is already a per-process transient cache in its own directory.
+        // (A fresh memory-backed database always migrates, so this is necessarily Mode::Normal.)
+        dbgln("Disk cache index was created by a newer Ladybird version; using a transient cache this session");
+        return create(Mode::Partitioned);
+    }
+
     auto index = TRY(CacheIndex::create(database, cache_directory));
 
     return DiskCache { mode, move(database), move(cache_directory), move(index) };

--- a/Libraries/LibHTTP/Cache/Version.h
+++ b/Libraries/LibHTTP/Cache/Version.h
@@ -10,7 +10,8 @@
 
 namespace HTTP {
 
-// Increment this version when a breaking change is made to the cache index or cache entry formats.
+// Increment this version when a breaking change is made to the cache entry file format.
+// Index-only schema changes are handled by the CacheIndex schema migrations instead.
 static constexpr inline u32 CACHE_VERSION = 7u;
 
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -788,23 +788,28 @@ ErrorOr<void> Application::launch_services()
         // if any store then has to veto.
         auto cookies_outcome = TRY(CookieJar::migrate_schema(*m_database, Database::MigrationMode::CheckOnly));
         auto hsts_outcome = TRY(HSTSStore::migrate_schema(*m_database, Database::MigrationMode::CheckOnly));
+        auto storage_outcome = TRY(StorageJar::migrate_schema(*m_database, Database::MigrationMode::CheckOnly));
 
-        if (cookies_outcome == Database::MigrationOutcome::Success && hsts_outcome == Database::MigrationOutcome::Success) {
+        if (cookies_outcome == Database::MigrationOutcome::Success && hsts_outcome == Database::MigrationOutcome::Success && storage_outcome == Database::MigrationOutcome::Success) {
             // Apply in order, stopping at the first store that finds the database too new
             // (a concurrent process may have migrated it since the preflight).
             cookies_outcome = TRY(CookieJar::migrate_schema(*m_database));
             hsts_outcome = cookies_outcome == Database::MigrationOutcome::Success
                 ? TRY(HSTSStore::migrate_schema(*m_database))
                 : Database::MigrationOutcome::DatabaseTooNew;
+            storage_outcome = hsts_outcome == Database::MigrationOutcome::Success
+                ? TRY(StorageJar::migrate_schema(*m_database))
+                : Database::MigrationOutcome::DatabaseTooNew;
         }
 
         // If any store finds the shared file too new, including a concurrent process migrating it
         // between the preflight and an apply above, none of them may persist this session, even if
         // an earlier store already migrated. Otherwise, we would keep writing to a vetoed database.
-        if (cookies_outcome != Database::MigrationOutcome::Success || hsts_outcome != Database::MigrationOutcome::Success) {
+        if (cookies_outcome != Database::MigrationOutcome::Success || hsts_outcome != Database::MigrationOutcome::Success || storage_outcome != Database::MigrationOutcome::Success) {
             warnln("Browsing database was created by a newer Ladybird version; cookies, web storage and HSTS policies will not be persisted this session");
             cookies_outcome = Database::MigrationOutcome::DatabaseTooNew;
             hsts_outcome = Database::MigrationOutcome::DatabaseTooNew;
+            storage_outcome = Database::MigrationOutcome::DatabaseTooNew;
         }
 
         if (cookies_outcome == Database::MigrationOutcome::Success)
@@ -817,9 +822,7 @@ ErrorOr<void> Application::launch_services()
         else
             m_hsts_store = HSTSStore::create();
 
-        // The web storage store does not track schema versions yet, so it only persists
-        // when no store has vetoed the file.
-        if (cookies_outcome == Database::MigrationOutcome::Success && hsts_outcome == Database::MigrationOutcome::Success)
+        if (storage_outcome == Database::MigrationOutcome::Success)
             m_storage_jar = TRY(StorageJar::create(*m_database));
         else
             m_storage_jar = StorageJar::create();

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -784,17 +784,45 @@ ErrorOr<void> Application::launch_services()
 
         // The browsing database is shared by several stores, so the decision to fall back is
         // made for the file as a whole: if any store's schema is too new, none of them may
-        // modify the file.
-        if (TRY(CookieJar::migrate_schema(*m_database)) == Database::MigrationOutcome::Success) {
-            m_cookie_jar = TRY(CookieJar::create(*m_database));
-            m_hsts_store = TRY(HSTSStore::create(*m_database));
-            m_storage_jar = TRY(StorageJar::create(*m_database));
-        } else {
-            warnln("Browsing database was created by a newer Ladybird version; cookies, web storage and HSTS policies will not be persisted this session");
-            m_cookie_jar = CookieJar::create();
-            m_hsts_store = HSTSStore::create();
-            m_storage_jar = StorageJar::create();
+        // modify the file. The check-only preflight never writes, so the file is untouched
+        // if any store then has to veto.
+        auto cookies_outcome = TRY(CookieJar::migrate_schema(*m_database, Database::MigrationMode::CheckOnly));
+        auto hsts_outcome = TRY(HSTSStore::migrate_schema(*m_database, Database::MigrationMode::CheckOnly));
+
+        if (cookies_outcome == Database::MigrationOutcome::Success && hsts_outcome == Database::MigrationOutcome::Success) {
+            // Apply in order, stopping at the first store that finds the database too new
+            // (a concurrent process may have migrated it since the preflight).
+            cookies_outcome = TRY(CookieJar::migrate_schema(*m_database));
+            hsts_outcome = cookies_outcome == Database::MigrationOutcome::Success
+                ? TRY(HSTSStore::migrate_schema(*m_database))
+                : Database::MigrationOutcome::DatabaseTooNew;
         }
+
+        // If any store finds the shared file too new, including a concurrent process migrating it
+        // between the preflight and an apply above, none of them may persist this session, even if
+        // an earlier store already migrated. Otherwise, we would keep writing to a vetoed database.
+        if (cookies_outcome != Database::MigrationOutcome::Success || hsts_outcome != Database::MigrationOutcome::Success) {
+            warnln("Browsing database was created by a newer Ladybird version; cookies, web storage and HSTS policies will not be persisted this session");
+            cookies_outcome = Database::MigrationOutcome::DatabaseTooNew;
+            hsts_outcome = Database::MigrationOutcome::DatabaseTooNew;
+        }
+
+        if (cookies_outcome == Database::MigrationOutcome::Success)
+            m_cookie_jar = TRY(CookieJar::create(*m_database));
+        else
+            m_cookie_jar = CookieJar::create();
+
+        if (hsts_outcome == Database::MigrationOutcome::Success)
+            m_hsts_store = TRY(HSTSStore::create(*m_database));
+        else
+            m_hsts_store = HSTSStore::create();
+
+        // The web storage store does not track schema versions yet, so it only persists
+        // when no store has vetoed the file.
+        if (cookies_outcome == Database::MigrationOutcome::Success && hsts_outcome == Database::MigrationOutcome::Success)
+            m_storage_jar = TRY(StorageJar::create(*m_database));
+        else
+            m_storage_jar = StorageJar::create();
 
         if (TRY(HistoryStore::migrate_schema(*m_history_database)) == Database::MigrationOutcome::Success) {
             m_history_store = TRY(HistoryStore::create(*m_history_database));

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -783,9 +783,15 @@ ErrorOr<void> Application::launch_services()
             dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] SQL history is enabled, using {}", history_database_path->string());
 
         m_cookie_jar = TRY(CookieJar::create(*m_database));
-        m_history_store = TRY(HistoryStore::create(*m_history_database));
         m_hsts_store = TRY(HSTSStore::create(*m_database));
         m_storage_jar = TRY(StorageJar::create(*m_database));
+
+        if (TRY(HistoryStore::migrate_schema(*m_history_database)) == Database::MigrationOutcome::Success) {
+            m_history_store = TRY(HistoryStore::create(*m_history_database));
+        } else {
+            dbgln("History database was created by a newer Ladybird version; history will not be persisted this session");
+            m_history_store = HistoryStore::create();
+        }
     } else {
         dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] SQL history is disabled, disabling browsing history");
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -782,9 +782,19 @@ ErrorOr<void> Application::launch_services()
         if (auto history_database_path = m_history_database->database_path(); history_database_path.has_value())
             dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] SQL history is enabled, using {}", history_database_path->string());
 
-        m_cookie_jar = TRY(CookieJar::create(*m_database));
-        m_hsts_store = TRY(HSTSStore::create(*m_database));
-        m_storage_jar = TRY(StorageJar::create(*m_database));
+        // The browsing database is shared by several stores, so the decision to fall back is
+        // made for the file as a whole: if any store's schema is too new, none of them may
+        // modify the file.
+        if (TRY(CookieJar::migrate_schema(*m_database)) == Database::MigrationOutcome::Success) {
+            m_cookie_jar = TRY(CookieJar::create(*m_database));
+            m_hsts_store = TRY(HSTSStore::create(*m_database));
+            m_storage_jar = TRY(StorageJar::create(*m_database));
+        } else {
+            warnln("Browsing database was created by a newer Ladybird version; cookies, web storage and HSTS policies will not be persisted this session");
+            m_cookie_jar = CookieJar::create();
+            m_hsts_store = HSTSStore::create();
+            m_storage_jar = StorageJar::create();
+        }
 
         if (TRY(HistoryStore::migrate_schema(*m_history_database)) == Database::MigrationOutcome::Success) {
             m_history_store = TRY(HistoryStore::create(*m_history_database));

--- a/Libraries/LibWebView/CookieJar.cpp
+++ b/Libraries/LibWebView/CookieJar.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/IPv4Address.h>
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>
@@ -25,33 +26,45 @@ namespace WebView {
 
 static constexpr auto DATABASE_SYNCHRONIZATION_TIMER = AK::Duration::from_seconds(30);
 
+static constexpr u32 COOKIES_SCHEMA_BASELINE_VERSION = 1u;
+
 static CookieStorageKey storage_key_for_cookie(HTTP::Cookie::Cookie const& cookie)
 {
     return { cookie.name, cookie.domain, cookie.path };
 }
 
+ErrorOr<Database::MigrationOutcome> CookieJar::migrate_schema(Database::Database& database, Database::MigrationMode mode)
+{
+    // Shipped migration text is immutable, so the CHECK constraint hardcodes the largest
+    // SameSite value instead of deriving it from the enum.
+    static_assert(to_underlying(HTTP::Cookie::SameSite::Lax) == 3);
+
+    Array<Database::Migration, 1> migrations { {
+        { .version = COOKIES_SCHEMA_BASELINE_VERSION, .sql = R"#(
+            CREATE TABLE IF NOT EXISTS Cookies (
+                name TEXT,
+                value TEXT,
+                same_site INTEGER CHECK (same_site >= 0 AND same_site <= 3),
+                creation_time INTEGER,
+                last_access_time INTEGER,
+                expiry_time INTEGER,
+                domain TEXT,
+                path TEXT,
+                secure BOOLEAN,
+                http_only BOOLEAN,
+                host_only BOOLEAN,
+                persistent BOOLEAN,
+                PRIMARY KEY(name, domain, path)
+            );
+        )#"sv },
+    } };
+
+    return database.migrate("Cookies"sv, migrations, mode);
+}
+
 ErrorOr<NonnullOwnPtr<CookieJar>> CookieJar::create(Database::Database& database)
 {
     Statements statements {};
-
-    auto create_table = TRY(database.prepare_statement(MUST(String::formatted(R"#(
-        CREATE TABLE IF NOT EXISTS Cookies (
-            name TEXT,
-            value TEXT,
-            same_site INTEGER CHECK (same_site >= 0 AND same_site <= {}),
-            creation_time INTEGER,
-            last_access_time INTEGER,
-            expiry_time INTEGER,
-            domain TEXT,
-            path TEXT,
-            secure BOOLEAN,
-            http_only BOOLEAN,
-            host_only BOOLEAN,
-            persistent BOOLEAN,
-            PRIMARY KEY(name, domain, path)
-        );)#",
-        to_underlying(HTTP::Cookie::SameSite::Lax)))));
-    database.execute_statement(create_table, {});
 
     statements.insert_cookie = TRY(database.prepare_statement("INSERT OR REPLACE INTO Cookies (name, value, same_site, creation_time, last_access_time, expiry_time, domain, path, secure, http_only, host_only, persistent) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"sv));
     statements.expire_cookie = TRY(database.prepare_statement("DELETE FROM Cookies WHERE (expiry_time < ?);"sv));

--- a/Libraries/LibWebView/CookieJar.cpp
+++ b/Libraries/LibWebView/CookieJar.cpp
@@ -53,9 +53,9 @@ ErrorOr<NonnullOwnPtr<CookieJar>> CookieJar::create(Database::Database& database
         to_underlying(HTTP::Cookie::SameSite::Lax)))));
     database.execute_statement(create_table, {});
 
-    statements.insert_cookie = TRY(database.prepare_statement("INSERT OR REPLACE INTO Cookies VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"sv));
+    statements.insert_cookie = TRY(database.prepare_statement("INSERT OR REPLACE INTO Cookies (name, value, same_site, creation_time, last_access_time, expiry_time, domain, path, secure, http_only, host_only, persistent) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"sv));
     statements.expire_cookie = TRY(database.prepare_statement("DELETE FROM Cookies WHERE (expiry_time < ?);"sv));
-    statements.select_all_cookies = TRY(database.prepare_statement("SELECT * FROM Cookies;"sv));
+    statements.select_all_cookies = TRY(database.prepare_statement("SELECT name, value, same_site, creation_time, last_access_time, expiry_time, domain, path, secure, http_only, host_only, persistent FROM Cookies;"sv));
 
     return adopt_own(*new CookieJar { PersistedStorage { database, statements } });
 }

--- a/Libraries/LibWebView/CookieJar.h
+++ b/Libraries/LibWebView/CookieJar.h
@@ -32,6 +32,8 @@ struct CookieStorageKey {
 
 class WEBVIEW_API CookieJar {
 public:
+    static ErrorOr<Database::MigrationOutcome> migrate_schema(Database::Database&, Database::MigrationMode = Database::MigrationMode::Apply);
+
     static ErrorOr<NonnullOwnPtr<CookieJar>> create(Database::Database&);
     static NonnullOwnPtr<CookieJar> create();
 

--- a/Libraries/LibWebView/HSTSStore.cpp
+++ b/Libraries/LibWebView/HSTSStore.cpp
@@ -25,9 +25,9 @@ ErrorOr<NonnullOwnPtr<HSTSStore>> HSTSStore::create(Database::Database& database
                                                        ");"sv));
     database.execute_statement(create_table, {});
 
-    statements.insert_policy = TRY(database.prepare_statement("INSERT OR REPLACE INTO HSTSPolicies VALUES (?, ?, ?, ?);"sv));
+    statements.insert_policy = TRY(database.prepare_statement("INSERT OR REPLACE INTO HSTSPolicies (domain, expiry_time, include_sub_domains, last_observed_time) VALUES (?, ?, ?, ?);"sv));
     statements.delete_expired = TRY(database.prepare_statement("DELETE FROM HSTSPolicies WHERE (expiry_time < ?);"sv));
-    statements.select_all_policies = TRY(database.prepare_statement("SELECT * FROM HSTSPolicies;"sv));
+    statements.select_all_policies = TRY(database.prepare_statement("SELECT domain, expiry_time, include_sub_domains, last_observed_time FROM HSTSPolicies;"sv));
 
     return adopt_own(*new HSTSStore { PersistedStorage { database, statements } });
 }

--- a/Libraries/LibWebView/HSTSStore.cpp
+++ b/Libraries/LibWebView/HSTSStore.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Time.h>
 #include <LibDatabase/Database.h>
@@ -13,17 +14,25 @@ namespace WebView {
 
 static constexpr auto DATABASE_SYNCHRONIZATION_TIMER = AK::Duration::from_seconds(30);
 
+static constexpr u32 HSTS_SCHEMA_BASELINE_VERSION = 1u;
+
+ErrorOr<Database::MigrationOutcome> HSTSStore::migrate_schema(Database::Database& database, Database::MigrationMode mode)
+{
+    Array<Database::Migration, 1> migrations { {
+        { .version = HSTS_SCHEMA_BASELINE_VERSION, .sql = "CREATE TABLE IF NOT EXISTS HSTSPolicies ("
+                                                          "    domain TEXT PRIMARY KEY,"
+                                                          "    expiry_time INTEGER NOT NULL,"
+                                                          "    include_sub_domains BOOLEAN NOT NULL,"
+                                                          "    last_observed_time INTEGER NOT NULL"
+                                                          ");"sv },
+    } };
+
+    return database.migrate("HSTSPolicies"sv, migrations, mode);
+}
+
 ErrorOr<NonnullOwnPtr<HSTSStore>> HSTSStore::create(Database::Database& database)
 {
     Statements statements {};
-
-    auto create_table = TRY(database.prepare_statement("CREATE TABLE IF NOT EXISTS HSTSPolicies ("
-                                                       "    domain TEXT PRIMARY KEY,"
-                                                       "    expiry_time INTEGER NOT NULL,"
-                                                       "    include_sub_domains BOOLEAN NOT NULL,"
-                                                       "    last_observed_time INTEGER NOT NULL"
-                                                       ");"sv));
-    database.execute_statement(create_table, {});
 
     statements.insert_policy = TRY(database.prepare_statement("INSERT OR REPLACE INTO HSTSPolicies (domain, expiry_time, include_sub_domains, last_observed_time) VALUES (?, ?, ?, ?);"sv));
     statements.delete_expired = TRY(database.prepare_statement("DELETE FROM HSTSPolicies WHERE (expiry_time < ?);"sv));

--- a/Libraries/LibWebView/HSTSStore.h
+++ b/Libraries/LibWebView/HSTSStore.h
@@ -18,6 +18,8 @@ namespace WebView {
 
 class WEBVIEW_API HSTSStore {
 public:
+    static ErrorOr<Database::MigrationOutcome> migrate_schema(Database::Database&, Database::MigrationMode = Database::MigrationMode::Apply);
+
     static ErrorOr<NonnullOwnPtr<HSTSStore>> create(Database::Database&);
     static NonnullOwnPtr<HSTSStore> create();
 

--- a/Libraries/LibWebView/HistoryStore.cpp
+++ b/Libraries/LibWebView/HistoryStore.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/Debug.h>
 #include <AK/QuickSort.h>
 #include <AK/Utf8View.h>
@@ -17,6 +18,8 @@ namespace WebView {
 
 static constexpr auto DEFAULT_AUTOCOMPLETE_SUGGESTION_LIMIT = 8uz;
 static constexpr size_t MINIMUM_TITLE_AUTOCOMPLETE_QUERY_LENGTH = 3;
+
+static constexpr u32 HISTORY_SCHEMA_BASELINE_VERSION = 1u;
 
 static Optional<StringView> url_without_scheme(StringView url)
 {
@@ -122,6 +125,26 @@ static void sort_matching_entries(Vector<HistoryEntry const*>& matches, StringVi
     return history_log_suggestions(suggestions);
 }
 
+ErrorOr<Database::MigrationOutcome> HistoryStore::migrate_schema(Database::Database& database, Database::MigrationMode mode)
+{
+    Array<Database::Migration, 1> migrations { {
+        { .version = HISTORY_SCHEMA_BASELINE_VERSION, .sql = R"#(
+            CREATE TABLE IF NOT EXISTS History (
+                url TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                favicon TEXT,
+                visit_count INTEGER NOT NULL,
+                last_visited_time INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS HistoryLastVisitedTimeIndex
+            ON History(last_visited_time DESC);
+        )#"sv },
+    } };
+
+    return database.migrate("History"sv, migrations, mode);
+}
+
 ErrorOr<NonnullOwnPtr<HistoryStore>> HistoryStore::create(Database::Database& database)
 {
     if (auto database_path = database.database_path(); database_path.has_value())
@@ -130,23 +153,6 @@ ErrorOr<NonnullOwnPtr<HistoryStore>> HistoryStore::create(Database::Database& da
         dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Opening memory-backed persisted history store");
 
     Statements statements {};
-
-    auto create_history_table = TRY(database.prepare_statement(R"#(
-        CREATE TABLE IF NOT EXISTS History (
-            url TEXT PRIMARY KEY,
-            title TEXT NOT NULL,
-            favicon TEXT,
-            visit_count INTEGER NOT NULL,
-            last_visited_time INTEGER NOT NULL
-        );
-    )#"sv));
-    database.execute_statement(create_history_table, {});
-
-    auto create_last_visited_index = TRY(database.prepare_statement(R"#(
-        CREATE INDEX IF NOT EXISTS HistoryLastVisitedTimeIndex
-        ON History(last_visited_time DESC);
-    )#"sv));
-    database.execute_statement(create_last_visited_index, {});
 
     statements.upsert_entry = TRY(database.prepare_statement(R"#(
         INSERT INTO History (url, title, visit_count, last_visited_time)

--- a/Libraries/LibWebView/HistoryStore.h
+++ b/Libraries/LibWebView/HistoryStore.h
@@ -38,6 +38,8 @@ class WEBVIEW_API HistoryStore {
     AK_MAKE_NONMOVABLE(HistoryStore);
 
 public:
+    static ErrorOr<Database::MigrationOutcome> migrate_schema(Database::Database&, Database::MigrationMode = Database::MigrationMode::Apply);
+
     static ErrorOr<NonnullOwnPtr<HistoryStore>> create(Database::Database&);
     static NonnullOwnPtr<HistoryStore> create();
     static NonnullOwnPtr<HistoryStore> create_disabled();

--- a/Libraries/LibWebView/StorageJar.cpp
+++ b/Libraries/LibWebView/StorageJar.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/StdLibExtras.h>
 #include <LibDatabase/Database.h>
@@ -14,45 +15,29 @@ namespace WebView {
 // Quota size is specified in https://storage.spec.whatwg.org/#registered-storage-endpoints
 static constexpr size_t LOCAL_STORAGE_QUOTA = 5 * MiB;
 
-// Increment this version when needing to alter the WebStorage schema.
-static constexpr u32 WEB_STORAGE_VERSION = 2u;
+static constexpr u32 WEB_STORAGE_SCHEMA_BASELINE_VERSION = 1u;
 
-static constexpr u32 WEB_STORAGE_METADATA_KEY = 12389u;
+ErrorOr<Database::MigrationOutcome> StorageJar::migrate_schema(Database::Database& database, Database::MigrationMode mode)
+{
+    Array<Database::Migration, 1> migrations { {
+        { .version = WEB_STORAGE_SCHEMA_BASELINE_VERSION, .sql = R"#(
+            CREATE TABLE IF NOT EXISTS WebStorage (
+                storage_endpoint INTEGER,
+                storage_key TEXT,
+                bottle_key TEXT,
+                bottle_value TEXT,
+                last_access_time INTEGER,
+                PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
+            );
+        )#"sv },
+    } };
+
+    return database.migrate("WebStorage"sv, migrations, mode);
+}
 
 ErrorOr<NonnullOwnPtr<StorageJar>> StorageJar::create(Database::Database& database)
 {
     Statements statements {};
-
-    auto create_metadata_table = TRY(database.prepare_statement(R"#(
-        CREATE TABLE IF NOT EXISTS WebStorageMetadata (
-            metadata_key INTEGER,
-            version INTEGER,
-            PRIMARY KEY(metadata_key)
-        );
-    )#"sv));
-    database.execute_statement(create_metadata_table, {});
-
-    auto create_storage_table = TRY(database.prepare_statement(R"#(
-        CREATE TABLE IF NOT EXISTS WebStorage (
-            storage_endpoint INTEGER,
-            storage_key TEXT,
-            bottle_key TEXT,
-            bottle_value TEXT,
-            PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
-        );
-    )#"sv));
-    database.execute_statement(create_storage_table, {});
-
-    auto read_storage_version = TRY(database.prepare_statement("SELECT version FROM WebStorageMetadata WHERE metadata_key = ?;"sv));
-    auto storage_version = 0u;
-
-    database.execute_statement(
-        read_storage_version,
-        [&](auto statement_id) { storage_version = database.result_column<u32>(statement_id, 0); },
-        WEB_STORAGE_METADATA_KEY);
-
-    if (storage_version != WEB_STORAGE_VERSION)
-        TRY(upgrade_database(database, storage_version));
 
     statements.get_item = TRY(database.prepare_statement("SELECT bottle_value FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ? AND bottle_key = ?;"sv));
     statements.set_item = TRY(database.prepare_statement("INSERT OR REPLACE INTO WebStorage (storage_endpoint, storage_key, bottle_key, bottle_value, last_access_time) VALUES (?, ?, ?, ?, ?);"sv));
@@ -78,25 +63,6 @@ StorageJar::StorageJar(Optional<PersistedStorage> persisted_storage)
 }
 
 StorageJar::~StorageJar() = default;
-
-ErrorOr<void> StorageJar::upgrade_database(Database::Database& database, u32 current_version)
-{
-    // Track the version numbers for each schema change:
-    static constexpr u32 VERSION_ADDED_LAST_ACCESS_TIME = 2u;
-
-    if (current_version < VERSION_ADDED_LAST_ACCESS_TIME) {
-        auto add_last_access_time = TRY(database.prepare_statement("ALTER TABLE WebStorage ADD COLUMN last_access_time INTEGER;"sv));
-        database.execute_statement(add_last_access_time, {});
-
-        auto set_last_access_time = TRY(database.prepare_statement("UPDATE WebStorage SET last_access_time = ?;"sv));
-        database.execute_statement(set_last_access_time, {}, UnixDateTime::now());
-    }
-
-    auto set_storage_version = TRY(database.prepare_statement("INSERT OR REPLACE INTO WebStorageMetadata VALUES (?, ?);"sv));
-    database.execute_statement(set_storage_version, {}, WEB_STORAGE_METADATA_KEY, WEB_STORAGE_VERSION);
-
-    return {};
-}
 
 Optional<String> StorageJar::get_item(StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key)
 {

--- a/Libraries/LibWebView/StorageJar.cpp
+++ b/Libraries/LibWebView/StorageJar.cpp
@@ -55,7 +55,7 @@ ErrorOr<NonnullOwnPtr<StorageJar>> StorageJar::create(Database::Database& databa
         TRY(upgrade_database(database, storage_version));
 
     statements.get_item = TRY(database.prepare_statement("SELECT bottle_value FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ? AND bottle_key = ?;"sv));
-    statements.set_item = TRY(database.prepare_statement("INSERT OR REPLACE INTO WebStorage VALUES (?, ?, ?, ?, ?);"sv));
+    statements.set_item = TRY(database.prepare_statement("INSERT OR REPLACE INTO WebStorage (storage_endpoint, storage_key, bottle_key, bottle_value, last_access_time) VALUES (?, ?, ?, ?, ?);"sv));
     statements.delete_item = TRY(database.prepare_statement("DELETE FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ? AND bottle_key = ?;"sv));
     statements.delete_items_accessed_since = TRY(database.prepare_statement("DELETE FROM WebStorage WHERE last_access_time >= ?;"sv));
     statements.update_last_access_time = TRY(database.prepare_statement("UPDATE WebStorage SET last_access_time = ? WHERE storage_endpoint = ? AND storage_key = ? AND bottle_key = ?;"sv));

--- a/Libraries/LibWebView/StorageJar.h
+++ b/Libraries/LibWebView/StorageJar.h
@@ -33,6 +33,8 @@ class WEBVIEW_API StorageJar {
     AK_MAKE_NONMOVABLE(StorageJar);
 
 public:
+    static ErrorOr<Database::MigrationOutcome> migrate_schema(Database::Database&, Database::MigrationMode = Database::MigrationMode::Apply);
+
     static ErrorOr<NonnullOwnPtr<StorageJar>> create(Database::Database&);
     static NonnullOwnPtr<StorageJar> create();
 
@@ -92,8 +94,6 @@ private:
     };
 
     explicit StorageJar(Optional<PersistedStorage>);
-
-    static ErrorOr<void> upgrade_database(Database::Database&, u32 current_version);
 
     Optional<PersistedStorage> m_persisted_storage;
     TransientStorage m_transient_storage;

--- a/Tests/LibDatabase/CMakeLists.txt
+++ b/Tests/LibDatabase/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(TEST_SOURCES
     TestDatabase.cpp
+    TestMigrations.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibDatabase LIBS LibDatabase)
+    ladybird_test("${source}" LibDatabase LIBS LibCore LibDatabase LibFileSystem)
 endforeach()

--- a/Tests/LibDatabase/TestMigrations.cpp
+++ b/Tests/LibDatabase/TestMigrations.cpp
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Random.h>
+#include <AK/ScopeGuard.h>
+#include <AK/Time.h>
+#include <LibCore/Directory.h>
+#include <LibCore/StandardPaths.h>
+#include <LibDatabase/Database.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibTest/TestCase.h>
+
+static bool column_exists(Database::Database& database, String const& table, String const& column)
+{
+    bool exists = false;
+    auto statement = MUST(database.prepare_statement("SELECT 1 FROM pragma_table_info(?) WHERE name = ?;"sv));
+    database.execute_statement(statement, [&](auto) { exists = true; }, table, column);
+    return exists;
+}
+
+static u32 count_rows(Database::Database& database, StringView table)
+{
+    u32 count = 0;
+    auto statement = MUST(database.prepare_statement(MUST(String::formatted("SELECT COUNT(*) FROM {};", table))));
+    database.execute_statement(statement, [&](auto statement_id) { count = database.result_column<u32>(statement_id, 0); });
+    return count;
+}
+
+TEST_CASE(fresh_database_replays_all_migrations)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    Database::Migration migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+        { .version = 2, .sql = "ALTER TABLE Pets ADD COLUMN species TEXT;"sv },
+        { .version = 3, .sql = "ALTER TABLE Pets ADD COLUMN age INTEGER;"sv },
+    };
+
+    auto outcome = TRY_OR_FAIL(database->migrate("Pets"sv, migrations));
+    EXPECT_EQ(outcome, Database::MigrationOutcome::Success);
+
+    EXPECT(column_exists(*database, "Pets"_string, "species"_string));
+    EXPECT(column_exists(*database, "Pets"_string, "age"_string));
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Pets"sv)), Optional<u32> { 3u });
+}
+
+TEST_CASE(migrate_is_idempotent_at_latest_version)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    Database::Migration migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Sentinel (id INTEGER); INSERT INTO Sentinel (id) VALUES (1);"sv },
+    };
+
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Sentinel"sv, migrations)), Database::MigrationOutcome::Success);
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Sentinel"sv, migrations)), Database::MigrationOutcome::Success);
+
+    EXPECT_EQ(count_rows(*database, "Sentinel"sv), 1u);
+}
+
+TEST_CASE(partial_upgrade_runs_only_newer_migrations)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    Database::Migration version_1[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Sentinel (id INTEGER); INSERT INTO Sentinel (id) VALUES (1);"sv },
+    };
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Sentinel"sv, version_1)), Database::MigrationOutcome::Success);
+
+    Database::Migration version_2[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Sentinel (id INTEGER); INSERT INTO Sentinel (id) VALUES (1);"sv },
+        { .version = 2, .sql = "ALTER TABLE Sentinel ADD COLUMN extra INTEGER;"sv },
+    };
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Sentinel"sv, version_2)), Database::MigrationOutcome::Success);
+
+    EXPECT_EQ(count_rows(*database, "Sentinel"sv), 1u);
+    EXPECT(column_exists(*database, "Sentinel"_string, "extra"_string));
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Sentinel"sv)), Optional<u32> { 2u });
+}
+
+TEST_CASE(backfill_callback_can_bind_placeholders)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    Database::Migration migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Events (name TEXT); INSERT INTO Events (name) VALUES ('launch');"sv },
+        {
+            .version = 2,
+            .sql = "ALTER TABLE Events ADD COLUMN time INTEGER;"sv,
+            .backfill = [](Database::Database& database) -> ErrorOr<void> {
+                auto statement = TRY(database.prepare_statement("UPDATE Events SET time = ?;"sv));
+                TRY(database.try_execute_statement(statement, {}, UnixDateTime::from_seconds_since_epoch(123)));
+                return {};
+            },
+        },
+    };
+
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Events"sv, migrations)), Database::MigrationOutcome::Success);
+
+    Optional<UnixDateTime> time;
+    auto statement = TRY_OR_FAIL(database->prepare_statement("SELECT time FROM Events WHERE name = 'launch';"sv));
+    database->execute_statement(statement, [&](auto statement_id) { time = database->result_column<UnixDateTime>(statement_id, 0); });
+    EXPECT_EQ(time, Optional<UnixDateTime> { UnixDateTime::from_seconds_since_epoch(123) });
+}
+
+TEST_CASE(newer_database_version_is_left_untouched)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"sv));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('Pets', 99);"sv));
+
+    Database::Migration migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+    };
+
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Pets"sv, migrations)), Database::MigrationOutcome::DatabaseTooNew);
+
+    EXPECT(!TRY_OR_FAIL(database->table_exists("Pets"sv)));
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Pets"sv)), Optional<u32> { 99u });
+}
+
+TEST_CASE(failed_migration_rolls_back_entire_transaction)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    Database::Migration invalid_sql[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+        { .version = 2, .sql = "THIS IS NOT SQL;"sv },
+    };
+
+    EXPECT(database->migrate("Pets"sv, invalid_sql).is_error());
+    EXPECT(!TRY_OR_FAIL(database->table_exists("Pets"sv)));
+    EXPECT(!TRY_OR_FAIL(database->table_exists("SchemaVersions"sv)));
+
+    Database::Migration version_1[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+    };
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Pets"sv, version_1)), Database::MigrationOutcome::Success);
+
+    Database::Migration failing_backfill[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+        {
+            .version = 2,
+            .sql = "ALTER TABLE Pets ADD COLUMN species TEXT;"sv,
+            .backfill = [](Database::Database&) -> ErrorOr<void> {
+                return Error::from_string_literal("Backfill failed");
+            },
+        },
+    };
+
+    EXPECT(database->migrate("Pets"sv, failing_backfill).is_error());
+    EXPECT(!column_exists(*database, "Pets"_string, "species"_string));
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Pets"sv)), Optional<u32> { 1u });
+}
+
+TEST_CASE(preexisting_unversioned_table_is_stamped_by_baseline_replay)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE Pets (name TEXT PRIMARY KEY);"sv));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO Pets (name) VALUES ('Mochi');"sv));
+
+    Database::Migration migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+        { .version = 2, .sql = "ALTER TABLE Pets ADD COLUMN species TEXT;"sv },
+    };
+
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Pets"sv, migrations)), Database::MigrationOutcome::Success);
+
+    EXPECT_EQ(count_rows(*database, "Pets"sv), 1u);
+    EXPECT(column_exists(*database, "Pets"_string, "species"_string));
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Pets"sv)), Optional<u32> { 2u });
+}
+
+TEST_CASE(check_only_never_commits)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE Pets (name TEXT PRIMARY KEY);"sv));
+
+    Database::Migration migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+        { .version = 2, .sql = "ALTER TABLE Pets ADD COLUMN species TEXT;"sv },
+    };
+
+    auto outcome = TRY_OR_FAIL(database->migrate("Pets"sv, migrations, Database::MigrationMode::CheckOnly));
+    EXPECT_EQ(outcome, Database::MigrationOutcome::Success);
+
+    // CheckOnly rolls everything back: the pending migration is not applied and SchemaVersions is not created.
+    EXPECT(!column_exists(*database, "Pets"_string, "species"_string));
+    EXPECT(!TRY_OR_FAIL(database->table_exists("SchemaVersions"sv)));
+
+    outcome = TRY_OR_FAIL(database->migrate("Pets"sv, migrations));
+    EXPECT_EQ(outcome, Database::MigrationOutcome::Success);
+
+    EXPECT(column_exists(*database, "Pets"_string, "species"_string));
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Pets"sv)), Optional<u32> { 2u });
+}
+
+TEST_CASE(check_only_reports_database_too_new)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"sv));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('Pets', 99);"sv));
+
+    Database::Migration migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+    };
+
+    auto outcome = TRY_OR_FAIL(database->migrate("Pets"sv, migrations, Database::MigrationMode::CheckOnly));
+    EXPECT_EQ(outcome, Database::MigrationOutcome::DatabaseTooNew);
+
+    EXPECT(!TRY_OR_FAIL(database->table_exists("Pets"sv)));
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Pets"sv)), Optional<u32> { 99u });
+}
+
+TEST_CASE(multiple_stores_track_versions_independently)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    Database::Migration pets_migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Pets (name TEXT PRIMARY KEY);"sv },
+    };
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Pets"sv, pets_migrations)), Database::MigrationOutcome::Success);
+
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('Toys', 99);"sv));
+
+    Database::Migration toys_migrations[] = {
+        { .version = 1, .sql = "CREATE TABLE IF NOT EXISTS Toys (name TEXT PRIMARY KEY);"sv },
+    };
+    EXPECT_EQ(TRY_OR_FAIL(database->migrate("Toys"sv, toys_migrations)), Database::MigrationOutcome::DatabaseTooNew);
+
+    EXPECT(TRY_OR_FAIL(database->table_exists("Pets"sv)));
+    EXPECT(!TRY_OR_FAIL(database->table_exists("Toys"sv)));
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Pets"sv)), Optional<u32> { 1u });
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Toys"sv)), Optional<u32> { 99u });
+}
+
+TEST_CASE(reopened_database_resumes_from_recorded_version)
+{
+    auto database_directory = ByteString::formatted(
+        "{}/ladybird-migrations-test-{}",
+        Core::StandardPaths::tempfile_directory(),
+        generate_random_uuid());
+    TRY_OR_FAIL(Core::Directory::create(database_directory, Core::Directory::CreateDirectories::Yes));
+
+    auto cleanup = ScopeGuard([&] {
+        MUST(FileSystem::remove(database_directory, FileSystem::RecursionMode::Allowed));
+    });
+
+    // Deliberately not IF NOT EXISTS, so this test fails if migration 1 is ever replayed.
+    auto migration_1_sql = "CREATE TABLE Pets (name TEXT PRIMARY KEY);"sv;
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "Migrations"sv));
+
+        Database::Migration migrations[] = {
+            { .version = 1, .sql = migration_1_sql },
+        };
+        EXPECT_EQ(TRY_OR_FAIL(database->migrate("Pets"sv, migrations)), Database::MigrationOutcome::Success);
+    }
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "Migrations"sv));
+
+        Database::Migration migrations[] = {
+            { .version = 1, .sql = migration_1_sql },
+            { .version = 2, .sql = "ALTER TABLE Pets ADD COLUMN species TEXT;"sv },
+        };
+        EXPECT_EQ(TRY_OR_FAIL(database->migrate("Pets"sv, migrations)), Database::MigrationOutcome::Success);
+
+        EXPECT(column_exists(*database, "Pets"_string, "species"_string));
+        EXPECT_EQ(TRY_OR_FAIL(database->schema_version("Pets"sv)), Optional<u32> { 2u });
+    }
+}

--- a/Tests/LibHTTP/TestCacheIndex.cpp
+++ b/Tests/LibHTTP/TestCacheIndex.cpp
@@ -27,6 +27,7 @@ static LexicalPath cache_directory()
 static CacheIndexTestState create_cache_index()
 {
     auto database = MUST(Database::Database::create_memory_backed());
+    VERIFY(MUST(HTTP::CacheIndex::migrate_schema(*database)) == Database::MigrationOutcome::Success);
     auto index = MUST(HTTP::CacheIndex::create(*database, cache_directory()));
     return { move(database), move(index) };
 }
@@ -137,4 +138,15 @@ TEST_CASE(associated_data_counts_toward_cache_size)
 
     EXPECT(removed_entries.size() > 0);
     EXPECT(state.index.estimate_cache_size_accessed_since(UnixDateTime::earliest()).total <= 80u);
+}
+
+TEST_CASE(newer_cache_index_schema_reports_database_too_new)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"sv));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('CacheIndex', 99);"sv));
+
+    EXPECT_EQ(TRY_OR_FAIL(HTTP::CacheIndex::migrate_schema(*database)), Database::MigrationOutcome::DatabaseTooNew);
+    EXPECT_EQ(TRY_OR_FAIL(HTTP::CacheIndex::migrate_schema(*database, Database::MigrationMode::CheckOnly)), Database::MigrationOutcome::DatabaseTooNew);
 }

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_SOURCES
     TestHistoryStore.cpp
     TestHSTSStore.cpp
     TestSessionHistory.cpp
+    TestStorageJar.cpp
     TestWebViewURL.cpp
 )
 

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestCookieJar.cpp
     TestHistoryStore.cpp
     TestHSTSStore.cpp
     TestSessionHistory.cpp

--- a/Tests/LibWebView/TestCookieJar.cpp
+++ b/Tests/LibWebView/TestCookieJar.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NonnullOwnPtr.h>
+#include <LibDatabase/Database.h>
+#include <LibHTTP/Cookie/ParsedCookie.h>
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWebView/CookieJar.h>
+
+static URL::URL parse_url(StringView url)
+{
+    auto parsed_url = URL::Parser::basic_parse(url);
+    VERIFY(parsed_url.has_value());
+    return parsed_url.release_value();
+}
+
+TEST_CASE(cookies_round_trip_on_fresh_database)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+    EXPECT_EQ(TRY_OR_FAIL(WebView::CookieJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+
+    {
+        auto jar = TRY_OR_FAIL(WebView::CookieJar::create(*database));
+
+        HTTP::Cookie::ParsedCookie cookie {
+            .name = "foo"_string,
+            .value = "bar"_string,
+            .expiry_time_from_expires_attribute = UnixDateTime::now() + AK::Duration::from_seconds(3600),
+        };
+        jar->set_cookie(parse_url("https://example.com/"sv), cookie, HTTP::Cookie::Source::Http);
+
+        // The jar flushes dirty cookies to the database on destruction.
+    }
+
+    auto jar = TRY_OR_FAIL(WebView::CookieJar::create(*database));
+
+    auto cookies = jar->get_all_cookies();
+    EXPECT_EQ(cookies.size(), 1uz);
+    EXPECT_EQ(cookies[0].name, "foo"_string);
+    EXPECT_EQ(cookies[0].value, "bar"_string);
+}
+
+TEST_CASE(unversioned_cookie_table_is_stamped_and_preserved)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    // The Cookies table as created before schema versioning existed.
+    TRY_OR_FAIL(database->execute_raw(R"#(
+        CREATE TABLE Cookies (
+            name TEXT,
+            value TEXT,
+            same_site INTEGER CHECK (same_site >= 0 AND same_site <= 3),
+            creation_time INTEGER,
+            last_access_time INTEGER,
+            expiry_time INTEGER,
+            domain TEXT,
+            path TEXT,
+            secure BOOLEAN,
+            http_only BOOLEAN,
+            host_only BOOLEAN,
+            persistent BOOLEAN,
+            PRIMARY KEY(name, domain, path)
+        );
+    )#"sv));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO Cookies VALUES ('foo', 'bar', 0, 0, 0, 4102444800000, 'example.com', '/', 0, 0, 0, 1);"sv));
+
+    EXPECT_EQ(TRY_OR_FAIL(WebView::CookieJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+
+    Optional<u32> version;
+    auto statement = TRY_OR_FAIL(database->prepare_statement("SELECT version FROM SchemaVersions WHERE store = 'Cookies';"sv));
+    database->execute_statement(statement, [&](auto statement_id) { version = database->result_column<u32>(statement_id, 0); });
+    EXPECT_EQ(version, Optional<u32> { 1u });
+
+    auto jar = TRY_OR_FAIL(WebView::CookieJar::create(*database));
+
+    auto cookies = jar->get_all_cookies();
+    EXPECT_EQ(cookies.size(), 1uz);
+    EXPECT_EQ(cookies[0].name, "foo"_string);
+    EXPECT_EQ(cookies[0].value, "bar"_string);
+    EXPECT_EQ(cookies[0].domain, "example.com"_string);
+}
+
+TEST_CASE(newer_cookie_schema_reports_database_too_new)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"sv));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('Cookies', 99);"sv));
+
+    EXPECT_EQ(TRY_OR_FAIL(WebView::CookieJar::migrate_schema(*database)), Database::MigrationOutcome::DatabaseTooNew);
+    EXPECT_EQ(TRY_OR_FAIL(WebView::CookieJar::migrate_schema(*database, Database::MigrationMode::CheckOnly)), Database::MigrationOutcome::DatabaseTooNew);
+}

--- a/Tests/LibWebView/TestHSTSStore.cpp
+++ b/Tests/LibWebView/TestHSTSStore.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Time.h>
+#include <LibDatabase/Database.h>
 #include <LibHTTP/HSTS/ParsedHSTSPolicy.h>
 #include <LibTest/TestCase.h>
 #include <LibWebView/HSTSStore.h>
@@ -57,4 +58,31 @@ TEST_CASE(remove_policies_observed_since_clears_dynamic_data)
     store->store_policy("example.test"_string, HTTP::HSTS::ParsedHSTSPolicy { AK::Duration::from_seconds(3600), false });
     store->remove_policies_observed_since(UnixDateTime::earliest());
     EXPECT(!store->is_known_hsts_host("example.test"sv));
+}
+
+TEST_CASE(persisted_policies_round_trip_on_fresh_database)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+    EXPECT_EQ(TRY_OR_FAIL(WebView::HSTSStore::migrate_schema(*database)), Database::MigrationOutcome::Success);
+
+    {
+        auto store = TRY_OR_FAIL(WebView::HSTSStore::create(*database));
+        store->store_policy("example.test"_string, HTTP::HSTS::ParsedHSTSPolicy { AK::Duration::from_seconds(3600), false });
+
+        // The store flushes dirty policies to the database on destruction.
+    }
+
+    auto store = TRY_OR_FAIL(WebView::HSTSStore::create(*database));
+    EXPECT(store->is_known_hsts_host("example.test"sv));
+}
+
+TEST_CASE(newer_hsts_schema_reports_database_too_new)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('HSTSPolicies', 99);"));
+
+    EXPECT_EQ(TRY_OR_FAIL(WebView::HSTSStore::migrate_schema(*database)), Database::MigrationOutcome::DatabaseTooNew);
+    EXPECT_EQ(TRY_OR_FAIL(WebView::HSTSStore::migrate_schema(*database, Database::MigrationMode::CheckOnly)), Database::MigrationOutcome::DatabaseTooNew);
 }

--- a/Tests/LibWebView/TestHistoryStore.cpp
+++ b/Tests/LibWebView/TestHistoryStore.cpp
@@ -21,6 +21,12 @@ static URL::URL parse_url(StringView url)
     return parsed_url.release_value();
 }
 
+static NonnullOwnPtr<WebView::HistoryStore> create_persisted_store(Database::Database& database)
+{
+    VERIFY(MUST(WebView::HistoryStore::migrate_schema(database)) == Database::MigrationOutcome::Success);
+    return MUST(WebView::HistoryStore::create(database));
+}
+
 static void populate_history_for_url_autocomplete_tests(WebView::HistoryStore& store)
 {
     store.record_visit(parse_url("https://www.google.com/"sv), {}, UnixDateTime::from_seconds_since_epoch(30));
@@ -403,14 +409,14 @@ TEST_CASE(persisted_history_survives_reopen)
 
     {
         auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-        auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        auto store = create_persisted_store(*database);
         store->record_visit(parse_url("https://persist.example.com/"sv), "Persisted title"_string, UnixDateTime::from_seconds_since_epoch(77));
         store->update_favicon(parse_url("https://persist.example.com/"sv), "Zm9v"_string);
     }
 
     {
         auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-        auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        auto store = create_persisted_store(*database);
 
         auto entry = store->entry_for_url(parse_url("https://persist.example.com/"sv));
         VERIFY(entry.has_value());
@@ -439,7 +445,7 @@ TEST_CASE(persisted_history_entries_accessed_since_can_be_removed)
 
     {
         auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-        auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        auto store = create_persisted_store(*database);
         store->record_visit(older_url, "Older"_string, UnixDateTime::from_seconds_since_epoch(10));
         store->record_visit(newer_url, "Newer"_string, UnixDateTime::from_seconds_since_epoch(20));
         store->remove_entries_accessed_since(UnixDateTime::from_seconds_since_epoch(15));
@@ -447,7 +453,7 @@ TEST_CASE(persisted_history_entries_accessed_since_can_be_removed)
 
     {
         auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-        auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        auto store = create_persisted_store(*database);
 
         EXPECT(store->entry_for_url(older_url).has_value());
         EXPECT(!store->entry_for_url(newer_url).has_value());
@@ -467,7 +473,7 @@ TEST_CASE(persisted_history_autocomplete_ignores_scheme_and_www_boilerplate_pref
     });
 
     auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-    auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+    auto store = create_persisted_store(*database);
 
     expect_history_autocomplete_ignores_url_boilerplate(*store);
 }
@@ -485,7 +491,7 @@ TEST_CASE(persisted_history_autocomplete_requires_three_characters_for_title_mat
     });
 
     auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-    auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+    auto store = create_persisted_store(*database);
 
     expect_history_autocomplete_requires_three_characters_for_title_matches(*store);
 }
@@ -503,7 +509,7 @@ TEST_CASE(persisted_history_autocomplete_requires_three_characters_for_non_prefi
     });
 
     auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-    auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+    auto store = create_persisted_store(*database);
 
     expect_history_autocomplete_requires_three_characters_for_non_prefix_url_matches(*store);
 }
@@ -521,7 +527,7 @@ TEST_CASE(persisted_history_autocomplete_entries_include_metadata)
     });
 
     auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-    auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+    auto store = create_persisted_store(*database);
 
     expect_history_autocomplete_entries_include_metadata(*store);
 }
@@ -539,7 +545,7 @@ TEST_CASE(persisted_history_page_entries_are_paginated_and_searchable)
     });
 
     auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-    auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+    auto store = create_persisted_store(*database);
 
     expect_history_page_entries_are_paginated_and_searchable(*store);
 }
@@ -557,7 +563,7 @@ TEST_CASE(persisted_history_entries_can_be_removed)
     });
 
     auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-    auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+    auto store = create_persisted_store(*database);
 
     expect_history_entries_can_be_removed(*store);
 }
@@ -575,7 +581,18 @@ TEST_CASE(persisted_history_entries_for_same_site_can_be_removed)
     });
 
     auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
-    auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+    auto store = create_persisted_store(*database);
 
     expect_history_entries_for_same_site_can_be_removed(*store);
+}
+
+TEST_CASE(newer_history_schema_reports_database_too_new)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"sv));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('History', 99);"sv));
+
+    EXPECT_EQ(TRY_OR_FAIL(WebView::HistoryStore::migrate_schema(*database)), Database::MigrationOutcome::DatabaseTooNew);
+    EXPECT_EQ(TRY_OR_FAIL(WebView::HistoryStore::migrate_schema(*database, Database::MigrationMode::CheckOnly)), Database::MigrationOutcome::DatabaseTooNew);
 }

--- a/Tests/LibWebView/TestStorageJar.cpp
+++ b/Tests/LibWebView/TestStorageJar.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NonnullOwnPtr.h>
+#include <LibDatabase/Database.h>
+#include <LibTest/TestCase.h>
+#include <LibWebView/StorageJar.h>
+
+TEST_CASE(storage_round_trips_on_fresh_database)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+    EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+
+    auto jar = TRY_OR_FAIL(WebView::StorageJar::create(*database));
+
+    EXPECT_EQ(jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_string), Optional<String> {});
+    jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_string, "bar"_string);
+    EXPECT_EQ(jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_string), Optional<String> { "bar"_string });
+
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("WebStorage"sv)), Optional<u32> { 1u });
+}
+
+TEST_CASE(newer_storage_schema_reports_database_too_new)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('WebStorage', 99);"));
+
+    EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::DatabaseTooNew);
+    EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database, Database::MigrationMode::CheckOnly)), Database::MigrationOutcome::DatabaseTooNew);
+}


### PR DESCRIPTION
If the recorded version is newer than the running build understands, the database is left untouched so that callers can fall back to in-memory storage for the session instead of corrupting data written by a newer version of Ladybird.

See individual commits for more details.