### PR TITLE
LibWeb: Assume lengths are absolute in more places after computation

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -289,6 +289,11 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(PropertyID property_i
     return set_property_internal(PropertyNameAndID::from_id(property_id), css_text, priority);
 }
 
+static NonnullRefPtr<StyleValue const> style_value_for_css_pixels(CSSPixels css_pixels)
+{
+    return LengthStyleValue::create(Length::make_px(css_pixels));
+}
+
 static NonnullRefPtr<StyleValue const> style_value_for_length_percentage(LengthPercentage const& length_percentage)
 {
     if (length_percentage.is_percentage())
@@ -342,10 +347,10 @@ static RefPtr<StyleValue const> style_value_for_shadow(ShadowStyleValue::ShadowT
         return ShadowStyleValue::create(
             shadow_type,
             ColorStyleValue::create_from_color(shadow.color, ColorSyntax::Modern),
-            style_value_for_length_percentage(shadow.offset_x),
-            style_value_for_length_percentage(shadow.offset_y),
-            style_value_for_length_percentage(shadow.blur_radius),
-            style_value_for_length_percentage(shadow.spread_distance),
+            style_value_for_css_pixels(shadow.offset_x),
+            style_value_for_css_pixels(shadow.offset_y),
+            style_value_for_css_pixels(shadow.blur_radius),
+            style_value_for_css_pixels(shadow.spread_distance),
             shadow.placement);
     };
 

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -954,30 +954,30 @@ BackgroundBox ComputedProperties::background_color_clip() const
     return keyword_to_background_box(background_clip_values[final_layer_index]->to_keyword()).value();
 }
 
-Length ComputedProperties::border_spacing_horizontal() const
+CSSPixels ComputedProperties::border_spacing_horizontal() const
 {
     auto const& style_value = property(PropertyID::BorderSpacing);
 
     if (style_value.is_value_list()) {
         auto const& list = style_value.as_value_list();
         VERIFY(list.size() > 0);
-        return Length::from_style_value(list.value_at(0, false), {});
+        return Length::from_style_value(list.value_at(0, false), {}).absolute_length_to_px();
     }
 
-    return Length::from_style_value(style_value, {});
+    return Length::from_style_value(style_value, {}).absolute_length_to_px();
 }
 
-Length ComputedProperties::border_spacing_vertical() const
+CSSPixels ComputedProperties::border_spacing_vertical() const
 {
     auto const& style_value = property(PropertyID::BorderSpacing);
 
     if (style_value.is_value_list()) {
         auto const& list = style_value.as_value_list();
         VERIFY(list.size() > 1);
-        return Length::from_style_value(list.value_at(1, false), {});
+        return Length::from_style_value(list.value_at(1, false), {}).absolute_length_to_px();
     }
 
-    return Length::from_style_value(style_value, {});
+    return Length::from_style_value(style_value, {}).absolute_length_to_px();
 }
 
 CaptionSide ComputedProperties::caption_side() const
@@ -1280,13 +1280,13 @@ PointerEvents ComputedProperties::pointer_events() const
     return keyword_to_pointer_events(value.to_keyword()).release_value();
 }
 
-Variant<Length, double> ComputedProperties::tab_size() const
+Variant<CSSPixels, double> ComputedProperties::tab_size() const
 {
     auto const& value = property(PropertyID::TabSize);
     if (value.is_calculated()) {
         auto const& math_value = value.as_calculated();
         if (math_value.resolves_to_length()) {
-            return math_value.resolve_length({}).value();
+            return math_value.resolve_length({}).value().absolute_length_to_px();
         }
         if (math_value.resolves_to_number()) {
             return math_value.resolve_number({}).value();
@@ -1294,7 +1294,7 @@ Variant<Length, double> ComputedProperties::tab_size() const
     }
 
     if (value.is_length())
-        return value.as_length().length();
+        return value.as_length().length().absolute_length_to_px();
 
     return value.as_number().number();
 }
@@ -1643,10 +1643,10 @@ Vector<ShadowData> ComputedProperties::shadow(PropertyID property_id, Layout::No
     auto const& value = property(property_id);
 
     auto make_shadow_data = [&layout_node](ShadowStyleValue const& value) -> Optional<ShadowData> {
-        auto offset_x = Length::from_style_value(value.offset_x(), {});
-        auto offset_y = Length::from_style_value(value.offset_y(), {});
-        auto blur_radius = Length::from_style_value(value.blur_radius(), {});
-        auto spread_distance = Length::from_style_value(value.spread_distance(), {});
+        auto offset_x = Length::from_style_value(value.offset_x(), {}).absolute_length_to_px();
+        auto offset_y = Length::from_style_value(value.offset_y(), {}).absolute_length_to_px();
+        auto blur_radius = Length::from_style_value(value.blur_radius(), {}).absolute_length_to_px();
+        auto spread_distance = Length::from_style_value(value.spread_distance(), {}).absolute_length_to_px();
         return ShadowData {
             offset_x,
             offset_y,

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -175,8 +175,8 @@ public:
     Vector<BackgroundLayerData> background_layers() const;
     Vector<BackgroundLayerData> mask_layers() const;
     BackgroundBox background_color_clip() const;
-    Length border_spacing_horizontal() const;
-    Length border_spacing_vertical() const;
+    CSSPixels border_spacing_horizontal() const;
+    CSSPixels border_spacing_vertical() const;
     CaptionSide caption_side() const;
     Clip clip() const;
     Display display() const;
@@ -191,7 +191,7 @@ public:
     ContentDataAndQuoteNestingLevel content(DOM::AbstractElement&, u32 initial_quote_nesting_level) const;
     ContentVisibility content_visibility() const;
     Vector<CursorData> cursor() const;
-    Variant<Length, double> tab_size() const;
+    Variant<CSSPixels, double> tab_size() const;
     WhiteSpaceCollapse white_space_collapse() const;
     WhiteSpaceTrimData white_space_trim() const;
     WordBreak word_break() const;

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -70,10 +70,10 @@ struct Position {
     PositionEdge edge_y { PositionEdge::Top };
     LengthPercentage offset_y { Percentage(50) };
 
-    CSSPixelPoint resolved(Layout::Node const& node, CSSPixelRect const& rect) const
+    CSSPixelPoint resolved(CSSPixelRect const& rect) const
     {
-        CSSPixels x = offset_x.to_px(node, rect.width());
-        CSSPixels y = offset_y.to_px(node, rect.height());
+        CSSPixels x = offset_x.to_px(rect.width());
+        CSSPixels y = offset_y.to_px(rect.height());
         if (edge_x == PositionEdge::Right)
             x = rect.width() - x;
         if (edge_y == PositionEdge::Bottom)
@@ -466,6 +466,7 @@ struct WhiteSpaceTrimData {
 struct TransformOrigin {
     LengthPercentage x { Percentage(50) };
     LengthPercentage y { Percentage(50) };
+    // FIXME: We can store this as a CSSPixels since we know it's always an absolute length
     LengthPercentage z { Percentage(0) };
 };
 

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -148,7 +148,7 @@ using CursorData = Variant<NonnullRefPtr<CursorStyleValue const>, CursorPredefin
 
 struct OverflowClipMarginSide {
     Optional<BackgroundBox> visual_box {};
-    Length offset { Length::make_px(0) };
+    CSSPixels offset { 0 };
 
     bool operator==(OverflowClipMarginSide const&) const = default;
 };
@@ -171,7 +171,7 @@ public:
     static double font_weight() { return 400; }
     static CSSPixels line_height() { return 0; }
     static Float float_() { return Float::None; }
-    static Length border_spacing() { return Length::make_px(0); }
+    static CSSPixels border_spacing() { return 0; }
     static CaptionSide caption_side() { return CaptionSide::Top; }
     static Color caret_color() { return Color::Black; }
     static Clear clear() { return Clear::None; }
@@ -185,7 +185,7 @@ public:
     static FontVariantEmoji font_variant_emoji() { return FontVariantEmoji::Normal; }
     static CSSPixels word_spacing() { return 0; }
     static CSSPixels letter_spacing() { return 0; }
-    static Variant<Length, double> tab_size() { return 8; }
+    static Variant<CSSPixels, double> tab_size() { return 8; }
     static TextAlign text_align() { return TextAlign::Start; }
     static TextJustify text_justify() { return TextJustify::Auto; }
     static Positioning position() { return Positioning::Static; }
@@ -240,7 +240,7 @@ public:
     static LengthPercentage stroke_width() { return Length::make_px(1); }
     static float stop_opacity() { return 1.0f; }
     static TextAnchor text_anchor() { return TextAnchor::Start; }
-    static Length border_radius() { return Length::make_px(0); }
+    static LengthPercentage border_radius() { return LengthPercentage { Length::make_px(0) }; }
     static Variant<VerticalAlign, LengthPercentage> vertical_align() { return VerticalAlign::Baseline; }
     static LengthBox inset() { return {}; }
     static LengthBox margin() { return { Length::make_px(0), Length::make_px(0), Length::make_px(0), Length::make_px(0) }; }
@@ -271,7 +271,7 @@ public:
     static ObjectFit object_fit() { return ObjectFit::Fill; }
     static Position object_position() { return {}; }
     static Color outline_color() { return Color::Black; }
-    static Length outline_offset() { return Length::make_px(0); }
+    static CSSPixels outline_offset() { return 0; }
     static OutlineStyle outline_style() { return OutlineStyle::None; }
     static CSSPixels outline_width() { return 3; }
     static TableLayout table_layout() { return TableLayout::Auto; }
@@ -470,10 +470,10 @@ struct TransformOrigin {
 };
 
 struct ShadowData {
-    Length offset_x { Length::make_px(0) };
-    Length offset_y { Length::make_px(0) };
-    Length blur_radius { Length::make_px(0) };
-    Length spread_distance { Length::make_px(0) };
+    CSSPixels offset_x { 0 };
+    CSSPixels offset_y { 0 };
+    CSSPixels blur_radius { 0 };
+    CSSPixels spread_distance { 0 };
     Color color {};
     ShadowPlacement placement { ShadowPlacement::Outer };
 };
@@ -540,8 +540,8 @@ public:
 
     AspectRatio aspect_ratio() const { return m_noninherited.aspect_ratio; }
     Float float_() const { return m_noninherited.float_; }
-    Length border_spacing_horizontal() const { return m_inherited.border_spacing_horizontal; }
-    Length border_spacing_vertical() const { return m_inherited.border_spacing_vertical; }
+    CSSPixels border_spacing_horizontal() const { return m_inherited.border_spacing_horizontal; }
+    CSSPixels border_spacing_vertical() const { return m_inherited.border_spacing_vertical; }
     CaptionSide caption_side() const { return m_inherited.caption_side; }
     Color caret_color() const { return m_inherited.caret_color; }
     Clear clear() const { return m_noninherited.clear; }
@@ -555,7 +555,7 @@ public:
     Display display() const { return m_noninherited.display; }
     Display display_before_box_type_transformation() const { return m_noninherited.display_before_box_type_transformation; }
     Optional<int> const& z_index() const { return m_noninherited.z_index; }
-    Variant<Length, double> tab_size() const { return m_inherited.tab_size; }
+    Variant<CSSPixels, double> tab_size() const { return m_inherited.tab_size; }
     TextAlign text_align() const { return m_inherited.text_align; }
     TextJustify text_justify() const { return m_inherited.text_justify; }
     TextIndentData const& text_indent() const { return m_inherited.text_indent; }
@@ -748,7 +748,7 @@ public:
     CSSPixels line_height() const { return m_inherited.line_height; }
 
     Color outline_color() const { return m_noninherited.outline_color; }
-    Length outline_offset() const { return m_noninherited.outline_offset; }
+    CSSPixels outline_offset() const { return m_noninherited.outline_offset; }
     OutlineStyle outline_style() const { return m_noninherited.outline_style; }
     CSSPixels outline_width() const { return m_noninherited.outline_width; }
 
@@ -785,8 +785,8 @@ protected:
         CaptionSide caption_side { InitialValues::caption_side() };
         EmptyCells empty_cells { InitialValues::empty_cells() };
         ContentVisibility content_visibility { InitialValues::content_visibility() };
-        Length border_spacing_horizontal { InitialValues::border_spacing() };
-        Length border_spacing_vertical { InitialValues::border_spacing() };
+        CSSPixels border_spacing_horizontal { InitialValues::border_spacing() };
+        CSSPixels border_spacing_vertical { InitialValues::border_spacing() };
         Color color { InitialValues::color() };
         ColorInterpolation color_interpolation { InitialValues::color_interpolation() };
 
@@ -802,7 +802,7 @@ protected:
         TextWrapMode text_wrap_mode { InitialValues::text_wrap_mode() };
         TextDecorationSkipInk text_decoration_skip_ink { InitialValues::text_decoration_skip_ink() };
         TextUnderlinePosition text_underline_position { InitialValues::text_underline_position() };
-        Variant<Length, double> tab_size { InitialValues::tab_size() };
+        Variant<CSSPixels, double> tab_size { InitialValues::tab_size() };
         TextIndentData text_indent { InitialValues::text_indent() };
         CSSPixels text_underline_offset { InitialValues::text_underline_offset() };
         WhiteSpaceCollapse white_space_collapse { InitialValues::white_space_collapse() };
@@ -929,7 +929,7 @@ protected:
         float stop_opacity { InitialValues::stop_opacity() };
         Color outline_color { InitialValues::outline_color() };
         CSSPixels outline_width { InitialValues::outline_width() };
-        Length outline_offset { InitialValues::outline_offset() };
+        CSSPixels outline_offset { InitialValues::outline_offset() };
         TableLayout table_layout { InitialValues::table_layout() };
         UnicodeBidi unicode_bidi { InitialValues::unicode_bidi() };
         UserSelect user_select { InitialValues::user_select() };
@@ -989,8 +989,8 @@ public:
     void set_font_language_override(Optional<FlyString> font_language_override) { m_inherited.font_language_override = move(font_language_override); }
     void set_font_variation_settings(HashMap<FlyString, double> value) { m_inherited.font_variation_settings = move(value); }
     void set_line_height(CSSPixels line_height) { m_inherited.line_height = line_height; }
-    void set_border_spacing_horizontal(Length border_spacing_horizontal) { m_inherited.border_spacing_horizontal = move(border_spacing_horizontal); }
-    void set_border_spacing_vertical(Length border_spacing_vertical) { m_inherited.border_spacing_vertical = move(border_spacing_vertical); }
+    void set_border_spacing_horizontal(CSSPixels border_spacing_horizontal) { m_inherited.border_spacing_horizontal = move(border_spacing_horizontal); }
+    void set_border_spacing_vertical(CSSPixels border_spacing_vertical) { m_inherited.border_spacing_vertical = move(border_spacing_vertical); }
     void set_caption_side(CaptionSide caption_side) { m_inherited.caption_side = caption_side; }
     void set_color(Color color) { m_inherited.color = color; }
     void set_color_interpolation(ColorInterpolation color_interpolation) { m_inherited.color_interpolation = color_interpolation; }
@@ -1008,7 +1008,7 @@ public:
     void set_float(Float value) { m_noninherited.float_ = value; }
     void set_clear(Clear value) { m_noninherited.clear = value; }
     void set_z_index(Optional<int> value) { m_noninherited.z_index = move(value); }
-    void set_tab_size(Variant<Length, double> value) { m_inherited.tab_size = move(value); }
+    void set_tab_size(Variant<CSSPixels, double> value) { m_inherited.tab_size = move(value); }
     void set_text_align(TextAlign text_align) { m_inherited.text_align = text_align; }
     void set_text_justify(TextJustify text_justify) { m_inherited.text_justify = text_justify; }
     void set_text_decoration_line(Vector<TextDecorationLine> value) { m_noninherited.text_decoration_line = move(value); }
@@ -1160,7 +1160,7 @@ public:
     void set_stop_opacity(float value) { m_noninherited.stop_opacity = value; }
     void set_text_anchor(TextAnchor value) { m_inherited.text_anchor = value; }
     void set_outline_color(Color value) { m_noninherited.outline_color = value; }
-    void set_outline_offset(Length value) { m_noninherited.outline_offset = move(value); }
+    void set_outline_offset(CSSPixels value) { m_noninherited.outline_offset = move(value); }
     void set_outline_style(OutlineStyle value) { m_noninherited.outline_style = value; }
     void set_outline_width(CSSPixels value) { m_noninherited.outline_width = value; }
     void set_mask(MaskReference value) { m_noninherited.mask = value; }

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -399,18 +399,4 @@ LengthOrAuto LengthOrAuto::from_style_value(NonnullRefPtr<StyleValue const> cons
     return LengthOrAuto { Length::from_style_value(style_value, percentage_basis) };
 }
 
-Length Length::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, Layout::Node const& layout_node, Length const& reference_value)
-{
-    CalculationResolutionContext context {
-        .percentage_basis = reference_value,
-        .length_resolution_context = ResolutionContext::for_layout_node(layout_node),
-    };
-    return calculated->resolve_length(context).value();
-}
-
-Length Length::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, Layout::Node const& layout_node, CSSPixels reference_value)
-{
-    return resolve_calculated(calculated, layout_node, make_px(reference_value));
-}
-
 }

--- a/Libraries/LibWeb/CSS/Length.h
+++ b/Libraries/LibWeb/CSS/Length.h
@@ -213,6 +213,7 @@ private:
     double m_value { 0 };
 };
 
+// FIXME: This should be CSSPixelsOrAuto since it's only used after computation when lengths have been absolutized
 class LengthOrAuto {
 public:
     LengthOrAuto(Length length)
@@ -243,11 +244,11 @@ public:
         return builder.to_string_without_validation();
     }
 
-    CSSPixels to_px_or_zero(Layout::Node const& node) const
+    CSSPixels to_px_or_zero() const
     {
         if (is_auto())
             return 0;
-        return m_length->to_px(node);
+        return m_length->absolute_length_to_px();
     }
 
     bool is_font_relative() const { return m_length.has_value() && m_length->is_font_relative(); }

--- a/Libraries/LibWeb/CSS/Length.h
+++ b/Libraries/LibWeb/CSS/Length.h
@@ -251,9 +251,6 @@ public:
         return m_length->absolute_length_to_px();
     }
 
-    bool is_font_relative() const { return m_length.has_value() && m_length->is_font_relative(); }
-    bool is_computationally_independent() const { return !m_length.has_value() || m_length->is_computationally_independent(); }
-
     bool operator==(LengthOrAuto const&) const = default;
 
 private:

--- a/Libraries/LibWeb/CSS/Length.h
+++ b/Libraries/LibWeb/CSS/Length.h
@@ -206,9 +206,6 @@ public:
 
     static Length from_style_value(NonnullRefPtr<StyleValue const> const&, Optional<Length> percentage_basis);
 
-    static Length resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const&, Layout::Node const&, Length const& reference_value);
-    static Length resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const&, Layout::Node const&, CSSPixels reference_value);
-
 private:
     [[nodiscard]] CSSPixels to_px_slow_case(Layout::Node const&) const;
 

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -19,50 +19,34 @@
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/Time.h>
 
-// FIXME: LengthPercentage is the only remaining derived class of PercentageOr so we can just merge them together. It
-//        should also probably instead be CSSPixelsPercentage since it is only used after computation where we resolve
-//        all relative lengths.
 namespace Web::CSS {
 
-template<typename T>
-class PercentageOr {
+// FIXME: This should probably instead be CSSPixelsPercentage since it is only used after computation where we resolve
+//        all relative lengths.
+
+class LengthPercentage {
 public:
-    PercentageOr(T t)
+    LengthPercentage(Length t)
         : m_value(move(t))
     {
     }
 
-    PercentageOr(Percentage percentage)
+    LengthPercentage(Percentage percentage)
         : m_value(move(percentage))
     {
     }
 
-    PercentageOr(NonnullRefPtr<CalculatedStyleValue const> calculated)
+    LengthPercentage(NonnullRefPtr<CalculatedStyleValue const> calculated)
         : m_value(move(calculated))
     {
     }
 
-    ~PercentageOr() = default;
-
-    PercentageOr<T>& operator=(T t)
-    {
-        m_value = move(t);
-        return *this;
-    }
-
-    PercentageOr<T>& operator=(Percentage percentage)
-    {
-        m_value = move(percentage);
-        return *this;
-    }
-
-    bool is_percentage() const { return m_value.template has<Percentage>(); }
-    bool is_calculated() const { return m_value.template has<NonnullRefPtr<CalculatedStyleValue const>>(); }
+    ~LengthPercentage() = default;
 
     bool contains_percentage() const
     {
         return m_value.visit(
-            [&](T const&) {
+            [&](Length const&) {
                 return false;
             },
             [&](Percentage const&) {
@@ -87,41 +71,25 @@ public:
 
     CSSPixels to_px(Layout::Node const& layout_node, CSSPixels reference_value) const
     {
-        if constexpr (IsSame<T, Length>) {
-            if (auto const* length = m_value.template get_pointer<Length>()) {
-                if (length->is_absolute())
-                    return length->absolute_length_to_px();
-            }
+        if (auto const* length = m_value.template get_pointer<Length>()) {
+            if (length->is_absolute())
+                return length->absolute_length_to_px();
         }
+
         return resolved(layout_node, reference_value).to_px(layout_node);
     }
 
-    T resolved(Layout::Node const& layout_node, T reference_value) const
-    requires(!IsSame<T, Length>)
+    Length resolved(Layout::Node const& layout_node, CSSPixels reference_value) const
     {
         return m_value.visit(
-            [&](T const& t) {
-                return t;
-            },
-            [&](Percentage const& percentage) {
-                return reference_value.percentage_of(percentage);
-            },
-            [&](NonnullRefPtr<CalculatedStyleValue const> const& calculated) {
-                return T::resolve_calculated(calculated, layout_node, reference_value);
-            });
-    }
-
-    T resolved(Layout::Node const& layout_node, CSSPixels reference_value) const
-    {
-        return m_value.visit(
-            [&](T const& t) {
+            [&](Length const& t) {
                 return t;
             },
             [&](Percentage const& percentage) {
                 return Length::make_px(CSSPixels::truncated_value_for(reference_value.to_double() * percentage.as_fraction()));
             },
             [&](NonnullRefPtr<CalculatedStyleValue const> const& calculated) {
-                return T::resolve_calculated(calculated, layout_node, reference_value);
+                return Length::resolve_calculated(calculated, layout_node, reference_value);
             });
     }
 
@@ -132,7 +100,7 @@ public:
         } else if (is_percentage()) {
             m_value.template get<Percentage>().serialize(builder, mode);
         } else {
-            m_value.template get<T>().serialize(builder, mode);
+            m_value.template get<Length>().serialize(builder, mode);
         }
     }
 
@@ -142,55 +110,6 @@ public:
         serialize(builder, mode);
         return builder.to_string_without_validation();
     }
-
-    bool operator==(PercentageOr<T> const& other) const
-    {
-        if (is_calculated() != other.is_calculated())
-            return false;
-        if (is_percentage() != other.is_percentage())
-            return false;
-        if (is_calculated())
-            return (*m_value.template get<NonnullRefPtr<CalculatedStyleValue const>>() == *other.m_value.template get<NonnullRefPtr<CalculatedStyleValue const>>());
-        if (is_percentage())
-            return (m_value.template get<Percentage>() == other.m_value.template get<Percentage>());
-        return (m_value.template get<T>() == other.m_value.template get<T>());
-    }
-
-protected:
-    bool is_t() const { return m_value.template has<T>(); }
-    T const& get_t() const { return m_value.template get<T>(); }
-
-private:
-    Variant<T, Percentage, NonnullRefPtr<CalculatedStyleValue const>> m_value;
-};
-
-template<typename T>
-bool operator==(PercentageOr<T> const& percentage_or, T const& t)
-{
-    return percentage_or == PercentageOr<T> { t };
-}
-
-template<typename T>
-bool operator==(T const& t, PercentageOr<T> const& percentage_or)
-{
-    return t == percentage_or;
-}
-
-template<typename T>
-bool operator==(PercentageOr<T> const& percentage_or, Percentage const& percentage)
-{
-    return percentage_or == PercentageOr<T> { percentage };
-}
-
-template<typename T>
-bool operator==(Percentage const& percentage, PercentageOr<T> const& percentage_or)
-{
-    return percentage == percentage_or;
-}
-
-class LengthPercentage : public PercentageOr<Length> {
-public:
-    using PercentageOr<Length>::PercentageOr;
 
     static LengthPercentage from_style_value(NonnullRefPtr<StyleValue const> const& style_value)
     {
@@ -204,8 +123,15 @@ public:
         VERIFY_NOT_REACHED();
     }
 
-    bool is_length() const { return is_t(); }
-    Length const& length() const { return get_t(); }
+    bool is_percentage() const { return m_value.template has<Percentage>(); }
+    bool is_calculated() const { return m_value.template has<NonnullRefPtr<CalculatedStyleValue const>>(); }
+    bool is_length() const { return m_value.has<Length>(); }
+    Length const& length() const { return m_value.get<Length>(); }
+
+    bool operator==(LengthPercentage const& other) const = default;
+
+private:
+    Variant<Length, Percentage, NonnullRefPtr<CalculatedStyleValue const>> m_value;
 };
 
 class LengthPercentageOrAuto {

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -69,17 +69,12 @@ public:
         return m_value.template get<NonnullRefPtr<CalculatedStyleValue const>>();
     }
 
-    CSSPixels to_px(Layout::Node const& layout_node, CSSPixels reference_value) const
+    CSSPixels to_px(CSSPixels reference_value) const
     {
-        if (auto const* length = m_value.template get_pointer<Length>()) {
-            if (length->is_absolute())
-                return length->absolute_length_to_px();
-        }
-
-        return resolved(layout_node, reference_value).to_px(layout_node);
+        return resolved(reference_value).absolute_length_to_px();
     }
 
-    Length resolved(Layout::Node const& layout_node, CSSPixels reference_value) const
+    Length resolved(CSSPixels reference_value) const
     {
         return m_value.visit(
             [&](Length const& t) {
@@ -89,7 +84,7 @@ public:
                 return Length::make_px(CSSPixels::truncated_value_for(reference_value.to_double() * percentage.as_fraction()));
             },
             [&](NonnullRefPtr<CalculatedStyleValue const> const& calculated) {
-                return Length::resolve_calculated(calculated, layout_node, reference_value);
+                return calculated->resolve_length({ .percentage_basis = Length::make_px(reference_value) }).value();
             });
     }
 
@@ -176,18 +171,18 @@ public:
     Percentage const& percentage() const { return m_length_percentage->percentage(); }
     NonnullRefPtr<CalculatedStyleValue const> const& calculated() const { return m_length_percentage->calculated(); }
 
-    LengthOrAuto resolved_or_auto(Layout::Node const& layout_node, CSSPixels reference_value) const
+    LengthOrAuto resolved_or_auto(CSSPixels reference_value) const
     {
         if (is_auto())
             return LengthOrAuto::make_auto();
-        return length_percentage().resolved(layout_node, reference_value);
+        return length_percentage().resolved(reference_value);
     }
 
-    CSSPixels to_px_or_zero(Layout::Node const& layout_node, CSSPixels reference_value) const
+    CSSPixels to_px_or_zero(CSSPixels reference_value) const
     {
         if (is_auto())
             return 0;
-        return length_percentage().to_px(layout_node, reference_value);
+        return length_percentage().to_px(reference_value);
     }
 
     void serialize(StringBuilder& builder, SerializationMode mode) const

--- a/Libraries/LibWeb/CSS/Size.cpp
+++ b/Libraries/LibWeb/CSS/Size.cpp
@@ -16,11 +16,11 @@ Size::Size(Type type, Optional<LengthPercentage> length_percentage)
 {
 }
 
-CSSPixels Size::to_px(Layout::Node const& node, CSSPixels reference_value) const
+CSSPixels Size::to_px(CSSPixels reference_value) const
 {
     if (!m_length_percentage.has_value())
         return 0;
-    return m_length_percentage->resolved(node, reference_value).to_px(node);
+    return m_length_percentage->resolved(reference_value).absolute_length_to_px();
 }
 
 Size Size::make_auto()

--- a/Libraries/LibWeb/CSS/Size.h
+++ b/Libraries/LibWeb/CSS/Size.h
@@ -52,7 +52,7 @@ public:
     bool is_intrinsic_sizing_constraint() const { return is_min_content() || is_max_content() || is_fit_content(); }
     bool is_length_percentage() const { return is_length() || is_percentage() || is_calculated(); }
 
-    [[nodiscard]] CSSPixels to_px(Layout::Node const&, CSSPixels reference_value) const;
+    [[nodiscard]] CSSPixels to_px(CSSPixels reference_value) const;
 
     bool contains_percentage() const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.cpp
@@ -30,12 +30,12 @@ static Gfx::Path path_from_resolved_rect(float top, float right, float bottom, f
 }
 
 // https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-inset
-Gfx::Path Inset::to_path(CSSPixelRect reference_box, Layout::Node const& node) const
+Gfx::Path Inset::to_path(CSSPixelRect reference_box) const
 {
-    auto resolved_top = LengthPercentageOrAuto::from_style_value(top).to_px_or_zero(node, reference_box.height()).to_float();
-    auto resolved_right = LengthPercentageOrAuto::from_style_value(right).to_px_or_zero(node, reference_box.width()).to_float();
-    auto resolved_bottom = LengthPercentageOrAuto::from_style_value(bottom).to_px_or_zero(node, reference_box.height()).to_float();
-    auto resolved_left = LengthPercentageOrAuto::from_style_value(left).to_px_or_zero(node, reference_box.width()).to_float();
+    auto resolved_top = LengthPercentageOrAuto::from_style_value(top).to_px_or_zero(reference_box.height()).to_float();
+    auto resolved_right = LengthPercentageOrAuto::from_style_value(right).to_px_or_zero(reference_box.width()).to_float();
+    auto resolved_bottom = LengthPercentageOrAuto::from_style_value(bottom).to_px_or_zero(reference_box.height()).to_float();
+    auto resolved_left = LengthPercentageOrAuto::from_style_value(left).to_px_or_zero(reference_box.width()).to_float();
 
     // A pair of insets in either dimension that add up to more than the used dimension
     // (such as left and right insets of 75% apiece) use the CSS Backgrounds 3 § 4.5 Overlapping Curves rules
@@ -79,7 +79,6 @@ Gfx::Path Inset::to_path(CSSPixelRect reference_box, Layout::Node const& node) c
     };
 
     auto radii = Painting::normalize_border_radii_data(
-        node,
         inset_rect,
         reference_box,
         to_border_radius_data(*border_radius_rect.top_left()),
@@ -174,7 +173,7 @@ void Rect::serialize(StringBuilder& builder, SerializationMode mode) const
     builder.append(')');
 }
 
-Gfx::Path Circle::to_path(CSSPixelRect reference_box, Layout::Node const& node) const
+Gfx::Path Circle::to_path(CSSPixelRect reference_box) const
 {
     // Translating the reference box because PositionStyleValues are resolved to an absolute position.
     auto translated_reference_box = reference_box.translated(-reference_box.x(), -reference_box.y());
@@ -185,9 +184,9 @@ Gfx::Path Circle::to_path(CSSPixelRect reference_box, Layout::Node const& node) 
     if (position)
         resolved_position = position->as_position();
 
-    auto center = resolved_position->resolved(node, translated_reference_box);
+    auto center = resolved_position->resolved(translated_reference_box);
 
-    auto radius_px = radius->as_radial_size().resolve_circle_size(center, translated_reference_box, node).to_float();
+    auto radius_px = radius->as_radial_size().resolve_circle_size(center, translated_reference_box).to_float();
 
     Gfx::Path path;
     path.move_to(Gfx::FloatPoint { center.x().to_float(), center.y().to_float() + radius_px });
@@ -215,7 +214,7 @@ void Circle::serialize(StringBuilder& builder, SerializationMode mode) const
     builder.append(')');
 }
 
-Gfx::Path Ellipse::to_path(CSSPixelRect reference_box, Layout::Node const& node) const
+Gfx::Path Ellipse::to_path(CSSPixelRect reference_box) const
 {
     // Translating the reference box because PositionStyleValues are resolved to an absolute position.
     auto translated_reference_box = reference_box.translated(-reference_box.x(), -reference_box.y());
@@ -226,8 +225,8 @@ Gfx::Path Ellipse::to_path(CSSPixelRect reference_box, Layout::Node const& node)
     if (position)
         resolved_position = position->as_position();
 
-    auto center = resolved_position->resolved(node, translated_reference_box);
-    auto size = radius->as_radial_size().resolve_ellipse_size(center, translated_reference_box, node);
+    auto center = resolved_position->resolved(translated_reference_box);
+    auto size = radius->as_radial_size().resolve_ellipse_size(center, translated_reference_box);
 
     Gfx::Path path;
     path.move_to(Gfx::FloatPoint { center.x().to_float(), center.y().to_float() + size.height().to_float() });
@@ -255,15 +254,15 @@ void Ellipse::serialize(StringBuilder& builder, SerializationMode mode) const
     builder.append(')');
 }
 
-Gfx::Path Polygon::to_path(CSSPixelRect reference_box, Layout::Node const& node) const
+Gfx::Path Polygon::to_path(CSSPixelRect reference_box) const
 {
     Gfx::Path path;
     path.set_fill_type(fill_rule);
     bool first = true;
     for (auto const& point : points) {
         Gfx::FloatPoint resolved_point {
-            LengthPercentage::from_style_value(point.x).to_px(node, reference_box.width()).to_float(),
-            LengthPercentage::from_style_value(point.y).to_px(node, reference_box.height()).to_float()
+            LengthPercentage::from_style_value(point.x).to_px(reference_box.width()).to_float(),
+            LengthPercentage::from_style_value(point.y).to_px(reference_box.height()).to_float()
         };
         if (first)
             path.move_to(resolved_point);
@@ -297,7 +296,7 @@ void Polygon::serialize(StringBuilder& builder, SerializationMode mode) const
     builder.append(')');
 }
 
-Gfx::Path Path::to_path(CSSPixelRect, Layout::Node const&) const
+Gfx::Path Path::to_path(CSSPixelRect) const
 {
     auto result = path_instructions.to_gfx_path();
     result.set_fill_type(fill_rule);
@@ -328,13 +327,13 @@ void Path::serialize(StringBuilder& builder, SerializationMode mode) const
 
 BasicShapeStyleValue::~BasicShapeStyleValue() = default;
 
-Gfx::Path BasicShapeStyleValue::to_path(CSSPixelRect reference_box, Layout::Node const& node) const
+Gfx::Path BasicShapeStyleValue::to_path(CSSPixelRect reference_box) const
 {
     return m_basic_shape.visit([&](auto const& shape) -> Gfx::Path {
         // NB: Xywh and Rect don't require to_path functions as we should have already converted them to their
         //     respective Inset equivalents during absolutization
-        if constexpr (requires { shape.to_path(reference_box, node); }) {
-            return shape.to_path(reference_box, node);
+        if constexpr (requires { shape.to_path(reference_box); }) {
+            return shape.to_path(reference_box);
         }
 
         VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.h
@@ -16,7 +16,7 @@
 namespace Web::CSS {
 
 struct Inset {
-    Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
+    Gfx::Path to_path(CSSPixelRect reference_box) const;
     void serialize(StringBuilder&, SerializationMode) const;
 
     bool operator==(Inset const&) const = default;
@@ -83,7 +83,7 @@ struct Rect {
 };
 
 struct Circle {
-    Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
+    Gfx::Path to_path(CSSPixelRect reference_box) const;
     void serialize(StringBuilder&, SerializationMode) const;
 
     bool operator==(Circle const&) const = default;
@@ -99,7 +99,7 @@ struct Circle {
 };
 
 struct Ellipse {
-    Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
+    Gfx::Path to_path(CSSPixelRect reference_box) const;
     void serialize(StringBuilder&, SerializationMode) const;
 
     bool operator==(Ellipse const&) const = default;
@@ -121,7 +121,7 @@ struct Polygon {
         ValueComparingNonnullRefPtr<StyleValue const> y;
     };
 
-    Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
+    Gfx::Path to_path(CSSPixelRect reference_box) const;
     void serialize(StringBuilder&, SerializationMode) const;
 
     bool operator==(Polygon const&) const = default;
@@ -137,7 +137,7 @@ struct Polygon {
 
 // https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-path
 struct Path {
-    Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
+    Gfx::Path to_path(CSSPixelRect reference_box) const;
     void serialize(StringBuilder&, SerializationMode) const;
 
     bool operator==(Path const&) const = default;
@@ -171,7 +171,7 @@ public:
         return m_basic_shape.visit([](auto const& shape) { return shape.is_computationally_independent(); });
     }
 
-    Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
+    Gfx::Path to_path(CSSPixelRect reference_box) const;
 
 private:
     BasicShapeStyleValue(BasicShape basic_shape)

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
@@ -51,7 +51,7 @@ void ConicGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& node
         m_resolved_size = size;
         m_resolved = ResolvedData { Painting::resolve_conic_gradient_data(node, *this), {} };
     }
-    m_resolved->position = m_properties.position->resolved(node, CSSPixelRect { { 0, 0 }, size });
+    m_resolved->position = m_properties.position->resolved(CSSPixelRect { { 0, 0 }, size });
 }
 
 void ConicGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const

--- a/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.cpp
@@ -36,11 +36,11 @@ bool PositionStyleValue::is_center(SerializationMode mode) const
     return edge_x()->is_center(mode) && edge_y()->is_center(mode);
 }
 
-CSSPixelPoint PositionStyleValue::resolved(Layout::Node const& node, CSSPixelRect const& rect) const
+CSSPixelPoint PositionStyleValue::resolved(CSSPixelRect const& rect) const
 {
     // Note: A preset + a none default x/y_relative_to is impossible in the syntax (and makes little sense)
-    CSSPixels x = LengthPercentage::from_style_value(m_properties.edge_x->offset()).to_px(node, rect.width());
-    CSSPixels y = LengthPercentage::from_style_value(m_properties.edge_y->offset()).to_px(node, rect.height());
+    CSSPixels x = LengthPercentage::from_style_value(m_properties.edge_x->offset()).to_px(rect.width());
+    CSSPixels y = LengthPercentage::from_style_value(m_properties.edge_y->offset()).to_px(rect.height());
     return CSSPixelPoint { rect.x() + x, rect.y() + y };
 }
 

--- a/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.h
@@ -25,7 +25,7 @@ public:
     ValueComparingNonnullRefPtr<EdgeStyleValue const> edge_x() const { return m_properties.edge_x; }
     ValueComparingNonnullRefPtr<EdgeStyleValue const> edge_y() const { return m_properties.edge_y; }
     bool is_center(SerializationMode) const;
-    CSSPixelPoint resolved(Layout::Node const&, CSSPixelRect const&) const;
+    CSSPixelPoint resolved(CSSPixelRect const&) const;
 
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const& computation_context) const override;
     virtual void serialize(StringBuilder&, SerializationMode) const override;

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -53,21 +53,21 @@ void RadialGradientStyleValue::serialize(StringBuilder& builder, SerializationMo
     builder.append(')');
 }
 
-CSSPixelSize RadialGradientStyleValue::resolve_size(CSSPixelPoint center, CSSPixelRect const& reference_box, Layout::NodeWithStyle const& node) const
+CSSPixelSize RadialGradientStyleValue::resolve_size(CSSPixelPoint center, CSSPixelRect const& reference_box) const
 {
     if (m_properties.ending_shape == EndingShape::Circle) {
-        auto radius = m_properties.size->as_radial_size().resolve_circle_size(center, reference_box, node);
+        auto radius = m_properties.size->as_radial_size().resolve_circle_size(center, reference_box);
         return CSSPixelSize { radius, radius };
     }
 
-    return m_properties.size->as_radial_size().resolve_ellipse_size(center, reference_box, node);
+    return m_properties.size->as_radial_size().resolve_ellipse_size(center, reference_box);
 }
 
 void RadialGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& node, CSSPixelSize paint_size) const
 {
     CSSPixelRect gradient_box { { 0, 0 }, paint_size };
-    auto center = m_properties.position->resolved(node, gradient_box);
-    auto gradient_size = resolve_size(center, gradient_box, node);
+    auto center = m_properties.position->resolved(gradient_box);
+    auto gradient_size = resolve_size(center, gradient_box);
 
     if (m_resolved_size != paint_size) {
         m_resolved_size = move(paint_size);

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -56,7 +56,7 @@ public:
 
     void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 
-    CSSPixelSize resolve_size(CSSPixelPoint, CSSPixelRect const&, Layout::NodeWithStyle const&) const;
+    CSSPixelSize resolve_size(CSSPixelPoint, CSSPixelRect const&) const;
 
     bool is_repeating() const { return m_properties.repeating == GradientRepeating::Yes; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/RadialSizeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialSizeStyleValue.cpp
@@ -103,7 +103,7 @@ static CSSPixels farthest_corner_distance(CSSPixelPoint const& center, CSSPixelR
     return corner_distance(center, reference_box, [](CSSPixels a, CSSPixels b) { return a > b; }, corner);
 }
 
-CSSPixels RadialSizeStyleValue::resolve_circle_size(CSSPixelPoint const& center, CSSPixelRect const& reference_box, Layout::Node const& node) const
+CSSPixels RadialSizeStyleValue::resolve_circle_size(CSSPixelPoint const& center, CSSPixelRect const& reference_box) const
 {
     VERIFY(m_components.size() == 1);
 
@@ -132,8 +132,7 @@ CSSPixels RadialSizeStyleValue::resolve_circle_size(CSSPixelPoint const& center,
         },
         [&](NonnullRefPtr<StyleValue const> const& length_percentage) {
             auto radius_ref = sqrt(pow(reference_box.width().to_float(), 2) + pow(reference_box.height().to_float(), 2)) / AK::Sqrt2<float>;
-            // FIXME: We don't need to pass `node` here since we know that all relative lengths have already been absolutized
-            return CSSPixels::nearest_value_for(max(0.0f, LengthPercentage::from_style_value(length_percentage).to_px(node, CSSPixels::nearest_value_for(radius_ref)).to_float()));
+            return CSSPixels::nearest_value_for(max(0.0f, LengthPercentage::from_style_value(length_percentage).to_px(CSSPixels::nearest_value_for(radius_ref)).to_float()));
         });
 
     // https://w3c.github.io/csswg-drafts/css-images/#degenerate-radials
@@ -175,7 +174,7 @@ static CSSPixelSize ellipse_corner_shape(CSSPixelPoint const& center, CSSPixelRe
     return CSSPixelSize { radius_a, radius_b };
 }
 
-CSSPixelSize RadialSizeStyleValue::resolve_ellipse_size(CSSPixelPoint const& center, CSSPixelRect const& reference_box, Layout::Node const& node) const
+CSSPixelSize RadialSizeStyleValue::resolve_ellipse_size(CSSPixelPoint const& center, CSSPixelRect const& reference_box) const
 {
     VERIFY(m_components.size() == 1 || m_components.size() == 2);
 
@@ -196,8 +195,7 @@ CSSPixelSize RadialSizeStyleValue::resolve_ellipse_size(CSSPixelPoint const& cen
                 VERIFY_NOT_REACHED();
             },
             [&](NonnullRefPtr<StyleValue const> const& length_percentage) {
-                // FIXME: We don't need to pass `node` here since we know that all relative lengths have already been absolutized
-                auto value = LengthPercentage::from_style_value(length_percentage).to_px(node, reference_size);
+                auto value = LengthPercentage::from_style_value(length_percentage).to_px(reference_size);
 
                 return CSSPixelSize { value, value };
             });

--- a/Libraries/LibWeb/CSS/StyleValues/RadialSizeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialSizeStyleValue.h
@@ -27,8 +27,8 @@ public:
 
     Vector<Component> components() const { return m_components; }
 
-    CSSPixels resolve_circle_size(CSSPixelPoint const& center, CSSPixelRect const& reference_box, Layout::Node const&) const;
-    CSSPixelSize resolve_ellipse_size(CSSPixelPoint const& center, CSSPixelRect const& reference_box, Layout::Node const&) const;
+    CSSPixels resolve_circle_size(CSSPixelPoint const& center, CSSPixelRect const& reference_box) const;
+    CSSPixelSize resolve_ellipse_size(CSSPixelPoint const& center, CSSPixelRect const& reference_box) const;
 
     bool properties_equal(RadialSizeStyleValue const& other) const { return m_components == other.m_components; }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6159,10 +6159,10 @@ static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect t
                 auto const& layout_node = container->layout_node_with_style_and_box_metrics();
                 if (layout_node.is_scroll_container() && !scroll_margin.is_empty()) {
                     clip_rect.inflate(
-                        scroll_margin[0].to_px(layout_node, clip_rect.height()),
-                        scroll_margin[1].to_px(layout_node, clip_rect.width()),
-                        scroll_margin[2].to_px(layout_node, clip_rect.height()),
-                        scroll_margin[3].to_px(layout_node, clip_rect.width()));
+                        scroll_margin[0].to_px(clip_rect.height()),
+                        scroll_margin[1].to_px(clip_rect.width()),
+                        scroll_margin[2].to_px(clip_rect.height()),
+                        scroll_margin[3].to_px(clip_rect.width()));
                 }
 
                 intersection_rect.intersect(clip_rect);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2916,11 +2916,10 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
     // AD-HOC: The spec doesn't specify when to do this, but we need to apply scroll-margin and scroll-margin to target
     //         bounding border box (https://drafts.csswg.org/cssom-view-1/#example-51af1565).
     auto scroll_margin = target.computed_properties()->length_box(CSS::PropertyID::ScrollMarginLeft, CSS::PropertyID::ScrollMarginTop, CSS::PropertyID::ScrollMarginRight, CSS::PropertyID::ScrollMarginBottom, CSS::Length::make_px(0));
-    auto& target_layout_node = *target.layout_node();
-    auto scroll_margin_top = scroll_margin.top().to_px_or_zero(target_layout_node, CSSPixels { 0 });
-    auto scroll_margin_right = scroll_margin.right().to_px_or_zero(target_layout_node, CSSPixels { 0 });
-    auto scroll_margin_bottom = scroll_margin.bottom().to_px_or_zero(target_layout_node, CSSPixels { 0 });
-    auto scroll_margin_left = scroll_margin.left().to_px_or_zero(target_layout_node, CSSPixels { 0 });
+    auto scroll_margin_top = scroll_margin.top().to_px_or_zero(CSSPixels { 0 });
+    auto scroll_margin_right = scroll_margin.right().to_px_or_zero(CSSPixels { 0 });
+    auto scroll_margin_bottom = scroll_margin.bottom().to_px_or_zero(CSSPixels { 0 });
+    auto scroll_margin_left = scroll_margin.left().to_px_or_zero(CSSPixels { 0 });
 
     target_bounding_border_box.set_top(target_bounding_border_box.top() - scroll_margin_top);
     target_bounding_border_box.set_right(target_bounding_border_box.right() + scroll_margin_left + scroll_margin_right);
@@ -2943,14 +2942,13 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
 
     if (scrolling_box_computed_properties) {
         auto scroll_padding = scrolling_box_computed_properties->length_box(CSS::PropertyID::ScrollPaddingLeft, CSS::PropertyID::ScrollPaddingTop, CSS::PropertyID::ScrollPaddingRight, CSS::PropertyID::ScrollPaddingBottom, CSS::Length::make_px(0));
-        auto& scrolling_box_layout_node = *scrolling_box.layout_node();
         auto scrolling_box_width = scrolling_box_rect.width();
         auto scrolling_box_height = scrolling_box_rect.height();
 
-        auto scroll_padding_top = scroll_padding.top().to_px_or_zero(scrolling_box_layout_node, scrolling_box_height);
-        auto scroll_padding_right = scroll_padding.right().to_px_or_zero(scrolling_box_layout_node, scrolling_box_width);
-        auto scroll_padding_bottom = scroll_padding.bottom().to_px_or_zero(scrolling_box_layout_node, scrolling_box_height);
-        auto scroll_padding_left = scroll_padding.left().to_px_or_zero(scrolling_box_layout_node, scrolling_box_width);
+        auto scroll_padding_top = scroll_padding.top().to_px_or_zero(scrolling_box_height);
+        auto scroll_padding_right = scroll_padding.right().to_px_or_zero(scrolling_box_width);
+        auto scroll_padding_bottom = scroll_padding.bottom().to_px_or_zero(scrolling_box_height);
+        auto scroll_padding_left = scroll_padding.left().to_px_or_zero(scrolling_box_width);
 
         target_bounding_border_box.set_top(target_bounding_border_box.top() - scroll_padding_top);
         target_bounding_border_box.set_right(target_bounding_border_box.right() + scroll_padding_left + scroll_padding_right);

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -315,13 +315,11 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
         document = &intersection_root.get<GC::Ref<DOM::Element>>()->document();
     }
     if (m_document && document->origin().is_same_origin(m_document->origin())) {
-        if (auto layout_node = intersection_root.visit([&](auto& node) -> Layout::Node* { return node->layout_node(); })) {
-            rect.inflate(
-                m_root_margin[0].to_px(*layout_node, rect.height()),
-                m_root_margin[1].to_px(*layout_node, rect.width()),
-                m_root_margin[2].to_px(*layout_node, rect.height()),
-                m_root_margin[3].to_px(*layout_node, rect.width()));
-        }
+        rect.inflate(
+            m_root_margin[0].to_px(rect.height()),
+            m_root_margin[1].to_px(rect.width()),
+            m_root_margin[2].to_px(rect.height()),
+            m_root_margin[3].to_px(rect.width()));
     }
 
     return rect;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -219,10 +219,10 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     auto const& computed_values = box.computed_values();
     auto available_width_px = available_space.width.to_px_or_zero();
-    auto margin_left = computed_values.margin().left().resolved_or_auto(box, available_width_px);
-    auto margin_right = computed_values.margin().right().resolved_or_auto(box, available_width_px);
-    auto const padding_left = computed_values.padding().left().resolved_or_auto(box, available_width_px);
-    auto const padding_right = computed_values.padding().right().resolved_or_auto(box, available_width_px);
+    auto margin_left = computed_values.margin().left().resolved_or_auto(available_width_px);
+    auto margin_right = computed_values.margin().right().resolved_or_auto(available_width_px);
+    auto const padding_left = computed_values.padding().left().resolved_or_auto(available_width_px);
+    auto const padding_right = computed_values.padding().right().resolved_or_auto(available_width_px);
 
     auto& box_state = m_state.get_mutable(box);
     box_state.margin_left = margin_left.to_px_or_zero(box);
@@ -243,8 +243,8 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     auto try_compute_width = [&](CSS::LengthOrAuto const& a_width) {
         auto width = a_width;
-        margin_left = computed_values.margin().left().resolved_or_auto(box, available_space.width.to_px_or_zero());
-        margin_right = computed_values.margin().right().resolved_or_auto(box, available_space.width.to_px_or_zero());
+        margin_left = computed_values.margin().left().resolved_or_auto(available_space.width.to_px_or_zero());
+        margin_right = computed_values.margin().right().resolved_or_auto(available_space.width.to_px_or_zero());
         CSSPixels total_px = computed_values.border_left().width + computed_values.border_right().width;
         for (auto& value : { CSS::LengthOrAuto(margin_left), CSS::LengthOrAuto(padding_left), width, CSS::LengthOrAuto(padding_right), CSS::LengthOrAuto(margin_right) })
             total_px += value.to_px_or_zero(box);
@@ -400,12 +400,12 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     auto width_of_containing_block = available_space.width.to_px_or_zero();
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
-    auto margin_left = computed_values.margin().left().to_px_or_zero(box, width_of_containing_block);
-    auto margin_right = computed_values.margin().right().to_px_or_zero(box, width_of_containing_block);
+    auto margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
+    auto margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.padding_left = computed_values.padding().left().to_px_or_zero(box, width_of_containing_block);
-    box_state.padding_right = computed_values.padding().right().to_px_or_zero(box, width_of_containing_block);
+    box_state.padding_left = computed_values.padding().left().to_px_or_zero(width_of_containing_block);
+    box_state.padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
     box_state.margin_left = margin_left;
     box_state.margin_right = margin_right;
     box_state.border_left = computed_values.border_left().width;
@@ -480,10 +480,10 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
     // The used value of 'width' is determined as for inline replaced elements. Then the rules for
     // non-replaced block-level elements are applied to determine the margins.
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
-    auto margin_left = computed_values.margin().left().to_px_or_zero(box, width_of_containing_block);
-    auto margin_right = computed_values.margin().right().to_px_or_zero(box, width_of_containing_block);
-    auto const padding_left = computed_values.padding().left().to_px_or_zero(box, width_of_containing_block);
-    auto const padding_right = computed_values.padding().right().to_px_or_zero(box, width_of_containing_block);
+    auto margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
+    auto margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
+    auto const padding_left = computed_values.padding().left().to_px_or_zero(width_of_containing_block);
+    auto const padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
 
     auto& box_state = m_state.get_mutable(box);
     auto width = compute_width_for_replaced_element(box, available_space);
@@ -1112,12 +1112,12 @@ void BlockFormattingContext::resolve_vertical_box_model_metrics(Box const& box, 
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    box_state.margin_top = computed_values.margin().top().to_px_or_zero(box, width_of_containing_block);
-    box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(box, width_of_containing_block);
+    box_state.margin_top = computed_values.margin().top().to_px_or_zero(width_of_containing_block);
+    box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(width_of_containing_block);
     box_state.border_top = computed_values.border_top().width;
     box_state.border_bottom = computed_values.border_bottom().width;
-    box_state.padding_top = computed_values.padding().top().to_px_or_zero(box, width_of_containing_block);
-    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(box, width_of_containing_block);
+    box_state.padding_top = computed_values.padding().top().to_px_or_zero(width_of_containing_block);
+    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(width_of_containing_block);
 }
 
 void BlockFormattingContext::resolve_horizontal_box_model_metrics(Box const& box, CSSPixels width_of_containing_block)
@@ -1125,12 +1125,12 @@ void BlockFormattingContext::resolve_horizontal_box_model_metrics(Box const& box
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    box_state.margin_left = computed_values.margin().left().to_px_or_zero(box, width_of_containing_block);
-    box_state.margin_right = computed_values.margin().right().to_px_or_zero(box, width_of_containing_block);
+    box_state.margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
+    box_state.margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
-    box_state.padding_left = computed_values.padding().left().to_px_or_zero(box, width_of_containing_block);
-    box_state.padding_right = computed_values.padding().right().to_px_or_zero(box, width_of_containing_block);
+    box_state.padding_left = computed_values.padding().left().to_px_or_zero(width_of_containing_block);
+    box_state.padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
 }
 
 BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floating_boxes(Node const& child_box, Optional<InlineFormattingContext&> inline_formatting_context)
@@ -1733,7 +1733,7 @@ CSSPixels BlockFormattingContext::determine_used_value_for_column_width(CSSPixel
 CSSPixels BlockFormattingContext::get_column_width_used_value_for_multicol(CSSPixels const& U) const
 {
     // Used values will be clamped to a minimum of '1px'.
-    return max(root().computed_values().column_width().to_px(root(), U), 1);
+    return max(root().computed_values().column_width().to_px(U), 1);
 }
 
 // https://www.w3.org/TR/css-align-3/#column-row-gap
@@ -1742,7 +1742,7 @@ CSSPixels BlockFormattingContext::get_column_gap_used_value_for_multicol(CSSPixe
     // The 'normal' represents a used value of '1em' on multi-column containers
     return root().computed_values().column_gap().visit(
         [&](CSS::NormalGap) { return CSS::Length(1, CSS::LengthUnit::Em).to_px(root()); },
-        [&](auto const& gap) { return gap.to_px(root(), U); });
+        [&](auto const& gap) { return gap.to_px(U); });
 }
 
 }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -225,12 +225,12 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     auto const padding_right = computed_values.padding().right().resolved_or_auto(available_width_px);
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.margin_left = margin_left.to_px_or_zero(box);
-    box_state.margin_right = margin_right.to_px_or_zero(box);
+    box_state.margin_left = margin_left.to_px_or_zero();
+    box_state.margin_right = margin_right.to_px_or_zero();
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
-    box_state.padding_left = padding_left.to_px_or_zero(box);
-    box_state.padding_right = padding_right.to_px_or_zero(box);
+    box_state.padding_left = padding_left.to_px_or_zero();
+    box_state.padding_right = padding_right.to_px_or_zero();
 
     // NOTE: If we are calculating the min-content or max-content width of this box,
     //       and the width should be treated as auto, then we can simply return here,
@@ -247,7 +247,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         margin_right = computed_values.margin().right().resolved_or_auto(available_space.width.to_px_or_zero());
         CSSPixels total_px = computed_values.border_left().width + computed_values.border_right().width;
         for (auto& value : { CSS::LengthOrAuto(margin_left), CSS::LengthOrAuto(padding_left), width, CSS::LengthOrAuto(padding_right), CSS::LengthOrAuto(margin_right) })
-            total_px += value.to_px_or_zero(box);
+            total_px += value.to_px_or_zero();
 
         if (!box.is_inline()) {
             // 10.3.3 Block-level, non-replaced elements in normal flow
@@ -290,7 +290,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
                 }
             } else {
                 if (!margin_left.is_auto() && !margin_right.is_auto()) {
-                    margin_right = CSS::Length::make_px(margin_right.to_px_or_zero(box) + underflow_px);
+                    margin_right = CSS::Length::make_px(margin_right.to_px_or_zero() + underflow_px);
                 } else if (!margin_left.is_auto() && margin_right.is_auto()) {
                     margin_right = CSS::Length::make_px(underflow_px);
                 } else if (margin_left.is_auto() && !margin_right.is_auto()) {
@@ -334,7 +334,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.width)) {
         auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width());
-        if (used_width.to_px_or_zero(box) > max_width)
+        if (used_width.to_px_or_zero() > max_width)
             used_width = try_compute_width(CSS::Length::make_px(max_width));
     }
 
@@ -342,15 +342,15 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto() && !used_width.is_auto()) {
         auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width());
-        if (used_width.to_px_or_zero(box) < min_width)
+        if (used_width.to_px_or_zero() < min_width)
             used_width = try_compute_width(CSS::Length::make_px(min_width));
     }
 
     if (!box_is_sized_as_replaced_element(box, available_space) && !used_width.is_auto())
-        box_state.set_content_width(used_width.to_px_or_zero(box));
+        box_state.set_content_width(used_width.to_px_or_zero());
 
-    box_state.margin_left = margin_left.to_px_or_zero(box);
-    box_state.margin_right = margin_right.to_px_or_zero(box);
+    box_state.margin_left = margin_left.to_px_or_zero();
+    box_state.margin_right = margin_right.to_px_or_zero();
 }
 
 void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space)
@@ -454,7 +454,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.width)) {
         auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width());
-        if (width.to_px_or_zero(box) > max_width)
+        if (width.to_px_or_zero() > max_width)
             width = compute_width(CSS::Length::make_px(max_width));
     }
 
@@ -462,11 +462,11 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
         auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width());
-        if (width.to_px_or_zero(box) < min_width)
+        if (width.to_px_or_zero() < min_width)
             width = compute_width(CSS::Length::make_px(min_width));
     }
 
-    box_state.set_content_width(width.to_px_or_zero(box));
+    box_state.set_content_width(width.to_px_or_zero());
 }
 
 void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_normal_flow(Box const& box, AvailableSpace const& available_space)

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -308,10 +308,10 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
 {
     auto width_of_containing_block = m_flex_container_state.content_width();
 
-    item.used_values.padding_left = item.box.computed_values().padding().left().to_px_or_zero(item.box, width_of_containing_block);
-    item.used_values.padding_right = item.box.computed_values().padding().right().to_px_or_zero(item.box, width_of_containing_block);
-    item.used_values.padding_top = item.box.computed_values().padding().top().to_px_or_zero(item.box, width_of_containing_block);
-    item.used_values.padding_bottom = item.box.computed_values().padding().bottom().to_px_or_zero(item.box, width_of_containing_block);
+    item.used_values.padding_left = item.box.computed_values().padding().left().to_px_or_zero(width_of_containing_block);
+    item.used_values.padding_right = item.box.computed_values().padding().right().to_px_or_zero(width_of_containing_block);
+    item.used_values.padding_top = item.box.computed_values().padding().top().to_px_or_zero(width_of_containing_block);
+    item.used_values.padding_bottom = item.box.computed_values().padding().bottom().to_px_or_zero(width_of_containing_block);
 
     if (main_axis_is_horizontal()) {
         item.borders.main_before = item.box.computed_values().border_left().width;
@@ -319,15 +319,15 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
         item.borders.cross_before = item.box.computed_values().border_top().width;
         item.borders.cross_after = item.box.computed_values().border_bottom().width;
 
-        item.padding.main_before = item.box.computed_values().padding().left().to_px_or_zero(item.box, width_of_containing_block);
-        item.padding.main_after = item.box.computed_values().padding().right().to_px_or_zero(item.box, width_of_containing_block);
-        item.padding.cross_before = item.box.computed_values().padding().top().to_px_or_zero(item.box, width_of_containing_block);
-        item.padding.cross_after = item.box.computed_values().padding().bottom().to_px_or_zero(item.box, width_of_containing_block);
+        item.padding.main_before = item.box.computed_values().padding().left().to_px_or_zero(width_of_containing_block);
+        item.padding.main_after = item.box.computed_values().padding().right().to_px_or_zero(width_of_containing_block);
+        item.padding.cross_before = item.box.computed_values().padding().top().to_px_or_zero(width_of_containing_block);
+        item.padding.cross_after = item.box.computed_values().padding().bottom().to_px_or_zero(width_of_containing_block);
 
-        item.margins.main_before = item.box.computed_values().margin().left().to_px_or_zero(item.box, width_of_containing_block);
-        item.margins.main_after = item.box.computed_values().margin().right().to_px_or_zero(item.box, width_of_containing_block);
-        item.margins.cross_before = item.box.computed_values().margin().top().to_px_or_zero(item.box, width_of_containing_block);
-        item.margins.cross_after = item.box.computed_values().margin().bottom().to_px_or_zero(item.box, width_of_containing_block);
+        item.margins.main_before = item.box.computed_values().margin().left().to_px_or_zero(width_of_containing_block);
+        item.margins.main_after = item.box.computed_values().margin().right().to_px_or_zero(width_of_containing_block);
+        item.margins.cross_before = item.box.computed_values().margin().top().to_px_or_zero(width_of_containing_block);
+        item.margins.cross_after = item.box.computed_values().margin().bottom().to_px_or_zero(width_of_containing_block);
 
         item.margins.main_before_is_auto = item.box.computed_values().margin().left().is_auto();
         item.margins.main_after_is_auto = item.box.computed_values().margin().right().is_auto();
@@ -344,10 +344,10 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
         item.padding.cross_before = item.used_values.padding_left;
         item.padding.cross_after = item.used_values.padding_right;
 
-        item.margins.main_before = item.box.computed_values().margin().top().to_px_or_zero(item.box, width_of_containing_block);
-        item.margins.main_after = item.box.computed_values().margin().bottom().to_px_or_zero(item.box, width_of_containing_block);
-        item.margins.cross_before = item.box.computed_values().margin().left().to_px_or_zero(item.box, width_of_containing_block);
-        item.margins.cross_after = item.box.computed_values().margin().right().to_px_or_zero(item.box, width_of_containing_block);
+        item.margins.main_before = item.box.computed_values().margin().top().to_px_or_zero(width_of_containing_block);
+        item.margins.main_after = item.box.computed_values().margin().bottom().to_px_or_zero(width_of_containing_block);
+        item.margins.cross_before = item.box.computed_values().margin().left().to_px_or_zero(width_of_containing_block);
+        item.margins.cross_after = item.box.computed_values().margin().right().to_px_or_zero(width_of_containing_block);
 
         item.margins.main_before_is_auto = item.box.computed_values().margin().top().is_auto();
         item.margins.main_after_is_auto = item.box.computed_values().margin().bottom().is_auto();
@@ -635,12 +635,12 @@ CSSPixels FlexFormattingContext::calculate_cross_size_from_main_size_and_aspect_
 CSSPixels FlexFormattingContext::adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(Box const& box, CSSPixels main_size, CSS::Size const& min_cross_size, CSS::Size const& max_cross_size) const
 {
     if (!should_treat_cross_max_size_as_none(box)) {
-        auto max_cross_size_px = max_cross_size.to_px(box, cross_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
+        auto max_cross_size_px = max_cross_size.to_px(cross_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
         main_size = min(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(max_cross_size_px, box.preferred_aspect_ratio().value()));
     }
 
     if (!min_cross_size.is_auto()) {
-        auto min_cross_size_px = min_cross_size.to_px(box, cross_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
+        auto min_cross_size_px = min_cross_size.to_px(cross_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
         main_size = max(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(min_cross_size_px, box.preferred_aspect_ratio().value()));
     }
 
@@ -650,12 +650,12 @@ CSSPixels FlexFormattingContext::adjust_main_size_through_aspect_ratio_for_cross
 CSSPixels FlexFormattingContext::adjust_cross_size_through_aspect_ratio_for_main_size_min_max_constraints(Box const& box, CSSPixels cross_size, CSS::Size const& min_main_size, CSS::Size const& max_main_size) const
 {
     if (!should_treat_main_max_size_as_none(box)) {
-        auto max_main_size_px = max_main_size.to_px(box, main_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
+        auto max_main_size_px = max_main_size.to_px(main_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
         cross_size = min(cross_size, calculate_cross_size_from_main_size_and_aspect_ratio(max_main_size_px, box.preferred_aspect_ratio().value()));
     }
 
     if (!min_main_size.is_auto()) {
-        auto min_main_size_px = min_main_size.to_px(box, main_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
+        auto min_main_size_px = min_main_size.to_px(main_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
         cross_size = max(cross_size, calculate_cross_size_from_main_size_and_aspect_ratio(min_main_size_px, box.preferred_aspect_ratio().value()));
     }
 
@@ -1887,10 +1887,10 @@ void FlexFormattingContext::copy_dimensions_from_flex_items_to_boxes()
     for (auto& item : m_flex_items) {
         auto const& box = item.box;
 
-        item.used_values.margin_left = box.computed_values().margin().left().to_px_or_zero(box, m_flex_container_state.content_width());
-        item.used_values.margin_right = box.computed_values().margin().right().to_px_or_zero(box, m_flex_container_state.content_width());
-        item.used_values.margin_top = box.computed_values().margin().top().to_px_or_zero(box, m_flex_container_state.content_width());
-        item.used_values.margin_bottom = box.computed_values().margin().bottom().to_px_or_zero(box, m_flex_container_state.content_width());
+        item.used_values.margin_left = box.computed_values().margin().left().to_px_or_zero(m_flex_container_state.content_width());
+        item.used_values.margin_right = box.computed_values().margin().right().to_px_or_zero(m_flex_container_state.content_width());
+        item.used_values.margin_top = box.computed_values().margin().top().to_px_or_zero(m_flex_container_state.content_width());
+        item.used_values.margin_bottom = box.computed_values().margin().bottom().to_px_or_zero(m_flex_container_state.content_width());
 
         item.used_values.border_left = box.computed_values().border_left().width;
         item.used_values.border_right = box.computed_values().border_right().width;

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -678,8 +678,8 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
     auto height_of_containing_block = available_space.height.to_px_or_zero();
 
     // If 'margin-top', or 'margin-bottom' are computed as 'auto', their used value is '0'.
-    auto margin_top = computed_values.margin().top().resolved_or_auto(width_of_containing_block).to_px_or_zero(box);
-    auto margin_bottom = computed_values.margin().bottom().resolved_or_auto(width_of_containing_block).to_px_or_zero(box);
+    auto margin_top = computed_values.margin().top().resolved_or_auto(width_of_containing_block).to_px_or_zero();
+    auto margin_bottom = computed_values.margin().bottom().resolved_or_auto(width_of_containing_block).to_px_or_zero();
 
     // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
     auto available_height = height_of_containing_block - margin_top - margin_bottom;
@@ -914,15 +914,15 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         auto width = a_width;
 
         auto solve_for_left = [&] {
-            return width_of_containing_block - margin_left.to_px_or_zero(box) - border_left - padding_left - width.to_px_or_zero(box) - padding_right - border_right - margin_right.to_px_or_zero(box) - right;
+            return width_of_containing_block - margin_left.to_px_or_zero() - border_left - padding_left - width.to_px_or_zero() - padding_right - border_right - margin_right.to_px_or_zero() - right;
         };
 
         auto solve_for_width = [&] {
-            return CSS::Length::make_px(max(CSSPixels(0), width_of_containing_block - left - margin_left.to_px_or_zero(box) - border_left - padding_left - padding_right - border_right - margin_right.to_px_or_zero(box) - right));
+            return CSS::Length::make_px(max(CSSPixels(0), width_of_containing_block - left - margin_left.to_px_or_zero() - border_left - padding_left - padding_right - border_right - margin_right.to_px_or_zero() - right));
         };
 
         auto solve_for_right = [&] {
-            return width_of_containing_block - left - margin_left.to_px_or_zero(box) - border_left - padding_left - width.to_px_or_zero(box) - padding_right - border_right - margin_right.to_px_or_zero(box);
+            return width_of_containing_block - left - margin_left.to_px_or_zero() - border_left - padding_left - width.to_px_or_zero() - padding_right - border_right - margin_right.to_px_or_zero();
         };
 
         auto calculate_shrink_to_fit_width = [&] {
@@ -963,7 +963,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             // If both margin-left and margin-right are auto,
             // solve the equation under the extra constraint that the two margins get equal values
             // FIXME: unless this would make them negative, in which case when direction of the containing block is ltr (rtl), set margin-left (margin-right) to 0 and solve for margin-right (margin-left).
-            auto size_available_for_margins = width_of_containing_block - border_left - padding_left - width.to_px_or_zero(box) - padding_right - border_right - left - right;
+            auto size_available_for_margins = width_of_containing_block - border_left - padding_left - width.to_px_or_zero() - padding_right - border_right - left - right;
             if (margin_left.is_auto() && margin_right.is_auto()) {
                 margin_left = CSS::Length::make_px(size_available_for_margins / 2);
                 margin_right = CSS::Length::make_px(size_available_for_margins / 2);
@@ -1051,7 +1051,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.width)) {
         auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width());
-        if (used_width.to_px_or_zero(box) > max_width) {
+        if (used_width.to_px_or_zero() > max_width) {
             used_width = try_compute_width(CSS::Length::make_px(max_width));
         }
     }
@@ -1060,16 +1060,16 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
         auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width());
-        if (used_width.to_px_or_zero(box) < min_width) {
+        if (used_width.to_px_or_zero() < min_width) {
             used_width = try_compute_width(CSS::Length::make_px(min_width));
         }
     }
 
-    box_state.set_content_width(used_width.to_px_or_zero(box));
+    box_state.set_content_width(used_width.to_px_or_zero());
     box_state.inset_left = left;
     box_state.inset_right = right;
-    box_state.margin_left = margin_left.to_px_or_zero(box);
-    box_state.margin_right = margin_right.to_px_or_zero(box);
+    box_state.margin_left = margin_left.to_px_or_zero();
+    box_state.margin_right = margin_right.to_px_or_zero();
 }
 
 // https://drafts.csswg.org/css2/#abs-replaced-width
@@ -1174,12 +1174,12 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         auto constrained_height = unconstrained_height;
         if (!computed_max_height.is_none()) {
             auto inner_max_height = calculate_inner_height(box, available_space, computed_max_height);
-            if (inner_max_height < constrained_height.to_px_or_zero(box))
+            if (inner_max_height < constrained_height.to_px_or_zero())
                 constrained_height = CSS::Length::make_px(inner_max_height);
         }
         if (!computed_min_height.is_auto()) {
             auto inner_min_height = calculate_inner_height(box, available_space, computed_min_height);
-            if (inner_min_height > constrained_height.to_px_or_zero(box))
+            if (inner_min_height > constrained_height.to_px_or_zero())
                 constrained_height = CSS::Length::make_px(inner_min_height);
         }
         return constrained_height;
@@ -1212,12 +1212,12 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
                 - margin_top.to_px_or_zero(width_of_containing_block)
                 - box.computed_values().border_top().width
                 - state.padding_top
-                - height.to_px_or_zero(box)
+                - height.to_px_or_zero()
                 - state.padding_bottom
                 - box.computed_values().border_bottom().width
                 - margin_bottom.to_px_or_zero(width_of_containing_block)
                 - bottom.to_px_or_zero(height_of_containing_block)
-                + length_or_auto.to_px_or_zero(box);
+                + length_or_auto.to_px_or_zero();
             if (clamp_to_zero == ClampToZero::Yes)
                 return CSS::Length::make_px(max(CSSPixels(0), unclamped_value));
             return CSS::Length::make_px(unclamped_value);
@@ -1269,7 +1269,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             height = CSS::Length::make_px(maybe_height.value());
 
             auto constrained_height = apply_min_max_height_constraints(height);
-            m_state.get_mutable(box).set_content_height(constrained_height.to_px_or_zero(box));
+            m_state.get_mutable(box).set_content_height(constrained_height.to_px_or_zero());
 
             auto static_position = m_state.get(box).static_position();
             top = CSS::Length::make_px(static_position.y());
@@ -1381,7 +1381,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto const& computed_max_height = box.computed_values().max_height();
     if (!used_height.is_auto() && !computed_max_height.is_none()) {
         auto max_height = calculate_inner_height(box, available_space, computed_max_height);
-        if (used_height.to_px_or_zero(box) > max_height)
+        if (used_height.to_px_or_zero() > max_height)
             used_height = try_compute_height(CSS::Length::make_px(max_height));
     }
 
@@ -1390,7 +1390,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto const& computed_min_height = box.computed_values().min_height();
     if (!used_height.is_auto() && !computed_min_height.is_auto()) {
         auto min_height = calculate_inner_height(box, available_space, computed_min_height);
-        if (used_height.to_px_or_zero(box) < min_height)
+        if (used_height.to_px_or_zero() < min_height)
             used_height = try_compute_height(CSS::Length::make_px(min_height));
     }
 
@@ -1402,7 +1402,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     //       the final used values for vertical margin/border/padding.
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.set_content_height(used_height.to_px_or_zero(box));
+    box_state.set_content_height(used_height.to_px_or_zero());
 
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -89,14 +89,14 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
         Optional<CSSPixels> size_from_min_width;
         auto const& min_width = box.computed_values().min_width();
         if (min_width.is_length()) {
-            auto inline_size = min_width.to_px(box, 0);
+            auto inline_size = min_width.to_px(0);
             size_from_min_width = is_width ? inline_size : inline_size / aspect_ratio;
         }
 
         Optional<CSSPixels> size_from_min_height;
         auto const& min_height = box.computed_values().min_height();
         if (min_height.is_length()) {
-            auto block_size = min_height.to_px(box, 0);
+            auto block_size = min_height.to_px(0);
             size_from_min_height = is_width ? block_size * aspect_ratio : block_size;
         }
 
@@ -122,7 +122,7 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
     // If the box has a <length> as its computed minimum size (min-width/min-height) in that dimension, use that size.
     auto const& min_size = is_width ? box.computed_values().min_width() : box.computed_values().min_height();
     if (min_size.is_length())
-        return min_size.to_px(box, 0);
+        return min_size.to_px(0);
 
     // Otherwise, use 300px for the width and/or 150px for the height as needed.
     return is_width ? CSSPixels(300) : CSSPixels(150);
@@ -623,8 +623,8 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     auto width_of_containing_block = table_wrapper_containing_block_width.value_or(available_space.width.to_px_or_zero());
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
-    auto margin_left = computed_values.margin().left().to_px_or_zero(box, width_of_containing_block);
-    auto margin_right = computed_values.margin().right().to_px_or_zero(box, width_of_containing_block);
+    auto margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
+    auto margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
 
     // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
     auto available_width = width_of_containing_block - margin_left - margin_right;
@@ -650,8 +650,8 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     auto const& table_box_computed_values = table_box->computed_values();
     table_box_state.border_left = table_box_computed_values.border_left().width;
     table_box_state.border_right = table_box_computed_values.border_right().width;
-    table_box_state.padding_left = table_box_computed_values.padding().left().to_px_or_zero(*table_box, width_of_containing_block);
-    table_box_state.padding_right = table_box_computed_values.padding().right().to_px_or_zero(*table_box, width_of_containing_block);
+    table_box_state.padding_left = table_box_computed_values.padding().left().to_px_or_zero(width_of_containing_block);
+    table_box_state.padding_right = table_box_computed_values.padding().right().to_px_or_zero(width_of_containing_block);
 
     auto context = make<TableFormattingContext>(throwaway_state, LayoutMode::IntrinsicSizing, *table_box, this);
     context->run_until_width_calculation(
@@ -678,8 +678,8 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
     auto height_of_containing_block = available_space.height.to_px_or_zero();
 
     // If 'margin-top', or 'margin-bottom' are computed as 'auto', their used value is '0'.
-    auto margin_top = computed_values.margin().top().resolved_or_auto(box, width_of_containing_block).to_px_or_zero(box);
-    auto margin_bottom = computed_values.margin().bottom().resolved_or_auto(box, width_of_containing_block).to_px_or_zero(box);
+    auto margin_top = computed_values.margin().top().resolved_or_auto(width_of_containing_block).to_px_or_zero(box);
+    auto margin_bottom = computed_values.margin().bottom().resolved_or_auto(width_of_containing_block).to_px_or_zero(box);
 
     // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
     auto available_height = height_of_containing_block - margin_top - margin_bottom;
@@ -716,7 +716,7 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
 
     CSSPixels used_width = 0;
     if (computed_width.is_auto()) {
-        used_width = computed_width.to_px(box, available_space.width.to_px_or_zero());
+        used_width = computed_width.to_px(available_space.width.to_px_or_zero());
     } else {
         used_width = calculate_inner_width(box, available_space.width, computed_width);
     }
@@ -904,12 +904,12 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
     auto computed_left = computed_values.inset().left();
     auto computed_right = computed_values.inset().right();
-    auto left = computed_values.inset().left().to_px_or_zero(box, width_of_containing_block);
-    auto right = computed_values.inset().right().to_px_or_zero(box, width_of_containing_block);
+    auto left = computed_values.inset().left().to_px_or_zero(width_of_containing_block);
+    auto right = computed_values.inset().right().to_px_or_zero(width_of_containing_block);
 
     auto try_compute_width = [&](CSS::LengthOrAuto const& a_width) {
-        margin_left = computed_values.margin().left().resolved_or_auto(box, width_of_containing_block);
-        margin_right = computed_values.margin().right().resolved_or_auto(box, width_of_containing_block);
+        margin_left = computed_values.margin().left().resolved_or_auto(width_of_containing_block);
+        margin_right = computed_values.margin().right().resolved_or_auto(width_of_containing_block);
 
         auto width = a_width;
 
@@ -1097,7 +1097,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
     auto static_position = m_state.get(box).static_position();
 
     auto to_px = [&](CSS::LengthPercentageOrAuto const& l) {
-        return l.to_px_or_zero(box, width_of_containing_block);
+        return l.to_px_or_zero(width_of_containing_block);
     };
 
     // If 'margin-left' or 'margin-right' is specified as 'auto' its used value is determined by the rules below.
@@ -1208,15 +1208,15 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
 
         auto solve_for = [&](CSS::LengthOrAuto const& length_or_auto, ClampToZero clamp_to_zero = ClampToZero::No) {
             auto unclamped_value = height_of_containing_block
-                - top.to_px_or_zero(box, height_of_containing_block)
-                - margin_top.to_px_or_zero(box, width_of_containing_block)
+                - top.to_px_or_zero(height_of_containing_block)
+                - margin_top.to_px_or_zero(width_of_containing_block)
                 - box.computed_values().border_top().width
                 - state.padding_top
                 - height.to_px_or_zero(box)
                 - state.padding_bottom
                 - box.computed_values().border_bottom().width
-                - margin_bottom.to_px_or_zero(box, width_of_containing_block)
-                - bottom.to_px_or_zero(box, height_of_containing_block)
+                - margin_bottom.to_px_or_zero(width_of_containing_block)
+                - bottom.to_px_or_zero(height_of_containing_block)
                 + length_or_auto.to_px_or_zero(box);
             if (clamp_to_zero == ClampToZero::Yes)
                 return CSS::Length::make_px(max(CSSPixels(0), unclamped_value));
@@ -1224,11 +1224,11 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         };
 
         auto solve_for_top = [&] {
-            top = solve_for(top.resolved_or_auto(box, height_of_containing_block));
+            top = solve_for(top.resolved_or_auto(height_of_containing_block));
         };
 
         auto solve_for_bottom = [&] {
-            bottom = solve_for(bottom.resolved_or_auto(box, height_of_containing_block));
+            bottom = solve_for(bottom.resolved_or_auto(height_of_containing_block));
         };
 
         auto solve_for_height = [&] {
@@ -1236,15 +1236,15 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         };
 
         auto solve_for_margin_top = [&] {
-            margin_top = solve_for(margin_top.resolved_or_auto(box, width_of_containing_block));
+            margin_top = solve_for(margin_top.resolved_or_auto(width_of_containing_block));
         };
 
         auto solve_for_margin_bottom = [&] {
-            margin_bottom = solve_for(margin_bottom.resolved_or_auto(box, width_of_containing_block));
+            margin_bottom = solve_for(margin_bottom.resolved_or_auto(width_of_containing_block));
         };
 
         auto solve_for_margin_top_and_margin_bottom = [&] {
-            auto remainder = solve_for(CSS::Length::make_px(margin_top.to_px_or_zero(box, width_of_containing_block) + margin_bottom.to_px_or_zero(box, width_of_containing_block))).to_px(box);
+            auto remainder = solve_for(CSS::Length::make_px(margin_top.to_px_or_zero(width_of_containing_block) + margin_bottom.to_px_or_zero(width_of_containing_block))).to_px(box);
             margin_top = CSS::Length::make_px(remainder / 2);
             margin_bottom = CSS::Length::make_px(remainder / 2);
         };
@@ -1409,10 +1409,10 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         return;
     if (computed_height_establishes_definite_containing_block_height(box.computed_values().height()))
         box_state.set_has_definite_height(true);
-    box_state.inset_top = top.to_px_or_zero(box, height_of_containing_block);
-    box_state.inset_bottom = bottom.to_px_or_zero(box, height_of_containing_block);
-    box_state.margin_top = margin_top.to_px_or_zero(box, width_of_containing_block);
-    box_state.margin_bottom = margin_bottom.to_px_or_zero(box, width_of_containing_block);
+    box_state.inset_top = top.to_px_or_zero(height_of_containing_block);
+    box_state.inset_bottom = bottom.to_px_or_zero(height_of_containing_block);
+    box_state.margin_top = margin_top.to_px_or_zero(width_of_containing_block);
+    box_state.margin_bottom = margin_bottom.to_px_or_zero(width_of_containing_block);
 }
 
 // FIXME: Containing block handling for absolutely positioned elements needs architectural improvements.
@@ -1870,10 +1870,10 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     box_state.border_bottom = computed_values.border_bottom().width;
 
     auto const containing_block_width = available_space.width.to_px_or_zero();
-    box_state.padding_left = computed_values.padding().left().to_px_or_zero(box, containing_block_width);
-    box_state.padding_right = computed_values.padding().right().to_px_or_zero(box, containing_block_width);
-    box_state.padding_top = computed_values.padding().top().to_px_or_zero(box, containing_block_width);
-    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(box, containing_block_width);
+    box_state.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
+    box_state.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
+    box_state.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
+    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
 
     compute_width_for_absolutely_positioned_element(box, available_space);
 
@@ -2011,7 +2011,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     auto static_position = m_state.get(box).static_position();
 
     auto to_px = [&](CSS::LengthPercentageOrAuto const& l) {
-        return l.to_px_or_zero(box, height_of_containing_block);
+        return l.to_px_or_zero(height_of_containing_block);
     };
 
     // If 'margin-top' or 'margin-bottom' is specified as 'auto' its used value is determined by the rules below.
@@ -2087,8 +2087,8 @@ void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box
         return;
 
     auto resolve_two_opposing_insets = [&](CSS::LengthPercentageOrAuto const& computed_first, CSS::LengthPercentageOrAuto const& computed_second, CSSPixels& used_start, CSSPixels& used_end, CSSPixels reference_for_percentage) {
-        auto resolved_first = computed_first.to_px_or_zero(box, reference_for_percentage);
-        auto resolved_second = computed_second.to_px_or_zero(box, reference_for_percentage);
+        auto resolved_first = computed_first.to_px_or_zero(reference_for_percentage);
+        auto resolved_second = computed_second.to_px_or_zero(reference_for_percentage);
 
         if (computed_first.is_auto() && computed_second.is_auto()) {
             // If opposing inset properties in an axis both compute to auto (their initial values),
@@ -2188,9 +2188,9 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
         //        floored by any <length-percentage> minimum size from the opposite axis—resolving any
         //        such percentage against zero—transferred through the preferred aspect ratio.
         if (auto const& width = box.computed_values().width(); width.is_percentage())
-            return width.to_px(box, 0);
+            return width.to_px(0);
         if (auto const& max_width = box.computed_values().max_width(); max_width.is_percentage())
-            return max_width.to_px(box, 0);
+            return max_width.to_px(0);
     }
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_width())
         return auto_size.width.value();
@@ -2383,7 +2383,7 @@ CSSPixels FormattingContext::calculate_inner_width(Layout::Box const& box, Avail
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
         auto const& state = m_state.get(box);
-        auto inner_width = width.to_px(box, width_of_containing_block)
+        auto inner_width = width.to_px(width_of_containing_block)
             - computed_values.border_left().width
             - state.padding_left
             - computed_values.border_right().width
@@ -2391,7 +2391,7 @@ CSSPixels FormattingContext::calculate_inner_width(Layout::Box const& box, Avail
         return max(inner_width, 0);
     }
 
-    return width.to_px(box, width_of_containing_block);
+    return width.to_px(width_of_containing_block);
 }
 
 CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpace const& available_space, CSS::Size const& height) const
@@ -2448,7 +2448,7 @@ CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpa
 
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
         auto const& state = m_state.get(box);
-        auto inner_height = height.to_px(box, height_of_containing_block)
+        auto inner_height = height.to_px(height_of_containing_block)
             - computed_values.border_top().width
             - state.padding_top
             - computed_values.border_bottom().width
@@ -2456,7 +2456,7 @@ CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpa
         return max(inner_height, 0);
     }
 
-    return height.to_px(box, height_of_containing_block);
+    return height.to_px(height_of_containing_block);
 }
 
 CSSPixels FormattingContext::containing_block_width_for(NodeWithStyleAndBoxModelMetrics const& node) const
@@ -2892,7 +2892,7 @@ CSSPixels FormattingContext::gap_to_px(Variant<CSS::LengthPercentage, CSS::Norma
 {
     return gap.visit(
         [](CSS::NormalGap) { return CSSPixels(0); },
-        [&](auto const& gap) { return gap.to_px(context_box(), reference_value); });
+        [&](auto const& gap) { return gap.to_px(reference_value); });
 }
 
 }

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -534,7 +534,7 @@ bool GridFormattingContext::has_gaps(GridDimension dimension) const
 CSSPixels GridFormattingContext::resolve_definite_track_size(CSS::GridSize const& grid_size, AvailableSpace const& available_space) const
 {
     VERIFY(grid_size.is_definite());
-    return grid_size.css_size().to_px(grid_container(), available_space.width.to_px_or_zero());
+    return grid_size.css_size().to_px(available_space.width.to_px_or_zero());
 }
 
 int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimension dimension, CSS::ExplicitGridTrack const& repeated_track)
@@ -1185,13 +1185,13 @@ void GridFormattingContext::initialize_track_sizes(GridDimension dimension)
         }
 
         if (track.min_track_sizing_function.is_fixed(available_size)) {
-            track.base_size = track.min_track_sizing_function.css_size().to_px(grid_container(), available_size.to_px_or_zero());
+            track.base_size = track.min_track_sizing_function.css_size().to_px(available_size.to_px_or_zero());
         } else if (track.min_track_sizing_function.is_intrinsic(available_size)) {
             track.base_size = 0;
         }
 
         if (track.max_track_sizing_function.is_fixed(available_size)) {
-            track.growth_limit = track.max_track_sizing_function.css_size().to_px(grid_container(), available_size.to_px_or_zero());
+            track.growth_limit = track.max_track_sizing_function.css_size().to_px(available_size.to_px_or_zero());
         } else if (track.max_track_sizing_function.is_flexible_length()) {
             if (dimension == GridDimension::Column) {
                 m_has_flexible_column_tracks = true;
@@ -1526,7 +1526,7 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
                 track.growth_limit.value() += track.planned_increase;
                 if (track.growth_limit.value() < track.base_size)
                     track.growth_limit = track.base_size;
-                auto fit_content_limit = track.max_track_sizing_function.css_size().to_px(grid_container(), available_size.to_px_or_zero());
+                auto fit_content_limit = track.max_track_sizing_function.css_size().to_px(available_size.to_px_or_zero());
                 if (track.growth_limit.value() > fit_content_limit)
                     track.growth_limit = max(track.base_size, fit_content_limit);
             } else if (!track.growth_limit.has_value()) {
@@ -2588,22 +2588,22 @@ void GridFormattingContext::resolve_items_box_metrics(GridDimension dimension)
 
         CSSPixels containing_block_width = containing_block_size_for_item(item, GridDimension::Column);
         if (dimension == GridDimension::Column) {
-            item.used_values.padding_right = computed_values.padding().right().to_px_or_zero(grid_container(), containing_block_width);
-            item.used_values.padding_left = computed_values.padding().left().to_px_or_zero(grid_container(), containing_block_width);
+            item.used_values.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
+            item.used_values.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
 
-            item.used_values.margin_right = computed_values.margin().right().to_px_or_zero(grid_container(), containing_block_width);
-            item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(grid_container(), containing_block_width);
+            item.used_values.margin_right = computed_values.margin().right().to_px_or_zero(containing_block_width);
+            item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(containing_block_width);
 
             item.used_values.border_right = computed_values.border_right().width;
             item.used_values.border_left = computed_values.border_left().width;
 
             apply_subgrid_gap_extra_margins(item, dimension, m_available_space->width);
         } else {
-            item.used_values.padding_top = computed_values.padding().top().to_px_or_zero(grid_container(), containing_block_width);
-            item.used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(grid_container(), containing_block_width);
+            item.used_values.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
+            item.used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
 
-            item.used_values.margin_top = computed_values.margin().top().to_px_or_zero(grid_container(), containing_block_width);
-            item.used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(grid_container(), containing_block_width);
+            item.used_values.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_width);
+            item.used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_width);
 
             item.used_values.border_top = computed_values.border_top().width;
             item.used_values.border_bottom = computed_values.border_bottom().width;
@@ -3494,8 +3494,8 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
         table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.width, item.minimum_size(GridDimension::Column)));
 
     auto const& computed_values = item.box.computed_values();
-    item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(grid_container(), table_wrapper_containing_block_width);
-    item.used_values.margin_right = computed_values.margin().right().to_px_or_zero(grid_container(), table_wrapper_containing_block_width);
+    item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(table_wrapper_containing_block_width);
+    item.used_values.margin_right = computed_values.margin().right().to_px_or_zero(table_wrapper_containing_block_width);
 
     auto margin_start = item.used_margin_start(GridDimension::Column);
     auto margin_end = item.used_margin_end(GridDimension::Column);
@@ -3583,7 +3583,7 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
 
     auto maximum_size = CSSPixels::max();
     if (auto const& css_maximum_size = item.maximum_size(dimension); css_maximum_size.is_length_percentage() && !css_maximum_size.contains_percentage())
-        maximum_size = css_maximum_size.to_px(item.box, 0);
+        maximum_size = css_maximum_size.to_px(0);
 
     if (should_treat_preferred_size_as_auto) {
         CSSPixels min_content_size;
@@ -3617,7 +3617,7 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
 
     auto maximum_size = CSSPixels::max();
     if (auto const& css_maximum_size = item.maximum_size(dimension); css_maximum_size.is_length_percentage() && !css_maximum_size.contains_percentage())
-        maximum_size = css_maximum_size.to_px(item.box, 0);
+        maximum_size = css_maximum_size.to_px(0);
 
     auto preferred_size = item.preferred_size(dimension);
     if (should_treat_preferred_size_as_auto || preferred_size.is_fit_content()) {
@@ -3663,7 +3663,7 @@ Optional<CSSPixels> GridFormattingContext::calculate_fixed_max_track_size_limit(
 
         if (max_track_sizing_function.is_fixed(available_size)) {
             auto const& max_track_size = max_track_sizing_function.css_size();
-            result += max_track_size.to_px(grid_container(), available_size.to_px_or_zero());
+            result += max_track_size.to_px(available_size.to_px_or_zero());
             return;
         }
 
@@ -3672,7 +3672,7 @@ Optional<CSSPixels> GridFormattingContext::calculate_fixed_max_track_size_limit(
             auto const& fit_content_available_space = max_track_size.fit_content_available_space();
             if (fit_content_available_space.has_value()
                 && (!fit_content_available_space->contains_percentage() || available_size.is_definite())) {
-                result += max_track_size.to_px(grid_container(), available_size.to_px_or_zero());
+                result += max_track_size.to_px(available_size.to_px_or_zero());
                 return;
             }
         }
@@ -3751,7 +3751,7 @@ Optional<CSSPixels> GridFormattingContext::specified_size_suggestion(GridItem co
     if (has_definite_preferred_size) {
         // FIXME: consider margins, padding and borders because it is outer size.
         auto containing_block_size = containing_block_size_for_item(item, dimension);
-        return item.preferred_size(dimension).to_px(item.box, containing_block_size);
+        return item.preferred_size(dimension).to_px(containing_block_size);
     }
 
     return {};
@@ -3813,7 +3813,7 @@ CSSPixels GridFormattingContext::content_based_minimum_size(GridItem const& item
             spans_only_tracks_with_limited_max_track_sizing_function = false;
             break;
         }
-        sum_of_max_sizing_functions += track.max_track_sizing_function.css_size().to_px(item.box, m_available_space->width.to_px_or_zero());
+        sum_of_max_sizing_functions += track.max_track_sizing_function.css_size().to_px(m_available_space->width.to_px_or_zero());
     }
     if (spans_only_tracks_with_limited_max_track_sizing_function) {
         result = min(result, sum_of_max_sizing_functions);
@@ -3822,7 +3822,7 @@ CSSPixels GridFormattingContext::content_based_minimum_size(GridItem const& item
     // In all cases, the size suggestion is additionally clamped by the maximum size in the affected axis, if it’s definite.
     auto const& maximum_size = item.maximum_size(dimension);
     if (maximum_size.is_length_percentage() && !maximum_size.contains_percentage())
-        result = min(result, maximum_size.to_px(item.box, 0));
+        result = min(result, maximum_size.to_px(0));
 
     // If the item is a compressible replaced element, and has a definite preferred size or maximum size in the relevant axis,
     // the size suggestion is capped by those sizes; for this purpose, any indefinite percentages in these sizes are resolved

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -104,21 +104,21 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    box_state.margin_left = computed_values.margin().left().to_px_or_zero(box, width_of_containing_block);
+    box_state.margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
     box_state.border_left = computed_values.border_left().width;
-    box_state.padding_left = computed_values.padding().left().to_px_or_zero(box, width_of_containing_block);
+    box_state.padding_left = computed_values.padding().left().to_px_or_zero(width_of_containing_block);
 
-    box_state.margin_right = computed_values.margin().right().to_px_or_zero(box, width_of_containing_block);
+    box_state.margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
     box_state.border_right = computed_values.border_right().width;
-    box_state.padding_right = computed_values.padding().right().to_px_or_zero(box, width_of_containing_block);
+    box_state.padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
 
-    box_state.margin_top = computed_values.margin().top().to_px_or_zero(box, width_of_containing_block);
+    box_state.margin_top = computed_values.margin().top().to_px_or_zero(width_of_containing_block);
     box_state.border_top = computed_values.border_top().width;
-    box_state.padding_top = computed_values.padding().top().to_px_or_zero(box, width_of_containing_block);
+    box_state.padding_top = computed_values.padding().top().to_px_or_zero(width_of_containing_block);
 
-    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(box, width_of_containing_block);
+    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(width_of_containing_block);
     box_state.border_bottom = computed_values.border_bottom().width;
-    box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(box, width_of_containing_block);
+    box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(width_of_containing_block);
 
     if (box_is_sized_as_replaced_element(box, *m_available_space)) {
         box_state.set_content_width(compute_width_for_replaced_element(box, *m_available_space));

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -304,8 +304,8 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
 
             // https://drafts.csswg.org/css-text/#tab-size-property
             auto tab_width = text_node->computed_values().tab_size().visit(
-                [&](CSS::Length const& length) -> CSSPixels {
-                    return length.absolute_length_to_px();
+                [&](CSSPixels const& css_pixels) -> CSSPixels {
+                    return css_pixels;
                 },
                 [&](double tab_number) -> CSSPixels {
                     return CSSPixels::nearest_value_for(tab_number * (chunk.font->glyph_width(' ') + word_spacing.to_float() + letter_spacing.to_float()));

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -56,21 +56,21 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
     auto& used_values = m_layout_state.get_mutable(node);
     auto const& computed_values = node.computed_values();
 
-    used_values.margin_top = computed_values.margin().top().to_px_or_zero(node, m_containing_block_used_values.content_width());
-    used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(node, m_containing_block_used_values.content_width());
+    used_values.margin_top = computed_values.margin().top().to_px_or_zero(m_containing_block_used_values.content_width());
+    used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(m_containing_block_used_values.content_width());
 
-    used_values.margin_left = computed_values.margin().left().to_px_or_zero(node, m_containing_block_used_values.content_width());
+    used_values.margin_left = computed_values.margin().left().to_px_or_zero(m_containing_block_used_values.content_width());
     used_values.border_left = computed_values.border_left().width;
-    used_values.padding_left = computed_values.padding().left().to_px_or_zero(node, m_containing_block_used_values.content_width());
+    used_values.padding_left = computed_values.padding().left().to_px_or_zero(m_containing_block_used_values.content_width());
 
-    used_values.margin_right = computed_values.margin().right().to_px_or_zero(node, m_containing_block_used_values.content_width());
+    used_values.margin_right = computed_values.margin().right().to_px_or_zero(m_containing_block_used_values.content_width());
     used_values.border_right = computed_values.border_right().width;
-    used_values.padding_right = computed_values.padding().right().to_px_or_zero(node, m_containing_block_used_values.content_width());
+    used_values.padding_right = computed_values.padding().right().to_px_or_zero(m_containing_block_used_values.content_width());
 
     used_values.border_top = computed_values.border_top().width;
     used_values.border_bottom = computed_values.border_bottom().width;
-    used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(node, m_containing_block_used_values.content_width());
-    used_values.padding_top = computed_values.padding().top().to_px_or_zero(node, m_containing_block_used_values.content_width());
+    used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(m_containing_block_used_values.content_width());
+    used_values.padding_top = computed_values.padding().top().to_px_or_zero(m_containing_block_used_values.content_width());
 
     m_extra_leading_metrics->margin += used_values.margin_left;
     m_extra_leading_metrics->border += used_values.border_left;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -795,13 +795,13 @@ void LayoutState::commit(Box& root)
                     scrollport_size = nearest_scrollable_ancestor->absolute_rect().size();
 
                 if (!inset.top().is_auto())
-                    sticky_insets->top = inset.top().to_px_or_zero(node, scrollport_size.height());
+                    sticky_insets->top = inset.top().to_px_or_zero(scrollport_size.height());
                 if (!inset.right().is_auto())
-                    sticky_insets->right = inset.right().to_px_or_zero(node, scrollport_size.width());
+                    sticky_insets->right = inset.right().to_px_or_zero(scrollport_size.width());
                 if (!inset.bottom().is_auto())
-                    sticky_insets->bottom = inset.bottom().to_px_or_zero(node, scrollport_size.height());
+                    sticky_insets->bottom = inset.bottom().to_px_or_zero(scrollport_size.height());
                 if (!inset.left().is_auto())
-                    sticky_insets->left = inset.left().to_px_or_zero(node, scrollport_size.width());
+                    sticky_insets->left = inset.left().to_px_or_zero(scrollport_size.width());
                 paintable_box->set_sticky_insets(move(sticky_insets));
             }
         }
@@ -877,14 +877,14 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues con
 
         if (width) {
             border_and_padding = computed_values.border_left().width
-                + computed_values.padding().left().to_px_or_zero(*m_node, containing_block_used_values->content_width())
+                + computed_values.padding().left().to_px_or_zero(containing_block_used_values->content_width())
                 + computed_values.border_right().width
-                + computed_values.padding().right().to_px_or_zero(*m_node, containing_block_used_values->content_width());
+                + computed_values.padding().right().to_px_or_zero(containing_block_used_values->content_width());
         } else {
             border_and_padding = computed_values.border_top().width
-                + computed_values.padding().top().to_px_or_zero(*m_node, containing_block_used_values->content_width())
+                + computed_values.padding().top().to_px_or_zero(containing_block_used_values->content_width())
                 + computed_values.border_bottom().width
-                + computed_values.padding().bottom().to_px_or_zero(*m_node, containing_block_used_values->content_width());
+                + computed_values.padding().bottom().to_px_or_zero(containing_block_used_values->content_width());
         }
 
         return unadjusted_pixels - border_and_padding;
@@ -931,11 +931,11 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues con
                 if (!containing_block_has_definite_size)
                     return false;
                 auto containing_block_size_as_length = width ? containing_block_used_values->content_width() : containing_block_used_values->content_height();
-                resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(node, containing_block_size_as_length), size, width));
+                resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(containing_block_size_as_length), size, width));
                 return true;
             }
 
-            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(node, CSSPixels { 0 }), size, width));
+            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(CSSPixels { 0 }), size, width));
             return true;
         }
 

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -18,7 +18,7 @@ LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_s
     , m_writing_mode(writing_mode)
 {
     auto text_indent = m_context.containing_block().computed_values().text_indent();
-    m_text_indent = text_indent.length_percentage.to_px(m_context.containing_block(), m_containing_block_used_values.content_width());
+    m_text_indent = text_indent.length_percentage.to_px(m_containing_block_used_values.content_width());
     m_text_indent_each_line = text_indent.each_line;
     m_text_indent_hanging = text_indent.hanging;
     begin_new_line(false);
@@ -310,7 +310,7 @@ void LineBuilder::update_last_line()
             // NOTE: For fragments with a <length-percentage> vertical-align, shift the line box baseline down by the resolved amount.
             //       This ensures that we make enough vertical space on the line for any manually-aligned fragments.
             if (auto const* length_percentage = fragment.layout_node().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
-                fragment_baseline += length_percentage->to_px(fragment.layout_node(), line_height);
+                fragment_baseline += length_percentage->to_px(line_height);
             }
 
             if (fragment_baseline > line_box_baseline) {
@@ -390,7 +390,7 @@ void LineBuilder::update_last_line()
             new_fragment_block_offset = block_offset_value_for_alignment(vertical_align.get<CSS::VerticalAlign>());
         } else {
             if (auto const* length_percentage = vertical_align.get_pointer<CSS::LengthPercentage>()) {
-                auto vertical_align_amount = length_percentage->to_px(fragment.layout_node(), fragment.layout_node().computed_values().line_height());
+                auto vertical_align_amount = length_percentage->to_px(fragment.layout_node().computed_values().line_height());
                 new_fragment_block_offset = block_offset_value_for_alignment(CSS::VerticalAlign::Baseline) - vertical_align_amount;
             }
         }
@@ -415,7 +415,7 @@ void LineBuilder::update_last_line()
                 bottom_of_inline_box = (fragment.block_offset() + fragment.baseline() + CSSPixels::nearest_value_for(font_metrics.descent) + half_leading);
             }
             if (auto const* length_percentage = fragment.layout_node().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
-                bottom_of_inline_box += length_percentage->to_px(fragment.layout_node(), fragment.layout_node().computed_values().line_height());
+                bottom_of_inline_box += length_percentage->to_px(fragment.layout_node().computed_values().line_height());
             }
         }
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -861,9 +861,9 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
             auto const& value = computed_style.property(property_id);
             if (value.is_overflow_clip_margin()) {
                 auto const& overflow_clip_margin = value.as_overflow_clip_margin();
-                CSS::Length offset = CSS::Length::make_px(0);
+                CSSPixels offset = 0;
                 if (overflow_clip_margin.offset().is_length())
-                    offset = overflow_clip_margin.offset().as_length().length();
+                    offset = overflow_clip_margin.offset().as_length().length().absolute_length_to_px();
                 return { overflow_clip_margin.visual_box(), offset };
             }
             return {};
@@ -912,7 +912,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         computed_values.set_outline_color(outline_color.to_color(color_resolution_context).value());
     // FIXME: Support calc()
     if (auto const& outline_offset = computed_style.property(CSS::PropertyID::OutlineOffset); outline_offset.is_length())
-        computed_values.set_outline_offset(outline_offset.as_length().length());
+        computed_values.set_outline_offset(outline_offset.as_length().length().absolute_length_to_px());
     computed_values.set_outline_style(computed_style.outline_style());
 
     // FIXME: Interpolation can cause negative values - we clamp here but should instead clamp as part of interpolation.

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -321,12 +321,12 @@ void SVGFormattingContext::layout_svg_element(Box const& child)
         auto& child_state = m_state.get_mutable(child);
         CSSPixelRect rect {
             {
-                child.computed_values().x().to_px(child, m_available_space->width.to_px_or_zero()),
-                child.computed_values().y().to_px(child, m_available_space->height.to_px_or_zero()),
+                child.computed_values().x().to_px(m_available_space->width.to_px_or_zero()),
+                child.computed_values().y().to_px(m_available_space->height.to_px_or_zero()),
             },
             {
-                child.computed_values().width().to_px(child, m_available_space->width.to_px_or_zero()),
-                child.computed_values().height().to_px(child, m_available_space->height.to_px_or_zero()),
+                child.computed_values().width().to_px(m_available_space->width.to_px_or_zero()),
+                child.computed_values().height().to_px(m_available_space->height.to_px_or_zero()),
             }
         };
         auto parent_svg_transform = get_parent_svg_transform(child);
@@ -355,18 +355,18 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport)
     // Layout for a nested SVG viewport.
     // https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport.
     auto& nested_viewport_state = m_state.get_mutable(viewport);
-    auto resolve_dimension = [](auto& node, auto size, auto reference_value) {
+    auto resolve_dimension = [](auto size, auto reference_value) {
         // The value auto for width and height on the ‘svg’ element is treated as 100%.
         // https://svgwg.org/svg2-draft/geometry.html#Sizing
         if (size.is_auto())
             return reference_value;
-        return size.to_px(node, reference_value);
+        return size.to_px(reference_value);
     };
 
-    auto nested_viewport_x = viewport.computed_values().x().to_px(viewport, m_viewport_size.width());
-    auto nested_viewport_y = viewport.computed_values().y().to_px(viewport, m_viewport_size.height());
-    auto nested_viewport_width = resolve_dimension(viewport, viewport.computed_values().width(), m_viewport_size.width());
-    auto nested_viewport_height = resolve_dimension(viewport, viewport.computed_values().height(), m_viewport_size.height());
+    auto nested_viewport_x = viewport.computed_values().x().to_px(m_viewport_size.width());
+    auto nested_viewport_y = viewport.computed_values().y().to_px(m_viewport_size.height());
+    auto nested_viewport_width = resolve_dimension(viewport.computed_values().width(), m_viewport_size.width());
+    auto nested_viewport_height = resolve_dimension(viewport.computed_values().height(), m_viewport_size.height());
 
     CSSPixelPoint content_offset { nested_viewport_x, nested_viewport_y };
     auto content_width = nested_viewport_width;
@@ -499,7 +499,7 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
     } else if (auto* text_box = as_if<SVGTextBox>(graphics_box)) {
         // FIXME: Text offsets must be calculated per character. This only applies the first character's offset.
         auto text_positioning = text_box->dom_node().text_positioning();
-        text_positioning.apply_to_text_position(*text_box, m_viewport_size, m_current_text_position, 0u);
+        text_positioning.apply_to_text_position(m_viewport_size, m_current_text_position, 0u);
 
         path = compute_path_for_text(*text_box);
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -151,10 +151,10 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
 
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box.computed_values();
-        CSSPixels padding_top = computed_values.padding().top().to_px_or_zero(cell.box, containing_block_height);
-        CSSPixels padding_bottom = computed_values.padding().bottom().to_px_or_zero(cell.box, containing_block_height);
-        CSSPixels padding_left = computed_values.padding().left().to_px_or_zero(cell.box, containing_block_width);
-        CSSPixels padding_right = computed_values.padding().right().to_px_or_zero(cell.box, containing_block_width);
+        CSSPixels padding_top = computed_values.padding().top().to_px_or_zero(containing_block_height);
+        CSSPixels padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_height);
+        CSSPixels padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
+        CSSPixels padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
 
         auto const& cell_state = m_state.get(cell.box);
         auto use_collapsing_borders_model = cell_state.override_borders_data().has_value();
@@ -168,7 +168,7 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
         auto max_content_width = calculate_max_content_width(cell.box);
 
         // The outer min-content width of a table-cell is max(min-width, min-content width) adjusted by the cell intrinsic offsets.
-        auto min_width = computed_values.min_width().to_px(cell.box, containing_block_width);
+        auto min_width = computed_values.min_width().to_px(containing_block_width);
         auto cell_intrinsic_width_offsets = padding_left + padding_right + border_left + border_right;
         // For fixed mode, according to https://www.w3.org/TR/css-tables-3/#computing-column-measures:
         // The min-content and max-content width of cells is considered zero unless they are directly specified as a length-percentage,
@@ -183,15 +183,15 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
             auto max_content_height = calculate_max_content_height(cell.box, min_content_width);
 
             // The outer min-content height of a table-cell is max(min-height, min-content height) adjusted by the cell intrinsic offsets.
-            auto min_height = computed_values.min_height().to_px(cell.box, containing_block_height);
+            auto min_height = computed_values.min_height().to_px(containing_block_height);
             auto cell_intrinsic_height_offsets = padding_top + padding_bottom + border_top + border_bottom;
             cell.outer_min_height = max(min_height, min_content_height) + cell_intrinsic_height_offsets;
 
             // The tables specification isn't explicit on how to use the height and max-height CSS properties in the outer max-content formulas.
             // However, during this early phase we don't have enough information to resolve percentage sizes yet and the formulas for outer sizes
             // in the specification give enough clues to pick defaults in a way that makes sense.
-            auto height = computed_values.height().is_length() ? computed_values.height().to_px(cell.box, containing_block_height) : 0;
-            auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(cell.box, containing_block_height) : CSSPixels::max();
+            auto height = computed_values.height().is_length() ? computed_values.height().to_px(containing_block_height) : 0;
+            auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(containing_block_height) : CSSPixels::max();
             if (m_rows[cell.row_index].is_constrained) {
                 // The outer max-content height of a table-cell in a constrained row is
                 // max(min-height, height, min-content height, min(max-height, height)) adjusted by the cell intrinsic offsets.
@@ -205,8 +205,8 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
         }
 
         // See the explanation for height and max_height above.
-        auto width = computed_values.width().is_length() ? computed_values.width().to_px(cell.box, containing_block_width) : 0;
-        auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(cell.box, containing_block_width) : CSSPixels::max();
+        auto width = computed_values.width().is_length() ? computed_values.width().to_px(containing_block_width) : 0;
+        auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(containing_block_width) : CSSPixels::max();
         if (use_fixed_mode_layout() && !width_is_specified_length_or_percentage) {
             continue;
         }
@@ -232,9 +232,9 @@ void TableFormattingContext::compute_outer_content_sizes()
     TableGrid::for_each_child_box_matching(table_box(), is_table_column_group, [&](auto& column_group_box) {
         TableGrid::for_each_child_box_matching(column_group_box, is_table_column, [&](auto& column_box) {
             auto const& computed_values = column_box.computed_values();
-            auto min_width = computed_values.min_width().to_px(column_box, containing_block_width);
-            auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(column_box, containing_block_width) : CSSPixels::max();
-            auto width = computed_values.width().to_px(column_box, containing_block_width);
+            auto min_width = computed_values.min_width().to_px(containing_block_width);
+            auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(containing_block_width) : CSSPixels::max();
+            auto width = computed_values.width().to_px(containing_block_width);
             // The outer min-content width of a table-column or table-column-group is max(min-width, width).
             m_columns[column_index].min_size = max(min_width, width);
             // The outer max-content width of a table-column or table-column-group is max(min-width, min(max-width, width)).
@@ -247,9 +247,9 @@ void TableFormattingContext::compute_outer_content_sizes()
 
     for (auto& row : m_rows) {
         auto const& computed_values = row.box.computed_values();
-        auto min_height = computed_values.min_height().to_px(row.box, containing_block_height);
-        auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(row.box, containing_block_height) : CSSPixels::max();
-        auto height = computed_values.height().to_px(row.box, containing_block_height);
+        auto min_height = computed_values.min_height().to_px(containing_block_height);
+        auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(containing_block_height) : CSSPixels::max();
+        auto height = computed_values.height().to_px(containing_block_height);
         // The outer min-content height of a table-row or table-row-group is max(min-height, height).
         row.min_size = max(min_height, height);
         // The outer max-content height of a table-row or table-row-group is max(min-height, min(max-height, height)).
@@ -265,7 +265,7 @@ void TableFormattingContext::initialize_table_measures<TableFormattingContext::R
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box.computed_values();
         if (cell.row_span == 1) {
-            auto specified_height = computed_values.height().to_px(cell.box, containing_block_height);
+            auto specified_height = computed_values.height().to_px(containing_block_height);
             // https://www.w3.org/TR/css-tables-3/#row-layout makes specified cell height part of the initialization formula for row table measures:
             // This is done by running the same algorithm as the column measurement, with the span=1 value being initialized (for min-content) with
             // the largest of the resulting height of the previous row layout, the height specified on the corresponding table-row (if any), and
@@ -494,10 +494,10 @@ CSSPixels TableFormattingContext::compute_capmin()
         auto const& child_box = static_cast<Box const&>(*child);
         auto const& computed_values = child_box.computed_values();
 
-        auto margin_left = computed_values.margin().left().resolved_or_auto(child_box, width_of_table_wrapper_containing_block).to_px_or_zero(child_box);
-        auto margin_right = computed_values.margin().right().resolved_or_auto(child_box, width_of_table_wrapper_containing_block).to_px_or_zero(child_box);
-        auto padding_left = computed_values.padding().left().to_px_or_zero(child_box, width_of_table_wrapper_containing_block);
-        auto padding_right = computed_values.padding().right().to_px_or_zero(child_box, width_of_table_wrapper_containing_block);
+        auto margin_left = computed_values.margin().left().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero(child_box);
+        auto margin_right = computed_values.margin().right().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero(child_box);
+        auto padding_left = computed_values.padding().left().to_px_or_zero(width_of_table_wrapper_containing_block);
+        auto padding_right = computed_values.padding().right().to_px_or_zero(width_of_table_wrapper_containing_block);
         auto outer_size_for_inner_size = [&](CSSPixels inner_size) {
             return inner_size
                 + margin_left
@@ -571,12 +571,12 @@ void TableFormattingContext::compute_table_width()
         if (width_constraint.is_fit_content()) {
             auto fit_content_limit = width_of_table_wrapper_containing_block;
             if (auto const& fit_content_available_space = width_constraint.fit_content_available_space(); fit_content_available_space.has_value())
-                fit_content_limit = fit_content_available_space->to_px(table_box(), width_of_table_wrapper_containing_block);
+                fit_content_limit = fit_content_available_space->to_px(width_of_table_wrapper_containing_block);
             return min(grid_max, max(grid_min, fit_content_limit));
         }
         // CSS Sizing says box-sizing:border-box applies length/percentage width/min-width/max-width constraints to
         // the border box. The table width algorithm compares content widths, so convert them before comparing.
-        auto resolved_width = width_constraint.to_px(table_box(), width_of_table_wrapper_containing_block);
+        auto resolved_width = width_constraint.to_px(width_of_table_wrapper_containing_block);
         if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox)
             resolved_width -= table_box_state.border_box_left() + table_box_state.border_box_right();
         return max(CSSPixels(0), resolved_width);
@@ -987,7 +987,7 @@ void TableFormattingContext::compute_table_height()
         auto row_computed_height = row.box.computed_values().height();
         if (row_computed_height.is_length()) {
             auto height_of_containing_block = m_state.get(*row.box.containing_block()).content_height();
-            auto row_used_height = row_computed_height.to_px(row.box, height_of_containing_block);
+            auto row_used_height = row_computed_height.to_px(height_of_containing_block);
             row.base_height = max(row.base_height, row_used_height);
         }
     }
@@ -1004,10 +1004,10 @@ void TableFormattingContext::compute_table_height()
         auto width_of_containing_block = cell_state.containing_block_used_values()->content_width();
         auto height_of_containing_block = cell_state.containing_block_used_values()->content_height();
 
-        cell_state.padding_top = cell.box.computed_values().padding().top().to_px_or_zero(cell.box, width_of_containing_block);
-        cell_state.padding_bottom = cell.box.computed_values().padding().bottom().to_px_or_zero(cell.box, width_of_containing_block);
-        cell_state.padding_left = cell.box.computed_values().padding().left().to_px_or_zero(cell.box, width_of_containing_block);
-        cell_state.padding_right = cell.box.computed_values().padding().right().to_px_or_zero(cell.box, width_of_containing_block);
+        cell_state.padding_top = cell.box.computed_values().padding().top().to_px_or_zero(width_of_containing_block);
+        cell_state.padding_bottom = cell.box.computed_values().padding().bottom().to_px_or_zero(width_of_containing_block);
+        cell_state.padding_left = cell.box.computed_values().padding().left().to_px_or_zero(width_of_containing_block);
+        cell_state.padding_right = cell.box.computed_values().padding().right().to_px_or_zero(width_of_containing_block);
 
         if (table_box().computed_values().border_collapse() == CSS::BorderCollapse::Separate) {
             cell_state.border_top = cell.box.computed_values().border_top().width;
@@ -1019,7 +1019,7 @@ void TableFormattingContext::compute_table_height()
         if (!row.is_collapsed) {
             auto cell_computed_height = cell.box.computed_values().height();
             if (cell_computed_height.is_length()) {
-                auto cell_used_height = cell_computed_height.to_px(cell.box, height_of_containing_block);
+                auto cell_used_height = cell_computed_height.to_px(height_of_containing_block);
                 cell_state.set_content_height(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
 
                 row.base_height = max(row.base_height, cell_used_height);
@@ -1070,7 +1070,7 @@ void TableFormattingContext::compute_table_height()
         // table grid, and will eventually be distributed to the height of the rows if their collective minimum height
         // ends up smaller than this number.
         CSSPixels height_of_table_containing_block = table_wrapper_containing_block_height();
-        auto specified_table_height = table_box().computed_values().height().to_px(table_box(), height_of_table_containing_block);
+        auto specified_table_height = table_box().computed_values().height().to_px(height_of_table_containing_block);
         if (table_box().computed_values().box_sizing() == CSS::BoxSizing::BorderBox) {
             auto const& table_state = m_state.get(table_box());
             specified_table_height -= table_state.border_box_top() + table_state.border_box_bottom();
@@ -1099,7 +1099,7 @@ void TableFormattingContext::compute_table_height()
         }
         auto row_computed_height = row.box.computed_values().height();
         if (row_computed_height.is_percentage()) {
-            auto row_used_height = row_computed_height.to_px(row.box, m_table_height);
+            auto row_used_height = row_computed_height.to_px(m_table_height);
             row.reference_height = max(row.reference_height, row_used_height);
         } else {
             continue;
@@ -1118,7 +1118,7 @@ void TableFormattingContext::compute_table_height()
 
         auto cell_computed_height = cell.box.computed_values().height();
         if (cell_computed_height.is_percentage()) {
-            auto cell_used_height = cell_computed_height.to_px(cell.box, m_table_height);
+            auto cell_used_height = cell_computed_height.to_px(m_table_height);
             cell_state.set_content_height(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
 
             if (!row.is_collapsed)

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -494,8 +494,8 @@ CSSPixels TableFormattingContext::compute_capmin()
         auto const& child_box = static_cast<Box const&>(*child);
         auto const& computed_values = child_box.computed_values();
 
-        auto margin_left = computed_values.margin().left().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero(child_box);
-        auto margin_right = computed_values.margin().right().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero(child_box);
+        auto margin_left = computed_values.margin().left().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero();
+        auto margin_right = computed_values.margin().right().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero();
         auto padding_left = computed_values.padding().left().to_px_or_zero(width_of_table_wrapper_containing_block);
         auto padding_right = computed_values.padding().right().to_px_or_zero(width_of_table_wrapper_containing_block);
         auto outer_size_for_inner_size = [&](CSSPixels inner_size) {

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -2039,7 +2039,7 @@ CSSPixels TableFormattingContext::border_spacing_horizontal() const
     // https://www.w3.org/TR/css-tables-3/#collapsed-style-overrides
     if (computed_values.border_collapse() == CSS::BorderCollapse::Collapse)
         return 0;
-    return computed_values.border_spacing_horizontal().to_px(table_box());
+    return computed_values.border_spacing_horizontal();
 }
 
 CSSPixels TableFormattingContext::border_spacing_vertical() const
@@ -2049,7 +2049,7 @@ CSSPixels TableFormattingContext::border_spacing_vertical() const
     // https://www.w3.org/TR/css-tables-3/#collapsed-style-overrides
     if (computed_values.border_collapse() == CSS::BorderCollapse::Collapse)
         return 0;
-    return computed_values.border_spacing_vertical().to_px(table_box());
+    return computed_values.border_spacing_vertical();
 }
 
 StaticPositionRect TableFormattingContext::calculate_static_position_rect(Box const&) const

--- a/Libraries/LibWeb/Page/ElementResizeAction.cpp
+++ b/Libraries/LibWeb/Page/ElementResizeAction.cpp
@@ -76,16 +76,16 @@ void ElementResizeAction::handle_pointer_move(CSSPixelPoint pointer_position)
 
     if (reference_basis.has_value()) {
         if (auto const& min_width = computed.min_width(); !min_width.is_auto()) {
-            css_width = max(css_width, min_width.to_px(layout_node, reference_basis->width()));
+            css_width = max(css_width, min_width.to_px(reference_basis->width()));
         }
         if (auto const& max_width = computed.max_width(); !max_width.is_none()) {
-            css_width = min(css_width, max_width.to_px(layout_node, reference_basis->width()));
+            css_width = min(css_width, max_width.to_px(reference_basis->width()));
         }
         if (auto const& min_height = computed.min_height(); !min_height.is_auto()) {
-            css_height = max(css_height, min_height.to_px(layout_node, reference_basis->height()));
+            css_height = max(css_height, min_height.to_px(reference_basis->height()));
         }
         if (auto const& max_height = computed.max_height(); !max_height.is_none()) {
-            css_height = min(css_height, max_height.to_px(layout_node, reference_basis->height()));
+            css_height = min(css_height, max_height.to_px(reference_basis->height()));
         }
     }
     if (computed.box_sizing() == CSS::BoxSizing::ContentBox) {

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -97,9 +97,9 @@ static Optional<TransformData> compute_transform(PaintableBox const& paintable_b
     // offset properties as follows:
     auto reference_box = paintable_box.transform_reference_box();
     auto const& css_transform_origin = computed_values.transform_origin();
-    auto origin_x = css_transform_origin.x.to_px(paintable_box.layout_node(), reference_box.width());
-    auto origin_y = css_transform_origin.y.to_px(paintable_box.layout_node(), reference_box.height());
-    auto origin_z = css_transform_origin.z.to_px(paintable_box.layout_node(), 0).to_float();
+    auto origin_x = css_transform_origin.x.to_px(reference_box.width());
+    auto origin_y = css_transform_origin.y.to_px(reference_box.height());
+    auto origin_z = css_transform_origin.z.to_px(0).to_float();
 
     // 1. Start with the identity matrix.
     // 2. Translate by the computed X, Y, and Z values of transform-origin.
@@ -149,7 +149,7 @@ static Optional<Gfx::FloatMatrix4x4> compute_perspective_matrix(PaintableBox con
     // https://drafts.csswg.org/css-transforms-2/#perspective-origin-property
     // Percentages: refer to the size of the reference box
     auto reference_box = paintable_box.transform_reference_box();
-    auto perspective_origin = computed_values.perspective_origin().resolved(paintable_box.layout_node(), reference_box);
+    auto perspective_origin = computed_values.perspective_origin().resolved(reference_box);
     auto computed_x = perspective_origin.x().to_float();
     auto computed_y = perspective_origin.y().to_float();
     auto perspective_matrix = Gfx::translation_matrix(Vector3<float>(computed_x, computed_y, 0));
@@ -246,7 +246,7 @@ static Optional<ClipPathData> compute_basic_shape_clip_path_data(PaintableBox co
     auto masking_area = paintable_box.absolute_border_box_rect();
     auto reference_box = CSSPixelRect { {}, masking_area.size() };
     auto const& basic_shape = clip_path->basic_shape();
-    auto path = basic_shape.to_path(reference_box, paintable_box.layout_node());
+    auto path = basic_shape.to_path(reference_box);
     path.offset(masking_area.top_left().template to_type<float>());
     auto fill_rule = basic_shape.basic_shape().visit(
         [](CSS::Polygon const& polygon) { return polygon.fill_rule; },

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -428,9 +428,9 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
         Optional<CSSPixels> specified_height {};
         if (layer.size_type == CSS::BackgroundSize::LengthPercentage) {
             if (!layer.size_x.is_auto())
-                specified_width = layer.size_x.length_percentage().to_px(paintable_box.layout_node(), background_positioning_area.width());
+                specified_width = layer.size_x.length_percentage().to_px(background_positioning_area.width());
             if (!layer.size_y.is_auto())
-                specified_height = layer.size_y.length_percentage().to_px(paintable_box.layout_node(), background_positioning_area.height());
+                specified_height = layer.size_y.length_percentage().to_px(background_positioning_area.height());
         }
         auto concrete_image_size = CSS::run_default_sizing_algorithm(
             specified_width, specified_height,
@@ -509,8 +509,8 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
         CSSPixels space_x = background_positioning_area.width() - image_rect.width();
         CSSPixels space_y = background_positioning_area.height() - image_rect.height();
 
-        CSSPixels position_x = layer.position_x.to_px(paintable_box.layout_node(), space_x);
-        CSSPixels position_y = layer.position_y.to_px(paintable_box.layout_node(), space_y);
+        CSSPixels position_x = layer.position_x.to_px(space_x);
+        CSSPixels position_y = layer.position_y.to_px(space_y);
 
         resolved_layers.append({ .background_image = layer.background_image,
             .attachment = layer.attachment,

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -349,7 +349,7 @@ Paintable::SelectionStyle Paintable::selection_style() const
             Vector<ShadowData> shadows;
             shadows.ensure_capacity(css_shadows.size());
             for (auto const& shadow : css_shadows)
-                shadows.unchecked_append(ShadowData::from_css(shadow, *element_layout_node));
+                shadows.unchecked_append(ShadowData::from_css(shadow));
             style.text_shadow = move(shadows);
         }
 

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -240,15 +240,15 @@ CSSPixelPoint Paintable::box_type_agnostic_position() const
     return position;
 }
 
-Painting::BorderRadiiData normalize_border_radii_data(Layout::Node const& node, CSSPixelRect const& border_rect, CSSPixelRect const& reference_rect, CSS::BorderRadiusData const& top_left_radius, CSS::BorderRadiusData const& top_right_radius, CSS::BorderRadiusData const& bottom_right_radius, CSS::BorderRadiusData const& bottom_left_radius)
+Painting::BorderRadiiData normalize_border_radii_data(CSSPixelRect const& border_rect, CSSPixelRect const& reference_rect, CSS::BorderRadiusData const& top_left_radius, CSS::BorderRadiusData const& top_right_radius, CSS::BorderRadiusData const& bottom_right_radius, CSS::BorderRadiusData const& bottom_left_radius)
 {
     Painting::BorderRadiiData radii_px {
         .top_left = {
-            top_left_radius.horizontal_radius.to_px(node, reference_rect.width()),
-            top_left_radius.vertical_radius.to_px(node, reference_rect.height()) },
-        .top_right = { top_right_radius.horizontal_radius.to_px(node, reference_rect.width()), top_right_radius.vertical_radius.to_px(node, reference_rect.height()) },
-        .bottom_right = { bottom_right_radius.horizontal_radius.to_px(node, reference_rect.width()), bottom_right_radius.vertical_radius.to_px(node, reference_rect.height()) },
-        .bottom_left = { bottom_left_radius.horizontal_radius.to_px(node, reference_rect.width()), bottom_left_radius.vertical_radius.to_px(node, reference_rect.height()) }
+            top_left_radius.horizontal_radius.to_px(reference_rect.width()),
+            top_left_radius.vertical_radius.to_px(reference_rect.height()) },
+        .top_right = { top_right_radius.horizontal_radius.to_px(reference_rect.width()), top_right_radius.vertical_radius.to_px(reference_rect.height()) },
+        .bottom_right = { bottom_right_radius.horizontal_radius.to_px(reference_rect.width()), bottom_right_radius.vertical_radius.to_px(reference_rect.height()) },
+        .bottom_left = { bottom_left_radius.horizontal_radius.to_px(reference_rect.width()), bottom_left_radius.vertical_radius.to_px(reference_rect.height()) }
     };
 
     // Scale overlapping curves according to https://www.w3.org/TR/css-backgrounds-3/#corner-overlap

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -182,6 +182,6 @@ inline bool Paintable::fast_is<PaintableWithLines>() const { return is_paintable
 template<>
 inline bool Paintable::fast_is<TextPaintable>() const { return is_text_paintable(); }
 
-WEB_API Painting::BorderRadiiData normalize_border_radii_data(Layout::Node const& node, CSSPixelRect const& border_rect, CSSPixelRect const& reference_rect, CSS::BorderRadiusData const& top_left_radius, CSS::BorderRadiusData const& top_right_radius, CSS::BorderRadiusData const& bottom_right_radius, CSS::BorderRadiusData const& bottom_left_radius);
+WEB_API Painting::BorderRadiiData normalize_border_radii_data(CSSPixelRect const& border_rect, CSSPixelRect const& reference_rect, CSS::BorderRadiusData const& top_left_radius, CSS::BorderRadiusData const& top_right_radius, CSS::BorderRadiusData const& bottom_right_radius, CSS::BorderRadiusData const& bottom_left_radius);
 
 }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1951,7 +1951,7 @@ BorderRadiiData PaintableBox::border_radii_data() const
     auto border_top_right_radius = m_fragment_top_edge_away || m_fragment_right_edge_away ? CSS::BorderRadiusData {} : computed_values.border_top_right_radius();
     auto border_bottom_right_radius = m_fragment_bottom_edge_away || m_fragment_right_edge_away ? CSS::BorderRadiusData {} : computed_values.border_bottom_right_radius();
     auto border_bottom_left_radius = m_fragment_bottom_edge_away || m_fragment_left_edge_away ? CSS::BorderRadiusData {} : computed_values.border_bottom_left_radius();
-    return normalize_border_radii_data(layout_node(), border_rect, border_rect,
+    return normalize_border_radii_data(border_rect, border_rect,
         border_top_left_radius, border_top_right_radius,
         border_bottom_right_radius, border_bottom_left_radius);
 }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -828,10 +828,10 @@ CSSPixelRect PaintableBox::overflow_clip_edge_rect() const
     //     The specified offset dictates how much the overflow clip edge is expanded from the specified box edge
     //     Negative values are invalid. Defaults to zero if omitted.
     overflow_clip_edge.inflate(
-        overflow_clip_margin.top.offset.absolute_length_to_px(),
-        overflow_clip_margin.right.offset.absolute_length_to_px(),
-        overflow_clip_margin.bottom.offset.absolute_length_to_px(),
-        overflow_clip_margin.left.offset.absolute_length_to_px());
+        overflow_clip_margin.top.offset,
+        overflow_clip_margin.right.offset,
+        overflow_clip_margin.bottom.offset,
+        overflow_clip_margin.left.offset);
     return overflow_clip_edge;
 }
 
@@ -1716,7 +1716,7 @@ void PaintableBox::paint_box_shadow(DisplayListRecordingContext& context) const
     Vector<Painting::ShadowData> resolved_box_shadow_data;
     resolved_box_shadow_data.ensure_capacity(box_shadow_layers.size());
     for (auto const& layer : box_shadow_layers)
-        resolved_box_shadow_data.unchecked_append(ShadowData::from_css(layer, layout_node()));
+        resolved_box_shadow_data.unchecked_append(ShadowData::from_css(layer));
     auto borders_data = BordersData {
         .top = computed_values().border_top(),
         .right = computed_values().border_right(),
@@ -1964,7 +1964,7 @@ Optional<BordersData> PaintableBox::outline_data() const
 
 CSSPixels PaintableBox::outline_offset() const
 {
-    return computed_values().outline_offset().to_px(layout_node());
+    return computed_values().outline_offset();
 }
 
 ScrollFrameIndex PaintableBox::nearest_scroll_frame_index() const

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -106,7 +106,6 @@ void PaintableWithLines::record_hit_test_items(DisplayListRecordingContext& cont
 
 static void resolve_text_fragment_properties(PaintableWithLines const& paintable_with_lines)
 {
-    auto const& parent_layout_node = paintable_with_lines.layout_node();
     for (auto& fragment : const_cast<PaintableWithLines&>(paintable_with_lines).fragments()) {
         auto const* text_node = as_if<Layout::TextNode>(fragment.layout_node());
         if (!text_node)
@@ -142,7 +141,7 @@ static void resolve_text_fragment_properties(PaintableWithLines const& paintable
         if (!text_shadow.is_empty()) {
             resolved_shadow_data.ensure_capacity(text_shadow.size());
             for (auto const& layer : text_shadow)
-                resolved_shadow_data.append(ShadowData::from_css(layer, parent_layout_node));
+                resolved_shadow_data.append(ShadowData::from_css(layer));
         }
         fragment.set_shadows(move(resolved_shadow_data));
     }

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -130,7 +130,7 @@ static void resolve_text_fragment_properties(PaintableWithLines const& paintable
                 },
                 [&](CSS::LengthPercentage const& length_percentage) {
                     // https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-thickness-length-percentage
-                    auto resolved_length = length_percentage.resolved(*text_node, CSS::Length(1, CSS::LengthUnit::Em).to_px(*text_node)).to_px(*text_node);
+                    auto resolved_length = length_percentage.resolved(CSS::Length(1, CSS::LengthUnit::Em).to_px(*text_node)).to_px(*text_node);
                     return max(resolved_length, 1);
                 });
         }();

--- a/Libraries/LibWeb/Painting/ReplacedElementCommon.cpp
+++ b/Libraries/LibWeb/Painting/ReplacedElementCommon.cpp
@@ -77,16 +77,16 @@ Gfx::IntRect get_replaced_box_painting_area(PaintableBox const& paintable, Displ
 
     auto offset_x = CSSPixels::from_raw(0);
     if (object_position.edge_x == CSS::PositionEdge::Left) {
-        offset_x = object_position.offset_x.to_px(paintable.layout_node(), residual_horizontal);
+        offset_x = object_position.offset_x.to_px(residual_horizontal);
     } else if (object_position.edge_x == CSS::PositionEdge::Right) {
-        offset_x = residual_horizontal - object_position.offset_x.to_px(paintable.layout_node(), residual_horizontal);
+        offset_x = residual_horizontal - object_position.offset_x.to_px(residual_horizontal);
     }
 
     auto offset_y = CSSPixels::from_raw(0);
     if (object_position.edge_y == CSS::PositionEdge::Top) {
-        offset_y = object_position.offset_y.to_px(paintable.layout_node(), residual_vertical);
+        offset_y = object_position.offset_y.to_px(residual_vertical);
     } else if (object_position.edge_y == CSS::PositionEdge::Bottom) {
-        offset_y = residual_vertical - object_position.offset_y.to_px(paintable.layout_node(), residual_vertical);
+        offset_y = residual_vertical - object_position.offset_y.to_px(residual_vertical);
     }
 
     return Gfx::IntRect(

--- a/Libraries/LibWeb/Painting/ShadowData.h
+++ b/Libraries/LibWeb/Painting/ShadowData.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <LibGfx/Color.h>
+#include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Painting {
@@ -38,14 +39,14 @@ struct ShadowData {
     CSSPixels spread_distance;
     ShadowPlacement placement;
 
-    static ShadowData from_css(CSS::ShadowData const& shadow, Layout::Node const& layout_node)
+    static ShadowData from_css(CSS::ShadowData const& shadow)
     {
         return {
             shadow.color,
-            shadow.offset_x.to_px(layout_node),
-            shadow.offset_y.to_px(layout_node),
-            shadow.blur_radius.to_px(layout_node),
-            shadow.spread_distance.to_px(layout_node),
+            shadow.offset_x,
+            shadow.offset_y,
+            shadow.blur_radius,
+            shadow.spread_distance,
             shadow_placement_from_css(shadow.placement),
         };
     }

--- a/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -74,11 +74,11 @@ Gfx::Path SVGCircleElement::get_path(CSSPixelSize viewport_size)
         return {};
     }
 
-    auto cx = float(node->computed_values().cx().to_px(*node, viewport_size.width()));
-    auto cy = float(node->computed_values().cy().to_px(*node, viewport_size.height()));
+    auto cx = float(node->computed_values().cx().to_px(viewport_size.width()));
+    auto cy = float(node->computed_values().cy().to_px(viewport_size.height()));
     // Percentages refer to the normalized diagonal of the current SVG viewport
     // (see Units: https://svgwg.org/svg2-draft/coords.html#Units)
-    auto r = float(node->computed_values().r().to_px(*node, normalized_diagonal_length(viewport_size)));
+    auto r = float(node->computed_values().r().to_px(normalized_diagonal_length(viewport_size)));
 
     // A zero radius disables rendering.
     if (r == 0)

--- a/Libraries/LibWeb/SVG/SVGFEImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGFEImageElement.cpp
@@ -103,16 +103,16 @@ Optional<Gfx::IntRect> SVGFEImageElement::content_rect() const
     auto layout_node = this->unsafe_layout_node();
     if (!layout_node)
         return {};
-    auto width = layout_node->computed_values().width().to_px(*layout_node, 0);
+    auto width = layout_node->computed_values().width().to_px(0);
     if (width == 0)
         width = bitmap->width();
 
-    auto height = layout_node->computed_values().height().to_px(*layout_node, 0);
+    auto height = layout_node->computed_values().height().to_px(0);
     if (height == 0)
         height = bitmap->height();
 
-    auto x = layout_node->computed_values().x().to_px(*layout_node, 0);
-    auto y = layout_node->computed_values().y().to_px(*layout_node, 0);
+    auto x = layout_node->computed_values().x().to_px(0);
+    auto y = layout_node->computed_values().y().to_px(0);
     return Gfx::enclosing_int_rect({ x, y, width, height });
 }
 

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -293,12 +293,12 @@ float SVGGraphicsElement::resolve_relative_to_viewport_size(CSS::LengthPercentag
     CSSPixels viewport_height = 0;
     if (auto* svg_svg_element = first_flat_tree_ancestor_of_type<SVGSVGElement>()) {
         if (auto svg_svg_layout_node = svg_svg_element->unsafe_layout_node()) {
-            viewport_width = svg_svg_layout_node->computed_values().width().to_px(*svg_svg_layout_node, 0);
-            viewport_height = svg_svg_layout_node->computed_values().height().to_px(*svg_svg_layout_node, 0);
+            viewport_width = svg_svg_layout_node->computed_values().width().to_px(0);
+            viewport_height = svg_svg_layout_node->computed_values().height().to_px(0);
         }
     }
     auto scaled_viewport_size = (viewport_width + viewport_height) * CSSPixels(0.5);
-    return length_percentage.to_px(*unsafe_layout_node(), scaled_viewport_size).to_double();
+    return length_percentage.to_px(scaled_viewport_size).to_double();
 }
 
 Vector<float> SVGGraphicsElement::stroke_dasharray() const

--- a/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
@@ -71,9 +71,17 @@ TextPositioning SVGTextPositioningElement::text_positioning() const
     auto resolve_value = [&](FlyString const& attribute) -> Vector<TextPositioning::Position> {
         auto raw_value = get_attribute_value(attribute);
 
+        CSS::ComputationContext computation_context {
+            .length_resolution_context = CSS::Length::ResolutionContext::for_element(*this),
+            .abstract_element = *this,
+            // NB: color_scheme is irrelevant for resolving text positioning attribute values so isn't set.
+        };
+
+        // FIXME: Should we support tree-counting and/or calculated values here?
+
         auto style_value = parse_css_type(parsing_params, raw_value, CSS::ValueType::LengthPercentage);
         if (auto const* length_style_value = as_if<CSS::LengthStyleValue>(style_value.ptr()))
-            return { CSS::LengthPercentage::from_style_value(*length_style_value) };
+            return { CSS::LengthPercentage::from_style_value(*length_style_value->absolutized(computation_context)) };
 
         if (auto const* percentage_style_value = as_if<CSS::PercentageStyleValue>(style_value.ptr()))
             return { CSS::LengthPercentage::from_style_value(*percentage_style_value) };

--- a/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
+++ b/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
@@ -23,7 +23,7 @@ struct TextPositioning {
     Vector<Position> dy;
     Vector<float> rotate;
 
-    void apply_to_text_position(Layout::Node const& node, CSSPixelSize viewport, Gfx::FloatPoint& current_text_position, size_t character_index) const
+    void apply_to_text_position(CSSPixelSize viewport, Gfx::FloatPoint& current_text_position, size_t character_index) const
     {
         auto value_for_character = [&](Vector<Position> const& values) -> float {
             if (values.is_empty())
@@ -34,7 +34,7 @@ struct TextPositioning {
                 [](CSS::Number const& number) { return static_cast<float>(number.value()); },
                 [&](CSS::LengthPercentage const& length_percentage) {
                     auto reference = &values == &x || &values == &dx ? viewport.width() : viewport.height();
-                    return length_percentage.to_px(node, reference).to_float();
+                    return length_percentage.to_px(reference).to_float();
                 });
         };
 

--- a/Tests/LibWeb/Text/expected/interpolation-longhand-properties.txt
+++ b/Tests/LibWeb/Text/expected/interpolation-longhand-properties.txt
@@ -7,7 +7,7 @@ At time 400:
   background-repeat: repeat-x
   border-radius: 40.000001px 60.000001px 80.000001px 100.000001px
   bottom: auto
-  box-shadow: rgb(153, 0, 102) 40.000001px 80.000001px 126.000002px 0px inset, rgba(0, 0, 255, 0.4) 20px 4px 8px 12px
+  box-shadow: rgb(153, 0, 102) 40px 80px 126px 0px inset, rgba(0, 0, 255, 0.4) 20px 4px 8px 12px
   color: rgb(153, 0, 102)
   transform: matrix(1, 0, 0, 1, 40, 40)
 


### PR DESCRIPTION
Lengths are absolutized at computed value time so we don't need to reabsolutize them again later.

- Swaps `Length` for `CSSPixels` in `ComputedValues` members.
- Assumes lengths in `LengthPercentage`, `LengthPercentageOrAuto`, and `LengthOrAuto` are absolute. We should update these to store CSSPixels directly but that's left as FIXMEs for now.

See individual commits for details.