### PR TITLE
CI: Cache cargo crates and retry transient crates.io fetches

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[net]
+retry = 10
+
+[http]
+multiplexing = false

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -176,6 +176,16 @@ runs:
       shell: bash
       run: echo "${GITHUB_WORKSPACE}/${{ steps.wasm-tools.outputs.name }}" >> "$GITHUB_PATH"
 
+    - name: 'Cache cargo registry'
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          /opt/cargo/registry
+        key: cargo-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}-${{ runner.arch }}-
+
     - name: 'Set required environment variables'
       if: ${{ inputs.os == 'Linux' && inputs.arch == 'arm64' }}
       shell: bash


### PR DESCRIPTION
This includes two changes to make our CI cargo crates.io access more resilient:

**Cache the cargo registry.** Every CI job has been re-downloading 151 crates from crates.io on every run — which has become a recurring source of spurious CI failures (in particular, for the Lint job).

**Increase retries, and sidestep HTTP/2 framing errors.** This adds more download-retry attempts, and disables `http.multiplexing` — to sidestep HTTP/2 framing errors. (`"curl ... [16] Error in the HTTP2 framing layer"` is the error that shows up most frequently, so those seem to have been a specific cause of most of the failures).

Fixes https://github.com/LadybirdBrowser/ladybird/issues/8478.