### PR TITLE
LibGC: Decommit used physical memory when Heaps get destroyed

### DIFF
--- a/Libraries/LibGC/CellAllocator.cpp
+++ b/Libraries/LibGC/CellAllocator.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Badge.h>
+#include <AK/NeverDestroyed.h>
 #include <LibGC/BlockAllocator.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/Heap.h>
@@ -12,12 +13,33 @@
 
 namespace GC {
 
+BlockAllocator& CellAllocator::shared_block_allocator()
+{
+    static AK::NeverDestroyed<BlockAllocator> allocator;
+    return *allocator;
+}
+
 CellAllocator::CellAllocator(size_t cell_size, Optional<StringView> class_name, bool overrides_must_survive_garbage_collection, bool overrides_finalize)
     : m_class_name(class_name)
     , m_cell_size(cell_size)
+    , m_block_allocator(shared_block_allocator())
     , m_overrides_must_survive_garbage_collection(overrides_must_survive_garbage_collection)
     , m_overrides_finalize(overrides_finalize)
 {
+}
+
+CellAllocator::~CellAllocator()
+{
+    m_blocks_pending_sweep.clear();
+
+    auto reclaim_all = [this](BlockList& blocks) {
+        while (auto* block = blocks.take_first()) {
+            block->~HeapBlock();
+            m_block_allocator.deallocate_block(block, DeferDecommit::Yes);
+        }
+    };
+    reclaim_all(m_full_blocks);
+    reclaim_all(m_usable_blocks);
 }
 
 CellAllocator& CellAllocatorDescriptorBase::for_heap(Heap& heap)

--- a/Libraries/LibGC/CellAllocator.h
+++ b/Libraries/LibGC/CellAllocator.h
@@ -64,7 +64,9 @@ private:
 class GC_API CellAllocator {
 public:
     CellAllocator(size_t cell_size, Optional<StringView> = {}, bool overrides_must_survive_garbage_collection = false, bool overrides_finalize = false);
-    ~CellAllocator() = default;
+    ~CellAllocator();
+
+    static BlockAllocator& shared_block_allocator();
 
     Optional<StringView> class_name() const { return m_class_name; }
     size_t cell_size() const { return m_cell_size; }
@@ -106,7 +108,7 @@ private:
     Optional<StringView> m_class_name;
     size_t const m_cell_size;
 
-    BlockAllocator m_block_allocator;
+    BlockAllocator& m_block_allocator;
 
     using BlockList = IntrusiveList<&HeapBlock::m_list_node>;
     using SweepBlockList = IntrusiveList<&HeapBlock::m_sweep_list_node>;


### PR DESCRIPTION
This makes sure we don't leak physical memory on the heap-death of the universe, an issue 76f17f77033c997880404686c2b7507a5e289cc7 introduced by changing the lifetime of heaps.