### PR TITLE
LibWeb: Compress cyclic max-size flex contributions

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -488,6 +488,24 @@ CSSPixels FlexFormattingContext::specified_cross_max_size(FlexItem const& item) 
         : get_pixel_height(item, computed_cross_max_size(item.box));
 }
 
+CSSPixels FlexFormattingContext::specified_main_max_size_for_intrinsic_contribution(FlexItem const& item, AvailableSize const& available_size) const
+{
+    auto const& computed_max_size = computed_main_max_size(item.box);
+    if (should_treat_main_max_size_as_none(item.box))
+        return CSSPixels::max();
+
+    if (computed_max_size.contains_percentage()) {
+        // If the box is replaced, a cyclic percentage in the value of any max size property is resolved against
+        // zero when calculating the min-content contribution in the corresponding axis.
+        if (item.box.is_replaced_box() && available_size.is_min_content())
+            return 0;
+
+        return CSSPixels::max();
+    }
+
+    return specified_main_max_size(item);
+}
+
 bool FlexFormattingContext::is_cross_auto(Box const& box) const
 {
     auto& cross_length = computed_cross_size(box);
@@ -2018,10 +2036,10 @@ CSSPixels FlexFormattingContext::calculate_intrinsic_main_size_of_flex_container
                 auto result = item.flex_base_size + CSSPixels::nearest_value_for(product);
 
                 auto const& computed_min_size = this->computed_main_min_size(item.box);
-                auto const& computed_max_size = this->computed_main_max_size(item.box);
 
                 auto clamp_min = (!computed_min_size.is_auto() && !computed_min_size.contains_percentage()) ? specified_main_min_size(item) : automatic_minimum_size(item);
-                auto clamp_max = (!should_treat_main_max_size_as_none(item.box) && !computed_max_size.contains_percentage()) ? specified_main_max_size(item) : CSSPixels::max();
+                auto clamp_max = specified_main_max_size_for_intrinsic_contribution(
+                    item, m_available_space_for_items->main);
 
                 result = css_clamp(result, clamp_min, clamp_max);
 
@@ -2127,7 +2145,7 @@ CSSPixels FlexFormattingContext::calculate_main_min_content_contribution(FlexIte
     }();
 
     auto clamp_min = has_main_min_size(item.box) ? specified_main_min_size(item) : automatic_minimum_size(item);
-    auto clamp_max = has_main_max_size(item.box) ? specified_main_max_size(item) : CSSPixels::max();
+    auto clamp_max = specified_main_max_size_for_intrinsic_contribution(item, AvailableSize::make_min_content());
     auto clamped_inner_size = css_clamp(larger_size, clamp_min, clamp_max);
 
     return item.add_main_margin_box_sizes(clamped_inner_size);
@@ -2148,7 +2166,7 @@ CSSPixels FlexFormattingContext::calculate_main_max_content_contribution(FlexIte
     }();
 
     auto clamp_min = has_main_min_size(item.box) ? specified_main_min_size(item) : automatic_minimum_size(item);
-    auto clamp_max = has_main_max_size(item.box) ? specified_main_max_size(item) : CSSPixels::max();
+    auto clamp_max = specified_main_max_size_for_intrinsic_contribution(item, AvailableSize::make_max_content());
     auto clamped_inner_size = css_clamp(larger_size, clamp_min, clamp_max);
 
     return item.add_main_margin_box_sizes(clamped_inner_size);

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -137,6 +137,8 @@ private:
     bool has_cross_min_size(Box const&) const;
     CSSPixels specified_main_max_size(FlexItem const&) const;
     CSSPixels specified_cross_max_size(FlexItem const&) const;
+    CSSPixels specified_main_max_size_for_intrinsic_contribution(FlexItem const&,
+        AvailableSize const&) const;
     bool is_cross_auto(Box const&) const;
     CSSPixels specified_main_min_size(FlexItem const&) const;
     CSSPixels specified_cross_min_size(FlexItem const&) const;

--- a/Tests/LibWeb/Text/expected/flex-replaced-cyclic-percentage-calc-max-width.txt
+++ b/Tests/LibWeb/Text/expected/flex-replaced-cyclic-percentage-calc-max-width.txt
@@ -1,0 +1,2 @@
+flex width: 0
+canvas width: 0

--- a/Tests/LibWeb/Text/expected/grid/flex-item-replaced-child-cyclic-percentage-max-width.txt
+++ b/Tests/LibWeb/Text/expected/grid/flex-item-replaced-child-cyclic-percentage-max-width.txt
@@ -1,0 +1,2 @@
+grid-template-columns: 144.25px 144.25px 144.25px 144.25px
+last item right: 652

--- a/Tests/LibWeb/Text/input/flex-replaced-cyclic-percentage-calc-max-width.html
+++ b/Tests/LibWeb/Text/input/flex-replaced-cyclic-percentage-calc-max-width.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+#flex {
+    display: flex;
+    width: min-content;
+}
+
+canvas {
+    height: 20px;
+    max-width: calc(50% + 20px);
+    min-width: 0;
+    width: 100px;
+}
+</style>
+<div id="flex"><canvas id="canvas"></canvas></div>
+<script>
+test(() => {
+    const flexRect = document.getElementById("flex").getBoundingClientRect();
+    const canvasRect = document.getElementById("canvas").getBoundingClientRect();
+
+    println(`flex width: ${Math.round(flexRect.width)}`);
+    println(`canvas width: ${Math.round(canvasRect.width)}`);
+});
+</script>

--- a/Tests/LibWeb/Text/input/grid/flex-item-replaced-child-cyclic-percentage-max-width.html
+++ b/Tests/LibWeb/Text/input/grid/flex-item-replaced-child-cyclic-percentage-max-width.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+.grid {
+    display: grid;
+    gap: 25px;
+    grid-template-columns: repeat(4, 1fr);
+    width: 652px;
+}
+
+.grid > a {
+    display: flex;
+    justify-content: center;
+}
+
+.grid img {
+    display: block;
+    height: 56px;
+    max-width: 100%;
+    width: 165px;
+}
+</style>
+<div class="grid">
+    <a><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='165' height='56'%3E%3C/svg%3E"></a>
+    <a><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='165' height='56'%3E%3C/svg%3E"></a>
+    <a><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='165' height='56'%3E%3C/svg%3E"></a>
+    <a><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='165' height='56'%3E%3C/svg%3E"></a>
+</div>
+<script>
+test(() => {
+    let grid = document.querySelector(".grid");
+    let last_item = grid.lastElementChild;
+    println(`grid-template-columns: ${getComputedStyle(grid).gridTemplateColumns}`);
+    println(`last item right: ${last_item.getBoundingClientRect().right}`);
+});
+</script>


### PR DESCRIPTION
Resolve replaced flex item max main sizes through the intrinsic contribution rules when calculating min-content contributions. This keeps cyclic percentage max sizes from inflating a flex container's min-content size, which in turn lets CSS Grid flexible tracks shrink to their available space.

Add coverage for a grid of flex items containing replaced children with width and max-width: 100%.

This fixes excess horizontal overflow on https://slint.dev/