### PR TITLE
LibWeb: Resolve percentages for numeric SVG attributes

### DIFF
--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -564,7 +564,7 @@ void SVGFormattingContext::layout_image_element(SVGImageBox const& image_box)
     auto to_css_pixels_transform = Gfx::AffineTransform {}
                                        .multiply(m_current_viewbox_transform)
                                        .multiply(box_state.computed_svg_transforms()->svg_transform());
-    auto bounding_box = to_css_pixels_transform.map(image_box.dom_node().bounding_box()).to_type<CSSPixels>();
+    auto bounding_box = to_css_pixels_transform.map(image_box.dom_node().bounding_box(m_viewport_size)).to_type<CSSPixels>();
 
     box_state.set_content_x(bounding_box.x());
     box_state.set_content_y(bounding_box.y());

--- a/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -31,26 +31,26 @@ void SVGEllipseElement::attribute_changed(FlyString const& name, Optional<String
     Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == SVG::AttributeNames::cx) {
-        m_center_x = AttributeParser::parse_coordinate(value.value_or(String {}));
+        m_center_x = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::cy) {
-        m_center_y = AttributeParser::parse_coordinate(value.value_or(String {}));
+        m_center_y = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::rx) {
-        m_radius_x = AttributeParser::parse_positive_length(value.value_or(String {}));
+        m_radius_x = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::ry) {
-        m_radius_y = AttributeParser::parse_positive_length(value.value_or(String {}));
+        m_radius_y = AttributeParser::parse_number_percentage(value.value_or(String {}));
     }
 }
 
-Gfx::Path SVGEllipseElement::get_path(CSSPixelSize)
+Gfx::Path SVGEllipseElement::get_path(CSSPixelSize viewport_size)
 {
-    float rx = m_radius_x.value_or(0);
-    float ry = m_radius_y.value_or(0);
-    float cx = m_center_x.value_or(0);
-    float cy = m_center_y.value_or(0);
+    float rx = m_radius_x.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size.width().to_float());
+    float ry = m_radius_y.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size.height().to_float());
+    float cx = m_center_x.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size.width().to_float());
+    float cy = m_center_y.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size.height().to_float());
     Gfx::Path path;
 
     // A computed value of zero for either dimension, or a computed value of auto for both dimensions, disables rendering of the element.
-    if (rx == 0 || ry == 0)
+    if (rx <= 0 || ry <= 0)
         return path;
 
     Gfx::FloatSize radii = { rx, ry };
@@ -81,8 +81,9 @@ GC::Ref<SVGAnimatedLength> SVGEllipseElement::cx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_center_x.value_or(0), SVGLength::ReadOnly::No);
-    auto anim_length = SVGLength::create(realm(), 0, m_center_x.value_or(0), SVGLength::ReadOnly::Yes);
+    auto value = m_center_x.value_or(NumberPercentage::create_number(0)).value();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
     return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 
@@ -91,8 +92,9 @@ GC::Ref<SVGAnimatedLength> SVGEllipseElement::cy() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_center_y.value_or(0), SVGLength::ReadOnly::No);
-    auto anim_length = SVGLength::create(realm(), 0, m_center_y.value_or(0), SVGLength::ReadOnly::Yes);
+    auto value = m_center_y.value_or(NumberPercentage::create_number(0)).value();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
     return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 
@@ -101,8 +103,9 @@ GC::Ref<SVGAnimatedLength> SVGEllipseElement::rx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0), SVGLength::ReadOnly::No);
-    auto anim_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0), SVGLength::ReadOnly::Yes);
+    auto value = m_radius_x.value_or(NumberPercentage::create_number(0)).value();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
     return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 
@@ -111,8 +114,9 @@ GC::Ref<SVGAnimatedLength> SVGEllipseElement::ry() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0), SVGLength::ReadOnly::No);
-    auto anim_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0), SVGLength::ReadOnly::Yes);
+    auto value = m_radius_y.value_or(NumberPercentage::create_number(0)).value();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
     return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 

--- a/Libraries/LibWeb/SVG/SVGEllipseElement.h
+++ b/Libraries/LibWeb/SVG/SVGEllipseElement.h
@@ -32,10 +32,10 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    Optional<float> m_center_x;
-    Optional<float> m_center_y;
-    Optional<float> m_radius_x;
-    Optional<float> m_radius_y;
+    Optional<NumberPercentage> m_center_x;
+    Optional<NumberPercentage> m_center_y;
+    Optional<NumberPercentage> m_radius_x;
+    Optional<NumberPercentage> m_radius_y;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -45,10 +45,6 @@ void SVGImageElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     SVGURIReferenceMixin::visit_edges(visitor);
-    visitor.visit(m_x);
-    visitor.visit(m_y);
-    visitor.visit(m_width);
-    visitor.visit(m_height);
     visitor.visit(m_resource_request);
 }
 
@@ -65,17 +61,13 @@ void SVGImageElement::attribute_changed(FlyString const& name, Optional<String> 
     Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == SVG::AttributeNames::x) {
-        auto parsed_value = AttributeParser::parse_coordinate(value.value_or(String {}));
-        MUST(x()->base_val()->set_value(parsed_value.value_or(0)));
+        m_x = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::y) {
-        auto parsed_value = AttributeParser::parse_coordinate(value.value_or(String {}));
-        MUST(y()->base_val()->set_value(parsed_value.value_or(0)));
+        m_y = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::width) {
-        auto parsed_value = AttributeParser::parse_coordinate(value.value_or(String {}));
-        MUST(width()->base_val()->set_value(parsed_value.value_or(0)));
+        m_width = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::height) {
-        auto parsed_value = AttributeParser::parse_coordinate(value.value_or(String {}));
-        MUST(height()->base_val()->set_value(parsed_value.value_or(0)));
+        m_height = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::href) {
         // https://svgwg.org/svg2-draft/linking.html#XLinkRefAttrs
         // For backwards compatibility, elements with an ‘href’ attribute also recognize an ‘href’ attribute in the
@@ -96,58 +88,56 @@ void SVGImageElement::attribute_changed(FlyString const& name, Optional<String> 
 // https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__x
 GC::Ref<SVG::SVGAnimatedLength> SVGImageElement::x()
 {
-    if (!m_x)
-        m_x = fake_animated_length_fixme();
-
-    return *m_x;
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto value = m_x.value_or(NumberPercentage::create_number(0)).value();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
+    return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 
 // https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__y
 GC::Ref<SVG::SVGAnimatedLength> SVGImageElement::y()
 {
-    if (!m_y)
-        m_y = fake_animated_length_fixme();
-
-    return *m_y;
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto value = m_y.value_or(NumberPercentage::create_number(0)).value();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
+    return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 
 // https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__width
 GC::Ref<SVG::SVGAnimatedLength> SVGImageElement::width()
 {
-    if (!m_width) {
-        auto& realm = this->realm();
-        m_width = SVGAnimatedLength::create(
-            realm,
-            SVGLength::create(realm, 0, intrinsic_width().value_or(0).to_double(), SVGLength::ReadOnly::No),
-            SVGLength::create(realm, 0, 0, SVGLength::ReadOnly::Yes));
-    }
-
-    return *m_width;
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto value = m_width.has_value() ? m_width->value() : intrinsic_width().value_or(0).to_double();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
+    return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 
 // https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__height
 GC::Ref<SVG::SVGAnimatedLength> SVGImageElement::height()
 {
-    if (!m_height) {
-        auto& realm = this->realm();
-        m_height = SVGAnimatedLength::create(
-            realm,
-            SVGLength::create(realm, 0, intrinsic_height().value_or(0).to_double(), SVGLength::ReadOnly::No),
-            SVGLength::create(realm, 0, 0, SVGLength::ReadOnly::Yes));
-    }
-
-    return *m_height;
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto value = m_height.has_value() ? m_height->value() : intrinsic_height().value_or(0).to_double();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
+    return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 
-Gfx::FloatRect SVGImageElement::bounding_box() const
+Gfx::FloatRect SVGImageElement::bounding_box(CSSPixelSize viewport_size) const
 {
     Optional<float> width;
-    if (attribute(HTML::AttributeNames::width).has_value())
-        width = m_width->base_val()->value();
+    if (m_width.has_value())
+        width = m_width->resolve_relative_to(viewport_size.width().to_float());
 
     Optional<float> height;
-    if (attribute(HTML::AttributeNames::height).has_value())
-        height = m_height->base_val()->value();
+    if (m_height.has_value())
+        height = m_height->resolve_relative_to(viewport_size.height().to_float());
 
     if (!height.has_value() && width.has_value() && intrinsic_aspect_ratio().has_value())
         height = width.value() / intrinsic_aspect_ratio().value().to_float();
@@ -162,8 +152,8 @@ Gfx::FloatRect SVGImageElement::bounding_box() const
         height = intrinsic_height()->to_float();
 
     return {
-        m_x ? m_x->base_val()->value() : 0.0f,
-        m_y ? m_y->base_val()->value() : 0.0f,
+        m_x.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size.width().to_float()),
+        m_y.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size.height().to_float()),
         width.value_or(0.0f),
         height.value_or(0.0f),
     };

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -35,7 +35,7 @@ public:
     GC::Ref<SVG::SVGAnimatedLength> width();
     GC::Ref<SVG::SVGAnimatedLength> height();
 
-    Gfx::FloatRect bounding_box() const;
+    Gfx::FloatRect bounding_box(CSSPixelSize viewport_size) const;
 
     // ^Layout::ImageProvider
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override;
@@ -56,10 +56,10 @@ private:
     virtual RefPtr<Layout::Node> create_layout_node(CSS::ComputedProperties const&) override;
     virtual void decoded_image_data_did_update() override { set_needs_repaint(); }
 
-    GC::Ptr<SVG::SVGAnimatedLength> m_x;
-    GC::Ptr<SVG::SVGAnimatedLength> m_y;
-    GC::Ptr<SVG::SVGAnimatedLength> m_width;
-    GC::Ptr<SVG::SVGAnimatedLength> m_height;
+    Optional<NumberPercentage> m_x;
+    Optional<NumberPercentage> m_y;
+    Optional<NumberPercentage> m_width;
+    Optional<NumberPercentage> m_height;
 
     Optional<URL::URL> m_href;
 

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -176,9 +176,9 @@ void SVGUseElement::attribute_changed(FlyString const& name, Optional<String> co
 
     // https://svgwg.org/svg2-draft/struct.html#UseLayout
     if (name == SVG::AttributeNames::x) {
-        m_x = AttributeParser::parse_coordinate(value.value_or(String {}));
+        m_x = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::y) {
-        m_y = AttributeParser::parse_coordinate(value.value_or(String {}));
+        m_y = AttributeParser::parse_number_percentage(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::href || name == "xlink:href"_fly_string) {
         // When the ‘href’ attribute is set (or, in the absence of an ‘href’ attribute, an ‘xlink:href’ attribute), the user agent must process the URL.
         process_the_url(value);
@@ -218,9 +218,20 @@ bool SVGUseElement::is_referenced_element_same_document() const
 
 Gfx::AffineTransform SVGUseElement::element_transform() const
 {
+    CSSPixelSize viewport_size;
+    if (auto* svg_svg_element = first_flat_tree_ancestor_of_type<SVGSVGElement>()) {
+        if (auto view_box = svg_svg_element->active_view_box(); view_box.has_value())
+            viewport_size = { CSSPixels::nearest_value_for(view_box->width), CSSPixels::nearest_value_for(view_box->height) };
+        else if (auto svg_svg_layout_node = svg_svg_element->unsafe_layout_node())
+            viewport_size = { svg_svg_layout_node->computed_values().width().to_px(0), svg_svg_layout_node->computed_values().height().to_px(0) };
+    }
+
+    auto x = m_x.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size.width().to_float());
+    auto y = m_y.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size.height().to_float());
+
     // The x and y properties define an additional transformation (translate(x,y), where x and y represent the computed value of the corresponding property)
     // to be applied to the ‘use’ element, after any transformations specified with other properties
-    return Base::element_transform().translate(m_x.value_or(0), m_y.value_or(0));
+    return Base::element_transform().translate(x, y);
 }
 
 void SVGUseElement::svg_element_changed(SVGElement& svg_element)
@@ -390,8 +401,9 @@ GC::Ref<SVGAnimatedLength> SVGUseElement::x() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_x.value_or(0), SVGLength::ReadOnly::No);
-    auto anim_length = SVGLength::create(realm(), 0, m_x.value_or(0), SVGLength::ReadOnly::Yes);
+    auto value = m_x.value_or(NumberPercentage::create_number(0)).value();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
     return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 
@@ -400,8 +412,9 @@ GC::Ref<SVGAnimatedLength> SVGUseElement::y() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_y.value_or(0), SVGLength::ReadOnly::No);
-    auto anim_length = SVGLength::create(realm(), 0, m_y.value_or(0), SVGLength::ReadOnly::Yes);
+    auto value = m_y.value_or(NumberPercentage::create_number(0)).value();
+    auto base_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::No);
+    auto anim_length = SVGLength::create(realm(), 0, value, SVGLength::ReadOnly::Yes);
     return SVGAnimatedLength::create(realm(), base_length, anim_length);
 }
 

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -75,8 +75,8 @@ private:
     void register_for_referenced_element_changes();
     void unregister_for_referenced_element_changes();
 
-    Optional<float> m_x;
-    Optional<float> m_y;
+    Optional<NumberPercentage> m_x;
+    Optional<NumberPercentage> m_y;
     bool m_needs_document_complete_reclone { false };
 
     Optional<URL::URL> m_href;

--- a/Tests/LibWeb/Ref/expected/svg/ellipse-percentage-size-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/ellipse-percentage-size-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="100" height="60">
+    <ellipse cx="50" cy="30" rx="50" ry="30" fill="green" />
+</svg>

--- a/Tests/LibWeb/Ref/expected/svg/image-percentage-size-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/image-percentage-size-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="100" height="100">
+    <rect width="100" height="100" fill="green"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/expected/svg/use-percentage-offset-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/use-percentage-offset-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="200" height="200">
+    <rect x="100" y="100" width="100" height="100" fill="green" />
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/ellipse-percentage-size.html
+++ b/Tests/LibWeb/Ref/input/svg/ellipse-percentage-size.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/ellipse-percentage-size-ref.html" />
+<svg width="100" height="60">
+    <ellipse cx="50%" cy="50%" rx="50%" ry="50%" fill="green" />
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/image-percentage-size.html
+++ b/Tests/LibWeb/Ref/input/svg/image-percentage-size.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/image-percentage-size-ref.html" />
+<svg width="100" height="100">
+    <image href="../../data/50x50-green.svg" width="100%" height="100%" />
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/use-percentage-offset.html
+++ b/Tests/LibWeb/Ref/input/svg/use-percentage-offset.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/use-percentage-offset-ref.html" />
+<svg width="200" height="200">
+    <defs>
+        <rect id="r" width="100" height="100" fill="green" />
+    </defs>
+    <use href="#r" x="50%" y="50%" />
+</svg>


### PR DESCRIPTION
This PR makes the following SVG element attributes accept percentages where they didn't previously:

* `SVGImageElement` - `x`, `y`, `width` and `height`
* `SVGEllipseElement` - `cx`, `cy`, `rx` and `ry`
* `SVGUseElement` - `x` and `y`

The `<image>` changes make the user avatar appear when logged into https://reddit.com:

Before:
<img width="534" height="52" alt="image" src="https://github.com/user-attachments/assets/7f3b8b0b-398d-486e-8d25-6d935f442803" />


After:
<img width="534" height="52" alt="image" src="https://github.com/user-attachments/assets/d591cc98-a917-46d1-b721-8e6f545d8df1" />
