### PR TITLE
LibRequests+RequestServer: Quiet expected cancellation diagnostics

### DIFF
--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -56,6 +56,8 @@ Request::Request(RequestClient& client, u64 request_id)
 
 bool Request::stop()
 {
+    auto did_stop_request = m_client->stop_request({}, *this);
+
     on_headers_received = nullptr;
     on_finish = nullptr;
     on_certificate_requested = nullptr;
@@ -64,7 +66,7 @@ bool Request::stop()
     m_internal_stream_data = nullptr;
     m_mode = Mode::Unknown;
 
-    return m_client->stop_request({}, *this);
+    return did_stop_request;
 }
 
 void Request::set_request_fd(Badge<Requests::RequestClient>, int fd)

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -467,8 +467,10 @@ Request::Request(
 
 Request::~Request()
 {
-    if (!m_response_buffer.is_eof())
-        dbgln("Warning: Request destroyed with buffered data (it's likely that the client disappeared or the request was cancelled)");
+    if constexpr (REQUESTSERVER_DEBUG) {
+        if (!m_response_buffer.is_eof())
+            dbgln("Warning: Request destroyed with buffered data (it's likely that the client disappeared or the request was cancelled)");
+    }
 
     if (m_curl_easy_handle) {
         auto result = curl_multi_remove_handle(m_curl_multi_handle, m_curl_easy_handle);

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -1245,8 +1245,10 @@ ErrorOr<void> Request::write_queued_bytes_without_blocking()
         m_client_writer_notifier->set_enabled(false);
 
         m_client_writer_notifier->on_activation = weak_callback(*this, [](auto& self) {
-            if (auto result = self.write_queued_bytes_without_blocking(); result.is_error())
-                dbgln("Warning: Failed to write buffered request data (it's likely the client disappeared): {}", result.error());
+            if (auto result = self.write_queued_bytes_without_blocking(); result.is_error()) {
+                self.m_client_writer_notifier->set_enabled(false);
+                dbgln_if(REQUESTSERVER_DEBUG, "Warning: Failed to write buffered request data (it's likely the client disappeared): {}", result.error());
+            }
         });
     }
 


### PR DESCRIPTION
Keep client response pipes alive until RequestServer acknowledges request cancellation, so queued response bytes do not race with WebContent tearing down its stream state.

Also move expected buffered-data and buffered-write diagnostics behind REQUESTSERVER_DEBUG. Media seeks and browser shutdown can legitimately cancel requests while RequestServer still has queued body bytes, and normal builds should not report those paths as warnings.