### PR TITLE
Fix Linux Compositor GPU sandbox access

### DIFF
--- a/Libraries/LibSandbox/Sandbox.cpp
+++ b/Libraries/LibSandbox/Sandbox.cpp
@@ -494,7 +494,8 @@ ErrorOr<void> restrict_filesystem_with_landlock(ReadonlySpan<LandlockPath> paths
 #        endif
 
             if (landlock_path.is_directory) {
-                path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_REMOVE_DIR
+                path_beneath.allowed_access |= LANDLOCK_ACCESS_FS_READ_DIR
+                    | LANDLOCK_ACCESS_FS_REMOVE_DIR
                     | LANDLOCK_ACCESS_FS_REMOVE_FILE
                     | LANDLOCK_ACCESS_FS_MAKE_DIR
                     | LANDLOCK_ACCESS_FS_MAKE_REG

--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -1061,6 +1061,32 @@ void SeccompPolicy::allow_executable_memory_mappings()
     append(SECCOMP_LOAD_SYSCALL_NR);
 }
 
+void SeccompPolicy::allow_writable_executable_memory_mappings()
+{
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_mmap, 0, 5));
+    append(SECCOMP_LOAD_ARGUMENT(2));
+    append(BPF_STMT(BPF_ALU | BPF_AND | BPF_K, PROT_WRITE | PROT_EXEC));
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, PROT_WRITE | PROT_EXEC, 0, 1));
+    append(SECCOMP_ALLOW);
+    append(SECCOMP_LOAD_SYSCALL_NR);
+
+#ifdef __NR_mmap2
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_mmap2, 0, 5));
+    append(SECCOMP_LOAD_ARGUMENT(2));
+    append(BPF_STMT(BPF_ALU | BPF_AND | BPF_K, PROT_WRITE | PROT_EXEC));
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, PROT_WRITE | PROT_EXEC, 0, 1));
+    append(SECCOMP_ALLOW);
+    append(SECCOMP_LOAD_SYSCALL_NR);
+#endif
+
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_mprotect, 0, 5));
+    append(SECCOMP_LOAD_ARGUMENT(2));
+    append(BPF_STMT(BPF_ALU | BPF_AND | BPF_K, PROT_WRITE | PROT_EXEC));
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, PROT_WRITE | PROT_EXEC, 0, 1));
+    append(SECCOMP_ALLOW);
+    append(SECCOMP_LOAD_SYSCALL_NR);
+}
+
 void SeccompPolicy::allow_threads()
 {
 #ifdef __NR_clone

--- a/Libraries/LibSandbox/Seccomp.h
+++ b/Libraries/LibSandbox/Seccomp.h
@@ -27,6 +27,7 @@ public:
     void allow_network();
     void allow_memory_without_executable_mappings();
     void allow_executable_memory_mappings();
+    void allow_writable_executable_memory_mappings();
     void allow_threads();
     void allow_signals();
     void allow_clocks();

--- a/Services/Compositor/SandboxLinux.cpp
+++ b/Services/Compositor/SandboxLinux.cpp
@@ -70,6 +70,9 @@ ErrorOr<void> apply_sandbox()
     policy.allow_gpu_device_operations();
     policy.allow_common_runtime();
     policy.allow_executable_memory_mappings();
+    // Some GPU drivers allocate writable executable code heaps lazily after
+    // context creation, including while handling WebGL commands.
+    policy.allow_writable_executable_memory_mappings();
     TRY(policy.install());
 
     return {};

--- a/Services/Compositor/SandboxLinux.cpp
+++ b/Services/Compositor/SandboxLinux.cpp
@@ -33,6 +33,7 @@ ErrorOr<void> apply_sandbox()
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/usr/share/drirc.d"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/usr/share/vulkan"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/dev/dri"sv, Sandbox::LandlockPath::Access::ReadWrite));
+    TRY(Sandbox::add_landlock_path_if_exists(paths, "/dev/udmabuf"sv, Sandbox::LandlockPath::Access::ReadWrite));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/sys"sv, Sandbox::LandlockPath::Access::ReadOnly));
     if (auto library_path = Core::Environment::get("LD_LIBRARY_PATH"sv); library_path.has_value()) {
         for (auto path : library_path->split_view(':'))


### PR DESCRIPTION
This fixes two Linux sandbox issues exposed by moving WebGL work into the Compositor process.

The Compositor seccomp policy now allows writable executable memory mappings used lazily by GPU drivers after WebGL context creation. This is scoped to the Compositor process, so WebContent keeps its existing mapping restrictions.

The Landlock policy now includes directory read access for read-write directory rules. Without this, paths such as /dev/dri could be writable but not enumerable after sandboxing, which made Mesa fail while probing GPU devices. The Compositor also allows /dev/udmabuf when present.
