### PR TITLE
LibIPC: Fix transferable-stream hangs from dropped final messages

### DIFF
--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -22,10 +22,16 @@
 namespace IPC {
 
 Atomic<u32> TransportSocket::s_eof_drain_window_for_test_ms { 0 };
+Atomic<bool> TransportSocket::s_skip_inloop_read_for_test { false };
 
 void TransportSocket::set_eof_drain_window_for_test(u32 milliseconds)
 {
     s_eof_drain_window_for_test_ms.store(milliseconds, AK::MemoryOrder::memory_order_relaxed);
+}
+
+void TransportSocket::set_skip_inloop_read_for_test(bool skip)
+{
+    s_skip_inloop_read_for_test.store(skip, AK::MemoryOrder::memory_order_relaxed);
 }
 
 ErrorOr<NonnullOwnPtr<TransportSocket>> TransportSocket::from_socket(NonnullOwnPtr<Core::LocalSocket> socket)
@@ -183,7 +189,7 @@ intptr_t TransportSocket::io_thread_loop()
             (void)Core::System::read(m_wakeup_io_thread_read_fd->value(), { buf, sizeof(buf) });
         }
 
-        if (pollfds[0].revents & POLLIN)
+        if ((pollfds[0].revents & POLLIN) && !s_skip_inloop_read_for_test.load(AK::MemoryOrder::memory_order_relaxed))
             read_incoming_messages();
 
         if (pollfds[0].revents & POLLHUP) {

--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -203,7 +203,9 @@ intptr_t TransportSocket::io_thread_loop()
 
     VERIFY(m_io_thread_state == IOThreadState::Stopped);
     if (!m_is_being_transferred.load(AK::MemoryOrder::memory_order_acquire)) {
+        Sync::MutexLocker locker(m_incoming_mutex);
         m_peer_eof = true;
+        m_incoming_eof = true;
         m_incoming_cv.broadcast();
         notify_read_available();
     }
@@ -515,14 +517,15 @@ void TransportSocket::read_incoming_messages()
         m_unprocessed_bytes.clear();
     }
 
-    if (!batch.is_empty()) {
+    bool const peer_eof = m_peer_eof;
+    if (!batch.is_empty() || peer_eof) {
         Sync::MutexLocker locker(m_incoming_mutex);
-        m_incoming_messages.extend(move(batch));
-        m_incoming_cv.broadcast();
-        notify_read_available();
-    }
-
-    if (m_peer_eof) {
+        if (!batch.is_empty())
+            m_incoming_messages.extend(move(batch));
+        // Publish EOF only after the final batch is appended — under the same lock the consumer drains with — so that a
+        // consumer which observes EOF has also taken every message that arrived before it.
+        if (peer_eof)
+            m_incoming_eof = true;
         m_incoming_cv.broadcast();
         notify_read_available();
     }
@@ -531,13 +534,15 @@ void TransportSocket::read_incoming_messages()
 TransportSocket::ShouldShutdown TransportSocket::read_as_many_messages_as_possible_without_blocking(Function<void(Message&&)>&& callback)
 {
     Vector<NonnullOwnPtr<Message>> messages;
+    bool eof;
     {
         Sync::MutexLocker locker(m_incoming_mutex);
         messages = move(m_incoming_messages);
+        eof = m_incoming_eof;
     }
     for (auto& message : messages)
         callback(move(*message));
-    return m_peer_eof ? ShouldShutdown::Yes : ShouldShutdown::No;
+    return eof ? ShouldShutdown::Yes : ShouldShutdown::No;
 }
 
 ErrorOr<TransportHandle> TransportSocket::release_for_transfer()

--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -210,6 +210,12 @@ intptr_t TransportSocket::io_thread_loop()
 
     VERIFY(m_io_thread_state == IOThreadState::Stopped);
     if (!m_is_being_transferred.load(AK::MemoryOrder::memory_order_acquire)) {
+        // The loop may have stopped on a send-side failure (the peer closed its end while we still had data queued to
+        // send — so transfer_data() returned SocketClosed) without reading a final inbound message left buffered on the
+        // socket. Drain it before publishing EOF — so a message that arrived just before teardown (e.g., a cross-realm
+        // transform stream's "error") is actually delivered — rather than discarded.
+        read_incoming_messages();
+
         Sync::MutexLocker locker(m_incoming_mutex);
         m_peer_eof = true;
         m_incoming_eof = true;

--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -21,6 +21,13 @@
 
 namespace IPC {
 
+Atomic<u32> TransportSocket::s_eof_drain_window_for_test_ms { 0 };
+
+void TransportSocket::set_eof_drain_window_for_test(u32 milliseconds)
+{
+    s_eof_drain_window_for_test_ms.store(milliseconds, AK::MemoryOrder::memory_order_relaxed);
+}
+
 ErrorOr<NonnullOwnPtr<TransportSocket>> TransportSocket::from_socket(NonnullOwnPtr<Core::LocalSocket> socket)
 {
     return make<TransportSocket>(move(socket));
@@ -415,6 +422,13 @@ void TransportSocket::read_incoming_messages()
         }
         for (auto const& fd : received_fds) {
             m_unprocessed_attachments.enqueue(Attachment::from_fd(fd));
+        }
+    }
+
+    if (m_peer_eof) {
+        if (auto window_ms = s_eof_drain_window_for_test_ms.load(AK::MemoryOrder::memory_order_relaxed); window_ms != 0) {
+            notify_read_available();
+            (void)Core::System::sleep_ms(window_ms);
         }
     }
 

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -102,6 +102,11 @@ public:
     // rare timing. No-op in production.
     static void set_eof_drain_window_for_test(u32 milliseconds);
 
+    // Test seam: When set, the IO thread skips its in-loop read on POLLIN — modelling a stop path that ends the loop
+    // without having read a message already buffered on the socket (e.g. SocketClosed from a failed send). Exercises
+    // the loop-exit drain. No-op in production.
+    static void set_skip_inloop_read_for_test(bool);
+
 private:
     enum class TransferState {
         Continue,
@@ -145,6 +150,7 @@ private:
     bool m_incoming_eof { false };
 
     static Atomic<u32> s_eof_drain_window_for_test_ms;
+    static Atomic<bool> s_skip_inloop_read_for_test;
 
     RefPtr<AutoCloseFileDescriptor> m_wakeup_io_thread_read_fd;
     RefPtr<AutoCloseFileDescriptor> m_wakeup_io_thread_write_fd;

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -96,6 +96,12 @@ public:
 
     ErrorOr<TransportHandle> release_for_transfer();
 
+    // Test seam: When set to a non-zero value, the IO thread wakes the consumer and then pauses for the given duration
+    // on EOF — before the messages it has just read are parsed and appended. That forces a consumer drain into the
+    // narrow window between observing EOF and the final message becoming available — which is otherwise hit only under
+    // rare timing. No-op in production.
+    static void set_eof_drain_window_for_test(u32 milliseconds);
+
 private:
     enum class TransferState {
         Continue,
@@ -137,6 +143,8 @@ private:
     // Consumer-visible EOF, guarded by m_incoming_mutex. Distinct from m_peer_eof. This is set only after the final
     // batch of messages have been parsed and appended to m_incoming_messages under the same lock.
     bool m_incoming_eof { false };
+
+    static Atomic<u32> s_eof_drain_window_for_test_ms;
 
     RefPtr<AutoCloseFileDescriptor> m_wakeup_io_thread_read_fd;
     RefPtr<AutoCloseFileDescriptor> m_wakeup_io_thread_write_fd;

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -134,6 +134,9 @@ private:
     Sync::Mutex m_incoming_mutex;
     Sync::ConditionVariable m_incoming_cv { m_incoming_mutex };
     Vector<NonnullOwnPtr<Message>> m_incoming_messages;
+    // Consumer-visible EOF, guarded by m_incoming_mutex. Distinct from m_peer_eof. This is set only after the final
+    // batch of messages have been parsed and appended to m_incoming_messages under the same lock.
+    bool m_incoming_eof { false };
 
     RefPtr<AutoCloseFileDescriptor> m_wakeup_io_thread_read_fd;
     RefPtr<AutoCloseFileDescriptor> m_wakeup_io_thread_write_fd;

--- a/Tests/LibIPC/TestTransportSocket.cpp
+++ b/Tests/LibIPC/TestTransportSocket.cpp
@@ -6,10 +6,13 @@
 
 #include <AK/Atomic.h>
 #include <AK/Function.h>
+#include <AK/ScopeGuard.h>
 #include <AK/Time.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Socket.h>
 #include <LibCore/System.h>
+#include <LibIPC/Attachment.h>
+#include <LibIPC/Forward.h>
 #include <LibIPC/TransportSocket.h>
 #include <LibTest/TestCase.h>
 
@@ -92,4 +95,61 @@ TEST_CASE(read_hook_is_notified_when_io_thread_exits_on_close)
     });
 
     EXPECT(observed_shutdown.load(AK::MemoryOrder::memory_order_relaxed));
+}
+
+// A message that arrives immediately before EOF must be delivered to the consumer — even when the consumer drains in
+// the narrow window between the IO thread observing EOF and that message becoming available. Otherwise, the consumer
+// (e.g. a MessagePort) can tear itself down on the EOF, and drop the final message. See the EOF/message ordering in
+// read_incoming_messages and read_as_many_messages_as_possible_without_blocking.
+TEST_CASE(message_arriving_just_before_eof_is_not_dropped_on_shutdown)
+{
+    Core::EventLoop loop;
+
+    int fds[2] = {};
+    MUST(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fds));
+
+    // Queue one message and hang up the peer before the reading transport (and its IO thread) exists — so the IO
+    // thread's first read sees the message bytes and EOF together.
+    {
+        auto peer_socket = TRY_OR_FAIL(Core::LocalSocket::adopt_fd(fds[1]));
+        MUST(peer_socket->set_blocking(false));
+        IPC::TransportSocket peer(move(peer_socket));
+
+        auto hello = "hello"sv.bytes();
+        IPC::MessageDataType payload;
+        payload.append(hello.data(), hello.size());
+        Vector<IPC::Attachment> no_attachments;
+        peer.post_message(move(payload), no_attachments);
+        peer.close_after_sending_all_pending_messages();
+    }
+
+    // Force the IO thread to wake the consumer and pause on EOF before it parses and appends the message it read — so
+    // the consumer's first drain falls inside the window that would otherwise drop the message.
+    IPC::TransportSocket::set_eof_drain_window_for_test(200);
+    ScopeGuard reset_window = [] { IPC::TransportSocket::set_eof_drain_window_for_test(0); };
+
+    auto reader_socket = TRY_OR_FAIL(Core::LocalSocket::adopt_fd(fds[0]));
+    MUST(reader_socket->set_blocking(false));
+    IPC::TransportSocket transport(move(reader_socket));
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<u32> delivered = 0;
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<bool> observed_shutdown = false;
+
+    transport.set_up_read_hook([&] {
+        // Model a consumer that tears itself down once it observes shutdown (as MessagePort does): A message not
+        // delivered before shutdown is observed is lost for good.
+        if (observed_shutdown.load(AK::MemoryOrder::memory_order_relaxed))
+            return;
+        auto should_shutdown = transport.read_as_many_messages_as_possible_without_blocking([&](auto&&) {
+            delivered.fetch_add(1, AK::MemoryOrder::memory_order_relaxed);
+        });
+        if (should_shutdown == IPC::TransportSocket::ShouldShutdown::Yes)
+            observed_shutdown.store(true, AK::MemoryOrder::memory_order_relaxed);
+    });
+
+    spin_until(loop, [&] {
+        return observed_shutdown.load(AK::MemoryOrder::memory_order_relaxed);
+    });
+
+    EXPECT_EQ(delivered.load(AK::MemoryOrder::memory_order_relaxed), 1u);
 }

--- a/Tests/LibIPC/TestTransportSocket.cpp
+++ b/Tests/LibIPC/TestTransportSocket.cpp
@@ -153,3 +153,59 @@ TEST_CASE(message_arriving_just_before_eof_is_not_dropped_on_shutdown)
 
     EXPECT_EQ(delivered.load(AK::MemoryOrder::memory_order_relaxed), 1u);
 }
+
+// A message already buffered on the socket when the IO thread stops must still be delivered — even if the loop stops on
+// a path that doesn't run its in-loop read. That happens when a send fails because the peer closed (transfer_data
+// returns SocketClosed): The loop ends without draining the receive side. The loop-exit drain is the backstop. Without
+// it, the message is lost, and a consumer that tears down on EOF (like MessagePort, e.g. a cross-realm transform stream
+// receiving a final "error") hangs its peer forever.
+TEST_CASE(buffered_message_is_drained_when_io_thread_stops_without_reading_it)
+{
+    Core::EventLoop loop;
+
+    int fds[2] = {};
+    MUST(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fds));
+
+    // Queue one message, and hang up the peer before the reading transport exists — so the reader's first poll sees the
+    // message bytes and EOF together.
+    {
+        auto peer_socket = TRY_OR_FAIL(Core::LocalSocket::adopt_fd(fds[1]));
+        MUST(peer_socket->set_blocking(false));
+        IPC::TransportSocket peer(move(peer_socket));
+
+        auto hello = "hello"sv.bytes();
+        IPC::MessageDataType payload;
+        payload.append(hello.data(), hello.size());
+        Vector<IPC::Attachment> no_attachments;
+        peer.post_message(move(payload), no_attachments);
+        peer.close_after_sending_all_pending_messages();
+    }
+
+    // Model a stop path that doesn't run the in-loop read (e.g. SocketClosed from a failed send): The loop reaches its
+    // exit with the message still buffered on the socket — so only the loop-exit drain can deliver it.
+    IPC::TransportSocket::set_skip_inloop_read_for_test(true);
+    ScopeGuard reset_skip = [] { IPC::TransportSocket::set_skip_inloop_read_for_test(false); };
+
+    auto reader_socket = TRY_OR_FAIL(Core::LocalSocket::adopt_fd(fds[0]));
+    MUST(reader_socket->set_blocking(false));
+    IPC::TransportSocket transport(move(reader_socket));
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<u32> delivered = 0;
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<bool> observed_shutdown = false;
+
+    transport.set_up_read_hook([&] {
+        if (observed_shutdown.load(AK::MemoryOrder::memory_order_relaxed))
+            return;
+        auto should_shutdown = transport.read_as_many_messages_as_possible_without_blocking([&](auto&&) {
+            delivered.fetch_add(1, AK::MemoryOrder::memory_order_relaxed);
+        });
+        if (should_shutdown == IPC::TransportSocket::ShouldShutdown::Yes)
+            observed_shutdown.store(true, AK::MemoryOrder::memory_order_relaxed);
+    });
+
+    spin_until(loop, [&] {
+        return observed_shutdown.load(AK::MemoryOrder::memory_order_relaxed);
+    });
+
+    EXPECT_EQ(delivered.load(AK::MemoryOrder::memory_order_relaxed), 1u);
+}


### PR DESCRIPTION
Two related races in `TransportSocket` could drop a cross-realm stream’s final message as the transport tears down — leaving a transferred stream’s promise pending forever. Both surfaced as intermittent timeouts in CI of the `streams/transferable` WPTs.

- **EOF/message delivery race** (`442af4d`): `read_as_many_messages_as_possible_without_blocking()` snapshotted the incoming messages under `m_incoming_mutex` — but read `m_peer_eof` outside it. A consumer draining concurrently could observe EOF while its snapshot still lacked the final message, tear its port down, and drop it. A separate consumer-visible `m_incoming_eof` flag is now published only after the final batch is appended, under the same lock the consumer drains with.

- **Drain on send-side stop** (`7508f7e`): When the peer closed mid-send, `transfer_data()` returned `SocketClosed` and the IO thread stopped the loop — without reading a final inbound message already buffered on the socket. The loop now drains the receive buffer once more at exit — before publishing EOF.
