### PR TITLE
Don't create GPU context and deny GPU operations in WebContent

### DIFF
--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibSandbox/Seccomp.h>
+#include <asm/termbits.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/audit.h>
@@ -928,6 +929,15 @@ void SeccompPolicy::allow_file_descriptor_operations()
     append(SECCOMP_ALLOW);
     append(SECCOMP_LOAD_SYSCALL_NR);
     append(BPF_STMT(BPF_ALU | BPF_ADD | BPF_K, 0));
+
+#ifdef TCGETS2
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_ioctl, 0, 5));
+    append(SECCOMP_LOAD_ARGUMENT(1));
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, TCGETS2, 0, 1));
+    append(SECCOMP_ALLOW);
+    append(SECCOMP_LOAD_SYSCALL_NR);
+    append(BPF_STMT(BPF_ALU | BPF_ADD | BPF_K, 0));
+#endif
 }
 
 void SeccompPolicy::allow_process_creation()

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -114,16 +114,10 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         image.resolve_for_size(layout_node, CSSPixelSize { bitmap.size() });
         image.paint(paint_context, document, DevicePixelRect { bitmap.rect() }, ImageRendering::Auto);
 
-        switch (document.page().client().display_list_player_type()) {
-        case DisplayListPlayerType::SkiaGPUIfAvailable:
-        case DisplayListPlayerType::SkiaCPU: {
-            auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
-            Painting::DisplayListPlayerSkia display_list_player;
-            display_list_player.execute(*display_list, visual_context_tree, resource_storage, {}, painting_surface);
-            display_list_player.flush(*painting_surface);
-            break;
-        }
-        }
+        auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
+        Painting::DisplayListPlayerSkia display_list_player;
+        display_list_player.execute(*display_list, visual_context_tree, resource_storage, {}, painting_surface);
+        display_list_player.flush(*painting_surface);
     }
 
     // "If the values are unspecified, then the natural hotspot defined inside the image resource itself is used.

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -403,11 +403,6 @@ private:
     bool m_processing_fullscreen_operations { false };
 };
 
-enum class DisplayListPlayerType {
-    SkiaGPUIfAvailable,
-    SkiaCPU,
-};
-
 enum class ContextMenuForInputEventsTarget : u8 {
     No,
     Yes,
@@ -565,8 +560,6 @@ public:
     virtual void page_did_take_screenshot(Gfx::ShareableBitmap const&) { }
 
     virtual void received_message_from_web_ui([[maybe_unused]] String const& name, [[maybe_unused]] JS::Value data) { }
-
-    virtual DisplayListPlayerType display_list_player_type() const = 0;
 
     virtual bool is_headless() const = 0;
 

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -213,17 +213,9 @@ RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize
     if (!display_list.has_value())
         return nullptr;
 
-    switch (m_page_client->display_list_player_type()) {
-    case DisplayListPlayerType::SkiaGPUIfAvailable:
-    case DisplayListPlayerType::SkiaCPU: {
-        Painting::DisplayListPlayerSkia display_list_player;
-        display_list_player.execute(*display_list->display_list, display_list->visual_context_tree, resource_storage, {}, surface);
-        display_list_player.flush(*surface);
-        break;
-    }
-    default:
-        VERIFY_NOT_REACHED();
-    }
+    Painting::DisplayListPlayerSkia display_list_player;
+    display_list_player.execute(*display_list->display_list, display_list->visual_context_tree, resource_storage, {}, surface);
+    display_list_player.flush(*surface);
 
     m_cached_rendered_surfaces.set(size, *surface);
     return surface;

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -102,7 +102,6 @@ public:
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] EventResult event_was_handled) override { }
     virtual void request_frame() override { }
 
-    virtual DisplayListPlayerType display_list_player_type() const override { return m_host_page->client().display_list_player_type(); }
     virtual bool is_headless() const override { return m_host_page->client().is_headless(); }
 
 private:

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -110,8 +110,6 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(u64
         arguments.append("--expose-experimental-interfaces"sv);
     if (web_content_options.expose_internals_object == WebView::ExposeInternalsObject::Yes)
         arguments.append("--expose-internals-object"sv);
-    if (web_content_options.force_cpu_painting == WebView::ForceCPUPainting::Yes)
-        arguments.append("--force-cpu-painting"sv);
     if (web_content_options.force_fontconfig == WebView::ForceFontconfig::Yes)
         arguments.append("--force-fontconfig"sv);
     if (web_content_options.collect_garbage_on_every_allocation == WebView::CollectGarbageOnEveryAllocation::Yes)

--- a/Services/RendererSandboxLinux.cpp
+++ b/Services/RendererSandboxLinux.cpp
@@ -57,7 +57,6 @@ ErrorOr<void> apply_sandbox(Optional<StringView> config_path)
     policy.allow_file_descriptor_operations();
     policy.allow_process_creation();
     policy.allow_ipc();
-    policy.allow_gpu_device_operations();
     policy.allow_common_runtime();
     policy.allow_executable_memory_mappings();
     TRY(policy.install());

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -52,7 +52,6 @@
 
 namespace WebContent {
 
-static PageClient::UseSkiaPainter s_use_skia_painter = PageClient::UseSkiaPainter::GPUBackendIfAvailable;
 static bool s_is_headless { false };
 static bool s_async_scrolling_enabled { false };
 static bool s_should_report_session_history_updates_in_test_mode { false };
@@ -66,11 +65,6 @@ static String serialize_dom_mutation_target(Web::DOM::Node const& target)
     target.serialize_tree_as_json(serializer);
     MUST(serializer.finish());
     return MUST(builder.to_string());
-}
-
-void PageClient::set_use_skia_painter(UseSkiaPainter use_skia_painter)
-{
-    s_use_skia_painter = use_skia_painter;
 }
 
 bool PageClient::is_headless() const
@@ -1233,18 +1227,6 @@ Vector<Web::CSS::StyleSheetIdentifier> PageClient::list_style_sheets() const
     });
 
     return results;
-}
-
-Web::DisplayListPlayerType PageClient::display_list_player_type() const
-{
-    switch (s_use_skia_painter) {
-    case UseSkiaPainter::GPUBackendIfAvailable:
-        return Web::DisplayListPlayerType::SkiaGPUIfAvailable;
-    case UseSkiaPainter::CPUBackend:
-        return Web::DisplayListPlayerType::SkiaCPU;
-    default:
-        VERIFY_NOT_REACHED();
-    }
 }
 
 void PageClient::ensure_compositor_host()

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -37,12 +37,6 @@ public:
 
     virtual u64 id() const override { return m_id; }
 
-    enum class UseSkiaPainter {
-        CPUBackend,
-        GPUBackendIfAvailable,
-    };
-    static void set_use_skia_painter(UseSkiaPainter);
-
     virtual bool is_headless() const override;
     static void set_is_headless(bool);
 
@@ -122,7 +116,6 @@ public:
     virtual double device_pixel_ratio() const override { return m_device_pixel_ratio; }
     virtual double device_pixels_per_css_pixel() const override { return m_device_pixel_ratio * m_zoom_level; }
 
-    virtual Web::DisplayListPlayerType display_list_player_type() const override;
     virtual bool supports_compositor() const override { return true; }
     virtual void ensure_compositor_host() override;
     virtual Web::Compositor::CompositorHost* compositor_host() override;

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -15,7 +15,6 @@
 #include <LibCrypto/OpenSSLForward.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
-#include <LibGfx/SkiaBackendContext.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibIPC/TransportHandle.h>
 #include <LibMain/Main.h>
@@ -145,7 +144,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     bool disable_site_isolation = false;
     bool enable_idl_tracing = false;
     bool enable_http_memory_cache = false;
-    bool force_cpu_painting = false;
     bool force_fontconfig = false;
     bool collect_garbage_on_every_allocation = false;
     bool is_headless = false;
@@ -170,7 +168,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(disable_site_isolation, "Disable site isolation", "disable-site-isolation");
     args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
     args_parser.add_option(enable_http_memory_cache, "Enable HTTP cache", "enable-http-memory-cache");
-    args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation");
     args_parser.add_option(disable_scrollbar_painting, "Don't paint horizontal or vertical viewport scrollbars", "disable-scrollbar-painting");
@@ -209,14 +206,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
     }
     font_provider.load_all_fonts_from_uri("resource://fonts"sv);
-
-    // Always use the CPU backend for tests, as the GPU backend is not deterministic
-    if (force_cpu_painting) {
-        WebContent::PageClient::set_use_skia_painter(WebContent::PageClient::UseSkiaPainter::CPUBackend);
-    } else {
-        Gfx::SkiaBackendContext::initialize_gpu_backend();
-        WebContent::PageClient::set_use_skia_painter(WebContent::PageClient::UseSkiaPainter::GPUBackendIfAvailable);
-    }
 
     WebContent::PageClient::set_is_headless(is_headless);
 

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -44,7 +44,6 @@ public:
     virtual void request_file(Web::FileRequest) override;
     virtual Web::HTML::WorkerAgentId start_worker_agent(Web::HTML::WorkerAgentStartRequest&&) override;
     virtual void close_worker_agent(Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken) override;
-    virtual Web::DisplayListPlayerType display_list_player_type() const override { VERIFY_NOT_REACHED(); }
     virtual bool is_headless() const override { VERIFY_NOT_REACHED(); }
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] Web::EventResult event_was_handled) override { VERIFY_NOT_REACHED(); }

--- a/Tests/LibWeb/TestPage.cpp
+++ b/Tests/LibWeb/TestPage.cpp
@@ -30,7 +30,6 @@ public:
     virtual void report_finished_handling_input_event(u64, Web::EventResult) override { }
     virtual void request_frame() override { }
     virtual void request_file(Web::FileRequest) override { }
-    virtual Web::DisplayListPlayerType display_list_player_type() const override { return Web::DisplayListPlayerType::SkiaCPU; }
     virtual bool is_headless() const override { return true; }
     virtual void visit_edges(Visitor& visitor) override
     {

--- a/Utilities/dump-html-tree.cpp
+++ b/Utilities/dump-html-tree.cpp
@@ -66,7 +66,6 @@ public:
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] Web::EventResult event_was_handled) override { }
     virtual void request_frame() override { }
     virtual void request_file(Web::FileRequest) override { }
-    virtual Web::DisplayListPlayerType display_list_player_type() const override { return Web::DisplayListPlayerType::SkiaCPU; }
     virtual bool is_headless() const override { return true; }
 
 private:


### PR DESCRIPTION
Canvas and display list rasterization now run in the Compositor process, so WebContent no longer needs its own GPU backend.