### PR TITLE
LibWebView+LibWeb: Add initial support for iframe site isolation

### DIFF
--- a/Base/res/ladybird/about-pages/processes.html
+++ b/Base/res/ladybird/about-pages/processes.html
@@ -81,6 +81,11 @@
             tbody tr:hover {
                 background-color: var(--table-row-hover);
             }
+
+            td.process-name {
+                --process-depth: 0;
+                padding-left: calc(4px + var(--process-depth) * 20px);
+            }
         </style>
     </head>
     <body>
@@ -140,7 +145,7 @@
 
                 const multiplier = window.sortDirection === Direction.ascending ? 1 : -1;
 
-                window.processes.sort((lhs, rhs) => {
+                const compareProcesses = (lhs, rhs) => {
                     const lhsValue = lhs[window.sortKey];
                     const rhsValue = rhs[window.sortKey];
 
@@ -149,24 +154,64 @@
                     }
 
                     return multiplier * (lhsValue - rhsValue);
-                });
+                };
 
                 let oldTable = document.getElementById("process-table");
 
                 let newTable = document.createElement("tbody");
                 newTable.setAttribute("id", "process-table");
 
-                const insertColumn = (row, value) => {
+                const insertColumn = (row, value, className) => {
                     let column = row.insertCell();
+                    if (className) {
+                        column.className = className;
+                    }
                     column.innerText = value;
+                    return column;
                 };
 
+                const processesByPID = new Map();
                 window.processes.forEach(process => {
+                    processesByPID.set(process.pid, process);
+                });
+
+                const childProcessesByEmbedderPID = new Map();
+                const rootProcesses = [];
+                window.processes.forEach(process => {
+                    if (process.embedderPID !== undefined && processesByPID.has(process.embedderPID)) {
+                        let childProcesses = childProcessesByEmbedderPID.get(process.embedderPID);
+                        if (!childProcesses) {
+                            childProcesses = [];
+                            childProcessesByEmbedderPID.set(process.embedderPID, childProcesses);
+                        }
+                        childProcesses.push(process);
+                    } else {
+                        rootProcesses.push(process);
+                    }
+                });
+
+                const insertProcess = (process, depth) => {
                     let row = newTable.insertRow();
-                    insertColumn(row, process.name);
+                    let nameColumn = insertColumn(row, process.name, "process-name");
+                    nameColumn.style.setProperty("--process-depth", depth);
                     insertColumn(row, process.pid);
                     insertColumn(row, cpuFormatter.format(process.cpu));
                     insertColumn(row, memoryFormatter.formatBytes(process.memory));
+
+                    const childProcesses = childProcessesByEmbedderPID.get(process.pid);
+                    if (!childProcesses) {
+                        return;
+                    }
+
+                    childProcesses.sort(compareProcesses);
+                    childProcesses.forEach(childProcess => {
+                        insertProcess(childProcess, depth + 1);
+                    });
+                };
+
+                rootProcesses.sort(compareProcesses);
+                rootProcesses.forEach(process => {
+                    insertProcess(process, 0);
                 });
 
                 oldTable.parentNode.replaceChild(newTable, oldTable);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5446,8 +5446,11 @@ void Document::destroy()
 
     // Not in the spec:
     for (auto& navigable_container : HTML::NavigableContainer::all_instances()) {
-        if (&navigable_container->document() == this && navigable_container->content_navigable())
-            navigable_container->content_navigable()->remove_from_all_navigables();
+        if (&navigable_container->document() == this && navigable_container->content_navigable()) {
+            auto& child_navigable = *navigable_container->content_navigable();
+            child_navigable.set_has_been_destroyed();
+            child_navigable.remove_from_all_navigables();
+        }
     }
 
     // 9. Set document's node navigable's active session history entry's document state's document to null.
@@ -5951,8 +5954,11 @@ void Document::make_active()
     // 2. Set document's browsing context's WindowProxy's [[Window]] internal slot value to window.
     m_browsing_context->window_proxy()->set_window(window);
 
-    if (m_browsing_context->is_top_level()) {
+    auto current_navigable = this->navigable();
+    if (current_navigable && current_navigable->is_top_level_traversable()) {
         page().client().page_did_change_active_document_in_top_level_browsing_context(*this);
+    } else if (current_navigable) {
+        page().client().page_did_commit_child_frame_navigation(current_navigable->id(), url());
     }
 
     // 3. Set window's relevant settings object's execution ready flag.

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -92,7 +92,7 @@ private:
     SandboxingFlagSet m_iframe_sandboxing_flag_set {};
 };
 
-void run_iframe_load_event_steps(HTML::HTMLIFrameElement&);
+WEB_API void run_iframe_load_event_steps(HTML::HTMLIFrameElement&);
 
 ReferrerPolicy::ReferrerPolicy determine_iframe_element_referrer_policy(GC::Ptr<DOM::Element> embedder);
 

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2317,7 +2317,8 @@ void Navigable::begin_navigation(NavigateParams params)
                 }
 
                 // AD-HOC: If we are not able to continue in this process, request a new process from the UI.
-                if (is_top_level_traversable() && !active_browsing_context()->page().client().is_url_suitable_for_same_process_navigation(this->active_document()->url(), url)) {
+                if (is_top_level_traversable()
+                    && active_browsing_context()->page().client().decide_navigation_process(this->active_document()->url(), url, NavigationTarget::TopLevel) == NavigationProcessDecision::Remote) {
                     active_browsing_context()->page().client().request_new_process_for_navigation(url, document_resource, history_handling);
                     set_delaying_load_events(false);
                     return;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -371,6 +371,9 @@ Navigable::~Navigable() = default;
 
 void Navigable::set_has_been_destroyed()
 {
+    if (!m_has_been_destroyed && parent())
+        page().client().page_did_destroy_child_frame(id());
+
     cancel_hover_update_after_async_scroll();
     destroy_compositor_context();
     m_has_been_destroyed = true;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2320,11 +2320,27 @@ void Navigable::begin_navigation(NavigateParams params)
                 }
 
                 // AD-HOC: If we are not able to continue in this process, request a new process from the UI.
-                if (is_top_level_traversable()
-                    && active_browsing_context()->page().client().decide_navigation_process(this->active_document()->url(), url, NavigationTarget::TopLevel) == NavigationProcessDecision::Remote) {
-                    active_browsing_context()->page().client().request_new_process_for_navigation(url, document_resource, history_handling);
+                auto& page_client = active_browsing_context()->page().client();
+                auto is_top_level_navigation = is_top_level_traversable();
+                auto target = is_top_level_navigation ? NavigationTarget::TopLevel : NavigationTarget::IFrame;
+                auto frame_id = is_top_level_navigation ? Optional<String> {} : Optional<String> { id() };
+                auto process_decision = page_client.decide_navigation_process(this->active_document()->url(), url, target, move(frame_id));
+                if (process_decision == NavigationProcessDecision::Remote && is_top_level_navigation) {
+                    page_client.request_new_process_for_navigation(url, document_resource, history_handling);
                     set_delaying_load_events(false);
                     return;
+                }
+                if (process_decision == NavigationProcessDecision::Remote) {
+                    if (has_compositor_context())
+                        compositor_context().set_parent_context({});
+                    page_client.request_new_process_for_child_frame_navigation(id(), url, document_resource, history_handling);
+                    set_delaying_load_events(false);
+                    return;
+                }
+                if (!is_top_level_navigation) {
+                    if (auto parent = this->parent();
+                        parent && has_compositor_context() && parent->has_compositor_context())
+                        compositor_context().set_parent_context(parent->compositor_context().id());
                 }
 
                 // AD-HOC: Tell the UI that we started loading.

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -106,6 +106,8 @@ void NavigableContainer::create_new_child_navigable()
     // 9. Set element's content navigable to navigable.
     m_content_navigable = navigable;
 
+    page.client().page_did_create_child_frame(parent_navigable->id(), navigable->id());
+
     // 10. Let historyEntry be navigable's active session history entry.
     auto history_entry = navigable->active_session_history_entry();
 

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -2237,7 +2237,7 @@ void TraversableNavigable::traverse_the_history_by_delta(int delta, GC::Ptr<DOM:
                 target_top_level_entry = entry;
             }
 
-            if (target_top_level_entry && current_session_history_entry() && !page().client().is_url_suitable_for_same_process_navigation(current_session_history_entry()->url(), target_top_level_entry->url())) {
+            if (target_top_level_entry && current_session_history_entry() && page().client().decide_navigation_process(current_session_history_entry()->url(), target_top_level_entry->url(), NavigationTarget::TopLevel) == NavigationProcessDecision::Remote) {
                 run_the_history_step_prechecks(target_step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, Navigable::NavigationAPIAbortBehavior::Abort,
                     GC::create_function(heap(), [this, delta, signal](HistoryStepResult result, int, Navigable::NavigationAPIAbortBehavior) {
                         if (result == HistoryStepResult::Applied)

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -728,6 +728,11 @@ String Internals::dump_ui_process_session_history()
     return document.page().client().page_did_request_ui_process_session_history_for_testing();
 }
 
+String Internals::dump_site_isolation_process_tree()
+{
+    return window().associated_document().page().client().dump_site_isolation_process_tree_for_testing();
+}
+
 GC::Ref<WebIDL::Promise> Internals::flush_session_history_traversal_queue()
 {
     auto& realm = this->realm();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -114,6 +114,7 @@ public:
     String dump_gc_graph();
     String dump_session_history();
     String dump_ui_process_session_history();
+    String dump_site_isolation_process_tree();
     GC::Ref<WebIDL::Promise> flush_session_history_traversal_queue();
     void clobber_next_navigation_with_a_traversal();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -103,6 +103,7 @@ interface Internals {
     DOMString dumpGCGraph();
     DOMString dumpSessionHistory();
     DOMString dumpUIProcessSessionHistory();
+    DOMString dumpSiteIsolationProcessTree();
     Promise<undefined> flushSessionHistoryTraversalQueue();
 
     // Test-only: deterministically reproduce the navigation-vs-traversal race in Navigable::begin_navigation by

--- a/Libraries/LibWeb/Layout/NavigableContainerViewport.cpp
+++ b/Libraries/LibWeb/Layout/NavigableContainerViewport.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/Layout/NavigableContainerViewport.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/NavigableContainerViewportPaintable.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
 
@@ -42,8 +43,11 @@ void NavigableContainerViewport::did_set_content_size()
 {
     ReplacedBox::did_set_content_size();
 
-    if (dom_node().content_navigable())
-        dom_node().content_navigable()->set_viewport_size(paintable_box()->content_size());
+    if (auto content_navigable = dom_node().content_navigable()) {
+        auto content_size = paintable_box()->content_size();
+        content_navigable->set_viewport_size(content_size);
+        document().page().client().page_did_update_child_frame_viewport(content_navigable->id(), paintable_box()->absolute_rect());
+    }
 }
 
 RefPtr<Painting::Paintable> NavigableContainerViewport::create_paintable() const

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -415,6 +415,16 @@ enum class HistoryTraversalPrecheck : u8 {
     SourceDocumentSandboxingAlreadyDone,
 };
 
+enum class NavigationTarget : u8 {
+    TopLevel,
+    IFrame,
+};
+
+enum class NavigationProcessDecision : u8 {
+    Local,
+    Remote,
+};
+
 class PageClient : public JS::Cell {
     GC_CELL(PageClient, JS::Cell);
 
@@ -425,7 +435,14 @@ public:
     virtual bool is_connection_open() const = 0;
     virtual bool has_focus() const { return true; }
     virtual bool has_active_devtools_client() const { return false; }
-    virtual bool is_url_suitable_for_same_process_navigation([[maybe_unused]] URL::URL const& current_url, [[maybe_unused]] URL::URL const& target_url) const { return true; }
+    // In Ladybird, Remote currently implies replacing the WebContent process.
+    virtual NavigationProcessDecision decide_navigation_process(
+        [[maybe_unused]] URL::URL const& current_url,
+        [[maybe_unused]] URL::URL const& target_url,
+        [[maybe_unused]] NavigationTarget target = NavigationTarget::TopLevel) const
+    {
+        return NavigationProcessDecision::Local;
+    }
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
     virtual Gfx::Palette palette() const = 0;
     virtual DevicePixelRect screen_rect() const = 0;

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -444,6 +444,10 @@ public:
         return NavigationProcessDecision::Local;
     }
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
+    virtual void page_did_create_child_frame(String const&, String const&) { }
+    virtual void page_did_update_child_frame_viewport(String const&, CSSPixelRect) { }
+    virtual void page_did_commit_child_frame_navigation(String const&, URL::URL const&) { }
+    virtual void page_did_destroy_child_frame(String const&) { }
     virtual Gfx::Palette palette() const = 0;
     virtual DevicePixelRect screen_rect() const = 0;
     virtual double zoom_level() const = 0;

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -439,15 +439,18 @@ public:
     virtual NavigationProcessDecision decide_navigation_process(
         [[maybe_unused]] URL::URL const& current_url,
         [[maybe_unused]] URL::URL const& target_url,
-        [[maybe_unused]] NavigationTarget target = NavigationTarget::TopLevel) const
+        [[maybe_unused]] NavigationTarget target = NavigationTarget::TopLevel,
+        [[maybe_unused]] Optional<String> frame_id = {}) const
     {
         return NavigationProcessDecision::Local;
     }
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
+    virtual void request_new_process_for_child_frame_navigation(String const&, URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
     virtual void page_did_create_child_frame(String const&, String const&) { }
     virtual void page_did_update_child_frame_viewport(String const&, CSSPixelRect) { }
     virtual void page_did_commit_child_frame_navigation(String const&, URL::URL const&) { }
     virtual void page_did_destroy_child_frame(String const&) { }
+    virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(String const&) const { return {}; }
     virtual Gfx::Palette palette() const = 0;
     virtual DevicePixelRect screen_rect() const = 0;
     virtual double zoom_level() const = 0;

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -451,6 +451,7 @@ public:
     virtual void page_did_commit_child_frame_navigation(String const&, URL::URL const&) { }
     virtual void page_did_destroy_child_frame(String const&) { }
     virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(String const&) const { return {}; }
+    virtual String dump_site_isolation_process_tree_for_testing() { return {}; }
     virtual Gfx::Palette palette() const = 0;
     virtual DevicePixelRect screen_rect() const = 0;
     virtual double zoom_level() const = 0;

--- a/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
@@ -38,16 +38,13 @@ void NavigableContainerViewportPaintable::paint(DisplayListRecordingContext& con
         ScopedCornerRadiusClip corner_clip { context, clip_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
 
         auto const& navigable_container = this->navigable_container();
-        auto* hosted_document = const_cast<DOM::Document*>(navigable_container.content_document_without_origin_check());
-        if (!hosted_document)
-            return;
-
-        if (hosted_document->is_render_blocked())
-            return;
-
         auto content_navigable = navigable_container.content_navigable();
         VERIFY(content_navigable);
         if (content_navigable->has_been_destroyed() || !content_navigable->has_compositor_context())
+            return;
+
+        auto* hosted_document = const_cast<DOM::Document*>(navigable_container.content_document_without_origin_check());
+        if (hosted_document && hosted_document->is_render_blocked())
             return;
 
         context.display_list_recorder().save();

--- a/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/HTML/NavigableContainer.h>
 #include <LibWeb/Layout/NavigableContainerViewport.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/NavigableContainerViewportPaintable.h>
@@ -40,18 +41,26 @@ void NavigableContainerViewportPaintable::paint(DisplayListRecordingContext& con
         auto const& navigable_container = this->navigable_container();
         auto content_navigable = navigable_container.content_navigable();
         VERIFY(content_navigable);
-        if (content_navigable->has_been_destroyed() || !content_navigable->has_compositor_context())
+        if (content_navigable->has_been_destroyed())
             return;
 
-        auto* hosted_document = const_cast<DOM::Document*>(navigable_container.content_document_without_origin_check());
-        if (hosted_document && hosted_document->is_render_blocked())
-            return;
+        auto context_id = document().page().client().compositor_context_id_for_remote_child_frame(content_navigable->id());
+        if (!context_id.has_value()) {
+            if (!content_navigable->has_compositor_context())
+                return;
+
+            auto* hosted_document = const_cast<DOM::Document*>(navigable_container.content_document_without_origin_check());
+            if (hosted_document && hosted_document->is_render_blocked())
+                return;
+
+            context_id = content_navigable->compositor_context().id();
+        }
 
         context.display_list_recorder().save();
         context.display_list_recorder().add_clip_rect(clip_rect.to_type<int>());
         context.display_list_recorder().draw_composited_context(
             context.enclosing_device_rect(absolute_rect).to_type<int>(),
-            content_navigable->compositor_context().id(),
+            *context_id,
             Gfx::ScalingMode::NearestNeighbor);
         context.display_list_recorder().restore();
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -541,9 +541,7 @@ void PaintableBox::reset_for_relayout()
     m_containing_line_box_data.clear();
     m_sticky_insets = nullptr;
 
-    m_absolute_rect.clear();
-    m_absolute_padding_box_rect.clear();
-    m_absolute_border_box_rect.clear();
+    invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::No);
 
     m_enclosing_scroll_frame_index = {};
     m_own_scroll_frame_index = {};
@@ -684,16 +682,36 @@ void PaintableBox::scroll_into_view(CSSPixelRect rect)
 
 void PaintableBox::set_offset(CSSPixelPoint offset)
 {
+    if (m_offset == offset)
+        return;
+
     m_offset = offset;
+    invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::Yes);
 }
 
 void PaintableBox::set_content_size(CSSPixelSize size)
 {
     auto old_size = m_content_size;
     m_content_size = size;
+    invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::No);
     if (auto layout_box = as_if<Layout::Box>(layout_node()))
         layout_box->did_set_content_size();
     invalidate_descendant_styles_for_container_query_size_change(*this, old_size, size);
+}
+
+void PaintableBox::invalidate_absolute_geometry_cache(InvalidateDescendantGeometry invalidate_descendants)
+{
+    m_absolute_rect.clear();
+    m_absolute_padding_box_rect.clear();
+    m_absolute_border_box_rect.clear();
+
+    if (invalidate_descendants == InvalidateDescendantGeometry::No)
+        return;
+
+    for_each_child_of_type<PaintableBox>([](auto& child) {
+        child.invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::Yes);
+        return IterationDecision::Continue;
+    });
 }
 
 void PaintableBox::set_fragmentation_state(FragmentationState fragmentation_state)

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -336,12 +336,17 @@ protected:
 
 private:
     struct CachedPaintData;
+    enum class InvalidateDescendantGeometry {
+        No,
+        Yes,
+    };
 
     [[nodiscard]] virtual bool is_paintable_box() const final { return true; }
 
     void paint_middle_button_scroll_indicator(DisplayListRecordingContext&) const;
     void acquire_cache_references_for_cached_commands(ReadonlyBytes) const;
     void release_cache_references_for_cached_commands(ReadonlyBytes) const;
+    void invalidate_absolute_geometry_cache(InvalidateDescendantGeometry);
 
     RefPtr<StackingContext> m_stacking_context;
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -36,6 +36,7 @@
 #include <LibWebView/HistoryStore.h>
 #include <LibWebView/Menu.h>
 #include <LibWebView/ProcessType.h>
+#include <LibWebView/SiteIsolation.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/UserAgent.h>
 #include <LibWebView/Utilities.h>
@@ -188,7 +189,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     bool enable_test_mode = false;
     bool validate_dnssec_locally = false;
     bool log_all_js_exceptions = false;
-    bool disable_site_isolation = false;
+    auto site_isolation_mode = SiteIsolationMode::TopLevel;
     bool enable_idl_tracing = false;
     bool disable_http_memory_cache = false;
     bool disable_http_disk_cache = false;
@@ -264,7 +265,20 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 #endif
     args_parser.add_option(enable_test_mode, "Enable test mode", "test-mode");
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
-    args_parser.add_option(disable_site_isolation, "Disable site isolation", "disable-site-isolation");
+    args_parser.add_option(Core::ArgsParser::Option {
+        .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
+        .help_string = "Set site isolation mode. Mode may be 'disable' or 'top-level' (default).",
+        .long_name = "site-isolation",
+        .value_name = "mode",
+        .accept_value = [&](StringView value) {
+            auto parsed_mode = site_isolation_mode_from_string(value);
+            if (!parsed_mode.has_value())
+                return false;
+
+            site_isolation_mode = *parsed_mode;
+            return true;
+        },
+    });
     args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
     args_parser.add_option(disable_http_memory_cache, "Disable HTTP memory cache", "disable-http-memory-cache");
     args_parser.add_option(disable_http_disk_cache, "Disable HTTP disk cache", "disable-http-disk-cache");
@@ -373,7 +387,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 
     // Disable site isolation when debugging WebContent. Otherwise, the process swap may interfere with the gdb session.
     if (debug_process_types.contains_slow(ProcessType::WebContent))
-        disable_site_isolation = true;
+        site_isolation_mode = SiteIsolationMode::Disabled;
 
     m_browser_options = {
         .urls = sanitize_urls(raw_urls),
@@ -425,7 +439,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         .user_agent_preset = move(user_agent_preset),
         .is_test_mode = enable_test_mode ? IsTestMode::Yes : IsTestMode::No,
         .log_all_js_exceptions = log_all_js_exceptions ? LogAllJSExceptions::Yes : LogAllJSExceptions::No,
-        .disable_site_isolation = disable_site_isolation ? DisableSiteIsolation::Yes : DisableSiteIsolation::No,
+        .site_isolation_mode = site_isolation_mode,
         .enable_idl_tracing = enable_idl_tracing ? EnableIDLTracing::Yes : EnableIDLTracing::No,
         .enable_http_memory_cache = disable_http_memory_cache ? EnableMemoryHTTPCache::No : EnableMemoryHTTPCache::Yes,
         .expose_experimental_interfaces = expose_experimental_interfaces ? ExposeExperimentalInterfaces::Yes : ExposeExperimentalInterfaces::No,
@@ -452,6 +466,8 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 
     if (m_web_content_options.file_scheme_urls_have_tuple_origins == FileSchemeUrlsHaveTupleOrigins::Yes)
         URL::set_file_scheme_urls_have_tuple_origins();
+
+    set_site_isolation_mode(m_web_content_options.site_isolation_mode);
 
     if (auto result = load_content_blocker_lists(); result.is_error()) {
         warnln("\033[31;1mUnable to load all content blocker lists:\033[0m {}", result.error());

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1579,6 +1579,7 @@ void Application::initialize_actions()
     m_debug_menu->add_action(Action::create("Dump Layout Tree"sv, ActionID::DumpLayoutTree, debug_request("dump-layout-tree"sv)));
     m_debug_menu->add_action(Action::create("Dump Paint Tree"sv, ActionID::DumpPaintTree, debug_request("dump-paint-tree"sv)));
     m_debug_menu->add_action(Action::create("Dump Stacking Context Tree"sv, ActionID::DumpStackingContextTree, debug_request("dump-stacking-context-tree"sv)));
+    m_debug_menu->add_action(Action::create("Dump Site Isolation Process Tree"sv, ActionID::DumpSiteIsolationProcessTree, debug_request("dump-site-isolation-process-tree"sv)));
     m_debug_menu->add_action(Action::create("Dump Display List"sv, ActionID::DumpDisplayList, debug_request("dump-display-list"sv)));
     m_debug_menu->add_action(Action::create("Dump Style Sheets"sv, ActionID::DumpStyleSheets, debug_request("dump-style-sheets"sv)));
     m_debug_menu->add_action(Action::create("Dump All Resolved Styles"sv, ActionID::DumpStyles, debug_request("dump-all-resolved-styles"sv)));

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -267,7 +267,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
     args_parser.add_option(Core::ArgsParser::Option {
         .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
-        .help_string = "Set site isolation mode. Mode may be 'disable' or 'top-level' (default).",
+        .help_string = "Set site isolation mode. Mode may be 'disable', 'top-level' (default), or 'iframe'.",
         .long_name = "site-isolation",
         .value_name = "mode",
         .accept_value = [&](StringView value) {
@@ -716,6 +716,16 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process
 
     launch_spare_web_content_process();
     return create_web_content_client(view, allocate_page_id());
+}
+
+ErrorOr<Application::ChildFrameWebContentProcess> Application::launch_child_frame_web_content_process()
+{
+    auto page_id = allocate_page_id();
+    auto client = TRY(create_web_content_client({}, page_id));
+    return ChildFrameWebContentProcess {
+        .client = move(client),
+        .page_id = page_id,
+    };
 }
 
 void Application::launch_spare_web_content_process()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -95,6 +95,11 @@ public:
 #endif
 
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
+    struct ChildFrameWebContentProcess {
+        NonnullRefPtr<WebContentClient> client;
+        u64 page_id { 0 };
+    };
+    ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process();
     u64 allocate_page_id();
     Web::Compositor::CompositorContextId allocate_compositor_context_id();
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
     SessionHistory.cpp
     Settings.cpp
     SiteIsolation.cpp
+    SiteIsolationManager.cpp
     SourceHighlighter.cpp
     StorageJar.cpp
     URL.cpp

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -24,6 +24,7 @@ class Menu;
 class OutOfProcessWebView;
 class ProcessManager;
 class Settings;
+class SiteIsolationManager;
 class TraversableSessionHistory;
 class ViewImplementation;
 class WebContentClient;

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -100,8 +100,7 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(u64
         arguments.append("--test-mode"sv);
     if (web_content_options.log_all_js_exceptions == WebView::LogAllJSExceptions::Yes)
         arguments.append("--log-all-js-exceptions"sv);
-    if (web_content_options.disable_site_isolation == WebView::DisableSiteIsolation::Yes)
-        arguments.append("--disable-site-isolation"sv);
+    arguments.append(ByteString::formatted("--site-isolation={}", WebView::site_isolation_mode_to_string(web_content_options.site_isolation_mode)));
     if (web_content_options.enable_idl_tracing == WebView::EnableIDLTracing::Yes)
         arguments.append("--enable-idl-tracing"sv);
     if (web_content_options.enable_http_memory_cache == WebView::EnableMemoryHTTPCache::Yes)

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -96,6 +96,7 @@ enum class ActionID {
     DumpLayoutTree,
     DumpPaintTree,
     DumpStackingContextTree,
+    DumpSiteIsolationProcessTree,
     DumpDisplayList,
     DumpStyleSheets,
     DumpStyles,

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -12,6 +12,7 @@
 #include <AK/Vector.h>
 #include <LibURL/URL.h>
 #include <LibWebView/ProcessType.h>
+#include <LibWebView/SiteIsolation.h>
 
 namespace WebView {
 
@@ -135,11 +136,6 @@ enum class EnableMemoryHTTPCache {
     Yes,
 };
 
-enum class DisableSiteIsolation {
-    No,
-    Yes,
-};
-
 enum class ExposeExperimentalInterfaces {
     No,
     Yes,
@@ -190,7 +186,7 @@ struct WebContentOptions {
     Optional<StringView> user_agent_preset {};
     IsTestMode is_test_mode { IsTestMode::No };
     LogAllJSExceptions log_all_js_exceptions { LogAllJSExceptions::No };
-    DisableSiteIsolation disable_site_isolation { DisableSiteIsolation::No };
+    SiteIsolationMode site_isolation_mode { SiteIsolationMode::TopLevel };
     EnableIDLTracing enable_idl_tracing { EnableIDLTracing::No };
     EnableMemoryHTTPCache enable_http_memory_cache { EnableMemoryHTTPCache::No };
     ExposeExperimentalInterfaces expose_experimental_interfaces { ExposeExperimentalInterfaces::No };

--- a/Libraries/LibWebView/ProcessManager.cpp
+++ b/Libraries/LibWebView/ProcessManager.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/JsonArray.h>
-#include <AK/JsonObject.h>
 #include <AK/String.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
@@ -94,6 +92,18 @@ void ProcessManager::for_each_process(Function<void(Process&)> callback)
         callback(entry.value);
 }
 
+void ProcessManager::for_each_process_statistics(Function<void(Process&, Core::Platform::ProcessInfo const&)> callback)
+{
+    verify_event_loop();
+    m_statistics.for_each_process([&](auto const& process) {
+        auto process_handle = m_processes.get(process.pid);
+        if (!process_handle.has_value())
+            return;
+
+        callback(*process_handle, process);
+    });
+}
+
 #if defined(AK_OS_MACH)
 void ProcessManager::set_process_mach_port(pid_t pid, Core::MachPort&& port)
 {
@@ -156,32 +166,6 @@ void ProcessManager::update_all_process_statistics()
 {
     verify_event_loop();
     (void)update_process_statistics(m_statistics);
-}
-
-JsonValue ProcessManager::serialize_json()
-{
-    verify_event_loop();
-    JsonArray serialized;
-
-    m_statistics.for_each_process([&](auto const& process) {
-        auto& process_handle = m_processes.get(process.pid).value();
-
-        auto type = WebView::process_name_from_type(process_handle.type());
-        auto const& title = process_handle.title();
-
-        auto process_name = title.has_value()
-            ? MUST(String::formatted("{} - {}", type, *title))
-            : String::from_utf8_without_validation(type.bytes());
-
-        JsonObject object;
-        object.set("name"sv, move(process_name));
-        object.set("pid"sv, process.pid);
-        object.set("cpu"sv, process.cpu_percent);
-        object.set("memory"sv, process.memory_usage_bytes);
-        serialized.must_append(move(object));
-    });
-
-    return serialized;
 }
 
 void ProcessManager::verify_event_loop() const

--- a/Libraries/LibWebView/ProcessManager.h
+++ b/Libraries/LibWebView/ProcessManager.h
@@ -8,7 +8,6 @@
 
 #include <AK/Function.h>
 #include <AK/HashMap.h>
-#include <AK/JsonValue.h>
 #include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <LibCore/EventLoop.h>
@@ -32,6 +31,7 @@ public:
 
     void add_process(Process&&);
     void for_each_process(Function<void(Process&)>);
+    void for_each_process_statistics(Function<void(Process&, Core::Platform::ProcessInfo const&)>);
     Optional<Process> remove_process(pid_t);
     Optional<Process&> find_process(pid_t);
     void cancel_forced_exit(pid_t);
@@ -42,7 +42,6 @@ public:
 #endif
 
     void update_all_process_statistics();
-    JsonValue serialize_json();
 
     Function<void(Process&)> on_process_added; // test-web
     Function<void(Process&&, Optional<int> exit_status)> on_process_exited;

--- a/Libraries/LibWebView/SiteIsolation.cpp
+++ b/Libraries/LibWebView/SiteIsolation.cpp
@@ -19,6 +19,8 @@ Optional<SiteIsolationMode> site_isolation_mode_from_string(StringView mode)
         return SiteIsolationMode::Disabled;
     if (mode.equals_ignoring_ascii_case("top-level"sv))
         return SiteIsolationMode::TopLevel;
+    if (mode.equals_ignoring_ascii_case("iframe"sv) || mode.equals_ignoring_ascii_case("iframes"sv))
+        return SiteIsolationMode::IFrame;
     return {};
 }
 
@@ -29,6 +31,8 @@ StringView site_isolation_mode_to_string(SiteIsolationMode mode)
         return "disable"sv;
     case SiteIsolationMode::TopLevel:
         return "top-level"sv;
+    case SiteIsolationMode::IFrame:
+        return "iframe"sv;
     }
     VERIFY_NOT_REACHED();
 }
@@ -38,9 +42,12 @@ void set_site_isolation_mode(SiteIsolationMode mode)
     s_site_isolation_mode = mode;
 }
 
-bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url)
+bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target)
 {
     if (s_site_isolation_mode == SiteIsolationMode::Disabled)
+        return true;
+
+    if (target == Web::NavigationTarget::IFrame && s_site_isolation_mode != SiteIsolationMode::IFrame)
         return true;
 
     // Allow navigating from about:blank to any site.

--- a/Libraries/LibWebView/SiteIsolation.cpp
+++ b/Libraries/LibWebView/SiteIsolation.cpp
@@ -11,16 +11,36 @@
 
 namespace WebView {
 
-static bool s_site_isolation_enabled = true;
+static SiteIsolationMode s_site_isolation_mode = SiteIsolationMode::TopLevel;
 
-void disable_site_isolation()
+Optional<SiteIsolationMode> site_isolation_mode_from_string(StringView mode)
 {
-    s_site_isolation_enabled = false;
+    if (mode.equals_ignoring_ascii_case("disable"sv) || mode.equals_ignoring_ascii_case("disabled"sv))
+        return SiteIsolationMode::Disabled;
+    if (mode.equals_ignoring_ascii_case("top-level"sv))
+        return SiteIsolationMode::TopLevel;
+    return {};
+}
+
+StringView site_isolation_mode_to_string(SiteIsolationMode mode)
+{
+    switch (mode) {
+    case SiteIsolationMode::Disabled:
+        return "disable"sv;
+    case SiteIsolationMode::TopLevel:
+        return "top-level"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+void set_site_isolation_mode(SiteIsolationMode mode)
+{
+    s_site_isolation_mode = mode;
 }
 
 bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url)
 {
-    if (!s_site_isolation_enabled)
+    if (s_site_isolation_mode == SiteIsolationMode::Disabled)
         return true;
 
     // Allow navigating from about:blank to any site.

--- a/Libraries/LibWebView/SiteIsolation.h
+++ b/Libraries/LibWebView/SiteIsolation.h
@@ -6,12 +6,21 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+#include <AK/StringView.h>
 #include <LibURL/Forward.h>
 #include <LibWebView/Forward.h>
 
 namespace WebView {
 
-WEBVIEW_API void disable_site_isolation();
+enum class SiteIsolationMode {
+    Disabled,
+    TopLevel,
+};
+
+[[nodiscard]] WEBVIEW_API Optional<SiteIsolationMode> site_isolation_mode_from_string(StringView);
+[[nodiscard]] WEBVIEW_API StringView site_isolation_mode_to_string(SiteIsolationMode);
+WEBVIEW_API void set_site_isolation_mode(SiteIsolationMode);
 [[nodiscard]] WEBVIEW_API bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url);
 
 }

--- a/Libraries/LibWebView/SiteIsolation.h
+++ b/Libraries/LibWebView/SiteIsolation.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/StringView.h>
 #include <LibURL/Forward.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWebView/Forward.h>
 
 namespace WebView {
@@ -16,11 +17,12 @@ namespace WebView {
 enum class SiteIsolationMode {
     Disabled,
     TopLevel,
+    IFrame,
 };
 
 [[nodiscard]] WEBVIEW_API Optional<SiteIsolationMode> site_isolation_mode_from_string(StringView);
 [[nodiscard]] WEBVIEW_API StringView site_isolation_mode_to_string(SiteIsolationMode);
 WEBVIEW_API void set_site_isolation_mode(SiteIsolationMode);
-[[nodiscard]] WEBVIEW_API bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url);
+[[nodiscard]] WEBVIEW_API bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget = Web::NavigationTarget::TopLevel);
 
 }

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/SiteIsolationManager.h>
+
+namespace WebView {
+
+SiteIsolationManager& SiteIsolationManager::the()
+{
+    static auto& manager = *new SiteIsolationManager;
+    return manager;
+}
+
+void SiteIsolationManager::did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id)
+{
+    auto& child_frames = m_child_frames.ensure(page_id, [] {
+        return HashMap<String, ChildFrameHost> {};
+    });
+    ChildFrameHost child_frame;
+    child_frame.parent_frame_id = move(parent_frame_id);
+    child_frames.set(move(frame_id), move(child_frame));
+}
+
+void SiteIsolationManager::did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
+{
+    auto child_frame = this->child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+
+    child_frame->viewport_rect = viewport_rect;
+    child_frame->device_pixel_ratio = device_pixel_ratio;
+}
+
+void SiteIsolationManager::did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url)
+{
+    auto child_frame = this->child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+
+    child_frame->last_committed_url = move(url);
+}
+
+void SiteIsolationManager::did_destroy_child_frame(u64 page_id, StringView frame_id)
+{
+    auto child_frames = m_child_frames.get(page_id);
+    if (!child_frames.has_value())
+        return;
+
+    child_frames->remove(frame_id);
+    if (child_frames->is_empty())
+        m_child_frames.remove(page_id);
+}
+
+void SiteIsolationManager::remove_page(u64 page_id)
+{
+    m_child_frames.remove(page_id);
+}
+
+Optional<SiteIsolationManager::ChildFrameHost&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id)
+{
+    auto child_frames = m_child_frames.get(page_id);
+    if (!child_frames.has_value())
+        return {};
+
+    return child_frames->get(frame_id);
+}
+
+Optional<SiteIsolationManager::ChildFrameHost const&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id) const
+{
+    auto child_frames = m_child_frames.get(page_id);
+    if (!child_frames.has_value())
+        return {};
+
+    return child_frames->get(frame_id);
+}
+
+}

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -6,6 +6,11 @@
 
 #include <LibWebView/SiteIsolationManager.h>
 
+#include <LibWeb/Page/ViewportIsFullscreen.h>
+#include <LibWebView/SiteIsolation.h>
+#include <LibWebView/ViewImplementation.h>
+#include <LibWebView/WebContentClient.h>
+
 namespace WebView {
 
 SiteIsolationManager& SiteIsolationManager::the()
@@ -24,6 +29,30 @@ void SiteIsolationManager::did_create_child_frame(u64 page_id, String parent_fra
     child_frames.set(move(frame_id), move(child_frame));
 }
 
+Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(WebContentClient& parent_client, u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
+{
+    if (target == Web::NavigationTarget::IFrame && frame_id.has_value()) {
+        if (auto child_frame = this->child_frame(page_id, *frame_id); child_frame.has_value())
+            current_url = embedding_page_url_for_child_frame_navigation(parent_client, page_id, *child_frame, current_url);
+    }
+
+    auto decision = WebView::is_url_suitable_for_same_process_navigation(current_url, target_url, target)
+        ? Web::NavigationProcessDecision::Local
+        : Web::NavigationProcessDecision::Remote;
+
+    if (target == Web::NavigationTarget::IFrame && frame_id.has_value()) {
+        auto target_owner = decision == Web::NavigationProcessDecision::Local
+            ? ChildFrameOwner::Local
+            : ChildFrameOwner::Remote;
+        record_pending_child_frame_navigation(page_id, *frame_id, target_url, target_owner);
+
+        if (target_owner == ChildFrameOwner::Local)
+            transition_child_frame_to_local(parent_client, page_id, *frame_id);
+    }
+
+    return decision;
+}
+
 void SiteIsolationManager::did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
@@ -32,31 +61,164 @@ void SiteIsolationManager::did_update_child_frame_viewport(u64 page_id, String f
 
     child_frame->viewport_rect = viewport_rect;
     child_frame->device_pixel_ratio = device_pixel_ratio;
+    if (child_frame->is_remote()) {
+        child_frame->remote_client->async_set_viewport(
+            child_frame->remote_page_id,
+            viewport_rect.size(),
+            device_pixel_ratio,
+            Web::ViewportIsFullscreen::No);
+    }
 }
 
-void SiteIsolationManager::did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url)
+bool SiteIsolationManager::did_commit_child_frame_navigation(WebContentClient& parent_client, u64 page_id, StringView frame_id, URL::URL const& url)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
-        return;
+        return false;
 
-    child_frame->last_committed_url = move(url);
+    if (child_frame->is_remote())
+        transition_child_frame_to_local(parent_client, page_id, frame_id);
+
+    child_frame->last_committed_url = url;
+    child_frame->pending_navigation.clear();
+    return true;
 }
 
-void SiteIsolationManager::did_destroy_child_frame(u64 page_id, StringView frame_id)
+void SiteIsolationManager::did_destroy_child_frame(WebContentClient& parent_client, u64 page_id, StringView frame_id)
 {
     auto child_frames = m_child_frames.get(page_id);
     if (!child_frames.has_value())
         return;
+
+    transition_child_frame_to_local(parent_client, page_id, frame_id);
 
     child_frames->remove(frame_id);
     if (child_frames->is_empty())
         m_child_frames.remove(page_id);
 }
 
+bool SiteIsolationManager::remote_child_frame_did_finish_loading(WebContentClient& remote_client, u64 remote_page_id, URL::URL const& url)
+{
+    auto parent_frame = parent_frame_for_remote_page(remote_client, remote_page_id);
+    if (!parent_frame.has_value())
+        return false;
+
+    parent_frame->child_frame->last_committed_url = url;
+    parent_frame->child_frame->pending_navigation.clear();
+    parent_frame->parent_client->async_run_iframe_load_event_steps(parent_frame->page_id, parent_frame->frame_id);
+    return true;
+}
+
+bool SiteIsolationManager::remote_child_frame_did_commit_navigation(WebContentClient& remote_client, u64 remote_page_id, URL::URL const& url)
+{
+    auto parent_frame = parent_frame_for_remote_page(remote_client, remote_page_id);
+    if (!parent_frame.has_value())
+        return false;
+
+    parent_frame->child_frame->last_committed_url = url;
+    parent_frame->child_frame->pending_navigation.clear();
+    return true;
+}
+
 void SiteIsolationManager::remove_page(u64 page_id)
 {
     m_child_frames.remove(page_id);
+}
+
+void SiteIsolationManager::remove_all_pages_for_client(WebContentClient& client)
+{
+    Vector<u64> page_ids;
+    for (auto const& page_child_frames : m_child_frames) {
+        auto page_id = page_child_frames.key;
+        if (client_owns_page(client, page_id))
+            page_ids.append(page_id);
+    }
+
+    for (auto page_id : page_ids)
+        remove_page(page_id);
+}
+
+bool SiteIsolationManager::has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, ChildFrameOwner target_owner) const
+{
+    auto child_frame = this->child_frame(page_id, frame_id);
+    if (!child_frame.has_value() || !child_frame->pending_navigation.has_value())
+        return false;
+
+    return child_frame->pending_navigation->target_owner == target_owner
+        && child_frame->pending_navigation->target_url == url;
+}
+
+void SiteIsolationManager::record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, ChildFrameOwner target_owner, Optional<u64> remote_page_id)
+{
+    auto child_frame = this->child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+
+    child_frame->pending_navigation = PendingChildFrameNavigation {
+        .target_url = url,
+        .target_owner = target_owner,
+        .remote_page_id = remote_page_id,
+    };
+}
+
+void SiteIsolationManager::clear_pending_child_frame_navigation(u64 page_id, StringView frame_id)
+{
+    auto child_frame = this->child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+
+    child_frame->pending_navigation.clear();
+}
+
+void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, RefPtr<WebContentClient> remote_client, u64 remote_page_id)
+{
+    auto child_frame = this->child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+
+    transition_child_frame_to_local(parent_client, page_id, frame_id);
+
+    child_frame->owner = ChildFrameOwner::Remote;
+    child_frame->remote_client = move(remote_client);
+    child_frame->remote_page_id = remote_page_id;
+    parent_client.async_set_remote_child_frame_compositor_context(
+        page_id,
+        MUST(String::from_utf8(frame_id)),
+        Web::Compositor::compositor_context_id_for_page(remote_page_id));
+}
+
+void SiteIsolationManager::transition_child_frame_to_local(WebContentClient& parent_client, u64 page_id, StringView frame_id)
+{
+    auto child_frame = this->child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+
+    parent_client.async_set_remote_child_frame_compositor_context(page_id, MUST(String::from_utf8(frame_id)), {});
+
+    if (child_frame->is_remote()) {
+        child_frame->remote_client->async_set_page_parent_context(child_frame->remote_page_id, {});
+        child_frame->remote_client->request_close(child_frame->remote_page_id);
+    }
+
+    child_frame->owner = ChildFrameOwner::Local;
+    child_frame->remote_client = nullptr;
+    child_frame->remote_page_id = 0;
+}
+
+void SiteIsolationManager::close_remote_child_frames_for_page(WebContentClient& parent_client, u64 page_id)
+{
+    auto child_frames = m_child_frames.get(page_id);
+    if (!child_frames.has_value())
+        return;
+
+    Vector<String> remote_child_frame_ids;
+    for (auto const& child_frame_entry : *child_frames) {
+        if (child_frame_entry.value.is_remote())
+            remote_child_frame_ids.append(child_frame_entry.key);
+    }
+
+    for (auto const& frame_id : remote_child_frame_ids)
+        transition_child_frame_to_local(parent_client, page_id, frame_id);
 }
 
 Optional<SiteIsolationManager::ChildFrameHost&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id)
@@ -75,6 +237,78 @@ Optional<SiteIsolationManager::ChildFrameHost const&> SiteIsolationManager::chil
         return {};
 
     return child_frames->get(frame_id);
+}
+
+bool SiteIsolationManager::client_owns_page(WebContentClient const& client, u64 page_id)
+{
+    return client.m_views.contains(page_id) || client.m_embedded_pages.contains(page_id);
+}
+
+Optional<SiteIsolationManager::ParentFrame> SiteIsolationManager::parent_frame_for_remote_page(WebContentClient& remote_client, u64 remote_page_id)
+{
+    Optional<ParentFrame> result;
+
+    WebContentClient::for_each_client([&](auto& parent_client) {
+        for (auto& page_child_frames : m_child_frames) {
+            auto parent_page_id = page_child_frames.key;
+            if (!client_owns_page(parent_client, parent_page_id))
+                continue;
+
+            for (auto& child_frame_entry : page_child_frames.value) {
+                auto& child_frame = child_frame_entry.value;
+                if (!child_frame.is_remote() || child_frame.remote_client.ptr() != &remote_client || child_frame.remote_page_id != remote_page_id)
+                    continue;
+
+                result = ParentFrame {
+                    .parent_client = &parent_client,
+                    .page_id = parent_page_id,
+                    .frame_id = child_frame_entry.key,
+                    .child_frame = &child_frame,
+                };
+                return IterationDecision::Break;
+            }
+        }
+
+        return IterationDecision::Continue;
+    });
+
+    return result;
+}
+
+Optional<URL::URL> SiteIsolationManager::document_url_for_child_frame(ChildFrameHost const& child_frame)
+{
+    if (child_frame.last_committed_url.has_value())
+        return child_frame.last_committed_url;
+
+    if (child_frame.pending_navigation.has_value())
+        return child_frame.pending_navigation->target_url;
+
+    return {};
+}
+
+URL::URL SiteIsolationManager::document_url_for_page(WebContentClient& client, u64 page_id, URL::URL const& fallback_url)
+{
+    if (auto view = client.view_for_page_id(page_id); view.has_value())
+        return view->url();
+
+    if (client.m_embedded_pages.contains(page_id)) {
+        if (auto parent_frame = parent_frame_for_remote_page(client, page_id); parent_frame.has_value()) {
+            if (auto url = document_url_for_child_frame(*parent_frame->child_frame); url.has_value())
+                return *url;
+        }
+    }
+
+    return fallback_url;
+}
+
+URL::URL SiteIsolationManager::embedding_page_url_for_child_frame_navigation(WebContentClient& parent_client, u64 page_id, ChildFrameHost const& child_frame, URL::URL const& fallback_url)
+{
+    if (auto parent_frame = this->child_frame(page_id, child_frame.parent_frame_id); parent_frame.has_value()) {
+        if (auto url = document_url_for_child_frame(*parent_frame); url.has_value())
+            return *url;
+    }
+
+    return document_url_for_page(parent_client, page_id, fallback_url);
 }
 
 }

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -235,6 +235,34 @@ String SiteIsolationManager::dump_process_tree(WebContentClient& client, u64 pag
     return builder.to_string_without_validation();
 }
 
+HashMap<pid_t, pid_t> SiteIsolationManager::remote_frame_process_embedders() const
+{
+    HashMap<pid_t, pid_t> embedders;
+
+    for (auto const& page_child_frames : m_child_frames) {
+        WebContentClient* embedder_client = nullptr;
+        WebContentClient::for_each_client([&](auto& client) {
+            if (!client_owns_page(client, page_child_frames.key))
+                return IterationDecision::Continue;
+
+            embedder_client = &client;
+            return IterationDecision::Break;
+        });
+        if (!embedder_client)
+            continue;
+
+        for (auto const& child_frame_entry : page_child_frames.value) {
+            auto const& child_frame = child_frame_entry.value;
+            if (!child_frame.is_remote())
+                continue;
+
+            embedders.set(child_frame.remote_client->pid(), embedder_client->pid());
+        }
+    }
+
+    return embedders;
+}
+
 bool SiteIsolationManager::has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, ChildFrameOwner target_owner) const
 {
     auto child_frame = this->child_frame(page_id, frame_id);

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -6,6 +6,8 @@
 
 #include <LibWebView/SiteIsolationManager.h>
 
+#include <AK/QuickSort.h>
+#include <AK/StringBuilder.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWebView/SiteIsolation.h>
 #include <LibWebView/ViewImplementation.h>
@@ -169,6 +171,68 @@ void SiteIsolationManager::remove_all_pages_for_client(WebContentClient& client)
 
     for (auto page_id : page_ids)
         remove_page(page_id);
+}
+
+String SiteIsolationManager::dump_process_tree(WebContentClient& client, u64 page_id) const
+{
+    StringBuilder builder;
+    Vector<WebContentClient const*> processes;
+
+    auto process_index = [&](WebContentClient const& process) -> size_t {
+        for (size_t i = 0; i < processes.size(); ++i) {
+            if (processes[i] == &process)
+                return i;
+        }
+        processes.append(&process);
+        return processes.size() - 1;
+    };
+
+    auto sorted_child_frame_ids = [&](u64 page_id, Optional<StringView> parent_frame_id) {
+        Vector<String> child_frame_ids;
+        auto child_frames = m_child_frames.get(page_id);
+        if (!child_frames.has_value())
+            return child_frame_ids;
+
+        for (auto const& child_frame_entry : *child_frames) {
+            auto const& child_frame = child_frame_entry.value;
+            auto is_child_of_parent_frame = parent_frame_id.has_value()
+                ? child_frame.parent_frame_id == *parent_frame_id
+                : !child_frames->contains(child_frame.parent_frame_id);
+            if (is_child_of_parent_frame)
+                child_frame_ids.append(child_frame_entry.key);
+        }
+
+        quick_sort(child_frame_ids);
+        return child_frame_ids;
+    };
+
+    Function<void(WebContentClient&, u64, Optional<StringView>, size_t)> dump_frame_tree;
+    dump_frame_tree = [&](WebContentClient& current_client, u64 current_page_id, Optional<StringView> parent_frame_id, size_t depth) {
+        auto child_frames = m_child_frames.get(current_page_id);
+        if (!child_frames.has_value())
+            return;
+
+        auto child_frame_ids = sorted_child_frame_ids(current_page_id, parent_frame_id);
+        for (size_t i = 0; i < child_frame_ids.size(); ++i) {
+            auto child_frame = child_frames->get(child_frame_ids[i]);
+            VERIFY(child_frame.has_value());
+
+            builder.append_repeated(' ', depth * 2);
+            builder.appendff("iframe#{}: {}", i, child_frame->is_remote() ? "remote"sv : "local"sv);
+            if (child_frame->is_remote())
+                builder.appendff(" WebContent#{}", process_index(*child_frame->remote_client));
+            builder.append('\n');
+
+            if (child_frame->is_remote())
+                dump_frame_tree(*child_frame->remote_client, child_frame->remote_page_id, {}, depth + 1);
+            else
+                dump_frame_tree(current_client, current_page_id, child_frame_ids[i].bytes_as_string_view(), depth + 1);
+        }
+    };
+
+    builder.appendff("WebContent#{}\n", process_index(client));
+    dump_frame_tree(client, page_id, {}, 1);
+    return builder.to_string_without_validation();
 }
 
 bool SiteIsolationManager::has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, ChildFrameOwner target_owner) const

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -97,6 +97,29 @@ void SiteIsolationManager::did_destroy_child_frame(WebContentClient& parent_clie
         m_child_frames.remove(page_id);
 }
 
+Optional<SiteIsolationManager::RemoteChildFrameInputTarget> SiteIsolationManager::remote_child_frame_input_target_at(u64 page_id, Web::DevicePixelPoint position) const
+{
+    auto child_frames = m_child_frames.get(page_id);
+    if (!child_frames.has_value())
+        return {};
+
+    for (auto const& child_frame_entry : *child_frames) {
+        auto const& child_frame = child_frame_entry.value;
+        if (!child_frame.is_remote() || !child_frame.viewport_rect.has_value())
+            continue;
+        if (!child_frame.viewport_rect->contains(position))
+            continue;
+
+        return RemoteChildFrameInputTarget {
+            .remote_client = child_frame.remote_client,
+            .remote_page_id = child_frame.remote_page_id,
+            .viewport_rect = *child_frame.viewport_rect,
+        };
+    }
+
+    return {};
+}
+
 bool SiteIsolationManager::remote_child_frame_did_finish_loading(WebContentClient& remote_client, u64 remote_page_id, URL::URL const& url)
 {
     auto parent_frame = parent_frame_for_remote_page(remote_client, remote_page_id);
@@ -117,6 +140,16 @@ bool SiteIsolationManager::remote_child_frame_did_commit_navigation(WebContentCl
 
     parent_frame->child_frame->last_committed_url = url;
     parent_frame->child_frame->pending_navigation.clear();
+    return true;
+}
+
+bool SiteIsolationManager::remote_child_frame_did_finish_handling_input_event(WebContentClient& remote_client, u64 remote_page_id, Web::EventResult event_result)
+{
+    auto parent_frame = parent_frame_for_remote_page(remote_client, remote_page_id);
+    if (!parent_frame.has_value())
+        return false;
+
+    parent_frame->parent_client->did_finish_handling_input_event(parent_frame->page_id, event_result);
     return true;
 }
 

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -69,6 +69,7 @@ public:
     bool remote_child_frame_did_finish_handling_input_event(WebContentClient& remote_client, u64 remote_page_id, Web::EventResult);
     void remove_page(u64 page_id);
     void remove_all_pages_for_client(WebContentClient&);
+    String dump_process_tree(WebContentClient&, u64 page_id) const;
 
     bool has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, ChildFrameOwner) const;
     void record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, ChildFrameOwner, Optional<u64> remote_page_id = {});

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -12,6 +12,8 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Page/EventResult.h>
+#include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/Forward.h>
@@ -49,14 +51,22 @@ public:
         }
     };
 
+    struct RemoteChildFrameInputTarget {
+        RefPtr<WebContentClient> remote_client;
+        u64 remote_page_id { 0 };
+        Web::DevicePixelRect viewport_rect;
+    };
+
     Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
 
     void did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id);
     void did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio);
     bool did_commit_child_frame_navigation(WebContentClient&, u64 page_id, StringView frame_id, URL::URL const& url);
     void did_destroy_child_frame(WebContentClient&, u64 page_id, StringView frame_id);
+    Optional<RemoteChildFrameInputTarget> remote_child_frame_input_target_at(u64 page_id, Web::DevicePixelPoint) const;
     bool remote_child_frame_did_commit_navigation(WebContentClient& remote_client, u64 remote_page_id, URL::URL const&);
     bool remote_child_frame_did_finish_loading(WebContentClient& remote_client, u64 remote_page_id, URL::URL const&);
+    bool remote_child_frame_did_finish_handling_input_event(WebContentClient& remote_client, u64 remote_page_id, Web::EventResult);
     void remove_page(u64 page_id);
     void remove_all_pages_for_client(WebContentClient&);
 

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <LibURL/URL.h>
+#include <LibWeb/PixelUnits.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+class WEBVIEW_API SiteIsolationManager {
+public:
+    static SiteIsolationManager& the();
+
+    struct ChildFrameHost {
+        String parent_frame_id;
+        Optional<URL::URL> last_committed_url;
+        Optional<Web::DevicePixelRect> viewport_rect;
+        double device_pixel_ratio { 1 };
+    };
+
+    void did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id);
+    void did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio);
+    void did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url);
+    void did_destroy_child_frame(u64 page_id, StringView frame_id);
+    void remove_page(u64 page_id);
+
+    Optional<ChildFrameHost&> child_frame(u64 page_id, StringView frame_id);
+    Optional<ChildFrameHost const&> child_frame(u64 page_id, StringView frame_id) const;
+
+    template<CallableAs<IterationDecision, String const&, ChildFrameHost const&> Callback>
+    void for_each_child_frame(u64 page_id, Callback callback) const;
+
+private:
+    SiteIsolationManager() = default;
+
+    HashMap<u64, HashMap<String, ChildFrameHost>> m_child_frames;
+};
+
+template<CallableAs<IterationDecision, String const&, SiteIsolationManager::ChildFrameHost const&> Callback>
+void SiteIsolationManager::for_each_child_frame(u64 page_id, Callback callback) const
+{
+    auto child_frames = m_child_frames.get(page_id);
+    if (!child_frames.has_value())
+        return;
+
+    for (auto const& entry : *child_frames) {
+        if (callback(entry.key, entry.value) == IterationDecision::Break)
+            return;
+    }
+}
+
+}

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -70,6 +70,7 @@ public:
     void remove_page(u64 page_id);
     void remove_all_pages_for_client(WebContentClient&);
     String dump_process_tree(WebContentClient&, u64 page_id) const;
+    HashMap<pid_t, pid_t> remote_frame_process_embedders() const;
 
     bool has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, ChildFrameOwner) const;
     void record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, ChildFrameOwner, Optional<u64> remote_page_id = {});

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -8,9 +8,11 @@
 
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
+#include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/Forward.h>
 
@@ -20,18 +22,50 @@ class WEBVIEW_API SiteIsolationManager {
 public:
     static SiteIsolationManager& the();
 
+    enum class ChildFrameOwner : u8 {
+        Local,
+        Remote,
+    };
+
+    struct PendingChildFrameNavigation {
+        URL::URL target_url;
+        ChildFrameOwner target_owner { ChildFrameOwner::Local };
+        Optional<u64> remote_page_id;
+    };
+
     struct ChildFrameHost {
         String parent_frame_id;
         Optional<URL::URL> last_committed_url;
+        Optional<PendingChildFrameNavigation> pending_navigation;
         Optional<Web::DevicePixelRect> viewport_rect;
         double device_pixel_ratio { 1 };
+        ChildFrameOwner owner { ChildFrameOwner::Local };
+        RefPtr<WebContentClient> remote_client;
+        u64 remote_page_id { 0 };
+
+        bool is_remote() const
+        {
+            return owner == ChildFrameOwner::Remote && remote_client && remote_page_id != 0;
+        }
     };
+
+    Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
 
     void did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id);
     void did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio);
-    void did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url);
-    void did_destroy_child_frame(u64 page_id, StringView frame_id);
+    bool did_commit_child_frame_navigation(WebContentClient&, u64 page_id, StringView frame_id, URL::URL const& url);
+    void did_destroy_child_frame(WebContentClient&, u64 page_id, StringView frame_id);
+    bool remote_child_frame_did_commit_navigation(WebContentClient& remote_client, u64 remote_page_id, URL::URL const&);
+    bool remote_child_frame_did_finish_loading(WebContentClient& remote_client, u64 remote_page_id, URL::URL const&);
     void remove_page(u64 page_id);
+    void remove_all_pages_for_client(WebContentClient&);
+
+    bool has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, ChildFrameOwner) const;
+    void record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, ChildFrameOwner, Optional<u64> remote_page_id = {});
+    void clear_pending_child_frame_navigation(u64 page_id, StringView frame_id);
+    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, RefPtr<WebContentClient>, u64 remote_page_id);
+    void transition_child_frame_to_local(WebContentClient& parent_client, u64 page_id, StringView frame_id);
+    void close_remote_child_frames_for_page(WebContentClient&, u64 page_id);
 
     Optional<ChildFrameHost&> child_frame(u64 page_id, StringView frame_id);
     Optional<ChildFrameHost const&> child_frame(u64 page_id, StringView frame_id) const;
@@ -41,6 +75,19 @@ public:
 
 private:
     SiteIsolationManager() = default;
+
+    struct ParentFrame {
+        WebContentClient* parent_client { nullptr };
+        u64 page_id { 0 };
+        String frame_id;
+        ChildFrameHost* child_frame { nullptr };
+    };
+
+    static bool client_owns_page(WebContentClient const&, u64 page_id);
+    Optional<ParentFrame> parent_frame_for_remote_page(WebContentClient&, u64 page_id);
+    URL::URL document_url_for_page(WebContentClient&, u64 page_id, URL::URL const& fallback_url);
+    Optional<URL::URL> document_url_for_child_frame(ChildFrameHost const&);
+    URL::URL embedding_page_url_for_child_frame_navigation(WebContentClient&, u64 page_id, ChildFrameHost const&, URL::URL const&);
 
     HashMap<u64, HashMap<String, ChildFrameHost>> m_child_frames;
 };

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -29,6 +29,7 @@
 #include <LibWebView/HistoryStore.h>
 #include <LibWebView/Menu.h>
 #include <LibWebView/SiteIsolation.h>
+#include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/UserAgent.h>
 #include <LibWebView/ViewImplementation.h>
@@ -1143,6 +1144,10 @@ void ViewImplementation::debug_request(ByteString const& request, ByteString con
 {
     if (request == "dump-session-history"sv)
         dump_session_history("debug-request"sv, SessionHistoryDumpMode::Always);
+    if (request == "dump-site-isolation-process-tree"sv) {
+        dbgln("{}", SiteIsolationManager::the().dump_process_tree(client(), page_id()));
+        return;
+    }
 
     client().async_debug_request(page_id(), request, argument);
 }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -161,6 +161,7 @@ void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 void WebContentClient::unregister_view(u64 page_id)
 {
     forget_compositor_context(Web::Compositor::compositor_context_id_for_page(page_id));
+    SiteIsolationManager::the().close_remote_child_frames_for_page(*this, page_id);
     SiteIsolationManager::the().remove_page(page_id);
 
     // A page that still needs a beforeunload check is not a detached
@@ -188,9 +189,23 @@ void WebContentClient::request_close(u64 page_id)
     async_request_close(page_id);
 }
 
+void WebContentClient::register_embedded_page(u64 page_id)
+{
+    m_embedded_pages.set(page_id);
+    Application::process_manager().cancel_forced_exit(pid());
+}
+
+void WebContentClient::unregister_embedded_page(u64 page_id)
+{
+    m_embedded_pages.remove(page_id);
+    close_server_if_unused();
+}
+
 void WebContentClient::close_server_if_unused()
 {
     if (!m_views.is_empty())
+        return;
+    if (!m_embedded_pages.is_empty())
         return;
 
     if (m_detached_pages_pending_close.is_empty()) {
@@ -271,8 +286,7 @@ void WebContentClient::notify_compositor_process_reconnected(Badge<Application>)
 void WebContentClient::notify_all_views_of_crash()
 {
     destroy_all_compositor_contexts();
-    for (auto const& [page_id, view] : m_views)
-        SiteIsolationManager::the().remove_page(page_id);
+    SiteIsolationManager::the().remove_all_pages_for_client(*this);
 
     // Collect view IDs first, then use deferred_invoke to handle crashes safely
     // (avoids signal handler deadlock and allows views to be looked up by ID
@@ -364,6 +378,46 @@ void WebContentClient::did_request_new_process_for_navigation(u64 page_id, URL::
         view->create_new_process_for_cross_site_navigation(url, move(document_resource), history_handling);
 }
 
+Messages::WebContentClient::DecideNavigationProcessResponse WebContentClient::decide_navigation_process(u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
+{
+    return SiteIsolationManager::the().decide_navigation_process(*this, page_id, move(frame_id), move(current_url), move(target_url), target);
+}
+
+void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 page_id, String frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+{
+    auto& site_isolation_manager = SiteIsolationManager::the();
+    auto child_frame = site_isolation_manager.child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+    if (!site_isolation_manager.has_matching_pending_child_frame_navigation(page_id, frame_id, url, ChildFrameOwner::Remote))
+        return;
+
+    auto remote_process_or_error = Application::the().launch_child_frame_web_content_process();
+    if (remote_process_or_error.is_error()) {
+        warnln("Unable to create WebContent process for child frame navigation: {}", remote_process_or_error.error());
+        site_isolation_manager.clear_pending_child_frame_navigation(page_id, frame_id);
+        return;
+    }
+
+    auto remote_process = remote_process_or_error.release_value();
+    auto remote_page_id = remote_process.page_id;
+    auto remote_client = move(remote_process.client);
+    site_isolation_manager.record_pending_child_frame_navigation(page_id, frame_id, url, ChildFrameOwner::Remote, remote_page_id);
+    remote_client->register_embedded_page(remote_page_id);
+    remote_client->async_set_page_parent_context(remote_page_id, Web::Compositor::compositor_context_id_for_page(page_id));
+    if (child_frame->viewport_rect.has_value()) {
+        remote_client->async_set_viewport(
+            remote_page_id,
+            child_frame->viewport_rect->size(),
+            child_frame->device_pixel_ratio,
+            Web::ViewportIsFullscreen::No);
+    }
+    remote_client->async_set_system_visibility_state(remote_page_id, Web::HTML::VisibilityState::Visible);
+    remote_client->async_load_url_with_document_resource(remote_page_id, url, move(document_resource), history_handling);
+
+    site_isolation_manager.transition_child_frame_to_remote(*this, page_id, frame_id, move(remote_client), remote_page_id);
+}
+
 void WebContentClient::did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id)
 {
     SiteIsolationManager::the().did_create_child_frame(page_id, move(parent_frame_id), move(frame_id));
@@ -376,12 +430,12 @@ void WebContentClient::did_update_child_frame_viewport(u64 page_id, String frame
 
 void WebContentClient::did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url)
 {
-    SiteIsolationManager::the().did_commit_child_frame_navigation(page_id, move(frame_id), move(url));
+    SiteIsolationManager::the().did_commit_child_frame_navigation(*this, page_id, frame_id, url);
 }
 
 void WebContentClient::did_destroy_child_frame(u64 page_id, String frame_id)
 {
-    SiteIsolationManager::the().did_destroy_child_frame(page_id, frame_id);
+    SiteIsolationManager::the().did_destroy_child_frame(*this, page_id, frame_id);
 }
 
 Optional<WebContentClient::ChildFrameHost const&> WebContentClient::child_frame(u64 page_id, StringView frame_id) const
@@ -488,6 +542,8 @@ void WebContentClient::did_finish_loading(u64 page_id, URL::URL url)
             if (listener.on_load_finish)
                 listener.on_load_finish(client_url);
         }
+    } else {
+        SiteIsolationManager::the().remote_child_frame_did_commit_navigation(*this, page_id, url);
     }
 }
 
@@ -584,6 +640,8 @@ void WebContentClient::did_change_url(u64 page_id, URL::URL url)
 
         if (view->on_url_change)
             view->on_url_change(url);
+    } else {
+        SiteIsolationManager::the().remote_child_frame_did_finish_loading(*this, page_id, url);
     }
 }
 
@@ -1154,7 +1212,9 @@ void WebContentClient::did_request_activate_tab(u64 page_id)
 
 void WebContentClient::did_close_browsing_context(u64 page_id)
 {
+    unregister_embedded_page(page_id);
     m_detached_pages_pending_close.remove(page_id);
+    SiteIsolationManager::the().close_remote_child_frames_for_page(*this, page_id);
     SiteIsolationManager::the().remove_page(page_id);
 
     if (auto view = m_views.get(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1574,6 +1574,11 @@ Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse 
     return { "{}"_string };
 }
 
+Messages::WebContentClient::DidRequestSiteIsolationProcessTreeForTestingResponse WebContentClient::did_request_site_isolation_process_tree_for_testing(u64 page_id)
+{
+    return { SiteIsolationManager::the().dump_process_tree(*this, page_id) };
+}
+
 Messages::WebContentClient::DidUpdateSessionHistoryAndRequestUiProcessSessionHistoryForTestingResponse WebContentClient::did_update_session_history_and_request_ui_process_session_history_for_testing(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -321,6 +321,13 @@ bool WebContentClient::send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPo
 
 bool WebContentClient::handle_mouse_event_in_compositor(u64 page_id, Web::MouseEvent const& event)
 {
+    if (auto target = SiteIsolationManager::the().remote_child_frame_input_target_at(page_id, event.position); target.has_value()) {
+        auto translated_event = event.clone_without_browser_data();
+        translated_event.position.set_x(event.position.x() - target->viewport_rect.x());
+        translated_event.position.set_y(event.position.y() - target->viewport_rect.y());
+        return target->remote_client->handle_mouse_event_in_compositor(target->remote_page_id, translated_event);
+    }
+
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
 
     auto handled = Application::the().handle_mouse_event_in_compositor(compositor_context_id_for_page(page_id), event);
@@ -343,6 +350,14 @@ bool WebContentClient::handle_pinch_event_in_compositor(u64 page_id, Web::PinchE
 
 void WebContentClient::dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const& event)
 {
+    if (auto target = SiteIsolationManager::the().remote_child_frame_input_target_at(page_id, event.position); target.has_value()) {
+        auto translated_event = event.clone_without_browser_data();
+        translated_event.position.set_x(event.position.x() - target->viewport_rect.x());
+        translated_event.position.set_y(event.position.y() - target->viewport_rect.y());
+        target->remote_client->dispatch_mouse_event_to_web_content(target->remote_page_id, translated_event);
+        return;
+    }
+
     auto context_id = compositor_context_id_for_page(page_id);
     if (Application::the().dispatch_mouse_event_to_web_content(context_id, event))
         return;
@@ -1472,8 +1487,12 @@ void WebContentClient::did_request_select_dropdown(u64 page_id, Gfx::IntPoint co
 
 void WebContentClient::did_finish_handling_input_event(u64 page_id, Web::EventResult event_result)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value())
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
         view->did_finish_handling_input_event({}, event_result);
+        return;
+    }
+
+    SiteIsolationManager::the().remote_child_frame_did_finish_handling_input_event(*this, page_id, event_result);
 }
 
 void WebContentClient::did_update_input_caret_rect(u64 page_id, Optional<Web::DevicePixelRect> rect)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -23,6 +23,7 @@
 #include <LibWebView/HSTSStore.h>
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/HistoryStore.h>
+#include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/SourceHighlighter.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
@@ -160,6 +161,7 @@ void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 void WebContentClient::unregister_view(u64 page_id)
 {
     forget_compositor_context(Web::Compositor::compositor_context_id_for_page(page_id));
+    SiteIsolationManager::the().remove_page(page_id);
 
     // A page that still needs a beforeunload check is not a detached
     // background close. It is being closed without waiting for WebContent,
@@ -269,6 +271,8 @@ void WebContentClient::notify_compositor_process_reconnected(Badge<Application>)
 void WebContentClient::notify_all_views_of_crash()
 {
     destroy_all_compositor_contexts();
+    for (auto const& [page_id, view] : m_views)
+        SiteIsolationManager::the().remove_page(page_id);
 
     // Collect view IDs first, then use deferred_invoke to handle crashes safely
     // (avoids signal handler deadlock and allows views to be looked up by ID
@@ -358,6 +362,31 @@ void WebContentClient::did_request_new_process_for_navigation(u64 page_id, URL::
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
         view->create_new_process_for_cross_site_navigation(url, move(document_resource), history_handling);
+}
+
+void WebContentClient::did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id)
+{
+    SiteIsolationManager::the().did_create_child_frame(page_id, move(parent_frame_id), move(frame_id));
+}
+
+void WebContentClient::did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
+{
+    SiteIsolationManager::the().did_update_child_frame_viewport(page_id, move(frame_id), viewport_rect, device_pixel_ratio);
+}
+
+void WebContentClient::did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url)
+{
+    SiteIsolationManager::the().did_commit_child_frame_navigation(page_id, move(frame_id), move(url));
+}
+
+void WebContentClient::did_destroy_child_frame(u64 page_id, String frame_id)
+{
+    SiteIsolationManager::the().did_destroy_child_frame(page_id, frame_id);
+}
+
+Optional<WebContentClient::ChildFrameHost const&> WebContentClient::child_frame(u64 page_id, StringView frame_id) const
+{
+    return SiteIsolationManager::the().child_frame(page_id, frame_id);
 }
 
 void WebContentClient::did_start_webdriver_navigation(u64 page_id, URL::URL url)
@@ -1126,6 +1155,7 @@ void WebContentClient::did_request_activate_tab(u64 page_id)
 void WebContentClient::did_close_browsing_context(u64 page_id)
 {
     m_detached_pages_pending_close.remove(page_id);
+    SiteIsolationManager::the().remove_page(page_id);
 
     if (auto view = m_views.get(page_id); view.has_value()) {
         if ((*view)->on_close)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -30,9 +30,11 @@
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
 #include <LibWeb/Page/EventResult.h>
+#include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/SiteIsolationManager.h>
@@ -50,6 +52,7 @@ class WEBVIEW_API WebContentClient final
 
 public:
     using InitTransport = Messages::WebContentServer::InitTransport;
+    using ChildFrameOwner = SiteIsolationManager::ChildFrameOwner;
     using ChildFrameHost = SiteIsolationManager::ChildFrameHost;
 
     template<CallableAs<IterationDecision, WebContentClient&> Callback>
@@ -70,6 +73,8 @@ public:
     void request_close(u64 page_id);
 
     void web_ui_disconnected(Badge<WebUI>);
+    void register_embedded_page(u64 page_id);
+    void unregister_embedded_page(u64 page_id);
 
     bool has_views() const { return !m_views.is_empty(); }
 
@@ -96,6 +101,8 @@ public:
     void set_pid(pid_t pid) { m_process_handle.pid = pid; }
 
 private:
+    friend class SiteIsolationManager;
+
     void maybe_record_history_visit_for_current_load(u64 page_id, URL::URL const&, Optional<String> title, StringView reason);
     void close_server_if_unused();
     bool forget_compositor_context(Web::Compositor::CompositorContextId);
@@ -105,7 +112,9 @@ private:
 
     virtual Messages::WebContentClient::AllocateCompositorContextIdResponse allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration) override;
     virtual void did_destroy_compositor_context(Web::Compositor::CompositorContextId) override;
+    virtual Messages::WebContentClient::DecideNavigationProcessResponse decide_navigation_process(u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget) override;
     virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
+    virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, String frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
     virtual void did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id) override;
     virtual void did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
     virtual void did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url) override;
@@ -234,6 +243,7 @@ private:
     void remember_compositor_context(Web::Compositor::CompositorContextId, Optional<u64> page_id);
 
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
+    HashTable<u64> m_embedded_pages;
     HashTable<u64> m_detached_pages_pending_close;
     HashMap<Web::Compositor::CompositorContextId, Optional<u64>> m_compositor_contexts;
     HashMap<u64, String> m_history_recorded_urls_for_current_load;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -229,6 +229,7 @@ private:
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual void did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index) override;
     virtual Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse did_request_ui_process_session_history_for_testing(u64 page_id) override;
+    virtual Messages::WebContentClient::DidRequestSiteIsolationProcessTreeForTestingResponse did_request_site_isolation_process_tree_for_testing(u64 page_id) override;
     virtual Messages::WebContentClient::DidUpdateSessionHistoryAndRequestUiProcessSessionHistoryForTestingResponse did_update_session_history_and_request_ui_process_session_history_for_testing(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index) override;
     virtual void did_set_top_level_session_history(u64 page_id, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index) override;
     virtual void did_traverse_the_history_to_step(u64 page_id, i32 step, bool step_was_available, Web::HTML::HistoryStepResult) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -35,6 +35,7 @@
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/SiteIsolationManager.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentServerEndpoint.h>
 
@@ -49,6 +50,7 @@ class WEBVIEW_API WebContentClient final
 
 public:
     using InitTransport = Messages::WebContentServer::InitTransport;
+    using ChildFrameHost = SiteIsolationManager::ChildFrameHost;
 
     template<CallableAs<IterationDecision, WebContentClient&> Callback>
     static void for_each_client(Callback callback);
@@ -85,6 +87,10 @@ public:
     void notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
     void did_present_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store);
     void did_present_bitmap(u64 page_id, Gfx::IntRect, i32 bitmap_id);
+    Optional<ChildFrameHost const&> child_frame(u64 page_id, StringView frame_id) const;
+
+    template<CallableAs<IterationDecision, String const&, ChildFrameHost const&> Callback>
+    void for_each_child_frame(u64 page_id, Callback callback) const;
 
     pid_t pid() const { return m_process_handle.pid; }
     void set_pid(pid_t pid) { m_process_handle.pid = pid; }
@@ -100,6 +106,10 @@ private:
     virtual Messages::WebContentClient::AllocateCompositorContextIdResponse allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration) override;
     virtual void did_destroy_compositor_context(Web::Compositor::CompositorContextId) override;
     virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
+    virtual void did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id) override;
+    virtual void did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
+    virtual void did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url) override;
+    virtual void did_destroy_child_frame(u64 page_id, String frame_id) override;
     virtual void did_start_webdriver_navigation(u64 page_id, URL::URL url) override;
     virtual void did_finish_loading(u64 page_id, URL::URL) override;
     virtual void did_request_refresh(u64 page_id) override;
@@ -245,6 +255,12 @@ void WebContentClient::for_each_client(Callback callback)
         if (callback(*it) == IterationDecision::Break)
             return;
     }
+}
+
+template<CallableAs<IterationDecision, String const&, WebContentClient::ChildFrameHost const&> Callback>
+void WebContentClient::for_each_child_frame(u64 page_id, Callback callback) const
+{
+    SiteIsolationManager::the().for_each_child_frame(page_id, move(callback));
 }
 
 }

--- a/Libraries/LibWebView/WebUI/ProcessesUI.cpp
+++ b/Libraries/LibWebView/WebUI/ProcessesUI.cpp
@@ -6,7 +6,12 @@
 
 #include <LibWebView/Application.h>
 #include <LibWebView/ProcessManager.h>
+#include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/WebUI/ProcessesUI.h>
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/String.h>
 
 namespace WebView {
 
@@ -22,7 +27,32 @@ void ProcessesUI::update_process_statistics()
     auto& process_manager = Application::process_manager();
     process_manager.update_all_process_statistics();
 
-    async_send_message("loadProcessStatistics"sv, process_manager.serialize_json());
+    auto process_embedders = SiteIsolationManager::the().remote_frame_process_embedders();
+    auto serialize_process_statistics = [&] {
+        JsonArray serialized;
+
+        process_manager.for_each_process_statistics([&](auto& process, auto const& statistics) {
+            auto type = process_name_from_type(process.type());
+            auto const& title = process.title();
+
+            auto process_name = title.has_value()
+                ? MUST(String::formatted("{} - {}", type, *title))
+                : MUST(String::from_utf8(type.bytes()));
+
+            JsonObject object;
+            object.set("name"sv, move(process_name));
+            object.set("pid"sv, statistics.pid);
+            object.set("cpu"sv, statistics.cpu_percent);
+            object.set("memory"sv, statistics.memory_usage_bytes);
+            if (auto embedder_pid = process_embedders.get(statistics.pid); embedder_pid.has_value())
+                object.set("embedderPID"sv, *embedder_pid);
+            serialized.must_append(move(object));
+        });
+
+        return serialized;
+    };
+
+    async_send_message("loadProcessStatistics"sv, serialize_process_statistics());
 }
 
 }

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -473,7 +473,7 @@ Web::Compositor::PendingAsyncScrollUpdates ContextState::take_pending_async_scro
 void ContextState::viewport_size_updated(Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
     m_viewport_size = viewport_size;
-    auto is_page_presentation_context = m_page_id.has_value();
+    auto is_page_presentation_context = m_page_id.has_value() && !m_parent_context_id.has_value();
     m_window_resize_in_progress = is_page_presentation_context
         ? window_resize_in_progress
         : Web::Compositor::WindowResizingInProgress::No;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -133,6 +133,18 @@ void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Co
     compositor_context.set_parent_context(parent_context_id);
 }
 
+void ConnectionFromClient::set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->set_remote_child_frame_compositor_context(move(frame_id), context_id);
+}
+
+void ConnectionFromClient::run_iframe_load_event_steps(u64 page_id, String frame_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->run_iframe_load_event_steps(frame_id);
+}
+
 Optional<PageClient&> ConnectionFromClient::page(u64 index, SourceLocation location)
 {
     if (auto page = m_page_host->page(index); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -121,6 +121,18 @@ void ConnectionFromClient::initialize(u64 initial_page_id)
     m_page_host->initialize(initial_page_id);
 }
 
+void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto& compositor_context = page->page().top_level_traversable()->compositor_context();
+    if (parent_context_id.has_value())
+        compositor_context.stop_presenting_to_client();
+    compositor_context.set_parent_context(parent_context_id);
+}
+
 Optional<PageClient&> ConnectionFromClient::page(u64 index, SourceLocation location)
 {
     if (auto page = m_page_host->page(index); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -90,7 +90,9 @@ private:
     virtual void load_html(u64 page_id, ByteString) override;
     virtual void load_html_with_url(u64 page_id, ByteString, URL::URL) override;
     virtual void reload(u64 page_id) override;
+    virtual void run_iframe_load_event_steps(u64 page_id, String frame_id) override;
     virtual void set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId>) override;
+    virtual void set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId>) override;
     virtual void traverse_the_history_by_delta(u64 page_id, i32 delta) override;
     virtual void traverse_the_history_to_step(u64 page_id, i32 step) override;
     virtual void check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) override;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -90,6 +90,7 @@ private:
     virtual void load_html(u64 page_id, ByteString) override;
     virtual void load_html_with_url(u64 page_id, ByteString, URL::URL) override;
     virtual void reload(u64 page_id) override;
+    virtual void set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId>) override;
     virtual void traverse_the_history_by_delta(u64 page_id, i32 delta) override;
     virtual void traverse_the_history_to_step(u64 page_id, i32 step) override;
     virtual void check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -193,6 +193,26 @@ void PageClient::request_new_process_for_navigation(URL::URL const& url, Variant
     client().async_did_request_new_process_for_navigation(m_id, url, move(document_resource), history_handling);
 }
 
+void PageClient::page_did_create_child_frame(String const& parent_frame_id, String const& frame_id)
+{
+    client().async_did_create_child_frame(m_id, parent_frame_id, frame_id);
+}
+
+void PageClient::page_did_update_child_frame_viewport(String const& frame_id, Web::CSSPixelRect viewport_rect)
+{
+    client().async_did_update_child_frame_viewport(m_id, frame_id, page().css_to_device_rect(viewport_rect), page().client().device_pixel_ratio());
+}
+
+void PageClient::page_did_commit_child_frame_navigation(String const& frame_id, URL::URL const& url)
+{
+    client().async_did_commit_child_frame_navigation(m_id, frame_id, url);
+}
+
+void PageClient::page_did_destroy_child_frame(String const& frame_id)
+{
+    client().async_did_destroy_child_frame(m_id, frame_id);
+}
+
 Gfx::Palette PageClient::palette() const
 {
     return Gfx::Palette(*m_palette_impl);

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -31,6 +31,7 @@
 #include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
@@ -175,12 +176,12 @@ bool PageClient::is_connection_open() const
     return client().is_open();
 }
 
-Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target) const
+Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target, Optional<String> frame_id) const
 {
     if (target != Web::NavigationTarget::TopLevel)
-        return Web::NavigationProcessDecision::Local;
+        return client().decide_navigation_process(m_id, move(frame_id), current_url, target_url, target);
 
-    return WebView::is_url_suitable_for_same_process_navigation(current_url, target_url)
+    return WebView::is_url_suitable_for_same_process_navigation(current_url, target_url, Web::NavigationTarget::TopLevel)
         ? Web::NavigationProcessDecision::Local
         : Web::NavigationProcessDecision::Remote;
 }
@@ -191,6 +192,11 @@ void PageClient::request_new_process_for_navigation(URL::URL const& url, Variant
         m_webdriver->page_did_start_window_replacement({}, page().top_level_traversable()->window_handle());
 
     client().async_did_request_new_process_for_navigation(m_id, url, move(document_resource), history_handling);
+}
+
+void PageClient::request_new_process_for_child_frame_navigation(String const& frame_id, URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+{
+    client().async_did_request_new_process_for_child_frame_navigation(m_id, frame_id, url, move(document_resource), history_handling);
 }
 
 void PageClient::page_did_create_child_frame(String const& parent_frame_id, String const& frame_id)
@@ -210,7 +216,44 @@ void PageClient::page_did_commit_child_frame_navigation(String const& frame_id, 
 
 void PageClient::page_did_destroy_child_frame(String const& frame_id)
 {
+    m_remote_child_frame_compositor_contexts.remove(frame_id);
     client().async_did_destroy_child_frame(m_id, frame_id);
+}
+
+void PageClient::set_remote_child_frame_compositor_context(String frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
+{
+    if (context_id.has_value())
+        m_remote_child_frame_compositor_contexts.set(move(frame_id), *context_id);
+    else
+        m_remote_child_frame_compositor_contexts.remove(frame_id);
+    request_frame();
+}
+
+Optional<Web::Compositor::CompositorContextId> PageClient::compositor_context_id_for_remote_child_frame(String const& frame_id) const
+{
+    return m_remote_child_frame_compositor_contexts.get(frame_id);
+}
+
+void PageClient::run_iframe_load_event_steps(String const& frame_id)
+{
+    auto active_document = page().top_level_traversable()->active_document();
+    if (!active_document)
+        return;
+
+    for (auto const& navigable : active_document->inclusive_descendant_navigables()) {
+        if (navigable->id() != frame_id)
+            continue;
+
+        auto container = GC::make_root(navigable->container());
+        if (!container || !is<Web::HTML::HTMLIFrameElement>(*container))
+            return;
+
+        container->queue_an_element_task(Web::HTML::Task::Source::DOMManipulation, [container] {
+            Web::HTML::run_iframe_load_event_steps(as<Web::HTML::HTMLIFrameElement>(*container));
+        });
+        container->document().schedule_html_parser_end_check();
+        return;
+    }
 }
 
 Gfx::Palette PageClient::palette() const

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -936,6 +936,11 @@ String PageClient::page_did_request_ui_process_session_history_for_testing()
     return client().did_request_ui_process_session_history_for_testing(m_id);
 }
 
+String PageClient::dump_site_isolation_process_tree_for_testing()
+{
+    return client().did_request_site_isolation_process_tree_for_testing(m_id);
+}
+
 String PageClient::page_did_update_session_history_and_request_ui_process_session_history_for_testing(Vector<Web::HTML::SessionHistoryEntryDescriptor> const& entries, Vector<i32> const& used_steps, size_t current_used_step_index)
 {
     return client().did_update_session_history_and_request_ui_process_session_history_for_testing(m_id, entries, used_steps, current_used_step_index);

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -175,9 +175,14 @@ bool PageClient::is_connection_open() const
     return client().is_open();
 }
 
-bool PageClient::is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url) const
+Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target) const
 {
-    return WebView::is_url_suitable_for_same_process_navigation(current_url, target_url);
+    if (target != Web::NavigationTarget::TopLevel)
+        return Web::NavigationProcessDecision::Local;
+
+    return WebView::is_url_suitable_for_same_process_navigation(current_url, target_url)
+        ? Web::NavigationProcessDecision::Local
+        : Web::NavigationProcessDecision::Remote;
 }
 
 void PageClient::request_new_process_for_navigation(URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -140,7 +140,7 @@ private:
 
     // ^PageClient
     virtual bool is_connection_open() const override;
-    virtual bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url) const override;
+    virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget) const override;
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_all_screen_rects[m_main_screen_index]; }

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -150,6 +150,7 @@ private:
     virtual void page_did_commit_child_frame_navigation(String const& frame_id, URL::URL const&) override;
     virtual void page_did_destroy_child_frame(String const& frame_id) override;
     virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(String const&) const override;
+    virtual String dump_site_isolation_process_tree_for_testing() override;
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_all_screen_rects[m_main_screen_index]; }
     virtual size_t screen_count() const override { return m_all_screen_rects.size(); }

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -142,6 +142,10 @@ private:
     virtual bool is_connection_open() const override;
     virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget) const override;
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
+    virtual void page_did_create_child_frame(String const& parent_frame_id, String const& frame_id) override;
+    virtual void page_did_update_child_frame_viewport(String const& frame_id, Web::CSSPixelRect) override;
+    virtual void page_did_commit_child_frame_navigation(String const& frame_id, URL::URL const&) override;
+    virtual void page_did_destroy_child_frame(String const& frame_id) override;
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_all_screen_rects[m_main_screen_index]; }
     virtual size_t screen_count() const override { return m_all_screen_rects.size(); }

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -125,6 +125,8 @@ public:
     void send_current_needs_beforeunload_check();
     void wait_for_webdriver_navigation_completion(Optional<u64> page_load_timeout, Function<void(Web::WebDriver::Response)>);
     void did_complete_webdriver_navigation_completion(u64 request_id, Web::WebDriver::Response);
+    void run_iframe_load_event_steps(String const& frame_id);
+    void set_remote_child_frame_compositor_context(String, Optional<Web::Compositor::CompositorContextId>);
     void clear_pending_dom_mutations();
     void did_delete_all_cookies(u64 request_id);
 
@@ -140,12 +142,14 @@ private:
 
     // ^PageClient
     virtual bool is_connection_open() const override;
-    virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget) const override;
+    virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget, Optional<String> frame_id) const override;
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
+    virtual void request_new_process_for_child_frame_navigation(String const& frame_id, URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
     virtual void page_did_create_child_frame(String const& parent_frame_id, String const& frame_id) override;
     virtual void page_did_update_child_frame_viewport(String const& frame_id, Web::CSSPixelRect) override;
     virtual void page_did_commit_child_frame_navigation(String const& frame_id, URL::URL const&) override;
     virtual void page_did_destroy_child_frame(String const& frame_id) override;
+    virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(String const&) const override;
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_all_screen_rects[m_main_screen_index]; }
     virtual size_t screen_count() const override { return m_all_screen_rects.size(); }
@@ -285,6 +289,7 @@ private:
     RefPtr<Core::Timer> m_frame_timer;
     Optional<double> m_last_frame_dispatch_time;
     Queue<PendingDOMMutation> m_pending_dom_mutations;
+    HashMap<String, Web::Compositor::CompositorContextId> m_remote_child_frame_compositor_contexts;
 
     u64 m_devtools_client_count { 0 };
 };

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -44,6 +44,10 @@ endpoint WebContentClient
     did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
 
     did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
+    did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id) =|
+    did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
+    did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url) =|
+    did_destroy_child_frame(u64 page_id, String frame_id) =|
     did_start_webdriver_navigation(u64 page_id, URL::URL url) =|
     did_start_loading(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     did_cancel_loading(u64 page_id, URL::URL url) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -43,7 +43,9 @@ endpoint WebContentClient
     allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
     did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
 
+    decide_navigation_process(u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target) => (Web::NavigationProcessDecision decision)
     did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
+    did_request_new_process_for_child_frame_navigation(u64 page_id, String frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id) =|
     did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
     did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -159,6 +159,7 @@ endpoint WebContentClient
     did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
     did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index) =|
     did_request_ui_process_session_history_for_testing(u64 page_id) => (String session_history)
+    did_request_site_isolation_process_tree_for_testing(u64 page_id) => (String process_tree)
     did_update_session_history_and_request_ui_process_session_history_for_testing(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index) => (String session_history)
     did_set_top_level_session_history(u64 page_id, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index) =|
     did_traverse_the_history_to_step(u64 page_id, i32 step, bool step_was_available, Web::HTML::HistoryStepResult result) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -58,7 +58,9 @@ endpoint WebContentServer
     load_html(u64 page_id, ByteString html) =|
     load_html_with_url(u64 page_id, ByteString html, URL::URL url) =|
     reload(u64 page_id) =|
+    run_iframe_load_event_steps(u64 page_id, String frame_id) =|
     set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id) =|
+    set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId> context_id) =|
     traverse_the_history_by_delta(u64 page_id, i32 delta) =|
     traverse_the_history_to_step(u64 page_id, i32 step) =|
     check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -6,6 +6,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/Clipboard/SystemClipboard.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
@@ -57,6 +58,7 @@ endpoint WebContentServer
     load_html(u64 page_id, ByteString html) =|
     load_html_with_url(u64 page_id, ByteString html, URL::URL url) =|
     reload(u64 page_id) =|
+    set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id) =|
     traverse_the_history_by_delta(u64 page_id, i32 delta) =|
     traverse_the_history_to_step(u64 page_id, i32 step) =|
     check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) =|

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -390,7 +390,7 @@ Messages::WebDriverClient::NavigateToResponse WebDriverConnection::navigate_to(J
     // FIXME: 3. If url is not an absolute URL or is not an absolute URL with fragment or not a local scheme, return error with error code invalid argument.
 
     auto const& current_url = current_top_level_browsing_context()->active_document()->url();
-    auto will_replace_web_content_process = !current_top_level_browsing_context()->page().client().is_url_suitable_for_same_process_navigation(current_url, url.value());
+    auto will_replace_web_content_process = current_top_level_browsing_context()->page().client().decide_navigation_process(current_url, url.value(), Web::NavigationTarget::TopLevel) == Web::NavigationProcessDecision::Remote;
 
     // 4. Handle any user prompts and return its value if it is an error.
     handle_any_user_prompts([this, url = move(url), will_replace_web_content_process]() {
@@ -568,7 +568,7 @@ Messages::WebDriverClient::LoadUrlFromUiResponse WebDriverConnection::load_url_f
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload has an invalid `url`"sv);
 
     auto const& current_url = current_top_level_browsing_context()->active_document()->url();
-    auto will_replace_web_content_process = !current_top_level_browsing_context()->page().client().is_url_suitable_for_same_process_navigation(current_url, *url);
+    auto will_replace_web_content_process = current_top_level_browsing_context()->page().client().decide_navigation_process(current_url, *url, Web::NavigationTarget::TopLevel) == Web::NavigationProcessDecision::Remote;
 
     auto& page_client = static_cast<WebContent::PageClient&>(current_top_level_browsing_context()->page().client());
     auto response = page_client.request_webdriver_load_url_from_ui(*url);

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -167,7 +167,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
     args_parser.add_option(Core::ArgsParser::Option {
         .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
-        .help_string = "Set site isolation mode. Mode may be 'disable' or 'top-level' (default).",
+        .help_string = "Set site isolation mode. Mode may be 'disable', 'top-level' (default), or 'iframe'.",
         .long_name = "site-isolation",
         .value_name = "mode",
         .accept_value = [&](StringView value) {

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -141,7 +141,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     bool expose_internals_object = false;
     bool wait_for_debugger = false;
     bool log_all_js_exceptions = false;
-    bool disable_site_isolation = false;
+    auto site_isolation_mode = WebView::SiteIsolationMode::TopLevel;
     bool enable_idl_tracing = false;
     bool enable_http_memory_cache = false;
     bool force_fontconfig = false;
@@ -165,7 +165,20 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
-    args_parser.add_option(disable_site_isolation, "Disable site isolation", "disable-site-isolation");
+    args_parser.add_option(Core::ArgsParser::Option {
+        .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
+        .help_string = "Set site isolation mode. Mode may be 'disable' or 'top-level' (default).",
+        .long_name = "site-isolation",
+        .value_name = "mode",
+        .accept_value = [&](StringView value) {
+            auto parsed_mode = WebView::site_isolation_mode_from_string(value);
+            if (!parsed_mode.has_value())
+                return false;
+
+            site_isolation_mode = *parsed_mode;
+            return true;
+        },
+    });
     args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
     args_parser.add_option(enable_http_memory_cache, "Enable HTTP cache", "enable-http-memory-cache");
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
@@ -209,8 +222,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     WebContent::PageClient::set_is_headless(is_headless);
 
-    if (disable_site_isolation)
-        WebView::disable_site_isolation();
+    WebView::set_site_isolation_mode(site_isolation_mode);
 
     if (enable_http_memory_cache)
         Web::Fetch::Fetching::set_http_memory_cache_enabled(true);

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -72,7 +72,7 @@ static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint,
 
     // FIXME: WebDriver does not yet handle the WebContent process switch brought by site isolation.
     if (!Core::Environment::has("LADYBIRD_WEBDRIVER_ENABLE_SITE_ISOLATION"sv))
-        arguments.append("--disable-site-isolation"sv);
+        arguments.append("--site-isolation=disable"sv);
 
     arguments.append("about:blank"sv);
     return arguments;

--- a/Tests/LibWeb/Text/expected/Internals/dump-site-isolation-process-tree.txt
+++ b/Tests/LibWeb/Text/expected/Internals/dump-site-isolation-process-tree.txt
@@ -1,0 +1,3 @@
+WebContent#0
+  iframe#0: local
+

--- a/Tests/LibWeb/Text/input/Internals/dump-site-isolation-process-tree.html
+++ b/Tests/LibWeb/Text/input/Internals/dump-site-isolation-process-tree.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<script src="../include.js"></script>
+<iframe srcdoc="<p>child</p>"></iframe>
+<script>
+    asyncTest(done => {
+        addEventListener("load", () => {
+            println(internals.dumpSiteIsolationProcessTree());
+            done();
+        });
+    });
+</script>

--- a/UI/Android/src/main/cpp/WebContentService.cpp
+++ b/UI/Android/src/main/cpp/WebContentService.cpp
@@ -66,7 +66,7 @@ ErrorOr<int> service_main(int ipc_socket)
     // Currently site isolation doesn't work on Android since everything is running
     // in the same process. It would require an entire redesign of this port
     // in order to make it work. For now, it's better to just disable it.
-    WebView::disable_site_isolation();
+    WebView::set_site_isolation_mode(WebView::SiteIsolationMode::Disabled);
 
     auto maybe_content_blocker_error = load_content_blockers();
     if (maybe_content_blocker_error.is_error())

--- a/UI/Gtk/Menu.cpp
+++ b/UI/Gtk/Menu.cpp
@@ -248,6 +248,7 @@ static void initialize_native_control(WebView::Action& action, GSimpleAction* ga
         break;
     case WebView::ActionID::DumpLayoutTree:
     case WebView::ActionID::DumpPaintTree:
+    case WebView::ActionID::DumpSiteIsolationProcessTree:
     case WebView::ActionID::DumpDisplayList:
         set_icon("view-list-symbolic");
         break;


### PR DESCRIPTION
This adds the first pieces needed to host cross-site iframes in separate
WebContent processes, exposed behind:

`--site-isolation=iframe`

At a high level, the UI process now tracks child frame hosts for each page.
When LibWeb decides that an iframe navigation should use a remote process,
LibWebView launches a child WebContent process, records the parent/child
relationship, loads the iframe document there, and embeds the child
compositor context back into the parent frame's viewport. Navigations back
to a same-site document transition the frame back to the local WebContent
process.

The UI process also forwards basic mouse input into remote iframes by using
the tracked child frame geometry, and forwards the remote event result back
through the embedding page. Debugging support is included via
about:processes and a site isolation process tree dump action.

There are still a lot of limitations in this support which need to be fixed before
being enabled by default. For example:

- input forwarding is limited to basic mouse events
- importantly, cross-frame JavaScript relationships are not fully remote-aware yet, so
  APIs like iframe.contentWindow/top/parent has gaps (this in particular is a problem for stuff like cloudflare turnstile)
- keyboard focus, pointer capture, touch, drag/drop, cursors, and context
  menus across remote frames need follow-up work
- hit testing uses iframe viewport geometry rather than full compositor hit
  test data
- remote iframe lifecycle, history, crash handling, and COOP/related process
  isolation policy still need more integration

This works well enough so that a simple test page like the following:

<img width="1395" height="762" alt="image" src="https://github.com/user-attachments/assets/7b706638-6670-4496-a677-7df1618dd668" />

Works as expected when clicking around switching between cross site iframe and same site iframe.