### PR TITLE
LibWeb: Repaint SVG images when embedded resources update

### DIFF
--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Checked.h>
 #include <AK/NumericLimits.h>
+#include <AK/ScopeGuard.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/PaintingSurface.h>
@@ -88,7 +89,9 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& rea
         dbgln("SVGDecodedImageData: Invalid SVG input (no SVGSVGElement found)");
         return Error::from_string_literal("SVGDecodedImageData: Invalid SVG input");
     }
-    return realm.create<SVGDecodedImageData>(page, page_client, document, *svg_root);
+    auto svg_image_data = realm.create<SVGDecodedImageData>(page, page_client, document, *svg_root);
+    page_client->m_svg_image_data = svg_image_data;
+    return svg_image_data;
 }
 
 SVGDecodedImageData::SVGDecodedImageData(GC::Ref<Page> page, GC::Ref<SVGPageClient> page_client, GC::Ref<DOM::Document> document, GC::Ref<SVG::SVGSVGElement> root_element)
@@ -174,6 +177,11 @@ Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list
         m_cached_display_lists.remove(m_cached_display_lists.begin());
         prune_cached_display_list_resources();
     }
+
+    m_is_recording_display_list = true;
+    ScopeGuard clear_recording_flag = [&] {
+        m_is_recording_display_list = false;
+    };
 
     m_document->navigable()->set_viewport_size(size.to_type<CSSPixels>());
     m_document->update_layout(DOM::UpdateLayoutReason::SVGDecodedImageDataRender);
@@ -298,6 +306,32 @@ void SVGDecodedImageData::SVGPageClient::visit_edges(Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_host_page);
     visitor.visit(m_svg_page);
+}
+
+void SVGDecodedImageData::SVGPageClient::request_frame()
+{
+    if (auto svg_image_data = m_svg_image_data.ptr())
+        svg_image_data->did_request_frame();
+}
+
+void SVGDecodedImageData::did_request_frame()
+{
+    // Recording the SVG image can itself schedule a frame request through the
+    // inner document. Ignore those requests so we do not invalidate caches while
+    // populating them.
+    if (m_is_recording_display_list)
+        return;
+
+    invalidate_cached_rendering();
+    notify_clients_did_update();
+}
+
+void SVGDecodedImageData::invalidate_cached_rendering()
+{
+    m_cached_rendered_frames.clear();
+    m_cached_rendered_surfaces.clear();
+    m_cached_display_lists.clear();
+    prune_cached_display_list_resources();
 }
 
 void SVGDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::IntRect dst_rect, CSS::ImageRendering) const

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Optional.h>
+#include <LibGC/Weak.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Page/Page.h>
@@ -45,6 +46,8 @@ private:
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
     Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
     void prune_cached_display_list_resources() const;
+    void did_request_frame();
+    void invalidate_cached_rendering();
 
     // FIXME: Remove this once everything is using surfaces instead.
     mutable HashMap<Gfx::IntSize, Gfx::DecodedImageFrame> m_cached_rendered_frames;
@@ -62,6 +65,8 @@ private:
 
     GC::Ref<DOM::Document> m_document;
     GC::Ref<SVG::SVGSVGElement> m_root_element;
+
+    mutable bool m_is_recording_display_list { false };
 };
 
 class SVGDecodedImageData::SVGPageClient final : public PageClient {
@@ -78,6 +83,7 @@ public:
 
     GC::Ref<Page> m_host_page;
     GC::Ptr<Page> m_svg_page;
+    GC::Weak<SVGDecodedImageData> m_svg_image_data;
 
     virtual u64 id() const override { VERIFY_NOT_REACHED(); }
     virtual Page& page() override { return *m_svg_page; }
@@ -95,7 +101,7 @@ public:
     virtual void request_file(FileRequest) override { }
     virtual Queue<QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] EventResult event_was_handled) override { }
-    virtual void request_frame() override { }
+    virtual void request_frame() override;
 
     virtual bool is_headless() const override { return m_host_page->client().is_headless(); }
 


### PR DESCRIPTION
Invalidate cached SVG image render data when the hidden SVG page requests a new frame. This lets image elements inside an SVG image propagate late load updates to outer image clients instead of leaving stale cached display lists until another repaint happens.

Add a ref test that blocks an embedded SVG image until after the outer SVG image has painted.

Fixes an issue on https://slint.dev/ where the GitHub profile pictures don't show up.

Before:
<img width="1077" height="796" alt="Screenshot 2026-06-27 at 01 33 38" src="https://github.com/user-attachments/assets/876a3645-d16c-4bfd-8515-bdad9948574e" />

After:
<img width="988" height="795" alt="Screenshot 2026-06-27 at 01 34 03" src="https://github.com/user-attachments/assets/bb229da1-b0bd-4111-aa0e-34dab883f6d1" />
