### PR TITLE
LibWeb/SVG: Some spec updates

### DIFF
--- a/Libraries/LibWeb/SVG/Default.css
+++ b/Libraries/LibWeb/SVG/Default.css
@@ -14,21 +14,6 @@ svg:not(:root), image, marker, pattern, symbol { overflow: hidden; }
     white-space-collapse: preserve-spaces;
 }
 
-/* NOTE: These rules are in the SVG spec, but don't match how other engines behave.
-         So we simply comment them out for now.
-defs,
-clipPath, mask, marker,
-desc, title, metadata,
-pattern, linearGradient, radialGradient,
-script, style,
-symbol {
-    display: none !important;
-}
-:host(use) > symbol {
-    display: inline !important;
-}
-*/
-
 :link, :visited {
     cursor: pointer;
 }

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -353,11 +353,19 @@ Optional<float> SVGGraphicsElement::stroke_width() const
 // https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox
 WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Optional<Bindings::SVGBoundingBoxOptions> const&)
 {
+    // The getBBox method is used to compute the bounding box of the current element.  When the getBBox(options) method
+    // is called, the bounding box algorithm is invoked for the current element, with fill, stroke, markers and clipped
+    // members of the options dictionary argument used to control which parts of the element are included in the
+    // bounding box, using the element's user coordinate system as the coordinate system to return the bounding box in.
+    // A newly created DOMRect object that defines the computed bounding box is returned.
+    // If the element's geometric attributes are missing or have invalid values (e.g. negative width or height), such
+    // that the element is not rendered, then a DOMRect with x, y, width and height all set to 0 is returned.
+
     // FIXME: It should be possible to compute this without layout updates. The bounding box is within the
-    // SVG coordinate space (before any viewbox or other transformations), so it should be possible to
-    // calculate this from SVG geometry without a full layout tree (at least for simple cases).
-    // See: https://svgwg.org/svg2-draft/coords.html#BoundingBoxes
-    const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::SVGGraphicsElementGetBBox);
+    //        SVG coordinate space (before any viewbox or other transformations), so it should be possible to
+    //        calculate this from SVG geometry without a full layout tree (at least for simple cases).
+    //        See: https://svgwg.org/svg2-draft/coords.html#BoundingBoxes
+    document().update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::SVGGraphicsElementGetBBox);
     if (!layout_node())
         return Geometry::DOMRect::create(realm());
     // Invert the SVG -> screen space transform.
@@ -367,15 +375,8 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Op
 
     auto owner_paintable = owner_svg_element->paintable_box();
     auto self_paintable = paintable_box();
-    if (!owner_paintable || !self_paintable) {
-        // Throw only for non-rendered *graphics* elements where geometry isn't computable
-        // (e.g. elements inside <marker>, <pattern>, etc.).
-        if (is<SVGSVGElement>(*this))
-            return Geometry::DOMRect::create(realm());
-        return WebIDL::InvalidStateError::create(
-            realm(),
-            "Element is not rendered and geometry is not computable"_utf16);
-    }
+    if (!owner_paintable || !self_paintable)
+        return Geometry::DOMRect::create(realm());
 
     auto svg_rect = owner_paintable->absolute_rect();
     auto rect = self_paintable->absolute_rect().to_type<float>().translated(-svg_rect.location().to_type<float>());
@@ -393,6 +394,9 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Op
         if (inv.has_value())
             rect = inv->map(rect);
     }
+
+    if (rect.is_empty())
+        return Geometry::DOMRect::create(realm());
     return Geometry::DOMRect::create(realm(), rect);
 }
 

--- a/Libraries/LibWeb/SVG/SVGStyleElement.idl
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.idl
@@ -1,9 +1,11 @@
 // https://svgwg.org/svg2-draft/single-page.html#styling-InterfaceSVGStyleElement
 [Exposed=Window]
 interface SVGStyleElement : SVGElement {
-    [Reflect] attribute DOMString type;
     [Reflect] attribute DOMString media;
     [Reflect] attribute DOMString title;
+    
+    // obsolete members
+    [Reflect] attribute DOMString type;
 };
 
 SVGStyleElement includes LinkStyle;

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/types/scripted/SVGGraphicsElement.getBBox-03.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/types/scripted/SVGGraphicsElement.getBBox-03.txt
@@ -2,17 +2,17 @@ Harness status: OK
 
 Found 12 tests
 
-3 Pass
-9 Fail
-Fail	rect1
+8 Pass
+4 Fail
+Pass	rect1
 Fail	rect2
 Pass	circle
 Fail	ellipse1
 Fail	ellipse2
 Pass	ellipse3
 Pass	ellipse4
-Fail	image3
-Fail	image4
-Fail	foreign1
-Fail	foreign2
+Pass	image3
+Pass	image4
+Pass	foreign1
+Pass	foreign2
 Fail	SVGGraphicsElement.prototype.getBBox for elements with negative sizes

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/types/scripted/SVGGraphicsElement.getBBox-03.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/types/scripted/SVGGraphicsElement.getBBox-03.txt
@@ -1,0 +1,18 @@
+Harness status: OK
+
+Found 12 tests
+
+3 Pass
+9 Fail
+Fail	rect1
+Fail	rect2
+Pass	circle
+Fail	ellipse1
+Fail	ellipse2
+Pass	ellipse3
+Pass	ellipse4
+Fail	image3
+Fail	image4
+Fail	foreign1
+Fail	foreign2
+Fail	SVGGraphicsElement.prototype.getBBox for elements with negative sizes

--- a/Tests/LibWeb/Text/input/wpt-import/svg/types/scripted/SVGGraphicsElement.getBBox-03.html
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/types/scripted/SVGGraphicsElement.getBBox-03.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<title>SVGGraphicsElement.prototype.getBBox for elements with negative sizes</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#BoundingBoxes">
+<svg>
+  <!-- negative values are errors, auto will be substituted, which for width,
+       height and r is 0 -->
+  <rect id="rect1" x="1" y="2" width="-10" height="20"/>
+  <rect id="rect2" x="1" y="2" width="10" height="-20"/>
+  <circle id="circle" cx="1" cy="2" r="-10"/>
+  <!-- specifying a negative value for rx or ry is invalid so the other valid
+       radius will be substituted only 0 will produce a degenerate ellipse -->
+  <ellipse id="ellipse1" cx="1" cy="12" rx="-5" ry="10"/>
+  <ellipse id="ellipse2" cx="6" cy="2" rx="5" ry="-10"/>
+  <circle id="ellipse1-ref" cx="1" cy="12" r="10"/>
+  <circle id="ellipse2-ref" cx="6" cy="2" r="5"/>
+  <ellipse id="ellipse3" cx="1" cy="12" rx="0" ry="10"/>
+  <ellipse id="ellipse4" cx="6" cy="2" rx="5" ry="0"/>
+  <image id="image1" x="1" y="2" width="-10" height="20" href="/images/green-100x50.png"/>
+  <image id="image2" x="1" y="2" width="10" height="-20" href="/images/green-100x50.png"/>
+  <image id="image3" x="1" y="2" width="-10" height="20"/>
+  <image id="image4" x="1" y="2" width="10" height="-20"/>
+  <foreignObject id="foreign1" x="1" y="2" width="-10" height="20"/>
+  <foreignObject id="foreign2" x="1" y="2" width="10" height="-20"/>
+</svg>
+<script>
+function assertBBox(id, x, y, width, height) {
+  let bbox = document.getElementById(id).getBBox();
+  assert_equals(bbox.x, x, id + ': x');
+  assert_equals(bbox.y, y, id + ': y');
+  assert_equals(bbox.width, width, id + ': width');
+  assert_equals(bbox.height, height, id + ': height');
+}
+
+function assertSameBBox(id1, id2) {
+  let bbox = document.getElementById(id2).getBBox();
+  assertBBox(id1, bbox.x, bbox.y, bbox.width, bbox.height);
+}
+
+function testBBox(id, x, y, width, height) {
+  test(() => { assertBBox(id, x, y, width, height) }, id);
+}
+
+function testSameBBox(id1, id2) {
+  test(() => { assertSameBBox(id1, id2) }, id1);
+}
+
+// Per resolution (issue #1018): if a shape is not rendered (negative or
+// zero dimension), getBBox returns (0, 0, 0, 0).
+testBBox('rect1', 0, 0, 0, 0);
+testBBox('rect2', 0, 0, 0, 0);
+testBBox('circle', 0, 0, 0, 0);
+testSameBBox('ellipse1', 'ellipse1-ref');
+testSameBBox('ellipse2', 'ellipse2-ref');
+testBBox('ellipse3', 0, 0, 0, 0);
+testBBox('ellipse4', 0, 0, 0, 0);
+testBBox('image3', 0, 0, 0, 0);
+testBBox('image4', 0, 0, 0, 0);
+testBBox('foreign1', 0, 0, 0, 0);
+testBBox('foreign2', 0, 0, 0, 0);
+
+async_test(t => {
+  onload = t.step_func_done(() => {
+    assertBBox('image1', 1, 2, 40, 20);
+    assertBBox('image2', 1, 2, 10, 5);
+  }, 'image1 and image2');
+});
+</script>


### PR DESCRIPTION
Only behaviour change is that `getBBox()` now returns a {0,0,0,0} rectangle if it's unable to measure the element (instead of throwing), or if the resulting rectangle is invalid.

https://svgwg.org/svg2-draft/ isn't kept up to date, so these changes don't appear on there yet, which is a bit frustrating.