### PR TITLE
WebWorker: Initialize transport peer pid on Windows

### DIFF
--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -9,6 +9,7 @@
 #include <LibWeb/HTML/WorkerAgentTypes.h>
 
 endpoint WebWorkerServer {
+    init_transport(int peer_pid) => (int peer_pid)
 
     connect_to_request_server(IPC::TransportHandle handle) =|
     connect_to_image_decoder(IPC::TransportHandle handle) =|

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -56,7 +56,7 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
             if constexpr (requires { client->set_pid(pid_t {}); })
                 client->set_pid(process.pid());
 
-            if constexpr (requires { client->transport().set_peer_pid(0); } && !IsSame<ClientType, WebWorkerClient>) {
+            if constexpr (requires { client->transport().set_peer_pid(0); }) {
                 auto response = client->template send_sync<typename ClientType::InitTransport>(Core::System::getpid());
                 client->transport().set_peer_pid(response->peer_pid());
             }

--- a/Libraries/LibWebView/WebWorkerClient.h
+++ b/Libraries/LibWebView/WebWorkerClient.h
@@ -26,6 +26,8 @@ class WEBVIEW_API WebWorkerClient final
     C_OBJECT_ABSTRACT(WebWorkerClient);
 
 public:
+    using InitTransport = Messages::WebWorkerServer::InitTransport;
+
     explicit WebWorkerClient(NonnullOwnPtr<IPC::Transport>, Web::HTML::WorkerAgentId agent_id);
     ~WebWorkerClient();
 

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/Process.h>
+#include <LibCore/System.h>
 #include <LibWeb/HTML/BroadcastChannel.h>
 #include <LibWeb/HTML/WorkerAgentParent.h>
 #include <WebWorker/ConnectionFromClient.h>
@@ -12,6 +13,15 @@
 #include <WebWorker/WorkerHost.h>
 
 namespace WebWorker {
+
+Messages::WebWorkerServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
+{
+#ifdef AK_OS_WINDOWS
+    m_transport->set_peer_pid(peer_pid);
+    return Core::System::getpid();
+#endif
+    VERIFY_NOT_REACHED();
+}
 
 void ConnectionFromClient::connect_to_request_server(IPC::TransportHandle handle)
 {

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -30,6 +30,7 @@ public:
 
     virtual void die() override;
 
+    virtual Messages::WebWorkerServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual void close_worker() override;
 
     void request_file(Web::FileRequest);


### PR DESCRIPTION
WebWorker control connections can transfer handles from the browser process to the worker process, including RequestServer and ImageDecoder transport handles sent during worker startup. On Windows, serializing those attachments needs the destination process id so DuplicateHandle and WSADuplicateSocketW can target the peer process. WebWorker was excluded from the generic helper-process InitTransport handshake, leaving the transport without a peer pid before any attachment-bearing message was sent.

Add InitTransport to the WebWorker server endpoint, implement the server-side peer pid exchange, expose the message type through WebWorkerClient, and let the shared helper launcher perform the handshake for workers as it does for other Windows IPC clients.