### PR TITLE
LibWeb: Avoid INT_MIN negation in createImageData/getImageData

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -687,8 +687,8 @@ WebIDL::ExceptionOr<GC::Ref<ImageData>> CanvasRenderingContext2D::create_image_d
     if (width == 0 || height == 0)
         return WebIDL::IndexSizeError::create(realm(), "Width and height must not be zero"_utf16);
 
-    int abs_width = abs(width);
-    int abs_height = abs(height);
+    int abs_width = width == NumericLimits<int>::min() ? NumericLimits<int>::max() : abs(width);
+    int abs_height = height == NumericLimits<int>::min() ? NumericLimits<int>::max() : abs(height);
 
     // 2. Let newImageData be a new ImageData object.
     // 3. Initialize newImageData given the absolute magnitude of sw, the absolute magnitude of sh, settings set to settings, and defaultColorSpace set to this's color space.
@@ -726,8 +726,8 @@ WebIDL::ExceptionOr<GC::Ptr<ImageData>> CanvasRenderingContext2D::get_image_data
 
     // ImageData initialization requires positive width and height
     // https://html.spec.whatwg.org/multipage/canvas.html#initialize-an-imagedata-object
-    int abs_width = abs(width);
-    int abs_height = abs(height);
+    int abs_width = width == NumericLimits<int>::min() ? NumericLimits<int>::max() : abs(width);
+    int abs_height = height == NumericLimits<int>::min() ? NumericLimits<int>::max() : abs(height);
 
     // 3. Let imageData be a new ImageData object.
     // 4. Initialize imageData given sw, sh, settings set to settings, and defaultColorSpace set to this's color space.

--- a/Tests/LibWeb/Crash/HTML/canvas-image-data-int-min-dimension.html
+++ b/Tests/LibWeb/Crash/HTML/canvas-image-data-int-min-dimension.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script>
+    const INT_MIN = -2147483648;
+    const ctx = document.createElement("canvas").getContext("2d");
+    for (const [w, h] of [[INT_MIN, 1], [1, INT_MIN], [INT_MIN, INT_MIN]]) {
+        try { ctx.createImageData(w, h); } catch (e) {}
+        try { ctx.getImageData(0, 0, w, h); } catch (e) {}
+    }
+</script>


### PR DESCRIPTION
**Problem:** Sanitizer build crash with a page that calls `createImageData` or `getImageData` with `INT_MIN` as a width or height.

**Cause:** Both functions took the absolute value of the requested width and height with `abs()` — but `abs()` is undefined for `INT_MIN`.

**Fix:** Just treat an `INT_MIN` dimension as `INT_MAX` instead of calling `abs()` on it. That’s still way too large to allocate — so the existing size check throws an `IndexSizeError`, exactly as the true magnitude would. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9993.
