### PR TITLE
LibWeb: Implement navigator.storage.estimate()

### DIFF
--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -529,6 +529,7 @@ public:
     virtual WebView::StorageSetResult page_did_set_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key, [[maybe_unused]] String const& value) { return WebView::StorageOperationError::QuotaExceededError; }
     virtual void page_did_remove_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key) { }
     virtual Vector<String> page_did_request_storage_keys([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { return {}; }
+    virtual u64 page_did_request_storage_usage([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { return 0; }
     virtual void page_did_clear_storage([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { }
     virtual void page_did_broadcast_storage_change([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& url, [[maybe_unused]] Optional<String> const& key, [[maybe_unused]] Optional<String> const& old_value, [[maybe_unused]] Optional<String> const& new_value) { }
     virtual void page_did_update_indexed_database([[maybe_unused]] String const& url, [[maybe_unused]] IndexedDB::TransactionChanges const&) { }

--- a/Libraries/LibWeb/StorageAPI/StorageManager.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageManager.cpp
@@ -4,10 +4,19 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Utf16String.h>
+#include <LibJS/Runtime/Error.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/StorageManager.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Page/Page.h>
+#include <LibWeb/StorageAPI/StorageBottle.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
+#include <LibWeb/StorageAPI/StorageKey.h>
 #include <LibWeb/StorageAPI/StorageManager.h>
+#include <LibWeb/StorageAPI/StorageType.h>
+#include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::StorageAPI {
 
@@ -27,6 +36,73 @@ void StorageManager::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(StorageManager);
     Base::initialize(realm);
+}
+
+// https://storage.spec.whatwg.org/#dom-storagemanager-estimate
+GC::Ref<WebIDL::Promise> StorageManager::estimate()
+{
+    auto& realm = this->realm();
+
+    // 1. Let promise be a new promise.
+    auto promise = WebIDL::create_promise(realm);
+
+    // 2. Let global be this's relevant global object.
+    auto& global = HTML::relevant_global_object(*this);
+
+    // 3. Let shelf be the result of running obtain a local storage shelf with this's relevant settings object.
+    // AD-HOC: We don't keep a single in-process local storage shelf. localStorage lives in StorageJar, and
+    //         sessionStorage lives on the traversable navigable — so rather than a shelf, we obtain the origin's
+    //         storage key here, and read usage from those stores below. Obtaining a storage key fails for an opaque
+    //         origin — which stands in for the spec's failure case.
+    auto& environment = HTML::relevant_settings_object(*this);
+    auto storage_key = obtain_a_storage_key(environment);
+
+    // 4. If shelf is failure, then reject promise with a TypeError.
+    if (!storage_key.has_value()) {
+        WebIDL::reject_promise(realm, promise, JS::TypeError::create(realm, "Unable to obtain a storage shelf for this origin"_utf16));
+        return promise;
+    }
+
+    // 5. Otherwise, run these steps in parallel:
+    // AD-HOC: Our implementation of storage access is synchronous (localStorage usage is read over a sync IPC, and
+    //         sessionStorage is in-process). So, rather than running in parallel and queuing a storage task to settle
+    //         the promise, we compute the values, and settle the promise synchronously below.
+
+    //    1. Let usage be storage usage for shelf.
+    //       NB: The spec's "storage usage" is an implementation-defined rough estimate of the bytes used. We report the
+    //       summed byte size of the origin's localStorage and sessionStorage entries.
+    u64 usage = 0;
+    if (auto* window = as_if<HTML::Window>(global)) {
+        usage += window->page().client().page_did_request_storage_usage(StorageEndpointType::LocalStorage, storage_key->to_string());
+
+        if (auto session_bottle = obtain_a_storage_bottle_map(StorageType::Session, environment, StorageEndpointType::SessionStorage)) {
+            for (auto const& bottle_key : session_bottle->keys()) {
+                usage += bottle_key.bytes().size();
+                if (auto value = session_bottle->get(bottle_key); value.has_value())
+                    usage += value->bytes().size();
+            }
+        }
+    }
+
+    //    2. Let quota be storage quota for shelf.
+    //       NB: The spec's "storage quota" is an implementation-defined conservative estimate of the total bytes it can
+    //            hold. We report the sum of the per-origin budgets we enforce for the tracked endpoints.
+    auto quota = StorageEndpoint::LOCAL_STORAGE_QUOTA + StorageEndpoint::SESSION_STORAGE_QUOTA;
+
+    //    3. Let dictionary be a new StorageEstimate dictionary whose usage member is usage and quota member is quota.
+    auto dictionary = JS::Object::create(realm, realm.intrinsics().object_prototype());
+    MUST(dictionary->create_data_property("usage"_utf16_fly_string, JS::Value(static_cast<double>(usage))));
+    MUST(dictionary->create_data_property("quota"_utf16_fly_string, JS::Value(static_cast<double>(quota))));
+
+    //    4. If there was an internal error while obtaining usage and quota, then queue a storage task with global to
+    //       reject promise with a TypeError.
+    //    AD-HOC: There's no recoverable internal-error path here; a disconnected storage IPC terminates the process.
+
+    //    5. Otherwise, queue a storage task with global to resolve promise with dictionary.
+    WebIDL::resolve_promise(realm, promise, dictionary);
+
+    // 6. Return promise.
+    return promise;
 }
 
 }

--- a/Libraries/LibWeb/StorageAPI/StorageManager.h
+++ b/Libraries/LibWeb/StorageAPI/StorageManager.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::StorageAPI {
 
@@ -17,6 +18,8 @@ class StorageManager final : public Bindings::PlatformObject {
 public:
     static WebIDL::ExceptionOr<GC::Ref<StorageManager>> create(JS::Realm&);
     virtual ~StorageManager() override = default;
+
+    GC::Ref<WebIDL::Promise> estimate();
 
 private:
     StorageManager(JS::Realm&);

--- a/Libraries/LibWeb/StorageAPI/StorageManager.idl
+++ b/Libraries/LibWeb/StorageAPI/StorageManager.idl
@@ -4,7 +4,7 @@ interface StorageManager {
     [FIXME] Promise<boolean> persisted();
     [FIXME, Exposed=Window] Promise<boolean> persist();
 
-    [FIXME] Promise<StorageEstimate> estimate();
+    Promise<StorageEstimate> estimate();
 };
 
 // https://storage.spec.whatwg.org/#dictdef-storageestimate

--- a/Libraries/LibWebView/StorageJar.cpp
+++ b/Libraries/LibWebView/StorageJar.cpp
@@ -47,6 +47,7 @@ ErrorOr<NonnullOwnPtr<StorageJar>> StorageJar::create(Database::Database& databa
     statements.clear = TRY(database.prepare_statement("DELETE FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ?;"sv));
     statements.get_keys = TRY(database.prepare_statement("SELECT bottle_key FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ?;"sv));
     statements.calculate_size_excluding_key = TRY(database.prepare_statement("SELECT SUM(OCTET_LENGTH(bottle_key) + OCTET_LENGTH(bottle_value)) FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ? AND bottle_key != ?;"sv));
+    statements.calculate_size = TRY(database.prepare_statement("SELECT COALESCE(SUM(OCTET_LENGTH(bottle_key) + OCTET_LENGTH(bottle_value)), 0) FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ?;"sv));
     statements.estimate_storage_size_accessed_since = TRY(database.prepare_statement("SELECT SUM(OCTET_LENGTH(storage_key)) + SUM(OCTET_LENGTH(bottle_key)) + SUM(OCTET_LENGTH(bottle_value)) FROM WebStorage WHERE last_access_time >= ?;"sv));
 
     return adopt_own(*new StorageJar { PersistedStorage { database, statements } });
@@ -113,6 +114,13 @@ Vector<String> StorageJar::get_all_keys(StorageEndpointType storage_endpoint, St
     if (m_persisted_storage.has_value())
         return m_persisted_storage->get_keys(storage_endpoint, storage_key);
     return m_transient_storage.get_keys(storage_endpoint, storage_key);
+}
+
+u64 StorageJar::calculate_size(StorageEndpointType storage_endpoint, String const& storage_key) const
+{
+    if (m_persisted_storage.has_value())
+        return m_persisted_storage->calculate_size(storage_endpoint, storage_key);
+    return m_transient_storage.calculate_size(storage_endpoint, storage_key);
 }
 
 Requests::CacheSizes StorageJar::estimate_storage_size_accessed_since(UnixDateTime since) const
@@ -187,6 +195,16 @@ Vector<String> StorageJar::TransientStorage::get_keys(StorageEndpointType storag
     }
 
     return keys;
+}
+
+u64 StorageJar::TransientStorage::calculate_size(StorageEndpointType storage_endpoint, String const& storage_key) const
+{
+    u64 size = 0;
+    for (auto const& [key, entry] : m_storage_items) {
+        if (key.storage_endpoint == storage_endpoint && key.storage_key == storage_key)
+            size += key.bottle_key.bytes().size() + entry.value.bytes().size();
+    }
+    return size;
 }
 
 Requests::CacheSizes StorageJar::TransientStorage::estimate_storage_size_accessed_since(UnixDateTime since) const
@@ -297,6 +315,17 @@ Vector<String> StorageJar::PersistedStorage::get_keys(StorageEndpointType storag
         storage_key);
 
     return keys;
+}
+
+u64 StorageJar::PersistedStorage::calculate_size(StorageEndpointType storage_endpoint, String const& storage_key) const
+{
+    u64 size = 0;
+    database.execute_statement(
+        statements.calculate_size,
+        [&](auto statement_id) { size = database.result_column<u64>(statement_id, 0); },
+        to_underlying(storage_endpoint),
+        storage_key);
+    return size;
 }
 
 Requests::CacheSizes StorageJar::PersistedStorage::estimate_storage_size_accessed_since(UnixDateTime since) const

--- a/Libraries/LibWebView/StorageJar.h
+++ b/Libraries/LibWebView/StorageJar.h
@@ -46,6 +46,7 @@ public:
     void remove_items_accessed_since(UnixDateTime);
     void clear_storage_key(StorageEndpointType storage_endpoint, String const& storage_key);
     Vector<String> get_all_keys(StorageEndpointType storage_endpoint, String const& storage_key);
+    u64 calculate_size(StorageEndpointType storage_endpoint, String const& storage_key) const;
     Requests::CacheSizes estimate_storage_size_accessed_since(UnixDateTime since) const;
 
 private:
@@ -58,6 +59,7 @@ private:
         Database::StatementID clear { 0 };
         Database::StatementID get_keys { 0 };
         Database::StatementID calculate_size_excluding_key { 0 };
+        Database::StatementID calculate_size { 0 };
         Database::StatementID estimate_storage_size_accessed_since { 0 };
     };
 
@@ -70,6 +72,7 @@ private:
         void clear(StorageEndpointType storage_endpoint, String const& storage_key);
         Vector<String> get_keys(StorageEndpointType storage_endpoint, String const& storage_key);
         Requests::CacheSizes estimate_storage_size_accessed_since(UnixDateTime since) const;
+        u64 calculate_size(StorageEndpointType storage_endpoint, String const& storage_key) const;
 
     private:
         struct Entry {
@@ -88,6 +91,7 @@ private:
         void clear(StorageEndpointType storage_endpoint, String const& storage_key);
         Vector<String> get_keys(StorageEndpointType storage_endpoint, String const& storage_key);
         Requests::CacheSizes estimate_storage_size_accessed_since(UnixDateTime since) const;
+        u64 calculate_size(StorageEndpointType storage_endpoint, String const& storage_key) const;
 
         Database::Database& database;
         Statements statements;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1192,6 +1192,11 @@ Messages::WebContentClient::DidRequestStorageKeysResponse WebContentClient::did_
     return Application::storage_jar().get_all_keys(storage_endpoint, storage_key);
 }
 
+Messages::WebContentClient::DidRequestStorageUsageResponse WebContentClient::did_request_storage_usage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key)
+{
+    return Application::storage_jar().calculate_size(storage_endpoint, storage_key);
+}
+
 void WebContentClient::did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key)
 {
     Application::storage_jar().clear_storage_key(storage_endpoint, storage_key);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -190,6 +190,7 @@ private:
     virtual Messages::WebContentClient::DidSetStorageItemResponse did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key, String value) override;
     virtual void did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) override;
     virtual Messages::WebContentClient::DidRequestStorageKeysResponse did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
+    virtual Messages::WebContentClient::DidRequestStorageUsageResponse did_request_storage_usage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
     virtual void did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
     virtual void did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<String> key, Optional<String> old_value, Optional<String> new_value) override;
     virtual void did_update_indexed_database(u64 page_id, String update) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -834,6 +834,16 @@ Vector<String> PageClient::page_did_request_storage_keys(Web::StorageAPI::Storag
     return response->take_keys();
 }
 
+u64 PageClient::page_did_request_storage_usage(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestStorageUsage>(storage_endpoint, storage_key);
+    if (!response) {
+        dbgln("WebContent client disconnected during DidRequestStorageUsage. Exiting peacefully.");
+        Core::Process::terminate_immediately(0);
+    }
+    return response->usage();
+}
+
 void PageClient::page_did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key)
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidClearStorage>(storage_endpoint, storage_key);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -214,6 +214,7 @@ private:
     virtual WebView::StorageSetResult page_did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key, String const& value) override;
     virtual void page_did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key) override;
     virtual Vector<String> page_did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
+    virtual u64 page_did_request_storage_usage(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
     virtual void page_did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
     virtual void page_did_broadcast_storage_change(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& url, Optional<String> const& key, Optional<String> const& old_value, Optional<String> const& new_value) override;
     virtual void page_did_update_indexed_database(String const& url, Web::IndexedDB::TransactionChanges const&) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -123,6 +123,7 @@ endpoint WebContentClient
     did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key, String value) => (WebView::StorageSetResult result)
     did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) => ()
     did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => (Vector<String> keys)
+    did_request_storage_usage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => (u64 usage)
     did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => ()
     did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<String> key, Optional<String> old_value, Optional<String> new_value) =|
     did_update_indexed_database(u64 page_id, String update) =|

--- a/Tests/LibWeb/Text/expected/navigator-storage-estimate.txt
+++ b/Tests/LibWeb/Text/expected/navigator-storage-estimate.txt
@@ -1,0 +1,4 @@
+usage is a number: true
+quota is a number: true
+usage does not exceed quota: true
+usage reflects written localStorage: true

--- a/Tests/LibWeb/Text/input/navigator-storage-estimate.html
+++ b/Tests/LibWeb/Text/input/navigator-storage-estimate.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="./include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        let estimate = await navigator.storage.estimate();
+        println(`usage is a number: ${typeof estimate.usage === "number"}`);
+        println(`quota is a number: ${typeof estimate.quota === "number"}`);
+        println(`usage does not exceed quota: ${estimate.usage <= estimate.quota}`);
+
+        // Use a unique key and assert the origin's usage includes at least our own entry (not a
+        // before/after delta): concurrent test runs share this origin's storage, so a delta is racy.
+        let key = `estimate-usage-${crypto.randomUUID()}`;
+        localStorage.setItem(key, "x".repeat(1000));
+        let usage = (await navigator.storage.estimate()).usage;
+        localStorage.removeItem(key);
+        println(`usage reflects written localStorage: ${usage >= 1000}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Implement `navigator.storage.estimate()` to return the real summed byte size of the origin’s tracked `localStorage` plus `sessionStorage`. The quota is the sum of the per-origin budgets we enforce for those. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10319.
