### PR TITLE
DevTools: Add inspection for IndexedDB

### DIFF
--- a/Libraries/LibDevTools/Actors/CookiesActor.cpp
+++ b/Libraries/LibDevTools/Actors/CookiesActor.cpp
@@ -270,37 +270,22 @@ void CookiesActor::handle_message(Message const& message)
 
 void CookiesActor::get_fields(Message const& message)
 {
-    enum class FieldState : u8 {
-        Immutable,
-        Editable,
-        Hidden,
-        Private,
-    };
-    auto make_field = [](StringView name, FieldState state) {
-        JsonObject field;
-        field.set("name"sv, name);
-        field.set("editable"sv, state == FieldState::Editable);
-        field.set("hidden"sv, state == FieldState::Hidden);
-        field.set("private"sv, state == FieldState::Private);
-        return field;
-    };
-
     JsonArray fields;
-    fields.must_append(make_field("uniqueKey"sv, FieldState::Private));
-    fields.must_append(make_field("name"sv, FieldState::Editable));
-    fields.must_append(make_field("value"sv, FieldState::Editable));
-    fields.must_append(make_field("host"sv, FieldState::Editable));
-    fields.must_append(make_field("path"sv, FieldState::Editable));
-    fields.must_append(make_field("expires"sv, FieldState::Editable));
-    fields.must_append(make_field("size"sv, FieldState::Immutable));
-    fields.must_append(make_field("isHttpOnly"sv, FieldState::Editable));
-    fields.must_append(make_field("isSecure"sv, FieldState::Editable));
-    fields.must_append(make_field("sameSite"sv, FieldState::Immutable));
-    fields.must_append(make_field("lastAccessed"sv, FieldState::Immutable));
-    fields.must_append(make_field("creationTime"sv, FieldState::Hidden));
-    fields.must_append(make_field("updateTime"sv, FieldState::Hidden));
-    fields.must_append(make_field("hostOnly"sv, FieldState::Hidden));
-    fields.must_append(make_field("partitionKey"sv, FieldState::Immutable));
+    fields.must_append(define_storage_field("uniqueKey"sv, StorageFieldType::Private));
+    fields.must_append(define_storage_field("name"sv, StorageFieldType::Mutable));
+    fields.must_append(define_storage_field("value"sv, StorageFieldType::Mutable));
+    fields.must_append(define_storage_field("host"sv, StorageFieldType::Mutable));
+    fields.must_append(define_storage_field("path"sv, StorageFieldType::Mutable));
+    fields.must_append(define_storage_field("expires"sv, StorageFieldType::Mutable));
+    fields.must_append(define_storage_field("size"sv, StorageFieldType::Immutable));
+    fields.must_append(define_storage_field("isHttpOnly"sv, StorageFieldType::Mutable));
+    fields.must_append(define_storage_field("isSecure"sv, StorageFieldType::Mutable));
+    fields.must_append(define_storage_field("sameSite"sv, StorageFieldType::Immutable));
+    fields.must_append(define_storage_field("lastAccessed"sv, StorageFieldType::Immutable));
+    fields.must_append(define_storage_field("creationTime"sv, StorageFieldType::Hidden));
+    fields.must_append(define_storage_field("updateTime"sv, StorageFieldType::Hidden));
+    fields.must_append(define_storage_field("hostOnly"sv, StorageFieldType::Hidden));
+    fields.must_append(define_storage_field("partitionKey"sv, StorageFieldType::Immutable));
 
     JsonObject response;
     response.set("value"sv, move(fields));

--- a/Libraries/LibDevTools/Actors/IndexedDBActor.cpp
+++ b/Libraries/LibDevTools/Actors/IndexedDBActor.cpp
@@ -99,6 +99,21 @@ void IndexedDBActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "removeDatabase"sv) {
+        remove_database(message);
+        return;
+    }
+
+    if (message.type == "removeAll"sv) {
+        remove_all(message);
+        return;
+    }
+
+    if (message.type == "removeItem"sv) {
+        remove_item(message);
+        return;
+    }
+
     send_unrecognized_packet_type_error(message);
 }
 
@@ -167,6 +182,135 @@ void IndexedDBActor::get_store_objects(Message const& message)
 
             self->send_response({ .id = message_id }, result.release_value());
         });
+}
+
+void IndexedDBActor::remove_database(Message const& message)
+{
+    auto host = get_required_parameter<String>(message, "host"sv);
+    auto name = get_required_parameter<String>(message, "name"sv);
+    if (!host.has_value() || !name.has_value())
+        return;
+
+    auto tab = m_tab.strong_ref();
+    if (!tab) {
+        send_inspection_error(message, Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    devtools().delegate().delete_indexed_database(tab->description(), *host, *name,
+        [weak_self = make_weak_ptr<IndexedDBActor>(), message_id = message.id, host = *host, name = *name](ErrorOr<JsonObject> result) mutable {
+            auto self = weak_self.strong_ref();
+            if (!self)
+                return;
+
+            if (result.is_error()) {
+                self->send_inspection_error({ .id = message_id }, result.error());
+                return;
+            }
+
+            auto response = result.release_value();
+            auto blocked = response.get_bool("blocked"sv).value_or(false);
+            self->send_response({ .id = message_id }, move(response));
+            if (!blocked) {
+                JsonArray path;
+                path.must_append(name);
+                self->send_indexed_database_update("deleted"sv, host, path.serialized());
+            }
+        });
+}
+
+void IndexedDBActor::remove_all(Message const& message)
+{
+    auto host = get_required_parameter<String>(message, "host"sv);
+    auto name = get_required_parameter<String>(message, "name"sv);
+    if (!host.has_value() || !name.has_value())
+        return;
+
+    auto tab = m_tab.strong_ref();
+    if (!tab) {
+        send_inspection_error(message, Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    devtools().delegate().clear_indexed_database_object_store(tab->description(), *host, *name,
+        [weak_self = make_weak_ptr<IndexedDBActor>(), message_id = message.id, host = *host, name = *name](ErrorOr<JsonObject> result) mutable {
+            auto self = weak_self.strong_ref();
+            if (!self)
+                return;
+
+            if (result.is_error()) {
+                self->send_inspection_error({ .id = message_id }, result.error());
+                return;
+            }
+
+            auto response = result.release_value();
+            self->send_response({ .id = message_id }, move(response));
+            self->send_indexed_database_clear(host, name);
+        });
+}
+
+void IndexedDBActor::remove_item(Message const& message)
+{
+    auto host = get_required_parameter<String>(message, "host"sv);
+    auto name = get_required_parameter<String>(message, "name"sv);
+    if (!host.has_value() || !name.has_value())
+        return;
+
+    auto tab = m_tab.strong_ref();
+    if (!tab) {
+        send_inspection_error(message, Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    devtools().delegate().delete_indexed_database_record(tab->description(), *host, *name,
+        [weak_self = make_weak_ptr<IndexedDBActor>(), message_id = message.id, host = *host, name = *name](ErrorOr<JsonObject> result) mutable {
+            auto self = weak_self.strong_ref();
+            if (!self)
+                return;
+
+            if (result.is_error()) {
+                self->send_inspection_error({ .id = message_id }, result.error());
+                return;
+            }
+
+            auto response = result.release_value();
+            self->send_response({ .id = message_id }, move(response));
+            self->send_indexed_database_update("deleted"sv, host, name);
+        });
+}
+
+void IndexedDBActor::send_indexed_database_update(StringView update_type, String const& host, String const& name)
+{
+    JsonArray paths;
+    paths.must_append(name);
+
+    JsonObject hosts;
+    hosts.set(host, move(paths));
+
+    JsonObject indexed_database;
+    indexed_database.set("indexedDB"sv, move(hosts));
+
+    JsonObject update;
+    update.set(update_type, move(indexed_database));
+
+    on_indexed_database_changed(move(update));
+}
+
+void IndexedDBActor::send_indexed_database_clear(String const& host, String const& name)
+{
+    JsonArray paths;
+    paths.must_append(name);
+
+    JsonObject hosts;
+    hosts.set(host, move(paths));
+
+    JsonObject data;
+    data.set("clearedHostsOrPaths"sv, move(hosts));
+
+    JsonObject message;
+    message.set("type"sv, "storesCleared"sv);
+    message.set("data"sv, move(data));
+    send_message(move(message));
 }
 
 void IndexedDBActor::on_indexed_database_changed(JsonObject update)

--- a/Libraries/LibDevTools/Actors/IndexedDBActor.cpp
+++ b/Libraries/LibDevTools/Actors/IndexedDBActor.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <LibDevTools/Actors/IndexedDBActor.h>
+#include <LibDevTools/Actors/TabActor.h>
+#include <LibDevTools/DevToolsDelegate.h>
+#include <LibDevTools/DevToolsServer.h>
+#include <LibDevTools/StorageHelpers.h>
+
+namespace DevTools {
+
+NonnullRefPtr<IndexedDBActor> IndexedDBActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
+{
+    return adopt_ref(*new IndexedDBActor(devtools, move(name), move(tab)));
+}
+
+IndexedDBActor::IndexedDBActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
+    : Actor(devtools, move(name))
+    , m_tab(move(tab))
+{
+}
+
+IndexedDBActor::~IndexedDBActor() = default;
+
+JsonObject IndexedDBActor::serialize_storage(JsonObject hosts) const
+{
+    if (hosts.is_empty()) {
+        if (auto tab = m_tab.strong_ref()) {
+            if (auto host = storage_host_for_url(tab->description().url); host.has_value())
+                hosts.set(*host, JsonArray {});
+        }
+    }
+
+    JsonObject traits;
+    traits.set("supportsAddItem"sv, false);
+    traits.set("supportsRemoveAll"sv, true);
+    traits.set("supportsRemoveAllSessionCookies"sv, false);
+    traits.set("supportsRemoveItem"sv, true);
+
+    JsonObject storage;
+    storage.set("actor"sv, name());
+    if (auto tab = m_tab.strong_ref()) {
+        storage.set("browsingContextID"sv, tab->description().id);
+        storage.set("innerWindowId"sv, tab->inner_window_id());
+        storage.set("resourceId"sv, MUST(String::formatted("indexed-db-{}", tab->inner_window_id())));
+    }
+    storage.set("hosts"sv, move(hosts));
+    storage.set("resourceKey"sv, "indexedDB"sv);
+    storage.set("traits"sv, move(traits));
+    return storage;
+}
+
+void IndexedDBActor::get_storage_resource(Function<void(JsonObject)> callback)
+{
+    auto tab = m_tab.strong_ref();
+    if (!tab) {
+        callback(serialize_storage({}));
+        return;
+    }
+
+    devtools().delegate().inspect_indexed_database_storage(tab->description(),
+        [weak_self = make_weak_ptr<IndexedDBActor>(), callback = move(callback)](ErrorOr<JsonObject> hosts_or_error) mutable {
+            auto self = weak_self.strong_ref();
+            if (!self)
+                return;
+
+            callback(self->serialize_storage(hosts_or_error.is_error() ? JsonObject {} : hosts_or_error.release_value()));
+        });
+}
+
+void IndexedDBActor::handle_message(Message const& message)
+{
+    if (message.type == "getFields"sv) {
+        get_fields(message);
+        return;
+    }
+
+    if (message.type == "getStoreObjects"sv) {
+        get_store_objects(message);
+        return;
+    }
+
+    send_unrecognized_packet_type_error(message);
+}
+
+void IndexedDBActor::get_fields(Message const& message)
+{
+    auto sub_type = message.data.get_string("subType"sv);
+
+    JsonArray fields;
+    if (sub_type == "database"sv) {
+        fields.must_append(define_storage_field("objectStore"sv, StorageFieldType::Immutable));
+        fields.must_append(define_storage_field("keyPath"sv, StorageFieldType::Immutable));
+        fields.must_append(define_storage_field("autoIncrement"sv, StorageFieldType::Immutable));
+        fields.must_append(define_storage_field("indexes"sv, StorageFieldType::Immutable));
+    } else if (sub_type == "object store"sv) {
+        fields.must_append(define_storage_field("name"sv, StorageFieldType::Immutable));
+        fields.must_append(define_storage_field("value"sv, StorageFieldType::Immutable));
+    } else {
+        fields.must_append(define_storage_field("uniqueKey"sv, StorageFieldType::Private));
+        fields.must_append(define_storage_field("db"sv, StorageFieldType::Immutable));
+        fields.must_append(define_storage_field("storage"sv, StorageFieldType::Immutable));
+        fields.must_append(define_storage_field("origin"sv, StorageFieldType::Immutable));
+        fields.must_append(define_storage_field("version"sv, StorageFieldType::Immutable));
+        fields.must_append(define_storage_field("objectStores"sv, StorageFieldType::Immutable));
+    }
+
+    JsonObject response;
+    response.set("value"sv, move(fields));
+    send_response(message, move(response));
+}
+
+void IndexedDBActor::send_inspection_error(Message const& message, Error const& error)
+{
+    JsonObject response;
+    response.set("error"sv, "indexedDBInspectionFailed"sv);
+    response.set("message"sv, error.string_literal());
+    send_response(message, move(response));
+}
+
+void IndexedDBActor::get_store_objects(Message const& message)
+{
+    auto host = get_required_parameter<String>(message, "host"sv);
+    if (!host.has_value())
+        return;
+
+    auto tab = m_tab.strong_ref();
+    if (!tab) {
+        send_inspection_error(message, Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    Optional<JsonArray> names;
+    if (auto names_array = message.data.get_array("names"sv); names_array.has_value())
+        names = *names_array;
+    auto options = message.data.get_object("options"sv).value_or({});
+
+    devtools().delegate().inspect_indexed_database_objects(tab->description(), *host, move(names), move(options),
+        [weak_self = make_weak_ptr<IndexedDBActor>(), message_id = message.id](ErrorOr<JsonObject> result) mutable {
+            auto self = weak_self.strong_ref();
+            if (!self)
+                return;
+
+            if (result.is_error()) {
+                self->send_inspection_error({ .id = message_id }, result.error());
+                return;
+            }
+
+            self->send_response({ .id = message_id }, result.release_value());
+        });
+}
+
+}

--- a/Libraries/LibDevTools/Actors/IndexedDBActor.cpp
+++ b/Libraries/LibDevTools/Actors/IndexedDBActor.cpp
@@ -23,9 +23,23 @@ IndexedDBActor::IndexedDBActor(DevToolsServer& devtools, String name, WeakPtr<Ta
     : Actor(devtools, move(name))
     , m_tab(move(tab))
 {
+    if (auto tab = m_tab.strong_ref()) {
+        m_indexed_database_change_listener_id = devtools.delegate().add_indexed_database_change_listener(
+            tab->description(),
+            weak_callback(*this, [](auto& self, JsonObject update) {
+                self.on_indexed_database_changed(move(update));
+            }));
+    }
 }
 
-IndexedDBActor::~IndexedDBActor() = default;
+IndexedDBActor::~IndexedDBActor()
+{
+    if (m_indexed_database_change_listener_id == 0)
+        return;
+
+    if (auto tab = m_tab.strong_ref())
+        devtools().delegate().remove_indexed_database_change_listener(tab->description(), m_indexed_database_change_listener_id);
+}
 
 JsonObject IndexedDBActor::serialize_storage(JsonObject hosts) const
 {
@@ -153,6 +167,14 @@ void IndexedDBActor::get_store_objects(Message const& message)
 
             self->send_response({ .id = message_id }, result.release_value());
         });
+}
+
+void IndexedDBActor::on_indexed_database_changed(JsonObject update)
+{
+    JsonObject message;
+    message.set("type"sv, "storesUpdate"sv);
+    message.set("data"sv, move(update));
+    send_message(move(message));
 }
 
 }

--- a/Libraries/LibDevTools/Actors/IndexedDBActor.h
+++ b/Libraries/LibDevTools/Actors/IndexedDBActor.h
@@ -27,11 +27,13 @@ private:
 
     void get_fields(Message const&);
     void get_store_objects(Message const&);
+    void on_indexed_database_changed(JsonObject);
 
     JsonObject serialize_storage(JsonObject hosts) const;
     void send_inspection_error(Message const&, Error const&);
 
     WeakPtr<TabActor> m_tab;
+    u64 m_indexed_database_change_listener_id { 0 };
 };
 
 }

--- a/Libraries/LibDevTools/Actors/IndexedDBActor.h
+++ b/Libraries/LibDevTools/Actors/IndexedDBActor.h
@@ -27,10 +27,15 @@ private:
 
     void get_fields(Message const&);
     void get_store_objects(Message const&);
+    void remove_database(Message const&);
+    void remove_all(Message const&);
+    void remove_item(Message const&);
     void on_indexed_database_changed(JsonObject);
 
     JsonObject serialize_storage(JsonObject hosts) const;
     void send_inspection_error(Message const&, Error const&);
+    void send_indexed_database_update(StringView update_type, String const& host, String const& name);
+    void send_indexed_database_clear(String const& host, String const& name);
 
     WeakPtr<TabActor> m_tab;
     u64 m_indexed_database_change_listener_id { 0 };

--- a/Libraries/LibDevTools/Actors/IndexedDBActor.h
+++ b/Libraries/LibDevTools/Actors/IndexedDBActor.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <LibDevTools/Actor.h>
+
+namespace DevTools {
+
+class DEVTOOLS_API IndexedDBActor final : public Actor {
+public:
+    static constexpr auto base_name = "indexed-db"sv;
+
+    static NonnullRefPtr<IndexedDBActor> create(DevToolsServer&, String name, WeakPtr<TabActor>);
+    virtual ~IndexedDBActor() override;
+
+    void get_storage_resource(Function<void(JsonObject)>);
+
+private:
+    IndexedDBActor(DevToolsServer&, String name, WeakPtr<TabActor>);
+
+    virtual void handle_message(Message const&) override;
+
+    void get_fields(Message const&);
+    void get_store_objects(Message const&);
+
+    JsonObject serialize_storage(JsonObject hosts) const;
+    void send_inspection_error(Message const&, Error const&);
+
+    WeakPtr<TabActor> m_tab;
+};
+
+}

--- a/Libraries/LibDevTools/Actors/StorageActor.cpp
+++ b/Libraries/LibDevTools/Actors/StorageActor.cpp
@@ -17,14 +17,6 @@ namespace DevTools {
 
 static constexpr auto max_store_object_count = 50uz;
 
-static JsonObject storage_field(StringView name)
-{
-    JsonObject field;
-    field.set("name"sv, name);
-    field.set("editable"sv, true);
-    return field;
-}
-
 static JsonObject serialize_storage_item(DevToolsDelegate::StorageItem const& item)
 {
     JsonObject object;
@@ -161,8 +153,8 @@ void StorageActor::handle_message(Message const& message)
 void StorageActor::get_fields(Message const& message)
 {
     JsonArray fields;
-    fields.must_append(storage_field("name"sv));
-    fields.must_append(storage_field("value"sv));
+    fields.must_append(define_storage_field("name"sv, StorageFieldType::Mutable));
+    fields.must_append(define_storage_field("value"sv, StorageFieldType::Mutable));
 
     JsonObject response;
     response.set("value"sv, move(fields));

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -12,6 +12,7 @@
 #include <LibDevTools/Actors/ConsoleActor.h>
 #include <LibDevTools/Actors/CookiesActor.h>
 #include <LibDevTools/Actors/FrameActor.h>
+#include <LibDevTools/Actors/IndexedDBActor.h>
 #include <LibDevTools/Actors/InspectorActor.h>
 #include <LibDevTools/Actors/NetworkParentActor.h>
 #include <LibDevTools/Actors/StorageActor.h>
@@ -92,13 +93,14 @@ void WatcherActor::handle_message(Message const& message)
             return;
 
         bool should_send_cookie_resources = false;
+        bool should_send_indexed_db_resources = false;
         bool should_send_local_storage_resources = false;
         bool should_send_session_storage_resources = false;
         if constexpr (DEVTOOLS_DEBUG) {
             for (auto const& resource_type : resource_types->values()) {
                 if (!resource_type.is_string())
                     continue;
-                if (!first_is_one_of(resource_type.as_string(), "console-message"sv, "cookies"sv, "local-storage"sv, "session-storage"sv))
+                if (!first_is_one_of(resource_type.as_string(), "console-message"sv, "cookies"sv, "indexed-db"sv, "local-storage"sv, "session-storage"sv))
                     dbgln("Unrecognized `watchResources` resource type: '{}'", resource_type.as_string());
             }
         }
@@ -108,6 +110,9 @@ void WatcherActor::handle_message(Message const& message)
             if (resource_type.as_string() == "cookies"sv) {
                 m_is_watching_cookie_resources = true;
                 should_send_cookie_resources = true;
+            } else if (resource_type.as_string() == "indexed-db"sv) {
+                m_is_watching_indexed_db_resources = true;
+                should_send_indexed_db_resources = true;
             } else if (resource_type.as_string() == "local-storage"sv) {
                 m_is_watching_local_storage_resources = true;
                 should_send_local_storage_resources = true;
@@ -120,6 +125,8 @@ void WatcherActor::handle_message(Message const& message)
         send_response(message, move(response));
         if (should_send_cookie_resources)
             send_cookies_resource_available_message();
+        if (should_send_indexed_db_resources)
+            send_indexed_db_resource_available_message();
         if (should_send_local_storage_resources)
             send_storage_resource_available_message(local_storage_actor());
         if (should_send_session_storage_resources)
@@ -164,7 +171,7 @@ JsonObject WatcherActor::serialize_description() const
     resources.set("document-event"sv, true);
     resources.set("error-message"sv, false);
     resources.set("extension-storage"sv, false);
-    resources.set("indexed-db"sv, false);
+    resources.set("indexed-db"sv, true);
     resources.set("jstracer-state"sv, false);
     resources.set("jstracer-trace"sv, false);
     resources.set("last-private-context-exit"sv, false);
@@ -227,6 +234,8 @@ void WatcherActor::switch_frame_target(FrameActor& previous_target, String const
     target.set_pending_navigation_document_events_after_target_switch(url, title);
     if (m_is_watching_cookie_resources)
         send_cookies_resource_available_message();
+    if (m_is_watching_indexed_db_resources)
+        send_indexed_db_resource_available_message();
     if (m_is_watching_local_storage_resources)
         send_storage_resource_available_message(local_storage_actor());
     if (m_is_watching_session_storage_resources)
@@ -261,6 +270,15 @@ CookiesActor& WatcherActor::cookies_actor()
 
     m_cookies = devtools().register_actor<CookiesActor>(m_tab);
     return *m_cookies.strong_ref();
+}
+
+IndexedDBActor& WatcherActor::indexed_db_actor()
+{
+    if (auto indexed_db = m_indexed_db.strong_ref())
+        return *indexed_db;
+
+    m_indexed_db = devtools().register_actor<IndexedDBActor>(m_tab);
+    return *m_indexed_db.strong_ref();
 }
 
 void WatcherActor::send_cookies_resource_available_message()
@@ -315,6 +333,30 @@ void WatcherActor::send_storage_resource_available_message(StorageActor& storage
     message.set("type"sv, "resources-available-array"sv);
     message.set("array"sv, move(array));
     send_message(move(message));
+}
+
+void WatcherActor::send_indexed_db_resource_available_message()
+{
+    indexed_db_actor().get_storage_resource([weak_self = make_weak_ptr<WatcherActor>()](JsonObject indexed_db) mutable {
+        auto self = weak_self.strong_ref();
+        if (!self)
+            return;
+
+        JsonArray indexed_databases;
+        indexed_databases.must_append(move(indexed_db));
+
+        JsonArray indexed_database_resources;
+        indexed_database_resources.must_append("indexed-db"sv);
+        indexed_database_resources.must_append(move(indexed_databases));
+
+        JsonArray array;
+        array.must_append(move(indexed_database_resources));
+
+        JsonObject message;
+        message.set("type"sv, "resources-available-array"sv);
+        message.set("array"sv, move(array));
+        self->send_message(move(message));
+    });
 }
 
 }

--- a/Libraries/LibDevTools/Actors/WatcherActor.h
+++ b/Libraries/LibDevTools/Actors/WatcherActor.h
@@ -36,10 +36,13 @@ private:
     StorageActor& local_storage_actor();
     StorageActor& session_storage_actor();
     void send_storage_resource_available_message(StorageActor&);
+    IndexedDBActor& indexed_db_actor();
+    void send_indexed_db_resource_available_message();
 
     WeakPtr<TabActor> m_tab;
     WeakPtr<FrameActor> m_target;
     WeakPtr<CookiesActor> m_cookies;
+    WeakPtr<IndexedDBActor> m_indexed_db;
     WeakPtr<StorageActor> m_local_storage;
     WeakPtr<StorageActor> m_session_storage;
     WeakPtr<TargetConfigurationActor> m_target_configuration;
@@ -47,6 +50,7 @@ private:
     WeakPtr<NetworkParentActor> m_network_parent;
     bool m_is_watching_frame_targets { false };
     bool m_is_watching_cookie_resources { false };
+    bool m_is_watching_indexed_db_resources { false };
     bool m_is_watching_local_storage_resources { false };
     bool m_is_watching_session_storage_resources { false };
 };

--- a/Libraries/LibDevTools/CMakeLists.txt
+++ b/Libraries/LibDevTools/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     Actors/DeviceActor.cpp
     Actors/FrameActor.cpp
     Actors/HighlighterActor.cpp
+    Actors/IndexedDBActor.cpp
     Actors/InspectorActor.cpp
     Actors/LayoutInspectorActor.cpp
     Actors/NetworkEventActor.cpp
@@ -30,6 +31,7 @@ set(SOURCES
     Actors/WatcherActor.cpp
     Connection.cpp
     DevToolsServer.cpp
+    IndexedDBSerialization.cpp
     StorageHelpers.cpp
 )
 

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -78,6 +78,9 @@ public:
     using OnIndexedDBInspectionComplete = Function<void(ErrorOr<JsonObject>)>;
     virtual void inspect_indexed_database_storage(TabDescription const&, OnIndexedDBInspectionComplete) const { }
     virtual void inspect_indexed_database_objects(TabDescription const&, String const&, Optional<JsonArray>, JsonObject, OnIndexedDBInspectionComplete) const { }
+    virtual void delete_indexed_database(TabDescription const&, String const&, String const&, OnIndexedDBInspectionComplete) const { }
+    virtual void clear_indexed_database_object_store(TabDescription const&, String const&, String const&, OnIndexedDBInspectionComplete) const { }
+    virtual void delete_indexed_database_record(TabDescription const&, String const&, String const&, OnIndexedDBInspectionComplete) const { }
     using OnIndexedDatabaseChange = Function<void(JsonObject)>;
     virtual u64 add_indexed_database_change_listener(TabDescription const&, OnIndexedDatabaseChange) const { return 0; }
     virtual void remove_indexed_database_change_listener(TabDescription const&, u64) const { }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -75,6 +75,10 @@ public:
     virtual u64 add_storage_change_listener(TabDescription const&, OnStorageChange) const { return 0; }
     virtual void remove_storage_change_listener(TabDescription const&, u64) const { }
 
+    using OnIndexedDBInspectionComplete = Function<void(ErrorOr<JsonObject>)>;
+    virtual void inspect_indexed_database_storage(TabDescription const&, OnIndexedDBInspectionComplete) const { }
+    virtual void inspect_indexed_database_objects(TabDescription const&, String const&, Optional<JsonArray>, JsonObject, OnIndexedDBInspectionComplete) const { }
+
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }
 

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -78,6 +78,9 @@ public:
     using OnIndexedDBInspectionComplete = Function<void(ErrorOr<JsonObject>)>;
     virtual void inspect_indexed_database_storage(TabDescription const&, OnIndexedDBInspectionComplete) const { }
     virtual void inspect_indexed_database_objects(TabDescription const&, String const&, Optional<JsonArray>, JsonObject, OnIndexedDBInspectionComplete) const { }
+    using OnIndexedDatabaseChange = Function<void(JsonObject)>;
+    virtual u64 add_indexed_database_change_listener(TabDescription const&, OnIndexedDatabaseChange) const { return 0; }
+    virtual void remove_indexed_database_change_listener(TabDescription const&, u64) const { }
 
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }

--- a/Libraries/LibDevTools/Forward.h
+++ b/Libraries/LibDevTools/Forward.h
@@ -23,6 +23,7 @@ class DevToolsDelegate;
 class DevToolsServer;
 class FrameActor;
 class HighlighterActor;
+class IndexedDBActor;
 class InspectorActor;
 class LayoutInspectorActor;
 class NetworkEventActor;

--- a/Libraries/LibDevTools/IndexedDBSerialization.cpp
+++ b/Libraries/LibDevTools/IndexedDBSerialization.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <LibDevTools/IndexedDBSerialization.h>
+#include <LibDevTools/StorageHelpers.h>
+#include <LibURL/URL.h>
+#include <LibWeb/IndexedDB/Inspection.h>
+
+namespace DevTools::IndexedDB {
+
+static constexpr auto indexed_database_default_storage_name = "default"sv;
+static constexpr auto indexed_database_default_storage_suffix = " (default)"sv;
+
+static String database_name_for_devtools(String const& database_name)
+{
+    return MUST(String::formatted("{}{}", database_name, indexed_database_default_storage_suffix));
+}
+
+static String database_name_from_devtools(String const& name)
+{
+    auto view = name.bytes_as_string_view();
+    if (view.ends_with(indexed_database_default_storage_suffix))
+        return MUST(String::from_utf8(view.substring_view(0, view.length() - indexed_database_default_storage_suffix.length())));
+    return name;
+}
+
+static String indexed_database_path(String const& database_name, Optional<String const&> object_store_name = {}, Optional<JsonValue const&> key = {})
+{
+    JsonArray path;
+    path.must_append(database_name_for_devtools(database_name));
+    if (object_store_name.has_value())
+        path.must_append(*object_store_name);
+    if (key.has_value())
+        path.must_append(*key);
+    return path.serialized();
+}
+
+JsonObject serialize_storage(Web::DOM::Document& document)
+{
+    JsonObject hosts;
+    for (auto const& storage_host : Web::IndexedDB::inspect_indexed_database_storage(document)) {
+        auto host = storage_host_for_url(storage_host.url);
+        if (!host.has_value())
+            continue;
+
+        JsonArray names;
+        for (auto const& database : storage_host.databases) {
+            if (database.object_store_names.is_empty()) {
+                names.must_append(indexed_database_path(database.name));
+                continue;
+            }
+
+            for (auto const& object_store_name : database.object_store_names)
+                names.must_append(indexed_database_path(database.name, object_store_name));
+        }
+
+        hosts.set(*host, move(names));
+    }
+    return hosts;
+}
+
+static Optional<Web::IndexedDB::InspectionPath> parse_indexed_database_path(JsonValue const& name)
+{
+    if (!name.is_string())
+        return {};
+
+    auto parsed = JsonValue::from_string(name.as_string());
+    if (parsed.is_error() || !parsed.value().is_array())
+        return {};
+
+    auto array = parsed.release_value().as_array();
+    if (array.is_empty() || !array.at(0).is_string())
+        return {};
+
+    Web::IndexedDB::InspectionPath path;
+    path.database_name = database_name_from_devtools(array.at(0).as_string());
+    if (array.size() >= 2) {
+        if (!array.at(1).is_string())
+            return {};
+        path.object_store_name = array.at(1).as_string();
+    }
+    if (array.size() >= 3)
+        path.key = array.at(2);
+    return path;
+}
+
+static Optional<Vector<Web::IndexedDB::InspectionPath>> parse_indexed_database_paths(Optional<JsonArray> const& names)
+{
+    if (!names.has_value())
+        return {};
+
+    Vector<Web::IndexedDB::InspectionPath> paths;
+    for (auto const& name : names->values()) {
+        auto path = parse_indexed_database_path(name);
+        if (path.has_value())
+            paths.append(path.release_value());
+    }
+    if (paths.is_empty())
+        return {};
+    return paths;
+}
+
+static Function<bool(URL::URL const&)> host_filter(String const& host)
+{
+    return [host](URL::URL const& url) {
+        auto storage_host = storage_host_for_url(url);
+        return storage_host.has_value() && *storage_host == host;
+    };
+}
+
+static JsonObject serialize_object_row(Web::IndexedDB::InspectionObject const& inspection_object, String const& host)
+{
+    return inspection_object.visit(
+        [&](Web::IndexedDB::InspectionDatabaseRow const& row) {
+            JsonObject object;
+            object.set("uniqueKey"sv, database_name_for_devtools(row.name));
+            object.set("db"sv, row.name);
+            object.set("storage"sv, indexed_database_default_storage_name);
+            object.set("origin"sv, host);
+            object.set("version"sv, row.version);
+            object.set("objectStores"sv, row.object_store_count);
+            return object;
+        },
+        [](Web::IndexedDB::InspectionObjectStore const& store) {
+            JsonArray indexes;
+            for (auto const& index : store.indexes) {
+                JsonObject object;
+                object.set("name"sv, index.name);
+                object.set("keyPath"sv, index.key_path);
+                object.set("unique"sv, index.unique);
+                object.set("multiEntry"sv, index.multi_entry);
+                indexes.must_append(move(object));
+            }
+            JsonObject object;
+            object.set("objectStore"sv, store.name);
+            if (store.key_path.has_value())
+                object.set("keyPath"sv, *store.key_path);
+            else
+                object.set("keyPath"sv, JsonValue {});
+            object.set("autoIncrement"sv, store.auto_increment);
+            object.set("indexes"sv, indexes.serialized());
+            return object;
+        },
+        [](Web::IndexedDB::InspectionRecord const& record) {
+            JsonObject object;
+            object.set("name"sv, record.key);
+            object.set("value"sv, record.value);
+            return object;
+        });
+}
+
+static JsonObject paginated_indexed_database_response(Vector<Web::IndexedDB::InspectionObject> rows, JsonObject const& options, String const& host)
+{
+    static constexpr auto max_objects_per_page = 50uz;
+
+    size_t offset = options.get_integer<size_t>("offset"sv).value_or(0);
+    auto size = min(options.get_integer<size_t>("size"sv).value_or(max_objects_per_page), max_objects_per_page);
+    auto total = rows.size();
+
+    JsonArray data;
+    if (offset < total) {
+        auto end = min(total, offset + size);
+        for (size_t i = offset; i < end; ++i)
+            data.must_append(serialize_object_row(rows.at(i), host));
+    } else {
+        offset = total;
+    }
+
+    JsonObject response;
+    response.set("offset"sv, offset);
+    response.set("total"sv, total);
+    response.set("data"sv, move(data));
+    return response;
+}
+
+JsonObject serialize_objects(Web::DOM::Document& document, String const& host, JsonValue const& names, JsonValue const& options)
+{
+    auto parsed_options = options.is_object() ? options.as_object() : JsonObject {};
+    auto parsed_named = names.is_array() ? names.as_array() : JsonArray {};
+    return paginated_indexed_database_response(
+        Web::IndexedDB::inspect_indexed_database_objects(document, host_filter(host), parse_indexed_database_paths(parsed_named)),
+        parsed_options,
+        host);
+}
+
+static ErrorOr<Web::IndexedDB::InspectionPath> parse_required_indexed_database_path(String const& name)
+{
+    auto path = parse_indexed_database_path(JsonValue { name });
+    if (!path.has_value())
+        return Error::from_string_literal("Invalid IndexedDB path");
+    return path.release_value();
+}
+
+ErrorOr<JsonObject> delete_database(Web::DOM::Document& document, String const& host, String const& name)
+{
+    auto blocked = TRY(Web::IndexedDB::delete_indexed_database_for_inspection(document, host_filter(host), database_name_from_devtools(name)));
+
+    JsonObject response;
+    if (blocked)
+        response.set("blocked"sv, true);
+    return response;
+}
+
+ErrorOr<JsonObject> clear_object_store(Web::DOM::Document& document, String const& host, String const& name)
+{
+    auto path = TRY(parse_required_indexed_database_path(name));
+    if (!path.object_store_name.has_value() || path.key.has_value())
+        return Error::from_string_literal("Invalid IndexedDB object store path");
+
+    TRY(Web::IndexedDB::clear_indexed_database_object_store_for_inspection(document, host_filter(host), path.database_name, *path.object_store_name));
+    return JsonObject {};
+}
+
+ErrorOr<JsonObject> delete_record(Web::DOM::Document& document, String const& host, String const& name)
+{
+    auto path = TRY(parse_required_indexed_database_path(name));
+    if (!path.object_store_name.has_value() || !path.key.has_value())
+        return Error::from_string_literal("Invalid IndexedDB record path");
+
+    TRY(Web::IndexedDB::delete_indexed_database_record_for_inspection(document, host_filter(host), path.database_name, *path.object_store_name, *path.key));
+    return JsonObject {};
+}
+
+}

--- a/Libraries/LibDevTools/IndexedDBSerialization.cpp
+++ b/Libraries/LibDevTools/IndexedDBSerialization.cpp
@@ -187,6 +187,48 @@ JsonObject serialize_objects(Web::DOM::Document& document, String const& host, J
         host);
 }
 
+static void append_indexed_database_update(JsonObject& update, StringView type, JsonArray paths, String const& host)
+{
+    if (paths.is_empty())
+        return;
+
+    JsonObject hosts;
+    hosts.set(host, move(paths));
+
+    JsonObject indexed_database;
+    indexed_database.set("indexedDB"sv, move(hosts));
+
+    update.set(type, move(indexed_database));
+}
+
+static JsonArray serialize_update_paths(Vector<Web::IndexedDB::TransactionChange> const& changes)
+{
+    JsonArray paths;
+    paths.ensure_capacity(changes.size());
+    for (auto const& change : changes) {
+        // FIXME: Firefox treats added IndexedDB update paths as storage tree additions, so record-level changes must
+        //        not be sent there or they appear as blank rows in the selected host view.
+        //        Remove this filter once Firefox supports record updates.
+        if (change.key.has_value())
+            continue;
+        paths.must_append(indexed_database_path(change.database_name, change.object_store_name, change.key));
+    }
+    return paths;
+}
+
+JsonObject serialize_update(String const& url, Web::IndexedDB::TransactionChanges const& changes)
+{
+    JsonObject update;
+    auto host = storage_host_for_url(url);
+    if (!host.has_value())
+        return update;
+
+    append_indexed_database_update(update, "added"sv, serialize_update_paths(changes.added), *host);
+    append_indexed_database_update(update, "changed"sv, serialize_update_paths(changes.changed), *host);
+    append_indexed_database_update(update, "deleted"sv, serialize_update_paths(changes.deleted), *host);
+    return update;
+}
+
 static ErrorOr<Web::IndexedDB::InspectionPath> parse_required_indexed_database_path(String const& name)
 {
     auto path = parse_indexed_database_path(JsonValue { name });

--- a/Libraries/LibDevTools/IndexedDBSerialization.h
+++ b/Libraries/LibDevTools/IndexedDBSerialization.h
@@ -11,11 +11,13 @@
 #include <AK/String.h>
 #include <LibDevTools/Forward.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/IndexedDB/TransactionChanges.h>
 
 namespace DevTools::IndexedDB {
 
 DEVTOOLS_API JsonObject serialize_storage(Web::DOM::Document&);
 DEVTOOLS_API JsonObject serialize_objects(Web::DOM::Document&, String const& host, JsonValue const& names, JsonValue const& options);
+DEVTOOLS_API JsonObject serialize_update(String const& url, Web::IndexedDB::TransactionChanges const&);
 DEVTOOLS_API ErrorOr<JsonObject> delete_database(Web::DOM::Document&, String const& host, String const& name);
 DEVTOOLS_API ErrorOr<JsonObject> clear_object_store(Web::DOM::Document&, String const& host, String const& name);
 DEVTOOLS_API ErrorOr<JsonObject> delete_record(Web::DOM::Document&, String const& host, String const& name);

--- a/Libraries/LibDevTools/IndexedDBSerialization.h
+++ b/Libraries/LibDevTools/IndexedDBSerialization.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
+#include <AK/String.h>
+#include <LibDevTools/Forward.h>
+#include <LibWeb/Forward.h>
+
+namespace DevTools::IndexedDB {
+
+DEVTOOLS_API JsonObject serialize_storage(Web::DOM::Document&);
+DEVTOOLS_API JsonObject serialize_objects(Web::DOM::Document&, String const& host, JsonValue const& names, JsonValue const& options);
+DEVTOOLS_API ErrorOr<JsonObject> delete_database(Web::DOM::Document&, String const& host, String const& name);
+DEVTOOLS_API ErrorOr<JsonObject> clear_object_store(Web::DOM::Document&, String const& host, String const& name);
+DEVTOOLS_API ErrorOr<JsonObject> delete_record(Web::DOM::Document&, String const& host, String const& name);
+
+}

--- a/Libraries/LibDevTools/StorageHelpers.cpp
+++ b/Libraries/LibDevTools/StorageHelpers.cpp
@@ -11,6 +11,20 @@
 
 namespace DevTools {
 
+JsonObject define_storage_field(StringView name, StorageFieldType state)
+{
+    JsonObject field;
+    field.set("name"sv, name);
+    field.set("editable"sv, state == StorageFieldType::Mutable);
+
+    if (state == StorageFieldType::Hidden)
+        field.set("hidden"sv, true);
+    else if (state == StorageFieldType::Private)
+        field.set("private"sv, true);
+
+    return field;
+}
+
 Optional<String> storage_host_for_url(String const& url_string)
 {
     auto url = URL::Parser::basic_parse(url_string);

--- a/Libraries/LibDevTools/StorageHelpers.cpp
+++ b/Libraries/LibDevTools/StorageHelpers.cpp
@@ -31,19 +31,24 @@ Optional<String> storage_host_for_url(String const& url_string)
     if (!url.has_value())
         return {};
 
-    auto const& scheme = url->scheme();
+    return storage_host_for_url(url.value());
+}
+
+Optional<String> storage_host_for_url(URL::URL const& url)
+{
+    auto const& scheme = url.scheme();
     if (scheme == "http"sv || scheme == "https"sv) {
         StringBuilder builder;
         builder.append(scheme);
         builder.append("://"sv);
-        builder.append(url->serialized_host());
-        if (auto port = url->port(); port.has_value())
+        builder.append(url.serialized_host());
+        if (auto port = url.port(); port.has_value())
             builder.appendff(":{}", *port);
         return builder.to_string_without_validation();
     }
 
     if (scheme == "about"sv || scheme == "file"sv || scheme == "javascript"sv || scheme == "resource"sv)
-        return url->serialize();
+        return url.serialize();
 
     return {};
 }

--- a/Libraries/LibDevTools/StorageHelpers.h
+++ b/Libraries/LibDevTools/StorageHelpers.h
@@ -11,10 +11,12 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <LibDevTools/Forward.h>
+#include <LibURL/Forward.h>
 
 namespace DevTools {
 
 DEVTOOLS_API Optional<String> storage_host_for_url(String const&);
+DEVTOOLS_API Optional<String> storage_host_for_url(URL::URL const& url);
 DEVTOOLS_API Optional<String> storage_host_name(String const&);
 
 enum class StorageFieldType : u8 {

--- a/Libraries/LibDevTools/StorageHelpers.h
+++ b/Libraries/LibDevTools/StorageHelpers.h
@@ -17,6 +17,14 @@ namespace DevTools {
 DEVTOOLS_API Optional<String> storage_host_for_url(String const&);
 DEVTOOLS_API Optional<String> storage_host_name(String const&);
 
+enum class StorageFieldType : u8 {
+    Immutable,
+    Mutable,
+    Hidden,
+    Private,
+};
+JsonObject define_storage_field(StringView name, StorageFieldType);
+
 JsonObject to_storage_operation_result(Optional<String> const& error_string);
 JsonObject to_storage_operation_result(ErrorOr<void> const& result);
 

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -731,6 +731,7 @@ set(SOURCES
     HTML/WorkerNavigator.cpp
     HTML/WorkletGlobalScope.cpp
     HTML/XMLSerializer.cpp
+    IndexedDB/Inspection.cpp
     IndexedDB/IDBCursor.cpp
     IndexedDB/IDBDatabase.cpp
     IndexedDB/IDBFactory.cpp

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -911,6 +911,7 @@ class IDBRequest;
 class IDBTransaction;
 class IDBVersionChangeEvent;
 class Index;
+class Key;
 class ObjectStore;
 class RequestList;
 

--- a/Libraries/LibWeb/IndexedDB/IDBTransaction.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBTransaction.cpp
@@ -7,12 +7,15 @@
 #include <LibWeb/Bindings/IDBDatabase.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/IndexedDB/IDBDatabase.h>
 #include <LibWeb/IndexedDB/IDBIndex.h>
 #include <LibWeb/IndexedDB/IDBObjectStore.h>
 #include <LibWeb/IndexedDB/IDBTransaction.h>
 #include <LibWeb/IndexedDB/Internal/Algorithms.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::IndexedDB {
 
@@ -236,6 +239,25 @@ void IDBTransaction::discard_mutation_logs()
     for (auto& entry : m_store_mutation_logs)
         entry.store->set_mutation_log(nullptr);
     m_store_mutation_logs.clear();
+}
+
+void IDBTransaction::notify_devtools_of_committed_changes()
+{
+    auto document = HTML::relevant_settings_object(*this).responsible_document();
+    if (!document)
+        return;
+
+    if (!document->page().client().has_active_devtools_client())
+        return;
+
+    TransactionChanges changes;
+    auto database_name = m_connection->associated_database()->name();
+    for (auto const& entry : m_store_mutation_logs)
+        entry.log->append_changes(database_name, entry.store->name(), changes);
+    if (changes.is_empty())
+        return;
+
+    document->page().client().page_did_update_indexed_database(document->url().serialize(), changes);
 }
 
 }

--- a/Libraries/LibWeb/IndexedDB/IDBTransaction.h
+++ b/Libraries/LibWeb/IndexedDB/IDBTransaction.h
@@ -108,6 +108,8 @@ public:
     void set_onerror(WebIDL::CallbackType*);
     WebIDL::CallbackType* onerror();
 
+    void notify_devtools_of_committed_changes();
+
 protected:
     explicit IDBTransaction(JS::Realm&, GC::Ref<IDBDatabase>, Bindings::IDBTransactionMode, Bindings::IDBTransactionDurability, Vector<GC::Ref<ObjectStore>>);
     virtual void initialize(JS::Realm&) override;

--- a/Libraries/LibWeb/IndexedDB/Inspection.cpp
+++ b/Libraries/LibWeb/IndexedDB/Inspection.cpp
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/NavigableContainer.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HTML/StructuredSerialize.h>
+#include <LibWeb/IndexedDB/IDBKeyRange.h>
+#include <LibWeb/IndexedDB/Inspection.h>
+#include <LibWeb/IndexedDB/Internal/Algorithms.h>
+#include <LibWeb/IndexedDB/Internal/Database.h>
+#include <LibWeb/IndexedDB/Internal/Index.h>
+#include <LibWeb/IndexedDB/Internal/Key.h>
+#include <LibWeb/IndexedDB/Internal/ObjectStore.h>
+#include <LibWeb/Infra/JSON.h>
+#include <LibWeb/StorageAPI/StorageKey.h>
+
+namespace Web::IndexedDB {
+
+struct IndexedDatabaseDocument {
+    String url;
+    GC::Ref<DOM::Document> document;
+    StorageAPI::StorageKey storage_key;
+};
+
+JsonValue serialize_key_for_inspection(Key& key)
+{
+    switch (key.type()) {
+    case Key::Invalid:
+        return {};
+    case Key::Number:
+    case Key::Date:
+        return key.value_as_double();
+    case Key::String:
+        return key.value_as_string();
+    case Key::Binary:
+        return key.dump();
+    case Key::Array: {
+        JsonArray keys;
+        for (auto const& subkey : key.subkeys())
+            keys.must_append(serialize_key_for_inspection(*subkey));
+        return keys;
+    }
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+static String serialize_key_path(KeyPath const& key_path)
+{
+    return key_path.visit(
+        [](String const& value) {
+            return value;
+        },
+        [](Vector<String> const& values) {
+            JsonArray array;
+            for (auto const& value : values)
+                array.must_append(value);
+            return array.serialized();
+        });
+}
+
+static String serialize_record_value(JS::Realm& realm, HTML::SerializationRecord const& record)
+{
+    HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+
+    auto value = HTML::structured_deserialize(realm.vm(), record, realm);
+    if (value.is_exception())
+        return "<unserializable>"_string;
+
+    auto serialized = Infra::serialize_javascript_value_to_json_string(realm.vm(), value.release_value());
+    if (serialized.is_exception())
+        return "<unserializable>"_string;
+
+    return serialized.release_value();
+}
+
+static Vector<IndexedDatabaseDocument> indexed_database_documents_for_inspection(DOM::Document& root_document)
+{
+    Vector<IndexedDatabaseDocument> documents;
+
+    auto append_document = [&](DOM::Document& document) {
+        auto storage_key = StorageAPI::obtain_a_storage_key(document.relevant_settings_object());
+        if (!storage_key.has_value())
+            return;
+
+        documents.append({ document.url().serialize(), document, storage_key.release_value() });
+    };
+
+    append_document(root_document);
+    root_document.for_each_in_subtree_of_type<HTML::NavigableContainer>([&](HTML::NavigableContainer& navigable_container) {
+        auto content_navigable = navigable_container.content_navigable();
+        if (!content_navigable)
+            return TraversalDecision::Continue;
+
+        auto content_document = content_navigable->active_document();
+        if (!content_document)
+            return TraversalDecision::Continue;
+
+        if (!content_document->origin().is_same_origin_domain(navigable_container.document().origin()))
+            return TraversalDecision::Continue;
+
+        append_document(*content_document);
+        return TraversalDecision::Continue;
+    });
+
+    return documents;
+}
+
+static Optional<IndexedDatabaseDocument> matching_document(DOM::Document& document, Function<bool(URL::URL const&)> const& document_matches)
+{
+    for (auto const& entry : indexed_database_documents_for_inspection(document)) {
+        if (document_matches(entry.document->url()))
+            return entry;
+    }
+    return {};
+}
+
+Vector<InspectionStorageHost> inspect_indexed_database_storage(DOM::Document& document)
+{
+    Vector<InspectionStorageHost> hosts;
+    for (auto const& entry : indexed_database_documents_for_inspection(document)) {
+        Vector<InspectionDatabase> databases;
+        for (auto& database : Database::for_key(entry.storage_key)) {
+            if (!database || database->version() == 0)
+                continue;
+
+            Vector<String> object_store_names;
+            for (auto const& object_store : database->object_stores())
+                object_store_names.append(object_store->name());
+
+            databases.append({ database->name(), database->version(), move(object_store_names) });
+        }
+
+        hosts.append({ entry.url, move(databases) });
+    }
+    return hosts;
+}
+
+static InspectionObjectStore inspect_object_store(ObjectStore& object_store)
+{
+    Vector<InspectionIndex> indexes;
+    for (auto const& entry : object_store.index_set()) {
+        auto const& index = *entry.value;
+        indexes.append({ index.name(), serialize_key_path(index.key_path()), index.unique(), index.multi_entry() });
+    }
+
+    Optional<String> key_path;
+    if (auto value = object_store.key_path(); value.has_value())
+        key_path = serialize_key_path(*value);
+
+    return { object_store.name(), move(key_path), object_store.uses_a_key_generator(), move(indexes) };
+}
+
+static void append_database_rows(Vector<InspectionObject>& rows, StorageAPI::StorageKey const& storage_key)
+{
+    for (auto& database : Database::for_key(storage_key)) {
+        if (!database || database->version() == 0)
+            continue;
+
+        rows.append(InspectionDatabaseRow { database->name(), database->version(), database->object_stores().size() });
+    }
+}
+
+static void append_object_store_rows(Vector<InspectionObject>& rows, StorageAPI::StorageKey const& storage_key, String const& database_name)
+{
+    auto database = Database::for_key_and_name(storage_key, database_name);
+    if (!database.has_value())
+        return;
+
+    for (auto const& object_store : database->object_stores())
+        rows.append(inspect_object_store(*object_store));
+}
+
+static void append_record_rows(Vector<InspectionObject>& rows, DOM::Document& document, StorageAPI::StorageKey const& storage_key, InspectionPath const& path)
+{
+    if (!path.object_store_name.has_value())
+        return;
+
+    auto database = Database::for_key_and_name(storage_key, path.database_name);
+    if (!database.has_value())
+        return;
+
+    auto object_store = database->object_store_with_name(*path.object_store_name);
+    if (!object_store)
+        return;
+
+    for (auto const& record : object_store->records()) {
+        auto serialized_record_key = serialize_key_for_inspection(*record.key);
+        if (path.key.has_value() && serialized_record_key.serialized() != path.key->serialized())
+            continue;
+        rows.append(InspectionRecord { serialized_record_key, serialize_record_value(document.realm(), *record.value) });
+    }
+}
+
+Vector<InspectionObject> inspect_indexed_database_objects(DOM::Document& document, Function<bool(URL::URL const&)> const& document_matches, Optional<Vector<InspectionPath>> const& paths)
+{
+    Vector<InspectionObject> rows;
+    for (auto const& entry : indexed_database_documents_for_inspection(document)) {
+        if (!document_matches(entry.document->url()))
+            continue;
+
+        if (!paths.has_value()) {
+            append_database_rows(rows, entry.storage_key);
+            continue;
+        }
+
+        for (auto const& path : *paths) {
+            if (!path.object_store_name.has_value())
+                append_object_store_rows(rows, entry.storage_key, path.database_name);
+            else
+                append_record_rows(rows, entry.document, entry.storage_key, path);
+        }
+    }
+
+    return rows;
+}
+
+ErrorOr<bool> delete_indexed_database_for_inspection(DOM::Document& document, Function<bool(URL::URL const&)> const& document_matches, String const& database_name)
+{
+    auto entry = matching_document(document, document_matches);
+    if (!entry.has_value())
+        return Error::from_string_literal("Unable to find IndexedDB host");
+
+    auto database = Database::for_key_and_name(entry->storage_key, database_name);
+    if (database.has_value() && !database->associated_connections_as_root_vector().is_empty())
+        return true;
+
+    TRY(Database::delete_for_key_and_name(entry->storage_key, database_name));
+    return false;
+}
+
+ErrorOr<void> clear_indexed_database_object_store_for_inspection(DOM::Document& document, Function<bool(URL::URL const&)> const& document_matches, String const& database_name, String const& object_store_name)
+{
+    auto entry = matching_document(document, document_matches);
+    if (!entry.has_value())
+        return Error::from_string_literal("Unable to find IndexedDB host");
+
+    auto database = Database::for_key_and_name(entry->storage_key, database_name);
+    if (!database.has_value())
+        return Error::from_string_literal("Unable to find IndexedDB database");
+
+    auto object_store = database->object_store_with_name(object_store_name);
+    if (!object_store)
+        return Error::from_string_literal("Unable to find IndexedDB object store");
+
+    clear_an_object_store(*object_store);
+    return {};
+}
+
+ErrorOr<void> delete_indexed_database_record_for_inspection(DOM::Document& document, Function<bool(URL::URL const&)> const& document_matches, String const& database_name, String const& object_store_name, JsonValue const& key)
+{
+    auto entry = matching_document(document, document_matches);
+    if (!entry.has_value())
+        return Error::from_string_literal("Unable to find IndexedDB host");
+
+    auto database = Database::for_key_and_name(entry->storage_key, database_name);
+    if (!database.has_value())
+        return Error::from_string_literal("Unable to find IndexedDB database");
+
+    auto object_store = database->object_store_with_name(object_store_name);
+    if (!object_store)
+        return Error::from_string_literal("Unable to find IndexedDB object store");
+
+    for (auto const& record : object_store->records()) {
+        if (serialize_key_for_inspection(*record.key).serialized() != key.serialized())
+            continue;
+
+        auto range = IDBKeyRange::create(entry->document->realm(), record.key, record.key, IDBKeyRange::LowerOpen::No, IDBKeyRange::UpperOpen::No);
+        delete_records_from_an_object_store(*object_store, range);
+        return {};
+    }
+
+    return Error::from_string_literal("Unable to find IndexedDB record");
+}
+
+}

--- a/Libraries/LibWeb/IndexedDB/Inspection.h
+++ b/Libraries/LibWeb/IndexedDB/Inspection.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/JsonValue.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibURL/Forward.h>
+#include <LibWeb/Export.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::IndexedDB {
+
+struct InspectionDatabase {
+    String name;
+    u64 version;
+    Vector<String> object_store_names;
+};
+
+struct InspectionStorageHost {
+    String url;
+    Vector<InspectionDatabase> databases;
+};
+
+struct InspectionDatabaseRow {
+    String name;
+    u64 version;
+    size_t object_store_count { 0 };
+};
+
+struct InspectionIndex {
+    String name;
+    String key_path;
+    bool unique { false };
+    bool multi_entry { false };
+};
+
+struct InspectionObjectStore {
+    String name;
+    Optional<String> key_path;
+    bool auto_increment { false };
+    Vector<InspectionIndex> indexes;
+};
+
+struct InspectionRecord {
+    JsonValue key;
+    String value;
+};
+
+using InspectionObject = Variant<InspectionDatabaseRow, InspectionObjectStore, InspectionRecord>;
+
+struct InspectionPath {
+    String database_name;
+    Optional<String> object_store_name;
+    Optional<JsonValue> key;
+};
+
+WEB_API JsonValue serialize_key_for_inspection(Key&);
+WEB_API Vector<InspectionStorageHost> inspect_indexed_database_storage(DOM::Document&);
+WEB_API Vector<InspectionObject> inspect_indexed_database_objects(DOM::Document&, Function<bool(URL::URL const&)> const& document_matches, Optional<Vector<InspectionPath>> const& paths);
+WEB_API ErrorOr<bool> delete_indexed_database_for_inspection(DOM::Document&, Function<bool(URL::URL const&)> const& document_matches, String const& database_name);
+WEB_API ErrorOr<void> clear_indexed_database_object_store_for_inspection(DOM::Document&, Function<bool(URL::URL const&)> const& document_matches, String const& database_name, String const& object_store_name);
+WEB_API ErrorOr<void> delete_indexed_database_record_for_inspection(DOM::Document&, Function<bool(URL::URL const&)> const& document_matches, String const& database_name, String const& object_store_name, JsonValue const& key);
+
+}

--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -885,6 +885,7 @@ void commit_a_transaction(JS::Realm& realm, GC::Ref<IDBTransaction> transaction)
                 transaction->connection()->associated_database()->set_upgrade_transaction(nullptr);
 
             // AD-HOC: Discard mutation logs now that changes are permanent.
+            transaction->notify_devtools_of_committed_changes();
             transaction->discard_mutation_logs();
 
             // 2. Set transaction’s state to finished.

--- a/Libraries/LibWeb/IndexedDB/Internal/MutationLog.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/MutationLog.cpp
@@ -5,8 +5,10 @@
  */
 
 #include <LibWeb/IndexedDB/IDBDatabase.h>
+#include <LibWeb/IndexedDB/Inspection.h>
 #include <LibWeb/IndexedDB/Internal/Database.h>
 #include <LibWeb/IndexedDB/Internal/Index.h>
+#include <LibWeb/IndexedDB/Internal/Key.h>
 #include <LibWeb/IndexedDB/Internal/MutationLog.h>
 #include <LibWeb/IndexedDB/Internal/ObjectStore.h>
 
@@ -118,6 +120,71 @@ void MutationLog::note_index_records_deleted(GC::Ref<Index> index, Vector<IndexR
 void MutationLog::note_index_record_stored(GC::Ref<Index> index, IndexRecord record)
 {
     m_entries.append(IndexRecordStored { index, record });
+}
+
+void MutationLog::append_changes(String const& database_name, String const& object_store_name, TransactionChanges& changes) const
+{
+    Vector<GC::Ref<Key>> stored_keys;
+    Vector<GC::Ref<Key>> changed_keys;
+    Vector<GC::Ref<Key>> deleted_keys;
+
+    auto remove_key = [](Vector<GC::Ref<Key>>& keys, Key& key) {
+        return keys.remove_first_matching([&](auto const& existing) {
+            return Key::equals(existing, GC::Ref { key });
+        });
+    };
+
+    auto append_deleted_key = [&](Key& key) {
+        if (remove_key(stored_keys, key))
+            return;
+        remove_key(changed_keys, key);
+        deleted_keys.append(GC::Ref { key });
+    };
+
+    auto append_stored_key = [&](Key& key) {
+        if (remove_key(deleted_keys, key)) {
+            changed_keys.append(GC::Ref { key });
+            return;
+        }
+        stored_keys.append(GC::Ref { key });
+    };
+
+    for (auto const& entry : m_entries) {
+        entry.visit(
+            [&](ObjectStoreCreated const&) {
+                changes.added.append({ database_name, object_store_name });
+            },
+            [&](ObjectStoreDeleted const&) {
+                changes.deleted.append({ database_name, object_store_name });
+            },
+            [&](ObjectStoreRenamed const& e) {
+                changes.deleted.append({ database_name, e.old_name });
+                changes.added.append({ database_name, object_store_name });
+            },
+            [&](IndexCreated const&) {},
+            [&](IndexDeleted const&) {},
+            [&](IndexRenamed const&) {},
+            [&](KeyGeneratorChanged const&) {
+            },
+            [&](RecordsDeleted const& e) {
+                for (auto const& record : e.records)
+                    append_deleted_key(*record.key);
+            },
+            [&](RecordStored const& e) {
+                append_stored_key(*e.key);
+            },
+            [&](IndexRecordsDeleted const&) {},
+            [&](IndexRecordStored const&) {});
+    }
+
+    for (auto const& key : stored_keys)
+        changes.added.append({ database_name, object_store_name, serialize_key_for_inspection(key) });
+
+    for (auto const& key : changed_keys)
+        changes.changed.append({ database_name, object_store_name, serialize_key_for_inspection(key) });
+
+    for (auto const& key : deleted_keys)
+        changes.deleted.append({ database_name, object_store_name, serialize_key_for_inspection(key) });
 }
 
 void MutationLog::revert(ObjectStore& store, GC::Ref<Database> database, GC::Ref<IDBDatabase> connection)

--- a/Libraries/LibWeb/IndexedDB/Internal/MutationLog.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/MutationLog.h
@@ -12,6 +12,7 @@
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/IndexedDB/IDBRecord.h>
 #include <LibWeb/IndexedDB/Internal/KeyGenerator.h>
+#include <LibWeb/IndexedDB/TransactionChanges.h>
 
 namespace Web::IndexedDB {
 
@@ -66,6 +67,8 @@ public:
 
     // Clear the log without reverting (used after successful transaction commit).
     void clear() { m_entries.clear(); }
+
+    void append_changes(String const& database_name, String const& object_store_name, TransactionChanges&) const;
 
     [[nodiscard]] size_t position() const { return m_entries.size(); }
 

--- a/Libraries/LibWeb/IndexedDB/TransactionChanges.h
+++ b/Libraries/LibWeb/IndexedDB/TransactionChanges.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonValue.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+namespace Web::IndexedDB {
+
+struct TransactionChange {
+    String database_name;
+    String object_store_name;
+    Optional<JsonValue> key {};
+};
+
+struct TransactionChanges {
+    Vector<TransactionChange> added;
+    Vector<TransactionChange> changed;
+    Vector<TransactionChange> deleted;
+
+    bool is_empty() const
+    {
+        return added.is_empty() && changed.is_empty() && deleted.is_empty();
+    }
+};
+
+}

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -49,6 +49,7 @@
 #include <LibWeb/HTML/TokenizedFeatures.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/HTML/WorkerAgentForward.h>
+#include <LibWeb/IndexedDB/TransactionChanges.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
@@ -508,6 +509,7 @@ public:
     virtual Vector<String> page_did_request_storage_keys([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { return {}; }
     virtual void page_did_clear_storage([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { }
     virtual void page_did_broadcast_storage_change([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& url, [[maybe_unused]] Optional<String> const& key, [[maybe_unused]] Optional<String> const& old_value, [[maybe_unused]] Optional<String> const& new_value) { }
+    virtual void page_did_update_indexed_database([[maybe_unused]] String const& url, [[maybe_unused]] IndexedDB::TransactionChanges const&) { }
     virtual void page_did_update_resource_count(i32) { }
     struct NewWebViewResult {
         GC::Ptr<Page> page;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1975,6 +1975,28 @@ void Application::remove_storage_change_listener(DevTools::TabDescription const&
         view->remove_storage_change_listener(listener_id);
 }
 
+void Application::inspect_indexed_database_storage(DevTools::TabDescription const& description, OnIndexedDBInspectionComplete on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    view->inspect_indexed_database_storage(move(on_complete));
+}
+
+void Application::inspect_indexed_database_objects(DevTools::TabDescription const& description, String const& host, Optional<JsonArray> names, JsonObject options, OnIndexedDBInspectionComplete on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    view->inspect_indexed_database_objects(host, move(names), move(options), move(on_complete));
+}
+
 void Application::inspect_tab(DevTools::TabDescription const& description, OnTabInspectionComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1997,6 +1997,52 @@ void Application::inspect_indexed_database_objects(DevTools::TabDescription cons
     view->inspect_indexed_database_objects(host, move(names), move(options), move(on_complete));
 }
 
+void Application::delete_indexed_database(DevTools::TabDescription const& description, String const& host, String const& name, OnIndexedDBInspectionComplete on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    view->delete_indexed_database(host, name, move(on_complete));
+}
+
+void Application::clear_indexed_database_object_store(DevTools::TabDescription const& description, String const& host, String const& name, OnIndexedDBInspectionComplete on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    view->clear_indexed_database_object_store(host, name, move(on_complete));
+}
+
+void Application::delete_indexed_database_record(DevTools::TabDescription const& description, String const& host, String const& name, OnIndexedDBInspectionComplete on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    view->delete_indexed_database_record(host, name, move(on_complete));
+}
+
+u64 Application::add_indexed_database_change_listener(DevTools::TabDescription const& description, OnIndexedDatabaseChange on_indexed_database_change) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        return view->add_indexed_database_change_listener(move(on_indexed_database_change));
+    return 0;
+}
+
+void Application::remove_indexed_database_change_listener(DevTools::TabDescription const& description, u64 listener_id) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->remove_indexed_database_change_listener(listener_id);
+}
+
 void Application::inspect_tab(DevTools::TabDescription const& description, OnTabInspectionComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -284,6 +284,11 @@ private:
     virtual void remove_storage_change_listener(DevTools::TabDescription const&, u64) const override;
     virtual void inspect_indexed_database_storage(DevTools::TabDescription const&, OnIndexedDBInspectionComplete) const override;
     virtual void inspect_indexed_database_objects(DevTools::TabDescription const&, String const&, Optional<JsonArray>, JsonObject, OnIndexedDBInspectionComplete) const override;
+    virtual void delete_indexed_database(DevTools::TabDescription const&, String const&, String const&, OnIndexedDBInspectionComplete) const override;
+    virtual void clear_indexed_database_object_store(DevTools::TabDescription const&, String const&, String const&, OnIndexedDBInspectionComplete) const override;
+    virtual void delete_indexed_database_record(DevTools::TabDescription const&, String const&, String const&, OnIndexedDBInspectionComplete) const override;
+    virtual u64 add_indexed_database_change_listener(DevTools::TabDescription const&, OnIndexedDatabaseChange) const override;
+    virtual void remove_indexed_database_change_listener(DevTools::TabDescription const&, u64) const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;
     virtual void inspect_accessibility_tree(DevTools::TabDescription const&, OnAccessibilityTreeInspectionComplete) const override;
     virtual void listen_for_dom_properties(DevTools::TabDescription const&, OnDOMNodePropertiesReceived) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -282,6 +282,8 @@ private:
     virtual ErrorOr<void> clear_storage(DevTools::TabDescription const&, Web::StorageAPI::StorageEndpointType, String const&) const override;
     virtual u64 add_storage_change_listener(DevTools::TabDescription const&, OnStorageChange) const override;
     virtual void remove_storage_change_listener(DevTools::TabDescription const&, u64) const override;
+    virtual void inspect_indexed_database_storage(DevTools::TabDescription const&, OnIndexedDBInspectionComplete) const override;
+    virtual void inspect_indexed_database_objects(DevTools::TabDescription const&, String const&, Optional<JsonArray>, JsonObject, OnIndexedDBInspectionComplete) const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;
     virtual void inspect_accessibility_tree(DevTools::TabDescription const&, OnAccessibilityTreeInspectionComplete) const override;
     virtual void listen_for_dom_properties(DevTools::TabDescription const&, OnDOMNodePropertiesReceived) const override;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -982,6 +982,27 @@ void ViewImplementation::inspect_indexed_database_objects(String const& host, Op
         client().async_inspect_indexed_database_objects(page_id(), request_id, host, JsonValue {}, JsonValue { move(options) });
 }
 
+void ViewImplementation::delete_indexed_database(String const& host, String const& name, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete on_complete)
+{
+    auto request_id = m_next_indexed_database_inspection_request_id++;
+    m_pending_indexed_database_inspection_requests.set(request_id, move(on_complete));
+    client().async_delete_indexed_database(page_id(), request_id, host, name);
+}
+
+void ViewImplementation::clear_indexed_database_object_store(String const& host, String const& name, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete on_complete)
+{
+    auto request_id = m_next_indexed_database_inspection_request_id++;
+    m_pending_indexed_database_inspection_requests.set(request_id, move(on_complete));
+    client().async_clear_indexed_database_object_store(page_id(), request_id, host, name);
+}
+
+void ViewImplementation::delete_indexed_database_record(String const& host, String const& name, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete on_complete)
+{
+    auto request_id = m_next_indexed_database_inspection_request_id++;
+    m_pending_indexed_database_inspection_requests.set(request_id, move(on_complete));
+    client().async_delete_indexed_database_record(page_id(), request_id, host, name);
+}
+
 void ViewImplementation::did_receive_indexed_database_inspection(u64 request_id, JsonObject result)
 {
     auto callback = m_pending_indexed_database_inspection_requests.take(request_id);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -947,6 +947,37 @@ void ViewImplementation::inspect_current_flexbox(Web::UniqueNodeID node_id, bool
     client().async_inspect_current_flexbox(page_id(), node_id, only_look_at_parents);
 }
 
+void ViewImplementation::inspect_indexed_database_storage(DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete on_complete)
+{
+    auto request_id = m_next_indexed_database_inspection_request_id++;
+    m_pending_indexed_database_inspection_requests.set(request_id, move(on_complete));
+    client().async_inspect_indexed_database_storage(page_id(), request_id);
+}
+
+void ViewImplementation::inspect_indexed_database_objects(String const& host, Optional<JsonArray> names, JsonObject options, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete on_complete)
+{
+    auto request_id = m_next_indexed_database_inspection_request_id++;
+    m_pending_indexed_database_inspection_requests.set(request_id, move(on_complete));
+    if (names.has_value())
+        client().async_inspect_indexed_database_objects(page_id(), request_id, host, JsonValue { names.release_value() }, JsonValue { move(options) });
+    else
+        client().async_inspect_indexed_database_objects(page_id(), request_id, host, JsonValue {}, JsonValue { move(options) });
+}
+
+void ViewImplementation::did_receive_indexed_database_inspection(u64 request_id, JsonObject result)
+{
+    auto callback = m_pending_indexed_database_inspection_requests.take(request_id);
+    if (!callback.has_value())
+        return;
+
+    if (result.has_string("error"sv)) {
+        (*callback)(Error::from_string_literal("IndexedDB operation failed"));
+        return;
+    }
+
+    (*callback)(move(result));
+}
+
 void ViewImplementation::clear_inspected_dom_node()
 {
     client().async_clear_inspected_dom_node(page_id());

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -718,6 +718,24 @@ void ViewImplementation::remove_storage_change_listener(u64 listener_id)
     m_storage_change_listeners.remove(listener_id);
 }
 
+void ViewImplementation::notify_indexed_database_changed(JsonObject update)
+{
+    for (auto& listener : m_indexed_database_change_listeners)
+        listener.value(update);
+}
+
+u64 ViewImplementation::add_indexed_database_change_listener(DevTools::DevToolsDelegate::OnIndexedDatabaseChange on_indexed_database_change)
+{
+    auto listener_id = m_next_indexed_database_change_listener_id++;
+    m_indexed_database_change_listeners.set(listener_id, move(on_indexed_database_change));
+    return listener_id;
+}
+
+void ViewImplementation::remove_indexed_database_change_listener(u64 listener_id)
+{
+    m_indexed_database_change_listeners.remove(listener_id);
+}
+
 ErrorOr<Core::SharedVersionIndex> ViewImplementation::ensure_document_cookie_version_index(Badge<WebContentClient>, String const& domain)
 {
     return m_document_cookie_version_indices.try_ensure(domain, [&]() -> ErrorOr<Core::SharedVersionIndex> {

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -147,6 +147,9 @@ public:
     u64 add_storage_change_listener(DevTools::DevToolsDelegate::OnStorageChange);
     void remove_storage_change_listener(u64 listener_id);
 
+    void inspect_indexed_database_storage(DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
+    void inspect_indexed_database_objects(String const& host, Optional<JsonArray> names, JsonObject options, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
+
     ByteString selected_text();
     ByteString cut_selected_text();
     Optional<String> selected_text_with_whitespace_collapsed();
@@ -605,6 +608,9 @@ protected:
     HashMap<u64, DevTools::DevToolsDelegate::OnStorageChange> m_storage_change_listeners;
     u64 m_next_storage_change_listener_id { 1 };
 
+    HashMap<u64, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete> m_pending_indexed_database_inspection_requests;
+    u64 m_next_indexed_database_inspection_request_id { 1 };
+
     // FIXME: Reconcile this ID with `page_id`. The latter is only unique per WebContent connection, whereas the view ID
     //        is required to be globally unique for Firefox DevTools.
     u64 m_view_id { 0 };
@@ -619,6 +625,7 @@ protected:
     };
     void request_node_picker_hit_test(NodePickerRequestType, Web::DevicePixelPoint);
     void did_receive_node_picker_hit_test(u64 request_id, Web::UniqueNodeID);
+    void did_receive_indexed_database_inspection(u64 request_id, JsonObject);
 
     bool m_node_picker_active { false };
     Optional<Web::UniqueNodeID> m_node_picker_hovered_node_id;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -152,6 +152,9 @@ public:
 
     void inspect_indexed_database_storage(DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
     void inspect_indexed_database_objects(String const& host, Optional<JsonArray> names, JsonObject options, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
+    void delete_indexed_database(String const& host, String const& name, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
+    void clear_indexed_database_object_store(String const& host, String const& name, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
+    void delete_indexed_database_record(String const& host, String const& name, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
 
     ByteString selected_text();
     ByteString cut_selected_text();

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -140,6 +140,9 @@ public:
     void notify_cookies_changed(HashTable<String> const& changed_domains, ReadonlySpan<HTTP::Cookie::Cookie> page_cookies, ReadonlySpan<HTTP::Cookie::Cookie> host_cookies);
     void listen_for_host_cookie_changes(DevTools::DevToolsDelegate::OnHostCookieChange);
     void stop_listening_for_host_cookie_changes();
+    void notify_indexed_database_changed(JsonObject);
+    u64 add_indexed_database_change_listener(DevTools::DevToolsDelegate::OnIndexedDatabaseChange);
+    void remove_indexed_database_change_listener(u64 listener_id);
     ErrorOr<Core::SharedVersionIndex> ensure_document_cookie_version_index(Badge<WebContentClient>, String const&);
     Optional<Core::SharedVersion> document_cookie_version(URL::URL const&) const;
 
@@ -604,6 +607,8 @@ protected:
     Core::AnonymousBuffer m_document_cookie_version_buffer;
     HashMap<String, Core::SharedVersionIndex> m_document_cookie_version_indices;
     DevTools::DevToolsDelegate::OnHostCookieChange m_on_host_cookie_change;
+    HashMap<u64, DevTools::DevToolsDelegate::OnIndexedDatabaseChange> m_indexed_database_change_listeners;
+    u64 m_next_indexed_database_change_listener_id { 1 };
 
     HashMap<u64, DevTools::DevToolsDelegate::OnStorageChange> m_storage_change_listeners;
     u64 m_next_storage_change_listener_id { 1 };

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -777,6 +777,12 @@ void WebContentClient::did_inspect_current_flexbox(u64 page_id, String flexbox_l
     }
 }
 
+void WebContentClient::did_inspect_indexed_database(u64 page_id, u64 request_id, String result)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_receive_indexed_database_inspection(request_id, parse_json(result, "IndexedDB inspection result"sv));
+}
+
 void WebContentClient::did_inspect_accessibility_tree(u64 page_id, String accessibility_tree)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1086,6 +1086,12 @@ void WebContentClient::did_change_storage_item(u64 page_id, Web::StorageAPI::Sto
     }
 }
 
+void WebContentClient::did_update_indexed_database(u64 page_id, String update)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->notify_indexed_database_changed(parse_json(update, "IndexedDB update"sv));
+}
+
 void WebContentClient::did_post_broadcast_channel_message(u64, Web::HTML::BroadcastChannelMessage message)
 {
     WebContentClient::for_each_client([&](auto& client) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -127,6 +127,7 @@ private:
     virtual void did_inspect_grid_layouts(u64 page_id, String) override;
     virtual void did_inspect_current_grid(u64 page_id, String) override;
     virtual void did_inspect_current_flexbox(u64 page_id, String) override;
+    virtual void did_inspect_indexed_database(u64 page_id, u64 request_id, String) override;
     virtual void did_inspect_accessibility_tree(u64 page_id, String) override;
     virtual void did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void did_get_node_id_at_position(u64 page_id, u64 request_id, Web::UniqueNodeID node_id) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -168,6 +168,7 @@ private:
     virtual Messages::WebContentClient::DidRequestStorageKeysResponse did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
     virtual void did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
     virtual void did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<String> key, Optional<String> old_value, Optional<String> new_value) override;
+    virtual void did_update_indexed_database(u64 page_id, String update) override;
     virtual void did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) override;
     virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints) override;
     virtual void did_request_activate_tab(u64 page_id) override;

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${CMAKE_CU
 target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}>)
 target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Services/>)
 
-target_link_libraries(webcontentservice PUBLIC LibCore LibCrypto LibFileSystem LibGfx LibHTTP LibIPC LibJS LibMain LibMedia LibWasm LibWeb LibWebSocket LibRequests LibWebView LibImageDecoderClient LibGC)
+target_link_libraries(webcontentservice PUBLIC LibCore LibCrypto LibDevTools LibFileSystem LibGfx LibHTTP LibIPC LibJS LibMain LibMedia LibWasm LibWeb LibWebSocket LibRequests LibWebView LibImageDecoderClient LibGC)
 target_link_libraries(webcontentservice PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 target_link_libraries(webcontentservice PRIVATE SDL3::SDL3)
 target_compile_options(webcontentservice PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,Clang,AppleClang>:-Wexit-time-destructors>)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -16,6 +16,7 @@
 #include <AK/QuickSort.h>
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
+#include <LibDevTools/IndexedDBSerialization.h>
 #include <LibGC/Heap.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
@@ -1231,6 +1232,93 @@ void ConnectionFromClient::inspect_current_flexbox(u64 page_id, Web::UniqueNodeI
     }
 
     async_did_inspect_current_flexbox(page_id, "null"_string);
+}
+
+void ConnectionFromClient::inspect_indexed_database_storage(u64 page_id, u64 request_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto* document = page->page().top_level_browsing_context().active_document();
+    if (!document) {
+        async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
+        return;
+    }
+
+    async_did_inspect_indexed_database(page_id, request_id, DevTools::IndexedDB::serialize_storage(*document).serialized());
+}
+
+void ConnectionFromClient::inspect_indexed_database_objects(u64 page_id, u64 request_id, String host, JsonValue names, JsonValue options)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto* document = page->page().top_level_browsing_context().active_document();
+    if (!document) {
+        async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
+        return;
+    }
+
+    async_did_inspect_indexed_database(page_id, request_id, DevTools::IndexedDB::serialize_objects(*document, host, names, options).serialized());
+}
+
+static void send_indexed_database_operation_result(ConnectionFromClient& connection, u64 page_id, u64 request_id, ErrorOr<JsonObject> result)
+{
+    if (result.is_error()) {
+        JsonObject error;
+        error.set("error"sv, result.error().string_literal());
+        connection.async_did_inspect_indexed_database(page_id, request_id, error.serialized());
+        return;
+    }
+
+    connection.async_did_inspect_indexed_database(page_id, request_id, result.release_value().serialized());
+}
+
+void ConnectionFromClient::delete_indexed_database(u64 page_id, u64 request_id, String host, String name)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto* document = page->page().top_level_browsing_context().active_document();
+    if (!document) {
+        async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
+        return;
+    }
+
+    send_indexed_database_operation_result(*this, page_id, request_id, DevTools::IndexedDB::delete_database(*document, host, name));
+}
+
+void ConnectionFromClient::clear_indexed_database_object_store(u64 page_id, u64 request_id, String host, String name)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto* document = page->page().top_level_browsing_context().active_document();
+    if (!document) {
+        async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
+        return;
+    }
+
+    send_indexed_database_operation_result(*this, page_id, request_id, DevTools::IndexedDB::clear_object_store(*document, host, name));
+}
+
+void ConnectionFromClient::delete_indexed_database_record(u64 page_id, u64 request_id, String host, String name)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto* document = page->page().top_level_browsing_context().active_document();
+    if (!document) {
+        async_did_inspect_indexed_database(page_id, request_id, "{}"_string);
+        return;
+    }
+
+    send_indexed_database_operation_result(*this, page_id, request_id, DevTools::IndexedDB::delete_record(*document, host, name));
 }
 
 void ConnectionFromClient::clear_inspected_dom_node(u64 page_id)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -110,6 +110,8 @@ private:
     virtual void inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) override;
     virtual void inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void inspect_current_flexbox(u64 page_id, Web::UniqueNodeID node_id, bool only_look_at_parents) override;
+    virtual void inspect_indexed_database_storage(u64 page_id, u64 request_id) override;
+    virtual void inspect_indexed_database_objects(u64 page_id, u64 request_id, String host, JsonValue names, JsonValue options) override;
     virtual void clear_inspected_dom_node(u64 page_id) override;
     virtual void highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) override;
     virtual void highlight_flexbox(u64 page_id, Web::UniqueNodeID node_id, JsonValue options) override;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -112,6 +112,9 @@ private:
     virtual void inspect_current_flexbox(u64 page_id, Web::UniqueNodeID node_id, bool only_look_at_parents) override;
     virtual void inspect_indexed_database_storage(u64 page_id, u64 request_id) override;
     virtual void inspect_indexed_database_objects(u64 page_id, u64 request_id, String host, JsonValue names, JsonValue options) override;
+    virtual void delete_indexed_database(u64 page_id, u64 request_id, String host, String name) override;
+    virtual void clear_indexed_database_object_store(u64 page_id, u64 request_id, String host, String name) override;
+    virtual void delete_indexed_database_record(u64 page_id, u64 request_id, String host, String name) override;
     virtual void clear_inspected_dom_node(u64 page_id) override;
     virtual void highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) override;
     virtual void highlight_flexbox(u64 page_id, Web::UniqueNodeID node_id, JsonValue options) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -12,6 +12,7 @@
 #include <AK/Math.h>
 #include <LibCore/Process.h>
 #include <LibCore/Timer.h>
+#include <LibDevTools/IndexedDBSerialization.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibHTTP/Cookie/ParsedCookie.h>
@@ -776,6 +777,18 @@ void PageClient::page_did_clear_storage(Web::StorageAPI::StorageEndpointType sto
 void PageClient::page_did_broadcast_storage_change(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& url, Optional<String> const& key, Optional<String> const& old_value, Optional<String> const& new_value)
 {
     client().async_did_change_storage_item(m_id, storage_endpoint, url, key, old_value, new_value);
+}
+
+void PageClient::page_did_update_indexed_database(String const& url, Web::IndexedDB::TransactionChanges const& changes)
+{
+    if (!has_devtools_client())
+        return;
+
+    auto update = DevTools::IndexedDB::serialize_update(url, changes);
+    if (update.is_empty())
+        return;
+
+    client().async_did_update_indexed_database(m_id, update.serialized());
 }
 
 void PageClient::page_did_post_broadcast_channel_message(Web::HTML::BroadcastChannelMessage const& message)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -210,6 +210,7 @@ private:
     virtual Vector<String> page_did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
     virtual void page_did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
     virtual void page_did_broadcast_storage_change(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& url, Optional<String> const& key, Optional<String> const& old_value, Optional<String> const& new_value) override;
+    virtual void page_did_update_indexed_database(String const& url, Web::IndexedDB::TransactionChanges const&) override;
     virtual void page_did_update_resource_count(i32) override;
     virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Web::HTML::TokenizedFeature::NoOpener) override;
     virtual void page_did_request_activate_tab() override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -78,6 +78,7 @@ endpoint WebContentClient
     did_inspect_grid_layouts(u64 page_id, String grid_layouts) =|
     did_inspect_current_grid(u64 page_id, String grid_layout) =|
     did_inspect_current_flexbox(u64 page_id, String flexbox_layout) =|
+    did_inspect_indexed_database(u64 page_id, u64 request_id, String result) =|
     did_inspect_accessibility_tree(u64 page_id, String accessibility_tree) =|
     did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) =|
     did_get_node_id_at_position(u64 page_id, u64 request_id, Web::UniqueNodeID node_id) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -114,6 +114,7 @@ endpoint WebContentClient
     did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => (Vector<String> keys)
     did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => ()
     did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<String> key, Optional<String> old_value, Optional<String> new_value) =|
+    did_update_indexed_database(u64 page_id, String update) =|
     did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) =|
 
     did_update_resource_count(u64 page_id, i32 count_waiting) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -81,6 +81,8 @@ endpoint WebContentServer
     inspect_grid_layouts(u64 page_id, Web::UniqueNodeID root_node_id) =|
     inspect_current_grid(u64 page_id, Web::UniqueNodeID node_id) =|
     inspect_current_flexbox(u64 page_id, Web::UniqueNodeID node_id, bool only_look_at_parents) =|
+    inspect_indexed_database_storage(u64 page_id, u64 request_id) =|
+    inspect_indexed_database_objects(u64 page_id, u64 request_id, String host, JsonValue names, JsonValue options) =|
     clear_inspected_dom_node(u64 page_id) =|
     highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) =|
     highlight_flexbox(u64 page_id, Web::UniqueNodeID node_id, JsonValue options) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -83,6 +83,9 @@ endpoint WebContentServer
     inspect_current_flexbox(u64 page_id, Web::UniqueNodeID node_id, bool only_look_at_parents) =|
     inspect_indexed_database_storage(u64 page_id, u64 request_id) =|
     inspect_indexed_database_objects(u64 page_id, u64 request_id, String host, JsonValue names, JsonValue options) =|
+    delete_indexed_database(u64 page_id, u64 request_id, String host, String name) =|
+    clear_indexed_database_object_store(u64 page_id, u64 request_id, String host, String name) =|
+    delete_indexed_database_record(u64 page_id, u64 request_id, String host, String name) =|
     clear_inspected_dom_node(u64 page_id) =|
     highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element) =|
     highlight_flexbox(u64 page_id, Web::UniqueNodeID node_id, JsonValue options) =|

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -17,6 +17,7 @@
 #include <LibDevTools/Connection.h>
 #include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/DevToolsServer.h>
+#include <LibDevTools/IndexedDBSerialization.h>
 #include <LibHTTP/Cookie/ParsedCookie.h>
 #include <LibHTTP/Header.h>
 #include <LibRequests/RequestTimingInfo.h>
@@ -829,6 +830,44 @@ public:
         callback(make_indexed_database_store_objects(names));
     }
 
+    virtual void delete_indexed_database(DevTools::TabDescription const&, String const& host, String const& name, OnIndexedDBInspectionComplete callback) const override
+    {
+        ++delete_indexed_database_call_count;
+        last_indexed_database_host = host;
+        last_indexed_database_name = name;
+        callback(JsonObject {});
+    }
+
+    virtual void clear_indexed_database_object_store(DevTools::TabDescription const&, String const& host, String const& name, OnIndexedDBInspectionComplete callback) const override
+    {
+        ++clear_indexed_database_object_store_call_count;
+        last_indexed_database_host = host;
+        last_indexed_database_name = name;
+        callback(JsonObject {});
+    }
+
+    virtual void delete_indexed_database_record(DevTools::TabDescription const&, String const& host, String const& name, OnIndexedDBInspectionComplete callback) const override
+    {
+        ++delete_indexed_database_record_call_count;
+        last_indexed_database_host = host;
+        last_indexed_database_name = name;
+        callback(JsonObject {});
+    }
+
+    virtual u64 add_indexed_database_change_listener(DevTools::TabDescription const&, OnIndexedDatabaseChange callback) const override
+    {
+        auto listener_id = next_indexed_database_change_listener_id++;
+        indexed_database_change_listeners.set(listener_id, move(callback));
+        ++add_indexed_database_change_listener_call_count;
+        return listener_id;
+    }
+
+    virtual void remove_indexed_database_change_listener(DevTools::TabDescription const&, u64 listener_id) const override
+    {
+        indexed_database_change_listeners.remove(listener_id);
+        ++remove_indexed_database_change_listener_call_count;
+    }
+
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete callback) const override
     {
         ++inspect_tab_call_count;
@@ -1243,6 +1282,13 @@ public:
         return fixture_session_storage_items;
     }
 
+    void emit_indexed_database_change(JsonObject update) const
+    {
+        VERIFY(!indexed_database_change_listeners.is_empty());
+        for (auto& listener : indexed_database_change_listeners)
+            listener.value(update);
+    }
+
     mutable Function<void(WebView::DOMNodeProperties)> on_dom_node_properties;
     mutable Function<void(WebView::Mutation)> on_dom_mutation;
     mutable Function<void(Web::CSS::StyleSheetIdentifier const&, String)> on_style_sheet_source;
@@ -1255,6 +1301,7 @@ public:
     mutable Function<void(Vector<HTTP::Cookie::Cookie>)> on_host_cookie_change;
     mutable HashMap<u64, Function<void(DevToolsDelegate::StorageChange)>> storage_change_listeners;
     String tab_url { "https://example.test/"_string };
+    mutable HashMap<u64, Function<void(JsonObject)>> indexed_database_change_listeners;
 
     struct NavigationListener {
         Function<void(String)> on_navigation_started;
@@ -1285,6 +1332,12 @@ public:
     mutable bool fail_clear_storage { false };
     mutable size_t inspect_indexed_database_storage_call_count { 0 };
     mutable size_t inspect_indexed_database_objects_call_count { 0 };
+    mutable size_t delete_indexed_database_call_count { 0 };
+    mutable size_t clear_indexed_database_object_store_call_count { 0 };
+    mutable size_t delete_indexed_database_record_call_count { 0 };
+    mutable size_t add_indexed_database_change_listener_call_count { 0 };
+    mutable size_t remove_indexed_database_change_listener_call_count { 0 };
+    mutable u64 next_indexed_database_change_listener_id { 1 };
     mutable size_t inspect_accessibility_tree_call_count { 0 };
     mutable size_t listen_for_dom_properties_call_count { 0 };
     mutable size_t stop_listening_for_dom_properties_call_count { 0 };
@@ -2494,6 +2547,85 @@ TEST_CASE(storage_indexed_database_store_objects)
     auto record = record_rows.at(0).as_object();
     EXPECT_EQ(record.get_integer<int>("name"sv).value(), 1);
     EXPECT_EQ(record.get_string("value"sv).value(), "{\"name\":\"Ada\"}"sv);
+}
+
+TEST_CASE(storage_indexed_database_change_events)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto indexed_database_actor = get_indexed_database_actor(client);
+    EXPECT_EQ(session->delegate.add_indexed_database_change_listener_call_count, 1u);
+
+    JsonArray added;
+    added.must_append(indexed_database_path("fixtures (default)"sv, "people"sv));
+
+    JsonArray record_path;
+    record_path.must_append("fixtures (default)"sv);
+    record_path.must_append("people"sv);
+    record_path.must_append(1);
+    JsonArray changed;
+    changed.must_append(record_path.serialized());
+
+    JsonArray deleted;
+    deleted.must_append(indexed_database_path("empty (default)"sv));
+
+    JsonObject added_hosts;
+    added_hosts.set("https://example.test"sv, move(added));
+    JsonObject added_types;
+    added_types.set("indexedDB"sv, move(added_hosts));
+
+    JsonObject changed_hosts;
+    changed_hosts.set("https://example.test"sv, move(changed));
+    JsonObject changed_types;
+    changed_types.set("indexedDB"sv, move(changed_hosts));
+
+    JsonObject deleted_hosts;
+    deleted_hosts.set("https://example.test"sv, move(deleted));
+    JsonObject deleted_types;
+    deleted_types.set("indexedDB"sv, move(deleted_hosts));
+
+    JsonObject update;
+    update.set("added"sv, move(added_types));
+    update.set("changed"sv, move(changed_types));
+    update.set("deleted"sv, move(deleted_types));
+    session->delegate.emit_indexed_database_change(move(update));
+
+    auto stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    EXPECT_EQ(stores_update.get_string("from"sv).value(), indexed_database_actor);
+
+    auto added_paths = get_indexed_database_update_paths(stores_update, "added"sv);
+    EXPECT_EQ(added_paths.size(), 1u);
+    EXPECT_EQ(added_paths.at(0).as_string(), indexed_database_path("fixtures (default)"sv, "people"sv));
+
+    auto changed_paths = get_indexed_database_update_paths(stores_update, "changed"sv);
+    EXPECT_EQ(changed_paths.size(), 1u);
+    EXPECT_EQ(changed_paths.at(0).as_string(), record_path.serialized());
+
+    auto deleted_paths = get_indexed_database_update_paths(stores_update, "deleted"sv);
+    EXPECT_EQ(deleted_paths.size(), 1u);
+    EXPECT_EQ(deleted_paths.at(0).as_string(), indexed_database_path("empty (default)"sv));
+}
+
+TEST_CASE(storage_indexed_database_serializes_live_tree_updates)
+{
+    Web::IndexedDB::TransactionChanges changes;
+    changes.added.append({ "fixtures"_string, "people"_string });
+    changes.added.append({ "fixtures"_string, "people"_string, JsonValue { 1 } });
+    changes.changed.append({ "fixtures"_string, "people"_string, JsonValue { 2 } });
+    changes.deleted.append({ "fixtures"_string, "people"_string, JsonValue { 3 } });
+
+    auto update = DevTools::IndexedDB::serialize_update("https://example.test/page"_string, changes);
+
+    auto added_paths = update.get_object("added"sv)
+                           ->get_object("indexedDB"sv)
+                           ->get_array("https://example.test"sv)
+                           .release_value();
+    EXPECT_EQ(added_paths.size(), 1u);
+    EXPECT_EQ(added_paths.at(0).as_string(), indexed_database_path("fixtures (default)"sv, "people"sv));
+    EXPECT(!update.get_object("changed"sv).has_value());
+    EXPECT(!update.get_object("deleted"sv).has_value());
 }
 
 TEST_CASE(storage_cookie_store_objects)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -543,6 +543,91 @@ static bool cookie_matches(HTTP::Cookie::Cookie const& cookie, StringView name, 
         && cookie.path == path;
 }
 
+static String indexed_database_path(StringView database, Optional<StringView> object_store = {})
+{
+    JsonArray path;
+    path.must_append(database);
+    if (object_store.has_value())
+        path.must_append(*object_store);
+    return path.serialized();
+}
+
+static JsonObject make_indexed_database_storage_hosts()
+{
+    JsonArray names;
+    names.must_append(indexed_database_path("fixtures (default)"sv, "people"sv));
+    names.must_append(indexed_database_path("empty (default)"sv));
+
+    JsonObject hosts;
+    hosts.set("https://example.test"sv, move(names));
+    return hosts;
+}
+
+static JsonObject make_indexed_database_store_objects(Optional<JsonArray> const& names)
+{
+    JsonArray data;
+
+    bool should_return_databases = !names.has_value() || names->is_empty();
+    Vector<JsonArray> paths;
+    if (names.has_value()) {
+        for (auto const& name : names->values()) {
+            if (!name.is_string())
+                continue;
+            auto parsed = JsonValue::from_string(name.as_string());
+            if (parsed.is_error() || !parsed.value().is_array())
+                continue;
+            auto path = parsed.release_value().as_array();
+            if (path.is_empty())
+                continue;
+            paths.append(move(path));
+        }
+        if (paths.is_empty())
+            should_return_databases = true;
+    }
+
+    if (should_return_databases) {
+        JsonObject fixtures;
+        fixtures.set("uniqueKey"sv, "fixtures (default)"sv);
+        fixtures.set("db"sv, "fixtures"sv);
+        fixtures.set("storage"sv, "default"sv);
+        fixtures.set("origin"sv, "https://example.test"sv);
+        fixtures.set("version"sv, 1);
+        fixtures.set("objectStores"sv, 1);
+        data.must_append(move(fixtures));
+
+        JsonObject empty;
+        empty.set("uniqueKey"sv, "empty (default)"sv);
+        empty.set("db"sv, "empty"sv);
+        empty.set("storage"sv, "default"sv);
+        empty.set("origin"sv, "https://example.test"sv);
+        empty.set("version"sv, 2);
+        empty.set("objectStores"sv, 0);
+        data.must_append(move(empty));
+    } else {
+        for (auto const& path : paths) {
+            if (path.size() == 1) {
+                JsonObject store;
+                store.set("objectStore"sv, "people"sv);
+                store.set("keyPath"sv, "id"sv);
+                store.set("autoIncrement"sv, true);
+                store.set("indexes"sv, "[]"_string);
+                data.must_append(move(store));
+            } else if (path.size() >= 2) {
+                JsonObject record;
+                record.set("name"sv, 1);
+                record.set("value"sv, "{\"name\":\"Ada\"}"sv);
+                data.must_append(move(record));
+            }
+        }
+    }
+
+    JsonObject response;
+    response.set("offset"sv, 0);
+    response.set("total"sv, data.size());
+    response.set("data"sv, move(data));
+    return response;
+}
+
 class TestDevToolsDelegate final : public DevTools::DevToolsDelegate {
 public:
     virtual Vector<DevTools::TabDescription> tab_list() const override
@@ -729,6 +814,19 @@ public:
     {
         storage_change_listeners.remove(listener_id);
         ++remove_storage_change_listener_call_count;
+    }
+
+    virtual void inspect_indexed_database_storage(DevTools::TabDescription const&, OnIndexedDBInspectionComplete callback) const override
+    {
+        ++inspect_indexed_database_storage_call_count;
+        callback(make_indexed_database_storage_hosts());
+    }
+
+    virtual void inspect_indexed_database_objects(DevTools::TabDescription const&, String const& host, Optional<JsonArray> names, JsonObject, OnIndexedDBInspectionComplete callback) const override
+    {
+        ++inspect_indexed_database_objects_call_count;
+        last_indexed_database_host = host;
+        callback(make_indexed_database_store_objects(names));
     }
 
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete callback) const override
@@ -1185,6 +1283,8 @@ public:
     mutable bool fail_set_storage_item { false };
     mutable bool fail_remove_storage_item { false };
     mutable bool fail_clear_storage { false };
+    mutable size_t inspect_indexed_database_storage_call_count { 0 };
+    mutable size_t inspect_indexed_database_objects_call_count { 0 };
     mutable size_t inspect_accessibility_tree_call_count { 0 };
     mutable size_t listen_for_dom_properties_call_count { 0 };
     mutable size_t stop_listening_for_dom_properties_call_count { 0 };
@@ -1257,6 +1357,7 @@ public:
     mutable Optional<String> last_navigated_url;
     mutable Optional<bool> last_reload_bypass_cache;
     mutable Optional<int> last_history_delta;
+    mutable Optional<String> last_indexed_database_host;
 };
 
 class ProtocolClient {
@@ -1619,6 +1720,68 @@ static JsonObject remove_all_storage_items(ProtocolClient& client, StringView st
     request.set("type"sv, "removeAll"sv);
     request.set("host"sv, "https://example.test"sv);
     return client.request(move(request));
+}
+
+static String get_indexed_database_actor(ProtocolClient& client)
+{
+    auto tab_actor = actor_from(get_tab(client), "actor"sv);
+    auto watcher_actor = actor_from(client.request(tab_actor, "getWatcher"sv), "actor"sv);
+
+    JsonObject watch_resources;
+    watch_resources.set("to"sv, watcher_actor);
+    watch_resources.set("type"sv, "watchResources"sv);
+    JsonArray resource_types;
+    resource_types.must_append("indexed-db"sv);
+    watch_resources.set("resourceTypes"sv, move(resource_types));
+    EXPECT_EQ(client.request(move(watch_resources)).get_string("from"sv).value(), watcher_actor);
+
+    auto indexed_database_resource = read_resource(client, "indexed-db"sv);
+    return actor_from(indexed_database_resource, "actor"sv);
+}
+
+static JsonObject get_indexed_database_store_objects(ProtocolClient& client, StringView indexed_database_actor, Optional<String> name = {})
+{
+    JsonObject get_store_objects;
+    get_store_objects.set("to"sv, indexed_database_actor);
+    get_store_objects.set("type"sv, "getStoreObjects"sv);
+    get_store_objects.set("host"sv, "https://example.test"sv);
+    if (name.has_value()) {
+        JsonArray names;
+        names.must_append(*name);
+        get_store_objects.set("names"sv, move(names));
+    } else {
+        get_store_objects.set("names"sv, JsonValue {});
+    }
+    get_store_objects.set("options"sv, JsonObject {});
+    return client.request(move(get_store_objects));
+}
+
+static JsonObject get_indexed_database_store_objects(ProtocolClient& client, StringView indexed_database_actor, JsonArray names)
+{
+    JsonObject get_store_objects;
+    get_store_objects.set("to"sv, indexed_database_actor);
+    get_store_objects.set("type"sv, "getStoreObjects"sv);
+    get_store_objects.set("host"sv, "https://example.test"sv);
+    get_store_objects.set("names"sv, move(names));
+    get_store_objects.set("options"sv, JsonObject {});
+    return client.request(move(get_store_objects));
+}
+
+static JsonArray get_indexed_database_update_paths(JsonObject const& stores_update, StringView update_type, StringView host = "https://example.test"sv)
+{
+    return stores_update.get_object("data"sv)
+        ->get_object(update_type)
+        ->get_object("indexedDB"sv)
+        ->get_array(host)
+        .release_value();
+}
+
+static JsonArray get_indexed_database_cleared_paths(JsonObject const& stores_cleared, StringView host = "https://example.test"sv)
+{
+    return stores_cleared.get_object("data"sv)
+        ->get_object("clearedHostsOrPaths"sv)
+        ->get_array(host)
+        .release_value();
 }
 
 static JsonObject make_cookie_edit_items(HTTP::Cookie::Cookie const& cookie)
@@ -2220,6 +2383,117 @@ TEST_CASE(storage_web_storage_mutation_errors)
     EXPECT_EQ(response.get_string("errorString"sv).value(), "Unable to clear storage"sv);
     EXPECT_EQ(session->delegate.clear_storage_call_count, 1u);
     EXPECT_EQ(session->delegate.fixture_local_storage_items.size(), 1u);
+}
+
+TEST_CASE(storage_indexed_database_resource)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto tab_actor = actor_from(get_tab(client), "actor"sv);
+    auto watcher_response = client.request(tab_actor, "getWatcher"sv);
+    auto watcher_actor = actor_from(watcher_response, "actor"sv);
+    auto resources = watcher_response.get_object("traits"sv)->get_object("resources"sv).release_value();
+    EXPECT(resources.get_bool("indexed-db"sv).value());
+
+    JsonObject watch_resources;
+    watch_resources.set("to"sv, watcher_actor);
+    watch_resources.set("type"sv, "watchResources"sv);
+    JsonArray resource_types;
+    resource_types.must_append("indexed-db"sv);
+    watch_resources.set("resourceTypes"sv, move(resource_types));
+    EXPECT_EQ(client.request(move(watch_resources)).get_string("from"sv).value(), watcher_actor);
+
+    auto indexed_database_resource = read_resource(client, "indexed-db"sv);
+    EXPECT_EQ(indexed_database_resource.get_string("resourceKey"sv).value(), "indexedDB"sv);
+    EXPECT_EQ(indexed_database_resource.get_integer<u64>("browsingContextID"sv).value(), 1u);
+    EXPECT_EQ(indexed_database_resource.get_integer<u64>("innerWindowId"sv).value(), 1u);
+    EXPECT_EQ(indexed_database_resource.get_string("resourceId"sv).value(), "indexed-db-1"sv);
+
+    auto hosts = indexed_database_resource.get_object("hosts"sv).release_value();
+    auto names = hosts.get_array("https://example.test"sv).release_value();
+    EXPECT_EQ(names.size(), 2u);
+    EXPECT_EQ(names.at(0).as_string(), "[\"fixtures (default)\",\"people\"]"sv);
+    EXPECT_EQ(names.at(1).as_string(), "[\"empty (default)\"]"sv);
+
+    auto traits = indexed_database_resource.get_object("traits"sv).release_value();
+    EXPECT(!traits.get_bool("supportsAddItem"sv).value());
+    EXPECT(traits.get_bool("supportsRemoveAll"sv).value());
+    EXPECT(!traits.get_bool("supportsRemoveAllSessionCookies"sv).value());
+    EXPECT(traits.get_bool("supportsRemoveItem"sv).value());
+
+    auto indexed_database_actor = actor_from(indexed_database_resource, "actor"sv);
+    auto fields = client.request(indexed_database_actor, "getFields"sv).get_array("value"sv).release_value();
+    EXPECT_EQ(fields.at(0).as_object().get_string("name"sv).value(), "uniqueKey"sv);
+    EXPECT(fields.at(0).as_object().get_bool("private"sv).value());
+    EXPECT_EQ(fields.at(1).as_object().get_string("name"sv).value(), "db"sv);
+
+    JsonObject database_fields_request;
+    database_fields_request.set("to"sv, indexed_database_actor);
+    database_fields_request.set("type"sv, "getFields"sv);
+    database_fields_request.set("subType"sv, "database"sv);
+    auto database_fields = client.request(move(database_fields_request)).get_array("value"sv).release_value();
+    EXPECT_EQ(database_fields.at(0).as_object().get_string("name"sv).value(), "objectStore"sv);
+
+    JsonObject object_store_fields_request;
+    object_store_fields_request.set("to"sv, indexed_database_actor);
+    object_store_fields_request.set("type"sv, "getFields"sv);
+    object_store_fields_request.set("subType"sv, "object store"sv);
+    auto object_store_fields = client.request(move(object_store_fields_request)).get_array("value"sv).release_value();
+    EXPECT_EQ(object_store_fields.at(0).as_object().get_string("name"sv).value(), "name"sv);
+    EXPECT_EQ(object_store_fields.at(1).as_object().get_string("name"sv).value(), "value"sv);
+
+    EXPECT_EQ(session->delegate.inspect_indexed_database_storage_call_count, 1u);
+}
+
+TEST_CASE(storage_indexed_database_store_objects)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto indexed_database_actor = get_indexed_database_actor(client);
+
+    auto databases = get_indexed_database_store_objects(client, indexed_database_actor);
+    EXPECT_EQ(session->delegate.inspect_indexed_database_objects_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_indexed_database_host.value(), "https://example.test"sv);
+    EXPECT_EQ(databases.get_integer<size_t>("offset"sv).value(), 0u);
+    EXPECT_EQ(databases.get_integer<size_t>("total"sv).value(), 2u);
+
+    auto database_rows = databases.get_array("data"sv).release_value();
+    EXPECT_EQ(database_rows.size(), 2u);
+    auto fixtures_database = database_rows.at(0).as_object();
+    EXPECT_EQ(fixtures_database.get_string("uniqueKey"sv).value(), "fixtures (default)"sv);
+    EXPECT_EQ(fixtures_database.get_string("db"sv).value(), "fixtures"sv);
+    EXPECT_EQ(fixtures_database.get_string("storage"sv).value(), "default"sv);
+    EXPECT_EQ(fixtures_database.get_string("origin"sv).value(), "https://example.test"sv);
+    EXPECT_EQ(fixtures_database.get_integer<int>("version"sv).value(), 1);
+    EXPECT_EQ(fixtures_database.get_integer<int>("objectStores"sv).value(), 1);
+
+    auto databases_from_empty_names = get_indexed_database_store_objects(client, indexed_database_actor, JsonArray {});
+    EXPECT_EQ(databases_from_empty_names.get_integer<size_t>("total"sv).value(), 2u);
+
+    JsonArray empty_path_names;
+    empty_path_names.must_append("[]"sv);
+    auto databases_from_empty_path = get_indexed_database_store_objects(client, indexed_database_actor, move(empty_path_names));
+    EXPECT_EQ(databases_from_empty_path.get_integer<size_t>("total"sv).value(), 2u);
+
+    auto object_stores = get_indexed_database_store_objects(client, indexed_database_actor, indexed_database_path("fixtures (default)"sv));
+    EXPECT_EQ(object_stores.get_integer<size_t>("total"sv).value(), 1u);
+    auto object_store_rows = object_stores.get_array("data"sv).release_value();
+    auto people_store = object_store_rows.at(0).as_object();
+    EXPECT_EQ(people_store.get_string("objectStore"sv).value(), "people"sv);
+    EXPECT_EQ(people_store.get_string("keyPath"sv).value(), "id"sv);
+    EXPECT(people_store.get_bool("autoIncrement"sv).value());
+    EXPECT_EQ(people_store.get_string("indexes"sv).value(), "[]"sv);
+
+    auto records = get_indexed_database_store_objects(client, indexed_database_actor, indexed_database_path("fixtures (default)"sv, "people"sv));
+    EXPECT_EQ(records.get_integer<size_t>("total"sv).value(), 1u);
+    auto record_rows = records.get_array("data"sv).release_value();
+    auto record = record_rows.at(0).as_object();
+    EXPECT_EQ(record.get_integer<int>("name"sv).value(), 1);
+    EXPECT_EQ(record.get_string("value"sv).value(), "{\"name\":\"Ada\"}"sv);
 }
 
 TEST_CASE(storage_cookie_store_objects)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -835,6 +835,10 @@ public:
         ++delete_indexed_database_call_count;
         last_indexed_database_host = host;
         last_indexed_database_name = name;
+        if (fail_delete_indexed_database) {
+            callback(Error::from_string_literal("IndexedDB operation failed"));
+            return;
+        }
         callback(JsonObject {});
     }
 
@@ -843,6 +847,10 @@ public:
         ++clear_indexed_database_object_store_call_count;
         last_indexed_database_host = host;
         last_indexed_database_name = name;
+        if (fail_clear_indexed_database_object_store) {
+            callback(Error::from_string_literal("IndexedDB operation failed"));
+            return;
+        }
         callback(JsonObject {});
     }
 
@@ -851,6 +859,10 @@ public:
         ++delete_indexed_database_record_call_count;
         last_indexed_database_host = host;
         last_indexed_database_name = name;
+        if (fail_delete_indexed_database_record) {
+            callback(Error::from_string_literal("IndexedDB operation failed"));
+            return;
+        }
         callback(JsonObject {});
     }
 
@@ -1338,6 +1350,9 @@ public:
     mutable size_t add_indexed_database_change_listener_call_count { 0 };
     mutable size_t remove_indexed_database_change_listener_call_count { 0 };
     mutable u64 next_indexed_database_change_listener_id { 1 };
+    mutable bool fail_delete_indexed_database { false };
+    mutable bool fail_clear_indexed_database_object_store { false };
+    mutable bool fail_delete_indexed_database_record { false };
     mutable size_t inspect_accessibility_tree_call_count { 0 };
     mutable size_t listen_for_dom_properties_call_count { 0 };
     mutable size_t stop_listening_for_dom_properties_call_count { 0 };
@@ -1411,6 +1426,7 @@ public:
     mutable Optional<bool> last_reload_bypass_cache;
     mutable Optional<int> last_history_delta;
     mutable Optional<String> last_indexed_database_host;
+    mutable Optional<String> last_indexed_database_name;
 };
 
 class ProtocolClient {
@@ -1435,6 +1451,23 @@ public:
             return message;
         }
         return read_message_from_socket();
+    }
+
+    bool has_pending_message(AK::Duration timeout = 50_ms)
+    {
+        if (!m_pending_messages.is_empty())
+            return true;
+
+        for (i64 elapsed_ms = 0; elapsed_ms < timeout.to_milliseconds(); elapsed_ms += 5) {
+            pump(m_loop);
+            if (MUST(m_socket->can_read_without_blocking())) {
+                m_pending_messages.append(read_message_now());
+                return true;
+            }
+            MUST(Core::System::sleep_ms(5));
+        }
+
+        return false;
     }
 
     void send(JsonObject message)
@@ -2626,6 +2659,167 @@ TEST_CASE(storage_indexed_database_serializes_live_tree_updates)
     EXPECT_EQ(added_paths.at(0).as_string(), indexed_database_path("fixtures (default)"sv, "people"sv));
     EXPECT(!update.get_object("changed"sv).has_value());
     EXPECT(!update.get_object("deleted"sv).has_value());
+}
+
+TEST_CASE(storage_indexed_database_remove_database)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto indexed_database_actor = get_indexed_database_actor(client);
+
+    JsonObject remove_database;
+    remove_database.set("to"sv, indexed_database_actor);
+    remove_database.set("type"sv, "removeDatabase"sv);
+    remove_database.set("host"sv, "https://example.test"sv);
+    remove_database.set("name"sv, "fixtures (default)"sv);
+    EXPECT_EQ(client.request(move(remove_database)).get_string("from"sv).value(), indexed_database_actor);
+
+    EXPECT_EQ(session->delegate.delete_indexed_database_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_indexed_database_host.value(), "https://example.test"sv);
+    EXPECT_EQ(session->delegate.last_indexed_database_name.value(), "fixtures (default)"sv);
+
+    auto stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    EXPECT_EQ(stores_update.get_string("from"sv).value(), indexed_database_actor);
+
+    auto deleted_paths = get_indexed_database_update_paths(stores_update, "deleted"sv);
+    EXPECT_EQ(deleted_paths.size(), 1u);
+    EXPECT_EQ(deleted_paths.at(0).as_string(), indexed_database_path("fixtures (default)"sv));
+}
+
+TEST_CASE(storage_indexed_database_remove_database_error)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+    session->delegate.fail_delete_indexed_database = true;
+
+    auto indexed_database_actor = get_indexed_database_actor(client);
+
+    JsonObject remove_database;
+    remove_database.set("to"sv, indexed_database_actor);
+    remove_database.set("type"sv, "removeDatabase"sv);
+    remove_database.set("host"sv, "https://example.test"sv);
+    remove_database.set("name"sv, "fixtures (default)"sv);
+    auto response = client.request(move(remove_database));
+    EXPECT_EQ(response.get_string("error"sv).value(), "indexedDBInspectionFailed"sv);
+    EXPECT_EQ(response.get_string("message"sv).value(), "IndexedDB operation failed"sv);
+
+    EXPECT_EQ(session->delegate.delete_indexed_database_call_count, 1u);
+    EXPECT(!client.has_pending_message());
+}
+
+TEST_CASE(storage_indexed_database_remove_all)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto indexed_database_actor = get_indexed_database_actor(client);
+    auto store_path = indexed_database_path("fixtures (default)"sv, "people"sv);
+
+    JsonObject remove_all;
+    remove_all.set("to"sv, indexed_database_actor);
+    remove_all.set("type"sv, "removeAll"sv);
+    remove_all.set("host"sv, "https://example.test"sv);
+    remove_all.set("name"sv, store_path);
+    EXPECT_EQ(client.request(move(remove_all)).get_string("from"sv).value(), indexed_database_actor);
+
+    EXPECT_EQ(session->delegate.clear_indexed_database_object_store_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_indexed_database_host.value(), "https://example.test"sv);
+    EXPECT_EQ(session->delegate.last_indexed_database_name.value(), store_path);
+
+    auto stores_cleared = read_packet_with_type(client, "storesCleared"sv);
+    EXPECT_EQ(stores_cleared.get_string("from"sv).value(), indexed_database_actor);
+
+    auto cleared_paths = get_indexed_database_cleared_paths(stores_cleared);
+    EXPECT_EQ(cleared_paths.size(), 1u);
+    EXPECT_EQ(cleared_paths.at(0).as_string(), store_path);
+}
+
+TEST_CASE(storage_indexed_database_remove_all_error)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+    session->delegate.fail_clear_indexed_database_object_store = true;
+
+    auto indexed_database_actor = get_indexed_database_actor(client);
+    auto store_path = indexed_database_path("fixtures (default)"sv, "people"sv);
+
+    JsonObject remove_all;
+    remove_all.set("to"sv, indexed_database_actor);
+    remove_all.set("type"sv, "removeAll"sv);
+    remove_all.set("host"sv, "https://example.test"sv);
+    remove_all.set("name"sv, store_path);
+    auto response = client.request(move(remove_all));
+    EXPECT_EQ(response.get_string("error"sv).value(), "indexedDBInspectionFailed"sv);
+    EXPECT_EQ(response.get_string("message"sv).value(), "IndexedDB operation failed"sv);
+
+    EXPECT_EQ(session->delegate.clear_indexed_database_object_store_call_count, 1u);
+    EXPECT(!client.has_pending_message());
+}
+
+TEST_CASE(storage_indexed_database_remove_item)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto indexed_database_actor = get_indexed_database_actor(client);
+
+    JsonArray record_path_array;
+    record_path_array.must_append("fixtures (default)"sv);
+    record_path_array.must_append("people"sv);
+    record_path_array.must_append(1);
+    auto record_path = record_path_array.serialized();
+
+    JsonObject remove_item;
+    remove_item.set("to"sv, indexed_database_actor);
+    remove_item.set("type"sv, "removeItem"sv);
+    remove_item.set("host"sv, "https://example.test"sv);
+    remove_item.set("name"sv, record_path);
+    EXPECT_EQ(client.request(move(remove_item)).get_string("from"sv).value(), indexed_database_actor);
+
+    EXPECT_EQ(session->delegate.delete_indexed_database_record_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_indexed_database_host.value(), "https://example.test"sv);
+    EXPECT_EQ(session->delegate.last_indexed_database_name.value(), record_path);
+
+    auto stores_update = read_packet_with_type(client, "storesUpdate"sv);
+    EXPECT_EQ(stores_update.get_string("from"sv).value(), indexed_database_actor);
+
+    auto deleted_paths = get_indexed_database_update_paths(stores_update, "deleted"sv);
+    EXPECT_EQ(deleted_paths.size(), 1u);
+    EXPECT_EQ(deleted_paths.at(0).as_string(), record_path);
+}
+
+TEST_CASE(storage_indexed_database_remove_item_error)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+    session->delegate.fail_delete_indexed_database_record = true;
+
+    auto indexed_database_actor = get_indexed_database_actor(client);
+
+    JsonArray record_path_array;
+    record_path_array.must_append("fixtures (default)"sv);
+    record_path_array.must_append("people"sv);
+    record_path_array.must_append(1);
+    auto record_path = record_path_array.serialized();
+
+    JsonObject remove_item;
+    remove_item.set("to"sv, indexed_database_actor);
+    remove_item.set("type"sv, "removeItem"sv);
+    remove_item.set("host"sv, "https://example.test"sv);
+    remove_item.set("name"sv, record_path);
+    auto response = client.request(move(remove_item));
+    EXPECT_EQ(response.get_string("error"sv).value(), "indexedDBInspectionFailed"sv);
+    EXPECT_EQ(response.get_string("message"sv).value(), "IndexedDB operation failed"sv);
+
+    EXPECT_EQ(session->delegate.delete_indexed_database_record_call_count, 1u);
+    EXPECT(!client.has_pending_message());
 }
 
 TEST_CASE(storage_cookie_store_objects)


### PR DESCRIPTION
Implements the "IndexedDB" part of the inspector's Storage tab in Firefox. Firefox is actually a bit weird about IndexedDB, even when inspecting its own pages. A lot of things don't automatically update, and you have to refresh the page to make new/modified databases show up. But this otherwise works like you'd expect.