### PR TITLE
LibSandbox: Allow syscalls required for WebGL with NVIDIA GPU

### DIFF
--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -111,6 +111,8 @@ static constexpr unsigned read_only_open_flags = O_CLOEXEC;
 #define IF_DEFINED_getpeername(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_getpid(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_getrandom(if_defined, if_not_defined) if_defined
+#define IF_DEFINED_getresgid(if_defined, if_not_defined) if_defined
+#define IF_DEFINED_getresuid(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_getrlimit(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_getrusage(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_getsockname(if_defined, if_not_defined) if_defined
@@ -173,7 +175,9 @@ static constexpr unsigned read_only_open_flags = O_CLOEXEC;
 #define IF_DEFINED_shutdown(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_socket(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_socketpair(if_defined, if_not_defined) if_defined
+#define IF_DEFINED_stat(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_statx(if_defined, if_not_defined) if_defined
+#define IF_DEFINED_symlink(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_sysinfo(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_tgkill(if_defined, if_not_defined) if_defined
 #define IF_DEFINED_unlink(if_defined, if_not_defined) if_defined
@@ -316,6 +320,14 @@ static constexpr unsigned read_only_open_flags = O_CLOEXEC;
 #    undef IF_DEFINED_getrandom
 #    define IF_DEFINED_getrandom(if_defined, if_not_defined) if_not_defined
 #endif
+#ifndef __NR_getresgid
+#    undef IF_DEFINED_getresgid
+#    define IF_DEFINED_getresgid(if_defined, if_not_defined) if_not_defined
+#endif
+#ifndef __NR_getresuid
+#    undef IF_DEFINED_getresuid
+#    define IF_DEFINED_getresuid(if_defined, if_not_defined) if_not_defined
+#endif
 #ifndef __NR_membarrier
 #    undef IF_DEFINED_membarrier
 #    define IF_DEFINED_membarrier(if_defined, if_not_defined) if_not_defined
@@ -432,9 +444,17 @@ static constexpr unsigned read_only_open_flags = O_CLOEXEC;
 #    undef IF_DEFINED_shutdown
 #    define IF_DEFINED_shutdown(if_defined, if_not_defined) if_not_defined
 #endif
+#ifndef __NR_stat
+#    undef IF_DEFINED_stat
+#    define IF_DEFINED_stat(if_defined, if_not_defined) if_not_defined
+#endif
 #ifndef __NR_statx
 #    undef IF_DEFINED_statx
 #    define IF_DEFINED_statx(if_defined, if_not_defined) if_not_defined
+#endif
+#ifndef __NR_symlink
+#    undef IF_DEFINED_symlink
+#    define IF_DEFINED_symlink(if_defined, if_not_defined) if_not_defined
 #endif
 #ifndef __NR_unlink
 #    undef IF_DEFINED_unlink
@@ -570,6 +590,12 @@ static char const* syscall_name(long syscall_number)
 #ifdef __NR_getdents64
         CASE_SYSCALL_NAME(getdents64);
 #endif
+#ifdef __NR_getresgid
+        CASE_SYSCALL_NAME(getresgid);
+#endif
+#ifdef __NR_getresuid
+        CASE_SYSCALL_NAME(getresuid);
+#endif
 #ifdef __NR_ioctl
         CASE_SYSCALL_NAME(ioctl);
 #endif
@@ -645,8 +671,14 @@ static char const* syscall_name(long syscall_number)
 #ifdef __NR_socket
         CASE_SYSCALL_NAME(socket);
 #endif
+#ifdef __NR_stat
+        CASE_SYSCALL_NAME(stat);
+#endif
 #ifdef __NR_statx
         CASE_SYSCALL_NAME(statx);
+#endif
+#ifdef __NR_symlink
+        CASE_SYSCALL_NAME(symlink);
 #endif
 #ifdef __NR_unlink
         CASE_SYSCALL_NAME(unlink);
@@ -800,6 +832,7 @@ void SeccompPolicy::allow_filesystem_metadata_queries()
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, newfstatat);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, readlink);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, readlinkat);
+    SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, stat);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, statx);
 }
 
@@ -816,6 +849,7 @@ void SeccompPolicy::allow_filesystem_writes()
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, renameat2);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, mkdir);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, mkdirat);
+    SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, symlink);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, rmdir);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, fsync);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, fdatasync);
@@ -1173,6 +1207,8 @@ void SeccompPolicy::allow_process_metadata()
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, geteuid);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, getgid);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, getegid);
+    SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, getresgid);
+    SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, getresuid);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, getrandom);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, gettimeofday);
     SECCOMP_APPEND_ALLOW_SYSCALL_IF_DEFINED(*this, getrlimit);


### PR DESCRIPTION
This fixes a crash introduced in 40cd42d when loading Text/input/wpt-import/webidl/current-realm.html with `--force-cpu-painting` on my machine