### PR TITLE
LibSandbox: Permit `ioctl(SIOCGIFINDEX)` in the network policy

### DIFF
--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -11,6 +11,7 @@
 #include <linux/audit.h>
 #include <linux/sched.h>
 #include <linux/seccomp.h>
+#include <linux/sockios.h>
 #include <signal.h>
 #include <stddef.h>
 #include <sys/ioctl.h>
@@ -993,6 +994,14 @@ void SeccompPolicy::allow_network()
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, accept);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, accept4);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, shutdown);
+
+    // Required by glibc's if_nametoindex() when resolving IPv6 link-local nameserver scopes.
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_ioctl, 0, 5));
+    append(SECCOMP_LOAD_ARGUMENT(1));
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SIOCGIFINDEX, 0, 1));
+    append(SECCOMP_ALLOW);
+    append(SECCOMP_LOAD_SYSCALL_NR);
+    append(BPF_STMT(BPF_ALU | BPF_ADD | BPF_K, 0));
 }
 
 void SeccompPolicy::allow_memory_without_executable_mappings()


### PR DESCRIPTION
Previously, this caused a sandbox violation.

Fixes #10208

I was able to reproduce the violation reported in the above issue by changing my local `/etc/resolv.conf` to include a link-local IPv6 nameserver. 

Tested by replacing `/etc/resolv.conf` with this:

```
nameserver fe80::1%lo
nameserver 127.0.0.53
options edns0 trust-ad
```