### PR TITLE
LibWeb: Re-resolve SVG use element href after document adoption

### DIFF
--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -72,6 +72,24 @@ void SVGUseElement::adopted_from(DOM::Document& old_document)
 
     if (m_load_event_delayer.has_value())
         m_load_event_delayer.emplace(document());
+
+    m_document_observer->set_document(document());
+
+    auto href = href_value();
+    if (!href.has_value())
+        return;
+
+    m_href = document().url().complete_url(href.value());
+    if (!m_href.has_value())
+        return;
+
+    if (!is_referenced_element_same_document()) {
+        fetch_the_document(*m_href);
+        return;
+    }
+
+    if (auto to_clone = referenced_element())
+        clone_element_tree_as_our_shadow_tree(to_clone);
 }
 
 void SVGUseElement::inserted()
@@ -165,6 +183,13 @@ void SVGUseElement::attribute_changed(FlyString const& name, Optional<String> co
         // When the ‘href’ attribute is set (or, in the absence of an ‘href’ attribute, an ‘xlink:href’ attribute), the user agent must process the URL.
         process_the_url(value);
     }
+}
+
+Optional<String> SVGUseElement::href_value() const
+{
+    if (auto href = get_attribute_ns(OptionalNone {}, AttributeNames::href); href.has_value())
+        return href;
+    return get_attribute_ns(Namespace::XLink, AttributeNames::href);
 }
 
 // https://www.w3.org/TR/SVG2/linking.html#processingURL

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -59,6 +59,7 @@ private:
     virtual RefPtr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
 
     void process_the_url(Optional<String> const& href);
+    Optional<String> href_value() const;
 
     static Optional<FlyString> parse_id_from_href(StringView);
 

--- a/Tests/LibWeb/Ref/expected/svg/use-href-resolves-after-fragment-parsing-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/use-href-resolves-after-fragment-parsing-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<svg width="100" height="100" style="display: block"><rect width="100" height="100" fill="green"/></svg>

--- a/Tests/LibWeb/Ref/input/svg/use-href-resolves-after-fragment-parsing.html
+++ b/Tests/LibWeb/Ref/input/svg/use-href-resolves-after-fragment-parsing.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/use-href-resolves-after-fragment-parsing-ref.html" />
+<svg style="display: none">
+    <symbol id="green-top" viewBox="0 0 100 50"><rect width="100" height="50" fill="green"/></symbol>
+    <symbol id="green-bottom" viewBox="0 0 100 50"><rect width="100" height="50" fill="green"/></symbol>
+</svg>
+<div id="container"></div>
+<script>
+    document.getElementById("container").innerHTML =
+        '<svg width="100" height="50" style="display: block"><use xlink:href="#green-top"></use></svg>' +
+        '<svg width="100" height="50" style="display: block"><use href="#green-bottom"></use></svg>';
+</script>


### PR DESCRIPTION
A use element resolves its href against the document URL when the attribute is set. Elements parsed via `innerHTML` are first created in a temporary "about:blank" document, so a same document reference such as  "#foo" resolves to "about:blank#foo". After adoption into the real document, the same document check failed and the referenced element was never cloned into the shadow tree.

We now re-resolve the href against the new document's URL on adoption so same document references keep working.

This makes the single/multi connection icon show up on https://speedtest.net:

Before:
<img width="192" height="97" alt="image" src="https://github.com/user-attachments/assets/82d5a713-5a8c-4ff8-a336-e38a2bfe4822" />


After:
<img width="192" height="97" alt="image" src="https://github.com/user-attachments/assets/0a19c151-6059-44e4-9a9d-506c7df63bce" />
