### PR TITLE
WebDriver: Tolerate a WebContent process swap during load-url-from-ui

### DIFF
--- a/Services/WebDriver/Client.cpp
+++ b/Services/WebDriver/Client.cpp
@@ -312,8 +312,11 @@ Web::WebDriver::Response Client::load_url_from_ui(Web::WebDriver::Parameters par
     auto session = TRY(find_session_with_ladybird_test_hooks(parameters));
 
     RefPtr previous_connection { &session->web_content_connection() };
-    auto response = TRY(session->perform_async_action([&](auto& connection) {
-        return connection.load_url_from_ui(move(payload));
+    auto response = TRY(session->perform_async_action([&](auto& connection) -> Web::WebDriver::Response {
+        auto reply = connection.template send_sync_but_allow_failure<Messages::WebDriverClient::LoadUrlFromUi>(move(payload));
+        if (!reply)
+            return JsonValue {};
+        return reply->take_response();
     }));
     if (response.is_object() && response.as_object().get_bool("willReplaceWebContentProcess"sv).value_or(false))
         session->mark_current_window_as_awaiting_replacement(*previous_connection);


### PR DESCRIPTION
**Problem:** Intermittent `TestWebDriverSessionHistory` crashes in CI.

**Cause:** A process-swap navigation driven through the `load-url-from-ui` test hook (introduced in 24f37c6732f / #10085) could tear down the WebContent process before it replied to the sync `LoadUrlFromUi` message, tripping an assert — even though the result is still delivered over the `driver-execution-complete` channel separately. (The reply’s just an ACK.)

**Fix:** Send the message with `send_sync_but_allow_failure`. Treat a dropped reply as the swap proceeding. Nothing’s lost: WebContent sends the async completion before this, and early errors return before any swap.
