### PR TITLE
LibWeb: Saturate math-depth addition to avoid signed overflow

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -4199,12 +4199,12 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_math_depth(NonnullRefPtr<
     // - If the specified value of math-depth is auto-add and the inherited value of math-style is compact
     //   then the computed value of math-depth of the element is its inherited value plus one.
     if (absolutized_value->to_keyword() == Keyword::AutoAdd && inherited_math_style == MathStyle::Compact)
-        return IntegerStyleValue::create(inherited_math_depth + 1);
+        return IntegerStyleValue::create(AK::saturating_add(inherited_math_depth, 1));
 
     // - If the specified value of math-depth is of the form add(<integer>) then the computed value of
     //   math-depth of the element is its inherited value plus the specified integer.
     if (absolutized_value->is_function())
-        return IntegerStyleValue::create(inherited_math_depth + int_from_style_value(absolutized_value->as_function().value()));
+        return IntegerStyleValue::create(AK::saturating_add(inherited_math_depth, int_from_style_value(absolutized_value->as_function().value())));
 
     // - If the specified value of math-depth is of the form <integer> then the computed value of math-depth
     //   of the element is the specified integer.

--- a/Tests/LibWeb/Crash/CSS/math-depth-add-overflow.html
+++ b/Tests/LibWeb/Crash/CSS/math-depth-add-overflow.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+    /* add(<integer>) on an INT_MAX inherited math-depth overflows the addition */
+    #p1 { math-depth: 2147483647; }
+    #c1 { math-depth: add(1); }
+    /* auto-add (with inherited compact math-style) does "inherited + 1" */
+    #p2 { math-style: compact; math-depth: 2147483647; }
+    #c2 { math-depth: auto-add; }
+</style>
+<div id="p1"><div id="c1">x</div></div>
+<div id="p2"><div id="c2">y</div></div>
+<script>
+    document.body.offsetTop;
+</script>


### PR DESCRIPTION
**Problem:** Sanitizer build crash with a signed-integer overflow in a page that pushes math-depth to its integer limit and then adds to it — e.g., `math-depth: 2147483647` on a parent and `math-depth: add(1)` on a child.

**Cause:** `compute_math_depth` added the inherited math-depth to the `add()` amount, overflowing when the inherited value is already near `INT_MAX`.

**Fix:** Use `AK::saturating_add` to clamp to the representable range. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10000.
