### PR TITLE
Meta: Update ICU to 78.3 by bumping the vcpkg baseline

### DIFF
--- a/Meta/CMake/check_for_dependencies.cmake
+++ b/Meta/CMake/check_for_dependencies.cmake
@@ -71,7 +71,7 @@ else()
 endif()
 
 find_package(CURL REQUIRED)
-find_package(ICU 78.2 EXACT REQUIRED COMPONENTS data i18n uc)
+find_package(ICU 78.3 EXACT REQUIRED COMPONENTS data i18n uc)
 find_package(LibXml2 REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(SDL3 CONFIG REQUIRED)

--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -215,7 +215,7 @@
         {
           "type": "git",
           "url": "https://github.com/unicode-org/icu.git",
-          "tag": "release-78.2"
+          "tag": "release-78.3"
         }
       ],
       "subdir": "icu4c/source/",

--- a/Meta/Linters/check_flatpak.py
+++ b/Meta/Linters/check_flatpak.py
@@ -39,6 +39,7 @@ flatpak_runtime_libs = [
     "curl",
     "dbus",
     "fontconfig",
+    "freetype",
     "harfbuzz",
     "libjpeg-turbo",
     "libproxy",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "48cfe1e0e928341709d97fc3d2eff10ad6262c96",
+  "builtin-baseline": "43ea817e84600347895efc196e2bb91162e9e679",
   "dependencies": [
     {
       "name": "angle",
@@ -313,6 +313,10 @@
       "version": "2.17.1#1"
     },
     {
+      "name": "freetype",
+      "version": "2.13.3#0"
+    },
+    {
       "name": "harfbuzz",
       "version": "10.2.0#0"
     },
@@ -322,7 +326,7 @@
     },
     {
       "name": "icu",
-      "version": "78.2#0"
+      "version": "78.3#1"
     },
     {
       "name": "libadwaita",


### PR DESCRIPTION
Alternative to #10163, which pins ICU with a `vcpkg` overlay port instead.

Bump the pinned ICU version from 78.2 to 78.3 — the current release — so the build works on systems that already ship 78.3. And bump our `vcpkg` baseline — because 78.3 is newer than our existing baseline. And pin `freetype` to 2.13.3 — because the baseline update otherwise pulls in 2.14.3, which has font-rendering changes that break our layout tests.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/10145
