### PR TITLE
LibWeb/DOM: Address infinite loop in TreeWalker's nextNode()

### DIFF
--- a/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -214,27 +214,25 @@ JS::ThrowCompletionOr<GC::Ptr<Node>> TreeWalker::next_node()
             // 2. Set sibling to temporary’s next sibling.
             sibling = temporary->next_sibling();
 
-            // 3. If sibling is non-null, then set node to sibling and break.
-            if (sibling) {
-                node = *sibling;
+            // 3. If sibling is non-null, then break.
+            if (sibling)
                 break;
-            }
 
             // 4. Set temporary to temporary’s parent.
             temporary = temporary->parent();
-
-            // NON-STANDARD: If temporary is null, then return null.
-            //               This prevents us from infinite looping if the current node is not connected.
-            //               Spec bug: https://github.com/whatwg/dom/issues/1102
-            if (temporary == nullptr) {
-                return nullptr;
-            }
         }
 
-        // 5. Set result to the result of filtering node within this.
+        // 5. If sibling is null, then return null.
+        if (!sibling)
+            return nullptr;
+
+        // 6. Set node to sibling.
+        node = *sibling;
+
+        // 7. Set result to the result of filtering node within this.
         result = TRY(filter(*node));
 
-        // 6. If result is FILTER_ACCEPT, then set this’s current to node and return node.
+        // 8. If result is FILTER_ACCEPT, then set this’s current to node and return node.
         if (result == NodeFilter::Result::FILTER_ACCEPT) {
             m_current = *node;
             return node;

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/TreeWalker-nextNode-detached-currentNode.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/TreeWalker-nextNode-detached-currentNode.window.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	nextNode() returns null when currentNode is a detached element with no descendants and whatToShow does not match it
+Pass	nextNode() returns null after exhausting a detached subtree
+Pass	nextNode() terminates when iterating over template.content not under the walker's root

--- a/Tests/LibWeb/Text/input/wpt-import/dom/traversal/TreeWalker-nextNode-detached-currentNode.window.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/traversal/TreeWalker-nextNode-detached-currentNode.window.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../dom/traversal/TreeWalker-nextNode-detached-currentNode.window.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/traversal/TreeWalker-nextNode-detached-currentNode.window.js
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/traversal/TreeWalker-nextNode-detached-currentNode.window.js
@@ -1,0 +1,27 @@
+test(() => {
+  const detached = document.createElement("div");
+  const walker = document.createTreeWalker(document, 0, null);
+  walker.currentNode = detached;
+  assert_equals(walker.nextNode(), null);
+}, "nextNode() returns null when currentNode is a detached element with no descendants and whatToShow does not match it");
+
+test(() => {
+  const detached = document.createElement("div");
+  detached.appendChild(document.createElement("span"));
+  const walker = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT, null);
+  walker.currentNode = detached;
+  assert_equals(walker.nextNode(), detached.firstChild);
+  assert_equals(walker.nextNode(), null);
+}, "nextNode() returns null after exhausting a detached subtree");
+
+test(() => {
+  const template = document.createElement("template");
+  template.innerHTML = "text<div></div>text";
+  const walker = document.createTreeWalker(
+    document,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT,
+    null);
+  walker.currentNode = template.content;
+  assert_equals(walker.nextNode(), template.content.children[0]);
+  assert_equals(walker.nextNode(), null);
+}, "nextNode() terminates when iterating over template.content not under the walker's root");


### PR DESCRIPTION
Corresponds to: https://github.com/whatwg/dom/commit/e1e7699ff74d4de11d765668b334644e3efe9641

Imported the associated WPT test too.