### PR TITLE
Tests: Wait for beforeunload before the script-back cancel assertion

### DIFF
--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -3223,10 +3223,23 @@ return [location.href, window.scriptBeforeUnloadCount, navigator.userActivation.
                 f"got {script_beforeunload_setup}\n" + "\n".join(log)
             )
         execute_script(webdriver_port, session_id, "history.back(); return location.href;")
-        script_blocked_back_state = execute_script(
+
+        def script_back_canceled_by_beforeunload(result):
+            return (
+                isinstance(result, list)
+                and len(result) == 2
+                and result[0] == url_b
+                and isinstance(result[1], int)
+                and result[1] >= 1
+            )
+
+        script_blocked_back_state = wait_for_script_result(
             webdriver_port,
             session_id,
+            "blocked script-initiated cross-site history.back() from /b",
             "return [location.href, window.scriptBeforeUnloadCount];",
+            script_back_canceled_by_beforeunload,
+            log,
         )
         if script_blocked_back_state != [url_b, 1]:
             raise AssertionError(


### PR DESCRIPTION
**Problem:** `TestWebDriverSessionHistory` flakes on slow (Sanitizer) CI runners. The subtest checking that cancellation of a script-initiated cross-site “back” by a beforeunload handler intermittently failed the assertion _“Expected beforeunload to cancel script-initiated cross-site history.back(), got [url_b, 0]”._ `scriptBeforeUnloadCount` was 0, not 1.

**Cause:** `history.back()` appends its traversal to the traversable’s session history queue and returns immediately. So the beforeunload prompt to unload runs async. The test read `scriptBeforeUnloadCount` in a separate `execute_script` right after — with no wait. So on a slow runner, the read beats the dispatch, and sees 0. Every other script-initiated navigation in the test waits for its target document to load — and the “refresh” beforeunload check already polls. But the canceled “back” loads no target document — and this one waited for nothing.

**Fix:** Poll with `wait_for_script_result` until the page is still on `/b` and `window.scriptBeforeUnloadCount` has incremented, before asserting the final state — mirroring the “refresh” beforeunload check.
