### PR TITLE
UI/Qt: Improve omnibox contrast across color schemes

### DIFF
--- a/UI/Qt/Autocomplete.cpp
+++ b/UI/Qt/Autocomplete.cpp
@@ -89,9 +89,23 @@ static QFont autocomplete_section_header_font()
     return font;
 }
 
+static bool autocomplete_color_is_dark(QColor const& color)
+{
+    return color.lightness() < 128;
+}
+
 static QColor autocomplete_selection_fill(QPalette const& palette)
 {
-    return ChromeStyle::chrome_surface_pressed(palette);
+    auto text = ChromeStyle::chrome_text(palette);
+    if (!autocomplete_color_is_dark(text))
+        return ChromeStyle::mix(ChromeStyle::chrome_surface_pressed(palette), text, 0.06);
+
+    auto surface = palette.color(QPalette::Base);
+    if (autocomplete_color_is_dark(surface))
+        surface = palette.color(QPalette::Window);
+    if (autocomplete_color_is_dark(surface))
+        surface = QColor(255, 255, 255);
+    return ChromeStyle::mix(surface, QColor(0, 0, 0), 0.08);
 }
 
 static QColor autocomplete_selection_border(QPalette const& palette)
@@ -440,7 +454,7 @@ void Autocomplete::update_chrome_style()
         return;
 
     m_is_updating_chrome_style = true;
-    auto palette = m_anchor->palette();
+    auto palette = QApplication::palette();
     m_popup->setPalette(palette);
     m_list_view->setPalette(palette);
     m_popup->setStyleSheet(ChromeStyle::autocomplete_popup_style_sheet(palette));

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -529,7 +529,7 @@ QString location_edit_style_sheet(QPalette const& palette)
     auto hover_border = style_sheet_color(hover_border_color);
     auto focus_border = style_sheet_color(focus_border_color);
     auto text = style_sheet_color(dark ? mix(chrome_text(palette), QColor(255, 255, 255), 0.08) : chrome_text(palette));
-    auto placeholder = style_sheet_color(mix(chrome_muted_text(palette), surface_color, dark ? 0.46 : 0.34));
+    auto placeholder = style_sheet_color(mix(chrome_muted_text(palette), surface_color, dark ? 0.20 : 0.34));
     auto selection = style_sheet_color(chrome_accent(palette));
     auto selection_text = style_sheet_color(palette.color(QPalette::HighlightedText));
     auto not_secure_text = style_sheet_color(dark ? QColor(224, 142, 136) : QColor(144, 62, 56));


### PR DESCRIPTION
The autocomplete popup now derives its selected-row fill from the popup
text color, which keeps light-mode selections readable on minimal Unix
desktops with inconsistent palette data. Dark-mode selections keep the
normal chrome pressed surface, with a small contrast boost.

The location edit placeholder is also blended less aggressively into the
field surface in dark mode, so the omnibox placeholder remains readable.
