### PR TITLE
LibWeb: Compute createImageBitmap crop and resize sizes in 64 bits

### DIFF
--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NumericLimits.h>
 #include <AK/QuickSort.h>
 #include <AK/String.h>
 #include <AK/Utf8View.h>
@@ -146,21 +147,25 @@ static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> crop_to_the_source_rectangle_with_for
     //    (sx, sy), (sx+sw, sy), (sx+sw, sy+sh), (sx, sy+sh). Otherwise, let sourceRectangle be a rectangle whose
     //    corners are the four points (0, 0), (width of input, 0), (width of input, height of input), (0, height of input).
     //    NOTE: If either sw or sh are negative, then the top-left corner of this rectangle will be to the left or above the (sx, sy) point.
+    auto clamp_to_i32 = [](i64 value) {
+        return static_cast<int>(AK::clamp<i64>(value, NumericLimits<int>::min(), NumericLimits<int>::max()));
+    };
+
     Gfx::IntRect source_rectangle;
     if (sx.has_value() && sy.has_value() && sw.has_value() && sh.has_value()) {
-        WebIDL::Long effective_sx = sx.value();
-        WebIDL::Long effective_sy = sy.value();
-        WebIDL::Long effective_sw = sw.value();
-        WebIDL::Long effective_sh = sh.value();
+        i64 effective_sx = sx.value();
+        i64 effective_sy = sy.value();
+        i64 effective_sw = sw.value();
+        i64 effective_sh = sh.value();
         if (effective_sw < 0) {
+            effective_sx += effective_sw;
             effective_sw = -effective_sw;
-            effective_sx -= effective_sw;
         }
         if (effective_sh < 0) {
+            effective_sy += effective_sh;
             effective_sh = -effective_sh;
-            effective_sy -= effective_sh;
         }
-        source_rectangle = { effective_sx, effective_sy, effective_sw, effective_sh };
+        source_rectangle = { clamp_to_i32(effective_sx), clamp_to_i32(effective_sy), clamp_to_i32(effective_sw), clamp_to_i32(effective_sh) };
     } else {
         source_rectangle = input->rect();
     }
@@ -176,7 +181,7 @@ static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> crop_to_the_source_rectangle_with_for
     else if (options.has_value() && options->resize_height.has_value()) {
         // the width of sourceRectangle, times the value of the resizeHeight member of options, divided by the height
         //  of sourceRectangle, rounded up to the nearest integer
-        output_width = ceil_div(source_rectangle.width() * options->resize_height.value(), source_rectangle.height());
+        output_width = clamp_to_i32(ceil_div(static_cast<i64>(source_rectangle.width()) * options->resize_height.value(), static_cast<i64>(source_rectangle.height())));
     }
     // -> If neither resizeWidth nor resizeHeight are specified
     else {
@@ -195,7 +200,7 @@ static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> crop_to_the_source_rectangle_with_for
     else if (options.has_value() && options->resize_width.has_value()) {
         // the height of sourceRectangle, times the value of the resizeWidth member of options, divided by the width
         //  of sourceRectangle, rounded up to the nearest integer
-        output_height = ceil_div(source_rectangle.height() * options->resize_width.value(), source_rectangle.width());
+        output_height = clamp_to_i32(ceil_div(static_cast<i64>(source_rectangle.height()) * options->resize_width.value(), static_cast<i64>(source_rectangle.width())));
     }
     // -> If neither resizeWidth nor resizeHeight are specified
     else {

--- a/Tests/LibWeb/Crash/HTML/create-image-bitmap-extreme-dimensions.html
+++ b/Tests/LibWeb/Crash/HTML/create-image-bitmap-extreme-dimensions.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<script>
+    // createImageBitmap with extreme crop/resize values overflowed i32 arithmetic: negating a -2^31 sw/sh, and
+    // multiplying a near-INT_MAX extent by a resize dimension. Each case must reject (or resolve) without crashing.
+    async function runCase(sx, sy, sw, sh, options) {
+        try {
+            const bitmap = await createImageBitmap(new ImageData(1, 1), sx, sy, sw, sh, options);
+            bitmap.close();
+        } catch (e) {
+        }
+    }
+    (async () => {
+        await runCase(0, 0, -2147483648, 1);
+        await runCase(0, 0, 1, -2147483648);
+        await runCase(0, 0, 2147483647, 1, { resizeHeight: 2 });
+        await runCase(0, 0, 1, 2147483647, { resizeWidth: 2 });
+        document.documentElement.classList.remove("test-wait");
+    })();
+</script>
+</html>


### PR DESCRIPTION
**Problem:** Sanitizer build crash when `createImageBitmap` is given an extreme crop value or resize value — e.g., an sw or sh of -2³¹, or a near-`INT_MAX` extent together with a resize dimension.

**Cause:** `crop_to_the_source_rectangle_with_formatting` did the rectangle flip and the resize-output computation in 32-bit ints. Negating a -2³¹ sw/sh overflows — and `width * resizeHeight` (and `height * resizeWidth`) overflows for large extents.

**Fix:** Do that arithmetic in 64 bits, and clamp back into the 32-bit rectangle and output dimensions. The bitmap allocator caps dimensions at `UINT16_MAX` — so those out-of-range inputs reject, rather than crashing. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9989.
