### PR TITLE
UI/Qt: Improve autocomplete and macOS window behavior

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1683,6 +1683,8 @@ void Application::create_bookmark_menu_items(Optional<MenuData> data)
                 auto action = Action::create(bookmark.title.value_or({}), ActionID::BookmarkItem, [this, url = bookmark.url]() {
                     if (auto view = active_web_view(); view.has_value())
                         view->load(url);
+                    else
+                        open_url_in_new_tab(url, Web::HTML::ActivateTab::Yes);
                 });
 
                 action->set_base64_png_icon(bookmark.favicon_base64_png);

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -111,7 +111,7 @@ public:
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
     virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }
     virtual bool activate_tab_with_url(URL::URL const&) const { return false; }
-    void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const;
+    virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const;
     void open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab) const;
 
     Main::Arguments const& command_line_arguments() const { return m_arguments; }

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -42,6 +42,12 @@ set(SOURCES
     CompositorClient.cpp
 )
 
+if (APPLE)
+    list(APPEND SOURCES
+        PlatformColorsMacOS.cpp
+    )
+endif()
+
 set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})
 
 compile_ipc(UIProcessServer.ipc UIProcessServerEndpoint.h)

--- a/Libraries/LibWebView/PlatformColors.h
+++ b/Libraries/LibWebView/PlatformColors.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Color.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+WEBVIEW_API Gfx::Color macos_web_selection_color();
+
+}

--- a/Libraries/LibWebView/PlatformColorsMacOS.cpp
+++ b/Libraries/LibWebView/PlatformColorsMacOS.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/PlatformColors.h>
+
+namespace WebView {
+
+Gfx::Color macos_web_selection_color()
+{
+    return Gfx::Color(128, 188, 254, 153);
+}
+
+}

--- a/UI/AppKit/Interface/Palette.mm
+++ b/UI/AppKit/Interface/Palette.mm
@@ -8,6 +8,7 @@
 #include <LibCore/Resource.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/SystemTheme.h>
+#include <LibWebView/PlatformColors.h>
 
 #import <Cocoa/Cocoa.h>
 #import <Interface/Palette.h>
@@ -39,7 +40,7 @@ Core::AnonymousBuffer create_system_palette()
     auto palette = Gfx::Palette(move(palette_impl));
     palette.set_flag(Gfx::FlagRole::IsDark, is_dark);
     palette.set_color(Gfx::ColorRole::Accent, ns_color_to_gfx_color([NSColor controlAccentColor]));
-    palette.set_color(Gfx::ColorRole::Selection, Gfx::Color(128, 188, 254, 153));
+    palette.set_color(Gfx::ColorRole::Selection, WebView::macos_web_selection_color());
     palette.set_color(Gfx::ColorRole::InactiveSelection, ns_color_to_gfx_color([NSColor unemphasizedSelectedTextBackgroundColor]));
     palette.set_color(Gfx::ColorRole::InactiveSelectionText, ns_color_to_gfx_color([NSColor unemphasizedSelectedTextColor]));
     // FIXME: There are more system colors we currently don't use (https://developer.apple.com/documentation/appkit/nscolor/3000782-controlaccentcolor?language=objc)

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -6,10 +6,12 @@
 
 #include <LibCore/ArgsParser.h>
 #include <LibURL/InternalURLs.h>
+#include <LibWebView/HistoryStore.h>
 #include <LibWebView/URL.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/EventLoopImplementationQt.h>
+#include <UI/Qt/Menu.h>
 #include <UI/Qt/Settings.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/WebContentView.h>
@@ -18,6 +20,7 @@
 #    include <UI/Qt/MacWindow.h>
 #endif
 
+#include <QAction>
 #include <QClipboard>
 #include <QDesktopServices>
 #include <QDialog>
@@ -25,10 +28,14 @@
 #include <QFileDialog>
 #include <QFileOpenEvent>
 #include <QFormLayout>
+#include <QKeySequence>
 #include <QLineEdit>
+#include <QMenu>
+#include <QMenuBar>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QStandardPaths>
+#include <QTimer>
 
 #if defined(AK_OS_WINDOWS)
 #    include <AK/Windows.h>
@@ -69,6 +76,7 @@ public:
         : QApplication(arguments.argc, arguments.argv)
     {
 #if defined(AK_OS_MACOS)
+        setQuitOnLastWindowClosed(false);
         install_appkit_event_capture();
 #endif
         update_chrome_style();
@@ -111,11 +119,121 @@ public:
         return handled;
     }
 
+#if defined(AK_OS_MACOS)
+    void update_reopen_recently_closed_action()
+    {
+        if (!m_reopen_recently_closed_tab_action)
+            return;
+
+        auto recently_closed_entry = Application::history_store().most_recently_closed_entry();
+        m_reopen_recently_closed_tab_action->setText("&Reopen Recently Closed Tab");
+        m_reopen_recently_closed_tab_action->setEnabled(recently_closed_entry.has_value());
+    }
+
+#endif
+
+#if defined(AK_OS_MACOS)
+    void create_application_menu_bar()
+    {
+        if (m_application_menu_bar)
+            return;
+
+        m_application_menu_bar = new QMenuBar;
+        auto& application = Application::the();
+
+        auto* file_menu = m_application_menu_bar->addMenu("&File");
+
+        auto* new_tab_action = add_application_menu_action(*file_menu, "New &Tab", QKeySequence::keyBindings(QKeySequence::StandardKey::AddTab));
+        QObject::connect(new_tab_action, &QAction::triggered, this, [] {
+            Application::the().open_new_tab();
+        });
+
+        auto* new_window_action = add_application_menu_action(*file_menu, "New &Window", QKeySequence::keyBindings(QKeySequence::StandardKey::New));
+        QObject::connect(new_window_action, &QAction::triggered, this, [] {
+            Application::the().open_new_window();
+        });
+
+        m_reopen_recently_closed_tab_action = add_application_menu_action(*file_menu, {}, { QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_T) });
+        QObject::connect(m_reopen_recently_closed_tab_action, &QAction::triggered, this, [] {
+            Application::the().reopen_recently_closed_tab();
+        });
+
+        auto* open_file_action = add_application_menu_action(*file_menu, "&Open File...", QKeySequence::keyBindings(QKeySequence::StandardKey::Open));
+        QObject::connect(open_file_action, &QAction::triggered, this, [] {
+            Application::the().open_file();
+        });
+
+        auto* open_location_action = add_application_menu_action(*file_menu, "Open &Location", { QKeySequence("Ctrl+L"), QKeySequence("Alt+D") });
+        QObject::connect(open_location_action, &QAction::triggered, this, [] {
+            Application::the().focus_location_editor();
+        });
+
+        file_menu->addSeparator();
+
+        auto* quit_action = add_application_menu_action(*file_menu, "&Quit", QKeySequence::keyBindings(QKeySequence::StandardKey::Quit));
+        QObject::connect(quit_action, &QAction::triggered, this, [] {
+            Application::the().quit();
+        });
+
+        auto* edit_menu = m_application_menu_bar->addMenu("&Edit");
+        edit_menu->addAction(create_application_action(*edit_menu, application.cut_selection_action(), IncludeActionIcon::No));
+        edit_menu->addAction(create_application_action(*edit_menu, application.copy_selection_action(), IncludeActionIcon::No));
+        edit_menu->addAction(create_application_action(*edit_menu, application.paste_action(), IncludeActionIcon::No));
+        edit_menu->addAction(create_application_action(*edit_menu, application.select_all_action(), IncludeActionIcon::No));
+        edit_menu->addSeparator();
+        edit_menu->addAction(create_application_action(*edit_menu, application.open_settings_page_action(), IncludeActionIcon::No));
+
+        auto* view_menu = m_application_menu_bar->addMenu("&View");
+        view_menu->addMenu(create_application_menu(*view_menu, application.color_scheme_menu()));
+        view_menu->addMenu(create_application_menu(*view_menu, application.contrast_menu()));
+        view_menu->addMenu(create_application_menu(*view_menu, application.motion_menu()));
+
+        m_application_menu_bar->addMenu(bookmarks_menu());
+        m_application_menu_bar->addMenu(create_application_menu(*m_application_menu_bar, application.history_menu()));
+
+        auto* help_menu = m_application_menu_bar->addMenu("&Help");
+        help_menu->addAction(create_application_action(*help_menu, application.open_about_page_action(), IncludeActionIcon::No));
+
+        update_reopen_recently_closed_action();
+    }
+#endif
+
+#if defined(AK_OS_MACOS)
+    QMenu* bookmarks_menu()
+    {
+        if (!m_bookmarks_menu)
+            m_bookmarks_menu = create_application_menu(*m_application_menu_bar, Application::the().bookmarks_menu());
+        return m_bookmarks_menu;
+    }
+
+    void rebuild_bookmarks_menu()
+    {
+        if (m_bookmarks_menu)
+            repopulate_application_menu(*m_bookmarks_menu, *m_application_menu_bar, Application::the().bookmarks_menu());
+    }
+#endif
+
 private:
+#if defined(AK_OS_MACOS)
+    QAction* add_application_menu_action(QMenu& menu, QString const& text, QList<QKeySequence> shortcuts)
+    {
+        auto* action = new QAction(text, m_application_menu_bar);
+        action->setShortcuts(shortcuts);
+        menu.addAction(action);
+        return action;
+    }
+#endif
+
     void update_chrome_style()
     {
         setStyleSheet(ChromeStyle::application_style_sheet(palette()));
     }
+
+#if defined(AK_OS_MACOS)
+    QMenuBar* m_application_menu_bar { nullptr };
+    QMenu* m_bookmarks_menu { nullptr };
+    QAction* m_reopen_recently_closed_tab_action { nullptr };
+#endif
 };
 
 Application::Application() = default;
@@ -145,12 +263,15 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Win
 {
     auto* window = new BrowserWindow(initial_urls, is_popup_window, parent_tab, move(page_index));
     set_active_window(*window);
+    QObject::connect(window, &QObject::destroyed, m_application.ptr(), [this, window] {
+        if (m_active_window == window)
+            m_active_window = nullptr;
+    });
 
-    if (initial_urls.size() == 1 && initial_urls.first() == URL::about_newtab()) {
-        if (auto* tab = window->current_tab()) {
+    auto should_focus_location_editor = initial_urls.size() == 1 && initial_urls.first() == WebView::Application::settings().new_tab_page_url();
+    if (should_focus_location_editor) {
+        if (auto* tab = window->current_tab())
             tab->set_url_is_hidden(true);
-            tab->focus_location_editor();
-        }
     }
 
     window->set_window_rect(configuration.x, configuration.y, configuration.width, configuration.height);
@@ -161,7 +282,105 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Win
 
     window->activateWindow();
     window->raise();
+    if (should_focus_location_editor) {
+        QTimer::singleShot(0, window, [window] {
+            if (auto* tab = window->current_tab())
+                tab->focus_location_editor();
+        });
+    }
     return *window;
+}
+
+void Application::open_new_tab()
+{
+    if (!m_active_window) {
+        new_window({ WebView::Application::settings().new_tab_page_url() });
+        return;
+    }
+
+    auto& tab = m_active_window->new_tab_from_url(WebView::Application::settings().new_tab_page_url(), Web::HTML::ActivateTab::Yes);
+    tab.set_url_is_hidden(true);
+    tab.focus_location_editor();
+}
+
+void Application::open_new_window()
+{
+    WindowConfiguration configuration {};
+    if (auto* previous_active_window = active_window_if_any()) {
+        configuration.width = previous_active_window->width();
+        configuration.height = previous_active_window->height();
+        configuration.maximized = previous_active_window->isMaximized();
+    }
+    new_window({ WebView::Application::settings().new_tab_page_url() }, configuration);
+}
+
+void Application::focus_location_editor()
+{
+    if (!m_active_window) {
+        new_window({ WebView::Application::settings().new_tab_page_url() });
+        return;
+    }
+
+    if (auto* tab = m_active_window->current_tab())
+        tab->focus_location_editor();
+}
+
+void Application::reopen_recently_closed_tab()
+{
+    auto recently_closed_entry = Application::history_store().pop_most_recently_closed_entry();
+    if (recently_closed_entry.has_value()) {
+        if (recently_closed_entry->was_window) {
+            auto& window = new_window(recently_closed_entry->urls);
+            window.activate_tab(static_cast<int>(recently_closed_entry->active_tab_index));
+        } else if (!recently_closed_entry->urls.is_empty()) {
+            if (!m_active_window)
+                new_window({ recently_closed_entry->urls[0] });
+            else
+                m_active_window->new_tab_from_url(recently_closed_entry->urls[0], Web::HTML::ActivateTab::Yes);
+        }
+    }
+    update_reopen_recently_closed_actions();
+}
+
+void Application::open_file()
+{
+    if (!m_active_window) {
+        auto filename = QFileDialog::getOpenFileUrl(nullptr, "Open file", QDir::homePath(), "All Files (*.*)");
+        if (filename.isValid())
+            new_window({ ak_url_from_qurl(filename) });
+        return;
+    }
+
+    m_active_window->open_file();
+}
+
+void Application::quit()
+{
+    QApplication::closeAllWindows();
+
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (as_if<BrowserWindow>(widget) && widget->isVisible())
+            return;
+    }
+
+    QApplication::quit();
+}
+
+void Application::initialize_macos_application_menu()
+{
+#if defined(AK_OS_MACOS)
+    if (m_application)
+        static_cast<LadybirdQApplication*>(m_application.ptr())->create_application_menu_bar();
+#endif
+}
+
+QMenu* Application::qt_bookmarks_menu() const
+{
+#if defined(AK_OS_MACOS)
+    if (m_application)
+        return static_cast<LadybirdQApplication*>(m_application.ptr())->bookmarks_menu();
+#endif
+    return nullptr;
 }
 
 Optional<WebView::ViewImplementation&> Application::active_web_view() const
@@ -173,8 +392,25 @@ Optional<WebView::ViewImplementation&> Application::active_web_view() const
 
 Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML::ActivateTab activate_tab) const
 {
+    if (!m_active_window) {
+        auto& window = const_cast<Application&>(*this).new_window({ WebView::Application::settings().new_tab_page_url() });
+        if (auto* tab = window.current_tab())
+            return tab->view();
+        return {};
+    }
+
     auto& tab = active_window().create_new_tab(activate_tab);
     return tab.view();
+}
+
+void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTab activate_tab) const
+{
+    if (!m_active_window) {
+        const_cast<Application&>(*this).new_window({ url });
+        return;
+    }
+
+    active_window().new_tab_from_url(url, activate_tab);
 }
 
 bool Application::activate_tab_with_url(URL::URL const& url) const
@@ -322,6 +558,11 @@ void Application::update_tabs_display() const
 
 void Application::rebuild_bookmarks_menu() const
 {
+#if defined(AK_OS_MACOS)
+    if (m_application)
+        static_cast<LadybirdQApplication*>(m_application.ptr())->rebuild_bookmarks_menu();
+#endif
+
     for (auto* widget : QApplication::topLevelWidgets()) {
         if (auto* window = as_if<BrowserWindow>(widget))
             window->rebuild_bookmarks_menu();
@@ -330,6 +571,11 @@ void Application::rebuild_bookmarks_menu() const
 
 void Application::update_reopen_recently_closed_actions() const
 {
+#if defined(AK_OS_MACOS)
+    if (m_application)
+        static_cast<LadybirdQApplication*>(m_application.ptr())->update_reopen_recently_closed_action();
+#endif
+
     for (auto* widget : QApplication::topLevelWidgets()) {
         if (auto* window = as_if<BrowserWindow>(widget))
             window->update_reopen_recently_closed_action();

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -13,6 +13,8 @@
 
 #include <QApplication>
 
+class QMenu;
+
 namespace Ladybird {
 
 struct WindowConfiguration {
@@ -31,9 +33,18 @@ public:
 
     Function<void(URL::URL)> on_open_file;
     BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& = {}, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    void open_new_tab();
+    void open_new_window();
+    void focus_location_editor();
+    void reopen_recently_closed_tab();
+    void open_file();
+    void quit();
+    void initialize_macos_application_menu();
+    QMenu* qt_bookmarks_menu() const;
 
     BrowserWindow& active_window() const { return *m_active_window; }
     void set_active_window(BrowserWindow& w) { m_active_window = &w; }
+    BrowserWindow* active_window_if_any() const { return m_active_window; }
 
     Tab* active_tab() const { return m_active_window ? m_active_window->current_tab() : nullptr; }
     void update_reopen_recently_closed_actions() const;
@@ -46,6 +57,7 @@ private:
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
+    virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const override;
     virtual bool activate_tab_with_url(URL::URL const&) const override;
     virtual void open_url_in_new_window(URL::URL const& url) override;
 

--- a/UI/Qt/Autocomplete.cpp
+++ b/UI/Qt/Autocomplete.cpp
@@ -471,8 +471,10 @@ void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion>
 
     update_chrome_style();
     position_popup();
-    if (!m_popup->isVisible())
+    if (!m_popup->isVisible()) {
         m_popup->show();
+        position_popup();
+    }
     m_popup->raise();
 
     int table_row = m_model->table_row_for_suggestion_index(selected_suggestion_index);
@@ -522,6 +524,7 @@ bool Autocomplete::select_next_suggestion()
     if (!m_popup->isVisible()) {
         position_popup();
         m_popup->show();
+        position_popup();
         m_popup->raise();
         int row = step_to_selectable_row(-1, 1);
         if (row != -1)
@@ -545,6 +548,7 @@ bool Autocomplete::select_previous_suggestion()
     if (!m_popup->isVisible()) {
         position_popup();
         m_popup->show();
+        position_popup();
         m_popup->raise();
         int row = step_to_selectable_row(0, -1);
         if (row != -1)

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -90,14 +90,6 @@ static Optional<u64> display_id_for_screen(QScreen* screen)
     });
 }
 
-static QString reopen_recently_closed_action_text(Optional<WebView::RecentlyClosedEntry const&> entry)
-{
-    if (entry.has_value() && entry->was_window)
-        return "&Reopen Recently Closed Window";
-
-    return "&Reopen Recently Closed Tab";
-}
-
 static Vector<URL::URL> recently_closed_urls_for_window(TabWidget const& tabs_container)
 {
     Vector<URL::URL> urls;
@@ -373,7 +365,9 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     if (show_menubar_option_available())
         view_menu->addAction(create_application_action(*view_menu, application.toggle_menu_bar_action(), IncludeActionIcon::No));
 
-    m_bookmarks_menu = create_application_menu(*this, application.bookmarks_menu());
+    m_bookmarks_menu = Application::the().qt_bookmarks_menu();
+    if (!m_bookmarks_menu)
+        m_bookmarks_menu = create_application_menu(*this, application.bookmarks_menu());
     m_hamburger_menu->addMenu(m_bookmarks_menu);
     menuBar()->addMenu(m_bookmarks_menu);
 
@@ -401,35 +395,26 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     quit_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Quit));
     m_hamburger_menu->addAction(quit_action);
     file_menu->addAction(quit_action);
+#if defined(AK_OS_MACOS)
+    QObject::connect(quit_action, &QAction::triggered, this, [] {
+        Application::the().quit();
+    });
+#else
     QObject::connect(quit_action, &QAction::triggered, this, &QMainWindow::close);
+#endif
 
-    QObject::connect(m_new_tab_action, &QAction::triggered, this, [this] {
-        auto& tab = new_tab_from_url(WebView::Application::settings().new_tab_page_url(), Web::HTML::ActivateTab::Yes);
-        tab.set_url_is_hidden(true);
-        tab.focus_location_editor();
+    QObject::connect(m_new_tab_action, &QAction::triggered, this, [] {
+        Application::the().open_new_tab();
     });
     QObject::connect(m_new_window_action, &QAction::triggered, this, [] {
-        auto const& previous_active_window = Application::the().active_window();
-        WindowConfiguration configuration {
-            .width = previous_active_window.width(),
-            .height = previous_active_window.height(),
-            .maximized = previous_active_window.isMaximized(),
-        };
-        Application::the().new_window({ WebView::Application::settings().new_tab_page_url() }, configuration);
+        Application::the().open_new_window();
     });
-    QObject::connect(m_reopen_recently_closed_tab_action, &QAction::triggered, this, [this] {
-        auto recently_closed_entry = Application::history_store().pop_most_recently_closed_entry();
-        if (recently_closed_entry.has_value()) {
-            if (recently_closed_entry->was_window) {
-                auto& window = Application::the().new_window(recently_closed_entry->urls);
-                window.activate_tab(static_cast<int>(recently_closed_entry->active_tab_index));
-            } else if (!recently_closed_entry->urls.is_empty()) {
-                new_tab_from_url(recently_closed_entry->urls[0], Web::HTML::ActivateTab::Yes);
-            }
-        }
-        Application::the().update_reopen_recently_closed_actions();
+    QObject::connect(m_reopen_recently_closed_tab_action, &QAction::triggered, this, [] {
+        Application::the().reopen_recently_closed_tab();
     });
-    QObject::connect(open_file_action, &QAction::triggered, this, &BrowserWindow::open_file);
+    QObject::connect(open_file_action, &QAction::triggered, this, [] {
+        Application::the().open_file();
+    });
 
     m_exit_button = new ExitFullscreenButton { this };
     m_fullscreen_mode = new FullscreenMode { this, m_exit_button };
@@ -514,7 +499,8 @@ void BrowserWindow::update_tabs_display()
 
 void BrowserWindow::rebuild_bookmarks_menu()
 {
-    repopulate_application_menu(*m_bookmarks_menu, *this, Application::the().bookmarks_menu());
+    if (m_bookmarks_menu != Application::the().qt_bookmarks_menu())
+        repopulate_application_menu(*m_bookmarks_menu, *this, Application::the().bookmarks_menu());
 
     for_each_tab([](Tab& tab) {
         tab.bookmarks_bar().rebuild();
@@ -751,7 +737,7 @@ void BrowserWindow::update_reopen_recently_closed_action()
         return;
 
     auto recently_closed_entry = Application::history_store().most_recently_closed_entry();
-    m_reopen_recently_closed_tab_action->setText(reopen_recently_closed_action_text(recently_closed_entry));
+    m_reopen_recently_closed_tab_action->setText("&Reopen Recently Closed Tab");
     m_reopen_recently_closed_tab_action->setEnabled(recently_closed_entry.has_value());
 }
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -64,6 +64,8 @@ static constexpr auto WINDOW_DRAG_REGION_PROPERTY = "LadybirdWindowDragRegion";
 #if defined(AK_OS_MACOS)
 static constexpr qreal WINDOW_CORNER_RADIUS = 12.0;
 #endif
+static constexpr int WINDOW_RESIZE_BORDER_WIDTH = 6;
+static constexpr int WINDOW_RESIZE_CORNER_WIDTH = WINDOW_RESIZE_BORDER_WIDTH * 2;
 
 static bool should_use_screen_signal_for_dpi_changes()
 {
@@ -243,6 +245,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     setWindowIcon(app_icon());
     qApp->installEventFilter(this);
     update_window_corners();
+    update_appkit_window_resizability();
     update_window_border();
 
     update_tabs_display();
@@ -992,6 +995,7 @@ void BrowserWindow::update_window_decoration_state()
         }
     }
 
+    update_appkit_window_resizability();
     update_menu_bar_visibility();
     update_window_border();
 }
@@ -1160,6 +1164,7 @@ bool BrowserWindow::event(QEvent* event)
 #if defined(AK_OS_MACOS)
             QTimer::singleShot(0, this, [this] {
                 update_window_corners();
+                update_appkit_window_resizability();
             });
 #endif
         } else if (platform_surface_event->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed) {
@@ -1169,10 +1174,17 @@ bool BrowserWindow::event(QEvent* event)
     if (event->type() == QEvent::ScreenChangeInternal)
         screen_changed(screen());
 
-    if (event->type() == QEvent::WindowActivate)
+    if (event->type() == QEvent::WindowActivate) {
         Application::the().set_active_window(*this);
-    else if (event->type() == QEvent::WindowDeactivate || event->type() == QEvent::Hide)
+        QTimer::singleShot(0, this, [this] {
+            refresh_resize_cursor_at_current_position(true);
+        });
+        QTimer::singleShot(50, this, [this] {
+            refresh_resize_cursor_at_current_position(true);
+        });
+    } else if (event->type() == QEvent::WindowDeactivate || event->type() == QEvent::Hide) {
         clear_resize_cursor();
+    }
 
     return QMainWindow::event(event);
 }
@@ -1184,6 +1196,18 @@ bool BrowserWindow::eventFilter(QObject* object, QEvent* event)
         return QMainWindow::eventFilter(object, event);
     if (!uses_client_side_decorations())
         return QMainWindow::eventFilter(object, event);
+
+    if (m_is_resizing_window) {
+        if (event->type() == QEvent::MouseMove) {
+            auto* mouse_event = static_cast<QMouseEvent*>(event);
+            update_window_resize(mouse_event->globalPosition().toPoint());
+            return true;
+        }
+        if (event->type() == QEvent::MouseButtonRelease) {
+            finish_window_resize();
+            return true;
+        }
+    }
 
     auto const is_button = qobject_cast<QAbstractButton*>(object) != nullptr;
 
@@ -1215,11 +1239,18 @@ bool BrowserWindow::eventFilter(QObject* object, QEvent* event)
         return QMainWindow::eventFilter(object, event);
 
     auto position = widget->mapTo(this, mouse_event->position().toPoint());
+    auto edges = resize_edges_for_position(position);
     if (event->type() == QEvent::MouseButtonPress && !isMaximized() && !isFullScreen()) {
-        auto edges = resize_edges_for_position(position);
-        auto* handle = windowHandle();
-        if (edges != Qt::Edges {} && handle && handle->startSystemResize(edges))
-            return true;
+        if (edges != Qt::Edges {}) {
+#if defined(AK_OS_MACOS)
+            if (start_window_resize(edges, mouse_event->globalPosition().toPoint()))
+                return true;
+#else
+            auto* handle = windowHandle();
+            if (handle && handle->startSystemResize(edges))
+                return true;
+#endif
+        }
     }
 
     auto is_empty_window_drag_region = widget->property(WINDOW_DRAG_REGION_PROPERTY).toBool()
@@ -1248,18 +1279,62 @@ bool BrowserWindow::eventFilter(QObject* object, QEvent* event)
     return QMainWindow::eventFilter(object, event);
 }
 
+bool BrowserWindow::position_is_in_rounded_corner_cutout(QPoint const& position) const
+{
+#if defined(AK_OS_MACOS)
+    auto should_use_rounded_corners = WebView::Application::settings().config_variable_as_bool(WebView::ConfigVariableID::UseRoundedWindowCorners);
+    if (!should_use_rounded_corners || isFullScreen())
+        return false;
+
+    auto const radius = WINDOW_CORNER_RADIUS;
+    auto const x = static_cast<qreal>(position.x());
+    auto const y = static_cast<qreal>(position.y());
+    auto const right = static_cast<qreal>(width());
+    auto const bottom = static_cast<qreal>(height());
+
+    auto is_outside_corner_arc = [radius](qreal dx, qreal dy) {
+        return dx * dx + dy * dy > radius * radius;
+    };
+
+    auto in_cutout = false;
+    if (x < radius && y < radius)
+        in_cutout = is_outside_corner_arc(radius - x, radius - y);
+    else if (x >= right - radius && y < radius)
+        in_cutout = is_outside_corner_arc(x - (right - radius), radius - y);
+    else if (x < radius && y >= bottom - radius)
+        in_cutout = is_outside_corner_arc(radius - x, y - (bottom - radius));
+    else if (x >= right - radius && y >= bottom - radius)
+        in_cutout = is_outside_corner_arc(x - (right - radius), y - (bottom - radius));
+
+    return in_cutout;
+#else
+    (void)position;
+#endif
+    return false;
+}
+
 Qt::Edges BrowserWindow::resize_edges_for_position(QPoint const& position) const
 {
-    static constexpr int resize_border_width = 6;
+    if (position_is_in_rounded_corner_cutout(position))
+        return {};
 
     Qt::Edges edges;
-    if (position.x() <= resize_border_width)
+    auto in_left_resize_edge = position.x() <= WINDOW_RESIZE_BORDER_WIDTH;
+    auto in_right_resize_edge = position.x() >= width() - WINDOW_RESIZE_BORDER_WIDTH;
+    auto in_top_resize_edge = position.y() <= WINDOW_RESIZE_BORDER_WIDTH;
+    auto in_bottom_resize_edge = position.y() >= height() - WINDOW_RESIZE_BORDER_WIDTH;
+    auto in_left_resize_corner = position.x() <= WINDOW_RESIZE_CORNER_WIDTH;
+    auto in_right_resize_corner = position.x() >= width() - WINDOW_RESIZE_CORNER_WIDTH;
+    auto in_top_resize_corner = position.y() <= WINDOW_RESIZE_CORNER_WIDTH;
+    auto in_bottom_resize_corner = position.y() >= height() - WINDOW_RESIZE_CORNER_WIDTH;
+
+    if (in_left_resize_edge || (in_left_resize_corner && (in_top_resize_corner || in_bottom_resize_corner)))
         edges |= Qt::LeftEdge;
-    if (position.x() >= width() - resize_border_width)
+    if (in_right_resize_edge || (in_right_resize_corner && (in_top_resize_corner || in_bottom_resize_corner)))
         edges |= Qt::RightEdge;
-    if (position.y() <= resize_border_width)
+    if (in_top_resize_edge || (in_top_resize_corner && (in_left_resize_corner || in_right_resize_corner)))
         edges |= Qt::TopEdge;
-    if (position.y() >= height() - resize_border_width)
+    if (in_bottom_resize_edge || (in_bottom_resize_corner && (in_left_resize_corner || in_right_resize_corner)))
         edges |= Qt::BottomEdge;
 
     return edges;
@@ -1282,6 +1357,56 @@ Optional<Qt::CursorShape> BrowserWindow::resize_cursor_for_edges(Qt::Edges edges
     return {};
 }
 
+bool BrowserWindow::start_window_resize(Qt::Edges edges, QPoint const& global_position)
+{
+    if (edges == Qt::Edges {} || isMaximized() || isFullScreen())
+        return false;
+
+    m_is_resizing_window = true;
+    m_resize_edges = edges;
+    m_resize_start_global_position = global_position;
+    m_resize_start_geometry = geometry();
+    grabMouse();
+    return true;
+}
+
+void BrowserWindow::update_window_resize(QPoint const& global_position)
+{
+    if (!m_is_resizing_window)
+        return;
+
+    auto delta = global_position - m_resize_start_global_position;
+    auto new_geometry = m_resize_start_geometry;
+
+    if (m_resize_edges & Qt::LeftEdge) {
+        auto new_width = qBound(minimumWidth(), m_resize_start_geometry.width() - delta.x(), maximumWidth());
+        new_geometry.setX(m_resize_start_geometry.right() - new_width + 1);
+    } else if (m_resize_edges & Qt::RightEdge) {
+        auto new_width = qBound(minimumWidth(), m_resize_start_geometry.width() + delta.x(), maximumWidth());
+        new_geometry.setWidth(new_width);
+    }
+
+    if (m_resize_edges & Qt::TopEdge) {
+        auto new_height = qBound(minimumHeight(), m_resize_start_geometry.height() - delta.y(), maximumHeight());
+        new_geometry.setY(m_resize_start_geometry.bottom() - new_height + 1);
+    } else if (m_resize_edges & Qt::BottomEdge) {
+        auto new_height = qBound(minimumHeight(), m_resize_start_geometry.height() + delta.y(), maximumHeight());
+        new_geometry.setHeight(new_height);
+    }
+
+    setGeometry(new_geometry);
+}
+
+void BrowserWindow::finish_window_resize()
+{
+    if (!m_is_resizing_window)
+        return;
+
+    m_is_resizing_window = false;
+    m_resize_edges = {};
+    releaseMouse();
+}
+
 void BrowserWindow::update_resize_cursor(QPoint const& position)
 {
     if (!uses_client_side_decorations() || isMaximized() || isFullScreen() || !rect().contains(position)) {
@@ -1301,6 +1426,25 @@ void BrowserWindow::update_resize_cursor(QPoint const& position)
         QApplication::setOverrideCursor(*cursor_shape);
         m_resize_cursor_active = true;
     }
+}
+
+void BrowserWindow::refresh_resize_cursor_at_current_position(bool force_reapply)
+{
+    auto position = mapFromGlobal(QCursor::pos());
+    auto* child = childAt(position);
+    for (auto* object = child; object; object = qobject_cast<QWidget*>(object->parent())) {
+        if (qobject_cast<QAbstractButton*>(object)) {
+            clear_resize_cursor();
+            return;
+        }
+    }
+
+    if (force_reapply && m_resize_cursor_active) {
+        QApplication::restoreOverrideCursor();
+        m_resize_cursor_active = false;
+    }
+
+    update_resize_cursor(position);
 }
 
 void BrowserWindow::clear_resize_cursor()
@@ -1370,6 +1514,13 @@ void BrowserWindow::update_window_corners()
 
     clearMask();
     set_rounded_window_corners(*this, should_round_window, WINDOW_CORNER_RADIUS, ChromeStyle::chrome_background(palette()));
+#endif
+}
+
+void BrowserWindow::update_appkit_window_resizability()
+{
+#if defined(AK_OS_MACOS)
+    set_appkit_window_resizable(*this, !uses_client_side_decorations());
 #endif
 }
 

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -18,6 +18,7 @@
 #include <QIcon>
 #include <QMainWindow>
 #include <QPushButton>
+#include <QRect>
 #include <QTabBar>
 
 class QPropertyAnimation;
@@ -167,11 +168,17 @@ private:
     void uninitialize_tab(Tab*);
 
     void set_current_tab(Tab* tab);
+    bool position_is_in_rounded_corner_cutout(QPoint const&) const;
     Qt::Edges resize_edges_for_position(QPoint const&) const;
     Optional<Qt::CursorShape> resize_cursor_for_edges(Qt::Edges) const;
+    bool start_window_resize(Qt::Edges, QPoint const& global_position);
+    void update_window_resize(QPoint const& global_position);
+    void finish_window_resize();
     void update_resize_cursor(QPoint const&);
+    void refresh_resize_cursor_at_current_position(bool force_reapply = false);
     void clear_resize_cursor();
     void update_window_corners();
+    void update_appkit_window_resizability();
     bool should_draw_window_border() const;
     void update_window_border();
 
@@ -232,6 +239,10 @@ private:
     bool m_restore_to_maximized { false };
     bool m_should_record_closed_window_on_close { true };
     bool m_resize_cursor_active { false };
+    bool m_is_resizing_window { false };
+    Qt::Edges m_resize_edges {};
+    QPoint m_resize_start_global_position;
+    QRect m_resize_start_geometry;
 };
 
 }

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -253,6 +253,10 @@ LocationEdit::LocationEdit(QWidget* parent)
     update_location_icon();
 
     m_autocomplete->on_query_complete = [this](auto suggestions, WebView::AutocompleteResultKind result_kind) {
+        if (!hasFocus())
+            return;
+
+        auto query = current_query();
         int selected_row = -1;
         if (!m_autocomplete_query_without_inline.isNull() && text() == m_autocomplete_query_without_inline)
             selected_row = 0;
@@ -263,10 +267,22 @@ LocationEdit::LocationEdit(QWidget* parent)
         // Intermediate updates are triggered on every keystroke and would
         // cause visible flicker in the suggestion list.
         // Only final results are used to refresh the UI.
-        if (result_kind == WebView::AutocompleteResultKind::Intermediate && m_autocomplete->is_visible())
+        bool should_activate_pending_query = !m_pending_autocomplete_activation_query.isNull()
+            && m_pending_autocomplete_activation_query == query;
+        if (result_kind == WebView::AutocompleteResultKind::Intermediate && m_autocomplete->is_visible() && !should_activate_pending_query)
             return;
 
+        m_autocomplete_popup_query = query;
         m_autocomplete->show_with_suggestions(AK::move(suggestions), selected_row);
+        if (should_activate_pending_query) {
+            auto selected = m_autocomplete->selected_suggestion();
+            if (result_kind == WebView::AutocompleteResultKind::Final
+                || (selected.has_value() && qstring_from_ak_string(*selected) != query)) {
+                m_pending_autocomplete_activation_query = QString();
+                m_should_skip_autocomplete_cancel_on_focus_out = true;
+                activate_selected_autocomplete_suggestion();
+            }
+        }
     };
 
     connect(m_autocomplete, &Autocomplete::suggestion_activated, this, [this](QString const& text) {
@@ -285,6 +301,8 @@ LocationEdit::LocationEdit(QWidget* parent)
     connect(m_autocomplete, &Autocomplete::did_close, this, [this] {
         m_current_inline_autocomplete_suggestion.clear();
         if (!m_autocomplete_query_without_inline.isNull()) {
+            if (hasSelectedText())
+                restore_query();
             m_autocomplete_query_without_inline = QString();
             return;
         }
@@ -317,6 +335,8 @@ LocationEdit::LocationEdit(QWidget* parent)
             m_has_user_edited_hidden_url = true;
 
         auto query = current_query();
+        if (!m_pending_autocomplete_activation_query.isNull() && m_pending_autocomplete_activation_query != query)
+            m_pending_autocomplete_activation_query = QString();
 
         if (m_should_suppress_inline_autocomplete_on_next_change) {
             m_suppressed_inline_autocomplete_query = query;
@@ -394,6 +414,7 @@ void LocationEdit::show_autocomplete()
         return;
 
     auto query = text();
+    m_autocomplete_popup_query = QString();
     m_autocomplete_query_without_inline = query;
     m_autocomplete->query_autocomplete_engine(ak_string_from_qstring(query));
 }
@@ -439,8 +460,18 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
 
     animate_focus_glow(0);
 
+    if (hasSelectedText()) {
+        auto query = current_query();
+        m_is_applying_inline_autocomplete = true;
+        setText(query);
+        setCursorPosition(query.length());
+        m_is_applying_inline_autocomplete = false;
+    }
+
+    auto should_cancel_pending_query = !m_should_skip_autocomplete_cancel_on_focus_out;
     reset_autocomplete_state();
-    m_autocomplete->cancel_pending_query();
+    if (should_cancel_pending_query)
+        m_autocomplete->cancel_pending_query();
     m_autocomplete->close();
     m_should_show_full_url_on_mouse_release = false;
 
@@ -501,15 +532,17 @@ void LocationEdit::keyPressEvent(QKeyEvent* event)
     }
 
     if ((event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) && m_autocomplete->is_visible()) {
-        if (auto selected = m_autocomplete->selected_suggestion(); selected.has_value()) {
-            m_is_applying_inline_autocomplete = true;
-            setText(qstring_from_ak_string(*selected));
-            m_is_applying_inline_autocomplete = false;
+        auto query = current_query();
+        if (m_autocomplete_popup_query == query) {
+            activate_selected_autocomplete_suggestion();
+            event->accept();
+            return;
+        } else {
+            m_pending_autocomplete_activation_query = query;
+            m_autocomplete->query_autocomplete_engine(ak_string_from_qstring(query));
+            event->accept();
+            return;
         }
-        m_autocomplete->close();
-        emit returnPressed();
-        event->accept();
-        return;
     }
 
     if (should_suppress_inline_autocomplete_for_key(event))
@@ -1075,6 +1108,17 @@ void LocationEdit::apply_inline_autocomplete_text(QString const& inline_text, QS
     m_is_applying_inline_autocomplete = false;
 }
 
+void LocationEdit::activate_selected_autocomplete_suggestion()
+{
+    if (auto selected = m_autocomplete->selected_suggestion(); selected.has_value()) {
+        m_is_applying_inline_autocomplete = true;
+        setText(qstring_from_ak_string(*selected));
+        m_is_applying_inline_autocomplete = false;
+    }
+    m_autocomplete->close();
+    emit returnPressed();
+}
+
 void LocationEdit::restore_query()
 {
     if (!hasFocus())
@@ -1092,8 +1136,11 @@ void LocationEdit::restore_query()
 
 void LocationEdit::reset_autocomplete_state()
 {
+    m_autocomplete_popup_query = QString();
     m_autocomplete_query_without_inline = QString();
     m_current_inline_autocomplete_suggestion.clear();
+    m_should_skip_autocomplete_cancel_on_focus_out = false;
+    m_pending_autocomplete_activation_query = QString();
     m_suppressed_inline_autocomplete_query = QString();
     m_should_suppress_inline_autocomplete_on_next_change = false;
 }

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -256,12 +256,20 @@ LocationEdit::LocationEdit(QWidget* parent)
         if (!hasFocus())
             return;
 
-        auto query = current_query();
+        auto query = autocomplete_query();
         int selected_row = -1;
-        if (!m_autocomplete_query_without_inline.isNull() && text() == m_autocomplete_query_without_inline)
+        if (!m_autocomplete_preview_query.isNull()) {
+            for (size_t i = 0; i < suggestions.size(); ++i) {
+                if (qstring_from_ak_string(suggestions[i].text) == text()) {
+                    selected_row = static_cast<int>(i);
+                    break;
+                }
+            }
+        } else if (!m_autocomplete_query_without_inline.isNull() && text() == m_autocomplete_query_without_inline) {
             selected_row = 0;
-        else
+        } else {
             selected_row = apply_inline_autocomplete(suggestions);
+        }
 
         // Do not update the popup while results are still changing.
         // Intermediate updates are triggered on every keystroke and would
@@ -286,22 +294,29 @@ LocationEdit::LocationEdit(QWidget* parent)
     };
 
     connect(m_autocomplete, &Autocomplete::suggestion_activated, this, [this](QString const& text) {
-        m_is_applying_inline_autocomplete = true;
-        setText(text);
-        m_is_applying_inline_autocomplete = false;
+        m_autocomplete_preview_query = QString();
+        m_current_inline_autocomplete_suggestion.clear();
+        set_text_without_inline_autocomplete(text);
         m_autocomplete->close();
         emit returnPressed();
     });
 
     connect(m_autocomplete, &Autocomplete::suggestion_highlighted, this, [this](QString const& text) {
-        auto query = current_query();
-        apply_inline_autocomplete_suggestion_text(text, query);
+        m_has_highlighted_autocomplete_suggestion = true;
+        auto query = autocomplete_query();
+        apply_inline_autocomplete_suggestion_text(text, query, true);
     });
 
     connect(m_autocomplete, &Autocomplete::did_close, this, [this] {
+        auto should_preserve_inline_autocomplete = m_should_preserve_inline_autocomplete_on_close;
+        auto should_restore_query = should_restore_autocomplete_query();
+        m_should_preserve_inline_autocomplete_on_close = false;
+        m_has_highlighted_autocomplete_suggestion = false;
         m_current_inline_autocomplete_suggestion.clear();
+        if (should_preserve_inline_autocomplete)
+            return;
         if (!m_autocomplete_query_without_inline.isNull()) {
-            if (hasSelectedText())
+            if (should_restore_query)
                 restore_query();
             m_autocomplete_query_without_inline = QString();
             return;
@@ -330,6 +345,8 @@ LocationEdit::LocationEdit(QWidget* parent)
             return;
 
         m_autocomplete_query_without_inline = QString();
+        m_autocomplete_preview_query = QString();
+        m_has_highlighted_autocomplete_suggestion = false;
 
         if (m_url_is_hidden)
             m_has_user_edited_hidden_url = true;
@@ -460,12 +477,10 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
 
     animate_focus_glow(0);
 
-    if (hasSelectedText()) {
+    if (should_restore_autocomplete_query()) {
         auto query = current_query();
-        m_is_applying_inline_autocomplete = true;
-        setText(query);
+        set_text_without_inline_autocomplete(query);
         setCursorPosition(query.length());
-        m_is_applying_inline_autocomplete = false;
     }
 
     auto should_cancel_pending_query = !m_should_skip_autocomplete_cancel_on_focus_out;
@@ -512,8 +527,17 @@ void LocationEdit::animate_focus_glow(int target_alpha)
 void LocationEdit::keyPressEvent(QKeyEvent* event)
 {
     if (event->key() == Qt::Key_Escape) {
-        if (m_autocomplete->close())
+        if (m_autocomplete->is_visible()
+            && m_autocomplete_query_without_inline.isNull()
+            && m_autocomplete_preview_query.isNull()
+            && !m_has_highlighted_autocomplete_suggestion
+            && hasSelectedText()) {
+            m_should_preserve_inline_autocomplete_on_close = true;
+        }
+        if (m_autocomplete->close()) {
+            m_autocomplete->cancel_pending_query();
             return;
+        }
         reset_autocomplete_state();
         if (m_url.has_value())
             setText(serialized_url());
@@ -532,7 +556,7 @@ void LocationEdit::keyPressEvent(QKeyEvent* event)
     }
 
     if ((event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) && m_autocomplete->is_visible()) {
-        auto query = current_query();
+        auto query = autocomplete_query();
         if (m_autocomplete_popup_query == query) {
             activate_selected_autocomplete_suggestion();
             event->accept();
@@ -952,6 +976,9 @@ QString LocationEdit::display_url() const
 
 QString LocationEdit::current_query() const
 {
+    if (!m_autocomplete_preview_query.isNull())
+        return m_autocomplete_preview_query;
+
     if (!hasSelectedText())
         return text();
     int start = selectionStart();
@@ -1070,7 +1097,7 @@ int LocationEdit::apply_inline_autocomplete(Vector<WebView::AutocompleteSuggesti
     return 0;
 }
 
-bool LocationEdit::apply_inline_autocomplete_suggestion_text(QString const& suggestion_text, QString const& query)
+bool LocationEdit::apply_inline_autocomplete_suggestion_text(QString const& suggestion_text, QString const& query, bool allow_preview)
 {
     if (suggestion_matches_query_exactly(query, suggestion_text)) {
         restore_query();
@@ -1079,6 +1106,10 @@ bool LocationEdit::apply_inline_autocomplete_suggestion_text(QString const& sugg
     }
 
     auto inline_text = inline_autocomplete_text_for_suggestion(query, suggestion_text);
+    if (inline_text.isEmpty() && allow_preview) {
+        apply_autocomplete_preview_text(suggestion_text, query);
+        return true;
+    }
     if (inline_text.isEmpty())
         return false;
 
@@ -1102,18 +1133,33 @@ void LocationEdit::apply_inline_autocomplete_text(QString const& inline_text, QS
         && selectedText().length() == completion_length)
         return;
 
-    m_is_applying_inline_autocomplete = true;
-    setText(inline_text);
+    m_autocomplete_preview_query = QString();
+    set_text_without_inline_autocomplete(inline_text);
     setSelection(completion_start, completion_length);
-    m_is_applying_inline_autocomplete = false;
+}
+
+void LocationEdit::apply_autocomplete_preview_text(QString const& suggestion_text, QString const& query)
+{
+    if (!hasFocus())
+        return;
+
+    if (text() == suggestion_text && hasSelectedText()
+        && selectionStart() == 0
+        && selectedText().length() == suggestion_text.length())
+        return;
+
+    m_current_inline_autocomplete_suggestion.clear();
+    m_autocomplete_preview_query = query;
+    set_text_without_inline_autocomplete(suggestion_text);
+    selectAll();
 }
 
 void LocationEdit::activate_selected_autocomplete_suggestion()
 {
     if (auto selected = m_autocomplete->selected_suggestion(); selected.has_value()) {
-        m_is_applying_inline_autocomplete = true;
-        setText(qstring_from_ak_string(*selected));
-        m_is_applying_inline_autocomplete = false;
+        m_autocomplete_preview_query = QString();
+        m_current_inline_autocomplete_suggestion.clear();
+        set_text_without_inline_autocomplete(qstring_from_ak_string(*selected));
     }
     m_autocomplete->close();
     emit returnPressed();
@@ -1128,17 +1174,38 @@ void LocationEdit::restore_query()
     if (text() == query && !hasSelectedText())
         return;
 
-    m_is_applying_inline_autocomplete = true;
-    setText(query);
+    set_text_without_inline_autocomplete(query);
     setCursorPosition(query.length());
+    m_autocomplete_preview_query = QString();
+}
+
+void LocationEdit::set_text_without_inline_autocomplete(QString const& text)
+{
+    m_is_applying_inline_autocomplete = true;
+    setText(text);
     m_is_applying_inline_autocomplete = false;
+}
+
+bool LocationEdit::should_restore_autocomplete_query() const
+{
+    return !m_autocomplete_preview_query.isNull() || !m_current_inline_autocomplete_suggestion.isEmpty();
+}
+
+QString LocationEdit::autocomplete_query() const
+{
+    if (!m_autocomplete_query_without_inline.isNull())
+        return m_autocomplete_query_without_inline;
+    return current_query();
 }
 
 void LocationEdit::reset_autocomplete_state()
 {
     m_autocomplete_popup_query = QString();
     m_autocomplete_query_without_inline = QString();
+    m_autocomplete_preview_query = QString();
     m_current_inline_autocomplete_suggestion.clear();
+    m_has_highlighted_autocomplete_suggestion = false;
+    m_should_preserve_inline_autocomplete_on_close = false;
     m_should_skip_autocomplete_cancel_on_focus_out = false;
     m_pending_autocomplete_activation_query = QString();
     m_suppressed_inline_autocomplete_query = QString();

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -253,7 +253,11 @@ LocationEdit::LocationEdit(QWidget* parent)
     update_location_icon();
 
     m_autocomplete->on_query_complete = [this](auto suggestions, WebView::AutocompleteResultKind result_kind) {
-        int selected_row = apply_inline_autocomplete(suggestions);
+        int selected_row = -1;
+        if (!m_autocomplete_query_without_inline.isNull() && text() == m_autocomplete_query_without_inline)
+            selected_row = 0;
+        else
+            selected_row = apply_inline_autocomplete(suggestions);
 
         // Do not update the popup while results are still changing.
         // Intermediate updates are triggered on every keystroke and would
@@ -280,6 +284,10 @@ LocationEdit::LocationEdit(QWidget* parent)
 
     connect(m_autocomplete, &Autocomplete::did_close, this, [this] {
         m_current_inline_autocomplete_suggestion.clear();
+        if (!m_autocomplete_query_without_inline.isNull()) {
+            m_autocomplete_query_without_inline = QString();
+            return;
+        }
         restore_query();
     });
 
@@ -302,6 +310,8 @@ LocationEdit::LocationEdit(QWidget* parent)
     connect(this, &QLineEdit::textEdited, this, [this] {
         if (m_is_applying_inline_autocomplete)
             return;
+
+        m_autocomplete_query_without_inline = QString();
 
         if (m_url_is_hidden)
             m_has_user_edited_hidden_url = true;
@@ -376,6 +386,16 @@ void LocationEdit::set_url_is_hidden(bool url_is_hidden)
 
     if (m_url_is_hidden)
         clear();
+}
+
+void LocationEdit::show_autocomplete()
+{
+    if (!window() || !window()->isVisible())
+        return;
+
+    auto query = text();
+    m_autocomplete_query_without_inline = query;
+    m_autocomplete->query_autocomplete_engine(ak_string_from_qstring(query));
 }
 
 void LocationEdit::changeEvent(QEvent* event)
@@ -1072,6 +1092,7 @@ void LocationEdit::restore_query()
 
 void LocationEdit::reset_autocomplete_state()
 {
+    m_autocomplete_query_without_inline = QString();
     m_current_inline_autocomplete_suggestion.clear();
     m_suppressed_inline_autocomplete_query = QString();
     m_should_suppress_inline_autocomplete_on_next_change = false;

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -75,6 +75,7 @@ private:
     int apply_inline_autocomplete(Vector<WebView::AutocompleteSuggestion> const&);
     bool apply_inline_autocomplete_suggestion_text(QString const& suggestion_text, QString const& query);
     void apply_inline_autocomplete_text(QString const& inline_text, QString const& query);
+    void activate_selected_autocomplete_suggestion();
     void restore_query();
     QString current_query() const;
     void reset_autocomplete_state();
@@ -98,8 +99,11 @@ private:
 
     bool m_is_applying_inline_autocomplete { false };
     bool m_should_suppress_inline_autocomplete_on_next_change { false };
+    bool m_should_skip_autocomplete_cancel_on_focus_out { false };
+    QString m_autocomplete_popup_query;
     QString m_autocomplete_query_without_inline;
     QString m_current_inline_autocomplete_suggestion;
+    QString m_pending_autocomplete_activation_query;
     QString m_suppressed_inline_autocomplete_query;
 };
 

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -73,10 +73,14 @@ private:
     QString display_url() const;
 
     int apply_inline_autocomplete(Vector<WebView::AutocompleteSuggestion> const&);
-    bool apply_inline_autocomplete_suggestion_text(QString const& suggestion_text, QString const& query);
+    bool apply_inline_autocomplete_suggestion_text(QString const& suggestion_text, QString const& query, bool allow_preview = false);
     void apply_inline_autocomplete_text(QString const& inline_text, QString const& query);
+    void apply_autocomplete_preview_text(QString const& suggestion_text, QString const& query);
     void activate_selected_autocomplete_suggestion();
     void restore_query();
+    void set_text_without_inline_autocomplete(QString const& text);
+    bool should_restore_autocomplete_query() const;
+    QString autocomplete_query() const;
     QString current_query() const;
     void reset_autocomplete_state();
 
@@ -99,9 +103,12 @@ private:
 
     bool m_is_applying_inline_autocomplete { false };
     bool m_should_suppress_inline_autocomplete_on_next_change { false };
+    bool m_has_highlighted_autocomplete_suggestion { false };
+    bool m_should_preserve_inline_autocomplete_on_close { false };
     bool m_should_skip_autocomplete_cancel_on_focus_out { false };
     QString m_autocomplete_popup_query;
     QString m_autocomplete_query_without_inline;
+    QString m_autocomplete_preview_query;
     QString m_current_inline_autocomplete_suggestion;
     QString m_pending_autocomplete_activation_query;
     QString m_suppressed_inline_autocomplete_query;

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -43,6 +43,7 @@ public:
     void set_url(Optional<URL::URL>);
     bool url_is_hidden() const { return m_url_is_hidden; }
     void set_url_is_hidden(bool);
+    void show_autocomplete();
 
 private:
     virtual void changeEvent(QEvent* event) override;
@@ -97,6 +98,7 @@ private:
 
     bool m_is_applying_inline_autocomplete { false };
     bool m_should_suppress_inline_autocomplete_on_next_change { false };
+    QString m_autocomplete_query_without_inline;
     QString m_current_inline_autocomplete_suggestion;
     QString m_suppressed_inline_autocomplete_query;
 };

--- a/UI/Qt/MacWindow.h
+++ b/UI/Qt/MacWindow.h
@@ -17,6 +17,7 @@ namespace Ladybird {
 void set_rounded_window_corners(QWidget&, bool enabled, double radius, QColor const& background_color);
 void install_always_active_window_control_hover_tracking(QWidget&, void (*hover_changed)(QWidget*));
 void install_appkit_event_capture();
+void make_appkit_window_first_responder(QWidget&);
 bool start_appkit_window_drag(QWidget&);
 #endif
 

--- a/UI/Qt/MacWindow.h
+++ b/UI/Qt/MacWindow.h
@@ -10,6 +10,11 @@
 
 class QWidget;
 class QColor;
+namespace Gfx {
+
+class Color;
+
+}
 
 namespace Ladybird {
 
@@ -19,6 +24,8 @@ void install_always_active_window_control_hover_tracking(QWidget&, void (*hover_
 void install_appkit_event_capture();
 void make_appkit_window_first_responder(QWidget&);
 bool start_appkit_window_drag(QWidget&);
+Gfx::Color appkit_web_inactive_selection_color();
+Gfx::Color appkit_web_inactive_selection_text_color();
 #endif
 
 }

--- a/UI/Qt/MacWindow.h
+++ b/UI/Qt/MacWindow.h
@@ -20,6 +20,7 @@ namespace Ladybird {
 
 #if defined(AK_OS_MACOS)
 void set_rounded_window_corners(QWidget&, bool enabled, double radius, QColor const& background_color);
+void set_appkit_window_resizable(QWidget&, bool enabled);
 void install_always_active_window_control_hover_tracking(QWidget&, void (*hover_changed)(QWidget*));
 void install_appkit_event_capture();
 void make_appkit_window_first_responder(QWidget&);

--- a/UI/Qt/MacWindow.mm
+++ b/UI/Qt/MacWindow.mm
@@ -176,6 +176,23 @@ void install_always_active_window_control_hover_tracking(QWidget& widget, void (
 #endif
 }
 
+void make_appkit_window_first_responder(QWidget& widget)
+{
+    auto* window_widget = widget.window();
+    if (!window_widget)
+        return;
+
+    auto* view = reinterpret_cast<NSView*>(window_widget->winId());
+    if (!view)
+        return;
+
+    auto* window = view.window;
+    if (!window)
+        return;
+
+    [window makeFirstResponder:view];
+}
+
 bool start_appkit_window_drag(QWidget& widget)
 {
     auto* window_widget = widget.window();

--- a/UI/Qt/MacWindow.mm
+++ b/UI/Qt/MacWindow.mm
@@ -6,6 +6,7 @@
 
 #include <UI/Qt/MacWindow.h>
 
+#include <LibGfx/Color.h>
 #include <QAbstractNativeEventFilter>
 #include <QColor>
 #include <QCoreApplication>
@@ -65,6 +66,19 @@
 namespace Ladybird {
 
 static NSEvent* s_latest_window_drag_event;
+
+static Gfx::Color ns_color_to_gfx_color(NSColor* color)
+{
+    auto* rgb_color = [color colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
+    if (rgb_color != nil)
+        return {
+            static_cast<u8>([rgb_color redComponent] * 255),
+            static_cast<u8>([rgb_color greenComponent] * 255),
+            static_cast<u8>([rgb_color blueComponent] * 255),
+            static_cast<u8>([rgb_color alphaComponent] * 255)
+        };
+    return {};
+}
 
 static bool is_window_drag_on_gesture_enabled()
 {
@@ -246,6 +260,16 @@ bool start_appkit_window_drag(QWidget& widget)
 
     [window performWindowDragWithEvent:event];
     return true;
+}
+
+Gfx::Color appkit_web_inactive_selection_color()
+{
+    return ns_color_to_gfx_color([NSColor unemphasizedSelectedTextBackgroundColor]);
+}
+
+Gfx::Color appkit_web_inactive_selection_text_color()
+{
+    return ns_color_to_gfx_color([NSColor unemphasizedSelectedTextColor]);
 }
 
 }

--- a/UI/Qt/MacWindow.mm
+++ b/UI/Qt/MacWindow.mm
@@ -66,6 +66,11 @@ namespace Ladybird {
 
 static NSEvent* s_latest_window_drag_event;
 
+static bool is_window_drag_on_gesture_enabled()
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"NSWindowShouldDragOnGesture"];
+}
+
 static bool is_appkit_event_type(QByteArray const& event_type)
 {
     return event_type == QByteArrayLiteral("NSEvent")
@@ -86,6 +91,25 @@ static bool is_window_drag_event(NSEvent* event)
     }
 }
 
+static bool should_start_window_drag_for_gesture(NSEvent* event)
+{
+    if (!event || event.type != NSEventTypeLeftMouseDown)
+        return false;
+
+    if (!is_window_drag_on_gesture_enabled())
+        return false;
+
+    auto modifier_flags = event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask;
+    if ((modifier_flags & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) != (NSEventModifierFlagCommand | NSEventModifierFlagControl))
+        return false;
+
+    auto* window = event.window;
+    if (!window || !window.isMovable || (window.styleMask & NSWindowStyleMaskFullScreen))
+        return false;
+
+    return true;
+}
+
 class LadybirdAppKitEventCaptureFilter final : public QAbstractNativeEventFilter {
 public:
     virtual bool nativeEventFilter(QByteArray const& event_type, void* message, qintptr*) override
@@ -94,6 +118,11 @@ public:
             return false;
 
         auto* event = static_cast<NSEvent*>(message);
+        if (should_start_window_drag_for_gesture(event)) {
+            [event.window performWindowDragWithEvent:event];
+            return true;
+        }
+
         if (!is_window_drag_event(event))
             return false;
 

--- a/UI/Qt/MacWindow.mm
+++ b/UI/Qt/MacWindow.mm
@@ -185,6 +185,22 @@ void set_rounded_window_corners(QWidget& widget, bool enabled, double radius, QC
     content_view.layer.backgroundColor = cg_color_from_qcolor(background_color);
 }
 
+void set_appkit_window_resizable(QWidget& widget, bool enabled)
+{
+    auto* view = reinterpret_cast<NSView*>(widget.winId());
+    if (!view)
+        return;
+
+    auto* window = view.window;
+    if (!window)
+        return;
+
+    if (enabled)
+        window.styleMask |= NSWindowStyleMaskResizable;
+    else
+        window.styleMask &= ~NSWindowStyleMaskResizable;
+}
+
 void install_always_active_window_control_hover_tracking(QWidget& widget, void (*hover_changed)(QWidget*))
 {
     static char tracker_key;

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -148,12 +148,12 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
     case WebView::ActionID::NavigateBack:
         if (include_action_icon == IncludeActionIcon::Yes)
             qaction.setIcon(create_chrome_icon(ChromeIcon::Back, palette));
-        qaction.setShortcut(QKeySequence::StandardKey::Back);
+        qaction.setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Back));
         break;
     case WebView::ActionID::NavigateForward:
         if (include_action_icon == IncludeActionIcon::Yes)
             qaction.setIcon(create_chrome_icon(ChromeIcon::Forward, palette));
-        qaction.setShortcut(QKeySequence::StandardKey::Forward);
+        qaction.setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Forward));
         break;
     case WebView::ActionID::Reload:
         if (include_action_icon == IncludeActionIcon::Yes)

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -16,6 +16,9 @@
 #include <UI/Qt/ChromeLayout.h>
 #include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
+#if defined(AK_OS_MACOS)
+#    include <UI/Qt/MacWindow.h>
+#endif
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/WindowControlButton.h>
@@ -598,6 +601,9 @@ Tab::~Tab() = default;
 
 void Tab::focus_location_editor()
 {
+#if defined(AK_OS_MACOS)
+    make_appkit_window_first_responder(*m_location_edit);
+#endif
     m_location_edit->setFocus();
     m_location_edit->selectAll();
     m_location_edit->show_autocomplete();

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -600,6 +600,7 @@ void Tab::focus_location_editor()
 {
     m_location_edit->setFocus();
     m_location_edit->selectAll();
+    m_location_edit->show_autocomplete();
 }
 
 void Tab::set_window(BrowserWindow& window)

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -24,9 +24,13 @@
 #include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/PlatformColors.h>
 #include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
 #include <UI/Qt/Application.h>
+#ifdef AK_OS_MACOS
+#    include <UI/Qt/MacWindow.h>
+#endif
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/WebContentView.h>
 
@@ -857,7 +861,13 @@ static Core::AnonymousBuffer make_system_theme_from_qt_palette(QWidget& widget, 
     translate(Gfx::ColorRole::VisitedLink, QPalette::ColorRole::LinkVisited);
     translate(Gfx::ColorRole::Button, QPalette::ColorRole::Button);
     translate(Gfx::ColorRole::ButtonText, QPalette::ColorRole::ButtonText);
+#ifdef AK_OS_MACOS
+    palette.set_color(Gfx::ColorRole::Selection, WebView::macos_web_selection_color());
+    palette.set_color(Gfx::ColorRole::InactiveSelection, appkit_web_inactive_selection_color());
+    palette.set_color(Gfx::ColorRole::InactiveSelectionText, appkit_web_inactive_selection_text_color());
+#else
     translate(Gfx::ColorRole::Selection, QPalette::ColorRole::Highlight);
+#endif
 
     palette.set_flag(Gfx::FlagRole::IsDark, is_using_dark_system_theme(widget));
 

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -53,6 +53,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 #endif
 
     auto app = TRY(Ladybird::Application::create(arguments));
+    app->initialize_macos_application_menu();
     WebView::BrowserProcess browser_process;
 
     WebView::copy_default_config_files(Ladybird::Settings::the()->directory());
@@ -68,12 +69,20 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         }
 
         app->on_open_file = [&](auto const& file_url) {
-            auto& window = app->active_window();
-            window.view().load(file_url);
+            if (auto* window = app->active_window_if_any()) {
+                window->view().load(file_url);
+                return;
+            }
+            app->new_window({ file_url });
         };
 
         browser_process.on_new_tab = [&](auto const& urls) {
-            auto& window = app->active_window();
+            if (!app->active_window_if_any()) {
+                app->new_window(urls);
+                return;
+            }
+
+            auto& window = *app->active_window_if_any();
             for (size_t i = 0; i < urls.size(); ++i) {
                 window.new_tab_from_url(urls[i], (i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No);
             }
@@ -83,12 +92,12 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         };
 
         browser_process.on_new_window = [&](auto const& urls) {
-            auto const& previous_active_window = app->active_window();
-            Ladybird::WindowConfiguration configuration {
-                .width = previous_active_window.width(),
-                .height = previous_active_window.height(),
-                .maximized = previous_active_window.isMaximized(),
-            };
+            Ladybird::WindowConfiguration configuration {};
+            if (auto* previous_active_window = app->active_window_if_any()) {
+                configuration.width = previous_active_window->width();
+                configuration.height = previous_active_window->height();
+                configuration.maximized = previous_active_window->isMaximized();
+            }
             app->new_window(urls, configuration);
         };
 


### PR DESCRIPTION
This PR improves a cluster of Qt UI interactions, mostly around the location editor and macOS integration.

The location editor now opens autocomplete when focused from browser actions such as Open Location/Cmd-L, handles pending autocomplete results without activating stale rows, and previews highlighted non-prefix suggestions without committing them. Dismissing autocomplete restores the right text, while Enter continues to activate or reload the intended URL.

On macOS, the Qt frontend now restores AppKit focus before focusing chrome, honors the system Cmd+Ctrl window-drag gesture, and uses AppKit-derived inactive selection colors for WebContent. Frameless windows also get manual resize handling so resize cursors and hit targets match the rounded client-side decoration.

The app now stays alive after the last browser window is closed and provides a useful application menu for creating windows/tabs, opening files and locations, reopening recently closed tabs/windows, bookmarks, history, settings, appearance controls, and quit. These commands share the same window-aware behavior as the browser UI, including opening real URLs directly when no window exists.