### PR TITLE
CI: Use the image-provided wasm-tools on the Linux jobs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -116,7 +116,7 @@ runs:
 
     - name: 'Resolve wasm-tools release'
       id: 'wasm-tools'
-      if: ${{ inputs.type == 'build' }}
+      if: ${{ inputs.type == 'build' && inputs.os != 'Linux' }}
       shell: bash
       run: |
         VERSION=1.243.0
@@ -139,14 +139,14 @@ runs:
 
     - name: 'Cache wasm-tools'
       id: 'wasm-tools-cache'
-      if: ${{ inputs.type == 'build' }}
+      if: ${{ inputs.type == 'build' && inputs.os != 'Linux' }}
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/${{ steps.wasm-tools.outputs.name }}
         key: ${{ steps.wasm-tools.outputs.name }}
 
     - name: 'Install wasm-tools'
-      if: ${{ inputs.type == 'build' && steps.wasm-tools-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.type == 'build' && inputs.os != 'Linux' && steps.wasm-tools-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         FILENAME="${{ steps.wasm-tools.outputs.filename }}"
@@ -172,7 +172,7 @@ runs:
         rm "${FILENAME}"
 
     - name: 'Add wasm-tools to PATH'
-      if: ${{ inputs.type == 'build' }}
+      if: ${{ inputs.type == 'build' && inputs.os != 'Linux' }}
       shell: bash
       run: echo "${GITHUB_WORKSPACE}/${{ steps.wasm-tools.outputs.name }}" >> "$GITHUB_PATH"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         toolchain: ['GNU']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-16vcpu-ubuntu-2404"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.14"}']
 
         include:
           - os_name: 'Linux'

--- a/.github/workflows/js-and-wasm-artifacts.yml
+++ b/.github/workflows/js-and-wasm-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
         toolchain: ['Clang']
         package_type: ['Linux-x86_64']
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.14"}']
 
         include:
           - os_name: 'macOS'

--- a/.github/workflows/js-and-wasm-benchmarks.yml
+++ b/.github/workflows/js-and-wasm-benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         arch: ['x86_64']
         package_type: ['Linux-x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "js-benchmarks", "self-hosted"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.14"}']
 
         include:
           - os_name: 'macOS'

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: 'blacksmith-16vcpu-ubuntu-2404'
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.14
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.14
 
     steps:
       - uses: actions/checkout@v6.0.3

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -24,7 +24,7 @@ jobs:
         toolchain: ['Clang']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404-arm"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.14"}']
 
         include:
           - os_name: 'Linux'

--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
         os_name: ['Linux']
         arch: ['x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "web-benchmarks", "self-hosted"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.02"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.06.14"}']
 
         include:
           - os_name: 'macOS'


### PR DESCRIPTION
Bump the workflow image pin to the `2026.06.14` tag that bakes in `wasm-tools`. And keep the `wasm-tools` download/caching steps for the macOS and Windows jobs — but skip those steps on Linux. So, the Linux jobs use the `wasm-tools` copy the image installs. Follow-up to https://github.com/LadybirdBrowser/ladybird/pull/9972.
