### PR TITLE
LibWeb: Thread transforms through SVG layout

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1667,18 +1667,6 @@ static void relayout_svg_root(Layout::SVGSVGBox& svg_root)
     if (auto paintable = svg_root.paintable_box())
         layout_state.populate_from_paintable(svg_root, *paintable);
 
-    // Pre-populate SVGGraphicsBox ancestors for get_parent_svg_transform().
-    for (auto* ancestor = svg_root.parent(); ancestor; ancestor = ancestor->parent()) {
-        if (auto const* svg_graphics_ancestor = as_if<Layout::SVGGraphicsBox>(*ancestor)) {
-            if (auto paintable = svg_graphics_ancestor->paintable_box())
-                layout_state.populate_from_paintable(*svg_graphics_ancestor, *paintable);
-        }
-        if (auto const* svg_svg_ancestor = as_if<Layout::SVGSVGBox>(*ancestor)) {
-            if (auto paintable = svg_svg_ancestor->paintable_box())
-                layout_state.populate_from_paintable(*svg_svg_ancestor, *paintable);
-        }
-    }
-
     // Pre-populate the viewport for position:fixed elements inside <foreignObject>.
     auto& viewport = svg_root.root();
     if (auto paintable = viewport.paintable_box())

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -1004,6 +1004,10 @@ void LayoutState::UsedValues::materialize_from_paintable(Painting::PaintableBox 
 
     if (auto const* svg_graphics_paintable = as_if<Painting::SVGGraphicsPaintable>(paintable))
         set_computed_svg_transforms(svg_graphics_paintable->computed_transforms());
+    if (auto const* svg_foreign_object_paintable = as_if<Painting::SVGForeignObjectPaintable>(paintable))
+        set_computed_svg_transforms(svg_foreign_object_paintable->computed_transforms());
+    if (auto const* svg_svg_paintable = as_if<Painting::SVGSVGPaintable>(paintable))
+        set_computed_svg_transforms(svg_svg_paintable->computed_transforms());
 }
 
 void LayoutState::UsedValues::set_content_width(CSSPixels width)

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -38,9 +38,10 @@
 
 namespace Web::Layout {
 
-SVGFormattingContext::SVGFormattingContext(LayoutState& state, LayoutMode layout_mode, Box const& box, FormattingContext* parent, Gfx::AffineTransform parent_viewbox_transform)
+SVGFormattingContext::SVGFormattingContext(LayoutState& state, LayoutMode layout_mode, Box const& box, FormattingContext* parent, Gfx::AffineTransform parent_viewbox_transform, Optional<Gfx::AffineTransform> parent_svg_transform)
     : FormattingContext(Type::SVG, layout_mode, state, box, parent)
     , m_parent_viewbox_transform(parent_viewbox_transform)
+    , m_parent_svg_transform(parent_svg_transform)
 {
 }
 
@@ -222,21 +223,12 @@ void SVGFormattingContext::run(AvailableSpace const& available_space)
         }
     }
 
-    if (auto const* svg_svg_box = as_if<SVGSVGBox>(context_box()); svg_svg_box && !svg_box_state.computed_svg_transforms().has_value()) {
-        bool has_svg_ancestor = false;
-        for (auto const* ancestor = svg_svg_box->parent(); ancestor; ancestor = ancestor->parent()) {
-            if (is<SVGSVGBox>(*ancestor) || is<SVGGraphicsBox>(*ancestor)) {
-                has_svg_ancestor = true;
-                break;
-            }
-        }
-        if (has_svg_ancestor) {
-            auto const& svg_graphics_element = as<SVG::SVGGraphicsElement>(*dom_node);
-            auto parent_svg_transform = get_parent_svg_transform(*svg_svg_box);
-            auto svg_transform = parent_svg_transform.multiply(svg_graphics_element.element_transform());
-            svg_box_state.set_computed_svg_transforms(
-                Painting::SVGGraphicsPaintable::ComputedTransforms(m_parent_viewbox_transform, svg_transform));
-        }
+    if (auto const* svg_svg_box = as_if<SVGSVGBox>(context_box()); svg_svg_box && m_parent_svg_transform.has_value() && !svg_box_state.computed_svg_transforms().has_value()) {
+        auto const& svg_graphics_element = as<SVG::SVGGraphicsElement>(*dom_node);
+        auto svg_transform = *m_parent_svg_transform;
+        svg_transform.multiply(svg_graphics_element.element_transform());
+        svg_box_state.set_computed_svg_transforms(
+            Painting::SVGGraphicsPaintable::ComputedTransforms(m_parent_viewbox_transform, svg_transform));
     }
 
     m_current_viewbox_transform = m_parent_viewbox_transform;
@@ -307,16 +299,20 @@ void SVGFormattingContext::run(AvailableSpace const& available_space)
         svg_box_state.set_has_definite_height(true);
     }
 
+    auto svg_transform_for_children = m_parent_svg_transform.value_or(Gfx::AffineTransform {});
+    if (svg_box_state.computed_svg_transforms().has_value())
+        svg_transform_for_children = svg_box_state.computed_svg_transforms()->svg_transform();
+
     context_box().for_each_child_of_type<Box>([&](Box const& child) {
-        layout_svg_element(child);
+        layout_svg_element(child, svg_transform_for_children);
         return IterationDecision::Continue;
     });
 }
 
-void SVGFormattingContext::layout_svg_element(Box const& child)
+void SVGFormattingContext::layout_svg_element(Box const& child, Gfx::AffineTransform const& parent_svg_transform)
 {
     if (is<SVG::SVGFitToViewBox>(child.dom_node())) {
-        layout_nested_viewport(child);
+        layout_nested_viewport(child, parent_svg_transform);
     } else if (auto* foreign_object_element = as_if<SVG::SVGForeignObjectElement>(child.dom_node()); foreign_object_element && is<BlockContainer>(child)) {
         Layout::BlockFormattingContext bfc(m_state, m_layout_mode, as<BlockContainer>(child), this);
         auto& child_state = m_state.get_mutable(child);
@@ -330,8 +326,8 @@ void SVGFormattingContext::layout_svg_element(Box const& child)
                 child.computed_values().height().to_px(m_available_space->height.to_px_or_zero()),
             }
         };
-        auto parent_svg_transform = get_parent_svg_transform(child);
-        auto svg_transform = parent_svg_transform.multiply(foreign_object_element->element_transform());
+        auto svg_transform = parent_svg_transform;
+        svg_transform.multiply(foreign_object_element->element_transform());
         child_state.set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
         auto to_css_pixels_transform = Gfx::AffineTransform {}.multiply(m_current_viewbox_transform).multiply(svg_transform);
         auto transformed_rect = to_css_pixels_transform.map(rect.to_type<float>()).to_type<CSSPixels>();
@@ -347,11 +343,11 @@ void SVGFormattingContext::layout_svg_element(Box const& child)
         if (auto* clip_box = child.first_child_of_type<SVGClipBox>())
             layout_mask_or_clip(*clip_box);
     } else if (is<SVGGraphicsBox>(child)) {
-        layout_graphics_element(static_cast<SVGGraphicsBox const&>(child));
+        layout_graphics_element(static_cast<SVGGraphicsBox const&>(child), parent_svg_transform);
     }
 }
 
-void SVGFormattingContext::layout_nested_viewport(Box const& viewport)
+void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::AffineTransform const& parent_svg_transform)
 {
     // Layout for a nested SVG viewport.
     // https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport.
@@ -393,7 +389,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport)
     nested_viewport_state.set_content_height(content_height);
     nested_viewport_state.set_has_definite_width(true);
     nested_viewport_state.set_has_definite_height(true);
-    SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform);
+    SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform, parent_svg_transform);
     nested_context.run(*m_available_space);
 }
 
@@ -507,7 +503,7 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
         // <text> and <tspan> elements can contain more text elements.
         text_box->for_each_child_of_type<SVGGraphicsBox>([&](auto& child) {
             if (is<SVGTextBox>(child) || is<SVGTextPathBox>(child))
-                layout_graphics_element(child);
+                layout_graphics_element(child, graphics_box_state.computed_svg_transforms()->svg_transform());
             return IterationDecision::Continue;
         });
     } else if (auto* text_path_box = as_if<SVGTextPathBox>(graphics_box)) {
@@ -529,40 +525,18 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
     graphics_box_state.set_computed_svg_path(move(path));
 }
 
-Gfx::AffineTransform SVGFormattingContext::get_parent_svg_transform(Box const& box) const
-{
-    // Mask/clip boxes are transform boundaries — the target's transform is applied separately at paint time.
-    for (auto* ancestor = box.parent(); ancestor; ancestor = ancestor->parent()) {
-        if (is<SVGMaskBox>(*ancestor) || is<SVGClipBox>(*ancestor) || is<SVGPatternBox>(*ancestor))
-            return {};
-        if (auto const* svg_svg_box = as_if<SVGSVGBox>(*ancestor)) {
-            if (auto const* ancestor_state = m_state.try_get(*svg_svg_box)) {
-                if (ancestor_state->computed_svg_transforms().has_value())
-                    return ancestor_state->computed_svg_transforms()->svg_transform();
-            }
-            continue;
-        }
-        if (auto const* svg_graphics_box = as_if<SVGGraphicsBox>(*ancestor)) {
-            auto const& ancestor_state = m_state.get(*svg_graphics_box);
-            if (ancestor_state.computed_svg_transforms().has_value())
-                return ancestor_state.computed_svg_transforms()->svg_transform();
-        }
-    }
-    return {};
-}
-
-void SVGFormattingContext::layout_graphics_element(SVGGraphicsBox const& graphics_box)
+void SVGFormattingContext::layout_graphics_element(SVGGraphicsBox const& graphics_box, Gfx::AffineTransform const& parent_svg_transform)
 {
     auto& graphics_box_state = m_state.get_mutable(graphics_box);
-    auto parent_svg_transform = get_parent_svg_transform(graphics_box);
-    auto svg_transform = parent_svg_transform.multiply(const_cast<SVGGraphicsBox&>(graphics_box).dom_node().element_transform());
+    auto svg_transform = parent_svg_transform;
+    svg_transform.multiply(const_cast<SVGGraphicsBox&>(graphics_box).dom_node().element_transform());
     graphics_box_state.set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
 
     if (is_container_element(graphics_box)) {
         // https://svgwg.org/svg2-draft/struct.html#Groups
         // 5.2. Grouping: the ‘g’ element
         // The ‘g’ element is a container element for grouping together related graphics elements.
-        layout_container_element(graphics_box);
+        layout_container_element(graphics_box, svg_transform);
     } else if (is<SVGImageBox>(graphics_box)) {
         layout_image_element(static_cast<SVGImageBox const&>(graphics_box));
     } else {
@@ -640,13 +614,13 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
         layout_state.set_content_height(m_viewport_size.height());
     }
     // Pretend masks/clips are a viewport so we can scale the contents depending on the `contentUnits`.
-    SVGFormattingContext nested_context(m_state, m_layout_mode, mask_or_clip, this, parent_viewbox_transform);
+    SVGFormattingContext nested_context(m_state, m_layout_mode, mask_or_clip, this, parent_viewbox_transform, Gfx::AffineTransform {});
     layout_state.set_has_definite_width(true);
     layout_state.set_has_definite_height(true);
     nested_context.run(*m_available_space);
 }
 
-void SVGFormattingContext::layout_container_element(SVGBox const& container)
+void SVGFormattingContext::layout_container_element(SVGBox const& container, Gfx::AffineTransform const& container_svg_transform)
 {
     auto& box_state = m_state.get_mutable(container);
     Gfx::BoundingBox<CSSPixels> bounding_box;
@@ -654,7 +628,7 @@ void SVGFormattingContext::layout_container_element(SVGBox const& container)
         // Masks/clips/patterns do not change the bounding box of their parents.
         if (is<SVGMaskBox>(child) || is<SVGClipBox>(child) || is<SVGPatternBox>(child))
             return IterationDecision::Continue;
-        layout_svg_element(child);
+        layout_svg_element(child, container_svg_transform);
         auto& child_state = m_state.get(child);
         bounding_box.add_point(child_state.offset);
         bounding_box.add_point(child_state.offset.translated(child_state.content_width(), child_state.content_height()));

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -17,7 +17,7 @@ namespace Web::Layout {
 
 class SVGFormattingContext final : public FormattingContext {
 public:
-    explicit SVGFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent, Gfx::AffineTransform parent_viewbox_transform = {});
+    explicit SVGFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent, Gfx::AffineTransform parent_viewbox_transform = {}, Optional<Gfx::AffineTransform> parent_svg_transform = {});
     ~SVGFormattingContext();
 
     virtual void run(AvailableSpace const&) override;
@@ -25,10 +25,10 @@ public:
     virtual CSSPixels automatic_content_height() const override;
 
 private:
-    void layout_svg_element(Box const&);
-    void layout_nested_viewport(Box const&);
-    void layout_container_element(SVGBox const&);
-    void layout_graphics_element(SVGGraphicsBox const&);
+    void layout_svg_element(Box const&, Gfx::AffineTransform const& parent_svg_transform);
+    void layout_nested_viewport(Box const&, Gfx::AffineTransform const& parent_svg_transform);
+    void layout_container_element(SVGBox const&, Gfx::AffineTransform const& container_svg_transform);
+    void layout_graphics_element(SVGGraphicsBox const&, Gfx::AffineTransform const& parent_svg_transform);
     void layout_path_like_element(SVGGraphicsBox const&);
     void layout_mask_or_clip(SVGBox const&);
     void layout_image_element(SVGImageBox const& image_box);
@@ -36,9 +36,8 @@ private:
     [[nodiscard]] Gfx::Path compute_path_for_text(SVGTextBox const&) const;
     [[nodiscard]] Gfx::Path compute_path_for_text_path(SVGTextPathBox const&) const;
 
-    [[nodiscard]] Gfx::AffineTransform get_parent_svg_transform(Box const&) const;
-
     Gfx::AffineTransform m_parent_viewbox_transform {};
+    Optional<Gfx::AffineTransform> m_parent_svg_transform {};
 
     Optional<AvailableSpace> m_available_space {};
     Gfx::AffineTransform m_current_viewbox_transform {};


### PR DESCRIPTION
SVG layout recovered the active graphics transform by walking ancestor layout nodes and reading their used values. That made nested SVG formatting contexts depend on layout state outside their own root, which breaks once SVG layout is rerun from a partial relayout state.

Pass the current SVG transform through SVGFormattingContext recursion and nested SVG context construction instead. Mask, clip, and pattern contexts still reset the graphics transform boundary. Partial SVG relayout no longer pre-populates ancestor SVG paintables just to serve that transform walk.

Restored layout state now copies computed transforms from SVG and foreignObject paintables so partial relayout starts with the same transform data as a full layout.