### PR TITLE
Meta: Bump curl to 8.20.0#2

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "43ea817e84600347895efc196e2bb91162e9e679",
+  "builtin-baseline": "81de6771512413aaf89ea77add5ad1fda126b9d0",
   "dependencies": [
     {
       "name": "angle",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -278,7 +278,7 @@
     },
     {
       "name": "curl",
-      "version": "8.19.0#0"
+      "version": "8.20.0#2"
     },
     {
       "name": "dav1d",


### PR DESCRIPTION
This brings in support for Apple SecTrust on macOS, which means curl uses the system's certificate verification mechanism.