### PR TITLE
DevTools: Add script sources display

### DIFF
--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -39,6 +39,19 @@ static JsonArray serialize_frame_list(WeakPtr<TabActor> const& tab_actor)
     return frames;
 }
 
+static void set_resources_available_message(JsonObject& message, StringView resource_type, JsonArray resources)
+{
+    JsonArray resource;
+    resource.must_append(resource_type);
+    resource.must_append(move(resources));
+
+    JsonArray array;
+    array.must_append(move(resource));
+
+    message.set("type"sv, "resources-available-array"sv);
+    message.set("array"sv, move(array));
+}
+
 NonnullRefPtr<FrameActor> FrameActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<WatcherActor> watcher, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<ConsoleActor> console, WeakPtr<InspectorActor> inspector, WeakPtr<StyleSheetsActor> style_sheets, WeakPtr<ThreadActor> thread, WeakPtr<AccessibilityActor> accessibility)
 {
     return adopt_ref(*new FrameActor(devtools, move(name), move(tab), move(watcher), move(css_properties), move(console), move(inspector), move(style_sheets), move(thread), move(accessibility)));
@@ -320,6 +333,36 @@ void FrameActor::style_sheets_available(JsonObject& response, Vector<Web::CSS::S
     response.set("array"sv, move(array));
 
     style_sheets_actor->set_style_sheets(move(style_sheets));
+}
+
+void FrameActor::send_source_resource_available_message()
+{
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return;
+
+    devtools().delegate().retrieve_sources(tab->description(),
+        async_handler<FrameActor>({}, [](auto& self, auto sources, auto& response) {
+            auto thread = self.m_thread.strong_ref();
+            if (!thread)
+                return;
+
+            set_resources_available_message(response, "source"sv, thread->serialize_sources(sources));
+        }));
+}
+
+void FrameActor::send_source_resource_available_message(Web::HTML::ScriptRegistry::Description const& source)
+{
+    auto thread = m_thread.strong_ref();
+    if (!thread)
+        return;
+
+    JsonArray serialized_sources;
+    serialized_sources.must_append(thread->serialize_source(source));
+
+    JsonObject message;
+    set_resources_available_message(message, "source"sv, move(serialized_sources));
+    send_message(move(message));
 }
 
 void FrameActor::on_console_message(WebView::ConsoleOutput console_output)

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -24,6 +24,21 @@
 
 namespace DevTools {
 
+static JsonArray serialize_frame_list(WeakPtr<TabActor> const& tab_actor)
+{
+    JsonArray frames;
+
+    if (auto tab = tab_actor.strong_ref()) {
+        JsonObject frame;
+        frame.set("id"sv, tab->description().id);
+        frame.set("title"sv, tab->description().title);
+        frame.set("url"sv, tab->description().url);
+        frames.must_append(move(frame));
+    }
+
+    return frames;
+}
+
 NonnullRefPtr<FrameActor> FrameActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<WatcherActor> watcher, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<ConsoleActor> console, WeakPtr<InspectorActor> inspector, WeakPtr<StyleSheetsActor> style_sheets, WeakPtr<ThreadActor> thread, WeakPtr<AccessibilityActor> accessibility)
 {
     return adopt_ref(*new FrameActor(devtools, move(name), move(tab), move(watcher), move(css_properties), move(console), move(inspector), move(style_sheets), move(thread), move(accessibility)));
@@ -150,8 +165,17 @@ void FrameActor::handle_message(Message const& message)
     }
 
     if (message.type == "listFrames"sv) {
+        response.set("frames"sv, serialize_frame_list(m_tab));
         send_response(message, move(response));
         send_pending_navigation_document_events_after_target_switch();
+        return;
+    }
+
+    if (message.type == "listWorkers"sv) {
+        // FIXME: Return dedicated, shared, and service worker targets once
+        //        Ladybird exposes worker targets to DevTools.
+        response.set("workers"sv, JsonArray {});
+        send_response(message, move(response));
         return;
     }
 
@@ -160,19 +184,9 @@ void FrameActor::handle_message(Message const& message)
 
 void FrameActor::send_frame_update_message()
 {
-    JsonArray frames;
-
-    if (auto tab_actor = m_tab.strong_ref()) {
-        JsonObject frame;
-        frame.set("id"sv, tab_actor->description().id);
-        frame.set("title"sv, tab_actor->description().title);
-        frame.set("url"sv, tab_actor->description().url);
-        frames.must_append(move(frame));
-    }
-
     JsonObject message;
     message.set("type"sv, "frameUpdate"sv);
-    message.set("frames"sv, move(frames));
+    message.set("frames"sv, serialize_frame_list(m_tab));
     send_message(move(message));
 }
 

--- a/Libraries/LibDevTools/Actors/FrameActor.h
+++ b/Libraries/LibDevTools/Actors/FrameActor.h
@@ -26,6 +26,8 @@ public:
     virtual ~FrameActor() override;
 
     void send_frame_update_message();
+    void send_source_resource_available_message();
+    void send_source_resource_available_message(Web::HTML::ScriptRegistry::Description const&);
     void set_pending_navigation_document_events_after_target_switch(String const& url, String const& title);
     void stop_listening();
 

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -78,6 +78,35 @@ void InspectorActor::handle_message(Message const& message)
         return;
     }
 
+    if (message.type == "resolveRelativeURL"sv) {
+        auto url = get_required_parameter<String>(message, "url"sv);
+        if (!url.has_value())
+            return;
+
+        Optional<Web::UniqueNodeID> node_id;
+        if (auto node_actor = message.data.get_string("node"sv); node_actor.has_value()) {
+            auto dom_node = WalkerActor::dom_node_for(m_walker, *node_actor);
+            if (!dom_node.has_value()) {
+                send_unknown_actor_error(message, *node_actor);
+                return;
+            }
+
+            node_id = dom_node->identifier.id;
+        }
+
+        if (auto tab = m_tab.strong_ref()) {
+            devtools().delegate().resolve_dom_node_url(tab->description(), node_id, *url,
+                async_handler<InspectorActor>(message, [](auto&, auto resolved_url, auto& response) {
+                    response.set("value"sv, move(resolved_url));
+                }));
+        } else {
+            response.set("value"sv, url.release_value());
+            send_response(message, move(response));
+        }
+
+        return;
+    }
+
     send_unrecognized_packet_type_error(message);
 }
 

--- a/Libraries/LibDevTools/Actors/RootActor.cpp
+++ b/Libraries/LibDevTools/Actors/RootActor.cpp
@@ -22,7 +22,7 @@ NonnullRefPtr<RootActor> RootActor::create(DevToolsServer& devtools, String name
     auto actor = adopt_ref(*new RootActor(devtools, move(name)));
 
     JsonObject traits;
-    traits.set("sources"sv, false);
+    traits.set("sources"sv, true);
     traits.set("highlightable"sv, true);
     traits.set("customHighlighters"sv, true);
     traits.set("networkMonitor"sv, true);

--- a/Libraries/LibDevTools/Actors/SourceActor.cpp
+++ b/Libraries/LibDevTools/Actors/SourceActor.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <LibDevTools/Actors/SourceActor.h>
+#include <LibDevTools/Actors/TabActor.h>
+#include <LibDevTools/DevToolsServer.h>
+
+namespace DevTools {
+
+NonnullRefPtr<SourceActor> SourceActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, Web::HTML::ScriptRegistry::Description source)
+{
+    return adopt_ref(*new SourceActor(devtools, move(name), move(tab), move(source)));
+}
+
+SourceActor::SourceActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, Web::HTML::ScriptRegistry::Description source)
+    : Actor(devtools, move(name))
+    , m_tab(move(tab))
+    , m_source(move(source))
+{
+}
+
+SourceActor::~SourceActor() = default;
+
+JsonObject SourceActor::serialize_source() const
+{
+    auto source_url = m_source.url.has_value() ? m_source.url->serialize() : m_source.display_url;
+
+    JsonObject source;
+    source.set("actor"sv, name());
+    source.set("extensionName"sv, JsonValue {});
+    source.set("url"sv, source_url);
+    source.set("isBlackBoxed"sv, false);
+    source.set("sourceMapBaseURL"sv, source_url);
+    source.set("sourceMapURL"sv, JsonValue {});
+    source.set("introductionType"sv, m_source.introduction_type);
+    source.set("isInlineSource"sv, m_source.is_inline_source);
+    source.set("sourceStartLine"sv, m_source.source_start_line);
+    source.set("sourceStartColumn"sv, m_source.source_start_column);
+    source.set("sourceLength"sv, static_cast<i64>(m_source.source_length));
+    if (auto tab = m_tab.strong_ref()) {
+        source.set("browsingContextID"sv, tab->description().id);
+        source.set("innerWindowId"sv, tab->inner_window_id());
+        source.set("resourceId"sv, MUST(String::formatted("source-{}-{}-{}", tab->inner_window_id(), m_source.id.document_id.value(), m_source.id.script_id)));
+    }
+    return source;
+}
+
+void SourceActor::handle_message(Message const& message)
+{
+    if (message.type == "source"sv) {
+        auto tab = m_tab.strong_ref();
+        if (!tab) {
+            JsonObject response;
+            response.set("source"sv, ""sv);
+            response.set("contentType"sv, m_source.content_type);
+            send_response(message, move(response));
+            return;
+        }
+
+        devtools().delegate().retrieve_source(tab->description(), m_source.id,
+            async_handler<SourceActor>(message, [](auto&, auto source_content, auto& response) {
+                // Firefox's longstring protocol accepts a primitive string and wraps it in a SimpleStringFront on the
+                // client side.
+                response.set("source"sv, move(source_content.text));
+                response.set("contentType"sv, move(source_content.content_type));
+            }));
+        return;
+    }
+
+    if (message.type == "getBreakableLines"sv) {
+        // FIXME: Compute real breakable lines from the parsed script source.
+        JsonObject response;
+        JsonArray lines;
+        response.set("lines"sv, move(lines));
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "getBreakpointPositionsCompressed"sv) {
+        // FIXME: Compute breakpoint positions once debugger bytecode/source
+        //        mapping is exposed to DevTools.
+        JsonObject response;
+        JsonObject positions;
+        response.set("positions"sv, move(positions));
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "setPausePoints"sv || message.type == "unblackbox"sv) {
+        // FIXME: Implement source pause points and blackboxing state.
+        JsonObject response;
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "blackbox"sv) {
+        // FIXME: Persist blackboxing state and apply it when debugging.
+        JsonObject response;
+        response.set("pausedInSource"sv, false);
+        send_response(message, move(response));
+        return;
+    }
+
+    send_unrecognized_packet_type_error(message);
+}
+
+}

--- a/Libraries/LibDevTools/Actors/SourceActor.h
+++ b/Libraries/LibDevTools/Actors/SourceActor.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <LibDevTools/Actor.h>
+#include <LibDevTools/DevToolsDelegate.h>
+#include <LibDevTools/Forward.h>
+
+namespace DevTools {
+
+class DEVTOOLS_API SourceActor final : public Actor {
+public:
+    static constexpr auto base_name = "source"sv;
+
+    static NonnullRefPtr<SourceActor> create(DevToolsServer&, String name, WeakPtr<TabActor>, Web::HTML::ScriptRegistry::Description);
+    virtual ~SourceActor() override;
+
+    JsonObject serialize_source() const;
+
+private:
+    SourceActor(DevToolsServer&, String name, WeakPtr<TabActor>, Web::HTML::ScriptRegistry::Description);
+
+    virtual void handle_message(Message const&) override;
+
+    WeakPtr<TabActor> m_tab;
+    Web::HTML::ScriptRegistry::Description m_source;
+};
+
+}

--- a/Libraries/LibDevTools/Actors/ThreadActor.cpp
+++ b/Libraries/LibDevTools/Actors/ThreadActor.cpp
@@ -4,25 +4,116 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <LibDevTools/Actors/SourceActor.h>
+#include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/ThreadActor.h>
+#include <LibDevTools/DevToolsServer.h>
 
 namespace DevTools {
 
-NonnullRefPtr<ThreadActor> ThreadActor::create(DevToolsServer& devtools, String name)
+NonnullRefPtr<ThreadActor> ThreadActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
 {
-    return adopt_ref(*new ThreadActor(devtools, move(name)));
+    return adopt_ref(*new ThreadActor(devtools, move(name), move(tab)));
 }
 
-ThreadActor::ThreadActor(DevToolsServer& devtools, String name)
+ThreadActor::ThreadActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
     : Actor(devtools, move(name))
+    , m_tab(move(tab))
 {
 }
 
-ThreadActor::~ThreadActor() = default;
+ThreadActor::~ThreadActor()
+{
+    for (auto const& actor : m_source_actors) {
+        if (auto source_actor = actor.value.strong_ref())
+            devtools().unregister_actor(source_actor->name());
+    }
+}
 
 void ThreadActor::handle_message(Message const& message)
 {
+    if (message.type == "attach"sv || message.type == "reconfigure"sv || message.type == "skipBreakpoints"sv || message.type == "resume"sv) {
+        JsonObject response;
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "getAvailableEventBreakpoints"sv) {
+        JsonObject response;
+        JsonArray breakpoints;
+        response.set("value"sv, move(breakpoints));
+        send_response(message, move(response));
+        return;
+    }
+
+    if (message.type == "sources"sv) {
+        auto tab = m_tab.strong_ref();
+        if (!tab) {
+            JsonObject response;
+            JsonArray sources;
+            response.set("sources"sv, move(sources));
+            send_response(message, move(response));
+            return;
+        }
+
+        devtools().delegate().retrieve_sources(tab->description(),
+            async_handler<ThreadActor>(message, [](auto& self, auto sources, auto& response) {
+                response.set("sources"sv, self.serialize_sources(sources));
+            }));
+        return;
+    }
+
     send_unrecognized_packet_type_error(message);
+}
+
+JsonObject ThreadActor::serialize_source(Web::HTML::ScriptRegistry::Description const& source)
+{
+    return source_actor_for(source).serialize_source();
+}
+
+JsonArray ThreadActor::serialize_sources(Vector<Web::HTML::ScriptRegistry::Description> const& sources)
+{
+    prune_source_actors(sources);
+
+    JsonArray serialized_sources;
+    for (auto const& source : sources)
+        serialized_sources.must_append(serialize_source(source));
+    return serialized_sources;
+}
+
+void ThreadActor::prune_source_actors(Vector<Web::HTML::ScriptRegistry::Description> const& sources)
+{
+    HashTable<Web::HTML::ScriptRegistry::Identifier> current_sources;
+    for (auto const& source : sources)
+        current_sources.set(source.id);
+
+    Vector<Web::HTML::ScriptRegistry::Identifier> stale_sources;
+    for (auto const& actor : m_source_actors) {
+        if (!current_sources.contains(actor.key))
+            stale_sources.append(actor.key);
+    }
+
+    for (auto const& source_id : stale_sources) {
+        auto actor = m_source_actors.take(source_id);
+        if (actor.has_value()) {
+            if (auto source_actor = actor->strong_ref())
+                devtools().unregister_actor(source_actor->name());
+        }
+    }
+}
+
+SourceActor& ThreadActor::source_actor_for(Web::HTML::ScriptRegistry::Description const& source)
+{
+    if (auto actor = m_source_actors.find(source.id); actor != m_source_actors.end()) {
+        if (auto source_actor = actor->value.strong_ref())
+            return *source_actor;
+    }
+
+    auto& actor = devtools().register_actor<SourceActor>(m_tab, source);
+    m_source_actors.set(source.id, actor);
+    return actor;
 }
 
 }

--- a/Libraries/LibDevTools/Actors/ThreadActor.h
+++ b/Libraries/LibDevTools/Actors/ThreadActor.h
@@ -6,8 +6,11 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
+#include <AK/HashTable.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibDevTools/Actor.h>
+#include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/Forward.h>
 
 namespace DevTools {
@@ -16,13 +19,22 @@ class DEVTOOLS_API ThreadActor final : public Actor {
 public:
     static constexpr auto base_name = "thread"sv;
 
-    static NonnullRefPtr<ThreadActor> create(DevToolsServer&, String name);
+    static NonnullRefPtr<ThreadActor> create(DevToolsServer&, String name, WeakPtr<TabActor>);
     virtual ~ThreadActor() override;
 
+    JsonObject serialize_source(Web::HTML::ScriptRegistry::Description const&);
+    JsonArray serialize_sources(Vector<Web::HTML::ScriptRegistry::Description> const&);
+
 private:
-    ThreadActor(DevToolsServer&, String name);
+    ThreadActor(DevToolsServer&, String name, WeakPtr<TabActor>);
 
     virtual void handle_message(Message const&) override;
+
+    void prune_source_actors(Vector<Web::HTML::ScriptRegistry::Description> const&);
+    SourceActor& source_actor_for(Web::HTML::ScriptRegistry::Description const&);
+
+    WeakPtr<TabActor> m_tab;
+    HashMap<Web::HTML::ScriptRegistry::Identifier, WeakPtr<SourceActor>> m_source_actors;
 };
 
 }

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -40,11 +40,12 @@ WatcherActor::WatcherActor(DevToolsServer& devtools, String name, WeakPtr<TabAct
 
 WatcherActor::~WatcherActor()
 {
-    if (!m_is_watching_frame_targets)
-        return;
+    stop_watching_source_resources();
 
-    if (auto tab = m_tab.strong_ref())
-        devtools().delegate().did_disconnect_devtools_client(tab->description());
+    if (m_is_watching_frame_targets) {
+        if (auto tab = m_tab.strong_ref())
+            devtools().delegate().did_disconnect_devtools_client(tab->description());
+    }
 }
 
 void WatcherActor::handle_message(Message const& message)
@@ -96,11 +97,23 @@ void WatcherActor::handle_message(Message const& message)
         bool should_send_indexed_db_resources = false;
         bool should_send_local_storage_resources = false;
         bool should_send_session_storage_resources = false;
+        bool should_send_source_resources = false;
         if constexpr (DEVTOOLS_DEBUG) {
             for (auto const& resource_type : resource_types->values()) {
                 if (!resource_type.is_string())
                     continue;
-                if (!first_is_one_of(resource_type.as_string(), "console-message"sv, "cookies"sv, "indexed-db"sv, "local-storage"sv, "session-storage"sv))
+                if (!first_is_one_of(resource_type.as_string(),
+                        "console-message"sv,
+                        "cookies"sv,
+                        "document-event"sv,
+                        "error-message"sv,
+                        "indexed-db"sv,
+                        "jstracer-state"sv,
+                        "jstracer-trace"sv,
+                        "local-storage"sv,
+                        "session-storage"sv,
+                        "source"sv,
+                        "thread-state"sv))
                     dbgln("Unrecognized `watchResources` resource type: '{}'", resource_type.as_string());
             }
         }
@@ -119,6 +132,18 @@ void WatcherActor::handle_message(Message const& message)
             } else if (resource_type.as_string() == "session-storage"sv) {
                 m_is_watching_session_storage_resources = true;
                 should_send_session_storage_resources = true;
+            } else if (resource_type.as_string() == "source"sv) {
+                start_watching_source_resources();
+                should_send_source_resources = true;
+            } else if (first_is_one_of(resource_type.as_string(),
+                           "document-event"sv,
+                           "error-message"sv,
+                           "jstracer-state"sv,
+                           "jstracer-trace"sv,
+                           "thread-state"sv)) {
+                // These resource types are part of Firefox's Debugger startup sequence. Ladybird either sends them from
+                // FrameActor when they happen, or does not produce them yet, so watching them only needs to opt out of
+                // Firefox's legacy listeners.
             }
         }
 
@@ -131,6 +156,8 @@ void WatcherActor::handle_message(Message const& message)
             send_storage_resource_available_message(local_storage_actor());
         if (should_send_session_storage_resources)
             send_storage_resource_available_message(session_storage_actor());
+        if (should_send_source_resources)
+            send_source_resource_available_message();
         return;
     }
 
@@ -169,11 +196,11 @@ JsonObject WatcherActor::serialize_description() const
     resources.set("css-message"sv, false);
     resources.set("css-registered-properties"sv, false);
     resources.set("document-event"sv, true);
-    resources.set("error-message"sv, false);
+    resources.set("error-message"sv, true);
     resources.set("extension-storage"sv, false);
     resources.set("indexed-db"sv, true);
-    resources.set("jstracer-state"sv, false);
-    resources.set("jstracer-trace"sv, false);
+    resources.set("jstracer-state"sv, true);
+    resources.set("jstracer-trace"sv, true);
     resources.set("last-private-context-exit"sv, false);
     resources.set("local-storage"sv, true);
     resources.set("network-event"sv, true);
@@ -182,9 +209,9 @@ JsonObject WatcherActor::serialize_description() const
     resources.set("reflow"sv, false);
     resources.set("server-sent-event"sv, false);
     resources.set("session-storage"sv, true);
-    resources.set("source"sv, false);
+    resources.set("source"sv, true);
     resources.set("stylesheet"sv, false);
-    resources.set("thread-state"sv, false);
+    resources.set("thread-state"sv, true);
     resources.set("websocket"sv, false);
 
     JsonObject description;
@@ -204,11 +231,12 @@ FrameActor& WatcherActor::create_frame_target()
     auto& console = devtools().register_actor<ConsoleActor>(m_tab);
     auto& style_sheets = devtools().register_actor<StyleSheetsActor>(m_tab);
     auto& inspector = devtools().register_actor<InspectorActor>(m_tab, style_sheets);
-    auto& thread = devtools().register_actor<ThreadActor>();
+    auto& thread = devtools().register_actor<ThreadActor>(m_tab);
     auto& accessibility = devtools().register_actor<AccessibilityActor>(m_tab);
 
     auto& target = devtools().register_actor<FrameActor>(m_tab, make_weak_ptr<WatcherActor>(), css_properties, console, inspector, style_sheets, thread, accessibility);
     m_target = target;
+    m_thread = thread;
     return target;
 }
 
@@ -240,6 +268,8 @@ void WatcherActor::switch_frame_target(FrameActor& previous_target, String const
         send_storage_resource_available_message(local_storage_actor());
     if (m_is_watching_session_storage_resources)
         send_storage_resource_available_message(session_storage_actor());
+    if (m_is_watching_source_resources)
+        send_source_resource_available_message();
 }
 
 void WatcherActor::send_frame_target_available_message(FrameActor& target)
@@ -297,6 +327,49 @@ void WatcherActor::send_cookies_resource_available_message()
     message.set("type"sv, "resources-available-array"sv);
     message.set("array"sv, move(array));
     send_message(move(message));
+}
+
+void WatcherActor::send_source_resource_available_message()
+{
+    if (auto target = m_target.strong_ref())
+        target->send_source_resource_available_message();
+}
+
+void WatcherActor::start_watching_source_resources()
+{
+    if (m_is_watching_source_resources)
+        return;
+
+    m_is_watching_source_resources = true;
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return;
+
+    devtools().delegate().listen_for_sources(tab->description(), [weak_this = make_weak_ptr<WatcherActor>()](auto source) mutable {
+        auto self = weak_this.strong_ref();
+        if (!self)
+            return;
+        self->send_source_resource_available_message(source);
+    });
+}
+
+void WatcherActor::stop_watching_source_resources()
+{
+    if (!m_is_watching_source_resources)
+        return;
+
+    m_is_watching_source_resources = false;
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return;
+
+    devtools().delegate().stop_listening_for_sources(tab->description());
+}
+
+void WatcherActor::send_source_resource_available_message(Web::HTML::ScriptRegistry::Description const& source)
+{
+    if (auto target = m_target.strong_ref())
+        target->send_source_resource_available_message(source);
 }
 
 StorageActor& WatcherActor::local_storage_actor()

--- a/Libraries/LibDevTools/Actors/WatcherActor.h
+++ b/Libraries/LibDevTools/Actors/WatcherActor.h
@@ -8,6 +8,7 @@
 
 #include <AK/NonnullRefPtr.h>
 #include <LibDevTools/Actor.h>
+#include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/Forward.h>
 
 namespace DevTools {
@@ -33,6 +34,10 @@ private:
     void send_frame_target_destroyed_message(FrameActor&);
     CookiesActor& cookies_actor();
     void send_cookies_resource_available_message();
+    void start_watching_source_resources();
+    void stop_watching_source_resources();
+    void send_source_resource_available_message();
+    void send_source_resource_available_message(Web::HTML::ScriptRegistry::Description const&);
     StorageActor& local_storage_actor();
     StorageActor& session_storage_actor();
     void send_storage_resource_available_message(StorageActor&);
@@ -45,6 +50,7 @@ private:
     WeakPtr<IndexedDBActor> m_indexed_db;
     WeakPtr<StorageActor> m_local_storage;
     WeakPtr<StorageActor> m_session_storage;
+    WeakPtr<ThreadActor> m_thread;
     WeakPtr<TargetConfigurationActor> m_target_configuration;
     WeakPtr<ThreadConfigurationActor> m_thread_configuration;
     WeakPtr<NetworkParentActor> m_network_parent;
@@ -53,6 +59,7 @@ private:
     bool m_is_watching_indexed_db_resources { false };
     bool m_is_watching_local_storage_resources { false };
     bool m_is_watching_session_storage_resources { false };
+    bool m_is_watching_source_resources { false };
 };
 
 }

--- a/Libraries/LibDevTools/CMakeLists.txt
+++ b/Libraries/LibDevTools/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     Actors/PreferenceActor.cpp
     Actors/ProcessActor.cpp
     Actors/RootActor.cpp
+    Actors/SourceActor.cpp
     Actors/StyleRuleActor.cpp
     Actors/StyleSheetsActor.cpp
     Actors/StorageActor.cpp

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -24,6 +24,7 @@
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
@@ -152,6 +153,14 @@ public:
     virtual void retrieve_style_sheet_source(TabDescription const&, Web::CSS::StyleSheetIdentifier const&) const { }
     virtual void listen_for_style_sheet_sources(TabDescription const&, OnStyleSheetSourceReceived) const { }
     virtual void stop_listening_for_style_sheet_sources(TabDescription const&) const { }
+
+    using OnSourcesReceived = Function<void(ErrorOr<Vector<Web::HTML::ScriptRegistry::Description>>)>;
+    using OnSourceReceived = Function<void(ErrorOr<Web::HTML::ScriptRegistry::Content>)>;
+    using OnSourceAvailable = Function<void(Web::HTML::ScriptRegistry::Description)>;
+    virtual void retrieve_sources(TabDescription const&, OnSourcesReceived) const { }
+    virtual void retrieve_source(TabDescription const&, Web::HTML::ScriptRegistry::Identifier, OnSourceReceived) const { }
+    virtual void listen_for_sources(TabDescription const&, OnSourceAvailable) const { }
+    virtual void stop_listening_for_sources(TabDescription const&) const { }
 
     using OnScriptEvaluationComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void evaluate_javascript(TabDescription const&, String const&, OnScriptEvaluationComplete) const { }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -147,6 +147,9 @@ public:
     virtual void clone_dom_node(TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const { }
     virtual void remove_dom_node(TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const { }
 
+    using OnResolvedURLReceived = Function<void(ErrorOr<String>)>;
+    virtual void resolve_dom_node_url(TabDescription const&, Optional<Web::UniqueNodeID>, String const&, OnResolvedURLReceived) const { }
+
     using OnStyleSheetsReceived = Function<void(ErrorOr<Vector<Web::CSS::StyleSheetIdentifier>>)>;
     using OnStyleSheetSourceReceived = Function<void(Web::CSS::StyleSheetIdentifier const&, String)>;
     virtual void retrieve_style_sheets(TabDescription const&, OnStyleSheetsReceived) const { }

--- a/Libraries/LibDevTools/Forward.h
+++ b/Libraries/LibDevTools/Forward.h
@@ -34,6 +34,7 @@ class ParentAccessibilityActor;
 class PreferenceActor;
 class ProcessActor;
 class RootActor;
+class SourceActor;
 class StyleRuleActor;
 class StyleSheetsActor;
 class StorageActor;

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -676,6 +676,7 @@ set(SOURCES
     HTML/Scripting/ModuleMap.cpp
     HTML/Scripting/ModuleScript.cpp
     HTML/Scripting/Script.cpp
+    HTML/Scripting/ScriptRegistry.cpp
     HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
     HTML/Scripting/SimilarOriginWindowAgent.cpp
     HTML/Scripting/TemporaryExecutionContext.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -30,6 +30,7 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
+#include <LibJS/SourceCode.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibURL/Origin.h>
 #include <LibURL/Parser.h>

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -45,6 +45,7 @@
 #include <LibWeb/HTML/PaintConfig.h>
 #include <LibWeb/HTML/PreloadEntry.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/InvalidateDisplayList.h>
@@ -485,6 +486,9 @@ public:
     Vector<GC::Ref<HTML::HTMLScriptElement>>& scripts_to_execute_as_soon_as_possible() { return m_scripts_to_execute_as_soon_as_possible; }
 
     Vector<GC::Ref<HTML::HTMLScriptElement>>& scripts_to_execute_in_order_as_soon_as_possible() { return m_scripts_to_execute_in_order_as_soon_as_possible; }
+
+    HTML::ScriptRegistry& script_registry() { return m_script_registry; }
+    HTML::ScriptRegistry const& script_registry() const { return m_script_registry; }
 
     QuirksMode mode() const { return m_quirks_mode; }
     bool in_quirks_mode() const { return m_quirks_mode == QuirksMode::Yes; }
@@ -1284,6 +1288,8 @@ private:
 
     // https://html.spec.whatwg.org/multipage/scripting.html#set-of-scripts-that-will-execute-as-soon-as-possible
     Vector<GC::Ref<HTML::HTMLScriptElement>> m_scripts_to_execute_as_soon_as_possible;
+
+    HTML::ScriptRegistry m_script_registry;
 
     QuirksMode m_quirks_mode { QuirksMode::No };
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -839,6 +839,7 @@ class PreloadEntry;
 struct PreloadKey;
 class PromiseRejectionEvent;
 class RadioNodeList;
+class ScriptRegistry;
 class SelectedFile;
 class SessionHistoryEntry;
 class SharedResourceRequest;

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -506,7 +506,7 @@ void HTMLScriptElement::prepare_script()
         if (m_script_type == ScriptType::Classic) {
             // 1. Let script be the result of creating a classic script using source text, settings object, base URL, and options.
             // FIXME: Pass options.
-            auto script = ClassicScript::create(m_document->url().to_byte_string(), source_text_utf8, settings_object, base_url, m_source_line_number);
+            auto script = ClassicScript::create(m_document->url().to_byte_string(), source_text_utf8, settings_object, base_url, m_source_line_number, ClassicScript::MutedErrors::No, ScriptRegistry::IsInlineSource::Yes);
 
             // 2. Mark as ready el given script.
             mark_as_ready(Result(move(script)));
@@ -529,7 +529,7 @@ void HTMLScriptElement::prepare_script()
 
             // 2. Fetch an inline module script graph, given source text, base URL, settings object, options, and with the following steps given result:
             // FIXME: Pass options
-            fetch_inline_module_script_graph(realm(), m_document->url().to_byte_string(), source_text.utf16_view(), base_url, document().relevant_settings_object(), steps);
+            fetch_inline_module_script_graph(realm(), m_document->url().to_byte_string(), source_text.utf16_view(), base_url, document().relevant_settings_object(), m_source_line_number, steps);
         }
         // -> "importmap"
         else if (m_script_type == ScriptType::ImportMap) {

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <LibCore/ElapsedTimer.h>
+#include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
@@ -18,8 +19,18 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(ClassicScript);
 
+static void register_source(ClassicScript& script, ScriptRegistry::IsInlineSource is_inline_source, size_t source_line_number)
+{
+    auto* script_record = script.script_record();
+    if (!script_record || !script_record->cached_executable())
+        return;
+
+    auto const& source_code = script_record->cached_executable()->source_code;
+    register_javascript_source(script, source_code, is_inline_source, source_line_number);
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-classic-script
-GC::Ref<ClassicScript> ClassicScript::create(ByteString filename, StringView source, EnvironmentSettingsObject& settings, URL::URL base_url, size_t source_line_number, MutedErrors muted_errors)
+GC::Ref<ClassicScript> ClassicScript::create(ByteString filename, StringView source, EnvironmentSettingsObject& settings, URL::URL base_url, size_t source_line_number, MutedErrors muted_errors, ScriptRegistry::IsInlineSource is_inline_source)
 {
     auto& vm = settings.vm();
 
@@ -68,6 +79,7 @@ GC::Ref<ClassicScript> ClassicScript::create(ByteString filename, StringView sou
 
     // 12. Set script's record to result.
     script->m_script_record = *result.release_value();
+    register_source(*script, is_inline_source, source_line_number);
 
     // 13. Return script.
     return script;
@@ -102,6 +114,7 @@ GC::Ref<ClassicScript> ClassicScript::create_from_pre_parsed(ByteString filename
     }
 
     script->m_script_record = *result.release_value();
+    register_source(*script, ScriptRegistry::IsInlineSource::No, 1);
 
     return script;
 }
@@ -135,6 +148,7 @@ GC::Ref<ClassicScript> ClassicScript::create_from_pre_compiled(ByteString filena
     }
 
     script->m_script_record = *result.release_value();
+    register_source(*script, ScriptRegistry::IsInlineSource::No, 1);
 
     return script;
 }
@@ -168,6 +182,7 @@ GC::Ref<ClassicScript> ClassicScript::create_from_bytecode_cache(ByteString file
     }
 
     script->m_script_record = *result.release_value();
+    register_source(*script, ScriptRegistry::IsInlineSource::No, 1);
 
     return script;
 }

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -25,7 +25,7 @@ public:
         No,
         Yes,
     };
-    static GC::Ref<ClassicScript> create(ByteString filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url, size_t source_line_number = 1, MutedErrors = MutedErrors::No);
+    static GC::Ref<ClassicScript> create(ByteString filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url, size_t source_line_number = 1, MutedErrors = MutedErrors::No, ScriptRegistry::IsInlineSource = ScriptRegistry::IsInlineSource::No);
     static GC::Ref<ClassicScript> create_from_pre_parsed(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::ParsedProgram* parsed, MutedErrors = MutedErrors::No);
     static GC::Ref<ClassicScript> create_from_pre_compiled(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::CompiledProgram* compiled, MutedErrors = MutedErrors::No);
     static GC::Ref<ClassicScript> create_from_bytecode_cache(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, NonnullRefPtr<JS::RustIntegration::DecodedBytecodeCache>, MutedErrors = MutedErrors::No);

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -1356,10 +1356,10 @@ void fetch_external_module_script_graph(JS::Realm& realm, URL::URL const& url, E
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-inline-module-script-graph
-void fetch_inline_module_script_graph(JS::Realm& realm, ByteString const& filename, Utf16View source_text, URL::URL const& base_url, EnvironmentSettingsObject& settings_object, OnFetchScriptComplete on_complete)
+void fetch_inline_module_script_graph(JS::Realm& realm, ByteString const& filename, Utf16View source_text, URL::URL const& base_url, EnvironmentSettingsObject& settings_object, size_t source_line_number, OnFetchScriptComplete on_complete)
 {
     // 1. Let script be the result of creating a JavaScript module script using sourceText, settingsObject, baseURL, and options.
-    auto script = ModuleScript::create_a_javascript_module_script(filename, source_text, settings_object, base_url).release_value_but_fixme_should_propagate_errors();
+    auto script = ModuleScript::create_a_javascript_module_script(filename, source_text, settings_object, base_url, source_line_number, ScriptRegistry::IsInlineSource::Yes).release_value_but_fixme_should_propagate_errors();
 
     // 2. Fetch the descendants of and link script, given settingsObject, "script", and onComplete.
     fetch_descendants_of_and_link_a_module_script(realm, *script, settings_object, Fetch::Infrastructure::Request::Destination::Script, nullptr, on_complete);

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -95,7 +95,7 @@ WebIDL::ExceptionOr<GC::Ref<ClassicScript>> fetch_a_classic_worker_imported_scri
 WEB_API WebIDL::ExceptionOr<void> fetch_module_worker_script_graph(URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, EnvironmentSettingsObject& settings_object, PerformTheFetchHook, OnFetchScriptComplete);
 WebIDL::ExceptionOr<void> fetch_worklet_module_worker_script_graph(URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, EnvironmentSettingsObject& settings_object, PerformTheFetchHook, OnFetchScriptComplete);
 void fetch_external_module_script_graph(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& settings_object, ScriptFetchOptions const&, OnFetchScriptComplete on_complete);
-void fetch_inline_module_script_graph(JS::Realm&, ByteString const& filename, Utf16View source_text, URL::URL const& base_url, EnvironmentSettingsObject& settings_object, OnFetchScriptComplete on_complete);
+void fetch_inline_module_script_graph(JS::Realm&, ByteString const& filename, Utf16View source_text, URL::URL const& base_url, EnvironmentSettingsObject& settings_object, size_t source_line_number, OnFetchScriptComplete on_complete);
 void fetch_single_imported_module_script(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, ScriptFetchOptions const&, EnvironmentSettingsObject&, Fetch::Infrastructure::Request::ReferrerType, JS::ModuleRequest const&, PerformTheFetchHook, OnFetchScriptComplete on_complete);
 
 void fetch_descendants_of_and_link_a_module_script(JS::Realm&, ModuleScript&, EnvironmentSettingsObject&, Fetch::Infrastructure::Request::Destination, PerformTheFetchHook, OnFetchScriptComplete on_complete);

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/ModuleRequest.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
@@ -21,6 +22,17 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(ModuleScript);
 
+static void register_source(ModuleScript& script, ScriptRegistry::IsInlineSource is_inline_source, size_t source_line_number)
+{
+    auto record = script.record();
+    auto* module_record = record.get_pointer<GC::Ref<JS::SourceTextModule>>();
+    if (!module_record || !(*module_record)->cached_executable())
+        return;
+
+    auto const& source_code = (*module_record)->cached_executable()->source_code;
+    register_javascript_source(script, source_code, is_inline_source, source_line_number);
+}
+
 ModuleScript::~ModuleScript() = default;
 
 ModuleScript::ModuleScript(Optional<URL::URL> base_url, ByteString filename, EnvironmentSettingsObject& settings)
@@ -29,7 +41,7 @@ ModuleScript::ModuleScript(Optional<URL::URL> base_url, ByteString filename, Env
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-javascript-module-script
-WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_a_javascript_module_script(ByteString const& filename, Utf16View source, EnvironmentSettingsObject& settings, URL::URL base_url)
+WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_a_javascript_module_script(ByteString const& filename, Utf16View source, EnvironmentSettingsObject& settings, URL::URL base_url, size_t source_line_number, ScriptRegistry::IsInlineSource is_inline_source)
 {
     auto& realm = settings.realm();
 
@@ -65,6 +77,7 @@ WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_a_javascript_mod
 
     // 9. Set script's record to result.
     script->m_record = result.value();
+    register_source(*script, is_inline_source, source_line_number);
 
     // 10. Return script.
     return script;
@@ -88,6 +101,7 @@ WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_from_pre_parsed(
     }
 
     script->m_record = result.value();
+    register_source(*script, ScriptRegistry::IsInlineSource::No, 1);
     return script;
 }
 
@@ -109,6 +123,7 @@ WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_from_pre_compile
     }
 
     script->m_record = result.value();
+    register_source(*script, ScriptRegistry::IsInlineSource::No, 1);
     return script;
 }
 
@@ -130,6 +145,7 @@ WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_from_bytecode_ca
     }
 
     script->m_record = result.value();
+    register_source(*script, ScriptRegistry::IsInlineSource::No, 1);
     return script;
 }
 

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
@@ -35,7 +35,7 @@ public:
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_from_pre_parsed(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::ParsedProgram* parsed);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_from_pre_compiled(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::CompiledProgram* compiled);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_from_bytecode_cache(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, NonnullRefPtr<JS::RustIntegration::DecodedBytecodeCache>);
-    static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_javascript_module_script(ByteString const& filename, Utf16View source, EnvironmentSettingsObject&, URL::URL base_url);
+    static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_javascript_module_script(ByteString const& filename, Utf16View source, EnvironmentSettingsObject&, URL::URL base_url, size_t source_line_number = 1, ScriptRegistry::IsInlineSource = ScriptRegistry::IsInlineSource::No);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_css_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject&);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_json_module_script(ByteString const& filename, Utf16View source, EnvironmentSettingsObject&);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_webassembly_module_script(ByteString const& filename, ByteBuffer body_bytes, EnvironmentSettingsObject&, URL::URL base_url);

--- a/Libraries/LibWeb/HTML/Scripting/Script.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Script.cpp
@@ -4,12 +4,38 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/Script.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(Script);
+
+void register_javascript_source(Script& script, NonnullRefPtr<JS::SourceCode const> source_code, ScriptRegistry::IsInlineSource is_inline_source, size_t source_line_number)
+{
+    auto document = script.settings_object().responsible_document();
+    if (!document) {
+        // FIXME: Register worker sources once DevTools can target workers.
+        return;
+    }
+
+    auto source_length = is_inline_source == ScriptRegistry::IsInlineSource::Yes
+        ? document->source().byte_count()
+        : source_code->length_in_code_units();
+
+    auto const& registered_script = document->script_registry().register_javascript_source(
+        move(source_code),
+        script.filename(),
+        "scriptElement"_string,
+        is_inline_source,
+        source_line_number,
+        source_length);
+
+    if (document->page().client().has_active_devtools_client())
+        document->page().client().page_did_register_javascript_source(*document, registered_script.description);
+}
 
 Script::Script(Optional<URL::URL> base_url, ByteString filename, EnvironmentSettingsObject& settings)
     : m_base_url(move(base_url))

--- a/Libraries/LibWeb/HTML/Scripting/Script.h
+++ b/Libraries/LibWeb/HTML/Scripting/Script.h
@@ -9,9 +9,11 @@
 #include <AK/Utf16String.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Script.h>
+#include <LibJS/SourceCode.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 
 namespace Web::HTML {
 
@@ -60,6 +62,8 @@ private:
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-error-to-rethrow
     JS::Value m_error_to_rethrow;
 };
+
+void register_javascript_source(Script&, NonnullRefPtr<JS::SourceCode const>, ScriptRegistry::IsInlineSource, size_t source_line_number);
 
 }
 

--- a/Libraries/LibWeb/HTML/Scripting/ScriptRegistry.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ScriptRegistry.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibJS/SourceCode.h>
+#include <LibURL/Parser.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
+
+namespace Web::HTML {
+
+static ScriptRegistry::Content source_content(ScriptRegistry::Script const& script)
+{
+    return script.content.visit(
+        [&](ScriptRegistry::JavaScriptSource const& js_source) -> ScriptRegistry::Content {
+            return {
+                .content_type = script.description.content_type,
+                .text = js_source.source_code->code().to_utf8(),
+            };
+        });
+}
+
+ScriptRegistry::Script const& ScriptRegistry::register_javascript_source(NonnullRefPtr<JS::SourceCode const> source_code, ByteString const& filename, String introduction_type, IsInlineSource is_inline_source, size_t source_line_number, size_t source_length)
+{
+    // FIXME: Support WebAssembly sources once WebAssembly modules retain their original binary module bytes.
+    // FIXME: Register worker sources when DevTools can target workers.
+    auto parsed_url = URL::Parser::basic_parse(filename);
+    auto id = m_next_script_id++;
+    auto is_inline = is_inline_source == IsInlineSource::Yes;
+    m_scripts.set(id, {
+                          .description = {
+                              .id = { .document_id = {}, .script_id = id },
+                              .url = move(parsed_url),
+                              .display_url = String::from_utf8_with_replacement_character(filename),
+                              .introduction_type = move(introduction_type),
+                              .content_type = is_inline ? "text/html"_string : "text/javascript"_string,
+                              .is_inline_source = is_inline,
+                              .source_start_line = static_cast<u32>(source_line_number),
+                              .source_start_column = 0,
+                              .source_length = source_length,
+                          },
+                          .content = ContentHandle { JavaScriptSource { move(source_code) } },
+                      });
+
+    return m_scripts.find(id)->value;
+}
+
+Optional<ScriptRegistry::Content> ScriptRegistry::script_content(u64 script_id, String const& document_source) const
+{
+    auto script = m_scripts.find(script_id);
+    if (script == m_scripts.end())
+        return {};
+
+    if (script->value.description.is_inline_source && !document_source.is_empty()) {
+        return Content { .content_type = script->value.description.content_type, .text = document_source };
+    }
+
+    return source_content(script->value);
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::ScriptRegistry::Identifier const& identifier)
+{
+    TRY(encoder.encode(identifier.document_id));
+    TRY(encoder.encode(identifier.script_id));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::ScriptRegistry::Identifier> decode(Decoder& decoder)
+{
+    auto document_id = TRY(decoder.decode<Web::UniqueNodeID>());
+    auto script_id = TRY(decoder.decode<u64>());
+
+    return Web::HTML::ScriptRegistry::Identifier {
+        .document_id = document_id,
+        .script_id = script_id,
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::ScriptRegistry::Description const& source)
+{
+    TRY(encoder.encode(source.id));
+    TRY(encoder.encode(source.url));
+    TRY(encoder.encode(source.display_url));
+    TRY(encoder.encode(source.introduction_type));
+    TRY(encoder.encode(source.content_type));
+    TRY(encoder.encode(source.is_inline_source));
+    TRY(encoder.encode(source.source_start_line));
+    TRY(encoder.encode(source.source_start_column));
+    TRY(encoder.encode(source.source_length));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::ScriptRegistry::Description> decode(Decoder& decoder)
+{
+    auto id = TRY(decoder.decode<Web::HTML::ScriptRegistry::Identifier>());
+    auto url = TRY(decoder.decode<Optional<URL::URL>>());
+    auto display_url = TRY(decoder.decode<String>());
+    auto introduction_type = TRY(decoder.decode<String>());
+    auto content_type = TRY(decoder.decode<String>());
+    auto is_inline_source = TRY(decoder.decode<bool>());
+    auto source_start_line = TRY(decoder.decode<u32>());
+    auto source_start_column = TRY(decoder.decode<u32>());
+    auto source_length = TRY(decoder.decode<size_t>());
+
+    return Web::HTML::ScriptRegistry::Description {
+        .id = id,
+        .url = move(url),
+        .display_url = move(display_url),
+        .introduction_type = move(introduction_type),
+        .content_type = move(content_type),
+        .is_inline_source = is_inline_source,
+        .source_start_line = source_start_line,
+        .source_start_column = source_start_column,
+        .source_length = source_length,
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::ScriptRegistry::Content const& source_content)
+{
+    TRY(encoder.encode(source_content.content_type));
+    TRY(encoder.encode(source_content.text));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::ScriptRegistry::Content> decode(Decoder& decoder)
+{
+    auto content_type = TRY(decoder.decode<String>());
+    auto text = TRY(decoder.decode<String>());
+
+    return Web::HTML::ScriptRegistry::Content {
+        .content_type = move(content_type),
+        .text = move(text),
+    };
+}
+
+}

--- a/Libraries/LibWeb/HTML/Scripting/ScriptRegistry.h
+++ b/Libraries/LibWeb/HTML/Scripting/ScriptRegistry.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <AK/HashFunctions.h>
+#include <AK/HashMap.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/Types.h>
+#include <AK/Variant.h>
+#include <LibIPC/Forward.h>
+#include <LibJS/Forward.h>
+#include <LibURL/URL.h>
+#include <LibWeb/Export.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::HTML {
+
+class WEB_API ScriptRegistry {
+public:
+    struct Content {
+        String content_type;
+        String text;
+    };
+
+    struct Identifier {
+        UniqueNodeID document_id;
+        u64 script_id { 0 };
+
+        bool operator==(Identifier const&) const = default;
+    };
+
+    struct Description {
+        Identifier id;
+        Optional<URL::URL> url;
+        String display_url;
+        String introduction_type;
+        String content_type;
+        bool is_inline_source { false };
+        u32 source_start_line { 1 };
+        u32 source_start_column { 0 };
+        size_t source_length { 0 };
+    };
+
+    struct JavaScriptSource {
+        NonnullRefPtr<JS::SourceCode const> source_code;
+    };
+
+    using ContentHandle = Variant<JavaScriptSource>;
+
+    enum class IsInlineSource : u8 {
+        No,
+        Yes,
+    };
+
+    struct Script {
+        Description description;
+        ContentHandle content;
+    };
+
+    Script const& register_javascript_source(NonnullRefPtr<JS::SourceCode const>, ByteString const& filename, String introduction_type, IsInlineSource, size_t source_line_number, size_t source_length);
+
+    OrderedHashMap<u64, Script> const& scripts() const { return m_scripts; }
+    Optional<Content> script_content(u64 script_id, String const& document_source) const;
+
+private:
+    OrderedHashMap<u64, Script> m_scripts;
+    u64 m_next_script_id { 1 };
+};
+
+}
+
+template<>
+struct AK::Traits<Web::HTML::ScriptRegistry::Identifier> : public AK::DefaultTraits<Web::HTML::ScriptRegistry::Identifier> {
+    static bool equals(Web::HTML::ScriptRegistry::Identifier const& lhs, Web::HTML::ScriptRegistry::Identifier const& rhs)
+    {
+        return lhs == rhs;
+    }
+
+    static unsigned hash(Web::HTML::ScriptRegistry::Identifier const& identifier)
+    {
+        return pair_int_hash(identifier.document_id.value(), identifier.script_id);
+    }
+};
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::ScriptRegistry::Identifier const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::ScriptRegistry::Identifier> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::ScriptRegistry::Description const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::ScriptRegistry::Description> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::ScriptRegistry::Content const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::ScriptRegistry::Content> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -44,6 +44,7 @@
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/POSTResource.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/TokenizedFeatures.h>
@@ -551,6 +552,7 @@ public:
     virtual void page_did_receive_network_response_body([[maybe_unused]] u64 request_id, [[maybe_unused]] ReadonlyBytes data) { }
     virtual void page_did_finish_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] u64 body_size, [[maybe_unused]] Requests::RequestTimingInfo const& timing_info, [[maybe_unused]] Optional<Requests::NetworkError> const& network_error) { }
     virtual void page_did_report_worker_exception([[maybe_unused]] String const& message, [[maybe_unused]] String const& filename, [[maybe_unused]] u32 lineno, [[maybe_unused]] u32 colno) { }
+    virtual void page_did_register_javascript_source([[maybe_unused]] DOM::Document&, [[maybe_unused]] HTML::ScriptRegistry::Description const&) { }
     virtual void page_did_post_broadcast_channel_message([[maybe_unused]] HTML::BroadcastChannelMessage const& message) { }
 
     virtual HTML::WorkerAgentId start_worker_agent([[maybe_unused]] HTML::WorkerAgentStartRequest&& request) { return {}; }

--- a/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -159,7 +159,7 @@ void SVGScriptElement::process_the_script_element()
     // 3. The 'script' element's "already processed" flag is set to true.
     m_already_processed = true;
     m_script = HTML::ClassicScript::create(m_document->url().basename(), script_content,
-        HTML::relevant_settings_object(*this), m_document->base_url(), m_source_line_number);
+        HTML::relevant_settings_object(*this), m_document->base_url(), m_source_line_number, HTML::ClassicScript::MutedErrors::No, HTML::ScriptRegistry::IsInlineSource::Yes);
     execute_script();
 }
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -2394,6 +2394,57 @@ void Application::stop_listening_for_style_sheet_sources(DevTools::TabDescriptio
     view->on_received_style_sheet_source = nullptr;
 }
 
+void Application::retrieve_sources(DevTools::TabDescription const& description, OnSourcesReceived on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    view->retrieve_devtools_sources(move(on_complete));
+}
+
+void Application::retrieve_source(DevTools::TabDescription const& description, Web::HTML::ScriptRegistry::Identifier source_id, OnSourceReceived on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    view->on_received_devtools_source.set(source_id, [on_complete = move(on_complete)](Optional<Web::HTML::ScriptRegistry::Content> source) {
+        if (!source.has_value()) {
+            on_complete(Error::from_string_literal("Unable to locate source"));
+            return;
+        }
+
+        on_complete(source.release_value());
+    });
+
+    view->request_devtools_source(source_id);
+}
+
+void Application::listen_for_sources(DevTools::TabDescription const& description, OnSourceAvailable on_source_available) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    view->on_devtools_source_available = [on_source_available = move(on_source_available)](Web::HTML::ScriptRegistry::Description source) {
+        on_source_available(move(source));
+    };
+}
+
+void Application::stop_listening_for_sources(DevTools::TabDescription const& description) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    view->on_devtools_source_available = nullptr;
+}
+
 void Application::evaluate_javascript(DevTools::TabDescription const& description, String const& script, OnScriptEvaluationComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -2445,6 +2445,17 @@ void Application::stop_listening_for_sources(DevTools::TabDescription const& des
     view->on_devtools_source_available = nullptr;
 }
 
+void Application::resolve_dom_node_url(DevTools::TabDescription const& description, Optional<Web::UniqueNodeID> node_id, String const& url, OnResolvedURLReceived on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(url);
+        return;
+    }
+
+    view->resolve_dom_node_url(node_id, url, move(on_complete));
+}
+
 void Application::evaluate_javascript(DevTools::TabDescription const& description, String const& script, OnScriptEvaluationComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -325,6 +325,10 @@ private:
     virtual void retrieve_style_sheet_source(DevTools::TabDescription const&, Web::CSS::StyleSheetIdentifier const&) const override;
     virtual void listen_for_style_sheet_sources(DevTools::TabDescription const&, OnStyleSheetSourceReceived) const override;
     virtual void stop_listening_for_style_sheet_sources(DevTools::TabDescription const&) const override;
+    virtual void retrieve_sources(DevTools::TabDescription const&, OnSourcesReceived) const override;
+    virtual void retrieve_source(DevTools::TabDescription const&, Web::HTML::ScriptRegistry::Identifier, OnSourceReceived) const override;
+    virtual void listen_for_sources(DevTools::TabDescription const&, OnSourceAvailable) const override;
+    virtual void stop_listening_for_sources(DevTools::TabDescription const&) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String const&, OnScriptEvaluationComplete) const override;
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessage) const override;
     virtual void stop_listening_for_console_messages(DevTools::TabDescription const&) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -329,6 +329,7 @@ private:
     virtual void retrieve_source(DevTools::TabDescription const&, Web::HTML::ScriptRegistry::Identifier, OnSourceReceived) const override;
     virtual void listen_for_sources(DevTools::TabDescription const&, OnSourceAvailable) const override;
     virtual void stop_listening_for_sources(DevTools::TabDescription const&) const override;
+    virtual void resolve_dom_node_url(DevTools::TabDescription const&, Optional<Web::UniqueNodeID>, String const&, OnResolvedURLReceived) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String const&, OnScriptEvaluationComplete) const override;
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessage) const override;
     virtual void stop_listening_for_console_messages(DevTools::TabDescription const&) const override;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1017,6 +1017,18 @@ void ViewImplementation::did_receive_indexed_database_inspection(u64 request_id,
     (*callback)(move(result));
 }
 
+void ViewImplementation::retrieve_devtools_sources(DevTools::DevToolsDelegate::OnSourcesReceived on_complete)
+{
+    auto request_id = m_next_devtools_sources_request_id++;
+    on_received_devtools_sources.set(request_id, move(on_complete));
+    client().async_list_devtools_sources(page_id(), request_id);
+}
+
+void ViewImplementation::request_devtools_source(Web::HTML::ScriptRegistry::Identifier const& source_id)
+{
+    client().async_request_devtools_source(page_id(), source_id);
+}
+
 void ViewImplementation::clear_inspected_dom_node()
 {
     client().async_clear_inspected_dom_node(page_id());

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1029,6 +1029,13 @@ void ViewImplementation::request_devtools_source(Web::HTML::ScriptRegistry::Iden
     client().async_request_devtools_source(page_id(), source_id);
 }
 
+void ViewImplementation::resolve_dom_node_url(Optional<Web::UniqueNodeID> node_id, String const& url, DevTools::DevToolsDelegate::OnResolvedURLReceived on_complete)
+{
+    auto request_id = m_next_resolve_dom_node_url_request_id++;
+    on_resolved_dom_node_url.set(request_id, move(on_complete));
+    client().async_resolve_dom_node_url(page_id(), request_id, node_id, url);
+}
+
 void ViewImplementation::clear_inspected_dom_node()
 {
     client().async_clear_inspected_dom_node(page_id());

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -37,6 +37,7 @@
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
@@ -186,6 +187,8 @@ public:
     void inspect_grid_layouts(Web::UniqueNodeID root_node_id);
     void inspect_current_grid(Web::UniqueNodeID node_id);
     void inspect_current_flexbox(Web::UniqueNodeID node_id, bool only_look_at_parents);
+    void retrieve_devtools_sources(DevTools::DevToolsDelegate::OnSourcesReceived);
+    void request_devtools_source(Web::HTML::ScriptRegistry::Identifier const&);
     void clear_inspected_dom_node();
 
     void highlight_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element);
@@ -330,6 +333,9 @@ public:
     Function<void(String)> on_received_dom_node_html;
     Function<void(Vector<Web::CSS::StyleSheetIdentifier>)> on_received_style_sheet_list;
     Function<void(Web::CSS::StyleSheetIdentifier const&, URL::URL const&, String const&)> on_received_style_sheet_source;
+    HashMap<u64, DevTools::DevToolsDelegate::OnSourcesReceived> on_received_devtools_sources;
+    HashMap<Web::HTML::ScriptRegistry::Identifier, Function<void(Optional<Web::HTML::ScriptRegistry::Content>)>> on_received_devtools_source;
+    Function<void(Web::HTML::ScriptRegistry::Description)> on_devtools_source_available;
     Function<void(JsonValue)> on_received_js_console_result;
     Function<void(ConsoleOutput)> on_console_message;
     Function<void(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ByteBuffer, Optional<String>)> on_network_request_started;
@@ -615,6 +621,7 @@ protected:
 
     HashMap<u64, DevTools::DevToolsDelegate::OnStorageChange> m_storage_change_listeners;
     u64 m_next_storage_change_listener_id { 1 };
+    u64 m_next_devtools_sources_request_id { 1 };
 
     HashMap<u64, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete> m_pending_indexed_database_inspection_requests;
     u64 m_next_indexed_database_inspection_request_id { 1 };

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -189,6 +189,7 @@ public:
     void inspect_current_flexbox(Web::UniqueNodeID node_id, bool only_look_at_parents);
     void retrieve_devtools_sources(DevTools::DevToolsDelegate::OnSourcesReceived);
     void request_devtools_source(Web::HTML::ScriptRegistry::Identifier const&);
+    void resolve_dom_node_url(Optional<Web::UniqueNodeID> node_id, String const& url, DevTools::DevToolsDelegate::OnResolvedURLReceived);
     void clear_inspected_dom_node();
 
     void highlight_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::PseudoElement> pseudo_element);
@@ -335,6 +336,7 @@ public:
     Function<void(Web::CSS::StyleSheetIdentifier const&, URL::URL const&, String const&)> on_received_style_sheet_source;
     HashMap<u64, DevTools::DevToolsDelegate::OnSourcesReceived> on_received_devtools_sources;
     HashMap<Web::HTML::ScriptRegistry::Identifier, Function<void(Optional<Web::HTML::ScriptRegistry::Content>)>> on_received_devtools_source;
+    HashMap<u64, DevTools::DevToolsDelegate::OnResolvedURLReceived> on_resolved_dom_node_url;
     Function<void(Web::HTML::ScriptRegistry::Description)> on_devtools_source_available;
     Function<void(JsonValue)> on_received_js_console_result;
     Function<void(ConsoleOutput)> on_console_message;
@@ -622,6 +624,7 @@ protected:
     HashMap<u64, DevTools::DevToolsDelegate::OnStorageChange> m_storage_change_listeners;
     u64 m_next_storage_change_listener_id { 1 };
     u64 m_next_devtools_sources_request_id { 1 };
+    u64 m_next_resolve_dom_node_url_request_id { 1 };
 
     HashMap<u64, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete> m_pending_indexed_database_inspection_requests;
     u64 m_next_indexed_database_inspection_request_id { 1 };

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -846,6 +846,32 @@ void WebContentClient::did_get_style_sheet_source(u64 page_id, Web::CSS::StyleSh
     }
 }
 
+void WebContentClient::did_list_devtools_sources(u64 page_id, u64 request_id, Vector<Web::HTML::ScriptRegistry::Description> sources)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        auto handler = view->on_received_devtools_sources.take(request_id);
+        if (handler.has_value())
+            (*handler)(move(sources));
+    }
+}
+
+void WebContentClient::did_get_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id, Optional<Web::HTML::ScriptRegistry::Content> source)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        auto handler = view->on_received_devtools_source.take(source_id);
+        if (handler.has_value())
+            (*handler)(move(source));
+    }
+}
+
+void WebContentClient::did_add_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Description source)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_devtools_source_available)
+            view->on_devtools_source_available(move(source));
+    }
+}
+
 void WebContentClient::did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -872,6 +872,15 @@ void WebContentClient::did_add_devtools_source(u64 page_id, Web::HTML::ScriptReg
     }
 }
 
+void WebContentClient::did_resolve_dom_node_url(u64 page_id, u64 request_id, String resolved_url)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        auto handler = view->on_resolved_dom_node_url.take(request_id);
+        if (handler.has_value())
+            (*handler)(move(resolved_url));
+    }
+}
+
 void WebContentClient::did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -140,6 +140,7 @@ private:
     virtual void did_list_devtools_sources(u64 page_id, u64 request_id, Vector<Web::HTML::ScriptRegistry::Description> sources) override;
     virtual void did_get_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id, Optional<Web::HTML::ScriptRegistry::Content> source) override;
     virtual void did_add_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Description source) override;
+    virtual void did_resolve_dom_node_url(u64 page_id, u64 request_id, String resolved_url) override;
     virtual void did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) override;
     virtual void did_get_internal_page_info(u64 page_id, PageInfoType, Optional<Core::AnonymousBuffer>) override;
     virtual void did_execute_js_console_input(u64 page_id, JsonValue) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -28,6 +28,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/WebViewHints.h>
@@ -136,6 +137,9 @@ private:
     virtual void did_get_dom_node_html(u64 page_id, String html) override;
     virtual void did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> stylesheets) override;
     virtual void did_get_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier, URL::URL, String source) override;
+    virtual void did_list_devtools_sources(u64 page_id, u64 request_id, Vector<Web::HTML::ScriptRegistry::Description> sources) override;
+    virtual void did_get_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id, Optional<Web::HTML::ScriptRegistry::Content> source) override;
+    virtual void did_add_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Description source) override;
     virtual void did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) override;
     virtual void did_get_internal_page_info(u64 page_id, PageInfoType, Optional<Core::AnonymousBuffer>) override;
     virtual void did_execute_js_console_input(u64 page_id, JsonValue) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -41,6 +41,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ElementFactory.h>
+#include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Dump.h>
@@ -1549,6 +1550,35 @@ void ConnectionFromClient::request_devtools_source(u64 page_id, Web::HTML::Scrip
         return;
 
     async_did_get_devtools_source(page_id, source_id, page->devtools_source_content(source_id));
+}
+
+void ConnectionFromClient::resolve_dom_node_url(u64 page_id, u64 request_id, Optional<Web::UniqueNodeID> node_id, String url)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value()) {
+        async_did_resolve_dom_node_url(page_id, request_id, move(url));
+        return;
+    }
+
+    auto* document = [&]() -> Web::DOM::Document* {
+        if (node_id.has_value()) {
+            if (auto* node = Web::DOM::Node::from_unique_id(*node_id))
+                return &node->document();
+            return nullptr;
+        }
+
+        return page->page().top_level_browsing_context().active_document();
+    }();
+
+    auto resolved_url = document
+        ? document->encoding_parse_url(url)
+              .map([](auto const& parsed_url) {
+                  return parsed_url.serialize();
+              })
+              .value_or(url)
+        : url;
+
+    async_did_resolve_dom_node_url(page_id, request_id, move(resolved_url));
 }
 
 void ConnectionFromClient::set_listen_for_dom_mutations(u64 page_id, bool listen_for_dom_mutations)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1533,6 +1533,24 @@ void ConnectionFromClient::request_style_sheet_source(u64 page_id, Web::CSS::Sty
     }
 }
 
+void ConnectionFromClient::list_devtools_sources(u64 page_id, u64 request_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    async_did_list_devtools_sources(page_id, request_id, page->list_devtools_sources());
+}
+
+void ConnectionFromClient::request_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    async_did_get_devtools_source(page_id, source_id, page->devtools_source_content(source_id));
+}
+
 void ConnectionFromClient::set_listen_for_dom_mutations(u64 page_id, bool listen_for_dom_mutations)
 {
     auto page = this->page(page_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -128,6 +128,8 @@ private:
 
     virtual void list_style_sheets(u64 page_id) override;
     virtual void request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier) override;
+    virtual void list_devtools_sources(u64 page_id, u64 request_id) override;
+    virtual void request_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id) override;
 
     virtual void set_listen_for_dom_mutations(u64 page_id, bool) override;
     virtual void did_connect_devtools_client(u64 page_id) override;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -130,6 +130,7 @@ private:
     virtual void request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier) override;
     virtual void list_devtools_sources(u64 page_id, u64 request_id) override;
     virtual void request_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id) override;
+    virtual void resolve_dom_node_url(u64 page_id, u64 request_id, Optional<Web::UniqueNodeID> node_id, String url) override;
 
     virtual void set_listen_for_dom_mutations(u64 page_id, bool) override;
     virtual void did_connect_devtools_client(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -28,6 +28,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/MutationType.h>
+#include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
@@ -1240,6 +1241,56 @@ Vector<Web::CSS::StyleSheetIdentifier> PageClient::list_style_sheets() const
     });
 
     return results;
+}
+
+static Web::HTML::ScriptRegistry::Description exported_devtools_source_description(Web::DOM::Document const& document, Web::HTML::ScriptRegistry::Description description)
+{
+    description.id.document_id = document.unique_id();
+    return description;
+}
+
+static void append_devtools_sources_for_document(Vector<Web::HTML::ScriptRegistry::Description>& results, Web::DOM::Document const& document)
+{
+    for (auto const& source : document.script_registry().scripts()) {
+        auto description = exported_devtools_source_description(document, source.value.description);
+        results.append(move(description));
+    }
+
+    for (auto const& navigable : document.descendant_navigables()) {
+        auto content_document = navigable->active_document();
+        if (!content_document)
+            continue;
+        append_devtools_sources_for_document(results, *content_document);
+    }
+}
+
+Vector<Web::HTML::ScriptRegistry::Description> PageClient::list_devtools_sources() const
+{
+    Vector<Web::HTML::ScriptRegistry::Description> results;
+
+    auto const* document = page().top_level_browsing_context().active_document();
+    if (document)
+        append_devtools_sources_for_document(results, *document);
+
+    return results;
+}
+
+Optional<Web::HTML::ScriptRegistry::Content> PageClient::devtools_source_content(Web::HTML::ScriptRegistry::Identifier const& source_id) const
+{
+    auto* node = Web::DOM::Node::from_unique_id(source_id.document_id);
+    auto* document = as_if<Web::DOM::Document>(node);
+    if (!document)
+        return {};
+
+    return document->script_registry().script_content(source_id.script_id, document->source());
+}
+
+void PageClient::page_did_register_javascript_source(Web::DOM::Document& document, Web::HTML::ScriptRegistry::Description const& source)
+{
+    if (!has_devtools_client())
+        return;
+
+    client().async_did_add_devtools_source(m_id, exported_devtools_source_description(document, source));
 }
 
 void PageClient::ensure_compositor_host()

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
@@ -111,6 +112,8 @@ public:
     void console_peer_did_misbehave(char const* reason);
 
     Vector<Web::CSS::StyleSheetIdentifier> list_style_sheets() const;
+    Vector<Web::HTML::ScriptRegistry::Description> list_devtools_sources() const;
+    Optional<Web::HTML::ScriptRegistry::Content> devtools_source_content(Web::HTML::ScriptRegistry::Identifier const&) const;
 
     virtual double zoom_level() const override { return m_zoom_level; }
     virtual double device_pixel_ratio() const override { return m_device_pixel_ratio; }
@@ -242,6 +245,7 @@ private:
     virtual void page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String>, Vector<HTTP::Header> const&) override;
     virtual void page_did_receive_network_response_body(u64 request_id, ReadonlyBytes) override;
     virtual void page_did_finish_network_request(u64 request_id, u64 body_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const&) override;
+    virtual void page_did_register_javascript_source(Web::DOM::Document&, Web::HTML::ScriptRegistry::Description const&) override;
     virtual void page_did_post_broadcast_channel_message(Web::HTML::BroadcastChannelMessage const&) override;
 
     void setup_palette();

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -92,6 +92,7 @@ endpoint WebContentClient
     did_list_devtools_sources(u64 page_id, u64 request_id, Vector<Web::HTML::ScriptRegistry::Description> sources) =|
     did_get_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id, Optional<Web::HTML::ScriptRegistry::Content> source) =|
     did_add_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Description source) =|
+    did_resolve_dom_node_url(u64 page_id, u64 request_id, String resolved_url) =|
 
     did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) =|
 

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -27,6 +27,7 @@
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
 #include <LibWeb/Page/EventResult.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/WebDriver/Response.h>
 #include <LibWebView/Attribute.h>
@@ -88,6 +89,9 @@ endpoint WebContentClient
 
     did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> style_sheets) =|
     did_get_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier, URL::URL base_url, String source) =|
+    did_list_devtools_sources(u64 page_id, u64 request_id, Vector<Web::HTML::ScriptRegistry::Description> sources) =|
+    did_get_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id, Optional<Web::HTML::ScriptRegistry::Content> source) =|
+    did_add_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Description source) =|
 
     did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) =|
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -105,6 +105,7 @@ endpoint WebContentServer
     request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier) =|
     list_devtools_sources(u64 page_id, u64 request_id) =|
     request_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id) =|
+    resolve_dom_node_url(u64 page_id, u64 request_id, Optional<Web::UniqueNodeID> node_id, String url) =|
 
     set_listen_for_dom_mutations(u64 page_id, bool listen_for_dom_mutations) =|
     did_connect_devtools_client(u64 page_id) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -19,6 +19,7 @@
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
@@ -102,6 +103,8 @@ endpoint WebContentServer
 
     list_style_sheets(u64 page_id) =|
     request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier) =|
+    list_devtools_sources(u64 page_id, u64 request_id) =|
+    request_devtools_source(u64 page_id, Web::HTML::ScriptRegistry::Identifier source_id) =|
 
     set_listen_for_dom_mutations(u64 page_id, bool listen_for_dom_mutations) =|
     did_connect_devtools_client(u64 page_id) =|

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1172,6 +1172,14 @@ public:
         on_source_available = nullptr;
     }
 
+    virtual void resolve_dom_node_url(DevTools::TabDescription const&, Optional<Web::UniqueNodeID> node_id, String const& url, OnResolvedURLReceived callback) const override
+    {
+        ++resolve_dom_node_url_call_count;
+        last_resolved_url_node = node_id;
+        last_url_to_resolve = url;
+        callback(resolved_dom_node_url);
+    }
+
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessage callback) const override
     {
         ++listen_for_console_messages_call_count;
@@ -1456,6 +1464,7 @@ public:
     mutable size_t listen_for_sources_call_count { 0 };
     mutable size_t stop_listening_for_sources_call_count { 0 };
     mutable DevTools::DevToolsDelegate::OnSourceAvailable on_source_available;
+    mutable size_t resolve_dom_node_url_call_count { 0 };
     mutable size_t listen_for_console_messages_call_count { 0 };
     mutable size_t stop_listening_for_console_messages_call_count { 0 };
     mutable size_t listen_for_network_events_call_count { 0 };
@@ -1491,6 +1500,9 @@ public:
     mutable Optional<String> last_tag;
     mutable Optional<String> last_attribute;
     mutable size_t last_attribute_count { 0 };
+    mutable Optional<Web::UniqueNodeID> last_resolved_url_node;
+    mutable Optional<String> last_url_to_resolve;
+    mutable String resolved_dom_node_url { "https://example.test/scripts/app.js"_string };
     mutable Optional<String> last_navigated_url;
     mutable Optional<bool> last_reload_bypass_cache;
     mutable Optional<int> last_history_delta;
@@ -3571,6 +3583,43 @@ TEST_CASE(inspector_walker_navigation_reloads_root)
     EXPECT_EQ(session->delegate.stop_listening_for_navigation_events_call_count, 2u);
     EXPECT_EQ(session->delegate.did_connect_devtools_client_call_count, 1u);
     EXPECT_EQ(session->delegate.did_disconnect_devtools_client_call_count, 0u);
+}
+
+TEST_CASE(inspector_resolves_relative_urls)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto target = get_frame_target(client, actor_from(get_tab(client), "actor"sv));
+    auto inspector_actor = actor_from(target, "inspectorActor"sv);
+    auto walker = get_walker(client, inspector_actor);
+    auto walker_actor = actor_from(walker, "actor"sv);
+    auto root_node_actor = walker.get_object("root"sv)->get_string("actor"sv).release_value();
+    auto div_actor = query_selector(client, walker_actor, root_node_actor, "div"sv);
+
+    JsonObject resolve_with_node;
+    resolve_with_node.set("to"sv, inspector_actor);
+    resolve_with_node.set("type"sv, "resolveRelativeURL"sv);
+    resolve_with_node.set("url"sv, "scripts/app.js"sv);
+    resolve_with_node.set("node"sv, div_actor);
+
+    EXPECT_EQ(client.request(move(resolve_with_node)).get_string("value"sv).value(), "https://example.test/scripts/app.js"sv);
+    EXPECT_EQ(session->delegate.resolve_dom_node_url_call_count, 1u);
+    EXPECT_EQ(session->delegate.last_resolved_url_node.value(), 4u);
+    EXPECT_EQ(session->delegate.last_url_to_resolve.value(), "scripts/app.js"sv);
+
+    session->delegate.resolved_dom_node_url = "https://example.test/fallback.js"_string;
+
+    JsonObject resolve_without_node;
+    resolve_without_node.set("to"sv, inspector_actor);
+    resolve_without_node.set("type"sv, "resolveRelativeURL"sv);
+    resolve_without_node.set("url"sv, "fallback.js"sv);
+
+    EXPECT_EQ(client.request(move(resolve_without_node)).get_string("value"sv).value(), "https://example.test/fallback.js"sv);
+    EXPECT_EQ(session->delegate.resolve_dom_node_url_call_count, 2u);
+    EXPECT(!session->delegate.last_resolved_url_node.has_value());
+    EXPECT_EQ(session->delegate.last_url_to_resolve.value(), "fallback.js"sv);
 }
 
 TEST_CASE(inspector_walker_highlighter_layout_and_editing)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1132,6 +1132,46 @@ public:
 
     virtual void stop_listening_for_style_sheet_sources(DevTools::TabDescription const&) const override { ++stop_listening_for_style_sheet_sources_call_count; }
 
+    virtual void retrieve_sources(DevTools::TabDescription const&, OnSourcesReceived callback) const override
+    {
+        ++retrieve_sources_call_count;
+        callback(Vector<Web::HTML::ScriptRegistry::Description> { fixture_source });
+    }
+
+    virtual void retrieve_source(DevTools::TabDescription const&, Web::HTML::ScriptRegistry::Identifier source_id, OnSourceReceived callback) const override
+    {
+        ++retrieve_source_call_count;
+        if (source_id == fixture_live_source.id) {
+            callback(Web::HTML::ScriptRegistry::Content {
+                .content_type = fixture_live_source.content_type,
+                .text = "console.log('live source');"_string,
+            });
+            return;
+        }
+
+        if (source_id != fixture_source.id) {
+            callback(Error::from_string_literal("Source not found"));
+            return;
+        }
+
+        callback(Web::HTML::ScriptRegistry::Content {
+            .content_type = fixture_source.content_type,
+            .text = "console.log('hello from source');"_string,
+        });
+    }
+
+    virtual void listen_for_sources(DevTools::TabDescription const&, OnSourceAvailable callback) const override
+    {
+        ++listen_for_sources_call_count;
+        on_source_available = move(callback);
+    }
+
+    virtual void stop_listening_for_sources(DevTools::TabDescription const&) const override
+    {
+        ++stop_listening_for_sources_call_count;
+        on_source_available = nullptr;
+    }
+
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessage callback) const override
     {
         ++listen_for_console_messages_call_count;
@@ -1327,6 +1367,28 @@ public:
     mutable Vector<HTTP::Cookie::Cookie> fixture_cookies;
     mutable Vector<DevTools::DevToolsDelegate::StorageItem> fixture_local_storage_items;
     mutable Vector<DevTools::DevToolsDelegate::StorageItem> fixture_session_storage_items;
+    mutable Web::HTML::ScriptRegistry::Description fixture_source {
+        .id = { .document_id = 1, .script_id = 1 },
+        .url = {},
+        .display_url = "https://example.test/app.js"_string,
+        .introduction_type = "scriptElement"_string,
+        .content_type = "text/javascript"_string,
+        .is_inline_source = false,
+        .source_start_line = 1,
+        .source_start_column = 0,
+        .source_length = 33,
+    };
+    mutable Web::HTML::ScriptRegistry::Description fixture_live_source {
+        .id = { .document_id = 1, .script_id = 2 },
+        .url = {},
+        .display_url = "https://example.test/live.js"_string,
+        .introduction_type = "scriptElement"_string,
+        .content_type = "text/javascript"_string,
+        .is_inline_source = false,
+        .source_start_line = 1,
+        .source_start_column = 0,
+        .source_length = 31,
+    };
 
     mutable size_t inspect_tab_call_count { 0 };
     mutable size_t cookies_call_count { 0 };
@@ -1389,6 +1451,11 @@ public:
     mutable size_t retrieve_style_sheet_source_call_count { 0 };
     mutable size_t listen_for_style_sheet_sources_call_count { 0 };
     mutable size_t stop_listening_for_style_sheet_sources_call_count { 0 };
+    mutable size_t retrieve_sources_call_count { 0 };
+    mutable size_t retrieve_source_call_count { 0 };
+    mutable size_t listen_for_sources_call_count { 0 };
+    mutable size_t stop_listening_for_sources_call_count { 0 };
+    mutable DevTools::DevToolsDelegate::OnSourceAvailable on_source_available;
     mutable size_t listen_for_console_messages_call_count { 0 };
     mutable size_t stop_listening_for_console_messages_call_count { 0 };
     mutable size_t listen_for_network_events_call_count { 0 };
@@ -1638,6 +1705,16 @@ static size_t style_rule_actor_count(DevTools::DevToolsServer const& server)
     return count;
 }
 
+static size_t source_actor_count(DevTools::DevToolsServer const& server)
+{
+    size_t count = 0;
+    for (auto const& actor : server.actor_registry()) {
+        if (actor.key.bytes_as_string_view().contains("-source"sv))
+            ++count;
+    }
+    return count;
+}
+
 static JsonObject get_frame_target(ProtocolClient& client, StringView tab_actor)
 {
     auto watcher_actor = actor_from(client.request(tab_actor, "getWatcher"sv), "actor"sv);
@@ -1671,7 +1748,7 @@ static String query_selector(ProtocolClient& client, StringView walker_actor, St
     return client.request(move(request)).get_object("node"sv)->get_string("actor"sv).release_value();
 }
 
-static JsonObject read_resource(ProtocolClient& client, StringView resource_type, StringView packet_type = "resources-available-array"sv)
+static JsonObject read_resource(ProtocolClient& client, StringView resource_type, StringView packet_type = "resources-available-array"sv, StringView expected_sender = {})
 {
     while (true) {
         auto message = client.read_message();
@@ -1687,6 +1764,8 @@ static JsonObject read_resource(ProtocolClient& client, StringView resource_type
                 continue;
             if (!entry.as_array().at(0).is_string() || entry.as_array().at(0).as_string() != resource_type)
                 continue;
+            if (!expected_sender.is_empty())
+                EXPECT_EQ(message.get_string("from"sv).value(), expected_sender);
             auto const& resources = entry.as_array().at(1).as_array();
             VERIFY(!resources.is_empty());
             return resources.at(0).as_object();
@@ -2209,6 +2288,111 @@ TEST_CASE(storage_cookie_resource)
     EXPECT_EQ(objects.get_integer<size_t>("offset"sv).value(), 0u);
     EXPECT_EQ(objects.get_integer<size_t>("total"sv).value(), 0u);
     EXPECT(objects.get_array("data"sv)->is_empty());
+}
+
+TEST_CASE(source_resources)
+{
+    auto session = create_session();
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto tab_actor = actor_from(get_tab(client), "actor"sv);
+    auto watcher_response = client.request(tab_actor, "getWatcher"sv);
+    auto watcher_actor = actor_from(watcher_response, "actor"sv);
+    auto resources = watcher_response.get_object("traits"sv)->get_object("resources"sv).release_value();
+    EXPECT(resources.get_bool("source"sv).value());
+    EXPECT(resources.get_bool("document-event"sv).value());
+    EXPECT(resources.get_bool("error-message"sv).value());
+    EXPECT(resources.get_bool("jstracer-state"sv).value());
+    EXPECT(resources.get_bool("jstracer-trace"sv).value());
+    EXPECT(resources.get_bool("thread-state"sv).value());
+
+    JsonObject watch_targets;
+    watch_targets.set("to"sv, watcher_actor);
+    watch_targets.set("type"sv, "watchTargets"sv);
+    watch_targets.set("targetType"sv, "frame"sv);
+    EXPECT_EQ(client.request(move(watch_targets)).get_string("from"sv).value(), watcher_actor);
+
+    auto target = read_packet_with_type(client, "target-available-form"sv).get_object("target"sv).release_value();
+    auto target_actor = actor_from(target, "actor"sv);
+    auto thread_actor = actor_from(target, "threadActor"sv);
+
+    JsonObject attach;
+    attach.set("to"sv, thread_actor);
+    attach.set("type"sv, "attach"sv);
+    JsonObject options;
+    attach.set("options"sv, move(options));
+    EXPECT_EQ(client.request(move(attach)).get_string("from"sv).value(), thread_actor);
+
+    auto watch_resource_type = [&](StringView resource_type) {
+        JsonObject watch_resources;
+        watch_resources.set("to"sv, watcher_actor);
+        watch_resources.set("type"sv, "watchResources"sv);
+        JsonArray resource_types;
+        resource_types.must_append(resource_type);
+        watch_resources.set("resourceTypes"sv, move(resource_types));
+        EXPECT_EQ(client.request(move(watch_resources)).get_string("from"sv).value(), watcher_actor);
+    };
+
+    watch_resource_type("thread-state"sv);
+    watch_resource_type("error-message"sv);
+    watch_resource_type("document-event"sv);
+    watch_resource_type("jstracer-state"sv);
+    watch_resource_type("jstracer-trace"sv);
+
+    JsonObject watch_resources;
+    watch_resources.set("to"sv, watcher_actor);
+    watch_resources.set("type"sv, "watchResources"sv);
+    JsonArray resource_types;
+    resource_types.must_append("source"sv);
+    watch_resources.set("resourceTypes"sv, move(resource_types));
+    EXPECT_EQ(client.request(move(watch_resources)).get_string("from"sv).value(), watcher_actor);
+
+    auto source_resource = read_resource(client, "source"sv, "resources-available-array"sv, target_actor);
+    EXPECT_EQ(source_resource.get_string("url"sv).value(), "https://example.test/app.js"sv);
+    EXPECT_EQ(source_resource.get_bool("isBlackBoxed"sv).value(), false);
+    EXPECT_EQ(source_resource.get_integer<u64>("browsingContextID"sv).value(), 1u);
+    EXPECT_EQ(source_resource.get_integer<u64>("innerWindowId"sv).value(), 1u);
+    EXPECT_EQ(source_resource.get_string("resourceId"sv).value(), "source-1-1-1"sv);
+    EXPECT_EQ(source_resource.get_string("introductionType"sv).value(), "scriptElement"sv);
+    EXPECT_EQ(source_resource.get_bool("isInlineSource"sv).value(), false);
+    EXPECT_EQ(source_resource.get_integer<u32>("sourceStartLine"sv).value(), 1u);
+    EXPECT_EQ(source_resource.get_integer<u32>("sourceStartColumn"sv).value(), 0u);
+    auto source_actor = actor_from(source_resource, "actor"sv);
+
+    auto sources = client.request(thread_actor, "sources"sv).get_array("sources"sv).release_value();
+    EXPECT_EQ(sources.size(), 1u);
+    EXPECT_EQ(sources.at(0).as_object().get_string("actor"sv).value(), source_actor);
+    EXPECT_EQ(source_actor_count(*session->server), 1u);
+
+    auto source = client.request(source_actor, "source"sv);
+    EXPECT_EQ(source.get_string("contentType"sv).value(), "text/javascript"sv);
+    EXPECT_EQ(source.get_string("source"sv).value(), "console.log('hello from source');"sv);
+    EXPECT_EQ(session->delegate.retrieve_sources_call_count, 2u);
+    EXPECT_EQ(session->delegate.retrieve_source_call_count, 1u);
+    EXPECT_EQ(session->delegate.listen_for_sources_call_count, 1u);
+    VERIFY(session->delegate.on_source_available);
+
+    session->delegate.on_source_available(session->delegate.fixture_live_source);
+    auto live_source_resource = read_resource(client, "source"sv, "resources-available-array"sv, target_actor);
+    EXPECT_EQ(live_source_resource.get_string("url"sv).value(), "https://example.test/live.js"sv);
+    EXPECT_EQ(live_source_resource.get_integer<u64>("browsingContextID"sv).value(), 1u);
+    EXPECT_EQ(live_source_resource.get_integer<u64>("innerWindowId"sv).value(), 1u);
+    EXPECT_EQ(live_source_resource.get_string("resourceId"sv).value(), "source-1-1-2"sv);
+    auto live_source_actor = actor_from(live_source_resource, "actor"sv);
+    EXPECT_EQ(source_actor_count(*session->server), 2u);
+
+    auto live_source = client.request(live_source_actor, "source"sv);
+    EXPECT_EQ(live_source.get_string("contentType"sv).value(), "text/javascript"sv);
+    EXPECT_EQ(live_source.get_string("source"sv).value(), "console.log('live source');"sv);
+    EXPECT_EQ(session->delegate.retrieve_source_call_count, 2u);
+
+    sources = client.request(thread_actor, "sources"sv).get_array("sources"sv).release_value();
+    EXPECT_EQ(sources.size(), 1u);
+    spin_until(session->loop, [&] {
+        return source_actor_count(*session->server) == 1u
+            && !session->server->actor_registry().contains(live_source_actor);
+    });
 }
 
 TEST_CASE(storage_web_storage_resources)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -2142,7 +2142,14 @@ TEST_CASE(target_bootstrap_and_lifetime)
     EXPECT_EQ(session->delegate.listen_for_network_events_call_count, 1u);
     EXPECT_EQ(session->delegate.retrieve_style_sheets_call_count, 1u);
 
-    EXPECT_EQ(client.request(actor_from(target, "actor"sv), "detach"sv).get_string("from"sv).value(), actor_from(target, "actor"sv));
+    auto target_actor = actor_from(target, "actor"sv);
+    auto frames = client.request(target_actor, "listFrames"sv).get_array("frames"sv).release_value();
+    EXPECT_EQ(frames.size(), 1u);
+    EXPECT_EQ(frames.at(0).as_object().get_string("title"sv).value(), "Fixture page"sv);
+    EXPECT_EQ(frames.at(0).as_object().get_string("url"sv).value(), "https://example.test/"sv);
+    EXPECT(client.request(target_actor, "listWorkers"sv).get_array("workers"sv)->is_empty());
+
+    EXPECT_EQ(client.request(target_actor, "detach"sv).get_string("from"sv).value(), target_actor);
     EXPECT_EQ(session->delegate.stop_listening_for_console_messages_call_count, 1u);
     EXPECT_EQ(session->delegate.stop_listening_for_dom_mutations_call_count, 1u);
     EXPECT_EQ(session->delegate.clear_highlighted_dom_node_call_count, 1u);


### PR DESCRIPTION
<img width="1223" height="892" alt="Screenshot_20260619_154136" src="https://github.com/user-attachments/assets/64b1f7c7-952c-4148-87f2-983bc225e08d" />

Enough funtionality happens inside the inspector that we get pretty-printing, folding, search, and jump-to-definition for free. Pretty nice.

Unlike with style sheets, there isn't a single place that lists every script. So, this implements a ScriptRegistry that records some metadata and then a pointer to the existing `JS::SourceCode`. Eventually wasm will be recorded in the registry too.

The final commit makes the context-menu options work for style and script elements, to view their contents in the *Style Editor* and *Debugger* tabs respectively.