### PR TITLE
LibWeb: Bail on unresolved percentages in `resolve_value`

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -3162,7 +3162,7 @@ Optional<CalculatedStyleValue::ResolvedValue> CalculatedStyleValue::resolve_valu
     // NOTE: Any nodes which rely on dynamic state should have been simplified away in absolutized so we can pass a nullptr here
     auto simplified_tree = simplify_a_calculation_tree(m_calculation, m_context, resolution_context);
 
-    if (!is<NumericCalculationNode>(*simplified_tree))
+    if (!is<NumericCalculationNode>(*simplified_tree) || (simplified_tree->contains_percentage() && m_context.percentages_resolve_as.has_value()))
         return {};
 
     auto value = try_get_value_with_canonical_unit(simplified_tree, m_context, resolution_context);

--- a/Tests/LibWeb/Crash/CSS/unresolved-percentage-isnt-considered-resolvable.html
+++ b/Tests/LibWeb/Crash/CSS/unresolved-percentage-isnt-considered-resolvable.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<style>
+    input:focus {
+        transform: translateX(calc(10%));
+    }</style
+><input id="target" />
+<script>
+    target.focus();
+</script>


### PR DESCRIPTION
Previously we assumed that if the calculation had been simplified to a single `NumericCalculationNode` that we could resolve it - this isn't the case if we have a percentage that should be resolved to a different type.

Fixes #10209