### PR TITLE
UI/Qt: Keep location bar selection after the context menu closes

### DIFF
--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -446,6 +446,11 @@ void LocationEdit::changeEvent(QEvent* event)
 
 void LocationEdit::focusInEvent(QFocusEvent* event)
 {
+    if (event->reason() == Qt::PopupFocusReason) {
+        QLineEdit::focusInEvent(event);
+        return;
+    }
+
     auto should_defer_full_url = event->reason() == Qt::MouseFocusReason
         && m_url.has_value()
         && text() == display_url();
@@ -460,7 +465,7 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
     highlight_location();
     animate_focus_glow(58);
 
-    if (event->reason() != Qt::PopupFocusReason && !should_defer_full_url) {
+    if (!should_defer_full_url) {
         QTimer::singleShot(0, this, [this] {
             if (hasFocus())
                 selectAll();


### PR DESCRIPTION
Previously, trying to copy a non http/https URL from the location bar using the context menu would fail because the selection would be lost before any text was copied - this was because `focusInEvent` would call `setText()` to display the full URL. We now exit early if the `focusInEvent` was triggered by the context menu.

This is the same change as https://github.com/LadybirdBrowser/ladybird/pull/9826 but applied to `focusInEvent` rather than `focusOutEvent`.