### PR TITLE
LibWeb: Implement content replacement for CSS `content` image values

### DIFF
--- a/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -34,8 +34,8 @@ ImageBox::ImageBox(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::
     VERIFY(&image_provider == &image_provider_for_element(*element));
 }
 
-ImageBox::ImageBox(DOM::Document& document, CSS::ComputedProperties const& style, NonnullOwnPtr<ImageProvider> image_provider)
-    : ReplacedBox(document, nullptr, style)
+ImageBox::ImageBox(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style, NonnullOwnPtr<ImageProvider> image_provider)
+    : ReplacedBox(document, element, style)
     , m_owned_image_provider(move(image_provider))
 {
 }

--- a/Libraries/LibWeb/Layout/ImageBox.h
+++ b/Libraries/LibWeb/Layout/ImageBox.h
@@ -17,7 +17,7 @@ class ImageBox final : public ReplacedBox {
 
 public:
     ImageBox(DOM::Document&, GC::Ptr<DOM::Element>, CSS::ComputedProperties const&, ImageProvider const&);
-    ImageBox(DOM::Document&, CSS::ComputedProperties const&, NonnullOwnPtr<ImageProvider>);
+    ImageBox(DOM::Document&, GC::Ptr<DOM::Element>, CSS::ComputedProperties const&, NonnullOwnPtr<ImageProvider>);
     virtual ~ImageBox() override;
 
     bool renders_as_alt_text() const;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -253,6 +253,16 @@ private:
     mutable bool m_registered_as_image_style_value_client { true };
 };
 
+static NonnullRefPtr<ImageBox> create_content_image_box(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style, CSS::ImageStyleValue& image)
+{
+    image.load_any_resources(document);
+    auto image_provider = GeneratedContentImageProvider::create(document, image);
+    auto& image_provider_ref = *image_provider;
+    auto image_box = make_ref_counted<ImageBox>(document, element, style, move(image_provider));
+    image_provider_ref.set_layout_node(*image_box);
+    return image_box;
+}
+
 struct FirstLetterTarget {
     TextNode* text_node { nullptr };
     size_t letter_start { 0 };
@@ -572,11 +582,7 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
                     layout_node = make_ref_counted<GeneratedTextNode>(document, Utf16String::from_utf8(*string));
                 } else {
                     auto& image = *item.get<NonnullRefPtr<CSS::ImageStyleValue>>();
-                    image.load_any_resources(document);
-                    auto image_provider = GeneratedContentImageProvider::create(document, image);
-                    auto& image_provider_ref = *image_provider;
-                    layout_node = make_ref_counted<ImageBox>(document, *pseudo_element_style, move(image_provider));
-                    image_provider_ref.set_layout_node(*layout_node);
+                    layout_node = create_content_image_box(document, nullptr, *pseudo_element_style, image);
                 }
                 layout_node->set_generated_for(pseudo_element, element);
                 insert_node_into_inline_or_block_ancestor(*layout_node, layout_node->display(), AppendOrPrepend::Append);
@@ -588,6 +594,24 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
     }
 
     return pseudo_element_node;
+}
+
+RefPtr<NodeWithStyle> TreeBuilder::create_content_replacement_if_needed(DOM::Element& element, CSS::ComputedProperties const& style) const
+{
+    if (!style.property(CSS::PropertyID::Content).is_content())
+        return {};
+
+    DOM::AbstractElement element_reference { element };
+    auto [content, _] = style.content(element_reference, m_quote_nesting_level);
+
+    if (content.type != CSS::ContentData::Type::List
+        || content.data.size() != 1
+        || !content.data.first().has<NonnullRefPtr<CSS::ImageStyleValue>>()) {
+        return {};
+    }
+
+    auto& image = *content.data.first().get<NonnullRefPtr<CSS::ImageStyleValue>>();
+    return create_content_image_box(element.document(), element, style, image);
 }
 
 // Block nodes inside inline nodes are allowed, but to maintain the invariant that either all layout children are
@@ -921,8 +945,9 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
                 update_layout_tree_for_display_contents(element, context, must_create_subtree, should_create_layout_node);
                 return;
             }
-            // TODO: Implement changing element contents with the `content` property.
-            if (context.layout_svg_mask_or_clip_path) {
+            if (auto content_replacement = create_content_replacement_if_needed(element, *style)) {
+                layout_node = content_replacement.release_nonnull();
+            } else if (context.layout_svg_mask_or_clip_path) {
                 if (is<SVG::SVGMaskElement>(dom_node))
                     layout_node = make_ref_counted<Layout::SVGMaskBox>(document, static_cast<SVG::SVGMaskElement&>(dom_node), *style);
                 else if (is<SVG::SVGClipPathElement>(dom_node))

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -60,6 +60,7 @@ private:
     };
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
     RefPtr<NodeWithStyle> create_pseudo_element_if_needed(DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
+    RefPtr<NodeWithStyle> create_content_replacement_if_needed(DOM::Element&, CSS::ComputedProperties const&) const;
     static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);
     void restructure_block_node_in_inline_parent(NodeWithStyleAndBoxModelMetrics&);
 

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-content/element-replacement-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-content/element-replacement-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<title>Reference for the content CSS attribute can replace an element's contents</title>
+
+<img src='resources/rect.svg' />

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-content/element-replacement-root-canvas-bg-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-content/element-replacement-root-canvas-bg-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Reference for the content CSS attribute can replace a document's root</title>
+
+<style>
+:root {
+    background-color: aquamarine;
+}
+body {
+  margin: 0;
+}
+</style>
+
+<img src="resources/rect.svg" />

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-content/element-replacement-root-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-content/element-replacement-root-ref.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Reference for the content CSS attribute can replace a document's root</title>
+
+<style>
+body {
+  margin: 0;
+}
+</style>
+
+<img src="resources/rect.svg" />

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-content/resources/rect.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-content/resources/rect.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100" height="100" fill="green" />
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement-dynamic.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement-dynamic.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>The content CSS attribute can replace an element's contents dynamically</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />
+<link rel="match" href="../../../../expected/wpt-import/css/css-content/element-replacement-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<meta name="assert" content="This test checks that the CSS content propertly can replace a normal element's contents when changed dynamically" />
+
+<script src="../../common/reftest-wait.js"></script>
+<script src="../../common/rendering-utils.js"></script>
+
+<style>
+#target {
+  content: none;
+}
+#target.replaced {
+  content: url('resources/rect.svg');
+}
+</style>
+
+<div id="target">This text should not be visible</div>
+
+<script>
+waitForAtLeastOneFrame().then(() => {
+  document.getElementById("target").className = "replaced";
+  takeScreenshot();
+});
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement-root-canvas-bg-from-body.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement-root-canvas-bg-from-body.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>When content CSS attribute can replace a document's root, the HTML body element's background does not become the canvas background</title>
+<link rel="match" href="../../../../expected/wpt-import/css/css-content/element-replacement-root-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#body-background" />
+<meta name="assert" content="When the content CSS attribute replaces a document's root, its contents do not create boxes, so the HTML body element's background can't affect the canvas background." />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+}
+body {
+  background-color: aquamarine;
+}
+</style>
+
+<p>This text should not be visible</p>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement-root-canvas-bg.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement-root-canvas-bg.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>When content CSS attribute can replace a document's root, its canvas still becomes the canvas background</title>
+<link rel="match" href="../../../../expected/wpt-import/css/css-content/element-replacement-root-canvas-bg-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#root-background" />
+<meta name="assert" content="When the content CSS attribute replaces a document's root, it does not affect the fact that the root's background becomes the canvas background" />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+  background-color: aquamarine;
+}
+</style>
+
+<p>This text should not be visible</p>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement-root.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement-root.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>The content CSS attribute can replace a document's root</title>
+<link rel="match" href="../../../../expected/wpt-import/css/css-content/element-replacement-root-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<meta name="assert" content="This test checks that the CSS content propertly can replace the contents of a document's root" />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+}
+</style>
+
+<p>This text should not be visible</p>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-content/element-replacement.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>The content CSS attribute can replace an element's contents</title>
+<link rel="match" href="../../../../expected/wpt-import/css/css-content/element-replacement-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<meta name="assert" content"This test checks that the CSS content propertly can replace a normal element's contents" />
+
+<style>
+p {
+  margin: 0;
+  content: url('resources/rect.svg');
+}
+</style>
+
+<p>This text should not be visible</p>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-content/resources/rect.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-content/resources/rect.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100" height="100" fill="green" />
+</svg>


### PR DESCRIPTION
When an element's computed `content` value is a single image we now build a replaced `ImageBox` for it via the
`GeneratedContentImageProvider` which is already used for pseudo element content.

This ensures the correct logo is rendered on https://rubyllm.com in dark mode:

Before:
<img width="774" height="193" alt="image" src="https://github.com/user-attachments/assets/8b613727-3e2b-4915-9d22-75f1ab510fe2" />


After:
<img width="774" height="193" alt="image" src="https://github.com/user-attachments/assets/778fa44f-a4eb-486e-91b2-60d22a5c54f5" />
