### PR TITLE
LibWeb: Don’t bind a null Element when validating a CSSNumberish time

### DIFF
--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -14,6 +14,8 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSAnimation.h>
 #include <LibWeb/CSS/CSSNumericValue.h>
+#include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/StyleValues/ComputationContext.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
@@ -266,7 +268,13 @@ WebIDL::ExceptionOr<Optional<TimeValue>> Animation::validate_a_css_numberish_tim
 
     // FIXME: Figure out which element we should use for this, for now we just use the document element of the current
     //        window
-    return TimeValue::from_css_numberish(time.downcast<double, GC::Ref<CSS::CSSNumericValue>>(), DOM::AbstractElement { *as<HTML::Window>(realm().global_object()).associated_document().document_element() });
+    auto& document = as<HTML::Window>(realm().global_object()).associated_document();
+    CSS::ComputationContext computation_context {
+        .length_resolution_context = CSS::Length::ResolutionContext::for_document(document),
+    };
+    if (auto const* document_element = document.document_element())
+        computation_context.abstract_element = DOM::AbstractElement { *document_element };
+    return TimeValue::from_css_numberish(time.downcast<double, GC::Ref<CSS::CSSNumericValue>>(), computation_context);
 
     VERIFY_NOT_REACHED();
 }

--- a/Libraries/LibWeb/Animations/TimeValue.cpp
+++ b/Libraries/LibWeb/Animations/TimeValue.cpp
@@ -7,11 +7,12 @@
 #include "TimeValue.h"
 #include <LibWeb/Animations/AnimationTimeline.h>
 #include <LibWeb/CSS/CSSUnitValue.h>
+#include <LibWeb/CSS/CalculationResolutionContext.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 
 namespace Web::Animations {
 
-TimeValue TimeValue::from_css_numberish(CSS::CSSNumberish const& time, DOM::AbstractElement const& abstract_element)
+TimeValue TimeValue::from_css_numberish(CSS::CSSNumberish const& time, CSS::ComputationContext const& computation_context)
 {
     if (time.has<double>())
         return { Type::Milliseconds, time.get<double>() };
@@ -38,10 +39,7 @@ TimeValue TimeValue::from_css_numberish(CSS::CSSNumberish const& time, DOM::Abst
 
     auto style_value = CSS::CalculatedStyleValue::create(calculation_node, calculation_node->numeric_type().value(), {});
 
-    CSS::CalculationResolutionContext calculation_resolution_context {
-        .length_resolution_context = CSS::Length::ResolutionContext::for_element(abstract_element),
-        .abstract_element = abstract_element,
-    };
+    auto calculation_resolution_context = CSS::CalculationResolutionContext::from_computation_context(computation_context);
 
     if (style_value->resolves_to_number())
         return { Type::Milliseconds, style_value->resolve_number(calculation_resolution_context).value() };

--- a/Libraries/LibWeb/Animations/TimeValue.h
+++ b/Libraries/LibWeb/Animations/TimeValue.h
@@ -12,7 +12,7 @@
 namespace Web::Animations {
 
 struct TimeValue {
-    static TimeValue from_css_numberish(CSS::CSSNumberish const&, DOM::AbstractElement const&);
+    static TimeValue from_css_numberish(CSS::CSSNumberish const&, CSS::ComputationContext const&);
     static TimeValue create_zero(GC::Ptr<AnimationTimeline> const& timeline);
 
     enum class Type : u8 {

--- a/Tests/LibWeb/Crash/CSS/animation-start-time-without-document-element.html
+++ b/Tests/LibWeb/Crash/CSS/animation-start-time-without-document-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+        const html = document.documentElement;
+        html.remove();
+        // With no document element, there's nothing to resolve a CSSNumberish start time against; setting one must not crash.
+        const animation = new Animation();
+        animation.startTime = new CSSMathSum(1, 2);
+        // Restore the document element, so the page can finish loading.
+        document.appendChild(html);
+    });
+</script>


### PR DESCRIPTION
**Problem:** Sanitizer build crash when setting an animation’s start/current time to a `CSSNumericValue` after the document element has been removed.

**Cause:** `validate_a_css_numberish_time` dereferenced `document_element()` without any null check.

**Fix:** Build a `ComputationContext` in `validate_a_css_numberish_time`, and pass it to `from_css_numberish`. The length context resolves against the document — so a removed document element no longer crashes. The element is attached only when it exists. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10007.
