### PR TITLE
LibWeb: Don’t crash on a child navigable with no active window

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5550,13 +5550,16 @@ void Document::destroy_a_document_and_its_descendants(GC::Ptr<GC::Function<void(
     // 4. For each childNavigable of childNavigables, queue a global task on the navigation and traversal task source
     //    given childNavigable's active window to perform the following steps:
     for (auto& child_navigable : child_navigables) {
-        queue_global_task(HTML::Task::Source::NavigationAndTraversal, *child_navigable->active_window(),
-            GC::create_function(heap(), [&heap = heap(), destruction_state, child_navigable] {
+        HTML::queue_a_task(HTML::Task::Source::NavigationAndTraversal, nullptr, nullptr,
+            GC::create_function(heap(), [&heap = heap(), destruction_state, child_navigable = child_navigable.ptr()] {
                 // 1. Let incrementDestroyed be an algorithm step which increments numberDestroyed.
                 auto increment_destroyed = GC::create_function(heap, [destruction_state] { destruction_state->did_process_child(); });
 
                 // 2. Destroy a document and its descendants given childNavigable's active document and incrementDestroyed.
-                child_navigable->active_document()->destroy_a_document_and_its_descendants(increment_destroyed);
+                if (auto active_document = child_navigable->active_document())
+                    active_document->destroy_a_document_and_its_descendants(increment_destroyed);
+                else
+                    increment_destroyed->function()();
             }));
     }
 

--- a/Tests/LibWeb/Crash/HTML/destroy-document-with-unloaded-child-navigable.html
+++ b/Tests/LibWeb/Crash/HTML/destroy-document-with-unloaded-child-navigable.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!-- While an iframe (outer) is navigating, its descendants unload first — which clears the inner iframe's navigable's
+     active document. Removing outer in its pagehide handler then runs destroy_a_document_and_its_descendants on outer's
+     document, whose child navigable (inner) now has no active window. Iterating that child must not dereference the
+     null active window. -->
+<html class="test-wait">
+<body>
+<script>
+    const outer = document.createElement("iframe");
+    outer.srcdoc = "<div>outer</div>";
+    let navigated = false;
+    outer.addEventListener("load", () => {
+        if (navigated)
+            return;
+        navigated = true;
+
+        const outerDoc = outer.contentDocument;
+        const outerWin = outer.contentWindow;
+
+        const inner = outerDoc.createElement("iframe");
+        inner.srcdoc = "<div>inner</div>";
+        outerDoc.body.appendChild(inner);
+
+        inner.addEventListener("load", () => {
+            outerWin.addEventListener("pagehide", () => {
+                // inner's navigable now has a null active document; removing outer runs
+                // destroy_a_document_and_its_descendants over outer's child (inner).
+                outer.remove();
+                document.documentElement.classList.remove("test-wait");
+            });
+
+            // Navigate outer so its descendants (inner) unload first.
+            outer.srcdoc = "<div>outer after</div>";
+        });
+    });
+    document.body.appendChild(outer);
+</script>
+</body>
+</html>


### PR DESCRIPTION
**Problem:** Crash in `destroy_a_document_and_its_descendants` when navigating away from a document with child navigables (e.g., ad iframes).

**Cause:** A change introduced in #8397 / a095e4c led to dereferencing a childNavigable’s active document in a case where it was null because the child navigable’s document was already destroyed but its navigable still lingered in `child_navigables()`.

**Fix:** Same as we did for `unload_a_document_and_its_descendants` in #9959 / b42cf66: Queue with `queue_a_task` — which doesn’t require an active window — and skip any child whose active document is gone. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10266.
