### PR TITLE
LibWeb: Use computed display value for `::first-letter` layout wrappers

### DIFF
--- a/Documentation/CSSGeneratedFiles.md
+++ b/Documentation/CSSGeneratedFiles.md
@@ -297,7 +297,7 @@ The following categories are supported:
 - `#inline-typesetting-properties`: Properties defined in [CSS Text](https://drafts.csswg.org/css-text-4/)
 - `#margin-properties`: `margin` and its longhands
 - `#padding-properties`: `padding` and its longhands
-- `#text-decoration-properties`: `text-decoration` and its longhands
+- `#text-decoration-properties`: Properties defined in [CSS Text Decoration](https://drafts.csswg.org/css-text-decor-4/)
 
 ### `implementation`
 

--- a/Libraries/LibWeb/CSS/PseudoElements.json
+++ b/Libraries/LibWeb/CSS/PseudoElements.json
@@ -73,6 +73,7 @@
       "#padding-properties",
       "#border-properties",
       "box-shadow",
+      "float",
       "#custom-properties"
     ],
     "implementation": "synthetic"
@@ -124,7 +125,6 @@
       "color",
       "background-color",
       "#text-decoration-properties",
-      "text-shadow",
       "FIXME: stroke-color",
       "FIXME: fill-color",
       "stroke-width",

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -447,7 +447,9 @@ void TreeBuilder::create_first_letter_wrapper_if_needed(DOM::Element& element, B
         first_letter_slice = make_ref_counted<GeneratedTextNode>(document, Utf16String::from_utf16(text.utf16_view().substring_view(0, letter_end)));
     }
 
-    auto first_letter_wrapper = make_ref_counted<InlineNode>(document, nullptr, *first_letter_style);
+    auto first_letter_wrapper = DOM::Element::create_layout_node_for_display_type(document, first_letter_style->display(), *first_letter_style, nullptr);
+    if (!first_letter_wrapper)
+        return;
     first_letter_wrapper->set_generated_for(CSS::PseudoElement::FirstLetter, element);
     first_letter_wrapper->set_children_are_inline(true);
     first_letter_wrapper->append_child(*first_letter_slice);

--- a/Meta/Generators/generate_libweb_css_pseudo_element.py
+++ b/Meta/Generators/generate_libweb_css_pseudo_element.py
@@ -137,32 +137,15 @@ PROPERTY_GROUPS = {
     "#inline-typesetting-properties": [
         # https://drafts.csswg.org/css-text-4/#property-index
         # FIXME: hanging-punctuation
-        # FIXME: hyphenate-character
-        # FIXME: hyphenate-limit-chars
-        # FIXME: hyphenate-limit-last
-        # FIXME: hyphenate-limit-lines
-        # FIXME: hyphenate-limit-zone
-        # FIXME: hyphens
         "letter-spacing",
-        # FIXME: line-break
         # FIXME: line-padding
-        "overflow-wrap",
-        "tab-size",
         # FIXME: text-autospace
         "text-justify",
         # FIXME: text-spacing
         # FIXME: text-spacing-trim
         "text-transform",
-        "text-wrap-mode",
-        "white-space",
-        "white-space-collapse",
-        "white-space-trim",
-        "word-break",
         # FIXME: word-space-transform
         "word-spacing",
-        # FIXME: wrap-after
-        # FIXME: wrap-before
-        # FIXME: wrap-inside
     ],
     "#margin-properties": [
         "margin",

--- a/Meta/Generators/generate_libweb_css_pseudo_element.py
+++ b/Meta/Generators/generate_libweb_css_pseudo_element.py
@@ -29,6 +29,7 @@ PROPERTY_GROUPS = {
         # https://drafts.csswg.org/css-backgrounds/#property-index
         "background",
         "background-attachment",
+        "background-blend-mode",
         "background-clip",
         "background-color",
         "background-image",
@@ -96,9 +97,9 @@ PROPERTY_GROUPS = {
         "font",
         "font-family",
         "font-feature-settings",
-        # FIXME: font-kerning
+        "font-kerning",
         "font-language-override",
-        # FIXME: font-optical-sizing
+        "font-optical-sizing",
         # FIXME: font-palette
         "font-size",
         # FIXME: font-size-adjust
@@ -200,8 +201,12 @@ PROPERTY_GROUPS = {
         "text-decoration",
         "text-decoration-color",
         "text-decoration-line",
+        "text-decoration-skip-ink",
         "text-decoration-style",
         "text-decoration-thickness",
+        "text-shadow",
+        "text-underline-offset",
+        "text-underline-position",
     ],
 }
 

--- a/Meta/Generators/generate_libweb_css_pseudo_element.py
+++ b/Meta/Generators/generate_libweb_css_pseudo_element.py
@@ -148,19 +148,12 @@ PROPERTY_GROUPS = {
         # FIXME: line-padding
         "overflow-wrap",
         "tab-size",
-        "text-align",
-        # FIXME: text-align-all
-        # FIXME: text-align-last
         # FIXME: text-autospace
-        # FIXME: text-group-align
-        "text-indent",
         "text-justify",
         # FIXME: text-spacing
         # FIXME: text-spacing-trim
         "text-transform",
-        "text-wrap",
         "text-wrap-mode",
-        "text-wrap-style",
         "white-space",
         "white-space-collapse",
         "white-space-trim",

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-pseudo/first-letter-and-whitespace-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-pseudo/first-letter-and-whitespace-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Reference File</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:futhark@chromium.org">
+<p>Pass if no space between "A", space between "B".</p>
+<div><span style="float:left">A</span>A</div>
+<div><span style="float:left">A</span>A</div>
+<div>B B</div>
+<div>B B</div>
+<div>AAB B</div>
+<div>AAB B</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-pseudo/first-letter-and-whitespace.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-pseudo/first-letter-and-whitespace.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: White-spaces around floated ::first-letter</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:futhark@chromium.org">
+<link rel="match" href="../../../../expected/wpt-import/css/css-pseudo/first-letter-and-whitespace-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#first-letter-styling">
+<meta name="assert" content="Test checks that white-spaces are correctly rendered for floated ::first-letter changes">
+<style>
+  div::first-letter {
+    color: black;
+  }
+  .floatLetter::first-letter {
+    float: left;
+  }
+</style>
+<p>Pass if no space between "A", space between "B".</p>
+<div id="t1"> <!---->AA</div>
+<div id="t2"> <!---->A<!----> <!---->A</div>
+<div id="t3" class="floatLetter">  <!---->B<!----> <!---->B</div>
+<div id="t4" class="floatLetter">  <!---->B <!---->B</div>
+<div id="t5" class="floatLetter">  <!---->AAB<!----> <!---->B</div>
+<div id="t6" class="floatLetter">  <!---->AAB<!----> B</div>
+<script>
+  document.body.offsetTop;
+  t1.className = "floatLetter";
+  t2.className = "floatLetter";
+  t3.className = "";
+  t4.className = "";
+  t5.className = "";
+  t6.className = "";
+</script>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-pseudo/first-letter-allowed-properties.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-pseudo/first-letter-allowed-properties.txt
@@ -1,0 +1,42 @@
+Harness status: OK
+
+Found 36 tests
+
+33 Pass
+3 Fail
+Pass	pre test setup
+Pass	backgroundAttachment should be applied to first-letter pseudo elements.
+Pass	backgroundBlendMode should be applied to first-letter pseudo elements.
+Pass	backgroundClip should be applied to first-letter pseudo elements.
+Pass	backgroundColor should be applied to first-letter pseudo elements.
+Pass	backgroundImage should be applied to first-letter pseudo elements.
+Pass	backgroundOrigin should be applied to first-letter pseudo elements.
+Pass	backgroundPosition should be applied to first-letter pseudo elements.
+Pass	backgroundRepeat should be applied to first-letter pseudo elements.
+Pass	backgroundSize should be applied to first-letter pseudo elements.
+Pass	border should be applied to first-letter pseudo elements.
+Pass	borderImage should be applied to first-letter pseudo elements.
+Pass	borderRadius should be applied to first-letter pseudo elements.
+Pass	boxShadow should be applied to first-letter pseudo elements.
+Pass	color should be applied to first-letter pseudo elements.
+Pass	float should be applied to first-letter pseudo elements.
+Pass	font should be applied to first-letter pseudo elements.
+Pass	fontFeatureSettings should be applied to first-letter pseudo elements.
+Fail	fontSizeAdjust should be applied to first-letter pseudo elements.
+Pass	fontKerning should be applied to first-letter pseudo elements.
+Pass	fontVariationSettings should be applied to first-letter pseudo elements.
+Pass	letterSpacing should be applied to first-letter pseudo elements.
+Pass	margin should be applied to first-letter pseudo elements.
+Pass	padding should be applied to first-letter pseudo elements.
+Pass	opacity should be applied to first-letter pseudo elements.
+Pass	textDecoration should be applied to first-letter pseudo elements.
+Pass	textJustify should be applied to first-letter pseudo elements.
+Pass	textShadow should be applied to first-letter pseudo elements.
+Pass	textTransform should be applied to first-letter pseudo elements.
+Pass	textUnderlinePosition should be applied to first-letter pseudo elements.
+Pass	verticalAlign should be applied to first-letter pseudo elements.
+Pass	wordSpacing should be applied to first-letter pseudo elements.
+Pass	position should not be applied to first-letter pseudo elements.
+Fail	transition should not be applied to first-letter pseudo elements.
+Pass	transform should not be applied to first-letter pseudo elements.
+Fail	wordBreak should not be applied to first-letter pseudo elements.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-pseudo/first-letter-allowed-properties.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-pseudo/first-letter-allowed-properties.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 36 tests
 
-33 Pass
-3 Fail
+34 Pass
+2 Fail
 Pass	pre test setup
 Pass	backgroundAttachment should be applied to first-letter pseudo elements.
 Pass	backgroundBlendMode should be applied to first-letter pseudo elements.
@@ -39,4 +39,4 @@ Pass	wordSpacing should be applied to first-letter pseudo elements.
 Pass	position should not be applied to first-letter pseudo elements.
 Fail	transition should not be applied to first-letter pseudo elements.
 Pass	transform should not be applied to first-letter pseudo elements.
-Fail	wordBreak should not be applied to first-letter pseudo elements.
+Pass	wordBreak should not be applied to first-letter pseudo elements.

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-pseudo/first-letter-allowed-properties.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-pseudo/first-letter-allowed-properties.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<title>CSS Test: Properties allowed on ::first-letter pseudo elements</title>
+<link rel="author" title="Chris Nardi" href="mailto:cnardi@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#first-letter-styling">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+#target::first-letter {}
+#target { visibility: hidden; }
+</style>
+<div id="target">text</div>
+<script>
+'use strict';
+var style;
+const target = document.querySelector("#target");
+var defaultComputedStyle = getComputedStyle(target);
+
+test(function() {
+  var styleRule = document.styleSheets[0].cssRules[0];
+  assert_equals(styleRule.selectorText, '#target::first-letter', 'make sure we have the correct style rule');
+  style = styleRule.style;
+}, 'pre test setup');
+
+var validProperties = {
+  backgroundAttachment: 'fixed',
+  backgroundBlendMode: 'hue',
+  backgroundClip: 'padding-box',
+  backgroundColor: 'rgb(10, 20, 30)',
+  backgroundImage: 'linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255))',
+  backgroundOrigin: 'border-box',
+  backgroundPosition: '10px 20px',
+  backgroundRepeat: 'no-repeat',
+  backgroundSize: '10px 20px',
+  border: '40px dotted rgb(10, 20, 30)',
+  borderImage: 'linear-gradient(rgb(0, 0, 0), rgb(255, 255, 255)) 10% / 20 / 30px repeat',
+  borderRadius: '10px 20px',
+  boxShadow: 'rgb(10, 20, 30) 10px 20px 30px 40px inset',
+  color: 'rgba(10, 20, 30, 0.4)',
+  float: 'right',
+  font: 'italic small-caps 900 10px / 20px sans-serif',
+  fontFeatureSettings: '"vert" 2',
+  fontSizeAdjust: '0.5',
+  fontKerning: 'none',
+  fontVariationSettings: '"XHGT" 0.7',
+  letterSpacing: '12px',
+  margin: '10px 20px 30px 40px',
+  padding: '10px 20px 30px 40px',
+  opacity: '0.5',
+  textDecoration: 'overline wavy rgb(10, 20, 30)',
+  textJustify: 'inter-word',
+  textShadow: 'rgb(10, 20, 30) 10px 20px 30px',
+  textTransform: 'capitalize',
+  textUnderlinePosition: 'under',
+  verticalAlign: '12%',
+  wordSpacing: '12px'
+};
+
+var invalidProperties = {
+  position: 'absolute',
+  transition: 'transform 1s',
+  transform: 'rotate(45deg)',
+  wordBreak: 'break-all'
+};
+
+function testFirstLetterProperty(property, rule, expected, reason) {
+  test(function() {
+    style[property] = "";
+    style[property] = rule;
+    assert_equals(getComputedStyle(target, '::first-letter')[property], expected);
+    style[property] = "";
+  }, reason);
+}
+
+for (var property in validProperties) {
+  testFirstLetterProperty(property, validProperties[property], validProperties[property],
+                          property + " should be applied to first-letter pseudo elements.");
+}
+
+for (var property in invalidProperties) {
+  testFirstLetterProperty(property, invalidProperties[property], defaultComputedStyle[property],
+                          property + " should not be applied to first-letter pseudo elements.");
+}
+</script>


### PR DESCRIPTION
Previously, `::first-letter` elements were always wrapped in an inline box, meaning these elements were not correctly blockified when floated.

I've also included commits that align the properties allowed by `::first-letter` and other pseudo elements with the specification - previously `float` wasn't being applied to `::first-letter` elements.

This fixes the alignment of the drop cap I spotted on https://samreich.com:

Before:

<img width="163" height="91" alt="image" src="https://github.com/user-attachments/assets/aca0465b-d01a-44d7-8af1-1953e5ce7c33" />

After (NB: This matches the appearance of Chromium but not Firefox, but I believe this is the intended rendering):

<img width="163" height="91" alt="image" src="https://github.com/user-attachments/assets/4d32234c-25d4-4528-baac-35b10fb9b2c7" />
