### PR TITLE
LibWeb: Add `fast_is` to SVG types used in `Node::is_transformable()`

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -155,6 +155,7 @@ public:
     virtual bool is_svg_g_element() const { return false; }
     virtual bool is_svg_foreign_object_element() const { return false; }
     virtual bool is_svg_gradient_element() const { return false; }
+    virtual bool is_svg_pattern_element() const { return false; }
 
     bool in_a_document_tree() const;
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -157,6 +157,7 @@ public:
     virtual bool is_svg_gradient_element() const { return false; }
     virtual bool is_svg_pattern_element() const { return false; }
     virtual bool is_svg_clip_path_element() const { return false; }
+    virtual bool is_svg_text_content_element() const { return false; }
 
     bool in_a_document_tree() const;
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -156,6 +156,7 @@ public:
     virtual bool is_svg_foreign_object_element() const { return false; }
     virtual bool is_svg_gradient_element() const { return false; }
     virtual bool is_svg_pattern_element() const { return false; }
+    virtual bool is_svg_clip_path_element() const { return false; }
 
     bool in_a_document_tree() const;
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -154,6 +154,7 @@ public:
     virtual bool is_svg_a_element() const { return false; }
     virtual bool is_svg_g_element() const { return false; }
     virtual bool is_svg_foreign_object_element() const { return false; }
+    virtual bool is_svg_gradient_element() const { return false; }
 
     bool in_a_document_tree() const;
 

--- a/Libraries/LibWeb/SVG/SVGClipPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGClipPathElement.h
@@ -40,7 +40,16 @@ private:
     SVGClipPathElement(DOM::Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
 
+    virtual bool is_svg_clip_path_element() const final { return true; }
+
     Optional<ClipPathUnits> m_clip_path_units = {};
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGClipPathElement>() const { return is_svg_clip_path_element(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -76,6 +76,8 @@ protected:
     void add_color_stops(Painting::GradientPaintStyle&) const;
 
 private:
+    virtual bool is_svg_gradient_element() const final { return true; }
+
     template<VoidFunction<SVGStopElement> Callback>
     void for_each_color_stop_impl(Callback const& callback, GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
     {
@@ -101,5 +103,12 @@ private:
     Optional<SpreadMethod> m_spread_method = {};
     Optional<Gfx::AffineTransform> m_gradient_transform = {};
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGGradientElement>() const { return is_svg_gradient_element(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGPatternElement.h
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.h
@@ -56,6 +56,8 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
+    virtual bool is_svg_pattern_element() const final { return true; }
+
     GC::Ptr<SVGPatternElement const> linked_pattern(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
     GC::Ptr<SVGPatternElement const> pattern_content_element_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
 
@@ -75,5 +77,12 @@ private:
     Optional<NumberPercentage> m_width;
     Optional<NumberPercentage> m_height;
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGPatternElement>() const { return is_svg_pattern_element(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGTextContentElement.h
+++ b/Libraries/LibWeb/SVG/SVGTextContentElement.h
@@ -31,6 +31,16 @@ protected:
     SVGTextContentElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+
+private:
+    virtual bool is_svg_text_content_element() const final { return true; }
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGTextContentElement>() const { return is_svg_text_content_element(); }
 
 }


### PR DESCRIPTION
Typing into the main input on https://chatgpt.com was noticeably laggy. Previously, over a 20 second profile of typing into the main input 1.71 seconds was spent in  `Node::is_transformable()` mostly doing dynamic casts. Avoiding these dynamic casts drops the time spent in this function down to 33ms over the same 20 second profile time.