### PR TITLE
LibWeb: Preserve parsed user style sheets

### DIFF
--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -158,11 +158,12 @@ void StyleScope::invalidate_rule_cache()
 {
     invalidate_counter_style_cache();
     m_rule_cache = nullptr;
+}
 
-    // NOTE: We could be smarter about keeping the user rule cache, and style sheet.
-    //       Currently we are re-parsing the user style sheet every time we build the caches,
-    //       as it may have changed.
+void StyleScope::invalidate_user_style_sheet()
+{
     m_user_style_sheet = nullptr;
+    invalidate_rule_cache();
 }
 
 void StyleScope::build_user_style_sheet_if_needed()

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -120,6 +120,7 @@ public:
 
     [[nodiscard]] bool has_valid_rule_cache() const { return m_rule_cache; }
     void invalidate_rule_cache();
+    void invalidate_user_style_sheet();
 
     [[nodiscard]] RuleCache const& get_pseudo_class_rule_cache(PseudoClass) const;
 

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -858,7 +858,7 @@ void Page::invalidate_user_style()
 
     auto invalidate_document = [](DOM::Document& document) {
         document.invalidate_content_blocker_style_sheet();
-        document.style_scope().invalidate_rule_cache();
+        document.style_scope().invalidate_user_style_sheet();
         document.for_each_shadow_root([](auto& shadow_root) {
             shadow_root.invalidate_style(DOM::StyleInvalidationReason::StyleSheetReplace);
         });


### PR DESCRIPTION
Keep regular rule cache invalidation from discarding the parsed user style sheet. User style and content blocker source changes now use an explicit invalidation path that clears the parsed sheet before the rule cache is rebuilt.

This avoids reparsing user CSS for unrelated style changes, which was very annoying when browsing with cosmetic CSS from content blockers.