### PR TITLE
LibWeb: Don’t negate INT64_MIN when converting a BigInt to a Wasm i64

### DIFF
--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -791,9 +791,8 @@ JS::ThrowCompletionOr<Wasm::Value> to_webassembly_value(JS::VM& vm, JS::Value va
         auto bigint = TRY(value.to_bigint(vm));
         auto value = bigint->big_integer().divided_by(two_64).remainder;
         VERIFY(value.unsigned_value().byte_length() <= sizeof(i64));
-        i64 integer = static_cast<i64>(value.unsigned_value().to_u64());
-        if (value.is_negative())
-            integer = -integer;
+        auto magnitude = value.unsigned_value().to_u64();
+        i64 integer = static_cast<i64>(value.is_negative() ? 0 - magnitude : magnitude);
         return Wasm::Value { integer };
     }
     case Wasm::ValueType::I32: {

--- a/Tests/LibWeb/Crash/Wasm/call-with-i64-minimum-argument.html
+++ b/Tests/LibWeb/Crash/Wasm/call-with-i64-minimum-argument.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script>
+    // Passing the minimum i64 value (-2^63) as a BigInt to a Wasm function with an i64 parameter. Converting the BigInt
+    // to a Wasm i64 negates a magnitude that lands on INT64_MIN, and doing that with signed arithmetic is overflow UB.
+    const bytes = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+        0x01, 0x05, 0x01, 0x60, 0x01, 0x7e, 0x00,       // type: (func (param i64))
+        0x03, 0x02, 0x01, 0x00,                         // function: 1 func of type 0
+        0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,       // export: "f" -> func 0
+        0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,             // code: empty body
+    ]);
+
+    const module = new WebAssembly.Module(bytes);
+    const instance = new WebAssembly.Instance(module);
+    instance.exports.f(-9223372036854775808n);
+</script>


### PR DESCRIPTION
**Problem:** Sanitizer build crash when the minimum i64 value is passed as a BigInt to a Wasm function that takes an i64 parameter.

**Cause:** `to_webassembly_value()` took the BigInt’s magnitude as an i64 and negated it for negative values. Negating `INT64_MIN` is UB.

**Fix:** Negate in unsigned space — where the wraparound is well-defined — then cast to `i64`. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9996.
