### PR TITLE
LibSandbox: Report sandbox violations instead of killing the process

### DIFF
--- a/Libraries/LibSandbox/Sandbox.cpp
+++ b/Libraries/LibSandbox/Sandbox.cpp
@@ -25,7 +25,6 @@
 #    include <errno.h>
 #    include <limits.h>
 #    include <sandbox.h>
-#    include <signal.h>
 #    include <stdlib.h>
 #    include <sys/stat.h>
 #    include <unistd.h>
@@ -211,33 +210,12 @@ static ErrorOr<void> append_allowed_iokit_user_client_classes(StringBuilder& bui
     return {};
 }
 
-static void sandbox_violation_signal_handler(int)
-{
-    char const message[] = "Sandbox violation: terminating process\n";
-    [[maybe_unused]] auto nwritten = write(STDERR_FILENO, message, sizeof(message) - 1);
-    _exit(128 + SIGSYS);
-}
-
-static ErrorOr<void> install_sandbox_violation_signal_handler()
-{
-    struct sigaction action {};
-    action.sa_handler = sandbox_violation_signal_handler;
-    sigemptyset(&action.sa_mask);
-    action.sa_flags = SA_RESETHAND;
-    if (sigaction(SIGSYS, &action, nullptr) < 0)
-        return Error::from_syscall("sigaction(SIGSYS)"sv, errno);
-    return {};
-}
-
 ErrorOr<void> apply_macos_sandbox(ReadonlySpan<SeatbeltPath> paths, NetworkAccess network_access, ReadonlySpan<ByteString> executable_paths, ReadonlySpan<StringView> iokit_user_client_classes)
 {
-    TRY(install_sandbox_violation_signal_handler());
-
     StringBuilder profile;
     TRY(profile.try_append(R"~~~(
 (version 1)
 (deny default
-    (with send-signal SIGSYS)
     (with message "Ladybird macOS sandbox default deny"))
 
 (allow process-info*)


### PR DESCRIPTION
**Problem:** Crash on macOS 15 and 27 beta due to the sandbox code.

**Cause:** A helper symbolizes its own startup backtraces by reading its object files, which pulls in a code-signing check that macOS 15 (and 27?) denies. `send-signal SIGSYS` on the deny-default makes that process-killing fatal.

**Fix:** Drop `send-signal` from the catch-all deny-default, so a violation is just denied+logged (the call returns `EPERM`), rather than fatally killing the process. That matches Chrome and Firefox: both make the deny-default non-fatal. The `syscall-unix SIGKILL` still hard-kills the real vectors.

Hit this on my PR #9156 branch, which adds a GitHub-hosted macOS 15 (Sanitizer) CI job for AppKit+VoiceOver testing.

Also fixes https://github.com/LadybirdBrowser/ladybird/issues/10379, which the issue reporter independently hit in a macOS 27 Golden Gate Developer Beta 2 environment. So perhaps this is somehow not  actually related to the OS version. Or else I guess maybe the made some system change in the 27 beta that flipped it back to how it was in 15.