### PR TITLE
Enable WebGL tests in GPU-less CI

### DIFF
--- a/Libraries/LibSandbox/Sandbox.cpp
+++ b/Libraries/LibSandbox/Sandbox.cpp
@@ -200,6 +200,17 @@ static ErrorOr<void> append_allowed_executables(StringBuilder& builder, Readonly
     return {};
 }
 
+static ErrorOr<void> append_allowed_iokit_user_client_classes(StringBuilder& builder, ReadonlySpan<StringView> iokit_user_client_classes)
+{
+    for (auto const& user_client_class : iokit_user_client_classes) {
+        builder.append("(allow iokit-open-user-client (iokit-user-client-class "sv);
+        append_sandbox_string_literal(builder, user_client_class);
+        builder.append("))\n"sv);
+    }
+
+    return {};
+}
+
 static void sandbox_violation_signal_handler(int)
 {
     char const message[] = "Sandbox violation: terminating process\n";
@@ -218,7 +229,7 @@ static ErrorOr<void> install_sandbox_violation_signal_handler()
     return {};
 }
 
-ErrorOr<void> apply_macos_sandbox(ReadonlySpan<SeatbeltPath> paths, NetworkAccess network_access, ReadonlySpan<ByteString> executable_paths)
+ErrorOr<void> apply_macos_sandbox(ReadonlySpan<SeatbeltPath> paths, NetworkAccess network_access, ReadonlySpan<ByteString> executable_paths, ReadonlySpan<StringView> iokit_user_client_classes)
 {
     TRY(install_sandbox_violation_signal_handler());
 
@@ -390,6 +401,7 @@ ErrorOr<void> apply_macos_sandbox(ReadonlySpan<SeatbeltPath> paths, NetworkAcces
     TRY(append_allowed_path_extensions(profile, paths, SeatbeltPath::Access::ReadOnly));
     TRY(append_allowed_path_extensions(profile, paths, SeatbeltPath::Access::ReadWrite));
     TRY(append_allowed_executables(profile, executable_paths));
+    TRY(append_allowed_iokit_user_client_classes(profile, iokit_user_client_classes));
 
     auto profile_string = profile.to_byte_string();
 

--- a/Libraries/LibSandbox/Sandbox.h
+++ b/Libraries/LibSandbox/Sandbox.h
@@ -58,7 +58,7 @@ enum class NetworkAccess {
 
 #if defined(AK_OS_MACOS)
 [[nodiscard]] ErrorOr<void> add_seatbelt_path_if_exists(Vector<SeatbeltPath>& paths, StringView path, SeatbeltPath::Access);
-[[nodiscard]] ErrorOr<void> apply_macos_sandbox(ReadonlySpan<SeatbeltPath>, NetworkAccess, ReadonlySpan<ByteString> executable_paths = {});
+[[nodiscard]] ErrorOr<void> apply_macos_sandbox(ReadonlySpan<SeatbeltPath>, NetworkAccess, ReadonlySpan<ByteString> executable_paths = {}, ReadonlySpan<StringView> iokit_user_client_classes = {});
 #endif
 
 }

--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -92,6 +92,7 @@ static constexpr unsigned read_only_open_flags = O_CLOEXEC;
 #define IF_DEFINED_execveat(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_exit(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_exit_group(if_defined, if_not_defined) if_defined
+#define IF_DEFINED_fallocate(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_fcntl(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_fcntl64(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_fdatasync(if_defined, if_not_defined) if_defined
@@ -258,6 +259,10 @@ static constexpr unsigned read_only_open_flags = O_CLOEXEC;
 #ifndef __NR_execveat
 #    undef IF_DEFINED_execveat
 #    define IF_DEFINED_execveat(if_defined, if_not_defined) if_not_defined
+#endif
+#ifndef __NR_fallocate
+#    undef IF_DEFINED_fallocate
+#    define IF_DEFINED_fallocate(if_defined, if_not_defined) if_not_defined
 #endif
 #ifndef __NR_fcntl64
 #    undef IF_DEFINED_fcntl64
@@ -544,6 +549,9 @@ static char const* syscall_name(long syscall_number)
 #ifdef __NR_faccessat2
         CASE_SYSCALL_NAME(faccessat2);
 #endif
+#ifdef __NR_fallocate
+        CASE_SYSCALL_NAME(fallocate);
+#endif
 #ifdef __NR_fcntl
         CASE_SYSCALL_NAME(fcntl);
 #endif
@@ -811,6 +819,7 @@ void SeccompPolicy::allow_filesystem_writes()
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, rmdir);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, fsync);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, fdatasync);
+    SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, fallocate);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, flock);
 
     append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_fcntl, 0, 5));

--- a/Services/Compositor/CanvasHost.cpp
+++ b/Services/Compositor/CanvasHost.cpp
@@ -93,10 +93,7 @@ Optional<Web::Painting::CanvasId> CanvasHost::create_2d_context(Gfx::IntSize siz
 
 CanvasHost::CreateWebGLContextResult CanvasHost::create_webgl_context(Web::WebGL::WebGLVersion version, Gfx::IntSize size, bool depth, bool stencil, bool antialias)
 {
-    if (!m_skia_backend_context)
-        return {};
-
-    auto context = HostWebGLContext::create(*m_skia_backend_context, version, { .depth = depth, .stencil = stencil, .antialias = antialias }, size);
+    auto context = HostWebGLContext::create(m_skia_backend_context, version, { .depth = depth, .stencil = stencil, .antialias = antialias }, size);
     if (!context)
         return {};
 

--- a/Services/Compositor/HostWebGLContext.cpp
+++ b/Services/Compositor/HostWebGLContext.cpp
@@ -27,7 +27,7 @@ HostWebGLContext::HostWebGLContext(NonnullOwnPtr<OpenGLContext> gl_context)
 {
 }
 
-OwnPtr<HostWebGLContext> HostWebGLContext::create(NonnullRefPtr<Gfx::SkiaBackendContext> skia_backend_context, OpenGLContext::WebGLVersion version, OpenGLContext::DrawingBufferOptions options, Gfx::IntSize initial_size)
+OwnPtr<HostWebGLContext> HostWebGLContext::create(RefPtr<Gfx::SkiaBackendContext> skia_backend_context, OpenGLContext::WebGLVersion version, OpenGLContext::DrawingBufferOptions options, Gfx::IntSize initial_size)
 {
     if (initial_size.width() < 1 || initial_size.width() > max_webgl_drawing_buffer_dimension
         || initial_size.height() < 1 || initial_size.height() > max_webgl_drawing_buffer_dimension)

--- a/Services/Compositor/HostWebGLContext.h
+++ b/Services/Compositor/HostWebGLContext.h
@@ -30,7 +30,7 @@ namespace Compositor {
 
 class HostWebGLContext {
 public:
-    static OwnPtr<HostWebGLContext> create(NonnullRefPtr<Gfx::SkiaBackendContext>, OpenGLContext::WebGLVersion, OpenGLContext::DrawingBufferOptions, Gfx::IntSize initial_size);
+    static OwnPtr<HostWebGLContext> create(RefPtr<Gfx::SkiaBackendContext>, OpenGLContext::WebGLVersion, OpenGLContext::DrawingBufferOptions, Gfx::IntSize initial_size);
 
     ErrorOr<void> execute_commands(ReadonlyBytes, Vector<Gfx::DecodedImageFrame> const& bitmaps);
     ErrorOr<ByteBuffer> execute_sync_call(ReadonlyBytes request);

--- a/Services/Compositor/OpenGLContext.cpp
+++ b/Services/Compositor/OpenGLContext.cpp
@@ -59,7 +59,7 @@ struct OpenGLContext::Impl {
 #endif
 };
 
-OpenGLContext::OpenGLContext(NonnullRefPtr<Gfx::SkiaBackendContext> skia_backend_context, Impl impl, WebGLVersion webgl_version, DrawingBufferOptions drawing_buffer_options)
+OpenGLContext::OpenGLContext(RefPtr<Gfx::SkiaBackendContext> skia_backend_context, Impl impl, WebGLVersion webgl_version, DrawingBufferOptions drawing_buffer_options)
     : m_skia_backend_context(move(skia_backend_context))
     , m_impl(make<Impl>(impl))
     , m_webgl_version(webgl_version)
@@ -138,9 +138,12 @@ static EGLConfig get_egl_config(EGLDisplay display)
 }
 #endif
 
-OwnPtr<OpenGLContext> OpenGLContext::create(NonnullRefPtr<Gfx::SkiaBackendContext> skia_backend_context, WebGLVersion webgl_version, [[maybe_unused]] DrawingBufferOptions drawing_buffer_options)
+OwnPtr<OpenGLContext> OpenGLContext::create(RefPtr<Gfx::SkiaBackendContext> skia_backend_context, WebGLVersion webgl_version, [[maybe_unused]] DrawingBufferOptions drawing_buffer_options)
 {
 #ifdef ENABLE_WEBGL
+    if (!skia_backend_context)
+        return {};
+
     EGLAttrib display_attributes[] = {
         EGL_PLATFORM_ANGLE_TYPE_ANGLE,
 #    if defined(AK_OS_MACOS)
@@ -294,7 +297,7 @@ void OpenGLContext::clear_buffer_to_default_values()
 void OpenGLContext::allocate_iosurface_painting_surface()
 {
     m_shared_image_buffer = make<Gfx::SharedImageBuffer>(Gfx::SharedImageBuffer::create(m_size));
-    m_painting_surface = Gfx::PaintingSurface::create_from_shared_image_buffer(*m_shared_image_buffer, m_skia_backend_context, Gfx::PaintingSurface::Origin::BottomLeft);
+    m_painting_surface = Gfx::PaintingSurface::create_from_shared_image_buffer(*m_shared_image_buffer, *m_skia_backend_context, Gfx::PaintingSurface::Origin::BottomLeft);
 
     EGLint const surface_attributes[] = {
         EGL_WIDTH,
@@ -357,7 +360,7 @@ void OpenGLContext::allocate_vkimage_painting_surface()
     }
 
     auto vulkan_image = MUST(Gfx::create_shared_vulkan_image(m_skia_backend_context->vulkan_context(), m_size.width(), m_size.height(), vulkan_format, renderable_modifiers));
-    m_painting_surface = Gfx::PaintingSurface::create_from_vkimage(m_skia_backend_context, vulkan_image, Gfx::PaintingSurface::Origin::BottomLeft);
+    m_painting_surface = Gfx::PaintingSurface::create_from_vkimage(*m_skia_backend_context, vulkan_image, Gfx::PaintingSurface::Origin::BottomLeft);
 
     EGLAttrib attribs[] = {
         EGL_WIDTH,

--- a/Services/Compositor/OpenGLContext.cpp
+++ b/Services/Compositor/OpenGLContext.cpp
@@ -23,6 +23,7 @@ extern "C" {
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/SharedImageBuffer.h>
 #ifdef USE_VULKAN_DMABUF_IMAGES
@@ -30,8 +31,9 @@ extern "C" {
 #endif
 #include <Compositor/OpenGLContext.h>
 
-// Enable WebGL if we're on MacOS and can use Metal or if we can use shareable Vulkan images
-#if defined(AK_OS_MACOS) || defined(USE_VULKAN_DMABUF_IMAGES)
+// Enable WebGL if we're on macOS and can use Metal, if Linux can use ANGLE's
+// OpenGL backend for CPU-painting tests, or if we can use shareable Vulkan images.
+#if defined(AK_OS_MACOS) || (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)) || defined(USE_VULKAN_DMABUF_IMAGES)
 #    define ENABLE_WEBGL 1
 #endif
 
@@ -49,6 +51,7 @@ struct OpenGLContext::Impl {
     GLuint color_buffer { 0 };
     GLuint depth_buffer { 0 };
     EGLint texture_target { 0 };
+    bool uses_cpu_painting_surface { false };
 
 #ifdef USE_VULKAN_DMABUF_IMAGES
     EGLImage egl_image { EGL_NO_IMAGE };
@@ -141,14 +144,27 @@ static EGLConfig get_egl_config(EGLDisplay display)
 OwnPtr<OpenGLContext> OpenGLContext::create(RefPtr<Gfx::SkiaBackendContext> skia_backend_context, WebGLVersion webgl_version, [[maybe_unused]] DrawingBufferOptions drawing_buffer_options)
 {
 #ifdef ENABLE_WEBGL
-    if (!skia_backend_context)
+#    if defined(AK_OS_MACOS) || (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID))
+    bool use_cpu_painting_surface = !skia_backend_context;
+#    else
+    bool use_cpu_painting_surface = false;
+#    endif
+
+#    if defined(AK_OS_MACOS) || defined(USE_VULKAN_DMABUF_IMAGES)
+    if (!use_cpu_painting_surface && !skia_backend_context)
         return {};
+#    endif
+
+#    if !defined(AK_OS_MACOS) && !defined(USE_VULKAN_DMABUF_IMAGES)
+    if (!use_cpu_painting_surface)
+        return {};
+#    endif
 
     EGLAttrib display_attributes[] = {
         EGL_PLATFORM_ANGLE_TYPE_ANGLE,
 #    if defined(AK_OS_MACOS)
         EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE,
-#    elif defined(USE_VULKAN_DMABUF_IMAGES)
+#    elif defined(USE_VULKAN_DMABUF_IMAGES) || (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID))
         EGL_PLATFORM_ANGLE_TYPE_OPENGL_ANGLE,
         EGL_PLATFORM_ANGLE_NATIVE_PLATFORM_TYPE_ANGLE,
         EGL_PLATFORM_SURFACELESS_MESA,
@@ -176,9 +192,13 @@ OwnPtr<OpenGLContext> OpenGLContext::create(RefPtr<Gfx::SkiaBackendContext> skia
 
     EGLint texture_target;
 #    if defined(AK_OS_MACOS)
-    eglGetConfigAttrib(display, config, EGL_BIND_TO_TEXTURE_TARGET_ANGLE, &texture_target);
-    VERIFY(texture_target == EGL_TEXTURE_RECTANGLE_ANGLE || texture_target == EGL_TEXTURE_2D);
-#    elif defined(USE_VULKAN_DMABUF_IMAGES)
+    if (use_cpu_painting_surface) {
+        texture_target = EGL_TEXTURE_2D;
+    } else {
+        eglGetConfigAttrib(display, config, EGL_BIND_TO_TEXTURE_TARGET_ANGLE, &texture_target);
+        VERIFY(texture_target == EGL_TEXTURE_RECTANGLE_ANGLE || texture_target == EGL_TEXTURE_2D);
+    }
+#    else
     texture_target = EGL_TEXTURE_2D;
 #    endif
 
@@ -206,16 +226,21 @@ OwnPtr<OpenGLContext> OpenGLContext::create(RefPtr<Gfx::SkiaBackendContext> skia
     }
 
 #    ifdef USE_VULKAN_DMABUF_IMAGES
-    auto pfn_egl_query_dma_buf_formats_ext = reinterpret_cast<PFNEGLQUERYDMABUFFORMATSEXTPROC>(eglGetProcAddress("eglQueryDmaBufFormatsEXT"));
-    if (!pfn_egl_query_dma_buf_formats_ext) {
-        dbgln("eglQueryDmaBufFormatsEXT unavailable");
-        return {};
-    }
+    PFNEGLQUERYDMABUFFORMATSEXTPROC pfn_egl_query_dma_buf_formats_ext = nullptr;
+    PFNEGLQUERYDMABUFMODIFIERSEXTPROC pfn_egl_query_dma_buf_modifiers_ext = nullptr;
 
-    auto pfn_egl_query_dma_buf_modifiers_ext = reinterpret_cast<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(eglGetProcAddress("eglQueryDmaBufModifiersEXT"));
-    if (!pfn_egl_query_dma_buf_modifiers_ext) {
-        dbgln("eglQueryDmaBufModifiersEXT unavailable");
-        return {};
+    if (!use_cpu_painting_surface) {
+        pfn_egl_query_dma_buf_formats_ext = reinterpret_cast<PFNEGLQUERYDMABUFFORMATSEXTPROC>(eglGetProcAddress("eglQueryDmaBufFormatsEXT"));
+        if (!pfn_egl_query_dma_buf_formats_ext) {
+            dbgln("eglQueryDmaBufFormatsEXT unavailable");
+            return {};
+        }
+
+        pfn_egl_query_dma_buf_modifiers_ext = reinterpret_cast<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(eglGetProcAddress("eglQueryDmaBufModifiersEXT"));
+        if (!pfn_egl_query_dma_buf_modifiers_ext) {
+            dbgln("eglQueryDmaBufModifiersEXT unavailable");
+            return {};
+        }
     }
 #    endif
 
@@ -224,6 +249,7 @@ OwnPtr<OpenGLContext> OpenGLContext::create(RefPtr<Gfx::SkiaBackendContext> skia
                                                          .config = config,
                                                          .context = context,
                                                          .texture_target = texture_target,
+                                                         .uses_cpu_painting_surface = use_cpu_painting_surface,
 #    ifdef USE_VULKAN_DMABUF_IMAGES
                                                          .ext_procs = {
                                                              .query_dma_buf_formats = pfn_egl_query_dma_buf_formats_ext,
@@ -242,6 +268,8 @@ OwnPtr<OpenGLContext> OpenGLContext::create(RefPtr<Gfx::SkiaBackendContext> skia
 void OpenGLContext::notify_content_will_change()
 {
 #ifdef ENABLE_WEBGL
+    if (m_impl->uses_cpu_painting_surface)
+        return;
     m_painting_surface->notify_content_will_change();
 #endif
 }
@@ -333,6 +361,8 @@ void OpenGLContext::allocate_iosurface_painting_surface()
 #ifdef USE_VULKAN_DMABUF_IMAGES
 void OpenGLContext::allocate_vkimage_painting_surface()
 {
+    VERIFY(m_skia_backend_context);
+
     VkFormat vulkan_format = VK_FORMAT_B8G8R8A8_UNORM;
     uint32_t drm_format = Gfx::vk_format_to_drm_format(vulkan_format);
 
@@ -395,6 +425,100 @@ void OpenGLContext::allocate_vkimage_painting_surface()
 }
 #endif
 
+#if defined(AK_OS_MACOS) || (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID))
+void OpenGLContext::allocate_cpu_painting_surface()
+{
+    m_painting_surface = Gfx::PaintingSurface::create_with_size(
+        m_size,
+        Gfx::BitmapFormat::BGRA8888,
+        Gfx::AlphaType::Premultiplied);
+
+    m_impl->surface = EGL_NO_SURFACE;
+    eglMakeCurrent(m_impl->display, m_impl->surface, m_impl->surface, m_impl->context);
+
+    glGenTextures(1, &m_impl->color_buffer);
+    glBindTexture(GL_TEXTURE_2D, m_impl->color_buffer);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    GLint original_pixel_unpack_buffer = 0;
+    if (m_webgl_version == WebGLVersion::WebGL2) {
+        glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, &original_pixel_unpack_buffer);
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    }
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_size.width(), m_size.height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    if (m_webgl_version == WebGLVersion::WebGL2)
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, original_pixel_unpack_buffer);
+
+    glViewport(0, 0, m_size.width(), m_size.height());
+}
+
+void OpenGLContext::copy_default_framebuffer_to_cpu_painting_surface()
+{
+    VERIFY(m_impl->uses_cpu_painting_surface);
+    VERIFY(m_painting_surface);
+
+    auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::RGBA8888, Gfx::AlphaType::Premultiplied, m_size));
+
+    GLenum framebuffer_target = GL_FRAMEBUFFER;
+    GLenum framebuffer_binding = GL_FRAMEBUFFER_BINDING;
+    if (m_webgl_version == WebGLVersion::WebGL2) {
+        framebuffer_target = GL_READ_FRAMEBUFFER;
+        framebuffer_binding = GL_READ_FRAMEBUFFER_BINDING;
+    }
+
+    GLint original_framebuffer;
+    glGetIntegerv(framebuffer_binding, &original_framebuffer);
+
+    GLint original_read_buffer = GL_COLOR_ATTACHMENT0;
+    if (m_webgl_version == WebGLVersion::WebGL2)
+        glGetIntegerv(GL_READ_BUFFER, &original_read_buffer);
+
+    glBindFramebuffer(framebuffer_target, default_framebuffer());
+    if (m_webgl_version == WebGLVersion::WebGL2)
+        glReadBuffer(GL_COLOR_ATTACHMENT0);
+
+    GLint original_pack_alignment;
+    glGetIntegerv(GL_PACK_ALIGNMENT, &original_pack_alignment);
+    glPixelStorei(GL_PACK_ALIGNMENT, 4);
+
+    GLint original_pixel_pack_buffer = 0;
+    GLint original_pack_row_length = 0;
+    GLint original_pack_skip_pixels = 0;
+    GLint original_pack_skip_rows = 0;
+    if (m_webgl_version == WebGLVersion::WebGL2) {
+        glGetIntegerv(GL_PIXEL_PACK_BUFFER_BINDING, &original_pixel_pack_buffer);
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+        glGetIntegerv(GL_PACK_ROW_LENGTH, &original_pack_row_length);
+        glGetIntegerv(GL_PACK_SKIP_PIXELS, &original_pack_skip_pixels);
+        glGetIntegerv(GL_PACK_SKIP_ROWS, &original_pack_skip_rows);
+        glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+        glPixelStorei(GL_PACK_SKIP_PIXELS, 0);
+        glPixelStorei(GL_PACK_SKIP_ROWS, 0);
+    }
+
+    for (int source_y = 0; source_y < m_size.height(); ++source_y)
+        glReadPixels(0, source_y, m_size.width(), 1, GL_RGBA, GL_UNSIGNED_BYTE, bitmap->scanline_u8(m_size.height() - source_y - 1));
+
+    if (m_webgl_version == WebGLVersion::WebGL2) {
+        glPixelStorei(GL_PACK_ROW_LENGTH, original_pack_row_length);
+        glPixelStorei(GL_PACK_SKIP_PIXELS, original_pack_skip_pixels);
+        glPixelStorei(GL_PACK_SKIP_ROWS, original_pack_skip_rows);
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, original_pixel_pack_buffer);
+    }
+    glPixelStorei(GL_PACK_ALIGNMENT, original_pack_alignment);
+
+    glBindFramebuffer(framebuffer_target, original_framebuffer);
+    if (m_webgl_version == WebGLVersion::WebGL2)
+        glReadBuffer(original_read_buffer);
+
+    m_painting_surface->write_from_bitmap(*bitmap);
+}
+#endif
+
 void OpenGLContext::allocate_painting_surface_if_needed()
 {
 #ifdef ENABLE_WEBGL
@@ -406,9 +530,22 @@ void OpenGLContext::allocate_painting_surface_if_needed()
     VERIFY(!m_size.is_empty());
 
 #    if defined(AK_OS_MACOS)
-    allocate_iosurface_painting_surface();
+    if (m_impl->uses_cpu_painting_surface) {
+        allocate_cpu_painting_surface();
+    } else {
+        allocate_iosurface_painting_surface();
+    }
 #    elif defined(USE_VULKAN_DMABUF_IMAGES)
-    allocate_vkimage_painting_surface();
+#        if defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)
+    if (m_impl->uses_cpu_painting_surface) {
+        allocate_cpu_painting_surface();
+    } else
+#        endif
+    {
+        allocate_vkimage_painting_surface();
+    }
+#    elif defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)
+    allocate_cpu_painting_surface();
 #    endif
     VERIFY(m_painting_surface);
     VERIFY(eglGetCurrentContext() == m_impl->context);
@@ -464,10 +601,20 @@ void OpenGLContext::present(bool preserve_drawing_buffer)
     // eglWaitUntilWorkScheduledANGLE flushes the command buffer, and waits until it has been scheduled, hence the name.
     // eglWaitUntilWorkScheduledANGLE only has an effect on CGL and Metal backends, so we only use it on macOS.
 #    if defined(AK_OS_MACOS)
-    eglWaitUntilWorkScheduledANGLE(m_impl->display);
+    if (m_impl->uses_cpu_painting_surface)
+        glFinish();
+    else
+        eglWaitUntilWorkScheduledANGLE(m_impl->display);
 #    elif defined(USE_VULKAN_DMABUF_IMAGES)
     // FIXME: CPU sync for now, but it would be better to export a fence and have Skia wait for it before reading from the surface
     glFinish();
+#    elif defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)
+    glFinish();
+#    endif
+
+#    if defined(AK_OS_MACOS) || (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID))
+    if (m_impl->uses_cpu_painting_surface)
+        copy_default_framebuffer_to_cpu_painting_surface();
 #    endif
 
     // "By default, after compositing the contents of the drawing buffer shall be cleared to their default values, as shown in the table above.
@@ -507,16 +654,16 @@ Vector<String> OpenGLContext::get_supported_opengl_extensions()
 
     Vector<String> extensions;
 
-    auto const* extensions_string = reinterpret_cast<char const*>(glGetString(GL_EXTENSIONS));
-    StringView extensions_view(extensions_string, strlen(extensions_string));
-    for (auto extension : extensions_view.split_view(' ')) {
-        extensions.append(MUST(String::from_utf8(extension)));
+    if (auto const* extensions_string = reinterpret_cast<char const*>(glGetString(GL_EXTENSIONS))) {
+        StringView extensions_view(extensions_string, strlen(extensions_string));
+        for (auto extension : extensions_view.split_view(' '))
+            extensions.append(MUST(String::from_utf8(extension)));
     }
 
-    auto const* requestable_extensions_string = reinterpret_cast<char const*>(glGetString(GL_REQUESTABLE_EXTENSIONS_ANGLE));
-    StringView requestable_extensions_view(requestable_extensions_string, strlen(requestable_extensions_string));
-    for (auto extension : requestable_extensions_view.split_view(' ')) {
-        extensions.append(MUST(String::from_utf8(extension)));
+    if (auto const* requestable_extensions_string = reinterpret_cast<char const*>(glGetString(GL_REQUESTABLE_EXTENSIONS_ANGLE))) {
+        StringView requestable_extensions_view(requestable_extensions_string, strlen(requestable_extensions_string));
+        for (auto extension : requestable_extensions_view.split_view(' '))
+            extensions.append(MUST(String::from_utf8(extension)));
     }
 
     // We must cache this, because once extensions have been requested, they're no longer requestable extensions and would

--- a/Services/Compositor/OpenGLContext.h
+++ b/Services/Compositor/OpenGLContext.h
@@ -66,8 +66,13 @@ private:
     void free_surface_resources();
 #if defined(AK_OS_MACOS)
     void allocate_iosurface_painting_surface();
-#elif defined(USE_VULKAN_DMABUF_IMAGES)
+#endif
+#if defined(USE_VULKAN_DMABUF_IMAGES)
     void allocate_vkimage_painting_surface();
+#endif
+#if defined(AK_OS_MACOS) || (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID))
+    void allocate_cpu_painting_surface();
+    void copy_default_framebuffer_to_cpu_painting_surface();
 #endif
 };
 

--- a/Services/Compositor/OpenGLContext.h
+++ b/Services/Compositor/OpenGLContext.h
@@ -27,14 +27,14 @@ public:
         bool antialias;
     };
 
-    static OwnPtr<OpenGLContext> create(NonnullRefPtr<Gfx::SkiaBackendContext>, WebGLVersion, DrawingBufferOptions);
+    static OwnPtr<OpenGLContext> create(RefPtr<Gfx::SkiaBackendContext>, WebGLVersion, DrawingBufferOptions);
 
     void notify_content_will_change();
     void clear_buffer_to_default_values();
     void allocate_painting_surface_if_needed();
 
     struct Impl;
-    OpenGLContext(NonnullRefPtr<Gfx::SkiaBackendContext>, Impl, WebGLVersion, DrawingBufferOptions);
+    OpenGLContext(RefPtr<Gfx::SkiaBackendContext>, Impl, WebGLVersion, DrawingBufferOptions);
 
     ~OpenGLContext();
 
@@ -52,7 +52,7 @@ public:
     Vector<String> get_supported_opengl_extensions();
 
 private:
-    NonnullRefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
+    RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
     Gfx::IntSize m_size;
     RefPtr<Gfx::PaintingSurface> m_painting_surface;
 #ifdef AK_OS_MACOS

--- a/Services/Compositor/SandboxMacOS.cpp
+++ b/Services/Compositor/SandboxMacOS.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/LexicalPath.h>
 #include <Compositor/Sandbox.h>
 #include <LibCore/Directory.h>
@@ -50,7 +51,12 @@ ErrorOr<void> apply_sandbox()
         }
     }
 
-    return Sandbox::apply_macos_sandbox(paths.span(), Sandbox::NetworkAccess::Denied);
+    // ANGLE's Metal backend opens this while creating WebGL contexts.
+    static constexpr Array metal_iokit_user_client_classes {
+        "AGXDeviceUserClient"sv,
+    };
+
+    return Sandbox::apply_macos_sandbox(paths.span(), Sandbox::NetworkAccess::Denied, {}, metal_iokit_user_client_classes);
 }
 
 }

--- a/Tests/LibWeb/Crash/HTML/webgl-large-command-buffer.html
+++ b/Tests/LibWeb/Crash/HTML/webgl-large-command-buffer.html
@@ -1,16 +1,18 @@
 <!doctype html>
+<html class="test-wait">
 <canvas id="c"></canvas>
 <script>
     let gl = c.getContext("webgl2");
+    if (!gl)
+        throw new Error("Failed to create WebGL2 context");
 
-    // FIXME: This test relies on having a GPU backend enabled, which is not available in tests.
-    if (gl) {
-        let w = 4096;
-        let h = 4096;
-        let pixels = new Uint8Array(w * h * 4);
-        let texture = gl.createTexture();
-        gl.bindTexture(gl.TEXTURE_2D, texture);
-        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, w, h);
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixels, 0);
-    }
+    let w = 4096;
+    let h = 4096;
+    let pixels = new Uint8Array(w * h * 4);
+    let texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, w, h);
+    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixels, 0);
+
+    document.documentElement.classList.remove("test-wait");
 </script>

--- a/Tests/LibWeb/Text/expected/canvas/webgl-create-canvas.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-create-canvas.txt
@@ -1,6 +1,5 @@
-FIXME: This test relies on having a GPU backend enabled, which it is not in run-tests mode :(
-context instanceof WebGLRenderingContext: false
-context is null: true
+context instanceof WebGLRenderingContext: true
+context is null: false
 typeof WebGL2RenderingContext.prototype.texImage2D: function
-context2 instanceof WebGL2RenderingContext: false
-context2 is null: true
+context2 instanceof WebGL2RenderingContext: true
+context2 is null: false

--- a/Tests/LibWeb/Text/expected/canvas/webgl-present-with-bound-offscreen-framebuffer.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-present-with-bound-offscreen-framebuffer.txt
@@ -1,1 +1,0 @@
-FIXME: This test relies on having a GPU backend enabled, which it is not in run-tests mode :(

--- a/Tests/LibWeb/Text/expected/wpt-import/webxr/xrSession_end.https.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webxr/xrSession_end.https.txt
@@ -2,8 +2,9 @@ Harness status: OK
 
 Found 4 tests
 
-4 Fail
+2 Pass
+2 Fail
 Fail	end event fires when immersive session ends - webgl
 Fail	end event fires when immersive session ends - webgl2
-Fail	end event fires when non-immersive session ends - webgl
-Fail	end event fires when non-immersive session ends - webgl2
+Pass	end event fires when non-immersive session ends - webgl
+Pass	end event fires when non-immersive session ends - webgl2

--- a/Tests/LibWeb/Text/input/canvas/webgl-create-canvas.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-create-canvas.html
@@ -2,8 +2,6 @@
 <script src="../include.js"></script>
 <script>
     test(() => {
-        println("FIXME: This test relies on having a GPU backend enabled, which it is not in run-tests mode :(");
-
         let canvas = document.createElement("canvas");
         let context = canvas.getContext("webgl");
         println(`context instanceof WebGLRenderingContext: ${context instanceof WebGLRenderingContext}`);


### PR DESCRIPTION
This makes test-web able to create and present WebGL contexts when running with CPU painting, which lets us run WebGL tests in CI without GPU access.

Previously, Linux WebGL creation depended on having a Skia GPU backend so the Compositor could present through the dmabuf-backed Vulkan image path. That failed in CPU-only environments before ANGLE could be used, even though ANGLE can create a WebGL-compatible GLES context through its OpenGL backend on surfaceless Mesa, with Mesa using CPU rasterization such as llvmpipe.

The new path keeps ANGLE responsible for WebGL command execution, but presents through a CPU PaintingSurface: when the canvas is presented, the Compositor reads back the default framebuffer with glReadPixels and copies it into the CPU surface. The existing macOS and dmabuf-backed Linux presentation paths remain the accelerated paths.