### PR TITLE
LibWeb: Scale SVG filter primitive lengths to device pixels

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -38,6 +38,7 @@
 #include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ResizeHandle.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/Painting/SVGPaintable.h>
 #include <LibWeb/Painting/SVGSVGPaintable.h>
 #include <LibWeb/Painting/Scrollbar.h>
@@ -430,7 +431,16 @@ ResolvedCSSFilter resolve_css_filter(CSS::Filter const& computed_filter, Paintab
                 if (!maybe_filter)
                     return;
                 if (auto* filter_element = as_if<SVG::SVGFilterElement>(*maybe_filter)) {
-                    result.svg_filter = filter_element->gfx_filter(layout_node);
+                    // Filter primitive lengths are specified in the filtered element's user coordinate system, but the
+                    // resulting filter operates in device pixels. Compute the user-unit-to-device-pixel scale so the
+                    // filter can convert its lengths accordingly.
+                    auto device_pixels_per_css_pixel = paintable_box.document().page().client().device_pixels_per_css_pixel();
+                    auto filter_scale = Gfx::FloatPoint { device_pixels_per_css_pixel, device_pixels_per_css_pixel };
+                    if (auto const* svg_graphics_paintable = as_if<SVGGraphicsPaintable>(paintable_box)) {
+                        auto svg_to_css_pixels = svg_graphics_paintable->computed_transforms().svg_to_css_pixels_transform();
+                        filter_scale.scale_by(svg_to_css_pixels.x_scale(), svg_to_css_pixels.y_scale());
+                    }
+                    result.svg_filter = filter_element->gfx_filter(layout_node, filter_scale);
                     auto bounds = paintable_box.absolute_border_box_rect();
                     if (bounds.is_empty()) {
                         if (auto svg_ancestor = paintable_box.first_ancestor_of_type<SVGSVGPaintable>())

--- a/Libraries/LibWeb/SVG/SVGFilterElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGFilterElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
 #include <AK/StringConversions.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/Bindings/SVGFilterElement.h>
@@ -69,8 +70,11 @@ void SVGFilterElement::attribute_changed(FlyString const& name, Optional<String>
 }
 
 // https://drafts.fxtf.org/filter-effects-1/#ColorInterpolationFiltersProperty
-Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& referenced_node)
+Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& referenced_node, Gfx::FloatPoint filter_scale)
 {
+    auto scale_x = filter_scale.x();
+    auto scale_y = filter_scale.y();
+
     struct FilterResult {
         Optional<Gfx::Filter> filter;
         Gfx::InterpolationColorSpace color_space { Gfx::InterpolationColorSpace::SRGB };
@@ -203,8 +207,8 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& 
         } else if (auto* blur_primitive = as_if<SVGFEGaussianBlurElement>(node)) {
             auto input = resolve_input_in_color_space(blur_primitive->in1()->base_val(), operating_space);
 
-            auto radius_x = blur_primitive->std_deviation_x()->base_val();
-            auto radius_y = blur_primitive->std_deviation_y()->base_val();
+            auto radius_x = blur_primitive->std_deviation_x()->base_val() * scale_x;
+            auto radius_y = blur_primitive->std_deviation_y()->base_val() * scale_y;
 
             root = { Gfx::Filter::blur(radius_x, radius_y, input), operating_space };
             update_result_map(*blur_primitive);
@@ -327,8 +331,8 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& 
         } else if (auto* morphology_primitive = as_if<SVGFEMorphologyElement>(node)) {
             auto input = resolve_input_in_color_space(morphology_primitive->in1()->base_val(), operating_space);
 
-            auto radius_x = morphology_primitive->radius_x()->base_val();
-            auto radius_y = morphology_primitive->radius_y()->base_val();
+            auto radius_x = morphology_primitive->radius_x()->base_val() * scale_x;
+            auto radius_y = morphology_primitive->radius_y()->base_val() * scale_y;
             auto morphology_operator = morphology_primitive->morphology_operator();
             switch (morphology_operator) {
             case Gfx::MorphologyOperator::Erode:
@@ -345,8 +349,8 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& 
         } else if (auto* offset_primitive = as_if<SVGFEOffsetElement>(node)) {
             auto input = resolve_input(offset_primitive->in1()->base_val());
 
-            auto dx = offset_primitive->dx()->base_val();
-            auto dy = offset_primitive->dy()->base_val();
+            auto dx = offset_primitive->dx()->base_val() * scale_x;
+            auto dy = offset_primitive->dy()->base_val() * scale_y;
 
             root = { Gfx::Filter::offset(dx, dy, input.filter), input.color_space };
             update_result_map(*offset_primitive);
@@ -364,16 +368,16 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& 
                 0, 0, 0, 1, 0
             };
             auto alpha_input = Gfx::Filter::color_matrix(alpha_matrix, input);
-            auto std_x = drop_shadow->std_deviation_x()->base_val();
-            auto std_y = drop_shadow->std_deviation_y()->base_val();
+            auto std_x = drop_shadow->std_deviation_x()->base_val() * scale_x;
+            auto std_y = drop_shadow->std_deviation_y()->base_val() * scale_y;
             auto blurred = Gfx::Filter::blur(std_x, std_y, alpha_input);
 
             // 2. Offset the result of step 1 by dx and dy as specified on the feDropShadow element, equivalent to
             //    applying an feOffset with these parameters:
             //
             // <feOffset dx="dx-of-feDropShadow" dy="dy-of-feDropShadow" result="offsetblur"/>
-            auto dx = drop_shadow->dx()->base_val();
-            auto dy = drop_shadow->dy()->base_val();
+            auto dx = drop_shadow->dx()->base_val() * scale_x;
+            auto dy = drop_shadow->dy()->base_val() * scale_y;
             auto offset_blur = Gfx::Filter::offset(dx, dy, blurred);
 
             // 3. Do processing as if an feFlood element with flood-color and flood-opacity as specified on the
@@ -398,8 +402,8 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& 
             root = { Gfx::Filter::merge({ colored_shadow, input }), operating_space };
             update_result_map(*drop_shadow);
         } else if (auto* turbulence = as_if<SVGFETurbulenceElement>(node)) {
-            auto base_frequency_x = turbulence->base_frequency_x()->base_val();
-            auto base_frequency_y = turbulence->base_frequency_y()->base_val();
+            auto base_frequency_x = turbulence->base_frequency_x()->base_val() / scale_x;
+            auto base_frequency_y = turbulence->base_frequency_y()->base_val() / scale_y;
             auto num_octaves = turbulence->num_octaves()->base_val();
             auto seed = turbulence->seed()->base_val();
 
@@ -415,12 +419,12 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& 
                 }
             }();
 
-            auto tile_stitch_size = [turbulence] {
+            auto tile_stitch_size = [turbulence, scale_x, scale_y] {
                 auto stitch_tiles = turbulence->stitch_tiles()->base_val();
                 switch (stitch_tiles) {
                 case to_underlying(SVGFETurbulenceElement::StitchType::Stitch):
                     // FIXME: Are these the correct width and height?
-                    return Gfx::IntSize { turbulence->width()->base_val()->value(), turbulence->height()->base_val()->value() };
+                    return Gfx::IntSize { round_to<int>(turbulence->width()->base_val()->value() * scale_x), round_to<int>(turbulence->height()->base_val()->value() * scale_y) };
                 case to_underlying(SVGFETurbulenceElement::StitchType::NoStitch):
                     return Gfx::IntSize {};
                 default:
@@ -433,7 +437,9 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& 
         } else if (auto* displacement_map = as_if<SVGFEDisplacementMapElement>(node)) {
             auto color = resolve_input(displacement_map->in1()->base_val());
             auto displacement = resolve_input_in_color_space(displacement_map->in2()->base_val(), operating_space);
-            auto scale = displacement_map->scale()->base_val();
+            // FIXME: Skia's displacement map takes a single scale factor, so we ignore the vertical scale here,
+            //        applying the horizontal scale only.
+            auto scale = displacement_map->scale()->base_val() * scale_x;
 
             auto convert_channel_selector = [](u16 channel_selector) {
                 switch (channel_selector) {

--- a/Libraries/LibWeb/SVG/SVGFilterElement.h
+++ b/Libraries/LibWeb/SVG/SVGFilterElement.h
@@ -27,7 +27,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
-    Optional<Gfx::Filter> gfx_filter(Layout::NodeWithStyle const& referenced_node);
+    Optional<Gfx::Filter> gfx_filter(Layout::NodeWithStyle const& referenced_node, Gfx::FloatPoint filter_scale);
 
     GC::Ref<SVGAnimatedEnumeration> filter_units() const;
     GC::Ref<SVGAnimatedEnumeration> primitive_units() const;

--- a/Tests/LibWeb/Ref/expected/svg/filter-primitive-scale-with-viewbox-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/filter-primitive-scale-with-viewbox-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+    <filter id="offset" x="-50%" y="-50%" width="200%" height="200%">
+        <feOffset dx="20" dy="20" />
+    </filter>
+    <rect x="10" y="10" width="40" height="40" fill="blue" filter="url(#offset)" />
+</svg>
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+    <filter id="blur" x="-50%" y="-50%" width="200%" height="200%">
+        <feGaussianBlur stdDeviation="4" />
+    </filter>
+    <rect x="20" y="20" width="60" height="60" fill="green" filter="url(#blur)" />
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/filter-primitive-scale-with-viewbox.html
+++ b/Tests/LibWeb/Ref/input/svg/filter-primitive-scale-with-viewbox.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/filter-primitive-scale-with-viewbox-ref.html" />
+<svg width="100" height="100" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+    <filter id="offset" x="-50%" y="-50%" width="200%" height="200%">
+        <feOffset dx="10" dy="10" />
+    </filter>
+    <rect x="5" y="5" width="20" height="20" fill="blue" filter="url(#offset)" />
+</svg>
+<svg width="100" height="100" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+    <filter id="blur" x="-50%" y="-50%" width="200%" height="200%">
+        <feGaussianBlur stdDeviation="2" />
+    </filter>
+    <rect x="10" y="10" width="30" height="30" fill="green" filter="url(#blur)" />
+</svg>


### PR DESCRIPTION
Length-valued filter primitive parameters such as feGaussianBlur's `stdDeviation`, feOffset's `dx` and `dy`, feMorphology's `radius` and feDropShadow's offsets are specified in the filtered element's user coordinate system, but the resulting `Gfx::Filter` operates in device pixels. They were previously used verbatim, so filters rendered at the wrong size whenever user space was scaled relative to device pixels, for example through a viewBox, page zoom or a high device pixel ratio.

This makes the dark-mode background effect on https://statusdude.com/blog render correctly:

Before:

<img width="487" height="159" alt="image" src="https://github.com/user-attachments/assets/f1b36c47-528d-4970-91e1-bb08620ca188" />


After:
<img width="487" height="159" alt="image" src="https://github.com/user-attachments/assets/edd10525-3f82-448d-bf1c-6427f0c4e7e7" />

(I'm not sure how clear the image is - the background now has noise that is generated by an `<feDisplacementMap>` filter primitive.)