### PR TITLE
LibWeb: Reduce selector matching work during style update

### DIFF
--- a/Libraries/LibWeb/CSS/AncestorFilter.h
+++ b/Libraries/LibWeb/CSS/AncestorFilter.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Web::CSS {
+
+// Separate otherwise identical string hashes by selector component kind,
+// e.g. `.article` versus `<article>`.
+static constexpr u32 ancestor_filter_hash_for_tag_name(u32 hash)
+{
+    return hash * 13;
+}
+
+static constexpr u32 ancestor_filter_hash_for_id(u32 hash)
+{
+    return hash * 17;
+}
+
+static constexpr u32 ancestor_filter_hash_for_class(u32 hash)
+{
+    return hash * 19;
+}
+
+static constexpr u32 ancestor_filter_hash_for_attribute(u32 hash)
+{
+    return hash * 23;
+}
+
+}

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
@@ -310,21 +310,29 @@ static bool has_rule_that_may_be_affected_by_mutation(StyleScope& style_scope, D
         }
     };
 
+    auto check_rule_map = [&](auto const& map) {
+        for (auto const& entry : map) {
+            check_rule_vector(entry.value);
+            if (may_be_affected)
+                return;
+        }
+    };
+
+    auto check_rule_buckets = [&](auto const& rule_buckets) {
+        check_rule_map(rule_buckets.rules_by_id);
+        check_rule_map(rule_buckets.rules_by_class);
+        check_rule_map(rule_buckets.rules_by_tag_name);
+        check_rule_map(rule_buckets.rules_by_attribute_name);
+        check_rule_vector(rule_buckets.root_rules);
+        check_rule_vector(rule_buckets.other_rules);
+    };
+
     auto const& has_rule_cache = style_scope.get_pseudo_class_rule_cache(PseudoClass::Has);
-    for (auto const& entry : has_rule_cache.rules_by_id)
-        check_rule_vector(entry.value);
-    for (auto const& entry : has_rule_cache.rules_by_class)
-        check_rule_vector(entry.value);
-    for (auto const& entry : has_rule_cache.rules_by_tag_name)
-        check_rule_vector(entry.value);
-    for (auto const& entry : has_rule_cache.rules_by_attribute_name)
-        check_rule_vector(entry.value);
+    check_rule_buckets(has_rule_cache);
     for (auto const& rules : has_rule_cache.rules_by_pseudo_element)
-        check_rule_vector(rules);
-    check_rule_vector(has_rule_cache.root_rules);
+        check_rule_buckets(rules);
     check_rule_vector(has_rule_cache.slotted_rules);
     check_rule_vector(has_rule_cache.part_rules);
-    check_rule_vector(has_rule_cache.other_rules);
 
     return !found_has_rule || may_be_affected;
 }

--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -154,39 +154,56 @@ void Selector::collect_ancestor_hashes()
     }
 
     size_t next_hash_index = 0;
-    auto append_unique_hash = [&](u32 hash) -> bool {
-        if (next_hash_index >= m_ancestor_hashes.size())
-            return true;
-        for (size_t i = 0; i < next_hash_index; ++i) {
-            if (m_ancestor_hashes[i] == hash)
-                return false;
-        }
-        m_ancestor_hashes[next_hash_index++] = hash;
-        return false;
-    };
+    struct AncestorHashCollector {
+        Array<u32, 8>& ancestor_hashes;
+        size_t& next_hash_index;
 
-    auto append_hashes_from_compound = [&](CompoundSelector const& compound_selector) {
-        for (auto const& simple_selector : compound_selector.simple_selectors) {
+        bool append_unique_hash(u32 hash)
+        {
+            if (next_hash_index >= ancestor_hashes.size())
+                return true;
+            for (size_t i = 0; i < next_hash_index; ++i) {
+                if (ancestor_hashes[i] == hash)
+                    return false;
+            }
+            ancestor_hashes[next_hash_index++] = hash;
+            return false;
+        }
+
+        bool append_hashes_from_simple_selector(SimpleSelector const& simple_selector)
+        {
             switch (simple_selector.type) {
             case SimpleSelector::Type::Id:
             case SimpleSelector::Type::Class:
-                if (append_unique_hash(simple_selector.name().hash()))
-                    return true;
-                break;
+                return append_unique_hash(simple_selector.name().hash());
             case SimpleSelector::Type::TagName:
-                if (append_unique_hash(simple_selector.qualified_name().name.lowercase_name.hash()))
-                    return true;
-                break;
+                return append_unique_hash(simple_selector.qualified_name().name.lowercase_name.hash());
             case SimpleSelector::Type::Attribute:
-                if (append_unique_hash(simple_selector.attribute().qualified_name.name.lowercase_name.hash()))
-                    return true;
-                break;
+                return append_unique_hash(simple_selector.attribute().qualified_name.name.lowercase_name.hash());
+            case SimpleSelector::Type::PseudoClass: {
+                auto const& pseudo_class = simple_selector.pseudo_class();
+                if (pseudo_class.type != PseudoClass::Is && pseudo_class.type != PseudoClass::Where)
+                    return false;
+                if (pseudo_class.argument_selector_list.size() != 1)
+                    return false;
+                auto const& argument_selector = *pseudo_class.argument_selector_list.first();
+                return append_hashes_from_compound(argument_selector.compound_selectors().last());
+            }
             default:
-                break;
+                return false;
             }
         }
-        return false;
+
+        bool append_hashes_from_compound(CompoundSelector const& compound_selector)
+        {
+            for (auto const& simple_selector : compound_selector.simple_selectors) {
+                if (append_hashes_from_simple_selector(simple_selector))
+                    return true;
+            }
+            return false;
+        }
     };
+    AncestorHashCollector ancestor_hash_collector { m_ancestor_hashes, next_hash_index };
 
     // Walk from the compound immediately to the left of the subject toward the left.
     // The combinator that connects `i` to `i+1` is stored on `i+1`.
@@ -204,7 +221,7 @@ void Selector::collect_ancestor_hashes()
         case Combinator::PseudoElement:
             // This compound is on the ancestor axis (directly, as the originating element for a pseudo-element,
             // or as a shared ancestor past a sibling boundary).
-            if (append_hashes_from_compound(compound_selector)) {
+            if (ancestor_hash_collector.append_hashes_from_compound(compound_selector)) {
                 m_can_use_ancestor_filter = (next_hash_index > 0);
                 return;
             }

--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -8,6 +8,7 @@
 #include "Selector.h"
 #include <AK/GenericShorthands.h>
 #include <AK/NeverDestroyed.h>
+#include <LibWeb/CSS/AncestorFilter.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/Parser/ErrorReporter.h>
 #include <LibWeb/CSS/Serialize.h>
@@ -201,14 +202,16 @@ void Selector::collect_ancestor_hashes()
             Vector<u32> hashes;
             switch (simple_selector.type) {
             case SimpleSelector::Type::Id:
+                hashes.append(ancestor_filter_hash_for_id(simple_selector.name().hash()));
+                break;
             case SimpleSelector::Type::Class:
-                hashes.append(simple_selector.name().hash());
+                hashes.append(ancestor_filter_hash_for_class(simple_selector.name().hash()));
                 break;
             case SimpleSelector::Type::TagName:
-                hashes.append(simple_selector.qualified_name().name.lowercase_name.hash());
+                hashes.append(ancestor_filter_hash_for_tag_name(simple_selector.qualified_name().name.lowercase_name.hash()));
                 break;
             case SimpleSelector::Type::Attribute:
-                hashes.append(simple_selector.attribute().qualified_name.name.lowercase_name.hash());
+                hashes.append(ancestor_filter_hash_for_attribute(simple_selector.attribute().qualified_name.name.lowercase_name.hash()));
                 break;
             case SimpleSelector::Type::PseudoClass: {
                 auto const& pseudo_class = simple_selector.pseudo_class();

--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -156,6 +156,11 @@ void Selector::collect_ancestor_hashes()
 
     size_t next_hash_index = 0;
     struct AncestorHashCollector {
+        enum class IncludeRightmostCompound : bool {
+            No,
+            Yes,
+        };
+
         Array<u32, 8>& ancestor_hashes;
         size_t& next_hash_index;
 
@@ -220,7 +225,7 @@ void Selector::collect_ancestor_hashes()
 
                 // The selector's ancestor hashes are all mandatory. For :is()/:where(), only
                 // hashes required by every alternative can reject the selector without running it.
-                hashes = common_hashes_from_selector_list(pseudo_class.argument_selector_list);
+                hashes = common_hashes_from_selector_list(pseudo_class.argument_selector_list, IncludeRightmostCompound::Yes);
                 break;
             }
             default:
@@ -239,19 +244,42 @@ void Selector::collect_ancestor_hashes()
             return hashes;
         }
 
-        Vector<u32> hashes_from_selector_matched_as_ancestor(Selector const& selector)
+        Vector<u32> hashes_from_subject_compound_selector_list_pseudo_classes(CompoundSelector const& compound_selector)
+        {
+            Vector<u32> hashes;
+            for (auto const& simple_selector : compound_selector.simple_selectors) {
+                if (simple_selector.type != SimpleSelector::Type::PseudoClass)
+                    continue;
+
+                auto const& pseudo_class = simple_selector.pseudo_class();
+                if (pseudo_class.type != PseudoClass::Is && pseudo_class.type != PseudoClass::Where)
+                    continue;
+
+                for (auto hash : common_hashes_from_selector_list(pseudo_class.argument_selector_list, IncludeRightmostCompound::No))
+                    append_unique_hash(hashes, hash);
+            }
+            return hashes;
+        }
+
+        Vector<u32> hashes_from_selector(Selector const& selector, IncludeRightmostCompound include_rightmost_compound)
         {
             Vector<u32> hashes;
             auto const& compound_selectors = selector.compound_selectors();
             if (compound_selectors.is_empty())
                 return hashes;
 
-            // A selector-list pseudo-class in an ancestor compound matches that ancestor.
-            // The argument selector's rightmost compound is therefore on the subject's
-            // ancestor chain. After a sibling combinator, the sibling compound itself is
-            // not an ancestor, but compounds further left are shared ancestors.
-            for (auto hash : hashes_from_compound(compound_selectors.last()))
-                append_unique_hash(hashes, hash);
+            if (include_rightmost_compound == IncludeRightmostCompound::Yes) {
+                // A selector-list pseudo-class in an ancestor compound matches that ancestor.
+                // The argument selector's rightmost compound is therefore on the subject's
+                // ancestor chain.
+                for (auto hash : hashes_from_compound(compound_selectors.last()))
+                    append_unique_hash(hashes, hash);
+            } else {
+                // A selector-list pseudo-class in the subject compound can still contain
+                // ancestor requirements inside its alternatives, e.g. `:is(.foo > .bar)`.
+                for (auto hash : hashes_from_subject_compound_selector_list_pseudo_classes(compound_selectors.last()))
+                    append_unique_hash(hashes, hash);
+            }
 
             auto combinator_to_right = compound_selectors.last().combinator;
             for (ssize_t i = static_cast<ssize_t>(compound_selectors.size()) - 2; i >= 0; --i) {
@@ -278,14 +306,14 @@ void Selector::collect_ancestor_hashes()
             return hashes;
         }
 
-        Vector<u32> common_hashes_from_selector_list(SelectorList const& selector_list)
+        Vector<u32> common_hashes_from_selector_list(SelectorList const& selector_list, IncludeRightmostCompound include_rightmost_compound)
         {
             if (selector_list.is_empty())
                 return {};
 
             Optional<Vector<u32>> common_hashes;
             for (auto const& argument_selector : selector_list) {
-                auto hashes = hashes_from_selector_matched_as_ancestor(*argument_selector);
+                auto hashes = hashes_from_selector(*argument_selector, include_rightmost_compound);
                 if (!common_hashes.has_value()) {
                     common_hashes = move(hashes);
                     continue;
@@ -318,6 +346,13 @@ void Selector::collect_ancestor_hashes()
         }
     };
     AncestorHashCollector ancestor_hash_collector { m_ancestor_hashes, next_hash_index };
+
+    for (auto hash : ancestor_hash_collector.hashes_from_subject_compound_selector_list_pseudo_classes(m_compound_selectors.last())) {
+        if (ancestor_hash_collector.append_unique_hash(hash)) {
+            m_can_use_ancestor_filter = (next_hash_index > 0);
+            return;
+        }
+    }
 
     // Walk from the compound immediately to the left of the subject toward the left.
     // The combinator that connects `i` to `i+1` is stored on `i+1`.

--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -158,6 +158,32 @@ void Selector::collect_ancestor_hashes()
         Array<u32, 8>& ancestor_hashes;
         size_t& next_hash_index;
 
+        static bool contains_hash(Vector<u32> const& hashes, u32 hash)
+        {
+            for (auto existing_hash : hashes) {
+                if (existing_hash == hash)
+                    return true;
+            }
+            return false;
+        }
+
+        static void append_unique_hash(Vector<u32>& hashes, u32 hash)
+        {
+            if (!contains_hash(hashes, hash))
+                hashes.append(hash);
+        }
+
+        static void intersect_hashes(Vector<u32>& hashes, Vector<u32> const& other_hashes)
+        {
+            for (size_t i = 0; i < hashes.size();) {
+                if (contains_hash(other_hashes, hashes[i])) {
+                    ++i;
+                    continue;
+                }
+                hashes.remove(i);
+            }
+        }
+
         bool append_unique_hash(u32 hash)
         {
             if (next_hash_index >= ancestor_hashes.size())
@@ -170,28 +196,113 @@ void Selector::collect_ancestor_hashes()
             return false;
         }
 
-        bool append_hashes_from_simple_selector(SimpleSelector const& simple_selector)
+        Vector<u32> hashes_from_simple_selector(SimpleSelector const& simple_selector)
         {
+            Vector<u32> hashes;
             switch (simple_selector.type) {
             case SimpleSelector::Type::Id:
             case SimpleSelector::Type::Class:
-                return append_unique_hash(simple_selector.name().hash());
+                hashes.append(simple_selector.name().hash());
+                break;
             case SimpleSelector::Type::TagName:
-                return append_unique_hash(simple_selector.qualified_name().name.lowercase_name.hash());
+                hashes.append(simple_selector.qualified_name().name.lowercase_name.hash());
+                break;
             case SimpleSelector::Type::Attribute:
-                return append_unique_hash(simple_selector.attribute().qualified_name.name.lowercase_name.hash());
+                hashes.append(simple_selector.attribute().qualified_name.name.lowercase_name.hash());
+                break;
             case SimpleSelector::Type::PseudoClass: {
                 auto const& pseudo_class = simple_selector.pseudo_class();
                 if (pseudo_class.type != PseudoClass::Is && pseudo_class.type != PseudoClass::Where)
-                    return false;
-                if (pseudo_class.argument_selector_list.size() != 1)
-                    return false;
-                auto const& argument_selector = *pseudo_class.argument_selector_list.first();
-                return append_hashes_from_compound(argument_selector.compound_selectors().last());
+                    break;
+
+                // The selector's ancestor hashes are all mandatory. For :is()/:where(), only
+                // hashes required by every alternative can reject the selector without running it.
+                hashes = common_hashes_from_selector_list(pseudo_class.argument_selector_list);
+                break;
             }
             default:
-                return false;
+                break;
             }
+            return hashes;
+        }
+
+        Vector<u32> hashes_from_compound(CompoundSelector const& compound_selector)
+        {
+            Vector<u32> hashes;
+            for (auto const& simple_selector : compound_selector.simple_selectors) {
+                for (auto hash : hashes_from_simple_selector(simple_selector))
+                    append_unique_hash(hashes, hash);
+            }
+            return hashes;
+        }
+
+        Vector<u32> hashes_from_selector_matched_as_ancestor(Selector const& selector)
+        {
+            Vector<u32> hashes;
+            auto const& compound_selectors = selector.compound_selectors();
+            if (compound_selectors.is_empty())
+                return hashes;
+
+            // A selector-list pseudo-class in an ancestor compound matches that ancestor.
+            // The argument selector's rightmost compound is therefore on the subject's
+            // ancestor chain. After a sibling combinator, the sibling compound itself is
+            // not an ancestor, but compounds further left are shared ancestors.
+            for (auto hash : hashes_from_compound(compound_selectors.last()))
+                append_unique_hash(hashes, hash);
+
+            auto combinator_to_right = compound_selectors.last().combinator;
+            for (ssize_t i = static_cast<ssize_t>(compound_selectors.size()) - 2; i >= 0; --i) {
+                auto const& compound_selector = compound_selectors[i];
+
+                switch (combinator_to_right) {
+                case Combinator::Descendant:
+                case Combinator::ImmediateChild:
+                case Combinator::PseudoElement:
+                    for (auto hash : hashes_from_compound(compound_selector))
+                        append_unique_hash(hashes, hash);
+                    break;
+                case Combinator::NextSibling:
+                case Combinator::SubsequentSibling:
+                    break;
+                case Combinator::Column:
+                default:
+                    return hashes;
+                }
+
+                combinator_to_right = compound_selector.combinator;
+            }
+
+            return hashes;
+        }
+
+        Vector<u32> common_hashes_from_selector_list(SelectorList const& selector_list)
+        {
+            if (selector_list.is_empty())
+                return {};
+
+            Optional<Vector<u32>> common_hashes;
+            for (auto const& argument_selector : selector_list) {
+                auto hashes = hashes_from_selector_matched_as_ancestor(*argument_selector);
+                if (!common_hashes.has_value()) {
+                    common_hashes = move(hashes);
+                    continue;
+                }
+
+                intersect_hashes(common_hashes.value(), hashes);
+                if (common_hashes->is_empty())
+                    break;
+            }
+
+            return common_hashes.release_value();
+        }
+
+        bool append_hashes_from_simple_selector(SimpleSelector const& simple_selector)
+        {
+            for (auto hash : hashes_from_simple_selector(simple_selector)) {
+                if (append_unique_hash(hash))
+                    return true;
+            }
+            return false;
         }
 
         bool append_hashes_from_compound(CompoundSelector const& compound_selector)

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3047,7 +3047,39 @@ struct SimplifiedSelectorForBucketing {
     FlyString name;
 };
 
-static Optional<SimplifiedSelectorForBucketing> is_roundabout_selector_bucketable_as_something_simpler(CSS::Selector::SimpleSelector const& simple_selector)
+static Optional<SimplifiedSelectorForBucketing> bucket_for_is_or_where_selector(CSS::Selector::SimpleSelector const&);
+
+static Optional<SimplifiedSelectorForBucketing> bucket_for_compound_selector(CSS::Selector::CompoundSelector const& compound_selector)
+{
+    Optional<SimplifiedSelectorForBucketing> attribute_bucket;
+    for (auto const& simple_selector : compound_selector.simple_selectors.in_reverse()) {
+        if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Class
+            || simple_selector.type == CSS::Selector::SimpleSelector::Type::Id) {
+            return SimplifiedSelectorForBucketing { simple_selector.type, simple_selector.name() };
+        }
+
+        if (simple_selector.type == CSS::Selector::SimpleSelector::Type::TagName) {
+            return SimplifiedSelectorForBucketing { simple_selector.type, simple_selector.qualified_name().name.lowercase_name };
+        }
+
+        if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Attribute) {
+            if (!attribute_bucket.has_value())
+                attribute_bucket = SimplifiedSelectorForBucketing { simple_selector.type, simple_selector.attribute().qualified_name.name.lowercase_name };
+            continue;
+        }
+
+        if (auto bucket = bucket_for_is_or_where_selector(simple_selector); bucket.has_value()) {
+            if (bucket->type != CSS::Selector::SimpleSelector::Type::Attribute)
+                return bucket;
+            if (!attribute_bucket.has_value())
+                attribute_bucket = bucket.release_value();
+        }
+    }
+
+    return attribute_bucket;
+}
+
+static Optional<SimplifiedSelectorForBucketing> bucket_for_is_or_where_selector(CSS::Selector::SimpleSelector const& simple_selector)
 {
     if (simple_selector.type != CSS::Selector::SimpleSelector::Type::PseudoClass)
         return {};
@@ -3060,22 +3092,7 @@ static Optional<SimplifiedSelectorForBucketing> is_roundabout_selector_bucketabl
         return {};
 
     auto const& argument_selector = *simple_selector.pseudo_class().argument_selector_list.first();
-
-    auto const& compound_selector = argument_selector.compound_selectors().last();
-    if (compound_selector.simple_selectors.size() != 1)
-        return {};
-
-    auto const& inner_simple_selector = compound_selector.simple_selectors.first();
-    if (inner_simple_selector.type == CSS::Selector::SimpleSelector::Type::Class
-        || inner_simple_selector.type == CSS::Selector::SimpleSelector::Type::Id) {
-        return SimplifiedSelectorForBucketing { inner_simple_selector.type, inner_simple_selector.name() };
-    }
-
-    if (inner_simple_selector.type == CSS::Selector::SimpleSelector::Type::TagName) {
-        return SimplifiedSelectorForBucketing { inner_simple_selector.type, inner_simple_selector.qualified_name().name.lowercase_name };
-    }
-
-    return {};
+    return bucket_for_compound_selector(argument_selector.compound_selectors().last());
 }
 
 NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(DOM::AbstractElement abstract_element, Utf16FlyString const& name, Optional<Parser::GuardedSubstitutionContexts&> guarded_contexts)
@@ -3824,6 +3841,10 @@ static void add_rule_to_rule_buckets(RuleBuckets& rule_buckets, MatchingRule con
         rule_buckets.rules_by_tag_name.ensure(name).append(matching_rule);
     };
 
+    auto add_to_attribute_bucket = [&](FlyString const& name) {
+        rule_buckets.rules_by_attribute_name.ensure(name).append(matching_rule);
+    };
+
     for (auto const& simple_selector : bucket_compound_selector.simple_selectors.in_reverse()) {
         if (simple_selector.type == Selector::SimpleSelector::Type::Id) {
             add_to_id_bucket(simple_selector.name());
@@ -3837,8 +3858,9 @@ static void add_rule_to_rule_buckets(RuleBuckets& rule_buckets, MatchingRule con
             add_to_tag_name_bucket(simple_selector.qualified_name().name.lowercase_name);
             return;
         }
-        // NOTE: Selectors like `:is/where(.foo)` and `:is/where(.foo .bar)` are bucketed as class selectors for `foo` and `bar` respectively.
-        if (auto simplified = is_roundabout_selector_bucketable_as_something_simpler(simple_selector); simplified.has_value()) {
+        // NOTE: Single-argument :is()/:where() selectors can be bucketed by a mandatory
+        //       id, class, tag, or attribute in their rightmost compound selector.
+        if (auto simplified = bucket_for_is_or_where_selector(simple_selector); simplified.has_value()) {
             if (simplified->type == Selector::SimpleSelector::Type::TagName) {
                 add_to_tag_name_bucket(simplified->name);
                 return;
@@ -3851,6 +3873,10 @@ static void add_rule_to_rule_buckets(RuleBuckets& rule_buckets, MatchingRule con
                 add_to_id_bucket(simplified->name);
                 return;
             }
+            if (simplified->type == Selector::SimpleSelector::Type::Attribute) {
+                add_to_attribute_bucket(simplified->name);
+                return;
+            }
         }
     }
 
@@ -3859,7 +3885,7 @@ static void add_rule_to_rule_buckets(RuleBuckets& rule_buckets, MatchingRule con
     } else {
         for (auto const& simple_selector : bucket_compound_selector.simple_selectors) {
             if (simple_selector.type == Selector::SimpleSelector::Type::Attribute) {
-                rule_buckets.rules_by_attribute_name.ensure(simple_selector.attribute().qualified_name.name.lowercase_name).append(matching_rule);
+                add_to_attribute_bucket(simple_selector.attribute().qualified_name.name.lowercase_name);
                 return;
             }
         }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -25,6 +25,7 @@
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
+#include <LibWeb/CSS/AncestorFilter.h>
 #include <LibWeb/CSS/AnimationEvent.h>
 #include <LibWeb/CSS/CSSAnimation.h>
 #include <LibWeb/CSS/CSSContainerRule.h>
@@ -3787,13 +3788,13 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_math_depth(NonnullRefPtr<
 
 static void for_each_element_hash(DOM::Element const& element, auto callback)
 {
-    callback(element.local_name().ascii_case_insensitive_hash());
+    callback(ancestor_filter_hash_for_tag_name(element.local_name().ascii_case_insensitive_hash()));
     if (element.id().has_value())
-        callback(element.id().value().hash());
+        callback(ancestor_filter_hash_for_id(element.id().value().hash()));
     for (auto const& class_ : element.class_names())
-        callback(class_.hash());
+        callback(ancestor_filter_hash_for_class(class_.hash()));
     element.for_each_attribute([&](auto& attribute) {
-        callback(attribute.name().ascii_case_insensitive_hash());
+        callback(ancestor_filter_hash_for_attribute(attribute.name().ascii_case_insensitive_hash()));
     });
 }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -381,6 +381,42 @@ static u64 pseudo_element_style_bit(PseudoElement pseudo_element)
     return 1ull << to_underlying(pseudo_element);
 }
 
+template<typename RuleBuckets>
+static IterationDecision for_each_matching_rule_bucket(DOM::AbstractElement abstract_element, RuleBuckets const& rule_buckets, Function<IterationDecision(Vector<MatchingRule> const&)> const& callback)
+{
+    for (auto const& class_name : abstract_element.element().class_names()) {
+        if (auto it = rule_buckets.rules_by_class.find(class_name); it != rule_buckets.rules_by_class.end()) {
+            if (callback(it->value) == IterationDecision::Break)
+                return IterationDecision::Break;
+        }
+    }
+    if (auto id = abstract_element.element().id(); id.has_value()) {
+        if (auto it = rule_buckets.rules_by_id.find(id.value()); it != rule_buckets.rules_by_id.end()) {
+            if (callback(it->value) == IterationDecision::Break)
+                return IterationDecision::Break;
+        }
+    }
+    if (auto it = rule_buckets.rules_by_tag_name.find(abstract_element.element().lowercased_local_name()); it != rule_buckets.rules_by_tag_name.end()) {
+        if (callback(it->value) == IterationDecision::Break)
+            return IterationDecision::Break;
+    }
+
+    if (abstract_element.element().is_document_element()) {
+        if (callback(rule_buckets.root_rules) == IterationDecision::Break)
+            return IterationDecision::Break;
+    }
+
+    IterationDecision decision = IterationDecision::Continue;
+    abstract_element.element().for_each_attribute([&](auto& name, auto&) {
+        if (auto it = rule_buckets.rules_by_attribute_name.find(name); it != rule_buckets.rules_by_attribute_name.end())
+            decision = callback(it->value);
+    });
+    if (decision == IterationDecision::Break)
+        return IterationDecision::Break;
+
+    return callback(rule_buckets.other_rules);
+}
+
 Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules_from_context(DOM::AbstractElement abstract_element, CascadeOrigin cascade_origin, GC::Ptr<DOM::ShadowRoot const> context_shadow_root, Optional<FlyString const> qualified_layer_name, u64* matching_pseudo_element_styles) const
 {
     auto const& root_node = abstract_element.element().root();
@@ -475,8 +511,12 @@ Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules_
             return IterationDecision::Continue;
         });
         if (!abstract_element.pseudo_element().has_value() && matching_pseudo_element_styles) {
-            for (auto const& matching_rules : rule_cache.rules_by_pseudo_element)
-                add_rules_to_run(matching_rules, rule_root);
+            for (auto const& pseudo_element_rules : rule_cache.rules_by_pseudo_element) {
+                (void)for_each_matching_rule_bucket(abstract_element, pseudo_element_rules, [&](auto const& matching_rules) {
+                    add_rules_to_run(matching_rules, rule_root);
+                    return IterationDecision::Continue;
+                });
+            }
         }
     };
 
@@ -3767,41 +3807,22 @@ void StyleComputer::pop_ancestor(DOM::Element const& element)
     });
 }
 
-void RuleCache::add_rule(MatchingRule const& matching_rule, Optional<PseudoElement> pseudo_element, bool contains_root_pseudo_class)
+template<typename RuleBuckets>
+static void add_rule_to_rule_buckets(RuleBuckets& rule_buckets, MatchingRule const& matching_rule, Selector::CompoundSelector const& bucket_compound_selector, bool contains_root_pseudo_class)
 {
-    if (matching_rule.slotted) {
-        slotted_rules.append(matching_rule);
-        return;
-    }
-    if (matching_rule.contains_part_pseudo_element) {
-        part_rules.append(matching_rule);
-        return;
-    }
     // NOTE: We traverse the simple selectors in reverse order to make sure that class/ID buckets are preferred over tag buckets
     //       in the common case of div.foo or div#foo selectors.
     auto add_to_id_bucket = [&](FlyString const& name) {
-        rules_by_id.ensure(name).append(matching_rule);
+        rule_buckets.rules_by_id.ensure(name).append(matching_rule);
     };
 
     auto add_to_class_bucket = [&](FlyString const& name) {
-        rules_by_class.ensure(name).append(matching_rule);
+        rule_buckets.rules_by_class.ensure(name).append(matching_rule);
     };
 
     auto add_to_tag_name_bucket = [&](FlyString const& name) {
-        rules_by_tag_name.ensure(name).append(matching_rule);
+        rule_buckets.rules_by_tag_name.ensure(name).append(matching_rule);
     };
-
-    auto const& bucket_compound_selector = [&]() -> Selector::CompoundSelector const& {
-        if (matching_rule.contains_pseudo_element && pseudo_element.has_value()) {
-            // Normalized pseudo-element selectors end with a pseudo-element compound; bucket them
-            // by the originating element compound so `.foo::before` keeps using the `.foo` bucket.
-            for (auto const& compound_selector : matching_rule.selector.compound_selectors().in_reverse()) {
-                if (compound_selector.combinator != Selector::Combinator::PseudoElement)
-                    return compound_selector;
-            }
-        }
-        return matching_rule.selector.compound_selectors().last();
-    }();
 
     for (auto const& simple_selector : bucket_compound_selector.simple_selectors.in_reverse()) {
         if (simple_selector.type == Selector::SimpleSelector::Type::Id) {
@@ -3833,67 +3854,61 @@ void RuleCache::add_rule(MatchingRule const& matching_rule, Optional<PseudoEleme
         }
     }
 
-    if (matching_rule.contains_pseudo_element && pseudo_element.has_value()) {
-        if (Selector::PseudoElementSelector::is_known_pseudo_element_type(pseudo_element.value())) {
-            rules_by_pseudo_element[to_underlying(pseudo_element.value())].append(matching_rule);
-        } else {
-            // NOTE: We don't cache rules for unknown pseudo-elements. They can't match anything anyway.
-        }
-    } else if (contains_root_pseudo_class) {
-        root_rules.append(matching_rule);
+    if (contains_root_pseudo_class) {
+        rule_buckets.root_rules.append(matching_rule);
     } else {
-        for (auto const& simple_selector : matching_rule.selector.compound_selectors().last().simple_selectors) {
+        for (auto const& simple_selector : bucket_compound_selector.simple_selectors) {
             if (simple_selector.type == Selector::SimpleSelector::Type::Attribute) {
-                rules_by_attribute_name.ensure(simple_selector.attribute().qualified_name.name.lowercase_name).append(matching_rule);
+                rule_buckets.rules_by_attribute_name.ensure(simple_selector.attribute().qualified_name.name.lowercase_name).append(matching_rule);
                 return;
             }
         }
-        other_rules.append(matching_rule);
+        rule_buckets.other_rules.append(matching_rule);
     }
+}
+
+void RuleCache::add_rule(MatchingRule const& matching_rule, Optional<PseudoElement> pseudo_element, bool contains_root_pseudo_class)
+{
+    if (matching_rule.slotted) {
+        slotted_rules.append(matching_rule);
+        return;
+    }
+    if (matching_rule.contains_part_pseudo_element) {
+        part_rules.append(matching_rule);
+        return;
+    }
+
+    if (matching_rule.contains_pseudo_element && pseudo_element.has_value()) {
+        if (Selector::PseudoElementSelector::is_known_pseudo_element_type(pseudo_element.value())) {
+            // Normalized pseudo-element selectors end with a pseudo-element compound; bucket them
+            // by the originating element compound so `.foo::before` keeps using the `.foo` bucket.
+            auto const& bucket_compound_selector = [&]() -> Selector::CompoundSelector const& {
+                for (auto const& compound_selector : matching_rule.selector.compound_selectors().in_reverse()) {
+                    if (compound_selector.combinator != Selector::Combinator::PseudoElement)
+                        return compound_selector;
+                }
+                return matching_rule.selector.compound_selectors().last();
+            }();
+            add_rule_to_rule_buckets(rules_by_pseudo_element[to_underlying(pseudo_element.value())], matching_rule, bucket_compound_selector, contains_root_pseudo_class);
+        }
+        return;
+    }
+
+    add_rule_to_rule_buckets(*this, matching_rule, matching_rule.selector.compound_selectors().last(), contains_root_pseudo_class);
 }
 
 void RuleCache::for_each_matching_rules(DOM::AbstractElement abstract_element, Function<IterationDecision(Vector<MatchingRule> const&)> callback) const
 {
-    for (auto const& class_name : abstract_element.element().class_names()) {
-        if (auto it = rules_by_class.find(class_name); it != rules_by_class.end()) {
-            if (callback(it->value) == IterationDecision::Break)
-                return;
-        }
-    }
-    if (auto id = abstract_element.element().id(); id.has_value()) {
-        if (auto it = rules_by_id.find(id.value()); it != rules_by_id.end()) {
-            if (callback(it->value) == IterationDecision::Break)
-                return;
-        }
-    }
-    if (auto it = rules_by_tag_name.find(abstract_element.element().lowercased_local_name()); it != rules_by_tag_name.end()) {
-        if (callback(it->value) == IterationDecision::Break)
-            return;
-    }
     if (abstract_element.pseudo_element().has_value()) {
         if (Selector::PseudoElementSelector::is_known_pseudo_element_type(abstract_element.pseudo_element().value())) {
-            if (callback(rules_by_pseudo_element.at(to_underlying(abstract_element.pseudo_element().value()))) == IterationDecision::Break)
-                return;
+            (void)for_each_matching_rule_bucket(abstract_element, rules_by_pseudo_element.at(to_underlying(abstract_element.pseudo_element().value())), callback);
         } else {
             // NOTE: We don't cache rules for unknown pseudo-elements. They can't match anything anyway.
         }
-    }
-
-    if (abstract_element.element().is_document_element()) {
-        if (callback(root_rules) == IterationDecision::Break)
-            return;
-    }
-
-    IterationDecision decision = IterationDecision::Continue;
-    abstract_element.element().for_each_attribute([&](auto& name, auto&) {
-        if (auto it = rules_by_attribute_name.find(name); it != rules_by_attribute_name.end()) {
-            decision = callback(it->value);
-        }
-    });
-    if (decision == IterationDecision::Break)
         return;
+    }
 
-    (void)callback(other_rules);
+    (void)for_each_matching_rule_bucket(abstract_element, *this, callback);
 }
 
 void StyleComputer::ScopedMatchingRule::visit_edges(GC::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -101,7 +101,12 @@ void RuleCache::visit_edges(GC::Cell::Visitor& visitor)
     visit_map(rules_by_tag_name);
     visit_map(rules_by_attribute_name);
     for (auto& rules : rules_by_pseudo_element) {
-        visit_vector(rules);
+        visit_map(rules.rules_by_id);
+        visit_map(rules.rules_by_class);
+        visit_map(rules.rules_by_tag_name);
+        visit_map(rules.rules_by_attribute_name);
+        visit_vector(rules.root_rules);
+        visit_vector(rules.other_rules);
     }
     visit_vector(root_rules);
     visit_vector(slotted_rules);

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -59,11 +59,20 @@ struct RuleCache {
     HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
     HashMap<FlyString, Vector<MatchingRule>> rules_by_tag_name;
     HashMap<FlyString, Vector<MatchingRule>, AK::ASCIICaseInsensitiveFlyStringTraits> rules_by_attribute_name;
-    Array<Vector<MatchingRule>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount)> rules_by_pseudo_element;
     Vector<MatchingRule> root_rules;
     Vector<MatchingRule> slotted_rules;
     Vector<MatchingRule> part_rules;
     Vector<MatchingRule> other_rules;
+
+    struct PseudoElementRules {
+        HashMap<FlyString, Vector<MatchingRule>> rules_by_id;
+        HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
+        HashMap<FlyString, Vector<MatchingRule>> rules_by_tag_name;
+        HashMap<FlyString, Vector<MatchingRule>, AK::ASCIICaseInsensitiveFlyStringTraits> rules_by_attribute_name;
+        Vector<MatchingRule> root_rules;
+        Vector<MatchingRule> other_rules;
+    };
+    Array<PseudoElementRules, to_underlying(CSS::PseudoElement::KnownPseudoElementCount)> rules_by_pseudo_element;
 
     HashMap<FlyString, NonnullRefPtr<Animations::KeyframeEffect::KeyFrameSet>> rules_by_animation_keyframes;
 


### PR DESCRIPTION
Pseudo-element rules now stay in pseudo-element-specific buckets, while still being bucketed by id, class, tag name, attribute, and :root within each known pseudo-element type. That keeps normal element style collection from considering pseudo-element rules unnecessarily.

The rule cache also looks through more :is() and :where() selectors when choosing buckets, including mandatory selectors from rightmost compounds and attribute buckets.

Finally, ancestor-filter hashes now extract more mandatory selector information from :is() and :where() selector lists. The hashes are salted by selector component kind, so identical strings from tags, ids, classes, and attributes do not satisfy each other accidentally while keeping the filter conservative.