### PR TITLE
Compositor+WebContent: Transfer WebGL commands over shared memory

### DIFF
--- a/Services/Compositor/CanvasHost.cpp
+++ b/Services/Compositor/CanvasHost.cpp
@@ -147,7 +147,7 @@ void CanvasHost::execute_canvas_2d_commands(Web::Painting::CanvasId canvas_id, G
         present_canvas_2d_context(canvas_id, canvas_context);
 }
 
-void CanvasHost::execute_webgl_commands(Web::Painting::CanvasId canvas_id, ByteBuffer const& commands, Vector<Gfx::DecodedImageFrame> const& bitmaps)
+void CanvasHost::execute_webgl_commands(Web::Painting::CanvasId canvas_id, ReadonlyBytes commands, Vector<Gfx::DecodedImageFrame> const& bitmaps)
 {
     auto* context = this->context(canvas_id);
     VERIFY(context);

--- a/Services/Compositor/CanvasHost.h
+++ b/Services/Compositor/CanvasHost.h
@@ -51,7 +51,7 @@ public:
     bool has_context(Web::Painting::CanvasId) const;
 
     void execute_canvas_2d_commands(Web::Painting::CanvasId, Gfx::CanvasCommandList const&, bool commit);
-    void execute_webgl_commands(Web::Painting::CanvasId, ByteBuffer const&, Vector<Gfx::DecodedImageFrame> const&);
+    void execute_webgl_commands(Web::Painting::CanvasId, ReadonlyBytes, Vector<Gfx::DecodedImageFrame> const&);
     ErrorOr<ByteBuffer> execute_webgl_sync_call(Web::Painting::CanvasId, ByteBuffer request);
     Web::WebGL::ReadPixelsResult webgl_read_pixels_robust_angle(Web::Painting::CanvasId, Web::WebGL::GLint x, Web::WebGL::GLint y, Web::WebGL::GLsizei width, Web::WebGL::GLsizei height, Web::WebGL::GLenum format, Web::WebGL::GLenum type, Web::WebGL::GLsizei buf_size, Core::AnonymousBuffer pixels);
     void webgl_read_buffer_sub_data(Web::Painting::CanvasId, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data);

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -37,7 +37,7 @@ endpoint CompositorWebContentServer
     get_canvas_pixels(Web::Painting::CanvasId canvas_id, Gfx::IntRect rect) => (Gfx::ShareableBitmap pixels)
 
     create_webgl_context(Web::WebGL::WebGLVersion webgl_version, Gfx::IntSize size, bool depth, bool stencil, bool antialias) => (bool success, Web::Painting::CanvasId canvas_id, Vector<String> supported_extensions)
-    webgl_commands(Web::Painting::CanvasId canvas_id, ByteBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps) =|
+    webgl_commands(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps) =|
     webgl_present_canvas(Web::Painting::CanvasId canvas_id, bool preserve_drawing_buffer) =|
     webgl_sync_call(Web::Painting::CanvasId canvas_id, ByteBuffer request) => (ByteBuffer reply)
     webgl_read_pixels(Web::Painting::CanvasId canvas_id, i32 x, i32 y, i32 width, i32 height, u32 format, u32 type, i32 buf_size, Core::AnonymousBuffer pixels) => (i32 length, i32 columns, i32 rows)

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -141,9 +141,14 @@ Messages::CompositorWebContentServer::CreateWebglContextResponse ConnectionFromW
     return { result.success, result.canvas_id, move(result.supported_extensions) };
 }
 
-void ConnectionFromWebContent::webgl_commands(Web::Painting::CanvasId canvas_id, ByteBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps)
+void ConnectionFromWebContent::webgl_commands(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps)
 {
-    m_canvas_host.execute_webgl_commands(canvas_id, commands, bitmaps);
+    if (!commands.is_valid()) {
+        did_misbehave("WebContent sent an invalid WebGL command buffer");
+        return;
+    }
+
+    m_canvas_host.execute_webgl_commands(canvas_id, commands.bytes(), bitmaps);
 }
 
 void ConnectionFromWebContent::webgl_present_canvas(Web::Painting::CanvasId canvas_id, bool preserve_drawing_buffer)

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -51,7 +51,7 @@ private:
     virtual Messages::CompositorWebContentServer::GetCanvasPixelsResponse get_canvas_pixels(Web::Painting::CanvasId, Gfx::IntRect) override;
 
     virtual Messages::CompositorWebContentServer::CreateWebglContextResponse create_webgl_context(Web::WebGL::WebGLVersion webgl_version, Gfx::IntSize size, bool depth, bool stencil, bool antialias) override;
-    virtual void webgl_commands(Web::Painting::CanvasId canvas_id, ByteBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps) override;
+    virtual void webgl_commands(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps) override;
     virtual void webgl_present_canvas(Web::Painting::CanvasId canvas_id, bool preserve_drawing_buffer) override;
     virtual Messages::CompositorWebContentServer::WebglSyncCallResponse webgl_sync_call(Web::Painting::CanvasId canvas_id, ByteBuffer request) override;
     virtual Messages::CompositorWebContentServer::WebglReadPixelsResponse webgl_read_pixels(Web::Painting::CanvasId canvas_id, i32 x, i32 y, i32 width, i32 height, u32 format, u32 type, i32 buf_size, Core::AnonymousBuffer pixels) override;

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -6,6 +6,7 @@
 
 #include <WebContent/CompositorConnection.h>
 
+#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/EventLoop.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/PaintingSurface.h>
@@ -200,7 +201,10 @@ void CompositorConnection::send_webgl_commands(Web::Painting::CanvasId canvas_id
     if (!can_send_message_to_compositor())
         return;
 
-    auto encoded_message = MUST(Messages::CompositorWebContentServer::WebglCommands::static_encode(canvas_id, commands, bitmaps));
+    auto shared_commands = MUST(Core::AnonymousBuffer::create_with_size(commands.size()));
+    commands.bytes().copy_to({ shared_commands.data<u8>(), shared_commands.size() });
+
+    auto encoded_message = MUST(Messages::CompositorWebContentServer::WebglCommands::static_encode(canvas_id, shared_commands, bitmaps));
     if (post_message(encoded_message).is_error())
         did_lose_compositor();
 }

--- a/Tests/LibWeb/Crash/HTML/webgl-large-command-buffer.html
+++ b/Tests/LibWeb/Crash/HTML/webgl-large-command-buffer.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<canvas id="c"></canvas>
+<script>
+    let gl = c.getContext("webgl2");
+
+    // FIXME: This test relies on having a GPU backend enabled, which is not available in tests.
+    if (gl) {
+        let w = 4096;
+        let h = 4096;
+        let pixels = new Uint8Array(w * h * 4);
+        let texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, w, h);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixels, 0);
+    }
+</script>


### PR DESCRIPTION
Strava uses WebGL to display routes on a map. The command buffer for the map are upwards of 100MB, which far exceeds our IPC message limit. We now transfer the buffer over shared memory.

Note the test running here won't actually run in CI, as WebGL is not available. There are similar existing FIXMEs for this in other tests.

Fixes #10263