### PR TITLE
LibWeb+LibWebView: Implement downloading for unsupported content types

### DIFF
--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -13,6 +13,7 @@
 #include <AK/Utf16FlyString.h>
 #include <LibCore/Promise.h>
 #include <LibCore/Resource.h>
+#include <LibHTTP/HeaderList.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibURL/URL.h>
@@ -32,6 +33,7 @@
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/MimeSniff/Resource.h>
 #include <LibWeb/Namespace.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/XML/XMLDocumentBuilder.h>
 #include <LibXML/Parser/Parser.h>
@@ -527,6 +529,7 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
     if (type.essence() == "multipart/x-mixed-replace"_string) {
         // FIXME: Return the result of loading a multipart/x-mixed-replace document, given navigationParams,
         //        sourceSnapshotParams, and initiatorOrigin.
+        // NB: Until we do implement this, control falls through such that the response downloaded (step 4 below).
     }
 
     // -> a supported image, video, or audio type
@@ -545,16 +548,20 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
 
     // Otherwise, proceed onward.
 
-    // FIXME: 3. If, given type, the new resource is to be handled by displaying some sort of inline content, e.g., a
+    // 3. If, given type, the new resource is to be handled by displaying some sort of inline content, e.g., a
     //    native rendering of the content or an error message because the specified type is not supported, then
     //    return the result of creating a document for inline content that doesn't have a DOM given navigationParams's
     //    navigable, navigationParams's id, navigationParams's navigation timing type, and navigationParams's user involvement.
+    // NB: We don't do "handled by displaying some sort of inline content"; instead, we "handle as a download" (below).
 
-    // FIXME: 4. Otherwise, the document's type is such that the resource will not affect navigationParams's navigable,
-    //        e.g., because the resource is to be handed to an external application or because it is an unknown type
-    //        that will be processed by handle as a download. Hand-off to external software given navigationParams's
-    //        response, navigationParams's navigable, navigationParams's final sandboxing flag set,
-    //        sourceSnapshotParams's has transient activation, and initiatorOrigin.
+    // 4. Otherwise, the document's type is such that the resource will not affect navigationParams's navigable,
+    //    e.g., because the resource is to be handed to an external application or because it is an unknown type
+    //    that will be processed by handle as a download. Hand-off to external software given navigationParams's
+    //    response, navigationParams's navigable, navigationParams's final sandboxing flag set,
+    //    sourceSnapshotParams's has transient activation, and initiatorOrigin.
+    // AD-HOC: We don't implement "Hand-off to external software". Instead we "handle as a download" — even though, as
+    //         currently written, the spec language cited above doesn't strictly/normatively hook into that here.
+    navigation_params.navigable->handle_as_a_download(*navigation_params.response);
 
     // 5. Return null.
     return nullptr;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -9,6 +9,7 @@
 #include <AK/NeverDestroyed.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/PaintingSurface.h>
+#include <LibHTTP/HeaderList.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/SystemColor.h>
@@ -30,6 +31,7 @@
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/Fetch/Infrastructure/URL.h>
 #include <LibWeb/FileAPI/File.h>
 #include <LibWeb/HTML/BrowsingContext.h>
@@ -673,6 +675,44 @@ GC::Ptr<DOM::Document> LocalNavigable::active_document() const
 {
     // A navigable's active document is its active session history entry's document.
     return m_active_document;
+}
+
+// A response specifies the attachment disposition type via a Content-Disposition header.
+static bool navigation_response_specifies_attachment(Fetch::Infrastructure::Response const& response)
+{
+    auto disposition = response.header_list()->get("Content-Disposition"sv);
+    if (!disposition.has_value())
+        return false;
+    auto value = StringView { disposition.value() };
+    auto disposition_type = value.find(';').map([&](size_t i) { return value.substring_view(0, i); }).value_or(value);
+    return disposition_type.trim_whitespace().equals_ignoring_ascii_case("attachment"sv);
+}
+
+// https://html.spec.whatwg.org/multipage/links.html#handle-as-a-download
+void LocalNavigable::handle_as_a_download(Fetch::Infrastructure::Response& response)
+{
+    // To handle as a download a response response with a navigable navigable and a navigation ID or null navigationId:
+    // 1. Let suggestedFilename be the result of getting the suggested filename for response.
+    // FIXME: We don't implement "getting the suggested filename" (the filename from Content-Disposition, sanitized);
+    //        instead (in FileDownloader::begin_streamed_download), we derive a filename from the response URL.
+    // FIXME: We don't implement steps 2 to 4 (the WebDriver BiDi download-will-begin and cancellation reporting, and
+    //        the destination-folder lookup).
+    // 5. Run these steps in parallel:
+    //    1. Run implementation-defined steps to save response for later use. If destinationFolder is not null, the
+    //       user agent should save the file to that path. If the user agent needs a filename, the user agent should
+    //       use the suggestedFilename.
+    // AD-HOC: We don't implement substeps 5.2 and 5.3 (the WebDriver BiDi download-end reporting); instead, we register
+    //         the response as a pending download and use PageClient::page_did_request_download to get a destination
+    //         into which we stream the response body. We still report completion/failure — just not via WebDriver BiDi.
+    // FIXME: We stream using the navigable's active document's global as the task destination, and bail if there is
+    //        none. That ties the download to a document it is meant to outlive, and silently drops it in the (near-
+    //        unreachable) no-active-document case; a stabler global/explicit handling would be better.
+    auto document = active_document();
+    if (!document)
+        return;
+    auto download_id = page().register_download(response, document->realm().global_object());
+    auto download_url = response.url().value_or(URL::about_blank());
+    page().client().page_did_request_download(download_url, String {}, download_id);
 }
 
 Optional<UniqueNodeID> LocalNavigable::active_document_id() const
@@ -1874,9 +1914,26 @@ void LocalNavigable::populate_session_history_entry_document(
                 }
             }
 
-            // FIXME: 5. Otherwise, if navigationParams's response has a `Content-Disposition` header specifying the attachment
-            //    disposition type, then:
-            else if (false) {
+            // 5. Otherwise, if navigationParams's response has a `Content-Disposition` header specifying the attachment
+            //    disposition type:
+            else if (navigation_params.has<GC::Ref<NavigationParams>>() && navigation_response_specifies_attachment(*navigation_params.get<GC::Ref<NavigationParams>>()->response)) {
+                auto const& nav_params = navigation_params.get<GC::Ref<NavigationParams>>();
+
+                // 1. Let sourceAllowsDownloading be sourceSnapshotParams's allows downloading.
+                // FIXME: We don't (yet) plumb through sourceSnapshotParams to here, so we don't implement step 1 here.
+                // 2. Let targetAllowsDownloading be false if navigationParams's final sandboxing flag set has the
+                //    sandboxed downloads browsing context flag set; otherwise true.
+                auto target_allows_downloading = !has_flag(nav_params->final_sandboxing_flag_set, SandboxingFlagSet::SandboxedDownloads);
+                // 3. Let uaAllowsDownloading be true.
+                // 4. Optionally, the user agent may set uaAllowsDownloading to false, if it believes doing so would
+                //    safeguard the user from a potentially hostile download.
+                // FIXME: We don't implement this (optional) uaAllowsDownloading safeguard (step 4).
+                // 5. If sourceAllowsDownloading, targetAllowsDownloading, and uaAllowsDownloading are true:
+                if (target_allows_downloading) {
+                    // 1. Handle as a download navigationParams's response with navigable and navigationId.
+                    handle_as_a_download(*nav_params->response);
+                }
+                // NOTE: This branch leaves entry's document state's document as null.
             }
 
             // 6. Otherwise, if navigationParams's response's status is not 204 and is not 205, then set entry's document state's document to the result of

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -229,6 +229,8 @@ public:
     Page& page() { return m_page; }
     Page const& page() const { return m_page; }
 
+    void handle_as_a_download(Fetch::Infrastructure::Response&);
+
     String selected_text() const;
     String cut_selected_text() const;
     void select_all();

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -92,6 +92,14 @@ void Internals::signal_test_is_done(String const& text)
     page().client().page_did_finish_test(text);
 }
 
+Optional<String> Internals::take_last_navigation_download_url()
+{
+    auto url = page().take_last_navigation_download_url();
+    if (!url.has_value())
+        return {};
+    return url->serialize();
+}
+
 void Internals::set_test_timeout(double milliseconds)
 {
     page().client().page_did_set_test_timeout(milliseconds);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -75,6 +75,7 @@ public:
 
     void spoof_current_url(String const& url);
     void load_url(String const& url);
+    Optional<String> take_last_navigation_download_url();
 
     GC::Ref<InternalAnimationTimeline> create_internal_animation_timeline();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -67,6 +67,9 @@ interface Internals {
     // session-history traversal-queue steps, as can one requested by ConnectionFromClient::load_url in the UI process.
     undefined loadURL(USVString url);
 
+    // Returns (and clears) the URL of the most-recently-requested navigation download — or null, if none.
+    USVString? takeLastNavigationDownloadURL();
+
     InternalAnimationTimeline createInternalAnimationTimeline();
 
     undefined simulateDragStart(double x, double y, DOMString mimeType, DOMString contents);

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/SourceLocation.h>
+#include <LibCore/File.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
@@ -51,6 +52,84 @@ Page::Page(GC::Ref<PageClient> client)
 
 Page::~Page() = default;
 
+namespace {
+
+struct DownloadSink : public RefCounted<DownloadSink> {
+    explicit DownloadSink(NonnullOwnPtr<Core::File> destination)
+        : file(move(destination))
+    {
+    }
+    NonnullOwnPtr<Core::File> file;
+    bool failed { false };
+};
+
+}
+
+Optional<URL::URL> Page::take_last_navigation_download_url()
+{
+    return AK::exchange(m_last_navigation_download_url, {});
+}
+
+u64 Page::register_download(Fetch::Infrastructure::Response& response, JS::Object& global)
+{
+    auto download_id = ++m_next_download_id;
+    m_pending_downloads.set(download_id, PendingDownload { response, global });
+    if (auto url = response.url(); url.has_value())
+        m_last_navigation_download_url = *url;
+    return download_id;
+}
+
+void Page::on_download_destination(u64 download_id, int destination_fd)
+{
+    auto pending = m_pending_downloads.take(download_id);
+
+    // Adopt the descriptor immediately, so it's closed (below) on any early return.
+    OwnPtr<Core::File> file;
+    if (destination_fd >= 0) {
+        if (auto opened = Core::File::adopt_fd(destination_fd, Core::File::OpenMode::Write); !opened.is_error())
+            file = opened.release_value();
+    }
+
+    // A missing entry means the download was already handled; a missing file means the user canceled the dialog.
+    if (!pending.has_value() || !file)
+        return;
+
+    auto body = pending->response->body();
+    if (!body) {
+        client().page_did_finish_download(download_id);
+        return;
+    }
+
+    auto sink = make_ref_counted<DownloadSink>(file.release_nonnull());
+
+    body->incrementally_read(
+        // NOLINTNEXTLINE(performance-unnecessary-value-param)
+        GC::create_function(heap(), [this, download_id, sink](ByteBuffer chunk) {
+            if (sink->failed)
+                return;
+            if (auto result = sink->file->write_until_depleted(chunk); result.is_error()) {
+                sink->failed = true;
+                dbgln("Download {}: failed to write to destination: {}", download_id, result.error());
+                client().page_did_fail_download(download_id, MUST(String::formatted("Failed to write download to disk: {}", result.error())));
+                // FIXME: Cancel the body reader / abort the fetch — so we stop pulling bytes after a write failure.
+            }
+        }),
+        GC::create_function(heap(), [this, download_id, sink]() {
+            if (sink->failed)
+                return;
+            sink->file->close();
+            client().page_did_finish_download(download_id);
+        }),
+        GC::create_function(heap(), [this, download_id, sink](JS::Value error) {
+            if (sink->failed)
+                return;
+            sink->failed = true;
+            dbgln("Download {}: failed: {}", download_id, error);
+            client().page_did_fail_download(download_id, MUST(String::formatted("The download failed: {}", error)));
+        }),
+        GC::Ref<JS::Object> { pending->global });
+}
+
 bool Page::has_compositor_host() const
 {
     return m_client->compositor_host();
@@ -86,6 +165,10 @@ void Page::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_window_rect_observer);
     visitor.visit(m_on_pending_dialog_closed);
     visitor.visit(m_pending_clipboard_requests);
+    for (auto& download : m_pending_downloads) {
+        visitor.visit(download.value.response);
+        visitor.visit(download.value.global);
+    }
     m_pending_fullscreen_operations.for_each([&](auto const& operation) {
         operation.visit([&](PendingFullscreenEnter const& enter_operation) {
                 visitor.visit(enter_operation.element);

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/JsonValue.h>
 #include <AK/Queue.h>
 #include <AK/Variant.h>
@@ -108,6 +109,10 @@ public:
 
     void load_html(StringView);
     void load_html(StringView, URL::URL const&);
+
+    u64 register_download(Fetch::Infrastructure::Response&, JS::Object& global);
+    Optional<URL::URL> take_last_navigation_download_url();
+    void on_download_destination(u64 download_id, int destination_fd);
 
     void reload();
 
@@ -363,6 +368,14 @@ private:
     HashMap<u64, ClipboardRequest> m_pending_clipboard_requests;
     u64 m_next_clipboard_request_id { 0 };
 
+    struct PendingDownload {
+        GC::Ref<Fetch::Infrastructure::Response> response;
+        GC::Ref<JS::Object> global;
+    };
+    u64 m_next_download_id { 0 };
+    HashMap<u64, PendingDownload> m_pending_downloads;
+    Optional<URL::URL> m_last_navigation_download_url;
+
     Vector<UniqueNodeID> m_media_elements;
     Vector<UniqueNodeID> m_canvas_elements;
     Optional<UniqueNodeID> m_media_context_menu_element_id;
@@ -554,6 +567,10 @@ public:
     virtual void page_did_request_color_picker([[maybe_unused]] Color current_color) { }
     virtual void page_did_request_file_picker([[maybe_unused]] HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles) { }
     virtual void page_did_request_select_dropdown([[maybe_unused]] Web::CSSPixelPoint content_position, [[maybe_unused]] Web::CSSPixels minimum_width, [[maybe_unused]] Vector<Web::HTML::SelectItem> items) { }
+
+    virtual void page_did_request_download([[maybe_unused]] URL::URL const& url, [[maybe_unused]] String const& suggested_name, [[maybe_unused]] u64 download_id) { }
+    virtual void page_did_finish_download([[maybe_unused]] u64 download_id) { }
+    virtual void page_did_fail_download([[maybe_unused]] u64 download_id, [[maybe_unused]] String const& error) { }
 
     virtual void page_did_finish_test([[maybe_unused]] String const& text) { }
     virtual void page_did_set_test_timeout([[maybe_unused]] double milliseconds) { }

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -5,7 +5,9 @@
  */
 
 #include <LibCore/File.h>
+#include <LibCore/System.h>
 #include <LibHTTP/HeaderList.h>
+#include <LibIPC/File.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
 #include <LibWeb/Loader/UserAgent.h>
@@ -67,6 +69,50 @@ void FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
         });
 
     m_requests.set(request_id, request.release_nonnull());
+}
+
+Optional<IPC::File> FileDownloader::begin_streamed_download(u64 page_id, u64 download_id, URL::URL const& url, String const& suggested_name)
+{
+    auto name = suggested_name.is_empty() ? url.basename() : suggested_name.to_byte_string();
+
+    auto download_path = Application::the().path_for_downloaded_file(name);
+    if (download_path.is_error())
+        return {};
+
+    // Stream into a temporary ".part" file — so a download that fails or is interrupted neither destroys an existing
+    // file at the destination, nor leaves a truncated one there; on success, the file is renamed into place.
+    auto partial_path = MUST(String::formatted("{}.part", download_path.value().string()));
+    auto file = Core::File::open(partial_path, Core::File::OpenMode::Write);
+    if (file.is_error()) {
+        Application::the().display_error_dialog(MUST(String::formatted("Unable to open download destination: {}", file.error())));
+        return {};
+    }
+
+    m_streamed_downloads.set({ page_id, download_id }, download_path.release_value());
+    return IPC::File::adopt_file(file.release_value());
+}
+
+void FileDownloader::streamed_download_finished(u64 page_id, u64 download_id)
+{
+    auto download = m_streamed_downloads.take({ page_id, download_id });
+    if (!download.has_value())
+        return;
+
+    auto partial_path = MUST(String::formatted("{}.part", download->string()));
+    if (auto result = Core::System::rename(partial_path, download->string()); result.is_error()) {
+        (void)Core::System::unlink(partial_path);
+        Application::the().display_error_dialog(MUST(String::formatted("Unable to save download {}: {}", download->basename(), result.error())));
+    }
+    // FIXME: Add download-manager UI, to show download completion to users.
+}
+
+void FileDownloader::streamed_download_failed(u64 page_id, u64 download_id, String const& error)
+{
+    auto download = m_streamed_downloads.take({ page_id, download_id });
+    if (download.has_value())
+        (void)Core::System::unlink(MUST(String::formatted("{}.part", download->string())));
+    auto name = download.has_value() ? download->basename() : "file"sv;
+    Application::the().display_error_dialog(MUST(String::formatted("Unable to download {}: {}", name, error)));
 }
 
 }

--- a/Libraries/LibWebView/FileDownloader.h
+++ b/Libraries/LibWebView/FileDownloader.h
@@ -9,6 +9,8 @@
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/String.h>
+#include <LibIPC/File.h>
 #include <LibRequests/Forward.h>
 #include <LibURL/Forward.h>
 #include <LibWebView/Forward.h>
@@ -22,8 +24,31 @@ public:
 
     void download_file(URL::URL const&, LexicalPath);
 
+    Optional<IPC::File> begin_streamed_download(u64 page_id, u64 download_id, URL::URL const&, String const& suggested_name);
+    void streamed_download_finished(u64 page_id, u64 download_id);
+    void streamed_download_failed(u64 page_id, u64 download_id, String const& error);
+
+    struct StreamedDownloadKey {
+        u64 page_id { 0 };
+        u64 download_id { 0 };
+        bool operator==(StreamedDownloadKey const&) const = default;
+    };
+
 private:
     HashMap<u64, NonnullRefPtr<Requests::Request>> m_requests;
+    HashMap<StreamedDownloadKey, LexicalPath> m_streamed_downloads;
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<WebView::FileDownloader::StreamedDownloadKey> : public DefaultTraits<WebView::FileDownloader::StreamedDownloadKey> {
+    static unsigned hash(WebView::FileDownloader::StreamedDownloadKey const& key)
+    {
+        return pair_int_hash(static_cast<u32>(key.page_id), static_cast<u32>(key.download_id));
+    }
 };
 
 }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -12,10 +12,12 @@
 #include <AK/String.h>
 #include <AK/Time.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibGfx/SharedImageBuffer.h>
+#include <LibIPC/File.h>
 #include <LibURL/Parser.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/Crypto/Crypto.h>
@@ -1219,6 +1221,14 @@ void ViewImplementation::prompt_closed(Optional<String> const& response)
 void ViewImplementation::color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state)
 {
     client().async_color_picker_update(page_id(), picked_color, state);
+}
+
+void ViewImplementation::did_request_download(Badge<WebContentClient>, u64 download_id, URL::URL const& url, String const& suggested_name)
+{
+    auto destination = on_request_download
+        ? on_request_download(download_id, url, suggested_name)
+        : Application::the().file_downloader().begin_streamed_download(page_id(), download_id, url, suggested_name);
+    client().async_download_destination(page_id(), download_id, destination);
 }
 
 void ViewImplementation::file_picker_closed(Vector<Web::HTML::SelectedFile> selected_files)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -253,6 +253,7 @@ public:
     Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
 
     void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled);
+    void did_request_download(Badge<WebContentClient>, u64 download_id, URL::URL const& url, String const& suggested_name);
     void did_update_session_history(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index);
     void did_update_session_history_for_testing(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index);
     void did_set_top_level_session_history(Badge<WebContentClient>, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index);
@@ -354,6 +355,7 @@ public:
     Function<void()> on_exit_fullscreen_window;
     Function<void(Color current_color)> on_request_color_picker;
     Function<void(Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles)> on_request_file_picker;
+    Function<Optional<IPC::File>(u64 download_id, URL::URL const& url, String const& suggested_name)> on_request_download;
     Function<void(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)> on_request_select_dropdown;
     Function<void(Web::KeyEvent const&)> on_finish_handling_key_event;
     Function<void(Web::DragEvent const&)> on_finish_handling_drag_event;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1512,6 +1512,22 @@ void WebContentClient::did_request_file_picker(u64 page_id, Web::HTML::FileFilte
     }
 }
 
+void WebContentClient::did_request_download(u64 page_id, u64 download_id, URL::URL url, String suggested_name)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_request_download({}, download_id, url, suggested_name);
+}
+
+void WebContentClient::did_finish_download(u64 page_id, u64 download_id)
+{
+    Application::the().file_downloader().streamed_download_finished(page_id, download_id);
+}
+
+void WebContentClient::did_fail_download(u64 page_id, u64 download_id, String error)
+{
+    Application::the().file_downloader().streamed_download_failed(page_id, download_id, error);
+}
+
 void WebContentClient::did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -216,6 +216,9 @@ private:
     virtual void did_request_file(u64 page_id, ByteString path, i32) override;
     virtual void did_request_color_picker(u64 page_id, Color current_color) override;
     virtual void did_request_file_picker(u64 page_id, Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles) override;
+    virtual void did_request_download(u64 page_id, u64 download_id, URL::URL url, String suggested_name) override;
+    virtual void did_finish_download(u64 page_id, u64 download_id) override;
+    virtual void did_fail_download(u64 page_id, u64 download_id, String error) override;
     virtual void did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) override;
     virtual void did_finish_handling_input_event(u64 page_id, Web::EventResult event_result) override;
     virtual void did_update_input_caret_rect(u64 page_id, Optional<Web::DevicePixelRect> rect) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2245,6 +2245,12 @@ void ConnectionFromClient::handle_file_return(u64, i32 error, Optional<IPC::File
     file_request.value().on_file_request_finish(error != 0 ? Error::from_errno(error) : ErrorOr<i32> { file->take_fd() });
 }
 
+void ConnectionFromClient::download_destination(u64 page_id, u64 download_id, Optional<IPC::File> file)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().on_download_destination(download_id, file.has_value() ? file->take_fd() : -1);
+}
+
 void ConnectionFromClient::request_file(u64 page_id, Web::FileRequest file_request)
 {
     i32 const id = last_id++;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -168,6 +168,7 @@ private:
     virtual void set_window_size(u64 page_id, Web::DevicePixelSize) override;
     virtual void did_update_window_rect(u64 page_id) override;
     virtual void handle_file_return(u64 page_id, i32 error, Optional<IPC::File> file, i32 request_id) override;
+    virtual void download_destination(u64 page_id, u64 download_id, Optional<IPC::File> file) override;
     virtual void did_delete_all_cookies(u64 page_id, u64 request_id) override;
     virtual void set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState) override;
     virtual void reset_zoom(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1012,6 +1012,21 @@ void PageClient::page_did_request_select_dropdown(Web::CSSPixelPoint content_pos
     client().async_did_request_select_dropdown(m_id, page().css_to_device_point(content_position).to_type<int>(), minimum_width * device_pixels_per_css_pixel(), items);
 }
 
+void PageClient::page_did_request_download(URL::URL const& url, String const& suggested_name, u64 download_id)
+{
+    client().async_did_request_download(m_id, download_id, url, suggested_name);
+}
+
+void PageClient::page_did_finish_download(u64 download_id)
+{
+    client().async_did_finish_download(m_id, download_id);
+}
+
+void PageClient::page_did_fail_download(u64 download_id, String const& error)
+{
+    client().async_did_fail_download(m_id, download_id, error);
+}
+
 void PageClient::page_did_change_theme_color(Gfx::Color color)
 {
     client().async_did_change_theme_color(m_id, color);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -231,6 +231,9 @@ private:
     virtual void request_file(Web::FileRequest) override;
     virtual void page_did_request_color_picker(Color current_color) override;
     virtual void page_did_request_file_picker(Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles) override;
+    virtual void page_did_request_download(URL::URL const& url, String const& suggested_name, u64 download_id) override;
+    virtual void page_did_finish_download(u64 download_id) override;
+    virtual void page_did_fail_download(u64 download_id, String const& error) override;
     virtual void page_did_request_select_dropdown(Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items) override;
     virtual void page_did_finish_test(String const& text) override;
     virtual void page_did_set_test_timeout(double milliseconds) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -150,6 +150,9 @@ endpoint WebContentClient
     did_request_file(u64 page_id, ByteString path, i32 request_id) =|
     did_request_color_picker(u64 page_id, Color current_color) =|
     did_request_file_picker(u64 page_id, Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles allow_multiple_files) =|
+    did_request_download(u64 page_id, u64 download_id, URL::URL url, String suggested_name) =|
+    did_finish_download(u64 page_id, u64 download_id) =|
+    did_fail_download(u64 page_id, u64 download_id, String error) =|
     did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) =|
     did_finish_handling_input_event(u64 page_id, Web::EventResult event_result) =|
     did_update_input_caret_rect(u64 page_id, Optional<Web::DevicePixelRect> rect) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -164,6 +164,7 @@ endpoint WebContentServer
     reset_zoom(u64 page_id) =|
 
     handle_file_return(u64 page_id, i32 error, Optional<IPC::File> file, i32 request_id) =|
+    download_destination(u64 page_id, u64 download_id, Optional<IPC::File> file) =|
     did_delete_all_cookies(u64 page_id, u64 request_id) =|
 
     set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state) =|

--- a/Tests/LibWeb/Text/expected/navigate-attachment-disposition-variants.txt
+++ b/Tests/LibWeb/Text/expected/navigate-attachment-disposition-variants.txt
@@ -1,0 +1,2 @@
+filename downloaded: true
+uppercase downloaded: true

--- a/Tests/LibWeb/Text/expected/navigate-attachment-downloads.txt
+++ b/Tests/LibWeb/Text/expected/navigate-attachment-downloads.txt
@@ -1,0 +1,1 @@
+attachment requested a download: true

--- a/Tests/LibWeb/Text/expected/navigate-renderable-not-downloaded.txt
+++ b/Tests/LibWeb/Text/expected/navigate-renderable-not-downloaded.txt
@@ -1,0 +1,2 @@
+download requested: false
+iframe rendered the response: true

--- a/Tests/LibWeb/Text/expected/navigate-unsupported-type-downloads.txt
+++ b/Tests/LibWeb/Text/expected/navigate-unsupported-type-downloads.txt
@@ -1,0 +1,2 @@
+download requested for octet-stream: true
+iframe rendered the response: false

--- a/Tests/LibWeb/Text/input/navigate-attachment-disposition-variants.html
+++ b/Tests/LibWeb/Text/input/navigate-attachment-disposition-variants.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        // Content-Disposition: attachment is matched case-insensitively and with parameters — so, each of these must be
+        // downloaded, exercising navigation_response_specifies_attachment's ';' split and case folding.
+        const httpServer = httpTestServer();
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+
+        async function expectDownloaded(label, disposition) {
+            const url = await httpServer.createEcho("GET", "/" + label, {
+                status: 200,
+                headers: { "Content-Type": "text/html", "Content-Disposition": disposition },
+                body: "<p>must not render</p>",
+            });
+            iframe.src = url;
+            await new Promise((resolve) => {
+                const poll = () => {
+                    const downloadURL = internals.takeLastNavigationDownloadURL();
+                    if (downloadURL !== null && downloadURL !== undefined)
+                        resolve();
+                    else
+                        requestAnimationFrame(poll);
+                };
+                requestAnimationFrame(poll);
+            });
+            println(label + " downloaded: true");
+        }
+
+        await expectDownloaded("filename", 'attachment; filename="x.bin"');
+        await expectDownloaded("uppercase", "ATTACHMENT");
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigate-attachment-downloads.html
+++ b/Tests/LibWeb/Text/input/navigate-attachment-downloads.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        // A renderable type (text/html) served with Content-Disposition: attachment is downloaded, not rendered.
+        const httpServer = httpTestServer();
+        const url = await httpServer.createEcho("GET", "/attachment-resource", {
+            status: 200,
+            headers: { "Content-Type": "text/html", "Content-Disposition": "attachment" },
+            body: "<p>must not render</p>",
+        });
+        const iframe = document.createElement("iframe");
+        iframe.src = url;
+        document.body.appendChild(iframe);
+        const check = () => {
+            const downloadURL = internals.takeLastNavigationDownloadURL();
+            if (downloadURL !== null && downloadURL !== undefined) {
+                println("attachment requested a download: " + downloadURL.endsWith("/echo/attachment-resource"));
+                done();
+            } else {
+                requestAnimationFrame(check);
+            }
+        };
+        requestAnimationFrame(check);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigate-renderable-not-downloaded.html
+++ b/Tests/LibWeb/Text/input/navigate-renderable-not-downloaded.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    asyncTest((done) => {
+        // A renderable response (served same-origin via a blob: URL — so that the iframe document is readable) must
+        // render in the iframe — not be downloaded. Guards against a regression that downloads renderable content.
+        const blob = new Blob(["<p>rendered-content</p>"], { type: "text/html" });
+        const iframe = document.createElement("iframe");
+        iframe.src = URL.createObjectURL(blob);
+        document.body.appendChild(iframe);
+
+        const check = () => {
+            const downloadURL = internals.takeLastNavigationDownloadURL();
+            const rendered = !!(iframe.contentDocument && iframe.contentDocument.body && iframe.contentDocument.body.textContent.includes("rendered-content"));
+            if (downloadURL !== null && downloadURL !== undefined) {
+                println("download requested: true");
+                done();
+            } else if (rendered) {
+                println("download requested: false");
+                println("iframe rendered the response: true");
+                done();
+            } else {
+                requestAnimationFrame(check);
+            }
+        };
+        requestAnimationFrame(check);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigate-unsupported-type-downloads.html
+++ b/Tests/LibWeb/Text/input/navigate-unsupported-type-downloads.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    asyncTest((done) => {
+        // A navigation to a content type the engine can't render is handed off as a download, not rendered.
+        // Served same-origin via a blob: URL, so that the render check can actually read the iframe document (a data:
+        // or cross-origin URL would make the document unreadable, and make the render check always report false).
+        const blob = new Blob(["must-not-render"], { type: "application/octet-stream" });
+        const iframe = document.createElement("iframe");
+        iframe.src = URL.createObjectURL(blob);
+        document.body.appendChild(iframe);
+
+        const check = () => {
+            const downloadURL = internals.takeLastNavigationDownloadURL();
+            if (downloadURL !== null && downloadURL !== undefined) {
+                println("download requested for octet-stream: " + downloadURL.startsWith("blob:"));
+                const rendered = !!(iframe.contentDocument && iframe.contentDocument.body && iframe.contentDocument.body.textContent.includes("must-not-render"));
+                println("iframe rendered the response: " + rendered);
+                done();
+            } else {
+                requestAnimationFrame(check);
+            }
+        };
+        requestAnimationFrame(check);
+    });
+</script>

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -957,6 +957,11 @@ static void run_test(TestWebView& view, TestRunContext& context, size_t test_ind
 
 static void set_ui_callbacks_for_tests(TestWebView& view, TestRunCapture& test_run_capture)
 {
+    view.on_request_download = [](u64, URL::URL const&, String const&) -> Optional<IPC::File> {
+        // Tests must not write downloads to disk; cancel the destination request.
+        return {};
+    };
+
     view.on_request_file_picker = [&](auto const& accepted_file_types, auto allow_multiple_files) {
         // Create some dummy files for tests.
         Vector<Web::HTML::SelectedFile> selected_files;


### PR DESCRIPTION
**Problem:** We unexpectedly spin forever after navigating to a resource with an unhandled content type (such as `application/octet-stream`).

**Cause:** `load_document` returned null for any non-renderable type, and a navigation that produced no document had no further handling — so the fetch was simply abandoned, and the navigable never stopped loading.

**Fix:** Implement the “handle as a download” mechanism from the HTML spec at https://html.spec.whatwg.org/multipage/#handle-as-a-download. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10238.
