### PR TITLE
UI: Add deep links for settings dialogs and a shortcut to clear browsing history

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -732,6 +732,8 @@
         <script src="resource://ladybird/about-pages/settings/tabs.js" type="module"></script>
 
         <script type="module">
+            import { tabForDeepLink } from "resource://ladybird/about-pages/settings/dialog-deep-link.js";
+
             function switchTab(name) {
                 const button = document.querySelector(`.tab-button[data-tab="${name}"]`);
                 const panel = document.getElementById(`tab-${name}`);
@@ -755,7 +757,7 @@
 
             const hash = location.hash.slice(1);
             if (hash) {
-                switchTab(hash);
+                switchTab(tabForDeepLink(hash));
             }
 
             // FIXME: Remove this once closedby="any" triggers for Esc key.

--- a/Base/res/ladybird/about-pages/settings/dialog-deep-link.js
+++ b/Base/res/ladybird/about-pages/settings/dialog-deep-link.js
@@ -1,0 +1,54 @@
+const REGISTRY = new Map();
+let globalListenersInstalled = false;
+
+function syncDialogs() {
+    if (!window.ladybird) {
+        return;
+    }
+
+    const activeHash = location.hash.slice(1);
+
+    for (const [hash, { dialog, onOpen }] of REGISTRY) {
+        const shouldBeOpen = hash === activeHash;
+        if (shouldBeOpen && !dialog.open) {
+            onOpen?.();
+            if (!dialog.open) {
+                dialog.showModal();
+            }
+        } else if (!shouldBeOpen && dialog.open) {
+            dialog.close();
+        }
+    }
+}
+
+export function registerDialogDeepLink({ hash, tab, dialog, onOpen }) {
+    REGISTRY.set(hash, { tab, dialog, onOpen });
+
+    dialog.addEventListener("close", () => {
+        if (location.hash.slice(1) === hash) {
+            history.back();
+        }
+    });
+
+    if (globalListenersInstalled) {
+        return;
+    }
+    globalListenersInstalled = true;
+
+    window.addEventListener("hashchange", syncDialogs);
+
+    document.addEventListener("WebUILoaded", () => {
+        const hash = location.hash.slice(1);
+        const config = REGISTRY.get(hash);
+        if (!config) {
+            return;
+        }
+
+        history.replaceState(null, "", `#${config.tab}`);
+        location.hash = hash;
+    });
+}
+
+export function tabForDeepLink(hash) {
+    return REGISTRY.get(hash)?.tab ?? hash;
+}

--- a/Base/res/ladybird/about-pages/settings/languages.js
+++ b/Base/res/ladybird/about-pages/settings/languages.js
@@ -1,3 +1,5 @@
+import { registerDialogDeepLink } from "./dialog-deep-link.js";
+
 const languagesAdd = document.querySelector("#languages-add");
 const languagesClose = document.querySelector("#languages-close");
 const languagesDialog = document.querySelector("#languages-dialog");
@@ -5,7 +7,7 @@ const languagesList = document.querySelector("#languages-list");
 const languagesSelect = document.querySelector("#languages-select");
 const languagesSettings = document.querySelector("#languages-settings");
 
-let LANGUAGES = {};
+let LANGUAGES = [];
 
 function loadSettings(settings) {
     LANGUAGES = settings.languages;
@@ -137,9 +139,15 @@ languagesSelect.addEventListener("change", () => {
     languagesAdd.disabled = !languagesSelect.value;
 });
 
-languagesSettings.addEventListener("click", event => {
-    showLanguages();
-    event.stopPropagation();
+registerDialogDeepLink({
+    hash: "languages",
+    tab: "general",
+    dialog: languagesDialog,
+    onOpen: showLanguages,
+});
+
+languagesSettings.addEventListener("click", () => {
+    location.hash = "languages";
 });
 
 document.addEventListener("WebUILoaded", () => {

--- a/Base/res/ladybird/about-pages/settings/permissions.js
+++ b/Base/res/ladybird/about-pages/settings/permissions.js
@@ -1,3 +1,5 @@
+import { registerDialogDeepLink } from "./dialog-deep-link.js";
+
 const siteSettings = document.querySelector("#site-settings");
 const siteSettingsAdd = document.querySelector("#site-settings-add");
 const siteSettingsClose = document.querySelector("#site-settings-close");
@@ -74,7 +76,10 @@ function showSiteSettings(title, settings) {
         });
     };
 
-    if (settings.siteFilters.length === 0) {
+    // A deep link can open this dialog before the settings have loaded, so tolerate a not-yet-populated object.
+    const siteFilters = settings.siteFilters ?? [];
+
+    if (siteFilters.length === 0) {
         const placeholder = document.createElement("div");
         placeholder.className = "dialog-list-item-placeholder";
         placeholder.textContent = "No sites added";
@@ -82,7 +87,7 @@ function showSiteSettings(title, settings) {
         siteSettingsList.appendChild(placeholder);
     }
 
-    settings.siteFilters.forEach(site => {
+    siteFilters.forEach(site => {
         const filter = document.createElement("span");
         filter.className = "dialog-list-item-label";
         filter.textContent = site;
@@ -147,9 +152,15 @@ siteSettingsRemoveAll.addEventListener("click", () => {
     });
 });
 
-autoplaySettings.addEventListener("click", event => {
-    showSiteSettings("Autoplay", AUTOPLAY_SETTINGS);
-    event.stopPropagation();
+registerDialogDeepLink({
+    hash: "autoplay",
+    tab: "permissions",
+    dialog: siteSettings,
+    onOpen: () => showSiteSettings("Autoplay", AUTOPLAY_SETTINGS),
+});
+
+autoplaySettings.addEventListener("click", () => {
+    location.hash = "autoplay";
 });
 
 document.addEventListener("WebUILoaded", () => {

--- a/Base/res/ladybird/about-pages/settings/privacy.js
+++ b/Base/res/ladybird/about-pages/settings/privacy.js
@@ -1,4 +1,5 @@
 import { getByteFormatter } from "../../utils.js";
+import { registerDialogDeepLink } from "./dialog-deep-link.js";
 
 const byteFormatter = getByteFormatter(unit => {
     return {
@@ -115,9 +116,15 @@ function showBrowsingDataSettings() {
     browsingDataSettingsMaxDiskCacheUnit.value = unit;
 }
 
+registerDialogDeepLink({
+    hash: "clearBrowsingData",
+    tab: "privacy",
+    dialog: browsingDataSettingsDialog,
+    onOpen: estimateBrowsingDataSizes,
+});
+
 browsingDataSettings.addEventListener("click", () => {
-    estimateBrowsingDataSizes();
-    browsingDataSettingsDialog.showModal();
+    location.hash = "clearBrowsingData";
 });
 
 browsingDataSettingsClose.addEventListener("click", () => {

--- a/Base/res/ladybird/about-pages/settings/search.js
+++ b/Base/res/ladybird/about-pages/settings/search.js
@@ -1,3 +1,5 @@
+import { registerDialogDeepLink } from "./dialog-deep-link.js";
+
 const searchClose = document.querySelector("#search-close");
 const searchCustomAdd = document.querySelector("#search-custom-add");
 const searchCustomName = document.querySelector("#search-custom-name");
@@ -205,9 +207,15 @@ searchClose.addEventListener("click", () => {
     searchDialog.close();
 });
 
-searchSettings.addEventListener("click", event => {
-    showSearchEngineSettings();
-    event.stopPropagation();
+registerDialogDeepLink({
+    hash: "searchEngines",
+    tab: "search",
+    dialog: searchDialog,
+    onOpen: showSearchEngineSettings,
+});
+
+searchSettings.addEventListener("click", () => {
+    location.hash = "searchEngines";
 });
 
 document.addEventListener("WebUILoaded", () => {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1553,6 +1553,14 @@ void Application::initialize_actions()
         if (!activate_tab_with_url(URL::about_history()))
             open_url_in_new_tab(URL::about_history(), Web::HTML::ActivateTab::Yes);
     }));
+    m_history_menu->add_separator();
+    m_history_menu->add_action(Action::create("Clear Browsing Data"sv, ActionID::ClearBrowsingData, [this]() {
+        auto url = URL::about_settings();
+        url.set_fragment("clearBrowsingData"_string);
+
+        if (!activate_tab_with_url(url))
+            open_url_in_new_tab(url, Web::HTML::ActivateTab::Yes);
+    }));
 
     m_inspect_menu = Menu::create("Inspect"sv);
 

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -28,6 +28,7 @@ enum class ActionID {
     NavigateForward,
     Reload,
     ViewHistory,
+    ClearBrowsingData,
 
     CopySelection,
     CutSelection,

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -503,7 +503,9 @@ void PageClient::page_did_change_active_document_in_top_level_browsing_context(W
     auto& realm = document.realm();
 
     clear_pending_dom_mutations();
-    m_web_ui.clear();
+
+    if (m_web_ui && &m_web_ui->document() != &document)
+        m_web_ui.clear();
 
     if (auto console_client = document.console_client()) {
         auto& web_content_console_client = as<WebContentConsoleClient>(*console_client);

--- a/Services/WebContent/WebUIConnection.h
+++ b/Services/WebContent/WebUIConnection.h
@@ -28,6 +28,8 @@ public:
 
     void received_message_from_web_ui(String const& name, JS::Value data);
 
+    Web::DOM::Document const& document() const { return m_document; }
+
 private:
     WebUIConnection(NonnullOwnPtr<IPC::Transport>, Web::DOM::Document&);
 

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -230,6 +230,8 @@ static void initialize_native_icon(WebView::Action& action, id control)
         break;
     case WebView::ActionID::ClearBrowsingData:
         set_control_image(control, @"trash");
+        [control setKeyEquivalent:@"\b"];
+        [control setKeyEquivalentModifierMask:NSEventModifierFlagCommand | NSEventModifierFlagShift];
         break;
 
     case WebView::ActionID::CopySelection:

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -228,6 +228,9 @@ static void initialize_native_icon(WebView::Action& action, id control)
     case WebView::ActionID::ViewHistory:
         set_control_image(control, @"clock");
         break;
+    case WebView::ActionID::ClearBrowsingData:
+        set_control_image(control, @"trash");
+        break;
 
     case WebView::ActionID::CopySelection:
         set_control_image(control, @"document.on.document");

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -204,6 +204,13 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::Key_H));
 #endif
         break;
+    case WebView::ActionID::ClearBrowsingData:
+#if defined(AK_OS_MACOS)
+        qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Backspace));
+#else
+        qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Delete));
+#endif
+        break;
     case WebView::ActionID::OpenProcessesPage:
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_M));
         break;

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -45,6 +45,7 @@ set(ABOUT_SETTINGS_RESOURCES
     advanced.js
     browsing-behavior.js
     default-zoom-level.js
+    dialog-deep-link.js
     languages.js
     network.js
     new-tab-page.js


### PR DESCRIPTION
This PR adds deep links to the following `about:settings` dialogs:

* about:settings#autoplay
* about:settings#clearBrowsingData
* about:settings#languages
* about:settings#searchEngines

It also adds a menu item and keyboard shortcut to clear browsing data by opening the deep link (Ctrl+Shift+Delete on Linux, Cmd+Shift+Backspace on MacOS).

