### PR TITLE
UI/Qt: Refresh the resize cursor over the native presentation window

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -600,6 +600,10 @@ void BrowserWindow::initialize_tab(Tab* tab)
             new_tab_from_url(ak_url_from_qurl(urls[i]), Web::HTML::ActivateTab::No);
     });
 
+    QObject::connect(&tab->view(), &WebContentView::native_window_pointer_event, this, [this] {
+        refresh_resize_cursor_at_current_position();
+    });
+
     tab->view().on_new_web_view = [this, tab](auto activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) {
         if (hints.popup) {
             WindowConfiguration configuration {

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -1088,6 +1088,7 @@ bool WebContentView::handle_vulkan_window_event(QEvent* event)
         return true;
     case QEvent::MouseMove:
         mouseMoveEvent(static_cast<QMouseEvent*>(event));
+        emit native_window_pointer_event();
         return true;
     case QEvent::MouseButtonPress:
         mousePressEvent(static_cast<QMouseEvent*>(event));
@@ -1103,6 +1104,7 @@ bool WebContentView::handle_vulkan_window_event(QEvent* event)
         return true;
     case QEvent::Leave:
         leaveEvent(event);
+        emit native_window_pointer_event();
         return true;
     case QEvent::FocusIn:
         focusInEvent(static_cast<QFocusEvent*>(event));

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -108,6 +108,8 @@ public slots:
 signals:
     void urls_dropped(QList<QUrl> const&);
 
+    void native_window_pointer_event();
+
 private:
     // ^WebView::ViewImplementation
     virtual void initialize_client(CreateNewClient) override;


### PR DESCRIPTION
The Linux DMABUF presentation path renders the web content into a native `QVulkanWindow` whose pointer events are delivered as `QWindow` events. These bypass the application-wide BrowserWindow event filter that drives the window-edge resize cursor, so the resize cursor shown when hovering a window edge was never invalidated after the resize. 

We now forward the native window's mouse move and leave events via a signal and refresh the resize cursor in response.