### PR TITLE
LibWeb: Don't crash when evaluating XPath against a rootless document

### DIFF
--- a/Libraries/LibWeb/XPath/XPath.cpp
+++ b/Libraries/LibWeb/XPath/XPath.cpp
@@ -92,7 +92,10 @@ static xmlNodePtr mirror_node(xmlDocPtr doc, DOM::Node const& node)
     }
     case DOM::NodeType::DOCUMENT_NODE: {
         auto const& document = static_cast<DOM::Document const&>(node);
-        return mirror_node(doc, *document.document_element());
+        auto const* document_element = document.document_element();
+        if (!document_element)
+            return nullptr;
+        return mirror_node(doc, *document_element);
     }
     case DOM::NodeType::DOCUMENT_TYPE_NODE: {
         return nullptr; // Unused in libxml2

--- a/Tests/LibWeb/Crash/DOM/xpath-evaluate-rootless-document.html
+++ b/Tests/LibWeb/Crash/DOM/xpath-evaluate-rootless-document.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<script>
+    // createDocument with an empty qualified name yields a document with no root element.
+    const doc = document.implementation.createDocument(null, "", null);
+    document.evaluate("/", doc, null, XPathResult.ANY_TYPE, null);
+</script>


### PR DESCRIPTION
**Problem:** Crash when evaluating an XPath expression against a document that has no root element.

**Cause:** `mirror_node()`’s `DOCUMENT_NODE` branch unconditionally mirrored `document.document_element()`. But a document may lack a root element — in which case, `document_element()` returns null.

**Fix:** Return null from `mirror_node()` when the document has no root element. (The caller already maps a null mirror result to a failed evaluation, and raises an error in that case.) Fixes https://github.com/LadybirdBrowser/ladybird/issues/10004.
