### PR TITLE
RequestServer+LibTLS: Read root certificates into memory pre-sandbox

### DIFF
--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -19,9 +19,33 @@
 
 #include <openssl/bio.h>
 #include <openssl/err.h>
+#include <openssl/pem.h>
 #include <openssl/ssl.h>
+#include <openssl/x509.h>
 
 namespace TLS {
+
+static ErrorOr<void> add_root_certificates_from_blob(SSL_CTX* ssl_ctx, ReadonlyBytes blob)
+{
+    auto* bio = OPENSSL_TRY_PTR(BIO_new_mem_buf(blob.data(), static_cast<int>(blob.size())));
+    ScopeGuard free_bio = [&] { BIO_free(bio); };
+
+    auto* store = SSL_CTX_get_cert_store(ssl_ctx);
+
+    size_t certificates_added = 0;
+    while (auto* certificate = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr)) {
+        if (X509_STORE_add_cert(store, certificate) == 1)
+            ++certificates_added;
+        X509_free(certificate);
+    }
+
+    ERR_clear_error();
+
+    if (certificates_added == 0)
+        return Error::from_string_literal("No certificates found in root certificate bundle");
+
+    return {};
+}
 
 ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect(ByteString const& host, u16 port, Options options)
 {
@@ -220,6 +244,8 @@ ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect_internal(NonnullOwnPtr<Core::TCPS
     if (options.root_certificates_path.has_value()) {
         auto path = options.root_certificates_path.value();
         SSL_CTX_load_verify_file(ssl_ctx, path.characters());
+    } else if (options.root_certificates_blob.has_value()) {
+        TRY(add_root_certificates_from_blob(ssl_ctx, *options.root_certificates_blob));
     } else {
         // Use the default trusted certificate store
 #if defined(AK_OS_WINDOWS)

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -15,6 +15,7 @@ namespace TLS {
 
 struct Options {
     Optional<ByteString> root_certificates_path;
+    Optional<ReadonlyBytes> root_certificates_blob;
 };
 
 class TLSv12 final : public Core::Socket {

--- a/Services/RequestServer/CURL.cpp
+++ b/Services/RequestServer/CURL.cpp
@@ -7,6 +7,9 @@
 
 #include <AK/Enumerate.h>
 #include <AK/Format.h>
+#include <AK/ScopeGuard.h>
+#include <LibCore/Environment.h>
+#include <LibCore/File.h>
 #include <RequestServer/CURL.h>
 
 namespace RequestServer {
@@ -19,6 +22,60 @@ ErrorOr<void> initialize_libcurl()
         return Error::from_string_literal("Failed to initialize libcurl");
     }
     return {};
+}
+
+static Optional<ByteString> resolve_default_root_certificate_bundle_path()
+{
+    if (auto value = Core::Environment::get("CURL_CA_BUNDLE"sv); value.has_value() && !value->is_empty())
+        return value->to_byte_string();
+    if (auto value = Core::Environment::get("SSL_CERT_FILE"sv); value.has_value() && !value->is_empty())
+        return value->to_byte_string();
+
+    auto* easy_handle = curl_easy_init();
+    if (!easy_handle)
+        return {};
+    ScopeGuard cleanup = [&] { curl_easy_cleanup(easy_handle); };
+
+    char* ca_info = nullptr;
+    if (curl_easy_getinfo(easy_handle, CURLINFO_CAINFO, &ca_info) == CURLE_OK && ca_info && *ca_info)
+        return ByteString { ca_info };
+
+    return {};
+}
+
+static ErrorOr<ByteBuffer> read_certificate_files(Vector<ByteString> const& paths)
+{
+    ByteBuffer bundle;
+
+    for (auto const& path : paths) {
+        auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
+        auto contents = TRY(file->read_until_eof());
+        TRY(bundle.try_append(contents));
+
+        // Concatenated PEM blocks must be newline-separated to remain individually parseable.
+        if (!bundle.is_empty() && bundle[bundle.size() - 1] != '\n')
+            TRY(bundle.try_append("\n", 1));
+    }
+
+    return bundle;
+}
+
+ErrorOr<ByteBuffer> read_default_root_certificate_bundle(Vector<ByteString> const& certificate_overrides)
+{
+    if (!certificate_overrides.is_empty())
+        return read_certificate_files(certificate_overrides);
+
+    auto bundle_path = resolve_default_root_certificate_bundle_path();
+    if (!bundle_path.has_value())
+        return ByteBuffer {};
+
+    auto file = Core::File::open(*bundle_path, Core::File::OpenMode::Read);
+    if (file.is_error()) {
+        warnln("RequestServer: Unable to open root certificate bundle '{}': {}", *bundle_path, file.error());
+        return ByteBuffer {};
+    }
+
+    return TRY(file.value()->read_until_eof());
 }
 
 ByteString build_curl_resolve_list(DNS::LookupResult const& dns_result, StringView host, u16 port)

--- a/Services/RequestServer/CURL.h
+++ b/Services/RequestServer/CURL.h
@@ -9,9 +9,11 @@
 
 // Include this header instead of <curl/curl.h>. Only include this header from .cpp files.
 
+#include <AK/ByteBuffer.h>
 #include <AK/ByteString.h>
 #include <AK/Error.h>
 #include <AK/StringView.h>
+#include <AK/Vector.h>
 #include <LibDNS/Resolver.h>
 #include <LibRequests/NetworkError.h>
 
@@ -26,5 +28,7 @@ namespace RequestServer {
 ByteString build_curl_resolve_list(DNS::LookupResult const& dns_result, StringView host, u16 port);
 Requests::NetworkError curl_code_to_network_error(int code);
 ErrorOr<void> initialize_libcurl();
+
+ErrorOr<ByteBuffer> read_default_root_certificate_bundle(Vector<ByteString> const& certificate_overrides);
 
 }

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -602,9 +602,6 @@ void ConnectionFromClient::websocket_connect(u64 websocket_id, URL::URL url, Byt
             connection_info.set_headers(HTTP::HeaderList::create(move(additional_request_headers)));
             connection_info.set_dns_result(move(dns_result));
 
-            if (auto const& path = default_certificate_path(); !path.is_empty())
-                connection_info.set_root_certificates_path(path);
-
             auto impl = WebSocketImplCurl::create(self->m_curl_multi);
             auto connection = WebSocket::WebSocket::create(move(connection_info), move(impl));
 

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -926,8 +926,14 @@ void Request::handle_fetch_state()
 
     set_option(CURLOPT_NOSIGNAL, 1L);
 
-    if (auto const& path = default_certificate_path(); !path.is_empty())
-        set_option(CURLOPT_CAINFO, path.characters());
+    if (auto const& bundle = root_certificate_bundle(); !bundle.is_empty()) {
+        curl_blob ca_info_blob {
+            .data = const_cast<u8*>(bundle.data()),
+            .len = bundle.size(),
+            .flags = CURL_BLOB_NOCOPY,
+        };
+        set_option(CURLOPT_CAINFO_BLOB, &ca_info_blob);
+    }
 
     set_option(CURLOPT_ACCEPT_ENCODING, ""); // Empty string lets curl define the accepted encodings.
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());

--- a/Services/RequestServer/Resolver.cpp
+++ b/Services/RequestServer/Resolver.cpp
@@ -10,16 +10,16 @@
 
 namespace RequestServer {
 
-static ByteString g_default_certificate_path;
+static ByteBuffer g_root_certificate_bundle;
 
-ByteString const& default_certificate_path()
+ByteBuffer const& root_certificate_bundle()
 {
-    return g_default_certificate_path;
+    return g_root_certificate_bundle;
 }
 
-void set_default_certificate_path(ByteString default_certificate_path)
+void set_root_certificate_bundle(ByteBuffer root_certificate_bundle)
 {
-    g_default_certificate_path = move(default_certificate_path);
+    g_root_certificate_bundle = move(root_certificate_bundle);
 }
 
 DNSInfo& DNSInfo::the()
@@ -53,8 +53,8 @@ NonnullRefPtr<Resolver> Resolver::default_resolver()
         if (dns_info.use_dns_over_tls) {
             TLS::Options options;
 
-            if (!g_default_certificate_path.is_empty())
-                options.root_certificates_path = g_default_certificate_path;
+            if (auto const& bundle = g_root_certificate_bundle; !bundle.is_empty())
+                options.root_certificates_blob = bundle.bytes();
 
             return DNS::Resolver::SocketResult {
                 MaybeOwned<Core::Socket>(TRY(TLS::TLSv12::connect(*dns_info.server_address, *dns_info.server_hostname, move(options)))),

--- a/Services/RequestServer/Resolver.h
+++ b/Services/RequestServer/Resolver.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/Optional.h>
 #include <AK/RefCounted.h>
 #include <AK/Weakable.h>
@@ -39,7 +40,7 @@ private:
     explicit Resolver(Function<ErrorOr<DNS::Resolver::SocketResult>()> create_socket);
 };
 
-ByteString const& default_certificate_path();
-void set_default_certificate_path(ByteString);
+ByteBuffer const& root_certificate_bundle();
+void set_root_certificate_bundle(ByteBuffer);
 
 }

--- a/Services/RequestServer/Sandbox.h
+++ b/Services/RequestServer/Sandbox.h
@@ -6,12 +6,11 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/Error.h>
-#include <AK/Vector.h>
+#include <AK/StringView.h>
 
 namespace RequestServer {
 
-[[nodiscard]] ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates, StringView cache_path);
+[[nodiscard]] ErrorOr<void> apply_sandbox(StringView cache_path);
 
 }

--- a/Services/RequestServer/SandboxLinux.cpp
+++ b/Services/RequestServer/SandboxLinux.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <LibCore/Directory.h>
 #include <LibSandbox/Sandbox.h>
@@ -13,7 +12,7 @@
 
 namespace RequestServer {
 
-ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates, StringView cache_path)
+ErrorOr<void> apply_sandbox(StringView cache_path)
 {
     TRY(Sandbox::install_no_new_privileges());
     TRY(Sandbox::configure_runtime());
@@ -21,20 +20,11 @@ ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates, StringView c
     Vector<Sandbox::LandlockPath> paths;
     TRY(Core::Directory::create(cache_path, Core::Directory::CreateDirectories::Yes));
 
-    TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/ssl"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/host.conf"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/hosts"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/nsswitch.conf"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/resolv.conf"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/run/systemd/resolve"sv, Sandbox::LandlockPath::Access::ReadOnly));
-
-    for (auto const& certificate : certificates) {
-        auto certificate_path = LexicalPath::dirname(certificate);
-        if (certificate_path.is_empty())
-            certificate_path = ".";
-
-        TRY(Sandbox::add_landlock_path_if_exists(paths, certificate_path, Sandbox::LandlockPath::Access::ReadOnly));
-    }
 
     TRY(Sandbox::add_landlock_path_if_exists(paths, cache_path, Sandbox::LandlockPath::Access::ReadWrite));
 

--- a/Services/RequestServer/SandboxMacOS.cpp
+++ b/Services/RequestServer/SandboxMacOS.cpp
@@ -14,7 +14,7 @@
 
 namespace RequestServer {
 
-ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates, StringView cache_path)
+ErrorOr<void> apply_sandbox(StringView cache_path)
 {
     TRY(Sandbox::configure_runtime());
 
@@ -33,16 +33,7 @@ ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates, StringView c
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, "/etc/resolv.conf"sv, Sandbox::SeatbeltPath::Access::ReadOnly));
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, "/private/etc/hosts"sv, Sandbox::SeatbeltPath::Access::ReadOnly));
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, "/private/etc/resolv.conf"sv, Sandbox::SeatbeltPath::Access::ReadOnly));
-    TRY(Sandbox::add_seatbelt_path_if_exists(paths, "/private/etc/ssl"sv, Sandbox::SeatbeltPath::Access::ReadOnly));
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, "/Library/Preferences/com.apple.networkd.plist"sv, Sandbox::SeatbeltPath::Access::ReadOnly));
-
-    for (auto const& certificate : certificates) {
-        auto certificate_path = LexicalPath::dirname(certificate);
-        if (certificate_path.is_empty())
-            certificate_path = ".";
-
-        TRY(Sandbox::add_seatbelt_path_if_exists(paths, certificate_path, Sandbox::SeatbeltPath::Access::ReadOnly));
-    }
 
     if (g_resource_substitution_map) {
         TRY(g_resource_substitution_map->for_each_substitution([&](auto const& substitution) -> ErrorOr<void> {

--- a/Services/RequestServer/SandboxUnimplemented.cpp
+++ b/Services/RequestServer/SandboxUnimplemented.cpp
@@ -8,7 +8,7 @@
 
 namespace RequestServer {
 
-ErrorOr<void> apply_sandbox(Vector<ByteString> const&, StringView)
+ErrorOr<void> apply_sandbox(StringView)
 {
     return {};
 }

--- a/Services/RequestServer/WebSocketImplCurl.cpp
+++ b/Services/RequestServer/WebSocketImplCurl.cpp
@@ -7,6 +7,7 @@
 #include <LibCore/Notifier.h>
 #include <RequestServer/CURL.h>
 #include <RequestServer/ConnectionFromClient.h>
+#include <RequestServer/Resolver.h>
 #include <RequestServer/WebSocketImplCurl.h>
 
 namespace RequestServer {
@@ -71,8 +72,14 @@ void WebSocketImplCurl::connect(WebSocket::ConnectionInfo const& info)
     set_option(CURLOPT_PORT, url.port_or_default());
     set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
 
-    if (auto root_certs = info.root_certificates_path(); root_certs.has_value())
-        set_option(CURLOPT_CAINFO, root_certs->characters());
+    if (auto const& bundle = root_certificate_bundle(); !bundle.is_empty()) {
+        curl_blob ca_info_blob {
+            .data = const_cast<u8*>(bundle.data()),
+            .len = bundle.size(),
+            .flags = CURL_BLOB_NOCOPY,
+        };
+        set_option(CURLOPT_CAINFO_BLOB, &ca_info_blob);
+    }
 
     auto const origin_header = ByteString::formatted("Origin: {}", info.origin());
     curl_slist* curl_headers = curl_slist_append(nullptr, origin_header.characters());

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/Format.h>
+#include <AK/Optional.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
@@ -61,10 +62,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     if (wait_for_debugger)
         Core::Process::wait_for_debugger_and_break();
 
-    // FIXME: Update RequestServer to support multiple custom root certificates.
-    if (!certificates.is_empty())
-        RequestServer::set_default_certificate_path(certificates.first());
-
     if (!resource_map_path.is_empty()) {
         auto map = RequestServer::ResourceSubstitutionMap::load_from_file(resource_map_path);
         if (map.is_error())
@@ -105,8 +102,13 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     TRY(RequestServer::initialize_libcurl());
 
+    if (auto bundle = RequestServer::read_default_root_certificate_bundle(certificates); bundle.is_error())
+        warnln("Unable to read root certificate bundle: {}", bundle.error());
+    else
+        RequestServer::set_root_certificate_bundle(bundle.release_value());
+
     if (!disable_sandbox)
-        TRY(RequestServer::apply_sandbox(certificates, cache_path));
+        TRY(RequestServer::apply_sandbox(cache_path));
 
     // Connections are stored on the stack to ensure they are destroyed before static destruction begins. This prevents
     // crashes from notifiers trying to unregister from already-destroyed thread data during process exit.


### PR DESCRIPTION
We now read the certificate bundle into memory before the sandbox is applied, following any symlinks while the filesystem is still reachable. We hand the bundle curl via `CURLOPT_CAINFO_BLOB`. The system trust store is therefore no longer accessed after sandboxing.

Because CURLOPT_CAINFO_BLOB accepts a concatenated PEM bundle, multiple custom root certificates passed via `-C` are now supported by combining their contents, which the single-file `CURLOPT_CAINFO` could not do.

Fixes #10241