### PR TITLE
LibWebView: Fix re-entrant crash when canceling an autocomplete query

### DIFF
--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -48,8 +48,12 @@ Autocomplete::~Autocomplete() = default;
 void Autocomplete::cancel_pending_query()
 {
     if (m_request) {
-        m_request->stop();
-        m_request.clear();
+        // This can be reached synchronously from inside the request's own completion callback: activating a suggestion
+        // clears the location bar's focus, canceling the query. Stopping the request inline would destroy a still-
+        // running callback — so defer the teardown (just as set_buffered_request_finished_callback defers its clear).
+        Core::deferred_invoke([request = move(m_request)] {
+            request->stop();
+        });
     }
 
     // Buffered callbacks may still arrive after we stop the request, so clear

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -682,6 +682,16 @@ void Settings::set_autocomplete_engine(Optional<StringView> autocomplete_engine_
         observer.autocomplete_engine_changed();
 }
 
+void Settings::set_autocomplete_engine(AutocompleteEngine autocomplete_engine)
+{
+    // Custom engines are not persisted: settings stores the engine by name and reloads it
+    // from the builtin list, so a non-builtin engine would not round-trip.
+    m_autocomplete_engine = autocomplete_engine;
+
+    for (auto& observer : m_observers)
+        observer.autocomplete_engine_changed();
+}
+
 void Settings::set_autoplay_policy(Web::HTML::AutoplayPolicy policy)
 {
     m_autoplay.policy = policy;

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -147,6 +147,7 @@ public:
 
     Optional<AutocompleteEngine> const& autocomplete_engine() const { return m_autocomplete_engine; }
     void set_autocomplete_engine(Optional<StringView> autocomplete_engine_name);
+    void set_autocomplete_engine(AutocompleteEngine);
 
     AutoplaySiteSetting const& autoplay_settings() const { return m_autoplay; }
     void set_autoplay_policy(Web::HTML::AutoplayPolicy);

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -248,7 +248,7 @@ void SettingsUI::set_search_engine(JsonValue const& search_engine)
 {
     if (search_engine.is_null()) {
         WebView::Application::settings().set_search_engine({});
-        WebView::Application::settings().set_autocomplete_engine({});
+        WebView::Application::settings().set_autocomplete_engine(OptionalNone {});
     } else if (search_engine.is_string()) {
         WebView::Application::settings().set_search_engine(search_engine.as_string());
     }
@@ -275,7 +275,7 @@ void SettingsUI::remove_custom_search_engine(JsonValue const& search_engine)
 void SettingsUI::set_autocomplete_engine(JsonValue const& autocomplete_engine)
 {
     if (autocomplete_engine.is_null())
-        WebView::Application::settings().set_autocomplete_engine({});
+        WebView::Application::settings().set_autocomplete_engine(OptionalNone {});
     else if (autocomplete_engine.is_string())
         WebView::Application::settings().set_autocomplete_engine(autocomplete_engine.as_string());
 }

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -11,10 +11,22 @@ foreach(source IN LISTS TEST_SOURCES)
     ladybird_test("${source}" LibWebView LIBS LibDatabase LibWebView LibURL)
 endforeach()
 
+if (NOT WIN32)
+    add_executable(TestAutocomplete TestAutocomplete.cpp)
+    add_dependencies(TestAutocomplete ${ladybird_helper_processes})
+    target_link_libraries(TestAutocomplete PRIVATE AK LibCore LibDiff LibFileSystem LibGfx LibImageDecoders LibImageDecoderClient LibIPC LibJS LibMain LibRequests LibURL LibWeb LibWebView)
+    if (APPLE)
+        target_compile_definitions(TestAutocomplete PRIVATE LADYBIRD_BINARY_PATH="$<TARGET_FILE_DIR:ladybird>")
+    endif()
+endif()
+
 if (BUILD_TESTING AND NOT WIN32)
     add_test(
         NAME TestWebDriverSessionHistory
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-webdriver-session-history.py $<TARGET_FILE:WebDriver>
     )
     set_tests_properties(TestWebDriverSessionHistory PROPERTIES TIMEOUT 120)
+
+    add_test(NAME TestAutocomplete COMMAND $<TARGET_FILE:TestAutocomplete>)
+    set_tests_properties(TestAutocomplete PROPERTIES TIMEOUT 60 ENVIRONMENT LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR})
 endif()

--- a/Tests/LibWebView/TestAutocomplete.cpp
+++ b/Tests/LibWebView/TestAutocomplete.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, sideshowbarker <mike@w3.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <LibCore/EventLoop.h>
+#include <LibMain/Main.h>
+#include <LibWebView/Application.h>
+#include <LibWebView/Autocomplete.h>
+#include <LibWebView/Settings.h>
+
+namespace {
+
+class TestApplication : public WebView::Application {
+    WEB_VIEW_APPLICATION(TestApplication)
+
+public:
+    explicit TestApplication(Optional<ByteString> ladybird_binary_path)
+        : WebView::Application(move(ladybird_binary_path))
+    {
+    }
+
+    virtual void create_platform_options(WebView::BrowserOptions& browser_options, WebView::RequestServerOptions&, WebView::WebContentOptions& web_content_options) override
+    {
+        browser_options.headless_mode = WebView::HeadlessMode::Test;
+        browser_options.disable_sql_database = WebView::DisableSQLDatabase::Yes;
+        web_content_options.is_test_mode = WebView::IsTestMode::Yes;
+    }
+};
+
+}
+
+// Canceling the pending autocomplete query from inside the query-complete callback is exactly what the Qt location bar
+// does: Activating a suggestion clears the bar's focus — whose focusOutEvent calls Autocomplete::cancel_pending_query.
+// That cancel runs while the request's completion callback is still on the stack — so, tearing the request down freed a
+// callback mid-call, and tripped an assert. Regression test for #10278.
+
+ErrorOr<int> ladybird_main(Main::Arguments arguments)
+{
+#if defined(LADYBIRD_BINARY_PATH)
+    auto app = TRY(TestApplication::create(arguments, LADYBIRD_BINARY_PATH));
+#else
+    auto app = TRY(TestApplication::create(arguments, OptionalNone {}));
+#endif
+
+    // A closed loopback port makes the request fail fast and deterministically (connection refused, no real network) —
+    // so, its on_finish runs and synchronously delivers the final result to the callback below. (A data: URL can't be
+    // used: it has no host, and the request server's DNS path asserts on a host-less URL.)
+    WebView::Application::settings().set_autocomplete_engine(WebView::AutocompleteEngine {
+        .name = "Test"sv,
+        .query_url = "http://127.0.0.1:47919/{}"sv,
+    });
+
+    WebView::Autocomplete autocomplete;
+
+    auto completed = false;
+    autocomplete.on_autocomplete_query_complete = [&](auto const&, WebView::AutocompleteResultKind kind) {
+        // Only the final result is delivered from within the request's on_finish — which is the re-entrant teardown
+        // that previously crashed.
+        if (kind != WebView::AutocompleteResultKind::Final)
+            return;
+        autocomplete.cancel_pending_query();
+        completed = true;
+    };
+
+    autocomplete.query_autocomplete_engine("test"_string);
+
+    Core::EventLoop::current().spin_until([&]() { return completed; });
+
+    outln("PASS: cancel_pending_query during query completion did not crash");
+    return 0;
+}


### PR DESCRIPTION
**Problem:** Crash when typing in address bar before autocomplete finishes.

**Cause:** Activating a suggestion clears the location bar’s focus, and the resulting `focusOutEvent` calls `Autocomplete::cancel_pending_query`. When that happened from within the request’s own completion callback, `cancel_pending_query` stopped, and destroyed the request inline — freeing the `InternalStreamData` and callback while it was still on the stack.

**Fix:** Defer the teardown in `cancel_pending_query` by moving the request into a `deferred_invoke`, and stopping it after the call stack unwinds — same as in the deferred `m_request.clear()` already used on completion.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/10278
