### PR TITLE
LibWeb: Lay out table-cell abspos children after vertical alignment

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1831,13 +1831,20 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
 
 void FormattingContext::layout_absolutely_positioned_children()
 {
+    // TableFormattingContext handles cell abspos layout after vertical alignment.
+    if (context_box().display().is_table_cell())
+        return;
+    layout_absolutely_positioned_children(context_box());
+}
+
+void FormattingContext::layout_absolutely_positioned_children(Box const& box)
+{
     if (m_layout_mode != LayoutMode::Normal)
         return;
-    for (auto& child : context_box().contained_abspos_children()) {
+    for (auto& child : box.contained_abspos_children()) {
         if (!child)
             continue;
-        auto& box = as<Box>(*child);
-        layout_absolutely_positioned_element(box);
+        layout_absolutely_positioned_element(as<Box>(*child));
     }
 }
 

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -223,6 +223,7 @@ protected:
     CSSPixels gap_to_px(Variant<CSS::LengthPercentage, CSS::NormalGap> const& gap, CSSPixels reference_value) const;
 
     void layout_absolutely_positioned_children();
+    void layout_absolutely_positioned_children(Box const&);
     virtual AbsposContainingBlockInfo resolve_abspos_containing_block_info(Box const&);
     void resolve_anchor_insets(Box&) const;
     void compute_width_for_absolutely_positioned_element(Box const&, AvailableSpace const&);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1861,6 +1861,9 @@ void TableFormattingContext::run(AvailableSpace const& available_space)
     position_row_boxes();
     position_cell_boxes();
 
+    for (auto& cell : m_cells)
+        layout_absolutely_positioned_children(cell.box);
+
     m_state.get_mutable(table_box()).set_content_height(m_table_height);
 
     total_captions_height += run_caption_layout(CSS::CaptionSide::Bottom, caption_available_space);

--- a/Tests/LibWeb/Ref/expected/abspos-bottom-inset-in-table-cell-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-bottom-inset-in-table-cell-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/abspos-bottom-inset-in-table-cell.html
+++ b/Tests/LibWeb/Ref/input/abspos-bottom-inset-in-table-cell.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-bottom-inset-in-table-cell-ref.html">
+<style>
+  table {
+    table-layout: fixed;
+    width: 100px;
+    border-spacing: 0;
+  }
+  tr {
+    height: 100px;
+  }
+  td {
+    padding: 0;
+    position: relative;
+    vertical-align: middle;
+  }
+  .bar {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+<table>
+  <tr>
+    <td><div class="bar"></div></td>
+  </tr>
+</table>


### PR DESCRIPTION
Absolutely positioned descendants of a table cell resolve their insets against the cell's padding box. A cell's padding box is enlarged during vertical alignment, which happens after the cell contents is laid out. The cell's inner formatting context previously positioned these abspos children before that adjustment, so insets resolved against a stale, content-sized padding box. We now defer absolute positioning for table cells so insets resolve against the final padding box.

This fixes the layout of tables on https://www.bbc.co.uk/sport/football/tables#FIFAWorldCup:

Before:
<img width="1263" height="588" alt="image" src="https://github.com/user-attachments/assets/6869a296-afca-4fca-b83c-5fb624d7206e" />

After:
<img width="1263" height="588" alt="image" src="https://github.com/user-attachments/assets/3e2487f7-914b-4f78-aa90-fdac88af03ae" />
