### PR TITLE
CI: Group dependabot version updates by dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "CI:"
+    groups:
+      actions:
+        group-by: dependency-name
 
   - package-ecosystem: "rust-toolchain"
     directory: "/"


### PR DESCRIPTION
With separate directories listed (one with a wildcard), we are getting a separate PR for each directory for a single action update. This config will group them into a single PR per dependency.

See:
<img width="672" height="174" alt="Screenshot_20260626_081735" src="https://github.com/user-attachments/assets/0e7fda6b-b9d0-440e-bc71-f3253a6a0bc0" />
