### PR TITLE
LibWeb: Account for transforms in scrollable overflow

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/LayoutState.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Painting/SVGForeignObjectPaintable.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
@@ -198,6 +199,21 @@ static PhysicalOverflowDirections physical_overflow_directions(Box const& box)
     };
 }
 
+static CSSPixelRect apply_css_transform_to_overflow_rect(Box const& box, CSSPixelRect const& rect)
+{
+    auto const& paintable_box = *box.paintable_box();
+    auto transform_data = Painting::compute_transform(paintable_box, box.computed_values(), 1.0);
+    if (!transform_data.has_value())
+        return rect;
+
+    auto affine = Gfx::extract_2d_affine_transform(transform_data->matrix);
+    auto transformed_rect = rect.to_type<float>();
+    transformed_rect.translate_by(-transform_data->origin);
+    transformed_rect = affine.map(transformed_rect);
+    transformed_rect.translate_by(transform_data->origin);
+    return transformed_rect.to_type<CSSPixels>();
+}
+
 static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const& contained_boxes_map)
 {
     if (!box.paintable_box())
@@ -256,7 +272,8 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
 
     // - The border boxes of all boxes for which it is the containing block and whose border boxes are positioned not
     //   wholly in the negative scrollable overflow region,
-    //   FIXME: accounting for transforms by projecting each box onto the plane of the element that establishes its 3D rendering context. [CSS3-TRANSFORMS]
+    //   FIXME: accounting for 3D transforms by projecting each box onto the plane of the element that establishes
+    //          its 3D rendering context. [CSS3-TRANSFORMS]
     if (auto it = contained_boxes_map.find(&box); it != contained_boxes_map.end()) {
         for (auto const* child_ptr : it->value) {
             auto const& child = *child_ptr;
@@ -268,7 +285,7 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
             if (child.is_fixed_position())
                 continue;
 
-            auto child_border_box = child.paintable_box()->absolute_border_box_rect();
+            auto child_border_box = apply_css_transform_to_overflow_rect(child, child.paintable_box()->absolute_border_box_rect());
 
             // NOTE: Only boxes that are not wholly in the unreachable scrollable overflow region contribute.
             auto wholly_in_unreachable_x = overflow_directions.x_positive
@@ -296,7 +313,7 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
                 continue;
 
             if (child.computed_values().overflow_x() == CSS::Overflow::Visible || child.computed_values().overflow_y() == CSS::Overflow::Visible) {
-                auto child_scrollable_overflow = measure_scrollable_overflow(child, contained_boxes_map);
+                auto child_scrollable_overflow = apply_css_transform_to_overflow_rect(child, measure_scrollable_overflow(child, contained_boxes_map));
                 if (!child_scrollable_overflow.is_empty()) {
                     if (child.computed_values().overflow_x() == CSS::Overflow::Visible) {
                         scrollable_overflow_rect.unite_horizontally(child_scrollable_overflow);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -88,7 +88,7 @@ static TransformData visual_viewport_transform_data(DOM::Document& document)
 }
 
 // https://drafts.csswg.org/css-transforms-2/#ctm
-static Optional<TransformData> compute_transform(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, double pixel_ratio)
+Optional<TransformData> compute_transform(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, double pixel_ratio)
 {
     if (!paintable_box.has_css_transform())
         return {};

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -22,8 +22,15 @@
 #include <LibWeb/Painting/ScrollFrame.h>
 #include <LibWeb/PixelUnits.h>
 
+namespace Web::CSS {
+
+class ComputedValues;
+
+}
+
 namespace Web::Painting {
 
+class PaintableBox;
 class ScrollStateSnapshot;
 
 AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, VisualContextIndex);
@@ -83,6 +90,8 @@ struct ScrollCompensation {
 };
 
 using VisualContextData = Variant<ScrollData, ClipData, TransformData, PerspectiveData, ClipPathData, EffectsData, ScrollCompensation>;
+
+Optional<TransformData> compute_transform(PaintableBox const&, CSS::ComputedValues const&, double pixel_ratio);
 
 struct AccumulatedVisualContextNode {
     VisualContextData data;

--- a/Tests/LibWeb/Ref/input/transform-and-opacity.html
+++ b/Tests/LibWeb/Ref/input/transform-and-opacity.html
@@ -2,6 +2,7 @@
 <link rel="match" href="../expected/transform-and-opacity-ref.html" />
 <style>
 #outer {
+    width: 100px;
     opacity: 0.5;
     transform: translate(100px, 100px);
 }

--- a/Tests/LibWeb/Text/expected/scrollable-overflow-transformed-child.txt
+++ b/Tests/LibWeb/Text/expected/scrollable-overflow-transformed-child.txt
@@ -1,0 +1,2 @@
+document scroll width: 800
+positive transform scroll width: 150

--- a/Tests/LibWeb/Text/input/scrollable-overflow-transformed-child.html
+++ b/Tests/LibWeb/Text/input/scrollable-overflow-transformed-child.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+#centered-absolute {
+    position: relative;
+    width: 800px;
+    height: 20px;
+}
+
+#centered-absolute .overlay {
+    position: absolute;
+    width: 100vw;
+    max-width: 600px;
+    height: 10px;
+    margin-left: 50%;
+    transform: translateX(-50%);
+}
+
+#positive-transform {
+    width: 100px;
+    height: 10px;
+}
+
+#positive-transform .child {
+    width: 50px;
+    height: 10px;
+    transform: translateX(100px);
+}
+</style>
+<div id="centered-absolute"><div class="overlay"></div></div>
+<div id="positive-transform"><div class="child"></div></div>
+<script>
+test(() => {
+    println(`document scroll width: ${document.documentElement.scrollWidth}`);
+    println(`positive transform scroll width: ${document.getElementById("positive-transform").scrollWidth}`);
+});
+</script>


### PR DESCRIPTION
Project child border boxes and child scrollable overflow through their own CSS transform before adding them to the parent scrollable overflow. This prevents transformed, visually centered content from making the viewport horizontally scrollable while still allowing positive transformed overflow to expand the relevant scroll range.

Add text coverage for a Steam-style centered absolute background and a positively translated child contributing to its parent's scroll width. Also keep an existing transform-and-opacity ref test independent of root scrollable overflow.

Fixes #10283