### PR TITLE
CI: Warm up the pinned Rust toolchain in the setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -114,6 +114,11 @@ runs:
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
       uses: dtolnay/rust-toolchain@stable
 
+    - name: 'Warm up the Rust toolchain'
+      if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
+      shell: bash
+      run: rustup toolchain install
+
     - name: 'Resolve wasm-tools release'
       id: 'wasm-tools'
       if: ${{ inputs.type == 'build' && inputs.os != 'Linux' }}


### PR DESCRIPTION
**Problem:** macOS CI jobs intermittently fail while building the first Rust crate — with a `rustup` _“detected conflict: `bin/cargo-clippy`”_ error while installing the `clippy` component.

**Cause:** Same cause as #9950 / 61d0fca: Several `cargo` invocations trying to install `1.96.0`, but `rustup` isn’t safe against concurrent installs.

**Fix:** Same fix as #9950 / 61d0fca: Warm up the pinned toolchain first.
