### PR TITLE
LibWeb/CSS: Store property and descriptor names as Utf16FlyStrings

### DIFF
--- a/Documentation/CSSGeneratedFiles.md
+++ b/Documentation/CSSGeneratedFiles.md
@@ -162,9 +162,9 @@ The generated code provides:
   the same name.
 - `FlyString to_string(AtRuleID)`, mostly for debug logging.
 - A `DescriptorID` enum, listing every descriptor.
-- `Optional<DescriptorID> descriptor_id_from_string(AtRuleID, StringView)` for getting a DescriptorID from a string, if
+- `Optional<DescriptorID> descriptor_id_from_string(AtRuleID, Utf16View)` for getting a DescriptorID from a string, if
   it exists in that at-rule.
-- `FlyString to_string(DescriptorID)` for serializing descriptor names.
+- `Utf16FlyString const& to_string(DescriptorID)` for serializing descriptor names.
 - `bool at_rule_supports_descriptor(AtRuleID, DescriptorID)` to query if the given at-rule allows the descriptor.
 - `RefPtr<StyleValue const> descriptor_initial_value(AtRuleID, DescriptorID)` for getting a descriptor's initial value.
 - `DescriptorMetadata get_descriptor_metadata(AtRuleID, DescriptorID)` returns data used for parsing the descriptor.

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -878,7 +878,7 @@ WebIDL::ExceptionOr<GC::RootVector<JS::Object*>> KeyframeEffect::get_keyframes()
             }
 
             for (auto const& [id, value] : keyframe.parsed_properties()) {
-                auto key = Utf16FlyString::from_utf8(CSS::camel_case_string_from_property_id(id));
+                auto key = CSS::camel_case_string_from_property_id(id);
                 auto value_string = JS::PrimitiveString::create(vm, Utf16String::from_utf8(value->to_string(CSS::SerializationMode::Normal)));
                 TRY(object->set(JS::PropertyKey { move(key), JS::PropertyKey::StringMayBeNumber::No }, value_string, ShouldThrowExceptions::Yes));
             }

--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -231,7 +231,7 @@ String CSSDescriptors::serialized() const
         auto value = descriptor.value->to_string(SerializationMode::Normal);
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value, and the important flag set if declaration has its important flag set.
-        auto serialized_declaration = serialize_a_css_declaration(property_string.ascii_view(), value, Important::No);
+        auto serialized_declaration = serialize_a_css_declaration(property_string, value, Important::No);
 
         // 7. Append serialized declaration to list.
         list.append(serialized_declaration);

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -154,13 +154,13 @@ Utf16String CSSStyleProperties::item(size_t index) const
 
     if (is_computed()) {
         auto property_id = static_cast<PropertyID>(index + to_underlying(first_longhand_property_id));
-        return Utf16String::from_utf8(string_from_property_id(property_id));
+        return string_from_property_id(property_id).to_utf16_string();
     }
 
     if (index < custom_properties_count)
         return m_custom_properties.keys()[index].to_utf16_string();
 
-    return Utf16String::from_utf8(CSS::string_from_property_id(m_properties[index - custom_properties_count].property_id));
+    return string_from_property_id(m_properties[index - custom_properties_count].property_id).to_utf16_string();
 }
 
 Optional<StyleProperty> CSSStyleProperties::get_property(PropertyID property_id) const
@@ -1269,9 +1269,7 @@ String CSSStyleProperties::serialized() const
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value,
         //    and the important flag set if declaration has its important flag set.
-        // NB: We have to inline this here as the actual implementation does not accept custom properties.
-        auto property_string = property.to_utf16_string().to_utf8_but_should_be_ported_to_utf16();
-        String serialized_declaration = serialize_a_css_declaration(property_string, value, declaration.value.important);
+        String serialized_declaration = serialize_a_css_declaration(property, value, declaration.value.important);
 
         // 7. Append serialized declaration to list.
         list.append(move(serialized_declaration));

--- a/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -36,7 +36,7 @@ GC::Ref<CSSTransition> CSSTransition::start_a_transition(
     return realm.create<CSSTransition>(realm, abstract_element, property_id, transition_generation, delay, start_time, end_time, start_value, end_value, reversing_adjusted_start_value, reversing_shortening_factor);
 }
 
-StringView CSSTransition::transition_property() const
+Utf16FlyString const& CSSTransition::transition_property() const
 {
     return string_from_property_id(m_transition_property);
 }
@@ -85,8 +85,7 @@ int CSSTransition::class_specific_composite_order(GC::Ref<Animations::Animation>
     // 5. Otherwise, sort A and B in ascending order by the Unicode codepoints that make up the expanded transition
     //    property name of each transition (i.e. without attempting case conversion and such that ‘-moz-column-width’
     //    sorts before ‘column-width’).
-    // FIXME: This should operate on Unicode strings, not StringViews.
-    return transition_property().compare(other->transition_property());
+    return transition_property() <=> other->transition_property();
 }
 
 CSSTransition::CSSTransition(

--- a/Libraries/LibWeb/CSS/CSSTransition.h
+++ b/Libraries/LibWeb/CSS/CSSTransition.h
@@ -9,7 +9,6 @@
 
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/CSS/Interpolation.h>
-#include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 
 namespace Web::CSS {
@@ -31,7 +30,7 @@ public:
         NonnullRefPtr<StyleValue const> reversing_adjusted_start_value,
         double reversing_shortening_factor);
 
-    StringView transition_property() const;
+    Utf16FlyString const& transition_property() const;
 
     virtual Animations::AnimationClass animation_class() const override;
     virtual int class_specific_composite_order(GC::Ref<Animations::Animation> other) const override;

--- a/Libraries/LibWeb/CSS/DescriptorNameAndID.h
+++ b/Libraries/LibWeb/CSS/DescriptorNameAndID.h
@@ -20,14 +20,10 @@ public:
         if (is_a_custom_property_name_string(name))
             return DescriptorNameAndID(move(name), DescriptorID::Custom);
 
-        if (!name.is_ascii())
-            return {};
-
-        auto name_string = name.to_utf16_string();
-        if (auto descriptor_id = descriptor_id_from_string(at_rule_id, name_string.ascii_view()); descriptor_id.has_value()) {
+        if (auto descriptor_id = descriptor_id_from_string(at_rule_id, name); descriptor_id.has_value()) {
             // NB: We use the serialized ID as the name here instead of the input name to ensure that legacy alias
             //     mapping is reflected
-            return DescriptorNameAndID(Utf16FlyString::from_utf8(CSS::to_string(descriptor_id.value())), descriptor_id.value());
+            return DescriptorNameAndID(CSS::to_string(descriptor_id.value()), descriptor_id.value());
         }
 
         return {};
@@ -36,7 +32,7 @@ public:
     static DescriptorNameAndID from_id(DescriptorID descriptor_id)
     {
         VERIFY(descriptor_id != DescriptorID::Custom);
-        return DescriptorNameAndID(Utf16FlyString::from_utf8(CSS::to_string(descriptor_id)), descriptor_id);
+        return DescriptorNameAndID(CSS::to_string(descriptor_id), descriptor_id);
     }
 
     DescriptorID id() const { return m_id; }

--- a/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
@@ -22,19 +22,12 @@
 
 namespace Web::CSS::Parser {
 
-static FlyString descriptor_name_to_fly_string(DescriptorNameAndID const& descriptor_name_and_id)
-{
-    auto descriptor_name = descriptor_name_and_id.name().to_utf16_string();
-    auto descriptor_name_utf8 = descriptor_name.to_utf8_but_should_be_ported_to_utf16();
-    return MUST(FlyString::from_utf8(descriptor_name_utf8.bytes_as_string_view()));
-}
-
 Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_descriptor_value(AtRuleID at_rule_id, DescriptorNameAndID const& descriptor_name_and_id, TokenStream<ComponentValue>& tokens)
 {
     if (!at_rule_supports_descriptor(at_rule_id, descriptor_name_and_id.id())) {
         ErrorReporter::the().report(UnknownPropertyError {
             .rule_name = to_string(at_rule_id),
-            .property_name = descriptor_name_to_fly_string(descriptor_name_and_id),
+            .property_name = descriptor_name_and_id.name(),
         });
         return ParseError::SyntaxError;
     }
@@ -67,10 +60,9 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_descriptor_v
         // NB: Since we are not in a property value context we only allow ASFs if they are explicitly allowed in
         //     Descriptors.json
         if (!metadata.allow_arbitrary_substitution_functions) {
-            auto descriptor_name = descriptor_name_to_fly_string(descriptor_name_and_id);
-            auto value_type = MUST(String::formatted("{}/{}", to_string(at_rule_id), descriptor_name));
-            ErrorReporter::the().report(InvalidValueError {
-                .value_type = MUST(FlyString::from_utf8(value_type.bytes_as_string_view())),
+            ErrorReporter::the().report(InvalidPropertyError {
+                .rule_name = to_string(at_rule_id),
+                .property_name = descriptor_name_and_id.name(),
                 .value_string = tokens.dump_string(),
                 .description = "ASFs are not supported in this descriptor"_string,
             });
@@ -432,7 +424,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_descriptor_v
 
     ErrorReporter::the().report(InvalidPropertyError {
         .rule_name = to_string(at_rule_id),
-        .property_name = descriptor_name_to_fly_string(descriptor_name_and_id),
+        .property_name = descriptor_name_and_id.name(),
         .value_string = tokens.dump_string(),
         .description = "Failed to parse."_string,
     });

--- a/Libraries/LibWeb/CSS/Parser/ErrorReporter.h
+++ b/Libraries/LibWeb/CSS/Parser/ErrorReporter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2025-2026, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,13 +9,14 @@
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
+#include <AK/Utf16FlyString.h>
 #include <LibWeb/Export.h>
 
 namespace Web::CSS::Parser {
 
 struct UnknownPropertyError {
     FlyString rule_name { "style"_fly_string };
-    FlyString property_name;
+    Utf16FlyString property_name;
     bool operator==(UnknownPropertyError const&) const = default;
     unsigned hash() const
     {
@@ -47,7 +48,7 @@ struct UnknownPseudoClassOrElementError {
 
 struct InvalidPropertyError {
     FlyString rule_name { "style"_fly_string };
-    FlyString property_name;
+    Utf16FlyString property_name;
     String value_string;
     String description;
     bool operator==(InvalidPropertyError const&) const = default;

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1957,13 +1957,14 @@ GC::Ref<CSSStyleProperties> Parser::convert_to_style_declaration(Vector<Declarat
 
 Optional<StylePropertyAndName> Parser::convert_to_style_property(Declaration const& declaration)
 {
-    auto property = PropertyNameAndID::from_name(Utf16FlyString::from_utf8(declaration.name));
+    auto utf16_declaration_name = Utf16FlyString::from_utf8(declaration.name);
+    auto property = PropertyNameAndID::from_name(utf16_declaration_name);
 
     if (!property.has_value()) {
         if (has_ignored_vendor_prefix(declaration.name)) {
             return {};
         }
-        ErrorReporter::the().report(UnknownPropertyError { .property_name = declaration.name });
+        ErrorReporter::the().report(UnknownPropertyError { .property_name = utf16_declaration_name });
         return {};
     }
 
@@ -1971,10 +1972,8 @@ Optional<StylePropertyAndName> Parser::convert_to_style_property(Declaration con
     auto value = parse_css_value(property->id(), value_token_stream, declaration.original_value_text);
     if (value.is_error()) {
         if (value.error() == ParseError::SyntaxError) {
-            auto property_name = property->name().to_utf16_string();
-            auto property_name_utf8 = property_name.to_utf8_but_should_be_ported_to_utf16();
             ErrorReporter::the().report(InvalidPropertyError {
-                .property_name = MUST(FlyString::from_utf8(property_name_utf8.bytes_as_string_view())),
+                .property_name = property->name(),
                 .value_string = value_token_stream.dump_string(),
                 .description = "Failed to parse."_string,
             });

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -2687,7 +2687,7 @@ RefPtr<StyleValue const> Parser::parse_font_language_override_value(TokenStream<
         if (tokens.has_next_token()) {
             ErrorReporter::the().report(InvalidPropertyError {
                 .rule_name = "style"_fly_string,
-                .property_name = "font-language-override"_fly_string,
+                .property_name = "font-language-override"_utf16_fly_string,
                 .value_string = tokens.dump_string(),
                 .description = "Unexpected trailing tokens"_string,
             });
@@ -2697,7 +2697,7 @@ RefPtr<StyleValue const> Parser::parse_font_language_override_value(TokenStream<
         if (length == 0) {
             ErrorReporter::the().report(InvalidPropertyError {
                 .rule_name = "style"_fly_string,
-                .property_name = "font-language-override"_fly_string,
+                .property_name = "font-language-override"_utf16_fly_string,
                 .value_string = tokens.dump_string(),
                 .description = "<string> value is empty"_string,
             });
@@ -2706,7 +2706,7 @@ RefPtr<StyleValue const> Parser::parse_font_language_override_value(TokenStream<
         if (!string_value.is_ascii()) {
             ErrorReporter::the().report(InvalidPropertyError {
                 .rule_name = "style"_fly_string,
-                .property_name = "font-language-override"_fly_string,
+                .property_name = "font-language-override"_utf16_fly_string,
                 .value_string = tokens.dump_string(),
                 .description = MUST(String::formatted("<string> value \"{}\" contains non-ascii characters", string_value)),
             });
@@ -2715,7 +2715,7 @@ RefPtr<StyleValue const> Parser::parse_font_language_override_value(TokenStream<
         if (length > 4) {
             ErrorReporter::the().report(InvalidPropertyError {
                 .rule_name = "style"_fly_string,
-                .property_name = "font-language-override"_fly_string,
+                .property_name = "font-language-override"_utf16_fly_string,
                 .value_string = tokens.dump_string(),
                 .description = MUST(String::formatted("<string> value \"{}\" is too long", string_value)),
             });
@@ -2726,7 +2726,7 @@ RefPtr<StyleValue const> Parser::parse_font_language_override_value(TokenStream<
         if (trimmed.is_empty()) {
             ErrorReporter::the().report(InvalidPropertyError {
                 .rule_name = "style"_fly_string,
-                .property_name = "font-language-override"_fly_string,
+                .property_name = "font-language-override"_utf16_fly_string,
                 .value_string = tokens.dump_string(),
                 .description = MUST(String::formatted("<string> value \"{}\" is only whitespace", string_value)),
             });

--- a/Libraries/LibWeb/CSS/PropertyName.h
+++ b/Libraries/LibWeb/CSS/PropertyName.h
@@ -27,8 +27,12 @@ inline bool is_a_custom_property_name_string(StringView string)
     return string.starts_with("--"sv) && !is_invalid_custom_property_name_string(string);
 }
 
-inline bool is_a_custom_property_name_string(Utf16FlyString const& string)
+// https://drafts.csswg.org/css-variables-2/#custom-property
+inline bool is_a_custom_property_name_string(Utf16View string)
 {
+    // A custom property is any property whose name starts with two dashes (U+002D HYPHEN-MINUS), like --foo.
+    // The <custom-property-name> production corresponds to this: it’s defined as any <dashed-ident> (a valid
+    // identifier that starts with two dashes), except -- itself, which is reserved for future use by CSS.
     return string.length_in_code_units() > 2
         && string.code_unit_at(0) == '-'
         && string.code_unit_at(1) == '-';

--- a/Libraries/LibWeb/CSS/PropertyNameAndID.h
+++ b/Libraries/LibWeb/CSS/PropertyNameAndID.h
@@ -25,7 +25,7 @@ public:
 
         auto name_string = name.to_utf16_string();
         if (auto property_id = property_id_from_string(name_string.ascii_view()); property_id.has_value())
-            return PropertyNameAndID(Utf16FlyString::from_utf8(string_from_property_id(property_id.value())), property_id.value());
+            return PropertyNameAndID(string_from_property_id(property_id.value()), property_id.value());
 
         return {};
     }
@@ -42,7 +42,7 @@ public:
     Utf16FlyString const& name() const
     {
         if (!m_name.has_value())
-            m_name = Utf16FlyString::from_utf8(string_from_property_id(m_property_id));
+            m_name = string_from_property_id(m_property_id);
         return m_name.value();
     }
 

--- a/Libraries/LibWeb/CSS/Serialize.cpp
+++ b/Libraries/LibWeb/CSS/Serialize.cpp
@@ -79,6 +79,10 @@ void serialize_an_identifier(StringBuilder& builder, StringView ident)
         escape_a_character(builder, character);
     }
 }
+void serialize_an_identifier(StringBuilder& builder, Utf16View ident)
+{
+    serialize_an_identifier(builder, ident.to_utf8_but_should_be_ported_to_utf16());
+}
 
 // https://www.w3.org/TR/cssom-1/#serialize-a-string
 void serialize_a_string(StringBuilder& builder, StringView string)
@@ -196,7 +200,7 @@ String serialize_a_number(double value)
 }
 
 // https://drafts.csswg.org/cssom/#serialize-a-css-declaration
-String serialize_a_css_declaration(StringView property, StringView value, Important important)
+String serialize_a_css_declaration(Utf16View property, StringView value, Important important)
 {
     // 1. Let s be the empty string.
     StringBuilder builder;

--- a/Libraries/LibWeb/CSS/Serialize.h
+++ b/Libraries/LibWeb/CSS/Serialize.h
@@ -22,6 +22,7 @@ namespace Web::CSS {
 void escape_a_character(StringBuilder&, u32 character);
 void escape_a_character_as_code_point(StringBuilder&, u32 character);
 WEB_API void serialize_an_identifier(StringBuilder&, StringView ident);
+WEB_API void serialize_an_identifier(StringBuilder&, Utf16View ident);
 void serialize_a_string(StringBuilder&, StringView string);
 WEB_API void serialize_a_url(StringBuilder&, StringView url);
 void serialize_unicode_ranges(StringBuilder&, Vector<Gfx::UnicodeRange> const& unicode_ranges);
@@ -48,7 +49,7 @@ void serialize_a_comma_separated_list(StringBuilder& builder, Vector<T> const& i
     }
 }
 
-String serialize_a_css_declaration(StringView property, StringView value, Important = Important::No);
+String serialize_a_css_declaration(Utf16View property, StringView value, Important = Important::No);
 
 String serialize_a_series_of_component_values(ReadonlySpan<Parser::ComponentValue>);
 String serialize_a_series_of_component_values_preserving_original_source_text(ReadonlySpan<Parser::ComponentValue>);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1806,9 +1806,9 @@ static JsonArray serialize_devtools_style_declarations(DOM::Document const& docu
 {
     JsonArray declarations;
 
-    auto serialize_property = [&](String name, StyleProperty const& property, IsCustomProperty is_custom_property, Inherits inherits) {
+    auto serialize_property = [&](Utf16FlyString const& name, StyleProperty const& property, IsCustomProperty is_custom_property, Inherits inherits) {
         declarations.must_append(serialize_devtools_style_declaration(
-            move(name),
+            name.to_utf16_string().to_utf8_but_should_be_ported_to_utf16(),
             property.value->to_string(SerializationMode::Normal),
             property.important,
             is_custom_property,
@@ -1819,7 +1819,7 @@ static JsonArray serialize_devtools_style_declarations(DOM::Document const& docu
 
     for (auto const& property : declaration.properties()) {
         serialize_property(
-            string_from_property_id(property.property_id).to_string(),
+            string_from_property_id(property.property_id),
             property,
             IsCustomProperty::No,
             is_inherited_property(property.property_id) ? Inherits::Yes : Inherits::No);
@@ -1827,7 +1827,7 @@ static JsonArray serialize_devtools_style_declarations(DOM::Document const& docu
 
     for (auto const& custom_property : declaration.custom_properties())
         serialize_property(
-            custom_property.key.to_utf16_string().to_utf8_but_should_be_ported_to_utf16(),
+            custom_property.key,
             custom_property.value,
             IsCustomProperty::Yes,
             custom_property_inherits(document, custom_property.key) ? Inherits::Yes : Inherits::No);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3895,7 +3895,7 @@ void Document::dispatch_events_for_transition(GC::Ref<CSS::CSSTransition> transi
 
         Bindings::TransitionEventInit event_init {};
         event_init.bubbles = true;
-        event_init.property_name = MUST(String::from_utf8(transition->transition_property()));
+        event_init.property_name = transition->transition_property().to_utf16_string().to_utf8_but_should_be_ported_to_utf16();
         event_init.elapsed_time = elapsed_time_output;
         event_init.pseudo_element = transition->owning_element()->pseudo_element().map([](auto it) {
                                                                                       return MUST(String::formatted("::{}", CSS::pseudo_element_name(it)));

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -416,7 +416,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
 
     if (show_computed_properties && layout_node.dom_node() && layout_node.dom_node()->is_element() && as<DOM::Element>(layout_node.dom_node())->computed_properties()) {
         struct NameAndValue {
-            FlyString name;
+            Utf16FlyString name;
             String value;
         };
         Vector<NameAndValue> properties;

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -3894,7 +3894,7 @@ Optional<Utf16String> specified_command_value(GC::Ref<DOM::Element> element, Fly
     //     that it sets property to.
     // FIXME: Use property_in_style_attribute once it supports shorthands.
     if (auto inline_style = element->inline_style()) {
-        auto value = inline_style->get_property_value(Utf16FlyString::from_utf8(string_from_property_id(property.value())));
+        auto value = inline_style->get_property_value(string_from_property_id(property.value()));
         if (!value.is_empty())
             return Utf16String::from_utf8_without_validation(value);
     }

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -46,7 +46,7 @@ struct NamedPropertyID {
     {
     }
     NamedPropertyID(CSS::PropertyID property_id, Vector<FlyString> supported_elements = {})
-        : NamedPropertyID(property_id, CSS::string_from_property_id(property_id), move(supported_elements))
+        : NamedPropertyID(property_id, CSS::string_from_property_id(property_id).to_utf16_string().to_utf8_but_should_be_ported_to_utf16(), move(supported_elements))
     {
     }
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1829,7 +1829,7 @@ Vector<DevTools::CSSProperty> Application::css_property_list() const
         auto property_id = static_cast<Web::CSS::PropertyID>(i);
 
         DevTools::CSSProperty property;
-        property.name = Web::CSS::string_from_property_id(property_id).to_string();
+        property.name = Web::CSS::string_from_property_id(property_id).to_utf16_string().to_utf8_but_should_be_ported_to_utf16();
         property.is_inherited = Web::CSS::is_inherited_property(property_id);
         property_list.append(move(property));
     }

--- a/Meta/Generators/generate_libweb_css_descriptors.py
+++ b/Meta/Generators/generate_libweb_css_descriptors.py
@@ -41,7 +41,7 @@ def write_header_file(out: TextIO, at_rules_data: dict, all_descriptors: list) -
     out.write(f"""
 #pragma once
 
-#include <AK/FlyString.h>
+#include <AK/Utf16FlyString.h>
 #include <AK/Optional.h>
 #include <AK/Types.h>
 #include <LibWeb/Forward.h>
@@ -68,8 +68,8 @@ enum class DescriptorID : {descriptor_id_underlying_type} {{
     Custom,
 };
 
-Optional<DescriptorID> descriptor_id_from_string(AtRuleID, StringView);
-FlyString to_string(DescriptorID);
+Optional<DescriptorID> descriptor_id_from_string(AtRuleID, Utf16View);
+Utf16FlyString const& to_string(DescriptorID);
 
 bool at_rule_supports_descriptor(AtRuleID, DescriptorID);
 RefPtr<StyleValue const> descriptor_initial_value(AtRuleID, DescriptorID);
@@ -186,7 +186,7 @@ FlyString to_string(AtRuleID at_rule_id)
     VERIFY_NOT_REACHED();
 }
 
-Optional<DescriptorID> descriptor_id_from_string(AtRuleID at_rule_id, StringView string)
+Optional<DescriptorID> descriptor_id_from_string(AtRuleID at_rule_id, Utf16View string)
 {
     switch (at_rule_id) {
 """)
@@ -220,15 +220,17 @@ Optional<DescriptorID> descriptor_id_from_string(AtRuleID at_rule_id, StringView
     return {};
 }
 
-FlyString to_string(DescriptorID descriptor_id)
+Utf16FlyString const& to_string(DescriptorID descriptor_id)
 {
     switch (descriptor_id) {
 """)
 
     for descriptor_name in all_descriptors:
         out.write(f"""
-    case DescriptorID::{title_casify(descriptor_name)}:
-        return "{descriptor_name}"_fly_string;
+    case DescriptorID::{title_casify(descriptor_name)}: {{
+        static Utf16FlyString const& name = *new Utf16FlyString("{descriptor_name}"_utf16_fly_string);
+        return name;
+    }}
 """)
 
     out.write("""

--- a/Meta/Generators/generate_libweb_css_property_id.py
+++ b/Meta/Generators/generate_libweb_css_property_id.py
@@ -176,8 +176,8 @@ def write_header_file(out: TextIO, properties: dict, logical_property_groups: di
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
-#include <AK/StringView.h>
 #include <AK/Traits.h>
+#include <AK/Utf16FlyString.h>
 #include <AK/Variant.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/CSS/NumericRange.h>
@@ -243,8 +243,8 @@ bool is_animatable_property(PropertyID);
 
 Optional<PropertyID> property_id_from_camel_case_string(StringView);
 WEB_API Optional<PropertyID> property_id_from_string(StringView);
-[[nodiscard]] WEB_API FlyString const& string_from_property_id(PropertyID);
-[[nodiscard]] FlyString const& camel_case_string_from_property_id(PropertyID);
+[[nodiscard]] WEB_API Utf16FlyString const& string_from_property_id(PropertyID);
+[[nodiscard]] Utf16FlyString const& camel_case_string_from_property_id(PropertyID);
 WEB_API bool is_inherited_property(PropertyID);
 NonnullRefPtr<StyleValue const> property_initial_value(PropertyID);
 
@@ -338,10 +338,10 @@ Optional<LogicalPropertyGroup> logical_property_group_for_property(PropertyID);
 namespace AK {
 
 template<>
-struct Formatter<Web::CSS::PropertyID> : Formatter<StringView> {
+struct Formatter<Web::CSS::PropertyID> : Formatter<Utf16FlyString> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::PropertyID const& property_id)
     {
-        return Formatter<StringView>::format(builder, Web::CSS::string_from_property_id(property_id));
+        return Formatter<Utf16FlyString>::format(builder, Web::CSS::string_from_property_id(property_id));
     }
 };
 } // namespace AK
@@ -412,7 +412,7 @@ Optional<PropertyID> property_id_from_string(StringView string)
     return properties_table.get(string);
 }
 
-FlyString const& string_from_property_id(PropertyID property_id) {
+Utf16FlyString const& string_from_property_id(PropertyID property_id) {
     switch (property_id) {
 """)
 
@@ -421,20 +421,20 @@ FlyString const& string_from_property_id(PropertyID property_id) {
             continue
         out.write(f"""
     case PropertyID::{title_casify(name)}: {{
-        static FlyString const& name = *new FlyString("{name}"_fly_string);
+        static Utf16FlyString const& name = *new Utf16FlyString("{name}"_utf16_fly_string);
         return name;
     }}
 """)
 
     out.write("""
     default: {
-        static FlyString const& invalid_property_id_string = *new FlyString("(invalid CSS::PropertyID)"_fly_string);
+        static Utf16FlyString const& invalid_property_id_string = *new Utf16FlyString("(invalid CSS::PropertyID)"_utf16_fly_string);
         return invalid_property_id_string;
     }
     }
 }
 
-FlyString const& camel_case_string_from_property_id(PropertyID property_id) {
+Utf16FlyString const& camel_case_string_from_property_id(PropertyID property_id) {
     switch (property_id) {
 """)
 
@@ -443,14 +443,14 @@ FlyString const& camel_case_string_from_property_id(PropertyID property_id) {
             continue
         out.write(f"""
     case PropertyID::{title_casify(name)}: {{
-        static FlyString const& name = *new FlyString("{camel_casify(name)}"_fly_string);
+        static Utf16FlyString const& name = *new Utf16FlyString("{camel_casify(name)}"_utf16_fly_string);
         return name;
     }}
 """)
 
     out.write("""
     default: {
-        static FlyString const& invalid_property_id_string = *new FlyString("(invalid CSS::PropertyID)"_fly_string);
+        static Utf16FlyString const& invalid_property_id_string = *new Utf16FlyString("(invalid CSS::PropertyID)"_utf16_fly_string);
         return invalid_property_id_string;
     }
     }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -850,7 +850,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
 
         properties->for_each_property([&](auto property_id, auto& value) {
             serialized.set(
-                Web::CSS::string_from_property_id(property_id),
+                Web::CSS::string_from_property_id(property_id).to_utf16_string().to_utf8_but_should_be_ported_to_utf16(),
                 value.to_string(Web::CSS::SerializationMode::Normal));
         });
 


### PR DESCRIPTION
Removes some conversions, and is very slightly less code. 🎉 