### PR TITLE
LibWeb: Avoid signed overflow in extreme :nth-child(An+B) matching

### DIFF
--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -1195,9 +1195,10 @@ bool Selector::SimpleSelector::ANPlusBPattern::matches(int index) const
     if (step_size < 0 && offset < 0)
         return false;
 
-    // Like "a % b", but handles negative integers correctly.
-    auto const canonical_modulo = [](int a, int b) -> int {
-        int c = a % b;
+    // Like "a % b", but handles negative integers correctly. Done in 64 bits because "index - offset" and "-step_size"
+    // overflow a 32-bit int for an extreme An+B value such as :nth-child(2n-2147483648).
+    auto const canonical_modulo = [](i64 a, i64 b) -> i64 {
+        i64 c = a % b;
         if ((c < 0 && b > 0) || (c > 0 && b < 0)) {
             c += b;
         }
@@ -1206,10 +1207,10 @@ bool Selector::SimpleSelector::ANPlusBPattern::matches(int index) const
 
     // When "step_size < 0", we start at "offset" and count backwards.
     if (step_size < 0)
-        return index <= offset && canonical_modulo(index - offset, -step_size) == 0;
+        return index <= offset && canonical_modulo(static_cast<i64>(index) - offset, -static_cast<i64>(step_size)) == 0;
 
     // Otherwise, we start at "offset" and count forwards.
-    return index >= offset && canonical_modulo(index - offset, step_size) == 0;
+    return index >= offset && canonical_modulo(static_cast<i64>(index) - offset, step_size) == 0;
 }
 
 // https://drafts.csswg.org/css-syntax-3/#serializing-anb

--- a/Tests/LibWeb/Crash/CSS/nth-child-extreme-anplusb-overflow.html
+++ b/Tests/LibWeb/Crash/CSS/nth-child-extreme-anplusb-overflow.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    /* offset = INT_MIN: overflows "index - offset" */
+    .a > li:nth-child(2n-2147483648) { color: red; }
+    /* step_size = INT_MIN: overflows "-step_size" */
+    .b > li:nth-child(-2147483648n+1) { color: blue; }
+</style>
+<ol class="a"><li>x</li></ol>
+<ol class="b"><li>y</li></ol>
+<script>
+    document.body.offsetTop;
+</script>


### PR DESCRIPTION
**Problem:** Sanitizer build crash with a signed-integer overflow when style is computed for a matching element with an `An+B` selector that uses an extreme A or B, such as `:nth-child(2n-2147483648)`.

**Cause:** `ANPlusBPattern::matches` computed `index - offset` and `-step_size` in 32-bit int. With `offset` or `step_size` at `INT_MIN`, those overflowed — and the modulo could additionally hit the `INT_MIN % -1` UB case.

**Fix:** Compute the subtraction, negation, and modulo in 64 bits. The `An+B` arithmetic is exact — so widening (rather than saturating) keeps matching correct for every 32-bit A and B, while staying in range. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9995.
