### PR TITLE
LibWeb: Resolve replaced intrinsic width from definite height

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2192,6 +2192,8 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
         if (auto const& max_width = box.computed_values().max_width(); max_width.is_percentage())
             return max_width.to_px(0);
     }
+    if (auto transferred_width = calculate_transferred_width_for_replaced_element(box); transferred_width.has_value())
+        return transferred_width.value();
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_width())
         return auto_size.width.value();
 
@@ -2224,9 +2226,37 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
     return min_content_width;
 }
 
+// https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
+// "size constraints in the opposite dimension will transfer through and can affect the auto size in the considered one"
+Optional<CSSPixels> FormattingContext::calculate_transferred_width_for_replaced_element(Layout::Box const& box) const
+{
+    if (!box.is_replaced_box() || !box.has_preferred_aspect_ratio())
+        return {};
+
+    // https://drafts.csswg.org/css2/#inline-replaced-width
+    // "'width' has a computed value of 'auto', 'height' has some other computed value, and the element does have an intrinsic ratio"
+    if (!box.computed_values().width().is_auto())
+        return {};
+
+    auto const& computed_height = box.computed_values().height();
+    if (computed_height.is_auto() || computed_height.is_intrinsic_sizing_constraint())
+        return {};
+
+    auto available_space = m_state.get(box).available_inner_space_or_constraints_from(
+        AvailableSpace(AvailableSize::make_max_content(), AvailableSize::make_indefinite()));
+    if (should_treat_height_as_auto(box, available_space))
+        return {};
+
+    // https://drafts.csswg.org/css2/#inline-replaced-width
+    // "(used height) * (intrinsic ratio)"
+    return compute_width_for_replaced_element(box, available_space);
+}
+
 CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box) const
 {
     auto auto_size = box.auto_content_box_size();
+    if (auto transferred_width = calculate_transferred_width_for_replaced_element(box); transferred_width.has_value())
+        return transferred_width.value();
     if (!auto_size.has_width()) {
         // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
         // "If the box is non-replaced, then the entire value of any max size property or preferred size property

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -176,6 +176,7 @@ protected:
     FormattingContext(Type, LayoutMode, LayoutState&, Box const&, FormattingContext* parent = nullptr);
 
     [[nodiscard]] static bool computed_height_establishes_definite_containing_block_height(CSS::Size const&);
+    [[nodiscard]] Optional<CSSPixels> calculate_transferred_width_for_replaced_element(Layout::Box const&) const;
 
     [[nodiscard]] bool should_treat_width_as_auto(Box const&, AvailableSpace const&) const;
     [[nodiscard]] bool should_treat_height_as_auto(Box const&, AvailableSpace const&) const;

--- a/Tests/LibWeb/Layout/expected/flex-column-image-height-intrinsic-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-image-height-intrinsic-width.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 32 0+0+8] children: not-inline
+      Box <div.row> at [8,8] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 32 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.column> at [8,8] flex-container(column) flex-item [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [FFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          ImageBox <img> at [8,8] flex-item [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,40] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x32]
+      PaintableBox (Box<DIV>.row) [8,8 784x32]
+        PaintableBox (Box<DIV>.column) [8,8 32x32]
+          ImagePaintable (ImageBox<IMG>) [8,8 32x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,40 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x48] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex-column-image-height-intrinsic-width.html
+++ b/Tests/LibWeb/Layout/input/flex-column-image-height-intrinsic-width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+    .row {
+        display: flex;
+    }
+
+    .column {
+        display: flex;
+        flex-direction: column;
+    }
+</style>
+<div class="row">
+    <div class="column">
+        <img height="32" src="400.png">
+    </div>
+</div>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/flex-aspect-ratio-img-column-011.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/flex-aspect-ratio-img-column-011.txt
@@ -2,13 +2,12 @@ Harness status: OK
 
 Found 10 tests
 
-9 Pass
-1 Fail
+10 Pass
 Pass	.flexbox 1
 Pass	.flexbox 2
 Pass	.flexbox 3
 Pass	.flexbox 4
-Fail	.flexbox 5
+Pass	.flexbox 5
 Pass	.flexbox 6
 Pass	.flexbox 7
 Pass	.flexbox 8


### PR DESCRIPTION
For auto-width replaced elements with a preferred aspect ratio, let a definite height affect min/max-content width before falling back to natural width.

Fixes image sizing of WhatsApp logo in the header for the WhatsApp FAQ (https://faq.whatsapp.com).


Before:

<img width="1395" height="746" alt="image" src="https://github.com/user-attachments/assets/84d507a1-c924-48f2-86e1-a20ab8f828c0" />

After:

<img width="1395" height="746" alt="image" src="https://github.com/user-attachments/assets/91a32a80-77a2-42c3-84c7-e7062516e358" />
