### PR TITLE
UI/Qt: Add keyboard shortcut to view history

### DIFF
--- a/Base/res/ladybird/about-pages/history.html
+++ b/Base/res/ladybird/about-pages/history.html
@@ -223,6 +223,7 @@
                 class="search-input"
                 placeholder="Search history"
                 spellcheck="false"
+                autofocus
             />
         </div>
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1524,7 +1524,8 @@ void Application::initialize_actions()
 
     m_history_menu = Menu::create("History"sv);
     m_history_menu->add_action(Action::create("View History"sv, ActionID::ViewHistory, [this]() {
-        open_url_in_new_tab(URL::about_history(), Web::HTML::ActivateTab::Yes);
+        if (!activate_tab_with_url(URL::about_history()))
+            open_url_in_new_tab(URL::about_history(), Web::HTML::ActivateTab::Yes);
     }));
 
     m_inspect_menu = Menu::create("Inspect"sv);

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -110,6 +110,7 @@ public:
 
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
     virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }
+    virtual bool activate_tab_with_url(URL::URL const&) const { return false; }
     void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const;
     void open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab) const;
 

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -177,6 +177,13 @@ Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML
     return tab.view();
 }
 
+bool Application::activate_tab_with_url(URL::URL const& url) const
+{
+    if (!m_active_window)
+        return false;
+    return m_active_window->activate_tab_with_url(url);
+}
+
 void Application::open_url_in_new_window(URL::URL const& url)
 {
     this->new_window({ url });

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -46,6 +46,7 @@ private:
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
+    virtual bool activate_tab_with_url(URL::URL const&) const override;
     virtual void open_url_in_new_window(URL::URL const& url) override;
 
     virtual Optional<ByteString> ask_user_for_download_path(StringView file) const override;

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -715,6 +715,18 @@ void BrowserWindow::activate_tab(int index)
     m_tabs_container->set_current_index(index);
 }
 
+bool BrowserWindow::activate_tab_with_url(URL::URL const& url)
+{
+    for (int index = 0; index < m_tabs_container->count(); ++index) {
+        auto* tab = m_tabs_container->tab(index);
+        if (tab && tab->view().url() == url) {
+            m_tabs_container->set_current_index(index);
+            return true;
+        }
+    }
+    return false;
+}
+
 void BrowserWindow::definitely_close_tab(int index)
 {
     auto* tab = m_tabs_container->tab(index);

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -103,6 +103,7 @@ public:
 
     Tab& create_new_tab(Web::HTML::ActivateTab activate_tab);
     Tab* current_tab() const { return m_current_tab; }
+    bool activate_tab_with_url(URL::URL const&);
     FullscreenMode& fullscreen_mode();
 
     QMenu& hamburger_menu() const { return *m_hamburger_menu; }

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -193,6 +193,13 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
             qaction.setIcon(create_chrome_icon(ChromeIcon::Globe, palette));
         break;
 
+    case WebView::ActionID::ViewHistory:
+#if defined(AK_OS_MACOS)
+        qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Y));
+#else
+        qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::Key_H));
+#endif
+        break;
     case WebView::ActionID::OpenProcessesPage:
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_M));
         break;


### PR DESCRIPTION
Bind the canonical history shortcut used on each platform to the "View History" action: Ctrl+H on Linux and Windows, and Cmd+Y on macOS.

We also now switch to an existing `about:history` tab if one exists, rather than opening duplicate history tabs in the same window.