### PR TITLE
Documentation: Add `glslang-tools` as a dependency for Ubuntu

### DIFF
--- a/.devcontainer/features/ladybird/install-ubuntu.sh
+++ b/.devcontainer/features/ladybird/install-ubuntu.sh
@@ -31,7 +31,7 @@ install_cmake() {
 ### Install packages
 
 apt update -y
-apt install -y autoconf autoconf-archive automake bison build-essential ccache curl fonts-liberation2 git libdrm-dev libgl1-mesa-dev libncurses-dev libtool libxkbcommon-dev lsb-release nasm ninja-build pkg-config python3 qt6-base-dev qt6-tools-dev-tools qt6-wayland shellcheck tar unzip zip
+apt install -y autoconf autoconf-archive automake bison build-essential ccache curl fonts-liberation2 git glslang-tools libdrm-dev libgl1-mesa-dev libncurses-dev libtool libxkbcommon-dev lsb-release nasm ninja-build pkg-config python3 qt6-base-dev qt6-tools-dev-tools qt6-wayland shellcheck tar unzip zip
 
 install_cmake
 

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -17,7 +17,7 @@ CMake 3.30 or newer must be available in $PATH.
 
 <!-- Note: If you change something here, please also change it in the `devcontainer/devcontainer.json` file. -->
 ```bash
-sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git libdrm-dev libgl1-mesa-dev libncurses-dev libtool nasm ninja-build pkg-config python3-venv qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
+sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git glslang-tools libdrm-dev libgl1-mesa-dev libncurses-dev libtool nasm ninja-build pkg-config python3-venv qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
 ```
 
 #### CMake 3.30 or newer:


### PR DESCRIPTION
This is needed for WebGL to work on Ubuntu.