### PR TITLE
LibWeb: Saturate CSSPixels unary negation at the i32 minimum

### DIFF
--- a/Libraries/LibWeb/PixelUnits.h
+++ b/Libraries/LibWeb/PixelUnits.h
@@ -180,7 +180,7 @@ public:
     }
 
     constexpr CSSPixels operator+() const { return from_raw(+raw_value()); }
-    constexpr CSSPixels operator-() const { return from_raw(-raw_value()); }
+    constexpr CSSPixels operator-() const { return from_raw(saturating_sub(0, raw_value())); }
 
     constexpr CSSPixels operator+(CSSPixels const& other) const
     {

--- a/Tests/LibWeb/Text/expected/css-pixels-saturated-negation.txt
+++ b/Tests/LibWeb/Text/expected/css-pixels-saturated-negation.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/css-pixels-saturated-negation.html
+++ b/Tests/LibWeb/Text/input/css-pixels-saturated-negation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    /* A huge negative inset saturates the CSSPixels raw value to the i32 minimum. */
+    #target {
+        position: relative;
+        right: -999999999999999999999999999999999999px;
+        width: 1px;
+        height: 1px;
+    }
+</style>
+<div id="target"></div>
+<script>
+    test(() => {
+        // Forces layout, which negates the inset while resolving relative positioning.
+        document.documentElement.offsetHeight;
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
**Problem:** UBSan crash when computing layout for an element with a giant negative inset.

**Cause:** `CSSPixels::operator-()` returned `from_raw(-raw_value())`. Negating the `i32` minimum overflows `int`.

**Fix:** Negate with `saturating_sub(0, raw_value())` — matching the saturating arithmetic already used by the other `CSSPixels` operators. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9997.
