### PR TITLE
Compositor: Allow NVIDIA GPU access in sandbox

### DIFF
--- a/Libraries/LibSandbox/Sandbox.cpp
+++ b/Libraries/LibSandbox/Sandbox.cpp
@@ -504,14 +504,6 @@ ErrorOr<void> restrict_filesystem_with_landlock(ReadonlySpan<LandlockPath> paths
 
     return {};
 }
-
-ErrorOr<void> restrict_filesystem_with_landlock(ReadonlySpan<StringView> readable_paths)
-{
-    Vector<LandlockPath> paths;
-    for (auto readable_path : readable_paths)
-        TRY(paths.try_append({ readable_path.to_byte_string(), LandlockPath::Access::ReadOnly }));
-    return restrict_filesystem_with_landlock(paths.span());
-}
 #endif
 
 }

--- a/Libraries/LibSandbox/Sandbox.cpp
+++ b/Libraries/LibSandbox/Sandbox.cpp
@@ -71,15 +71,14 @@ ErrorOr<void> add_landlock_path_if_exists(Vector<LandlockPath>& paths, StringVie
         return Error::from_syscall("stat"sv, errno);
     }
 
-    if (!S_ISDIR(statbuf.st_mode))
-        path_bytes = LexicalPath::dirname(path_bytes);
+    bool is_directory = S_ISDIR(statbuf.st_mode);
 
     for (auto const& existing_path : paths) {
         if (existing_path.access == access && existing_path.path == path_bytes)
             return {};
     }
 
-    TRY(paths.try_append({ move(path_bytes), access }));
+    TRY(paths.try_append({ move(path_bytes), access, is_directory }));
     return {};
 }
 #endif
@@ -471,25 +470,44 @@ ErrorOr<void> restrict_filesystem_with_landlock(ReadonlySpan<LandlockPath> paths
         };
 
         landlock_path_beneath_attr path_beneath {};
-        path_beneath.allowed_access = LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR;
-        if (landlock_path.access == LandlockPath::Access::ReadAndExecute)
-            path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_EXECUTE;
-        if (landlock_path.access == LandlockPath::Access::ReadWrite) {
-            path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_WRITE_FILE
-                | LANDLOCK_ACCESS_FS_REMOVE_DIR
-                | LANDLOCK_ACCESS_FS_REMOVE_FILE
-                | LANDLOCK_ACCESS_FS_MAKE_DIR
-                | LANDLOCK_ACCESS_FS_MAKE_REG
-                | LANDLOCK_ACCESS_FS_MAKE_SOCK
-                | LANDLOCK_ACCESS_FS_MAKE_FIFO;
-#        ifdef LANDLOCK_ACCESS_FS_REFER
-            if (landlock_abi >= 2)
-                path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_REFER;
-#        endif
+        switch (landlock_path.access) {
+        case LandlockPath::Access::ReadOnly: {
+            path_beneath.allowed_access = LANDLOCK_ACCESS_FS_READ_FILE;
+
+            if (landlock_path.is_directory)
+                path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_READ_DIR;
+            break;
+        }
+        case LandlockPath::Access::ReadAndExecute: {
+            path_beneath.allowed_access = LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_EXECUTE;
+
+            if (landlock_path.is_directory)
+                path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_READ_DIR;
+            break;
+        }
+        case LandlockPath::Access::ReadWrite: {
+            path_beneath.allowed_access = LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_WRITE_FILE;
+
 #        ifdef LANDLOCK_ACCESS_FS_TRUNCATE
             if (landlock_abi >= 3)
                 path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_TRUNCATE;
 #        endif
+
+            if (landlock_path.is_directory) {
+                path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_REMOVE_DIR
+                    | LANDLOCK_ACCESS_FS_REMOVE_FILE
+                    | LANDLOCK_ACCESS_FS_MAKE_DIR
+                    | LANDLOCK_ACCESS_FS_MAKE_REG
+                    | LANDLOCK_ACCESS_FS_MAKE_SOCK
+                    | LANDLOCK_ACCESS_FS_MAKE_FIFO;
+
+#        ifdef LANDLOCK_ACCESS_FS_REFER
+                if (landlock_abi >= 2)
+                    path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_REFER;
+#        endif
+            }
+            break;
+        }
         }
         path_beneath.parent_fd = path_fd;
         if (syscall(__NR_landlock_add_rule, ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &path_beneath, 0) < 0)

--- a/Libraries/LibSandbox/Sandbox.h
+++ b/Libraries/LibSandbox/Sandbox.h
@@ -52,8 +52,7 @@ enum class NetworkAccess {
 
 #if defined(AK_OS_LINUX)
 [[nodiscard]] ErrorOr<void> add_landlock_path_if_exists(Vector<LandlockPath>& paths, StringView path, LandlockPath::Access);
-[[nodiscard]] ErrorOr<void> restrict_filesystem_with_landlock(ReadonlySpan<LandlockPath>);
-[[nodiscard]] ErrorOr<void> restrict_filesystem_with_landlock(ReadonlySpan<StringView> readable_paths = {});
+[[nodiscard]] ErrorOr<void> restrict_filesystem_with_landlock(ReadonlySpan<LandlockPath> = {});
 #endif
 
 #if defined(AK_OS_MACOS)

--- a/Libraries/LibSandbox/Sandbox.h
+++ b/Libraries/LibSandbox/Sandbox.h
@@ -25,6 +25,7 @@ struct LandlockPath {
 
     ByteString path;
     Access access { Access::ReadOnly };
+    bool is_directory { false };
 };
 #endif
 

--- a/Services/Compositor/SandboxLinux.cpp
+++ b/Services/Compositor/SandboxLinux.cpp
@@ -39,6 +39,20 @@ ErrorOr<void> apply_sandbox()
             TRY(Sandbox::add_landlock_path_if_exists(paths, path, Sandbox::LandlockPath::Access::ReadOnly));
     }
 
+    TRY(Sandbox::add_landlock_path_if_exists(paths, "/dev/nvidiactl"sv, Sandbox::LandlockPath::Access::ReadWrite));
+
+    // NB: Add all of the primary nvidia device files (e.g. /dev/nvidia0, /dev/nvidia1, etc).
+    auto flags = static_cast<Core::DirIterator::Flags>(Core::DirIterator::SkipDots | Core::DirIterator::NoStat);
+    TRY(Core::Directory::for_each_entry("/dev"sv, flags, [&](Core::DirectoryEntry const& entry, Core::Directory const&) -> ErrorOr<IterationDecision> {
+        if (entry.name.starts_with("nvidia"sv)) {
+            auto suffix = entry.name.substring_view(6);
+            if (!suffix.is_empty() && all_of(suffix, is_ascii_digit))
+                TRY(Sandbox::add_landlock_path_if_exists(paths, TRY(String::formatted("/dev/{}", entry.name)), Sandbox::LandlockPath::Access::ReadWrite));
+        }
+
+        return IterationDecision::Continue;
+    }));
+
     auto mesa_shader_cache_path = Core::Environment::get("MESA_SHADER_CACHE_DIR"sv)
                                       .map([](auto path) { return path.to_byte_string(); })
                                       .value_or_lazy_evaluated([] { return ByteString::formatted("{}/mesa_shader_cache", Core::StandardPaths::cache_directory()); });


### PR DESCRIPTION
This was required on my machine. Potentially related to #10155, #10172, and/or #10174

Also includes a bit of cleanup/hardening in LibSandbox - see individual commits for details.