### PR TITLE
Add download UI and start handling downloads

### DIFF
--- a/Base/res/ladybird/about-pages/downloads.html
+++ b/Base/res/ladybird/about-pages/downloads.html
@@ -1,0 +1,386 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>Downloads</title>
+        <link rel="icon" type="image/png" href="resource://icons/48x48/app-browser.png" />
+        <link rel="stylesheet" type="text/css" href="resource://ladybird/ladybird.css" />
+        <link rel="stylesheet" type="text/css" href="resource://ladybird/about-pages/webui.css" />
+        <style>
+            @media (prefers-color-scheme: light) {
+                :root {
+                    --download-progress-color: #5c8ecc;
+                    --download-progress-track-color: #dde4ec;
+                    --download-status-completed-color: #1f7a3f;
+                    --download-status-failed-color: #b33232;
+                }
+            }
+
+            @media (prefers-color-scheme: dark) {
+                :root {
+                    --download-progress-color: #77a1d1;
+                    --download-progress-track-color: #323841;
+                    --download-status-completed-color: #7bd493;
+                    --download-status-failed-color: #ff8585;
+                }
+            }
+
+            .downloads-content {
+                display: flex;
+                flex-direction: column;
+                gap: 16px;
+            }
+
+            .downloads-status,
+            .downloads-empty {
+                color: var(--secondary-text-color);
+                font-size: 13px;
+            }
+
+            .downloads-empty {
+                padding: 36px 12px;
+                text-align: center;
+                font-size: 14px;
+            }
+
+            .downloads-list {
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+            }
+
+            .download-entry {
+                display: grid;
+                grid-template-columns: minmax(0, 1fr) auto;
+                gap: 14px;
+
+                border-top: 1px solid var(--separator-color);
+                padding-top: 16px;
+            }
+
+            .download-entry:first-child {
+                border-top: none;
+                padding-top: 0;
+            }
+
+            .download-main {
+                min-width: 0;
+            }
+
+            .download-title {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+
+                font-size: 14px;
+                font-weight: 600;
+            }
+
+            .download-url,
+            .download-destination,
+            .download-detail {
+                color: var(--secondary-text-color);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+
+                font-size: 13px;
+                margin-top: 4px;
+            }
+
+            .download-state {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+
+                margin-top: 10px;
+            }
+
+            .download-state progress {
+                appearance: none;
+                width: 150px;
+                height: 8px;
+            }
+
+            .download-state progress::-webkit-progress-bar {
+                background-color: var(--download-progress-track-color);
+                border-radius: 999px;
+            }
+
+            .download-state progress::-webkit-progress-value {
+                background-color: var(--download-progress-color);
+                border-radius: 999px;
+            }
+
+            .download-status {
+                font-size: 13px;
+                font-weight: 600;
+                white-space: nowrap;
+            }
+
+            .download-status.completed {
+                color: var(--download-status-completed-color);
+            }
+
+            .download-status.failed {
+                color: var(--download-status-failed-color);
+            }
+
+            .download-status.canceled {
+                color: var(--secondary-text-color);
+            }
+
+            .download-actions {
+                display: flex;
+                align-items: flex-start;
+                gap: 8px;
+            }
+
+            .download-actions button {
+                white-space: nowrap;
+            }
+
+            @media (max-width: 640px) {
+                .download-entry {
+                    grid-template-columns: 1fr;
+                }
+
+                .download-actions {
+                    flex-wrap: wrap;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <picture>
+                <source srcset="resource://icons/128x128/app-browser.png" media="(prefers-color-scheme: dark)" />
+                <img src="resource://icons/128x128/app-browser-dark.png" />
+            </picture>
+            <h1>Downloads</h1>
+        </header>
+
+        <div class="card">
+            <div class="card-body downloads-content">
+                <div id="downloads-status" class="downloads-status">Loading downloads...</div>
+                <div id="downloads-empty" class="downloads-empty hidden"></div>
+                <div id="downloads-list" class="downloads-list"></div>
+            </div>
+        </div>
+
+        <script type="module">
+            const downloadsStatus = document.querySelector("#downloads-status");
+            const downloadsEmpty = document.querySelector("#downloads-empty");
+            const downloadsList = document.querySelector("#downloads-list");
+
+            const sizeFormatter = new Intl.NumberFormat([], {
+                maximumFractionDigits: 1,
+            });
+
+            let downloads = [];
+            const downloadRows = new Map();
+
+            function createElement(tagName, properties = {}, children = []) {
+                const element = document.createElement(tagName);
+                Object.assign(element, properties);
+                element.append(...children);
+                return element;
+            }
+
+            function pluralize(count, singular, plural = `${singular}s`) {
+                return `${count} ${count === 1 ? singular : plural}`;
+            }
+
+            function formatSize(size) {
+                if (size < 1024) return `${size} B`;
+
+                const units = ["KiB", "MiB", "GiB", "TiB"];
+                let value = size / 1024;
+                let unitIndex = 0;
+                while (value >= 1024 && unitIndex < units.length - 1) {
+                    value /= 1024;
+                    unitIndex++;
+                }
+
+                return `${sizeFormatter.format(value)} ${units[unitIndex]}`;
+            }
+
+            function statusLabel(download) {
+                if (download.status === "completed") return "Completed";
+                if (download.status === "canceled") return "Canceled";
+                if (download.status === "failed") return "Failed";
+                return "Downloading";
+            }
+
+            function detailLabel(download) {
+                if (download.status === "canceled") return "Partial file removed.";
+                if (download.status === "failed") return download.error || "The download failed.";
+                if (download.totalSize !== null && download.totalSize !== undefined)
+                    return `${formatSize(download.downloadedSize)} of ${formatSize(download.totalSize)}`;
+                return formatSize(download.downloadedSize);
+            }
+
+            function createActionButton(className, textContent, message, downloadId) {
+                return createElement("button", {
+                    className,
+                    textContent,
+                    onclick: () => ladybird.sendMessage(message, { id: downloadId }),
+                });
+            }
+
+            function updateActions(actions, download) {
+                if (actions.dataset.downloadId === `${download.id}` && actions.dataset.status === download.status)
+                    return;
+
+                actions.dataset.downloadId = download.id;
+                actions.dataset.status = download.status;
+
+                if (download.status === "in-progress") {
+                    actions.replaceChildren(
+                        createActionButton("secondary-button", "Cancel", "cancelDownload", download.id)
+                    );
+                    return;
+                }
+
+                if (download.status !== "completed") {
+                    actions.replaceChildren();
+                    return;
+                }
+
+                actions.replaceChildren(
+                    createActionButton("primary-button", "Open", "openDownload", download.id),
+                    createActionButton("secondary-button", "Show in folder", "showDownloadInFolder", download.id)
+                );
+            }
+
+            function createDownloadRow(download) {
+                const row = createElement("div", { className: "download-entry" }, [
+                    createElement("div", { className: "download-main" }, [
+                        createElement("div", {
+                            className: "download-title",
+                        }),
+                        createElement("div", {
+                            className: "download-url",
+                        }),
+                        createElement("div", {
+                            className: "download-destination",
+                        }),
+                        createElement("div", { className: "download-state" }, [
+                            createElement("progress"),
+                            createElement("span", {
+                                className: "download-status",
+                            }),
+                            createElement("span", {
+                                className: "download-detail",
+                            }),
+                        ]),
+                    ]),
+                    createElement("div", { className: "download-actions" }),
+                ]);
+
+                updateDownloadRow(row, download);
+                return row;
+            }
+
+            function updateDownloadRow(row, download) {
+                const title = row.querySelector(".download-title");
+                title.textContent = download.fileName;
+                title.title = download.fileName;
+
+                const url = row.querySelector(".download-url");
+                url.textContent = download.url;
+                url.title = download.url;
+
+                const destination = row.querySelector(".download-destination");
+                destination.textContent = download.destination;
+                destination.title = download.destination;
+
+                const progress = row.querySelector("progress");
+                const showProgress =
+                    download.status === "in-progress" &&
+                    download.totalSize !== null &&
+                    download.totalSize !== undefined &&
+                    download.totalSize !== 0;
+                progress.hidden = !showProgress;
+                if (showProgress) {
+                    progress.max = download.totalSize;
+                    progress.value = Math.min(download.downloadedSize, download.totalSize);
+                }
+
+                const status = row.querySelector(".download-status");
+                status.className = `download-status ${download.status}`;
+                status.textContent = statusLabel(download);
+
+                row.querySelector(".download-detail").textContent = detailLabel(download);
+                updateActions(row.querySelector(".download-actions"), download);
+            }
+
+            function updateDownloadList(sortedDownloads) {
+                const downloadIds = new Set(sortedDownloads.map(download => download.id));
+                for (const [id] of downloadRows) {
+                    if (!downloadIds.has(id)) downloadRows.delete(id);
+                }
+
+                const rows = sortedDownloads.map(download => {
+                    let row = downloadRows.get(download.id);
+                    if (!row) {
+                        row = createDownloadRow(download);
+                        downloadRows.set(download.id, row);
+                    } else {
+                        updateDownloadRow(row, download);
+                    }
+                    return row;
+                });
+
+                rows.forEach((row, index) => {
+                    if (downloadsList.children[index] !== row)
+                        downloadsList.insertBefore(row, downloadsList.children[index] || null);
+                });
+
+                while (downloadsList.children.length > rows.length) downloadsList.lastChild.remove();
+            }
+
+            function render() {
+                const sortedDownloads = [...downloads].sort((a, b) => b.id - a.id);
+                const activeCount = downloads.filter(download => download.status === "in-progress").length;
+
+                updateDownloadList(sortedDownloads);
+
+                const isEmpty = downloads.length === 0;
+                downloadsEmpty.classList.toggle("hidden", !isEmpty);
+                downloadsEmpty.textContent = "Files you download in this session will show up here.";
+
+                if (isEmpty) {
+                    downloadsStatus.textContent = "No downloads yet.";
+                } else if (activeCount > 0) {
+                    downloadsStatus.textContent = `${pluralize(activeCount, "active download")} - ${pluralize(downloads.length, "item")} total.`;
+                } else {
+                    downloadsStatus.textContent = `${pluralize(downloads.length, "download")} in this session.`;
+                }
+            }
+
+            function updateDownload(download) {
+                const index = downloads.findIndex(candidate => candidate.id === download.id);
+                if (index === -1) {
+                    downloads.push(download);
+                } else {
+                    downloads[index] = download;
+                }
+                render();
+            }
+
+            document.addEventListener("WebUILoaded", () => {
+                ladybird.sendMessage("loadDownloads");
+            });
+
+            document.addEventListener("WebUIMessage", event => {
+                const { name, data } = event.detail;
+                if (name === "loadDownloads") {
+                    downloads = data;
+                    render();
+                } else if (name === "downloadAdded" || name === "downloadUpdated") {
+                    updateDownload(data);
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/Base/res/ladybird/about-pages/downloads.html
+++ b/Base/res/ladybird/about-pages/downloads.html
@@ -36,6 +36,13 @@
                 font-size: 13px;
             }
 
+            .downloads-header {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 12px;
+            }
+
             .downloads-empty {
                 padding: 36px 12px;
                 text-align: center;
@@ -140,6 +147,11 @@
             }
 
             @media (max-width: 640px) {
+                .downloads-header {
+                    align-items: flex-start;
+                    flex-direction: column;
+                }
+
                 .download-entry {
                     grid-template-columns: 1fr;
                 }
@@ -161,7 +173,12 @@
 
         <div class="card">
             <div class="card-body downloads-content">
-                <div id="downloads-status" class="downloads-status">Loading downloads...</div>
+                <div class="downloads-header">
+                    <div id="downloads-status" class="downloads-status">Loading downloads...</div>
+                    <button id="prune-inactive-downloads" class="secondary-button" disabled>
+                        Clear finished downloads
+                    </button>
+                </div>
                 <div id="downloads-empty" class="downloads-empty hidden"></div>
                 <div id="downloads-list" class="downloads-list"></div>
             </div>
@@ -171,6 +188,7 @@
             const downloadsStatus = document.querySelector("#downloads-status");
             const downloadsEmpty = document.querySelector("#downloads-empty");
             const downloadsList = document.querySelector("#downloads-list");
+            const pruneInactiveDownloadsButton = document.querySelector("#prune-inactive-downloads");
 
             const sizeFormatter = new Intl.NumberFormat([], {
                 maximumFractionDigits: 1,
@@ -342,8 +360,10 @@
             function render() {
                 const sortedDownloads = [...downloads].sort((a, b) => b.id - a.id);
                 const activeCount = downloads.filter(download => download.status === "in-progress").length;
+                const inactiveCount = downloads.length - activeCount;
 
                 updateDownloadList(sortedDownloads);
+                pruneInactiveDownloadsButton.disabled = inactiveCount === 0;
 
                 const isEmpty = downloads.length === 0;
                 downloadsEmpty.classList.toggle("hidden", !isEmpty);
@@ -368,6 +388,16 @@
                 render();
             }
 
+            function removeDownload(downloadId) {
+                downloads = downloads.filter(download => download.id !== downloadId);
+                downloadRows.delete(downloadId);
+                render();
+            }
+
+            pruneInactiveDownloadsButton.addEventListener("click", () => {
+                ladybird.sendMessage("pruneInactiveDownloads");
+            });
+
             document.addEventListener("WebUILoaded", () => {
                 ladybird.sendMessage("loadDownloads");
             });
@@ -379,6 +409,8 @@
                     render();
                 } else if (name === "downloadAdded" || name === "downloadUpdated") {
                     updateDownload(data);
+                } else if (name === "downloadRemoved") {
+                    removeDownload(data);
                 }
             });
         </script>

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -151,6 +151,15 @@ ErrorOr<void> unlink(StringView path)
     return {};
 }
 
+ErrorOr<void> link(StringView old_path, StringView new_path)
+{
+    ByteString old_path_string = old_path;
+    ByteString new_path_string = new_path;
+    if (!CreateHardLinkA(new_path_string.characters(), old_path_string.characters(), nullptr))
+        return Error::from_windows_error();
+    return {};
+}
+
 ErrorOr<void> mkdir(StringView path, mode_t)
 {
     ByteString str = path;

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -114,6 +114,11 @@ void Request::release_for_transfer()
         client->release_request_for_transfer({}, *this);
 }
 
+bool Request::has_file_backed_response_body() const
+{
+    return m_internal_stream_data && m_internal_stream_data->file_backed_payload.has_value();
+}
+
 void Request::set_request_fd(Badge<Requests::RequestClient>, int fd)
 {
     VERIFY(m_fd == -1);
@@ -347,6 +352,8 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
 
             m_internal_stream_data->delivered_size += read_bytes.size();
             m_internal_stream_data->on_data_available(ResponseData::from_bytes(read_bytes));
+            if (!m_internal_stream_data)
+                return;
 
             if (m_internal_stream_data->body_delivery_remaining_byte_count.has_value()) {
                 if (read_bytes.size() >= *m_internal_stream_data->body_delivery_remaining_byte_count) {

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -54,9 +54,22 @@ Request::Request(RequestClient& client, u64 request_id)
 {
 }
 
+Request::~Request()
+{
+    if (m_fd != -1 && !m_fd_is_owned_by_read_stream)
+        (void)Core::System::close(m_fd);
+}
+
+int Request::request_server_client_id() const
+{
+    return m_client->request_server_client_id();
+}
+
 bool Request::stop()
 {
-    auto did_stop_request = m_client->stop_request({}, *this);
+    RefPtr keep_alive = *this;
+    auto had_active_request = m_client->stop_request({}, *this);
+    auto on_stop = move(m_on_stop);
 
     on_headers_received = nullptr;
     on_finish = nullptr;
@@ -66,21 +79,61 @@ bool Request::stop()
     m_internal_stream_data = nullptr;
     m_mode = Mode::Unknown;
 
-    return did_stop_request;
+    if (had_active_request && on_stop)
+        on_stop();
+
+    return had_active_request;
+}
+
+void Request::set_body_delivery_paused(bool paused)
+{
+    m_body_delivery_paused = paused;
+    if (m_internal_stream_data && m_internal_stream_data->read_notifier)
+        m_internal_stream_data->read_notifier->set_enabled(!m_body_delivery_paused);
+}
+
+void Request::resume_body_delivery()
+{
+    if (m_internal_stream_data)
+        m_internal_stream_data->body_delivery_remaining_byte_count = {};
+    set_body_delivery_paused(false);
+}
+
+void Request::resume_body_delivery_up_to(size_t byte_count)
+{
+    if (!m_internal_stream_data)
+        return;
+
+    m_internal_stream_data->body_delivery_remaining_byte_count = byte_count;
+    set_body_delivery_paused(false);
+}
+
+void Request::release_for_transfer()
+{
+    if (auto client = m_client.strong_ref())
+        client->release_request_for_transfer({}, *this);
 }
 
 void Request::set_request_fd(Badge<Requests::RequestClient>, int fd)
 {
-    // If the request was stopped while this IPC was in-flight, just bail.
-    if (!m_internal_stream_data)
-        return;
-
     VERIFY(m_fd == -1);
     m_fd = fd;
 
-    auto read_stream = MUST(ReadStream::create(fd));
+    if (m_internal_stream_data)
+        attach_read_stream();
+}
+
+void Request::attach_read_stream()
+{
+    VERIFY(m_internal_stream_data);
+    if (m_fd == -1 || m_fd_is_owned_by_read_stream)
+        return;
+
+    auto read_stream = MUST(ReadStream::create(m_fd));
+    m_fd_is_owned_by_read_stream = true;
     auto notifier = read_stream->notifier();
     notifier->on_activation = move(m_internal_stream_data->read_notifier->on_activation);
+    notifier->set_enabled(!m_body_delivery_paused);
     m_internal_stream_data->read_notifier = notifier;
     m_internal_stream_data->read_stream = move(read_stream);
 }
@@ -104,8 +157,10 @@ void Request::set_request_body_file(Badge<Requests::RequestClient>, int fd, u64 
     }
 
     m_internal_stream_data->file_backed_payload = payload.release_value();
-    if (m_internal_stream_data->on_data_available)
+    if (m_internal_stream_data->on_data_available) {
+        m_internal_stream_data->delivered_size += m_internal_stream_data->file_backed_payload->size();
         m_internal_stream_data->on_data_available(ResponseData::from_immutable_bytes(*m_internal_stream_data->file_backed_payload));
+    }
 }
 
 void Request::set_request_cached_body_file(Badge<Requests::RequestClient>, int fd, u64 offset, u64 size)
@@ -183,6 +238,11 @@ void Request::set_unbuffered_request_callbacks(HeadersReceived on_headers_receiv
     m_internal_stream_data->on_cached_body_available = move(on_cached_body_available);
 }
 
+void Request::set_stop_callback(RequestStopped on_stop)
+{
+    m_on_stop = move(on_stop);
+}
+
 void Request::did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error)
 {
     auto effective_network_error = m_body_delivery_error.has_value() ? m_body_delivery_error : network_error;
@@ -206,6 +266,22 @@ void Request::did_request_certificates(Badge<RequestClient>)
     }
 }
 
+void Request::did_transfer(Badge<RequestClient>)
+{
+    auto on_stop = move(m_on_stop);
+
+    on_headers_received = nullptr;
+    on_finish = nullptr;
+    on_certificate_requested = nullptr;
+
+    m_internal_buffered_data = nullptr;
+    m_internal_stream_data = nullptr;
+    m_mode = Mode::Unknown;
+
+    if (on_stop)
+        on_stop();
+}
+
 void Request::set_up_internal_stream_data(DataReceived on_data_available)
 {
     VERIFY(!m_internal_stream_data);
@@ -213,8 +289,8 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
     m_internal_stream_data = make<InternalStreamData>();
     m_internal_stream_data->on_data_available = move(on_data_available);
     m_internal_stream_data->read_notifier = Core::Notifier::construct(fd(), Core::Notifier::Type::Read);
-    if (fd() != -1)
-        m_internal_stream_data->read_stream = MUST(ReadStream::create(fd()));
+    m_internal_stream_data->read_notifier->set_enabled(!m_body_delivery_paused);
+    attach_read_stream();
 
     auto user_on_finish = move(on_finish);
     on_finish = [this](auto total_size, auto const& timing_info, auto network_error) {
@@ -234,7 +310,8 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
         if (!m_internal_stream_data)
             return;
 
-        if (!m_internal_stream_data->user_finish_called && (!m_internal_stream_data->read_stream || m_internal_stream_data->read_stream->is_eof())) {
+        auto has_received_all_reported_bytes = m_internal_stream_data->request_done && m_internal_stream_data->delivered_size >= m_internal_stream_data->total_size;
+        if (!m_internal_stream_data->user_finish_called && (!m_internal_stream_data->read_stream || m_internal_stream_data->read_stream->is_eof() || has_received_all_reported_bytes)) {
             m_internal_stream_data->user_finish_called = true;
             user_on_finish(m_internal_stream_data->total_size, m_internal_stream_data->timing_info, m_internal_stream_data->network_error);
         }
@@ -249,7 +326,16 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
             return;
 
         do {
-            auto result = m_internal_stream_data->read_stream->read_some({ buffer, buffer_size });
+            auto bytes_to_read = buffer_size;
+            if (m_internal_stream_data->body_delivery_remaining_byte_count.has_value()) {
+                if (*m_internal_stream_data->body_delivery_remaining_byte_count == 0) {
+                    set_body_delivery_paused(true);
+                    break;
+                }
+                bytes_to_read = min(bytes_to_read, *m_internal_stream_data->body_delivery_remaining_byte_count);
+            }
+
+            auto result = m_internal_stream_data->read_stream->read_some({ buffer, bytes_to_read });
             if (result.is_error() && (!result.error().is_errno() || (result.error().is_errno() && result.error().code() != EINTR)))
                 break;
             if (result.is_error())
@@ -259,7 +345,17 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
             if (read_bytes.is_empty())
                 break;
 
+            m_internal_stream_data->delivered_size += read_bytes.size();
             m_internal_stream_data->on_data_available(ResponseData::from_bytes(read_bytes));
+
+            if (m_internal_stream_data->body_delivery_remaining_byte_count.has_value()) {
+                if (read_bytes.size() >= *m_internal_stream_data->body_delivery_remaining_byte_count) {
+                    m_internal_stream_data->body_delivery_remaining_byte_count = 0;
+                    set_body_delivery_paused(true);
+                    break;
+                }
+                *m_internal_stream_data->body_delivery_remaining_byte_count -= read_bytes.size();
+            }
         } while (true);
 
         if (m_internal_stream_data->read_stream->is_eof())

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -95,6 +95,7 @@ public:
     void resume_body_delivery();
     void resume_body_delivery_up_to(size_t);
     void release_for_transfer();
+    [[nodiscard]] bool has_file_backed_response_body() const;
 
     using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, Core::ImmutableBytes payload)>;
 

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -85,9 +85,16 @@ public:
         return adopt_ref(*new Request(client, request_id));
     }
 
+    ~Request();
+
     u64 id() const { return m_request_id; }
+    int request_server_client_id() const;
     int fd() const { return m_fd; }
     bool stop();
+    void set_body_delivery_paused(bool);
+    void resume_body_delivery();
+    void resume_body_delivery_up_to(size_t);
+    void release_for_transfer();
 
     using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, Core::ImmutableBytes payload)>;
 
@@ -99,16 +106,19 @@ public:
     using DataReceived = Function<void(ResponseData data)>;
     using CachedBodyAvailable = Function<void(Core::ImmutableBytes data)>;
     using RequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> network_error)>;
+    using RequestStopped = Function<void()>;
 
     // Configure the request such that the response data is provided unbuffered as it is received. Using this method is
     // mutually exclusive with `set_buffered_request_finished_callback`.
     void set_unbuffered_request_callbacks(HeadersReceived, DataReceived, CachedBodyAvailable, RequestFinished);
+    void set_stop_callback(RequestStopped);
 
     Function<CertificateAndKey()> on_certificate_requested;
 
     void did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error);
     void did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key);
     void did_request_certificates(Badge<RequestClient>);
+    void did_transfer(Badge<RequestClient>);
 
     RefPtr<Core::Notifier>& write_notifier(Badge<RequestClient>) { return m_write_notifier; }
     void set_request_fd(Badge<RequestClient>, int fd);
@@ -118,12 +128,14 @@ public:
 private:
     Request(RequestClient&, u64 request_id);
 
+    void attach_read_stream();
     void set_up_internal_stream_data(DataReceived on_data_available);
 
     WeakPtr<RequestClient> m_client;
     u64 m_request_id { 0 };
     RefPtr<Core::Notifier> m_write_notifier;
     int m_fd { -1 };
+    bool m_fd_is_owned_by_read_stream { false };
 
     enum class Mode {
         Buffered,
@@ -134,6 +146,7 @@ private:
 
     HeadersReceived on_headers_received;
     RequestFinished on_finish;
+    RequestStopped m_on_stop;
 
     struct InternalBufferedData {
         InternalBufferedData();
@@ -153,6 +166,7 @@ private:
         OwnPtr<ReadStream> read_stream;
         RefPtr<Core::Notifier> read_notifier;
         u64 total_size { 0 };
+        u64 delivered_size { 0 };
         Optional<NetworkError> network_error;
         bool request_done { false };
         RequestTimingInfo timing_info;
@@ -162,11 +176,13 @@ private:
         bool user_finish_called { false };
         Optional<Core::ImmutableBytes> file_backed_payload;
         Optional<Core::ImmutableBytes> cached_payload;
+        Optional<size_t> body_delivery_remaining_byte_count;
     };
 
     OwnPtr<InternalBufferedData> m_internal_buffered_data;
     OwnPtr<InternalStreamData> m_internal_stream_data;
     Optional<NetworkError> m_body_delivery_error;
+    bool m_body_delivery_paused { false };
 };
 
 }

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -37,6 +37,7 @@ static Optional<Core::ImmutableBytes> map_javascript_bytecode_file(int fd, u64 s
 RequestClient::RequestClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>(*this, move(transport))
 {
+    m_request_server_client_id = send_sync<Messages::RequestServer::GetClientId>()->client_id();
 }
 
 RequestClient::~RequestClient() = default;
@@ -76,12 +77,22 @@ void RequestClient::die()
     }
 }
 
-RefPtr<Request> RequestClient::start_request(ByteString const& method, URL::URL const& url, Optional<HTTP::HeaderList const&> request_headers, ReadonlyBytes request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData const& proxy_data)
+RefPtr<Request> RequestClient::start_request(ByteString const& method, URL::URL const& url, Optional<HTTP::HeaderList const&> request_headers, ReadonlyBytes request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData const& proxy_data, KeepAliveForTransfer keep_alive_for_transfer)
 {
     auto request_id = m_next_request_id++;
     auto headers = request_headers.map([](auto const& headers) { return headers.headers().span(); }).value_or({});
 
-    IPCProxy::async_start_request(request_id, method, url, headers, request_body, cache_mode, include_credentials, proxy_data);
+    IPCProxy::async_start_request(request_id, method, url, headers, request_body, cache_mode, include_credentials, proxy_data, keep_alive_for_transfer == KeepAliveForTransfer::Yes);
+    auto request = Request::create_from_id({}, *this, request_id);
+    m_requests.set(request_id, request);
+    return request;
+}
+
+RefPtr<Request> RequestClient::adopt_request(int source_client_id, u64 source_request_id)
+{
+    auto request_id = m_next_request_id++;
+
+    IPCProxy::async_adopt_request(source_client_id, source_request_id, request_id);
     auto request = Request::create_from_id({}, *this, request_id);
     m_requests.set(request_id, request);
     return request;
@@ -109,9 +120,17 @@ ErrorOr<bool> RequestClient::create_synthetic_cache_entry(URL::URL const& url, B
 
 bool RequestClient::stop_request(Badge<Request>, Request& request)
 {
-    if (!m_requests.contains(request.id()))
+    auto stopped_request = m_requests.take(request.id());
+    if (!stopped_request.has_value())
         return false;
-    return IPCProxy::stop_request(request.id());
+
+    (void)IPCProxy::stop_request(request.id());
+    return true;
+}
+
+void RequestClient::release_request_for_transfer(Badge<Request>, Request& request)
+{
+    async_release_request_for_transfer(request.id());
 }
 
 void RequestClient::ensure_connection(URL::URL const& url, RequestServer::CacheLevel cache_level)
@@ -199,6 +218,15 @@ void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header
         (*request)->did_receive_headers({}, HTTP::HeaderList::create(move(response_headers)), status_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
     else
         warnln("Received headers for non-existent request {}", request_id);
+}
+
+void RequestClient::request_transferred(u64 request_id)
+{
+    auto request = m_requests.take(request_id);
+    if (!request.has_value())
+        return;
+
+    (*request)->did_transfer({});
 }
 
 void RequestClient::retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url)

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -32,12 +32,20 @@ class RequestClient final
 public:
     using InitTransport = Messages::RequestServer::InitTransport;
 
+    enum class KeepAliveForTransfer : u8 {
+        No,
+        Yes,
+    };
+
     explicit RequestClient(NonnullOwnPtr<IPC::Transport>);
     virtual ~RequestClient() override;
 
-    RefPtr<Request> start_request(ByteString const& method, URL::URL const&, Optional<HTTP::HeaderList const&> request_headers = {}, ReadonlyBytes request_body = {}, HTTP::CacheMode = HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials = HTTP::Cookie::IncludeCredentials::Yes, Core::ProxyData const& = {});
+    RefPtr<Request> start_request(ByteString const& method, URL::URL const&, Optional<HTTP::HeaderList const&> request_headers = {}, ReadonlyBytes request_body = {}, HTTP::CacheMode = HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials = HTTP::Cookie::IncludeCredentials::Yes, Core::ProxyData const& = {}, KeepAliveForTransfer = KeepAliveForTransfer::No);
+    RefPtr<Request> adopt_request(int source_client_id, u64 source_request_id);
     bool stop_request(Badge<Request>, Request&);
+    void release_request_for_transfer(Badge<Request>, Request&);
     void ensure_connection(URL::URL const&, RequestServer::CacheLevel);
+    int request_server_client_id() const { return m_request_server_client_id; }
 
     bool set_certificate(Badge<Request>, Request&, ByteString, ByteString);
 
@@ -59,6 +67,7 @@ private:
     virtual void request_cached_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
     virtual void request_finished(u64 request_id, u64, RequestTimingInfo, Optional<NetworkError>) override;
     virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<IPC::File>, u64 javascript_bytecode_size, Optional<u64>) override;
+    virtual void request_transferred(u64 request_id) override;
 
     virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url) override;
 
@@ -76,6 +85,7 @@ private:
 
     HashMap<u64, RefPtr<Request>> m_requests;
     u64 m_next_request_id { 0 };
+    int m_request_server_client_id { -1 };
 
     HashMap<u64, NonnullRefPtr<WebSocket>> m_websockets;
     u64 m_next_websocket_id { 0 };

--- a/Libraries/LibURL/InternalURLs.h
+++ b/Libraries/LibURL/InternalURLs.h
@@ -14,6 +14,7 @@ namespace URL {
 
 #define ENUMERATE_INTERNAL_URLS \
     __URL_ENUMERATE(bookmarks)  \
+    __URL_ENUMERATE(downloads)  \
     __URL_ENUMERATE(history)    \
     __URL_ENUMERATE(newtab)     \
     __URL_ENUMERATE(processes)  \

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2247,7 +2247,7 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
     // 13. Set up stream with byte reading support with pullAlgorithm set to pullAlgorithm, cancelAlgorithm set to cancelAlgorithm.
     stream->set_up_with_byte_reading_support(pull_algorithm, cancel_algorithm);
 
-    auto on_headers_received = GC::create_function(vm.heap(), [&vm, pending_response, stream, request, fetched_data_receiver](HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) {
+    auto on_headers_received = GC::create_function(vm.heap(), [&vm, pending_response, stream, request, fetched_data_receiver](Requests::Request* request_server_request, HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) {
         if (pending_response->is_resolved()) {
             // RequestServer will send us the response headers twice, the second time being for HTTP trailers. This
             // fetch algorithm is not interested in trailers, so just drop them here.
@@ -2261,6 +2261,13 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
             response->set_status_message(reason_phrase->to_byte_string());
         response->set_javascript_bytecode_cache(move(javascript_bytecode));
         response->set_javascript_bytecode_cache_vary_key(javascript_bytecode_cache_vary_key);
+        if (request_server_request) {
+            response->set_request_server_request({
+                .client_id = request_server_request->request_server_client_id(),
+                .request_id = request_server_request->id(),
+                .request = request_server_request,
+            });
+        }
 
         (void)request;
         if constexpr (WEB_FETCH_DEBUG) {
@@ -2314,7 +2321,12 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
         }
     });
 
-    auto network_request = ResourceLoader::the().load(load_request, on_headers_received, on_data_received, on_cached_body_available, on_complete);
+    auto keep_alive_for_transfer = request->destination() == Infrastructure::Request::Destination::Document
+        ? Requests::RequestClient::KeepAliveForTransfer::Yes
+        : Requests::RequestClient::KeepAliveForTransfer::No;
+    auto network_request = ResourceLoader::the().load(load_request, on_headers_received, on_data_received, on_cached_body_available, on_complete, keep_alive_for_transfer);
+    if (network_request && request->destination() == Infrastructure::Request::Destination::Document)
+        network_request->set_body_delivery_paused(true);
     fetch_params.controller()->set_pending_request(network_request);
 
     return pending_response;

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -178,7 +178,7 @@ void Body::fully_read(JS::Realm& realm, Web::Fetch::Infrastructure::Body::Proces
 }
 
 // https://fetch.spec.whatwg.org/#body-incrementally-read
-void Body::incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination)
+GC::Ref<Streams::ReadableStreamDefaultReader> Body::incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination)
 {
     HTML::TemporaryExecutionContext const execution_context { m_stream->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
@@ -193,6 +193,7 @@ void Body::incrementally_read(ProcessBodyChunkCallback process_body_chunk, Proce
     // 3. Perform the incrementally-read loop given reader, taskDestination, processBodyChunk, processEndOfBody, and processBodyError.
     VERIFY(!task_destination.has<Empty>());
     incrementally_read_loop(reader, task_destination.get<GC::Ref<JS::Object>>(), process_body_chunk, process_end_of_body, process_body_error);
+    return reader;
 }
 
 // https://fetch.spec.whatwg.org/#incrementally-read-loop
@@ -212,6 +213,11 @@ GC::Ref<Body> byte_sequence_as_body(JS::Realm& realm, ReadonlyBytes bytes)
     // To get a byte sequence bytes as a body, return the body of the result of safely extracting bytes.
     auto [body, _] = safely_extract_body(realm, bytes);
     return body;
+}
+
+void cancel_incremental_read(Streams::ReadableStreamDefaultReader& reader)
+{
+    reader.cancel({});
 }
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -67,7 +67,7 @@ public:
     [[nodiscard]] GC::Ref<Body> clone(JS::Realm&);
 
     void fully_read(JS::Realm&, ProcessBodyCallback process_body, ProcessBodyErrorCallback process_body_error, TaskDestination) const;
-    void incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination);
+    GC::Ref<Streams::ReadableStreamDefaultReader> incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination);
     void incrementally_read_loop(Streams::ReadableStreamDefaultReader& reader, TaskDestination, ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
@@ -103,5 +103,6 @@ struct BodyWithType {
 };
 
 WEB_API GC::Ref<Body> byte_sequence_as_body(JS::Realm&, ReadonlyBytes);
+WEB_API void cancel_incremental_read(Streams::ReadableStreamDefaultReader&);
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -9,6 +9,7 @@
 #include <LibGC/Heap.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibRequests/Request.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/Fetch/Infrastructure/FetchParams.h>
@@ -105,6 +106,29 @@ bool Response::is_network_error() const
     return true;
 }
 
+void Response::release_request_for_transfer() const
+{
+    if (m_request_server_request.has_value() && m_request_server_request->request)
+        m_request_server_request->request->release_for_transfer();
+}
+
+void Response::resume_body_delivery() const
+{
+    release_request_for_transfer();
+    if (m_request_server_request.has_value()) {
+        if (m_request_server_request->request)
+            m_request_server_request->request->resume_body_delivery();
+    }
+}
+
+void Response::resume_body_delivery_up_to(size_t byte_count) const
+{
+    if (m_request_server_request.has_value()) {
+        if (m_request_server_request->request)
+            m_request_server_request->request->resume_body_delivery_up_to(byte_count);
+    }
+}
+
 // https://fetch.spec.whatwg.org/#concept-response-url
 Optional<URL::URL const&> Response::url() const
 {
@@ -182,6 +206,8 @@ GC::Ref<Response> Response::clone(JS::Realm& realm) const
     new_response->set_body_info(m_body_info);
     new_response->set_javascript_bytecode_cache(m_javascript_bytecode_cache);
     new_response->set_javascript_bytecode_cache_vary_key(m_javascript_bytecode_cache_vary_key);
+    if (m_request_server_request.has_value())
+        new_response->set_request_server_request(*m_request_server_request);
     if (m_javascript_bytecode_cache_memory_cache_request_headers.has_value())
         new_response->set_javascript_bytecode_cache_memory_cache_request_headers(HTTP::HeaderList::create((*m_javascript_bytecode_cache_memory_cache_request_headers)->headers()));
     // FIXME: service worker timing info

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -17,6 +17,8 @@
 #include <LibHTTP/HeaderList.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibRequests/Forward.h>
+#include <LibRequests/Request.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP.h>
@@ -57,6 +59,12 @@ public:
         String content_type {};
 
         bool operator==(BodyInfo const&) const = default;
+    };
+
+    struct RequestServerRequest {
+        int client_id { -1 };
+        u64 request_id { 0 };
+        RefPtr<Requests::Request> request;
     };
 
     [[nodiscard]] static GC::Ref<Response> create(JS::VM&);
@@ -132,6 +140,11 @@ public:
     // Non-standard
     [[nodiscard]] Optional<String> const& network_error_message() const { return m_network_error_message; }
     MonotonicTime monotonic_response_time() const { return m_monotonic_response_time; }
+    [[nodiscard]] virtual Optional<RequestServerRequest> const& request_server_request() const { return m_request_server_request; }
+    virtual void set_request_server_request(RequestServerRequest request) { m_request_server_request = move(request); }
+    virtual void release_request_for_transfer() const;
+    virtual void resume_body_delivery() const;
+    virtual void resume_body_delivery_up_to(size_t) const;
 
 protected:
     explicit Response(NonnullRefPtr<HTTP::HeaderList>);
@@ -206,6 +219,7 @@ private:
     Optional<Core::ImmutableBytes> m_javascript_bytecode_cache;
     Optional<u64> m_javascript_bytecode_cache_vary_key;
     Optional<NonnullRefPtr<HTTP::HeaderList>> m_javascript_bytecode_cache_memory_cache_request_headers;
+    Optional<RequestServerRequest> m_request_server_request;
 
 public:
     [[nodiscard]] ByteString const& method() const { return m_method; }
@@ -258,6 +272,11 @@ public:
 
     [[nodiscard]] virtual BodyInfo const& body_info() const override { return m_internal_response->body_info(); }
     virtual void set_body_info(BodyInfo body_info) override { m_internal_response->set_body_info(move(body_info)); }
+    [[nodiscard]] virtual Optional<RequestServerRequest> const& request_server_request() const override { return m_internal_response->request_server_request(); }
+    virtual void set_request_server_request(RequestServerRequest request) override { m_internal_response->set_request_server_request(move(request)); }
+    virtual void release_request_for_transfer() const override { m_internal_response->release_request_for_transfer(); }
+    virtual void resume_body_delivery() const override { m_internal_response->resume_body_delivery(); }
+    virtual void resume_body_delivery_up_to(size_t byte_count) const override { m_internal_response->resume_body_delivery_up_to(byte_count); }
 
     [[nodiscard]] GC::Ref<Response> internal_response() const { return m_internal_response; }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -71,7 +71,10 @@
 #include <LibWeb/XHR/FormData.h>
 
 #include <AK/Debug.h>
+#include <AK/LexicalPath.h>
 #include <AK/StdLibExtras.h>
+#include <AK/StringBuilder.h>
+#include <LibHTTP/HTTP.h>
 
 namespace Web::HTML {
 
@@ -194,6 +197,204 @@ private:
 GC_DEFINE_ALLOCATOR(InternalNavigationResult);
 
 GC_DEFINE_ALLOCATOR(PopulateSessionHistoryEntryDocumentOutput);
+
+static Vector<StringView> split_content_disposition_parameters(StringView value)
+{
+    Vector<StringView> parameters;
+    bool in_quoted_string = false;
+    bool escaped = false;
+    size_t parameter_start = 0;
+
+    for (size_t i = 0; i < value.length(); ++i) {
+        auto ch = value[i];
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+
+        if (in_quoted_string && ch == '\\') {
+            escaped = true;
+            continue;
+        }
+
+        if (ch == '"') {
+            in_quoted_string = !in_quoted_string;
+            continue;
+        }
+
+        if (ch != ';' || in_quoted_string)
+            continue;
+
+        parameters.append(value.substring_view(parameter_start, i - parameter_start).trim(HTTP::HTTP_TAB_OR_SPACE, TrimMode::Both));
+        parameter_start = i + 1;
+    }
+
+    parameters.append(value.substring_view(parameter_start).trim(HTTP::HTTP_TAB_OR_SPACE, TrimMode::Both));
+    return parameters;
+}
+
+static ByteString parse_content_disposition_parameter_value(StringView value)
+{
+    value = value.trim(HTTP::HTTP_TAB_OR_SPACE, TrimMode::Both);
+    if (!value.starts_with('"'))
+        return value;
+
+    StringBuilder builder;
+    bool escaped = false;
+    for (size_t i = 1; i < value.length(); ++i) {
+        auto ch = value[i];
+        if (escaped) {
+            builder.append(ch);
+            escaped = false;
+            continue;
+        }
+
+        if (ch == '\\') {
+            escaped = true;
+            continue;
+        }
+
+        if (ch == '"')
+            break;
+
+        builder.append(ch);
+    }
+    return builder.to_byte_string();
+}
+
+static Optional<ByteString> parse_content_disposition_extended_filename(StringView value)
+{
+    auto decoded_value = parse_content_disposition_parameter_value(value);
+    auto decoded_view = decoded_value.view();
+    auto first_separator = decoded_view.find('\'');
+    if (!first_separator.has_value())
+        return URL::percent_decode(decoded_view);
+
+    auto second_separator = decoded_view.find('\'', *first_separator + 1);
+    if (!second_separator.has_value())
+        return {};
+
+    return URL::percent_decode(decoded_view.substring_view(*second_separator + 1));
+}
+
+struct ContentDispositionInfo {
+    bool is_attachment { false };
+    Optional<ByteString> filename;
+};
+
+static ContentDispositionInfo parse_content_disposition(HTTP::HeaderList const& headers)
+{
+    auto header = headers.get("Content-Disposition"sv);
+    if (!header.has_value())
+        return {};
+
+    auto parameters = split_content_disposition_parameters(header->view());
+    if (parameters.is_empty())
+        return {};
+
+    ContentDispositionInfo info;
+    info.is_attachment = parameters.first().equals_ignoring_ascii_case("attachment"sv);
+
+    Optional<ByteString> filename;
+    Optional<ByteString> extended_filename;
+    for (size_t i = 1; i < parameters.size(); ++i) {
+        auto parameter = parameters[i];
+        auto equals_index = parameter.find('=');
+        if (!equals_index.has_value())
+            continue;
+
+        auto name = parameter.substring_view(0, *equals_index).trim(HTTP::HTTP_TAB_OR_SPACE, TrimMode::Both);
+        auto value = parameter.substring_view(*equals_index + 1);
+        if (name.equals_ignoring_ascii_case("filename*"sv))
+            extended_filename = parse_content_disposition_extended_filename(value);
+        else if (name.equals_ignoring_ascii_case("filename"sv))
+            filename = parse_content_disposition_parameter_value(value);
+    }
+
+    info.filename = extended_filename.has_value() ? move(extended_filename) : move(filename);
+    return info;
+}
+
+static ByteString sanitize_suggested_download_filename(ByteString filename)
+{
+    filename = LexicalPath::basename(move(filename));
+
+    StringBuilder builder;
+    for (auto byte : filename.bytes()) {
+        if (byte == '\0' || byte == '/' || byte == '\\')
+            builder.append('_');
+        else
+            builder.append(static_cast<char>(byte));
+    }
+
+    auto sanitized = builder.to_byte_string();
+    if (sanitized.is_empty() || sanitized == "."sv || sanitized == ".."sv)
+        return "download";
+    return sanitized;
+}
+
+static ByteString suggested_download_filename(URL::URL const& url, HTTP::HeaderList const& headers)
+{
+    auto content_disposition = parse_content_disposition(headers);
+    if (content_disposition.filename.has_value())
+        return sanitize_suggested_download_filename(content_disposition.filename.release_value());
+
+    return sanitize_suggested_download_filename(url.basename());
+}
+
+static Optional<u64> response_content_length(HTTP::HeaderList const& headers)
+{
+    auto extracted_length = headers.extract_length();
+    if (extracted_length.has<u64>())
+        return extracted_length.get<u64>();
+    return {};
+}
+
+static bool handle_navigation_response_as_download(JS::Realm& realm, GC::Ref<NavigationParams> navigation_params, GC::Ref<SourceSnapshotParams> source_snapshot_params, Optional<ReadonlyBytes> initial_data = {})
+{
+    auto response = navigation_params->response;
+    if (!response || !response->body())
+        return true;
+
+    if (!source_snapshot_params->allows_downloading) {
+        response->release_request_for_transfer();
+        if (navigation_params->fetch_controller)
+            navigation_params->fetch_controller->abort(realm, {});
+        return true;
+    }
+
+    VERIFY(navigation_params->navigable);
+    auto active_window = navigation_params->navigable->active_window();
+    if (!active_window) {
+        response->release_request_for_transfer();
+        return true;
+    }
+
+    auto download_url = response->url().value_or(navigation_params->request ? navigation_params->request->current_url() : URL::about_blank());
+    auto suggested_filename = suggested_download_filename(download_url, *response->header_list());
+    if (auto const& request_server_request = response->request_server_request(); request_server_request.has_value()) {
+        ByteBuffer initial_data_buffer;
+        if (initial_data.has_value() && !initial_data->is_empty())
+            initial_data_buffer = MUST(ByteBuffer::copy(*initial_data));
+
+        auto download_id = navigation_params->navigable->page().client().page_did_start_download(download_url, suggested_filename, response_content_length(*response->header_list()), request_server_request->client_id, request_server_request->request_id, move(initial_data_buffer));
+        if (!download_id.has_value()) {
+            if (navigation_params->fetch_controller)
+                navigation_params->fetch_controller->stop_fetch();
+            return true;
+        }
+
+        if (navigation_params->fetch_controller)
+            navigation_params->fetch_controller->terminate();
+
+        return true;
+    }
+
+    if (navigation_params->fetch_controller)
+        navigation_params->fetch_controller->stop_fetch();
+
+    return true;
+}
 
 void PopulateSessionHistoryEntryDocumentOutput::apply_to(NonnullRefPtr<SessionHistoryEntry> entry)
 {
@@ -1779,13 +1980,13 @@ void LocalNavigable::populate_session_history_entry_document(
     // 3. Let documentResource be entry's document state's resource.
     // NOTE: documentResource is passed as a parameter.
 
-    auto received_navigation_params = GC::create_function(heap(), [this, url, navigation_id, user_involvement, completion_steps, csp_navigation_type](GC::Ref<InternalNavigationResult> result) {
+    auto received_navigation_params = GC::create_function(heap(), [this, url, navigation_id, user_involvement, completion_steps, csp_navigation_type, source_snapshot_params](GC::Ref<InternalNavigationResult> result) {
         // AD-HOC: Not in the spec but subsequent steps will fail if the navigable doesn't have an active window.
         if (!active_window())
             return;
 
         // 5. Queue a global task on the navigation and traversal task source, given navigable's active window, to run these steps:
-        queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), GC::create_function(heap(), [this, url, result, navigation_id, user_involvement, completion_steps, csp_navigation_type]() mutable {
+        queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), GC::create_function(heap(), [this, url, result, navigation_id, user_involvement, completion_steps, csp_navigation_type, source_snapshot_params]() mutable {
             auto& navigation_params = result->navigation_params;
 
             // 1. If navigable's ongoing navigation no longer equals navigationId, then run completionSteps and abort these steps.
@@ -1874,9 +2075,12 @@ void LocalNavigable::populate_session_history_entry_document(
                 }
             }
 
-            // FIXME: 5. Otherwise, if navigationParams's response has a `Content-Disposition` header specifying the attachment
+            // 5. Otherwise, if navigationParams's response has a `Content-Disposition` header specifying the attachment
             //    disposition type, then:
-            else if (false) {
+            else if (auto nav_params = navigation_params.get<GC::Ref<NavigationParams>>();
+                parse_content_disposition(*nav_params->response->header_list()).is_attachment) {
+                output->download_handled = handle_navigation_response_as_download(active_window()->realm(), nav_params, source_snapshot_params);
+                output->save_extra_document_state = false;
             }
 
             // 6. Otherwise, if navigationParams's response's status is not 204 and is not 205, then set entry's document state's document to the result of
@@ -1890,12 +2094,22 @@ void LocalNavigable::populate_session_history_entry_document(
                 auto sniff_bytes = body ? body->sniff_bytes_if_available() : Optional<ReadonlyBytes> { ReadonlyBytes {} };
                 if (!sniff_bytes.has_value()) {
                     // Async path: bytes not yet available, wait for them
+                    nav_params->response->resume_body_delivery_up_to(Fetch::Infrastructure::MAX_SNIFF_BYTES);
                     body->wait_for_sniff_bytes(GC::create_function(heap(),
-                        [output, nav_params, navigation_params, completion_steps](ReadonlyBytes sniff_bytes) {
+                        [output, nav_params, navigation_params, completion_steps, source_snapshot_params](ReadonlyBytes sniff_bytes) {
                             // AD-HOC: The document may have been destroyed between when the fetch started and when the
                             //         bytes arrived.
-                            if (nav_params->navigable->active_browsing_context())
+                            if (nav_params->navigable->active_browsing_context()) {
                                 output->document = load_document(nav_params, sniff_bytes);
+                                if (!output->document) {
+                                    output->download_handled = handle_navigation_response_as_download(nav_params->navigable->active_window()->realm(), nav_params, source_snapshot_params, sniff_bytes);
+                                    output->save_extra_document_state = false;
+                                } else {
+                                    nav_params->response->resume_body_delivery();
+                                }
+                            } else {
+                                nav_params->response->release_request_for_transfer();
+                            }
                             output->navigation_params = navigation_params;
                             if (completion_steps)
                                 completion_steps->function()(output);
@@ -1905,6 +2119,15 @@ void LocalNavigable::populate_session_history_entry_document(
 
                 // Sync path: bytes available immediately
                 output->document = load_document(nav_params, sniff_bytes.value());
+                if (!output->document) {
+                    output->download_handled = handle_navigation_response_as_download(active_window()->realm(), nav_params, source_snapshot_params, sniff_bytes.value());
+                    output->save_extra_document_state = false;
+                } else {
+                    nav_params->response->resume_body_delivery();
+                }
+            } else {
+                auto nav_params = navigation_params.get<GC::Ref<NavigationParams>>();
+                nav_params->response->release_request_for_transfer();
             }
 
             output->navigation_params = navigation_params;
@@ -2488,6 +2711,14 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                     history_entry->document_state()->reload_pending(),
                     history_entry->document_state()->ever_populated(),
                     source_snapshot_params, target_snapshot_params, user_involvement, navigation_id, navigation_params, csp_navigation_type, true, GC::create_function(heap(), [this, history_entry, history_handling, navigation_id, user_involvement](GC::Ptr<PopulateSessionHistoryEntryDocumentOutput> output) {
+                        if (output && output->download_handled) {
+                            if (is_top_level_traversable())
+                                active_browsing_context()->page().client().page_did_cancel_loading(history_entry->url());
+                            set_ongoing_navigation({});
+                            set_delaying_load_events(false);
+                            return;
+                        }
+
                         if (output)
                             output->apply_to(*history_entry);
                         auto pending_document = output ? output->document : GC::Ptr<DOM::Document> {};

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -335,8 +335,12 @@ static ByteString sanitize_suggested_download_filename(ByteString filename)
 
 static ByteString suggested_download_filename(URL::URL const& url, HTTP::HeaderList const& headers)
 {
+    // https://html.spec.whatwg.org/multipage/links.html#getting-the-suggested-filename
+    // FIXME: This is a partial implementation. We do not yet model the
+    //        hyperlink download attribute, trusted operation, or extension
+    //        adjustment steps.
     auto content_disposition = parse_content_disposition(headers);
-    if (content_disposition.filename.has_value())
+    if (content_disposition.is_attachment && content_disposition.filename.has_value())
         return sanitize_suggested_download_filename(content_disposition.filename.release_value());
 
     return sanitize_suggested_download_filename(url.basename());
@@ -350,16 +354,22 @@ static Optional<u64> response_content_length(HTTP::HeaderList const& headers)
     return {};
 }
 
+// https://html.spec.whatwg.org/multipage/links.html#handle-as-a-download
 static bool handle_navigation_response_as_download(JS::Realm& realm, GC::Ref<NavigationParams> navigation_params, GC::Ref<SourceSnapshotParams> source_snapshot_params, Optional<ReadonlyBytes> initial_data = {})
 {
     auto response = navigation_params->response;
     if (!response || !response->body())
         return true;
 
-    if (!source_snapshot_params->allows_downloading) {
-        response->release_request_for_transfer();
+    // FIXME: Implement the WebDriver BiDi download will begin/end hooks.
+    //        uaAllowsDownloading is currently always true.
+    auto source_allows_downloading = source_snapshot_params->allows_downloading;
+    auto target_allows_downloading = !has_flag(navigation_params->final_sandboxing_flag_set, SandboxingFlagSet::SandboxedDownloads);
+    if (!source_allows_downloading || !target_allows_downloading) {
         if (navigation_params->fetch_controller)
-            navigation_params->fetch_controller->abort(realm, {});
+            navigation_params->fetch_controller->stop_fetch();
+        else
+            response->resume_body_delivery();
         return true;
     }
 
@@ -373,8 +383,9 @@ static bool handle_navigation_response_as_download(JS::Realm& realm, GC::Ref<Nav
     auto download_url = response->url().value_or(navigation_params->request ? navigation_params->request->current_url() : URL::about_blank());
     auto suggested_filename = suggested_download_filename(download_url, *response->header_list());
     if (auto const& request_server_request = response->request_server_request(); request_server_request.has_value()) {
+        auto response_body_will_be_transferred_in_full = request_server_request->request && request_server_request->request->has_file_backed_response_body();
         ByteBuffer initial_data_buffer;
-        if (initial_data.has_value() && !initial_data->is_empty())
+        if (initial_data.has_value() && !initial_data->is_empty() && !response_body_will_be_transferred_in_full)
             initial_data_buffer = MUST(ByteBuffer::copy(*initial_data));
 
         auto download_id = navigation_params->navigable->page().client().page_did_start_download(download_url, suggested_filename, response_content_length(*response->header_list()), request_server_request->client_id, request_server_request->request_id, move(initial_data_buffer));
@@ -390,10 +401,57 @@ static bool handle_navigation_response_as_download(JS::Realm& realm, GC::Ref<Nav
         return true;
     }
 
+    auto download_id = navigation_params->navigable->page().client().page_did_start_download(download_url, suggested_filename, response_content_length(*response->header_list()));
+    if (!download_id.has_value()) {
+        if (navigation_params->fetch_controller)
+            navigation_params->fetch_controller->stop_fetch();
+        return true;
+    }
+
     if (navigation_params->fetch_controller)
-        navigation_params->fetch_controller->stop_fetch();
+        navigation_params->navigable->page().client().page_did_register_download_controller(*download_id, *navigation_params->fetch_controller);
+
+    auto process_body_chunk = GC::create_function(realm.heap(), [navigable = navigation_params->navigable, download_id = *download_id](ByteBuffer data) {
+        if (navigable->page().client().page_is_download_canceled(download_id))
+            return;
+
+        navigable->page().client().page_did_receive_download_data(download_id, move(data));
+    });
+
+    auto process_end_of_body = GC::create_function(realm.heap(), [navigable = navigation_params->navigable, download_id = *download_id]() {
+        if (navigable->page().client().page_is_download_canceled(download_id))
+            return;
+
+        navigable->page().client().page_did_finish_download(download_id);
+    });
+
+    auto process_body_error = GC::create_function(realm.heap(), [navigable = navigation_params->navigable, download_id = *download_id](JS::Value) {
+        if (navigable->page().client().page_is_download_canceled(download_id))
+            return;
+
+        navigable->page().client().page_did_fail_download(download_id, "Unable to read downloaded file"_string);
+    });
+
+    // https://fetch.spec.whatwg.org/#body-incrementally-read
+    auto reader = response->body()->incrementally_read(process_body_chunk, process_end_of_body, process_body_error, GC::Ref { realm.global_object() });
+    navigation_params->navigable->page().client().page_did_register_download_reader(*download_id, reader);
+    response->resume_body_delivery();
 
     return true;
+}
+
+static void stop_or_resume_response_body_delivery(LocalNavigable::NavigationParamsVariant const& navigation_params)
+{
+    // AD-HOC: Fetch controller stop_fetch() is an implementation hook for
+    //         tearing down a paused network body when no spec consumer remains.
+    if (!navigation_params.has<GC::Ref<NavigationParams>>())
+        return;
+
+    auto const& nav_params = navigation_params.get<GC::Ref<NavigationParams>>();
+    if (nav_params->fetch_controller)
+        nav_params->fetch_controller->stop_fetch();
+    else
+        nav_params->response->resume_body_delivery();
 }
 
 void PopulateSessionHistoryEntryDocumentOutput::apply_to(NonnullRefPtr<SessionHistoryEntry> entry)
@@ -1968,8 +2026,10 @@ void LocalNavigable::populate_session_history_entry_document(
     GC::Ptr<GC::Function<void(GC::Ptr<PopulateSessionHistoryEntryDocumentOutput>)>> completion_steps)
 {
     // AD-HOC: Not in the spec but subsequent steps will fail if the navigable doesn't have an active window.
-    if (!active_window())
+    if (!active_window()) {
+        stop_or_resume_response_body_delivery(navigation_params);
         return;
+    }
 
     // FIXME: 1. Assert: this is running in parallel.
 
@@ -1982,8 +2042,10 @@ void LocalNavigable::populate_session_history_entry_document(
 
     auto received_navigation_params = GC::create_function(heap(), [this, url, navigation_id, user_involvement, completion_steps, csp_navigation_type, source_snapshot_params](GC::Ref<InternalNavigationResult> result) {
         // AD-HOC: Not in the spec but subsequent steps will fail if the navigable doesn't have an active window.
-        if (!active_window())
+        if (!active_window()) {
+            stop_or_resume_response_body_delivery(result->navigation_params);
             return;
+        }
 
         // 5. Queue a global task on the navigation and traversal task source, given navigable's active window, to run these steps:
         queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), GC::create_function(heap(), [this, url, result, navigation_id, user_involvement, completion_steps, csp_navigation_type, source_snapshot_params]() mutable {
@@ -2067,6 +2129,10 @@ void LocalNavigable::populate_session_history_entry_document(
                     // 1. Run the environment discarding steps for navigationParams's reserved environment.
                     navigation_params.visit(
                         [](GC::Ref<NavigationParams> const& it) {
+                            if (it->fetch_controller)
+                                it->fetch_controller->stop_fetch();
+                            else
+                                it->response->resume_body_delivery();
                             it->reserved_environment->discard_environment();
                         },
                         [](auto const&) {});
@@ -2108,7 +2174,7 @@ void LocalNavigable::populate_session_history_entry_document(
                                     nav_params->response->resume_body_delivery();
                                 }
                             } else {
-                                nav_params->response->release_request_for_transfer();
+                                stop_or_resume_response_body_delivery(navigation_params);
                             }
                             output->navigation_params = navigation_params;
                             if (completion_steps)

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -409,6 +409,7 @@ public:
 
     LocalNavigable::NavigationParamsVariant navigation_params { LocalNavigable::NullOrError {} };
     bool save_extra_document_state = true;
+    bool download_handled = false;
 
     Optional<URL::URL> redirected_url;
     Optional<SerializationRecord> classic_history_api_state;

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -383,7 +383,7 @@ void ResourceLoader::handle_resource_load_request(LoadRequest const& request, Re
     on_resource(load_result);
 }
 
-RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<OnHeadersReceived> on_headers_received, GC::Root<OnDataReceived> on_data_received, GC::Root<OnCachedBodyAvailable> on_cached_body_available, GC::Root<OnComplete> on_complete)
+RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<OnHeadersReceived> on_headers_received, GC::Root<OnDataReceived> on_data_received, GC::Root<OnCachedBodyAvailable> on_cached_body_available, GC::Root<OnComplete> on_complete, Requests::RequestClient::KeepAliveForTransfer keep_alive_for_transfer)
 {
     auto const& url = request.url().value();
 
@@ -400,7 +400,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             request,
             [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete = move(on_complete), request](ReadonlyBytes data, Requests::RequestTimingInfo const& timing_info, HTTP::HeaderList const& response_headers) {
                 log_success(request);
-                on_headers_received->function()(response_headers, {}, {}, {}, {});
+                on_headers_received->function()(nullptr, response_headers, {}, {}, {}, {});
                 on_data_received->function()(Requests::ResponseData::from_bytes(data));
                 on_complete->function()(true, timing_info, {});
             });
@@ -411,7 +411,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
         handle_resource_load_request(
             request,
             [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete](FileLoadResult const& load_result) {
-                on_headers_received->function()(load_result.response_headers, {}, {}, {}, {});
+                on_headers_received->function()(nullptr, load_result.response_headers, {}, {}, {}, {});
                 on_data_received->function()(Requests::ResponseData::from_bytes(load_result.data));
                 on_complete->function()(true, load_result.timing_info, {});
             },
@@ -427,7 +427,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             request,
             [request, on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete](FileLoadResult const& load_result) {
                 log_success(request);
-                on_headers_received->function()(load_result.response_headers, {}, {}, {}, {});
+                on_headers_received->function()(nullptr, load_result.response_headers, {}, {}, {}, {});
                 on_data_received->function()(Requests::ResponseData::from_bytes(load_result.data));
                 on_complete->function()(true, load_result.timing_info, {});
             },
@@ -446,19 +446,19 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
         return nullptr;
     }
 
-    auto protocol_request = start_network_request(request);
+    auto protocol_request = start_network_request(request, keep_alive_for_transfer);
     if (!protocol_request) {
         on_complete->function()(false, {}, "Failed to start network request"sv);
         return nullptr;
     }
 
-    auto protocol_headers_received = [this, on_headers_received = move(on_headers_received), request, request_id = protocol_request->id()](auto const& response_headers, auto status_code, auto const& reason_phrase, auto javascript_bytecode, auto javascript_bytecode_cache_vary_key) {
+    auto protocol_headers_received = [this, on_headers_received = move(on_headers_received), request, &protocol_request = *protocol_request](auto const& response_headers, auto status_code, auto const& reason_phrase, auto javascript_bytecode, auto javascript_bytecode_cache_vary_key) {
         handle_network_response_headers(request, response_headers);
 
         if (auto page = request.page())
-            page->client().page_did_receive_network_response_headers(request_id, status_code.value_or(0), reason_phrase, response_headers->headers());
+            page->client().page_did_receive_network_response_headers(protocol_request.id(), status_code.value_or(0), reason_phrase, response_headers->headers());
 
-        on_headers_received->function()(response_headers, move(status_code), reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
+        on_headers_received->function()(&protocol_request, response_headers, move(status_code), reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
     };
 
     auto protocol_data_received = [on_data_received = move(on_data_received), request, request_id = protocol_request->id()](auto data) {
@@ -490,10 +490,13 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
     };
 
     protocol_request->set_unbuffered_request_callbacks(move(protocol_headers_received), move(protocol_data_received), move(protocol_cached_body_available), move(protocol_complete));
+    protocol_request->set_stop_callback([this, &protocol_request = *protocol_request] {
+        finish_network_request(protocol_request);
+    });
     return protocol_request;
 }
 
-RefPtr<Requests::Request> ResourceLoader::start_network_request(LoadRequest const& request)
+RefPtr<Requests::Request> ResourceLoader::start_network_request(LoadRequest const& request, Requests::RequestClient::KeepAliveForTransfer keep_alive_for_transfer)
 {
     auto proxy = ProxyMappings::the().proxy_for_url(request.url().value());
 
@@ -503,7 +506,7 @@ RefPtr<Requests::Request> ResourceLoader::start_network_request(LoadRequest cons
         return nullptr;
     }
 
-    auto protocol_request = m_request_client->start_request(request.method(), request.url().value(), request.headers(), request.body(), request.cache_mode(), request.include_credentials(), proxy);
+    auto protocol_request = m_request_client->start_request(request.method(), request.url().value(), request.headers(), request.body(), request.cache_mode(), request.include_credentials(), proxy, keep_alive_for_transfer);
     if (!protocol_request) {
         log_failure(request, "Failed to initiate load"sv);
         return nullptr;

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -16,6 +16,7 @@
 #include <LibHTTP/HeaderList.h>
 #include <LibRequests/Forward.h>
 #include <LibRequests/Request.h>
+#include <LibRequests/RequestClient.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
@@ -33,12 +34,12 @@ public:
 
     void set_client(NonnullRefPtr<Requests::RequestClient>);
 
-    using OnHeadersReceived = GC::Function<void(HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
+    using OnHeadersReceived = GC::Function<void(Requests::Request*, HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
     using OnDataReceived = GC::Function<void(Requests::ResponseData data)>;
     using OnCachedBodyAvailable = GC::Function<void(Core::ImmutableBytes data)>;
     using OnComplete = GC::Function<void(bool success, Requests::RequestTimingInfo const& timing_info, Optional<StringView> error_message)>;
 
-    RefPtr<Requests::Request> load(LoadRequest&, GC::Root<OnHeadersReceived>, GC::Root<OnDataReceived>, GC::Root<OnCachedBodyAvailable>, GC::Root<OnComplete>);
+    RefPtr<Requests::Request> load(LoadRequest&, GC::Root<OnHeadersReceived>, GC::Root<OnDataReceived>, GC::Root<OnCachedBodyAvailable>, GC::Root<OnComplete>, Requests::RequestClient::KeepAliveForTransfer = Requests::RequestClient::KeepAliveForTransfer::No);
 
     RefPtr<Requests::RequestClient>& request_client() { return m_request_client; }
 
@@ -86,7 +87,7 @@ private:
     template<typename ResourceHandler, typename ErrorHandler>
     void handle_resource_load_request(LoadRequest const& request, ResourceHandler on_resource, ErrorHandler on_error);
 
-    RefPtr<Requests::Request> start_network_request(LoadRequest const&);
+    RefPtr<Requests::Request> start_network_request(LoadRequest const&, Requests::RequestClient::KeepAliveForTransfer);
     void handle_network_response_headers(LoadRequest const&, HTTP::HeaderList const&);
     void finish_network_request(NonnullRefPtr<Requests::Request>);
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -501,6 +501,12 @@ public:
         (void)initial_data;
         return {};
     }
+    virtual Optional<u64> page_did_start_download(URL::URL const&, ByteString const& suggested_filename, Optional<u64> total_size)
+    {
+        (void)suggested_filename;
+        (void)total_size;
+        return {};
+    }
     virtual void page_did_receive_download_data([[maybe_unused]] u64 download_id, [[maybe_unused]] ByteBuffer data) { }
     virtual void page_did_finish_download([[maybe_unused]] u64 download_id) { }
     virtual void page_did_fail_download([[maybe_unused]] u64 download_id, [[maybe_unused]] String const& error) { }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/JsonValue.h>
 #include <AK/Queue.h>
 #include <AK/Variant.h>
@@ -491,6 +492,22 @@ public:
     virtual void page_did_create_new_document(Web::DOM::Document&) { }
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) { }
     virtual void page_did_finish_loading(URL::URL const&) { }
+    virtual Optional<u64> page_did_start_download(URL::URL const&, ByteString const& suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data)
+    {
+        (void)suggested_filename;
+        (void)total_size;
+        (void)request_server_client_id;
+        (void)request_server_request_id;
+        (void)initial_data;
+        return {};
+    }
+    virtual void page_did_receive_download_data([[maybe_unused]] u64 download_id, [[maybe_unused]] ByteBuffer data) { }
+    virtual void page_did_finish_download([[maybe_unused]] u64 download_id) { }
+    virtual void page_did_fail_download([[maybe_unused]] u64 download_id, [[maybe_unused]] String const& error) { }
+    virtual void page_did_register_download_controller([[maybe_unused]] u64 download_id, [[maybe_unused]] GC::Ref<Fetch::Infrastructure::FetchController>) { }
+    virtual void page_did_register_download_reader([[maybe_unused]] u64 download_id, [[maybe_unused]] GC::Ref<Streams::ReadableStreamDefaultReader>) { }
+    virtual void page_did_unregister_download([[maybe_unused]] u64 download_id) { }
+    virtual bool page_is_download_canceled([[maybe_unused]] u64 download_id) const { return false; }
     virtual void page_did_request_cursor_change(Gfx::Cursor const&) { }
     virtual void page_did_request_context_menu(CSSPixelPoint, ContextMenuForInputEventsTarget) { }
     virtual void page_did_request_link_context_menu(CSSPixelPoint, URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -10,6 +10,7 @@
 #include <AK/JsonObject.h>
 #include <AK/Math.h>
 #include <AK/ScopeGuard.h>
+#include <AK/StringBuilder.h>
 #include <AK/Time.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ArgsParser.h>
@@ -1209,10 +1210,23 @@ void Application::process_did_exit(Process&& process, Optional<int> exit_status)
     }
 }
 
+static bool download_path_is_available(LexicalPath const& path)
+{
+    if (FileSystem::exists(path.string()))
+        return false;
+
+    for (auto const& download : Application::the().file_downloader().downloads()) {
+        if (download.status == FileDownloader::DownloadStatus::InProgress && download.destination.string() == path.string())
+            return false;
+    }
+
+    return true;
+}
+
 static LexicalPath unique_download_path(ByteString const& downloads_directory, ByteString const& file)
 {
     auto destination = LexicalPath::join(downloads_directory, file.view());
-    if (!FileSystem::exists(destination.string()))
+    if (download_path_is_available(destination))
         return destination;
 
     auto lexical_file = LexicalPath { file };
@@ -1223,9 +1237,27 @@ static LexicalPath unique_download_path(ByteString const& downloads_directory, B
             ? ByteString::formatted("{} ({})", title, index)
             : ByteString::formatted("{} ({}).{}", title, index, extension);
         auto candidate = LexicalPath::join(downloads_directory, candidate_filename.view());
-        if (!FileSystem::exists(candidate.string()))
+        if (download_path_is_available(candidate))
             return candidate;
     }
+}
+
+static ByteString sanitize_suggested_download_filename(ByteString filename)
+{
+    filename = LexicalPath::basename(move(filename));
+
+    StringBuilder builder;
+    for (auto byte : filename.bytes()) {
+        if (byte == '\0' || byte == '/' || byte == '\\')
+            builder.append('_');
+        else
+            builder.append(static_cast<char>(byte));
+    }
+
+    auto sanitized = builder.to_byte_string();
+    if (sanitized.is_empty() || sanitized == "."sv || sanitized == ".."sv)
+        return "download";
+    return sanitized;
 }
 
 ErrorOr<LexicalPath> Application::default_path_for_downloaded_file(ByteString const& file) const
@@ -1237,7 +1269,7 @@ ErrorOr<LexicalPath> Application::default_path_for_downloaded_file(ByteString co
         return Error::from_errno(ENOENT);
     }
 
-    return unique_download_path(downloads_directory, file);
+    return unique_download_path(downloads_directory, sanitize_suggested_download_filename(file));
 }
 
 ErrorOr<LexicalPath> Application::path_for_downloaded_file(ByteString const& file) const
@@ -1245,7 +1277,7 @@ ErrorOr<LexicalPath> Application::path_for_downloaded_file(ByteString const& fil
     if (browser_options().headless_mode.has_value())
         return default_path_for_downloaded_file(file);
 
-    auto download_path = ask_user_for_download_path(file);
+    auto download_path = ask_user_for_download_path(sanitize_suggested_download_filename(file));
     if (!download_path.has_value())
         return Error::from_errno(ECANCELED);
 
@@ -1260,6 +1292,21 @@ void Application::display_download_confirmation_dialog(StringView download_name,
 void Application::display_error_dialog(StringView error_message) const
 {
     warnln("{}", error_message);
+}
+
+static ErrorOr<String> download_path_for_frontend_action(LexicalPath const& path)
+{
+    return String::from_utf8(path.string().view());
+}
+
+ErrorOr<String> Application::download_file_path_for_frontend_action(FileDownloader::Download const& download) const
+{
+    return download_path_for_frontend_action(download.destination);
+}
+
+ErrorOr<String> Application::download_directory_path_for_frontend_action(FileDownloader::Download const& download) const
+{
+    return download_path_for_frontend_action(LexicalPath { download.destination.dirname() });
 }
 
 void Application::open_download(FileDownloader::Download const& download) const

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1209,7 +1209,7 @@ void Application::process_did_exit(Process&& process, Optional<int> exit_status)
     }
 }
 
-ErrorOr<LexicalPath> Application::path_for_downloaded_file(StringView file) const
+ErrorOr<LexicalPath> Application::path_for_downloaded_file(ByteString const& file) const
 {
     if (browser_options().headless_mode.has_value()) {
         auto downloads_directory = Core::StandardPaths::downloads_directory();
@@ -1219,7 +1219,7 @@ ErrorOr<LexicalPath> Application::path_for_downloaded_file(StringView file) cons
             return Error::from_errno(ENOENT);
         }
 
-        return LexicalPath::join(downloads_directory, file);
+        return LexicalPath::join(downloads_directory, file.view());
     }
 
     auto download_path = ask_user_for_download_path(file);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -128,6 +128,9 @@ Application::~Application()
     if (m_compositor_client)
         m_compositor_client->on_death = nullptr;
 
+    m_spare_web_content_process = nullptr;
+    m_process_manager = nullptr;
+
     s_the = nullptr;
 }
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1262,6 +1262,16 @@ void Application::display_error_dialog(StringView error_message) const
     warnln("{}", error_message);
 }
 
+void Application::open_download(FileDownloader::Download const& download) const
+{
+    outln("Open downloaded file: {}", download.destination);
+}
+
+void Application::show_download_in_folder(FileDownloader::Download const& download) const
+{
+    outln("Show downloaded file in folder: {}", download.destination);
+}
+
 bool Application::supports_clipboard_type(ClipboardType type) const
 {
     return type == ClipboardType::Text;
@@ -1414,6 +1424,10 @@ void Application::initialize_actions()
 
     m_open_about_page_action = Action::create("About Ladybird"sv, ActionID::OpenAboutPage, [this]() {
         open_url_in_new_tab(URL::about_version(), Web::HTML::ActivateTab::Yes);
+    });
+    m_open_downloads_page_action = Action::create("Downloads"sv, ActionID::ViewDownloads, [this]() {
+        if (!activate_tab_with_url(URL::about_downloads()))
+            open_url_in_new_tab(URL::about_downloads(), Web::HTML::ActivateTab::Yes);
     });
     m_open_settings_page_action = Action::create("Settings"sv, ActionID::OpenSettingsPage, [this]() {
         open_url_in_new_tab(URL::about_settings(), Web::HTML::ActivateTab::Yes);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1209,18 +1209,41 @@ void Application::process_did_exit(Process&& process, Optional<int> exit_status)
     }
 }
 
+static LexicalPath unique_download_path(ByteString const& downloads_directory, ByteString const& file)
+{
+    auto destination = LexicalPath::join(downloads_directory, file.view());
+    if (!FileSystem::exists(destination.string()))
+        return destination;
+
+    auto lexical_file = LexicalPath { file };
+    auto title = lexical_file.title();
+    auto extension = lexical_file.extension();
+    for (u64 index = 1;; ++index) {
+        auto candidate_filename = extension.is_empty()
+            ? ByteString::formatted("{} ({})", title, index)
+            : ByteString::formatted("{} ({}).{}", title, index, extension);
+        auto candidate = LexicalPath::join(downloads_directory, candidate_filename.view());
+        if (!FileSystem::exists(candidate.string()))
+            return candidate;
+    }
+}
+
+ErrorOr<LexicalPath> Application::default_path_for_downloaded_file(ByteString const& file) const
+{
+    auto downloads_directory = Core::StandardPaths::downloads_directory();
+
+    if (!FileSystem::is_directory(downloads_directory)) {
+        dbgln("Unable to find download folder, please ensure {} is a directory or use the XDG_DOWNLOAD_DIR environment variable to set a new download directory", downloads_directory);
+        return Error::from_errno(ENOENT);
+    }
+
+    return unique_download_path(downloads_directory, file);
+}
+
 ErrorOr<LexicalPath> Application::path_for_downloaded_file(ByteString const& file) const
 {
-    if (browser_options().headless_mode.has_value()) {
-        auto downloads_directory = Core::StandardPaths::downloads_directory();
-
-        if (!FileSystem::is_directory(downloads_directory)) {
-            dbgln("Unable to ask user for download folder in headless mode, please ensure {} is a directory or use the XDG_DOWNLOAD_DIR environment variable to set a new download directory", downloads_directory);
-            return Error::from_errno(ENOENT);
-        }
-
-        return LexicalPath::join(downloads_directory, file.view());
-    }
+    if (browser_options().headless_mode.has_value())
+        return default_path_for_downloaded_file(file);
 
     auto download_path = ask_user_for_download_path(file);
     if (!download_path.has_value())

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -132,7 +132,7 @@ public:
 
     virtual bool should_capture_web_content_output() const { return false; }
 
-    ErrorOr<LexicalPath> path_for_downloaded_file(StringView file) const;
+    ErrorOr<LexicalPath> path_for_downloaded_file(ByteString const& file) const;
 
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const;
     virtual void display_error_dialog(StringView error_message) const;
@@ -223,7 +223,7 @@ protected:
     virtual void create_platform_options(BrowserOptions&, RequestServerOptions&, WebContentOptions&) { }
     virtual Core::EventLoop& create_platform_event_loop();
 
-    virtual Optional<ByteString> ask_user_for_download_path([[maybe_unused]] StringView file) const { return {}; }
+    virtual Optional<ByteString> ask_user_for_download_path([[maybe_unused]] ByteString const& file) const { return {}; }
 
     virtual void update_tabs_display() const { }
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -132,6 +132,7 @@ public:
 
     virtual bool should_capture_web_content_output() const { return false; }
 
+    ErrorOr<LexicalPath> default_path_for_downloaded_file(ByteString const& file) const;
     ErrorOr<LexicalPath> path_for_downloaded_file(ByteString const& file) const;
 
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -137,6 +137,8 @@ public:
 
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const;
     virtual void display_error_dialog(StringView error_message) const;
+    ErrorOr<String> download_file_path_for_frontend_action(FileDownloader::Download const&) const;
+    ErrorOr<String> download_directory_path_for_frontend_action(FileDownloader::Download const&) const;
     virtual void open_download(FileDownloader::Download const&) const;
     virtual void show_download_in_folder(FileDownloader::Download const&) const;
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -137,6 +137,8 @@ public:
 
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const;
     virtual void display_error_dialog(StringView error_message) const;
+    virtual void open_download(FileDownloader::Download const&) const;
+    virtual void show_download_in_folder(FileDownloader::Download const&) const;
 
     // FIXME: We should implement UI-agnostic platform APIs to interact with the system clipboard.
     enum class ClipboardType : u8 {
@@ -179,6 +181,7 @@ public:
     Action& select_all_action() { return *m_select_all_action; }
 
     Action& open_about_page_action() { return *m_open_about_page_action; }
+    Action& open_downloads_page_action() { return *m_open_downloads_page_action; }
     Action& open_settings_page_action() { return *m_open_settings_page_action; }
 
     Menu& zoom_menu() { return *m_zoom_menu; }
@@ -394,6 +397,7 @@ private:
     RefPtr<Action> m_select_all_action;
 
     RefPtr<Action> m_open_about_page_action;
+    RefPtr<Action> m_open_downloads_page_action;
     RefPtr<Action> m_open_settings_page_action;
 
     RefPtr<Menu> m_zoom_menu;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES
     WorkerProcessManager.cpp
     WebUI.cpp
     WebUI/BookmarksUI.cpp
+    WebUI/DownloadsUI.cpp
     WebUI/HistoryUI.cpp
     WebUI/ProcessesUI.cpp
     WebUI/SettingsUI.cpp

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Random.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
@@ -44,7 +45,7 @@ FileDownloader::~FileDownloader() = default;
 
 static LexicalPath temporary_destination_for(LexicalPath const& destination, u64 download_id)
 {
-    return LexicalPath { ByteString::formatted("{}.{}.download", destination.string(), download_id) };
+    return LexicalPath { ByteString::formatted("{}.{}.{}.download", destination.string(), download_id, generate_random_uuid()) };
 }
 
 static String status_to_error_string(Optional<Requests::NetworkError> const& network_error, Optional<u32> response_code, Optional<String> const& reason_phrase)
@@ -166,7 +167,7 @@ u64 FileDownloader::start_download(URL::URL const& url, LexicalPath destination,
     notify_download_added(download);
 
     auto temporary_destination = temporary_destination_for(download.destination, download_id);
-    auto file_or_error = Core::File::open(temporary_destination.string(), Core::File::OpenMode::Write);
+    auto file_or_error = Core::File::open(temporary_destination.string(), Core::File::OpenMode::Write | Core::File::OpenMode::MustBeNew);
     if (file_or_error.is_error()) {
         fail_download(download_id, MUST(String::formatted("Unable to save downloaded file: {}", file_or_error.error())));
         return download_id;
@@ -273,6 +274,26 @@ void FileDownloader::set_cancel_callback(u64 id, Function<void()> on_cancel)
         active->on_cancel = move(on_cancel);
 }
 
+void FileDownloader::discard_active_download(u64 id)
+{
+    auto* active = active_download(id);
+    if (!active)
+        return;
+
+    active->stopped = true;
+    if (active->request)
+        active->request->stop();
+    if (active->on_cancel)
+        active->on_cancel();
+
+    active->file = nullptr;
+    (void)Core::System::unlink(active->temporary_destination.string());
+
+    Core::deferred_invoke([this, id] {
+        m_active_downloads.remove(id);
+    });
+}
+
 void FileDownloader::cancel_active_downloads()
 {
     Vector<u64> active_download_ids;
@@ -294,20 +315,7 @@ void FileDownloader::cancel_download(u64 id)
     download->status = DownloadStatus::Canceled;
     download->error = {};
 
-    if (auto* active = active_download(id)) {
-        active->stopped = true;
-        if (active->request)
-            active->request->stop();
-        if (active->on_cancel)
-            active->on_cancel();
-
-        active->file = nullptr;
-        (void)Core::System::unlink(active->temporary_destination.string());
-
-        Core::deferred_invoke([this, id] {
-            m_active_downloads.remove(id);
-        });
-    }
+    discard_active_download(id);
 
     notify_download_updated(*download);
 }
@@ -321,15 +329,7 @@ void FileDownloader::fail_download(u64 id, String error)
     download->status = DownloadStatus::Failed;
     download->error = move(error);
 
-    if (auto* active = active_download(id)) {
-        active->stopped = true;
-        active->file = nullptr;
-        (void)Core::System::unlink(active->temporary_destination.string());
-
-        Core::deferred_invoke([this, id] {
-            m_active_downloads.remove(id);
-        });
-    }
+    discard_active_download(id);
 
     notify_download_updated(*download);
 }

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
+#include <LibCore/System.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
@@ -14,19 +16,58 @@
 
 namespace WebView {
 
+struct FileDownloader::ActiveDownload {
+    ActiveDownload(NonnullRefPtr<Requests::Request> request, NonnullOwnPtr<Core::File> file, LexicalPath temporary_destination)
+        : request(move(request))
+        , file(move(file))
+        , temporary_destination(move(temporary_destination))
+    {
+    }
+
+    NonnullRefPtr<Requests::Request> request;
+    OwnPtr<Core::File> file;
+    LexicalPath temporary_destination;
+    bool failed { false };
+};
+
 FileDownloader::FileDownloader() = default;
 FileDownloader::~FileDownloader() = default;
 
-static ErrorOr<void> save_file(LexicalPath const& destination, ReadonlyBytes data)
+static LexicalPath temporary_destination_for(LexicalPath const& destination)
 {
-    auto file = TRY(Core::File::open(destination.string(), Core::File::OpenMode::Write));
-    TRY(file->write_until_depleted(data));
-    return {};
+    return LexicalPath { ByteString::formatted("{}.download", destination.string()) };
 }
 
-void FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
+static String status_to_error_string(Optional<Requests::NetworkError> const& network_error, Optional<u32> response_code, Optional<String> const& reason_phrase)
 {
-    static u64 next_request_id = 0;
+    if (network_error.has_value())
+        return MUST(String::formatted("Unable to download file: {}", Requests::network_error_to_string(*network_error)));
+
+    VERIFY(response_code.has_value());
+    if (reason_phrase.has_value())
+        return MUST(String::formatted("Received error response code {} while downloading file: {}", *response_code, *reason_phrase));
+    return MUST(String::formatted("Received error response code {} while downloading file", *response_code));
+}
+
+u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
+{
+    auto download_id = m_next_download_id++;
+
+    m_downloads.append(Download {
+        .id = download_id,
+        .url = url,
+        .destination = move(destination),
+    });
+    auto& download = m_downloads.last();
+    notify_download_added(download);
+
+    auto temporary_destination = temporary_destination_for(download.destination);
+    auto file_or_error = Core::File::open(temporary_destination.string(), Core::File::OpenMode::Write);
+    if (file_or_error.is_error()) {
+        fail_download(download_id, MUST(String::formatted("Unable to save downloaded file: {}", file_or_error.error())));
+        return download_id;
+    }
+    auto file = file_or_error.release_value();
 
     // FIXME: What other request headers should be set? Perhaps we want to use exactly the same request headers used to
     //        originally fetch the image in WebContent.
@@ -35,38 +76,159 @@ void FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
 
     auto request = Application::request_server_client().start_request("GET"sv, url, *request_headers);
     if (!request) {
-        Application::the().display_error_dialog("Unable to start request to download file"sv);
-        return;
+        file->close();
+        (void)Core::System::unlink(temporary_destination.string());
+        fail_download(download_id, "Unable to start request to download file"_string);
+        return download_id;
     }
 
-    auto request_id = next_request_id++;
+    auto request_ref = request.release_nonnull();
+    auto active_download_state = make<ActiveDownload>(request_ref, move(file), temporary_destination);
+    m_active_downloads.set(download_id, move(active_download_state));
 
-    request->set_buffered_request_finished_callback(
-        [this, request_id, destination = move(destination)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const&, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Core::ImmutableBytes payload) {
-            Core::deferred_invoke([this, request_id]() { m_requests.remove(request_id); });
+    request_ref->set_unbuffered_request_callbacks(
+        [this, download_id](NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>) {
+            auto& download = mutable_download(download_id);
 
-            if (network_error.has_value()) {
-                auto error = MUST(String::formatted("Unable to download file: {}", Requests::network_error_to_string(*network_error)));
-                Application::the().display_error_dialog(error);
-                return;
-            }
+            auto extracted_length = response_headers->extract_length();
+            if (extracted_length.has<u64>())
+                download.total_size = extracted_length.get<u64>();
+
             if (response_code.has_value() && *response_code >= 400) {
-                auto error = reason_phrase.has_value()
-                    ? MUST(String::formatted("Received error response code {} while downloading file: {}", *response_code, reason_phrase))
-                    : MUST(String::formatted("Received error response code {} while downloading file", *response_code));
-                Application::the().display_error_dialog(error);
+                auto error = status_to_error_string({}, response_code, reason_phrase);
+                fail_download(download_id, move(error));
                 return;
             }
 
-            if (auto result = save_file(destination, payload.bytes()); result.is_error()) {
-                auto error = MUST(String::formatted("Unable to save downloaded file file: {}", result.error()));
-                Application::the().display_error_dialog(error);
+            notify_download_updated(download);
+        },
+        [this, download_id](Requests::ResponseData data) {
+            auto* active = active_download(download_id);
+            if (!active || active->failed)
+                return;
+
+            auto& download = mutable_download(download_id);
+            auto bytes = data.bytes();
+
+            if (auto result = active->file->write_until_depleted(bytes); result.is_error()) {
+                fail_download(download_id, MUST(String::formatted("Unable to save downloaded file: {}", result.error())));
+                return;
             }
 
-            // FIXME: Add a UI element (i.e. a download manager) to indicate download completion.
+            download.downloaded_size += bytes.size();
+            notify_download_updated(download);
+        },
+        [](Core::ImmutableBytes) {
+        },
+        [this, download_id](u64 total_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> network_error) {
+            auto& download = mutable_download(download_id);
+            download.total_size = total_size;
+
+            auto* active = active_download(download_id);
+            if (!active) {
+                notify_download_updated(download);
+                return;
+            }
+
+            active->file = nullptr;
+
+            if (network_error.has_value())
+                fail_download(download_id, status_to_error_string(network_error, {}, {}));
+
+            if (!active->failed) {
+                if (auto result = Core::System::rename(active->temporary_destination.string(), download.destination.string()); result.is_error()) {
+                    fail_download(download_id, MUST(String::formatted("Unable to save downloaded file: {}", result.error())));
+                } else {
+                    download.status = DownloadStatus::Completed;
+                    download.downloaded_size = total_size;
+                    notify_download_updated(download);
+                }
+            }
+
+            Core::deferred_invoke([this, download_id] {
+                m_active_downloads.remove(download_id);
+            });
         });
 
-    m_requests.set(request_id, request.release_nonnull());
+    return download_id;
+}
+
+Optional<FileDownloader::Download const&> FileDownloader::download(u64 id) const
+{
+    for (auto const& download : m_downloads) {
+        if (download.id == id)
+            return download;
+    }
+    return {};
+}
+
+FileDownloader::Download& FileDownloader::mutable_download(u64 id)
+{
+    for (auto& download : m_downloads) {
+        if (download.id == id)
+            return download;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+FileDownloader::ActiveDownload* FileDownloader::active_download(u64 id)
+{
+    if (auto active_download = m_active_downloads.get(id); active_download.has_value())
+        return active_download.value();
+    return nullptr;
+}
+
+void FileDownloader::fail_download(u64 id, String error)
+{
+    auto& download = mutable_download(id);
+    if (download.status != DownloadStatus::InProgress)
+        return;
+
+    download.status = DownloadStatus::Failed;
+    download.error = move(error);
+
+    if (auto* active = active_download(id)) {
+        active->failed = true;
+        active->file = nullptr;
+        (void)Core::System::unlink(active->temporary_destination.string());
+    }
+
+    notify_download_updated(download);
+}
+
+void FileDownloader::notify_download_added(Download const& download)
+{
+    for (auto& observer : m_observers)
+        observer.download_added(download);
+}
+
+void FileDownloader::notify_download_updated(Download const& download)
+{
+    for (auto& observer : m_observers)
+        observer.download_updated(download);
+}
+
+void FileDownloader::add_observer(Badge<FileDownloaderObserver>, FileDownloaderObserver& observer)
+{
+    Application::the().file_downloader().m_observers.append(observer);
+}
+
+void FileDownloader::remove_observer(Badge<FileDownloaderObserver>, FileDownloaderObserver& observer)
+{
+    auto was_removed = Application::the().file_downloader().m_observers.remove_first_matching([&](auto const& candidate) {
+        return &candidate == &observer;
+    });
+    VERIFY(was_removed);
+}
+
+FileDownloaderObserver::FileDownloaderObserver()
+{
+    FileDownloader::add_observer({}, *this);
+}
+
+FileDownloaderObserver::~FileDownloaderObserver()
+{
+    FileDownloader::remove_observer({}, *this);
 }
 
 }

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/ElapsedTimer.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
@@ -17,6 +18,12 @@
 namespace WebView {
 
 struct FileDownloader::ActiveDownload {
+    ActiveDownload(NonnullOwnPtr<Core::File> file, LexicalPath temporary_destination)
+        : file(move(file))
+        , temporary_destination(move(temporary_destination))
+    {
+    }
+
     ActiveDownload(NonnullRefPtr<Requests::Request> request, NonnullOwnPtr<Core::File> file, LexicalPath temporary_destination)
         : request(move(request))
         , file(move(file))
@@ -24,18 +31,20 @@ struct FileDownloader::ActiveDownload {
     {
     }
 
-    NonnullRefPtr<Requests::Request> request;
+    RefPtr<Requests::Request> request;
+    Function<void()> on_cancel;
     OwnPtr<Core::File> file;
     LexicalPath temporary_destination;
-    bool failed { false };
+    Core::ElapsedTimer progress_update_timer;
+    bool stopped { false };
 };
 
 FileDownloader::FileDownloader() = default;
 FileDownloader::~FileDownloader() = default;
 
-static LexicalPath temporary_destination_for(LexicalPath const& destination)
+static LexicalPath temporary_destination_for(LexicalPath const& destination, u64 download_id)
 {
-    return LexicalPath { ByteString::formatted("{}.download", destination.string()) };
+    return LexicalPath { ByteString::formatted("{}.{}.download", destination.string(), download_id) };
 }
 
 static String status_to_error_string(Optional<Requests::NetworkError> const& network_error, Optional<u32> response_code, Optional<String> const& reason_phrase)
@@ -51,23 +60,10 @@ static String status_to_error_string(Optional<Requests::NetworkError> const& net
 
 u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
 {
-    auto download_id = m_next_download_id++;
-
-    m_downloads.append(Download {
-        .id = download_id,
-        .url = url,
-        .destination = move(destination),
-    });
-    auto& download = m_downloads.last();
-    notify_download_added(download);
-
-    auto temporary_destination = temporary_destination_for(download.destination);
-    auto file_or_error = Core::File::open(temporary_destination.string(), Core::File::OpenMode::Write);
-    if (file_or_error.is_error()) {
-        fail_download(download_id, MUST(String::formatted("Unable to save downloaded file: {}", file_or_error.error())));
+    auto download_id = start_download(url, move(destination));
+    auto* active = active_download(download_id);
+    if (!active)
         return download_id;
-    }
-    auto file = file_or_error.release_value();
 
     // FIXME: What other request headers should be set? Perhaps we want to use exactly the same request headers used to
     //        originally fetch the image in WebContent.
@@ -76,23 +72,57 @@ u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
 
     auto request = Application::request_server_client().start_request("GET"sv, url, *request_headers);
     if (!request) {
-        file->close();
-        (void)Core::System::unlink(temporary_destination.string());
         fail_download(download_id, "Unable to start request to download file"_string);
         return download_id;
     }
 
     auto request_ref = request.release_nonnull();
-    auto active_download_state = make<ActiveDownload>(request_ref, move(file), temporary_destination);
-    m_active_downloads.set(download_id, move(active_download_state));
+    attach_request_to_download(download_id, request_ref);
 
-    request_ref->set_unbuffered_request_callbacks(
+    return download_id;
+}
+
+u64 FileDownloader::adopt_download(URL::URL const& url, LexicalPath destination, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ReadonlyBytes initial_data)
+{
+    auto download_id = start_download(url, move(destination), total_size);
+    auto* active = active_download(download_id);
+    if (!active)
+        return download_id;
+
+    if (!initial_data.is_empty()) {
+        append_download_data(download_id, initial_data);
+        auto download = this->download(download_id);
+        if (!download.has_value() || download->status != DownloadStatus::InProgress)
+            return download_id;
+    }
+
+    auto request = Application::request_server_client().adopt_request(request_server_client_id, request_server_request_id);
+    if (!request) {
+        fail_download(download_id, "Unable to adopt request to download file"_string);
+        return download_id;
+    }
+
+    attach_request_to_download(download_id, request.release_nonnull());
+    return download_id;
+}
+
+void FileDownloader::attach_request_to_download(u64 download_id, NonnullRefPtr<Requests::Request> request)
+{
+    auto* active = active_download(download_id);
+    if (!active)
+        return;
+
+    active->request = request;
+
+    request->set_unbuffered_request_callbacks(
         [this, download_id](NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>) {
-            auto& download = mutable_download(download_id);
+            auto* download = mutable_download_or_null(download_id);
+            if (!download)
+                return;
 
             auto extracted_length = response_headers->extract_length();
             if (extracted_length.has<u64>())
-                download.total_size = extracted_length.get<u64>();
+                download->total_size = extracted_length.get<u64>();
 
             if (response_code.has_value() && *response_code >= 400) {
                 auto error = status_to_error_string({}, response_code, reason_phrase);
@@ -100,57 +130,116 @@ u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
                 return;
             }
 
-            notify_download_updated(download);
+            notify_download_updated(*download);
         },
         [this, download_id](Requests::ResponseData data) {
-            auto* active = active_download(download_id);
-            if (!active || active->failed)
-                return;
-
-            auto& download = mutable_download(download_id);
-            auto bytes = data.bytes();
-
-            if (auto result = active->file->write_until_depleted(bytes); result.is_error()) {
-                fail_download(download_id, MUST(String::formatted("Unable to save downloaded file: {}", result.error())));
-                return;
-            }
-
-            download.downloaded_size += bytes.size();
-            notify_download_updated(download);
+            append_download_data(download_id, data.bytes());
         },
         [](Core::ImmutableBytes) {
         },
         [this, download_id](u64 total_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> network_error) {
-            auto& download = mutable_download(download_id);
-            download.total_size = total_size;
-
-            auto* active = active_download(download_id);
-            if (!active) {
-                notify_download_updated(download);
+            auto* download = mutable_download_or_null(download_id);
+            if (!download)
                 return;
-            }
 
-            active->file = nullptr;
+            download->total_size = total_size;
 
             if (network_error.has_value())
                 fail_download(download_id, status_to_error_string(network_error, {}, {}));
-
-            if (!active->failed) {
-                if (auto result = Core::System::rename(active->temporary_destination.string(), download.destination.string()); result.is_error()) {
-                    fail_download(download_id, MUST(String::formatted("Unable to save downloaded file: {}", result.error())));
-                } else {
-                    download.status = DownloadStatus::Completed;
-                    download.downloaded_size = total_size;
-                    notify_download_updated(download);
-                }
-            }
-
-            Core::deferred_invoke([this, download_id] {
-                m_active_downloads.remove(download_id);
-            });
+            else
+                finish_download(download_id);
         });
+}
+
+u64 FileDownloader::start_download(URL::URL const& url, LexicalPath destination, Optional<u64> total_size)
+{
+    auto download_id = m_next_download_id++;
+
+    m_downloads.append(Download {
+        .id = download_id,
+        .url = url,
+        .destination = move(destination),
+        .total_size = total_size,
+        .error = {},
+    });
+    auto& download = m_downloads.last();
+    notify_download_added(download);
+
+    auto temporary_destination = temporary_destination_for(download.destination, download_id);
+    auto file_or_error = Core::File::open(temporary_destination.string(), Core::File::OpenMode::Write);
+    if (file_or_error.is_error()) {
+        fail_download(download_id, MUST(String::formatted("Unable to save downloaded file: {}", file_or_error.error())));
+        return download_id;
+    }
+    auto file = file_or_error.release_value();
+
+    m_active_downloads.set(download_id, make<ActiveDownload>(move(file), temporary_destination));
 
     return download_id;
+}
+
+bool FileDownloader::has_active_downloads() const
+{
+    for (auto const& download : m_downloads) {
+        if (download.status == DownloadStatus::InProgress)
+            return true;
+    }
+
+    return false;
+}
+
+void FileDownloader::append_download_data(u64 id, ReadonlyBytes bytes)
+{
+    constexpr i64 progress_update_interval_ms = 100;
+
+    auto* download = mutable_download_or_null(id);
+    if (!download || download->status != DownloadStatus::InProgress)
+        return;
+
+    auto* active = active_download(id);
+    if (!active || active->stopped)
+        return;
+
+    if (auto result = active->file->write_until_depleted(bytes); result.is_error()) {
+        fail_download(id, MUST(String::formatted("Unable to save downloaded file: {}", result.error())));
+        return;
+    }
+
+    download->downloaded_size += bytes.size();
+    if (active->progress_update_timer.is_valid() && active->progress_update_timer.elapsed_milliseconds() < progress_update_interval_ms)
+        return;
+
+    active->progress_update_timer.start();
+    notify_download_updated(*download);
+}
+
+void FileDownloader::finish_download(u64 id)
+{
+    auto* download = mutable_download_or_null(id);
+    if (!download || download->status != DownloadStatus::InProgress)
+        return;
+
+    auto* active = active_download(id);
+    if (!active) {
+        notify_download_updated(*download);
+        return;
+    }
+
+    active->file = nullptr;
+
+    if (auto result = Core::System::rename(active->temporary_destination.string(), download->destination.string()); result.is_error()) {
+        fail_download(id, MUST(String::formatted("Unable to save downloaded file: {}", result.error())));
+        return;
+    }
+
+    download->status = DownloadStatus::Completed;
+    if (!download->total_size.has_value())
+        download->total_size = download->downloaded_size;
+    notify_download_updated(*download);
+
+    Core::deferred_invoke([this, id] {
+        m_active_downloads.remove(id);
+    });
 }
 
 Optional<FileDownloader::Download const&> FileDownloader::download(u64 id) const
@@ -162,13 +251,13 @@ Optional<FileDownloader::Download const&> FileDownloader::download(u64 id) const
     return {};
 }
 
-FileDownloader::Download& FileDownloader::mutable_download(u64 id)
+FileDownloader::Download* FileDownloader::mutable_download_or_null(u64 id)
 {
     for (auto& download : m_downloads) {
         if (download.id == id)
-            return download;
+            return &download;
     }
-    VERIFY_NOT_REACHED();
+    return nullptr;
 }
 
 FileDownloader::ActiveDownload* FileDownloader::active_download(u64 id)
@@ -178,22 +267,92 @@ FileDownloader::ActiveDownload* FileDownloader::active_download(u64 id)
     return nullptr;
 }
 
-void FileDownloader::fail_download(u64 id, String error)
+void FileDownloader::set_cancel_callback(u64 id, Function<void()> on_cancel)
 {
-    auto& download = mutable_download(id);
-    if (download.status != DownloadStatus::InProgress)
-        return;
+    if (auto* active = active_download(id))
+        active->on_cancel = move(on_cancel);
+}
 
-    download.status = DownloadStatus::Failed;
-    download.error = move(error);
-
-    if (auto* active = active_download(id)) {
-        active->failed = true;
-        active->file = nullptr;
-        (void)Core::System::unlink(active->temporary_destination.string());
+void FileDownloader::cancel_active_downloads()
+{
+    Vector<u64> active_download_ids;
+    for (auto const& download : m_downloads) {
+        if (download.status == DownloadStatus::InProgress)
+            active_download_ids.append(download.id);
     }
 
-    notify_download_updated(download);
+    for (auto id : active_download_ids)
+        cancel_download(id);
+}
+
+void FileDownloader::cancel_download(u64 id)
+{
+    auto* download = mutable_download_or_null(id);
+    if (!download || download->status != DownloadStatus::InProgress)
+        return;
+
+    download->status = DownloadStatus::Canceled;
+    download->error = {};
+
+    if (auto* active = active_download(id)) {
+        active->stopped = true;
+        if (active->request)
+            active->request->stop();
+        if (active->on_cancel)
+            active->on_cancel();
+
+        active->file = nullptr;
+        (void)Core::System::unlink(active->temporary_destination.string());
+
+        Core::deferred_invoke([this, id] {
+            m_active_downloads.remove(id);
+        });
+    }
+
+    notify_download_updated(*download);
+}
+
+void FileDownloader::fail_download(u64 id, String error)
+{
+    auto* download = mutable_download_or_null(id);
+    if (!download || download->status != DownloadStatus::InProgress)
+        return;
+
+    download->status = DownloadStatus::Failed;
+    download->error = move(error);
+
+    if (auto* active = active_download(id)) {
+        active->stopped = true;
+        active->file = nullptr;
+        (void)Core::System::unlink(active->temporary_destination.string());
+
+        Core::deferred_invoke([this, id] {
+            m_active_downloads.remove(id);
+        });
+    }
+
+    notify_download_updated(*download);
+}
+
+Vector<u64> FileDownloader::prune_inactive_downloads()
+{
+    Vector<u64> removed_download_ids;
+
+    for (size_t i = m_downloads.size(); i > 0; --i) {
+        auto const index = i - 1;
+        auto const id = m_downloads[index].id;
+        if (m_downloads[index].status == DownloadStatus::InProgress)
+            continue;
+
+        m_active_downloads.remove(id);
+        m_downloads.remove(index);
+        removed_download_ids.append(id);
+    }
+
+    for (auto id : removed_download_ids)
+        notify_download_removed(id);
+
+    return removed_download_ids;
 }
 
 void FileDownloader::notify_download_added(Download const& download)
@@ -206,6 +365,12 @@ void FileDownloader::notify_download_updated(Download const& download)
 {
     for (auto& observer : m_observers)
         observer.download_updated(download);
+}
+
+void FileDownloader::notify_download_removed(u64 id)
+{
+    for (auto& observer : m_observers)
+        observer.download_removed(id);
 }
 
 void FileDownloader::add_observer(Badge<FileDownloaderObserver>, FileDownloaderObserver& observer)

--- a/Libraries/LibWebView/FileDownloader.h
+++ b/Libraries/LibWebView/FileDownloader.h
@@ -75,6 +75,7 @@ private:
     Download* mutable_download_or_null(u64 id);
     ActiveDownload* active_download(u64 id);
     void attach_request_to_download(u64 id, NonnullRefPtr<Requests::Request>);
+    void discard_active_download(u64 id);
 
     void notify_download_added(Download const&);
     void notify_download_updated(Download const&);

--- a/Libraries/LibWebView/FileDownloader.h
+++ b/Libraries/LibWebView/FileDownloader.h
@@ -6,24 +6,80 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
+#include <AK/OwnPtr.h>
+#include <AK/Span.h>
+#include <AK/String.h>
 #include <LibRequests/Forward.h>
-#include <LibURL/Forward.h>
+#include <LibURL/URL.h>
 #include <LibWebView/Forward.h>
+
+namespace Core {
+
+class File;
+
+}
 
 namespace WebView {
 
+class FileDownloaderObserver;
+
 class WEBVIEW_API FileDownloader {
 public:
+    enum class DownloadStatus : u8 {
+        InProgress,
+        Completed,
+        Failed,
+    };
+
+    struct Download {
+        u64 id { 0 };
+        URL::URL url;
+        LexicalPath destination;
+        DownloadStatus status { DownloadStatus::InProgress };
+        u64 downloaded_size { 0 };
+        Optional<u64> total_size;
+        Optional<String> error;
+    };
+
     FileDownloader();
     ~FileDownloader();
 
-    void download_file(URL::URL const&, LexicalPath);
+    u64 download_file(URL::URL const&, LexicalPath);
+
+    ReadonlySpan<Download> downloads() const { return m_downloads.span(); }
+    Optional<Download const&> download(u64 id) const;
+
+    static void add_observer(Badge<FileDownloaderObserver>, FileDownloaderObserver&);
+    static void remove_observer(Badge<FileDownloaderObserver>, FileDownloaderObserver&);
 
 private:
-    HashMap<u64, NonnullRefPtr<Requests::Request>> m_requests;
+    struct ActiveDownload;
+
+    Download& mutable_download(u64 id);
+    ActiveDownload* active_download(u64 id);
+
+    void fail_download(u64 id, String);
+    void notify_download_added(Download const&);
+    void notify_download_updated(Download const&);
+
+    Vector<Download> m_downloads;
+    HashMap<u64, NonnullOwnPtr<ActiveDownload>> m_active_downloads;
+    Vector<FileDownloaderObserver&> m_observers;
+    u64 m_next_download_id { 0 };
+};
+
+class WEBVIEW_API FileDownloaderObserver {
+public:
+    FileDownloaderObserver();
+    virtual ~FileDownloaderObserver();
+
+    virtual void download_added(FileDownloader::Download const&) { }
+    virtual void download_updated(FileDownloader::Download const&) { }
 };
 
 }

--- a/Libraries/LibWebView/FileDownloader.h
+++ b/Libraries/LibWebView/FileDownloader.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Badge.h>
+#include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
 #include <AK/NonnullRefPtr.h>
@@ -33,6 +34,7 @@ public:
     enum class DownloadStatus : u8 {
         InProgress,
         Completed,
+        Canceled,
         Failed,
     };
 
@@ -50,6 +52,16 @@ public:
     ~FileDownloader();
 
     u64 download_file(URL::URL const&, LexicalPath);
+    u64 adopt_download(URL::URL const&, LexicalPath, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ReadonlyBytes initial_data = {});
+    u64 start_download(URL::URL const&, LexicalPath, Optional<u64> total_size = {});
+    bool has_active_downloads() const;
+    void set_cancel_callback(u64 id, Function<void()>);
+    void append_download_data(u64 id, ReadonlyBytes);
+    void finish_download(u64 id);
+    void cancel_active_downloads();
+    void cancel_download(u64 id);
+    void fail_download(u64 id, String);
+    Vector<u64> prune_inactive_downloads();
 
     ReadonlySpan<Download> downloads() const { return m_downloads.span(); }
     Optional<Download const&> download(u64 id) const;
@@ -60,12 +72,13 @@ public:
 private:
     struct ActiveDownload;
 
-    Download& mutable_download(u64 id);
+    Download* mutable_download_or_null(u64 id);
     ActiveDownload* active_download(u64 id);
+    void attach_request_to_download(u64 id, NonnullRefPtr<Requests::Request>);
 
-    void fail_download(u64 id, String);
     void notify_download_added(Download const&);
     void notify_download_updated(Download const&);
+    void notify_download_removed(u64 id);
 
     Vector<Download> m_downloads;
     HashMap<u64, NonnullOwnPtr<ActiveDownload>> m_active_downloads;
@@ -80,6 +93,7 @@ public:
 
     virtual void download_added(FileDownloader::Download const&) { }
     virtual void download_updated(FileDownloader::Download const&) { }
+    virtual void download_removed(u64) { }
 };
 
 }

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -27,6 +27,7 @@ enum class ActionID {
     NavigateBack,
     NavigateForward,
     Reload,
+    ViewDownloads,
     ViewHistory,
     ClearBrowsingData,
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1642,11 +1642,11 @@ void ViewImplementation::did_start_navigation(URL::URL const& url, Variant<Empty
     dump_session_history("did-start-navigation"sv);
 }
 
-void ViewImplementation::did_cancel_navigation(URL::URL const& url)
+bool ViewImplementation::did_cancel_navigation(URL::URL const& url)
 {
     if (m_pending_session_history_navigation.has_value() && m_pending_session_history_navigation->url == url) {
         restore_pending_session_history_navigation("did-cancel-navigation"sv);
-        return;
+        return true;
     }
 
     if (m_session_history_entry_url_loading_from_ui_process.has_value() && *m_session_history_entry_url_loading_from_ui_process == url) {
@@ -1656,7 +1656,7 @@ void ViewImplementation::did_cancel_navigation(URL::URL const& url)
         m_session_history.forget_web_content_state();
         update_navigation_action_state();
         dump_session_history("did-cancel-ui-history-load"sv);
-        return;
+        return true;
     }
 
     if (m_webdriver_pending_navigation_url.has_value()) {
@@ -1664,9 +1664,11 @@ void ViewImplementation::did_cancel_navigation(URL::URL const& url)
         m_webdriver_pending_navigation_url = m_url;
         m_webdriver_pending_navigation_completes_with_session_history_update = false;
         complete_webdriver_pending_navigation_if_url_matches(m_url);
+        return true;
     }
 
     dump_session_history("did-cancel-navigation-ignored"sv);
+    return false;
 }
 
 void ViewImplementation::did_finish_navigation(URL::URL const& url)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -400,7 +400,7 @@ protected:
 
     void set_url(URL::URL);
     void did_start_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, bool is_redirect, Web::Bindings::NavigationHistoryBehavior);
-    void did_cancel_navigation(URL::URL const&);
+    bool did_cancel_navigation(URL::URL const&);
     void did_finish_navigation(URL::URL const&);
     void complete_webdriver_navigation_completion(u64 request_id, Web::WebDriver::Response);
     void complete_webdriver_pending_navigation_if_url_matches(URL::URL const&);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -54,6 +54,24 @@ static Optional<String> history_title(Utf16String const& title, URL::URL const& 
     return title_utf8;
 }
 
+static Optional<LexicalPath> choose_download_destination_or_report_error(URL::URL const& url, ByteString const& suggested_filename)
+{
+    auto destination = Application::the().default_path_for_downloaded_file(suggested_filename);
+    if (destination.is_error()) {
+        if (!destination.error().is_errno() || destination.error().code() != ECANCELED)
+            Application::the().display_error_dialog(ByteString::formatted("Unable to download {}: {}", url, destination.error()));
+        return {};
+    }
+
+    return destination.release_value();
+}
+
+static bool is_download_in_progress(FileDownloader const& file_downloader, u64 download_id)
+{
+    auto download = file_downloader.download(download_id);
+    return download.has_value() && download->status == FileDownloader::DownloadStatus::InProgress;
+}
+
 WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, u64 initial_page_id)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
     , m_initial_page_id(initial_page_id)
@@ -82,7 +100,7 @@ Optional<WebContentClient&> WebContentClient::client_for_compositor_context_id(W
 
 void WebContentClient::die()
 {
-    // Intentionally empty. Restart is handled at another level.
+    fail_renderer_owned_downloads();
 }
 
 Web::Compositor::CompositorContextId WebContentClient::compositor_context_id_for_page(u64 page_id)
@@ -173,6 +191,31 @@ void WebContentClient::unregister_view(u64 page_id)
     m_views.remove(page_id);
     m_history_recorded_urls_for_current_load.remove(page_id);
     close_server_if_unused();
+}
+
+bool WebContentClient::is_renderer_owned_download(u64 page_id, u64 download_id) const
+{
+    auto owning_page_id = m_renderer_owned_downloads.get(download_id);
+    return owning_page_id.has_value() && *owning_page_id == page_id;
+}
+
+void WebContentClient::forget_renderer_owned_download(u64 download_id)
+{
+    m_renderer_owned_downloads.remove(download_id);
+}
+
+void WebContentClient::fail_renderer_owned_downloads()
+{
+    Vector<u64> download_ids;
+    download_ids.ensure_capacity(m_renderer_owned_downloads.size());
+    for (auto const& entry : m_renderer_owned_downloads)
+        download_ids.append(entry.key);
+
+    m_renderer_owned_downloads.clear();
+
+    auto& file_downloader = Application::the().file_downloader();
+    for (auto download_id : download_ids)
+        file_downloader.fail_download(download_id, "Download process exited"_string);
 }
 
 void WebContentClient::prepare_for_detached_close(u64 page_id)
@@ -512,9 +555,7 @@ void WebContentClient::did_cancel_loading(u64 page_id, URL::URL url)
     m_history_recorded_urls_for_current_load.remove(page_id);
 
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        auto cancel_was_handled = view->did_cancel_navigation(url);
-        if (!cancel_was_handled)
-            return;
+        view->did_cancel_navigation(url);
 
         auto const& client_url = view->url();
         if (view->on_load_finish)
@@ -527,36 +568,69 @@ void WebContentClient::did_cancel_loading(u64 page_id, URL::URL url)
     }
 }
 
+Messages::WebContentClient::DidStartDownloadWithoutRequestResponse WebContentClient::did_start_download_without_request(u64 page_id, URL::URL url, ByteString suggested_filename, Optional<u64> total_size)
+{
+    auto destination = choose_download_destination_or_report_error(url, suggested_filename);
+    if (!destination.has_value())
+        return { Optional<u64> {} };
+
+    auto& file_downloader = Application::the().file_downloader();
+    auto download_id = file_downloader.start_download(url, destination.release_value(), total_size);
+    if (!is_download_in_progress(file_downloader, download_id))
+        return { Optional<u64> {} };
+
+    m_renderer_owned_downloads.set(download_id, page_id);
+
+    auto weak_this = static_cast<Core::EventReceiver&>(*this).make_weak_ptr();
+    file_downloader.set_cancel_callback(download_id, [weak_this, page_id, download_id] {
+        if (!weak_this)
+            return;
+
+        auto& client = static_cast<WebContentClient&>(*weak_this.ptr());
+        client.forget_renderer_owned_download(download_id);
+        client.async_cancel_download(page_id, download_id);
+    });
+
+    return { download_id };
+}
+
 Messages::WebContentClient::DidStartDownloadResponse WebContentClient::did_start_download(u64, URL::URL url, ByteString suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data)
 {
-    auto destination = Application::the().default_path_for_downloaded_file(suggested_filename);
-    if (destination.is_error()) {
-        if (!destination.error().is_errno() || destination.error().code() != ECANCELED)
-            Application::the().display_error_dialog(ByteString::formatted("Unable to download {}: {}", url, destination.error()));
+    auto destination = choose_download_destination_or_report_error(url, suggested_filename);
+    if (!destination.has_value())
         return { Optional<u64> {} };
-    }
 
     auto& file_downloader = Application::the().file_downloader();
     auto download_id = file_downloader.adopt_download(url, destination.release_value(), total_size, request_server_client_id, request_server_request_id, initial_data.bytes());
-    auto download = file_downloader.download(download_id);
-    if (!download.has_value() || download->status != FileDownloader::DownloadStatus::InProgress)
+    if (!is_download_in_progress(file_downloader, download_id))
         return { Optional<u64> {} };
 
     return { download_id };
 }
 
-void WebContentClient::did_receive_download_data(u64, u64 download_id, ByteBuffer data)
+void WebContentClient::did_receive_download_data(u64 page_id, u64 download_id, ByteBuffer data)
 {
+    if (!is_renderer_owned_download(page_id, download_id))
+        return;
+
     Application::the().file_downloader().append_download_data(download_id, data.bytes());
 }
 
-void WebContentClient::did_finish_download(u64, u64 download_id)
+void WebContentClient::did_finish_download(u64 page_id, u64 download_id)
 {
+    if (!is_renderer_owned_download(page_id, download_id))
+        return;
+
+    forget_renderer_owned_download(download_id);
     Application::the().file_downloader().finish_download(download_id);
 }
 
-void WebContentClient::did_fail_download(u64, u64 download_id, String error)
+void WebContentClient::did_fail_download(u64 page_id, u64 download_id, String error)
 {
+    if (!is_renderer_owned_download(page_id, download_id))
+        return;
+
+    forget_renderer_owned_download(download_id);
     Application::the().file_downloader().fail_download(download_id, move(error));
 }
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -511,8 +511,53 @@ void WebContentClient::did_cancel_loading(u64 page_id, URL::URL url)
 {
     m_history_recorded_urls_for_current_load.remove(page_id);
 
-    if (auto view = view_for_page_id(page_id); view.has_value())
-        view->did_cancel_navigation(url);
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        auto cancel_was_handled = view->did_cancel_navigation(url);
+        if (!cancel_was_handled)
+            return;
+
+        auto const& client_url = view->url();
+        if (view->on_load_finish)
+            view->on_load_finish(client_url);
+
+        for (auto const& [id, listener] : view->m_navigation_listeners) {
+            if (listener.on_load_finish)
+                listener.on_load_finish(client_url);
+        }
+    }
+}
+
+Messages::WebContentClient::DidStartDownloadResponse WebContentClient::did_start_download(u64, URL::URL url, ByteString suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data)
+{
+    auto destination = Application::the().default_path_for_downloaded_file(suggested_filename);
+    if (destination.is_error()) {
+        if (!destination.error().is_errno() || destination.error().code() != ECANCELED)
+            Application::the().display_error_dialog(ByteString::formatted("Unable to download {}: {}", url, destination.error()));
+        return { Optional<u64> {} };
+    }
+
+    auto& file_downloader = Application::the().file_downloader();
+    auto download_id = file_downloader.adopt_download(url, destination.release_value(), total_size, request_server_client_id, request_server_request_id, initial_data.bytes());
+    auto download = file_downloader.download(download_id);
+    if (!download.has_value() || download->status != FileDownloader::DownloadStatus::InProgress)
+        return { Optional<u64> {} };
+
+    return { download_id };
+}
+
+void WebContentClient::did_receive_download_data(u64, u64 download_id, ByteBuffer data)
+{
+    Application::the().file_downloader().append_download_data(download_id, data.bytes());
+}
+
+void WebContentClient::did_finish_download(u64, u64 download_id)
+{
+    Application::the().file_downloader().finish_download(download_id);
+}
+
+void WebContentClient::did_fail_download(u64, u64 download_id, String error)
+{
+    Application::the().file_downloader().fail_download(download_id, move(error));
 }
 
 void WebContentClient::did_finish_loading(u64 page_id, URL::URL url)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -136,6 +136,7 @@ private:
     virtual void did_middle_click_link(u64 page_id, URL::URL, ByteString, unsigned) override;
     virtual void did_start_loading(u64 page_id, URL::URL, Variant<Empty, String, Web::HTML::POSTResource>, bool, Web::Bindings::NavigationHistoryBehavior) override;
     virtual void did_cancel_loading(u64 page_id, URL::URL) override;
+    virtual Messages::WebContentClient::DidStartDownloadWithoutRequestResponse did_start_download_without_request(u64 page_id, URL::URL, ByteString suggested_filename, Optional<u64> total_size) override;
     virtual Messages::WebContentClient::DidStartDownloadResponse did_start_download(u64 page_id, URL::URL, ByteString suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) override;
     virtual void did_receive_download_data(u64 page_id, u64 download_id, ByteBuffer data) override;
     virtual void did_finish_download(u64 page_id, u64 download_id) override;
@@ -251,11 +252,15 @@ private:
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());
 
     void remember_compositor_context(Web::Compositor::CompositorContextId, Optional<u64> page_id);
+    bool is_renderer_owned_download(u64 page_id, u64 download_id) const;
+    void forget_renderer_owned_download(u64 download_id);
+    void fail_renderer_owned_downloads();
 
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
     HashTable<u64> m_embedded_pages;
     HashTable<u64> m_detached_pages_pending_close;
     HashMap<Web::Compositor::CompositorContextId, Optional<u64>> m_compositor_contexts;
+    HashMap<u64, u64> m_renderer_owned_downloads;
     HashMap<u64, String> m_history_recorded_urls_for_current_load;
     Optional<i32> m_compositor_connection_id;
     u64 m_initial_page_id { 0 };

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -136,6 +136,10 @@ private:
     virtual void did_middle_click_link(u64 page_id, URL::URL, ByteString, unsigned) override;
     virtual void did_start_loading(u64 page_id, URL::URL, Variant<Empty, String, Web::HTML::POSTResource>, bool, Web::Bindings::NavigationHistoryBehavior) override;
     virtual void did_cancel_loading(u64 page_id, URL::URL) override;
+    virtual Messages::WebContentClient::DidStartDownloadResponse did_start_download(u64 page_id, URL::URL, ByteString suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) override;
+    virtual void did_receive_download_data(u64 page_id, u64 download_id, ByteBuffer data) override;
+    virtual void did_finish_download(u64 page_id, u64 download_id) override;
+    virtual void did_fail_download(u64 page_id, u64 download_id, String error) override;
     virtual void did_request_context_menu(u64 page_id, Gfx::IntPoint, Web::ContextMenuForInputEventsTarget) override;
     virtual void did_request_link_context_menu(u64 page_id, Gfx::IntPoint, URL::URL, ByteString, unsigned) override;
     virtual void did_request_image_context_menu(u64 page_id, Gfx::IntPoint, URL::URL, ByteString, unsigned, Optional<Gfx::ShareableBitmap>) override;

--- a/Libraries/LibWebView/WebUI.cpp
+++ b/Libraries/LibWebView/WebUI.cpp
@@ -9,6 +9,7 @@
 #include <LibWebView/WebContentClient.h>
 #include <LibWebView/WebUI.h>
 #include <LibWebView/WebUI/BookmarksUI.h>
+#include <LibWebView/WebUI/DownloadsUI.h>
 #include <LibWebView/WebUI/HistoryUI.h>
 #include <LibWebView/WebUI/ProcessesUI.h>
 #include <LibWebView/WebUI/SettingsUI.h>
@@ -36,6 +37,8 @@ ErrorOr<RefPtr<WebUI>> WebUI::create(WebContentClient& client, u64 page_id, Stri
 
     if (host == "bookmarks"sv)
         web_ui = TRY(create_web_ui<BookmarksUI>(client, page_id, move(host)));
+    else if (host == "downloads"sv)
+        web_ui = TRY(create_web_ui<DownloadsUI>(client, page_id, move(host)));
     else if (host == "history"sv)
         web_ui = TRY(create_web_ui<HistoryUI>(client, page_id, move(host)));
     else if (host == "processes"sv)

--- a/Libraries/LibWebView/WebUI/BookmarksUI.cpp
+++ b/Libraries/LibWebView/WebUI/BookmarksUI.cpp
@@ -68,7 +68,7 @@ void BookmarksUI::export_bookmarks(JsonValue const& data)
     if (!data.is_string())
         return;
 
-    auto destination = Application::the().path_for_downloaded_file("bookmarks.html"sv);
+    auto destination = Application::the().path_for_downloaded_file(ByteString { "bookmarks.html" });
     if (destination.is_error())
         return;
 

--- a/Libraries/LibWebView/WebUI/DownloadsUI.cpp
+++ b/Libraries/LibWebView/WebUI/DownloadsUI.cpp
@@ -45,6 +45,9 @@ void DownloadsUI::register_interfaces()
     register_interface("loadDownloads"sv, [this](auto const&) {
         load_downloads();
     });
+    register_interface("pruneInactiveDownloads"sv, [this](auto const&) {
+        prune_inactive_downloads();
+    });
     register_interface("cancelDownload"sv, [this](auto const& data) {
         cancel_download(data);
     });
@@ -66,6 +69,11 @@ void DownloadsUI::download_updated(FileDownloader::Download const& download)
     async_send_message("downloadUpdated"sv, serialize_download(download));
 }
 
+void DownloadsUI::download_removed(u64 id)
+{
+    async_send_message("downloadRemoved"sv, JsonValue { id });
+}
+
 void DownloadsUI::load_downloads()
 {
     auto downloads = Application::the().file_downloader().downloads();
@@ -76,6 +84,11 @@ void DownloadsUI::load_downloads()
         serialized_downloads.must_append(serialize_download(download));
 
     async_send_message("loadDownloads"sv, move(serialized_downloads));
+}
+
+void DownloadsUI::prune_inactive_downloads()
+{
+    (void)Application::the().file_downloader().prune_inactive_downloads();
 }
 
 static Optional<FileDownloader::Download const&> download_from_message(JsonValue const& data)

--- a/Libraries/LibWebView/WebUI/DownloadsUI.cpp
+++ b/Libraries/LibWebView/WebUI/DownloadsUI.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <LibWebView/Application.h>
+#include <LibWebView/WebUI/DownloadsUI.h>
+
+namespace WebView {
+
+static StringView status_to_string(FileDownloader::DownloadStatus status)
+{
+    switch (status) {
+    case FileDownloader::DownloadStatus::InProgress:
+        return "in-progress"sv;
+    case FileDownloader::DownloadStatus::Completed:
+        return "completed"sv;
+    case FileDownloader::DownloadStatus::Canceled:
+        return "canceled"sv;
+    case FileDownloader::DownloadStatus::Failed:
+        return "failed"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static JsonObject serialize_download(FileDownloader::Download const& download)
+{
+    JsonObject serialized;
+    serialized.set("id"sv, download.id);
+    serialized.set("url"sv, download.url.serialize());
+    serialized.set("fileName"sv, download.destination.basename());
+    serialized.set("destination"sv, MUST(String::from_utf8(download.destination.string().view())));
+    serialized.set("status"sv, status_to_string(download.status));
+    serialized.set("downloadedSize"sv, download.downloaded_size);
+    serialized.set("totalSize"sv, download.total_size.has_value() ? JsonValue { *download.total_size } : JsonValue {});
+    serialized.set("error"sv, download.error.value_or(String {}));
+    return serialized;
+}
+
+void DownloadsUI::register_interfaces()
+{
+    register_interface("loadDownloads"sv, [this](auto const&) {
+        load_downloads();
+    });
+    register_interface("cancelDownload"sv, [this](auto const& data) {
+        cancel_download(data);
+    });
+    register_interface("openDownload"sv, [this](auto const& data) {
+        open_download(data);
+    });
+    register_interface("showDownloadInFolder"sv, [this](auto const& data) {
+        show_download_in_folder(data);
+    });
+}
+
+void DownloadsUI::download_added(FileDownloader::Download const& download)
+{
+    async_send_message("downloadAdded"sv, serialize_download(download));
+}
+
+void DownloadsUI::download_updated(FileDownloader::Download const& download)
+{
+    async_send_message("downloadUpdated"sv, serialize_download(download));
+}
+
+void DownloadsUI::load_downloads()
+{
+    auto downloads = Application::the().file_downloader().downloads();
+
+    JsonArray serialized_downloads;
+    serialized_downloads.ensure_capacity(downloads.size());
+    for (auto const& download : downloads)
+        serialized_downloads.must_append(serialize_download(download));
+
+    async_send_message("loadDownloads"sv, move(serialized_downloads));
+}
+
+static Optional<FileDownloader::Download const&> download_from_message(JsonValue const& data)
+{
+    if (!data.is_object())
+        return {};
+
+    auto id = data.as_object().get_integer<u64>("id"sv);
+    if (!id.has_value())
+        return {};
+
+    return Application::the().file_downloader().download(*id);
+}
+
+void DownloadsUI::cancel_download(JsonValue const& data)
+{
+    auto download = download_from_message(data);
+    if (!download.has_value())
+        return;
+
+    if (download->status != FileDownloader::DownloadStatus::InProgress)
+        return;
+
+    Application::the().file_downloader().cancel_download(download->id);
+}
+
+void DownloadsUI::open_download(JsonValue const& data)
+{
+    auto download = download_from_message(data);
+    if (!download.has_value())
+        return;
+
+    if (download->status != FileDownloader::DownloadStatus::Completed)
+        return;
+
+    Application::the().open_download(*download);
+}
+
+void DownloadsUI::show_download_in_folder(JsonValue const& data)
+{
+    auto download = download_from_message(data);
+    if (!download.has_value())
+        return;
+
+    if (download->status != FileDownloader::DownloadStatus::Completed)
+        return;
+
+    Application::the().show_download_in_folder(*download);
+}
+
+}

--- a/Libraries/LibWebView/WebUI/DownloadsUI.cpp
+++ b/Libraries/LibWebView/WebUI/DownloadsUI.cpp
@@ -26,13 +26,18 @@ static StringView status_to_string(FileDownloader::DownloadStatus status)
     VERIFY_NOT_REACHED();
 }
 
+static String path_string_for_display(StringView path)
+{
+    return String::from_utf8_with_replacement_character(path, String::WithBOMHandling::No);
+}
+
 static JsonObject serialize_download(FileDownloader::Download const& download)
 {
     JsonObject serialized;
     serialized.set("id"sv, download.id);
     serialized.set("url"sv, download.url.serialize());
-    serialized.set("fileName"sv, download.destination.basename());
-    serialized.set("destination"sv, MUST(String::from_utf8(download.destination.string().view())));
+    serialized.set("fileName"sv, path_string_for_display(download.destination.basename()));
+    serialized.set("destination"sv, path_string_for_display(download.destination.string().view()));
     serialized.set("status"sv, status_to_string(download.status));
     serialized.set("downloadedSize"sv, download.downloaded_size);
     serialized.set("totalSize"sv, download.total_size.has_value() ? JsonValue { *download.total_size } : JsonValue {});

--- a/Libraries/LibWebView/WebUI/DownloadsUI.h
+++ b/Libraries/LibWebView/WebUI/DownloadsUI.h
@@ -21,8 +21,10 @@ private:
 
     virtual void download_added(FileDownloader::Download const&) override;
     virtual void download_updated(FileDownloader::Download const&) override;
+    virtual void download_removed(u64) override;
 
     void load_downloads();
+    void prune_inactive_downloads();
     void cancel_download(JsonValue const&);
     void open_download(JsonValue const&);
     void show_download_in_folder(JsonValue const&);

--- a/Libraries/LibWebView/WebUI/DownloadsUI.h
+++ b/Libraries/LibWebView/WebUI/DownloadsUI.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWebView/FileDownloader.h>
+#include <LibWebView/WebUI.h>
+
+namespace WebView {
+
+class DownloadsUI final
+    : public WebUI
+    , public FileDownloaderObserver {
+    WEB_UI(DownloadsUI);
+
+private:
+    virtual void register_interfaces() override;
+
+    virtual void download_added(FileDownloader::Download const&) override;
+    virtual void download_updated(FileDownloader::Download const&) override;
+
+    void load_downloads();
+    void cancel_download(JsonValue const&);
+    void open_download(JsonValue const&);
+    void show_download_in_folder(JsonValue const&);
+};
+
+}

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -14,6 +14,7 @@
 #include <LibCore/System.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibIPC/TransportHandle.h>
+#include <LibRequests/NetworkError.h>
 #include <LibRequests/WebSocket.h>
 #include <LibWebSocket/ConnectionInfo.h>
 #include <LibWebSocket/Message.h>
@@ -136,6 +137,9 @@ Optional<ConnectionFromClient&> ConnectionFromClient::primary_connection()
 
 void ConnectionFromClient::request_complete(Badge<Request>, Request const& request)
 {
+    if (request.keep_alive_for_transfer())
+        return;
+
     Core::deferred_invoke([weak_self = make_weak_ptr<ConnectionFromClient>(), request_id = request.request_id(), type = request.type()] {
         if (auto self = weak_self.strong_ref()) {
             if (type == RequestType::BackgroundRevalidation)
@@ -219,6 +223,11 @@ Messages::RequestServer::IsSupportedProtocolResponse ConnectionFromClient::is_su
     return protocol == "http"sv || protocol == "https"sv;
 }
 
+Messages::RequestServer::GetClientIdResponse ConnectionFromClient::get_client_id()
+{
+    return client_id();
+}
+
 void ConnectionFromClient::set_dns_server(ByteString host_or_address, u16 port, bool use_tls, bool validate_dnssec_locally)
 {
     auto& dns_info = DNSInfo::the();
@@ -258,7 +267,7 @@ void ConnectionFromClient::set_use_system_dns()
     m_resolver->dns.reset_connection();
 }
 
-void ConnectionFromClient::start_request(u64 request_id, ByteString method, URL::URL url, Vector<HTTP::Header> request_headers, ByteBuffer request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data)
+void ConnectionFromClient::start_request(u64 request_id, ByteString method, URL::URL url, Vector<HTTP::Header> request_headers, ByteBuffer request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data, bool keep_alive_for_transfer)
 {
     note_event_tick("ipc-start-request"sv);
     dbgln_if(REQUESTSERVER_DEBUG, "RequestServer: start_request({}, {})", request_id, url);
@@ -277,8 +286,55 @@ void ConnectionFromClient::start_request(u64 request_id, ByteString method, URL:
         }
     }
 
-    auto request = Request::fetch(request_id, m_disk_cache, cache_mode, *this, m_curl_multi, m_resolver, move(url), move(method), HTTP::HeaderList::create(move(request_headers)), move(request_body), include_credentials, m_alt_svc_cache_path, proxy_data);
+    auto request = Request::fetch(request_id, m_disk_cache, cache_mode, *this, m_curl_multi, m_resolver, move(url), move(method), HTTP::HeaderList::create(move(request_headers)), move(request_body), include_credentials, m_alt_svc_cache_path, proxy_data, keep_alive_for_transfer);
     m_active_requests.set(request_id, move(request));
+}
+
+void ConnectionFromClient::adopt_request(int source_client_id, u64 source_request_id, u64 target_request_id)
+{
+    auto source_connection = m_connections.get(source_client_id);
+    if (!source_connection.has_value()) {
+        async_request_finished(target_request_id, 0, {}, Requests::NetworkError::Unknown);
+        return;
+    }
+
+    auto request = (*source_connection)->m_active_requests.take(source_request_id);
+    if (!request.has_value()) {
+        async_request_finished(target_request_id, 0, {}, Requests::NetworkError::Unknown);
+        return;
+    }
+
+    auto transfer_result = (*request)->transfer_to_client(*this, target_request_id);
+    if (transfer_result.is_error()) {
+        dbgln("RequestServer: Failed to transfer request {} from client {} to client {}: {}", source_request_id, source_client_id, client_id(), transfer_result.error());
+        (*source_connection)->m_active_requests.set(source_request_id, request.release_value());
+        async_request_finished(target_request_id, 0, {}, Requests::NetworkError::Unknown);
+        return;
+    }
+
+    auto should_remove_after_transfer = (*request)->is_complete();
+    m_active_requests.set(target_request_id, request.release_value());
+    if (should_remove_after_transfer) {
+        Core::deferred_invoke([weak_self = make_weak_ptr<ConnectionFromClient>(), target_request_id] {
+            if (auto self = weak_self.strong_ref())
+                self->m_active_requests.remove(target_request_id);
+        });
+    }
+}
+
+void ConnectionFromClient::release_request_for_transfer(u64 request_id)
+{
+    auto request = m_active_requests.get(request_id);
+    if (!request.has_value())
+        return;
+
+    (*request)->release_for_transfer();
+    if ((*request)->is_complete()) {
+        Core::deferred_invoke([weak_self = make_weak_ptr<ConnectionFromClient>(), request_id] {
+            if (auto self = weak_self.strong_ref())
+                self->m_active_requests.remove(request_id);
+        });
+    }
 }
 
 void ConnectionFromClient::start_revalidation_request(Badge<Request>, ByteString method, URL::URL url, NonnullRefPtr<HTTP::HeaderList> request_headers, ByteBuffer request_body, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data)

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -55,9 +55,12 @@ private:
     virtual void set_disk_cache_settings(HTTP::DiskCacheSettings) override;
 
     virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(ByteString) override;
+    virtual Messages::RequestServer::GetClientIdResponse get_client_id() override;
     virtual void set_dns_server(ByteString host_or_address, u16 port, bool use_tls, bool validate_dnssec_locally) override;
     virtual void set_use_system_dns() override;
-    virtual void start_request(u64 request_id, ByteString, URL::URL, Vector<HTTP::Header>, ByteBuffer, HTTP::CacheMode, HTTP::Cookie::IncludeCredentials, Core::ProxyData) override;
+    virtual void start_request(u64 request_id, ByteString, URL::URL, Vector<HTTP::Header>, ByteBuffer, HTTP::CacheMode, HTTP::Cookie::IncludeCredentials, Core::ProxyData, bool keep_alive_for_transfer) override;
+    virtual void adopt_request(int source_client_id, u64 source_request_id, u64 target_request_id) override;
+    virtual void release_request_for_transfer(u64 request_id) override;
     virtual Messages::RequestServer::StopRequestResponse stop_request(u64 request_id) override;
     virtual Messages::RequestServer::SetCertificateResponse set_certificate(u64 request_id, ByteString, ByteString) override;
     virtual void ensure_connection(u64 request_id, URL::URL url, ::RequestServer::CacheLevel cache_level) override;

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -27,6 +27,12 @@ extern OwnPtr<ResourceSubstitutionMap> g_resource_substitution_map;
 
 static long s_connect_timeout_seconds = 90L;
 
+Request::TransferredBodyFile::~TransferredBodyFile()
+{
+    if (fd != -1)
+        (void)Core::System::close(fd);
+}
+
 static void log_network_activity(URL::URL const& url, ByteString const& method, void* curl_easy_handle, int curl_result_code, bool is_revalidation, RequestType type)
 {
     if constexpr (!REQUESTSERVER_WIRE_DEBUG)
@@ -704,10 +710,20 @@ void Request::handle_read_cache_state()
     }
 
     auto file = body_file.release_value();
+    m_transferred_body_file.emplace();
+    m_transferred_body_file->fd = file.fd;
+    m_transferred_body_file->offset = file.offset;
+    m_transferred_body_file->size = file.size;
+
     m_bytes_transferred_to_client = file.size;
     m_curl_result_code = CURLE_OK;
 
-    m_client->async_request_body_file_available(m_request_id, IPC::File::adopt_fd(file.fd), file.offset, file.size);
+    if (send_transferred_body_file_to_client().is_error()) {
+        m_network_error = Requests::NetworkError::CacheReadFailed;
+        transition_to_state(State::Error);
+        return;
+    }
+
     m_cache_entry_reader.clear();
 
     transition_to_state(State::Complete);
@@ -1192,6 +1208,9 @@ ErrorOr<void> Request::transfer_to_client(ConnectionFromClient& client, u64 requ
     if (m_sent_response_headers_to_client)
         send_headers_to_client();
 
+    if (m_transferred_body_file.has_value())
+        TRY(send_transferred_body_file_to_client());
+
     if (was_complete) {
         if (m_state == State::Complete)
             m_client->async_request_finished(m_request_id, m_bytes_transferred_to_client, acquire_timing_info(), m_network_error);
@@ -1201,6 +1220,14 @@ ErrorOr<void> Request::transfer_to_client(ConnectionFromClient& client, u64 requ
         previous_client.async_request_transferred(previous_request_id);
     }
 
+    return {};
+}
+
+ErrorOr<void> Request::send_transferred_body_file_to_client()
+{
+    VERIFY(m_transferred_body_file.has_value());
+    auto fd = TRY(Core::System::dup(m_transferred_body_file->fd));
+    m_client->async_request_body_file_available(m_request_id, IPC::File::adopt_fd(fd), m_transferred_body_file->offset, m_transferred_body_file->size);
     return {};
 }
 

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 #include <LibCore/Notifier.h>
+#include <LibCore/System.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibHTTP/Cache/Utilities.h>
 #include <LibHTTP/Status.h>
@@ -369,9 +370,10 @@ NonnullOwnPtr<Request> Request::fetch(
     ByteBuffer request_body,
     HTTP::Cookie::IncludeCredentials include_credentials,
     ByteString alt_svc_cache_path,
-    Core::ProxyData proxy_data)
+    Core::ProxyData proxy_data,
+    bool keep_alive_for_transfer)
 {
-    auto request = adopt_own(*new Request { request_id, RequestType::Fetch, disk_cache, cache_mode, client, curl_multi, resolver, move(url), move(method), move(request_headers), move(request_body), include_credentials, move(alt_svc_cache_path), proxy_data });
+    auto request = adopt_own(*new Request { request_id, RequestType::Fetch, disk_cache, cache_mode, client, curl_multi, resolver, move(url), move(method), move(request_headers), move(request_body), include_credentials, move(alt_svc_cache_path), proxy_data, keep_alive_for_transfer });
     request->process();
 
     return request;
@@ -425,12 +427,13 @@ Request::Request(
     ByteBuffer request_body,
     HTTP::Cookie::IncludeCredentials include_credentials,
     ByteString alt_svc_cache_path,
-    Core::ProxyData proxy_data)
+    Core::ProxyData proxy_data,
+    bool keep_alive_for_transfer)
     : m_request_id(request_id)
     , m_type(type)
     , m_disk_cache(disk_cache)
     , m_cache_mode(cache_mode)
-    , m_client(client)
+    , m_client(&client)
     , m_curl_multi_handle(curl_multi)
     , m_resolver(resolver)
     , m_url(move(url))
@@ -441,6 +444,7 @@ Request::Request(
     , m_alt_svc_cache_path(move(alt_svc_cache_path))
     , m_proxy_data(proxy_data)
     , m_response_headers(HTTP::HeaderList::create())
+    , m_keep_alive_for_transfer(keep_alive_for_transfer)
 {
     if constexpr (REQUESTSERVER_WIRE_DEBUG)
         wire_stats().ensure(this).created_at = MonotonicTime::now();
@@ -454,7 +458,7 @@ Request::Request(
     URL::URL url)
     : m_request_id(request_id)
     , m_type(RequestType::Connect)
-    , m_client(client)
+    , m_client(&client)
     , m_curl_multi_handle(curl_multi)
     , m_resolver(resolver)
     , m_url(move(url))
@@ -473,8 +477,10 @@ Request::~Request()
     }
 
     if (m_curl_easy_handle) {
-        auto result = curl_multi_remove_handle(m_curl_multi_handle, m_curl_easy_handle);
-        VERIFY(result == CURLM_OK);
+        if (m_curl_easy_handle_is_in_multi) {
+            auto result = curl_multi_remove_handle(m_curl_multi_handle, m_curl_easy_handle);
+            VERIFY(result == CURLM_OK);
+        }
 
         curl_easy_cleanup(m_curl_easy_handle);
     }
@@ -613,7 +619,7 @@ void Request::handle_initial_state()
 
                     if (m_cache_entry_reader.has_value()) {
                         if (m_cache_entry_reader->revalidation_type() == HTTP::CacheEntryReader::RevalidationType::StaleWhileRevalidate)
-                            m_client.start_revalidation_request({}, m_method, m_url, m_request_headers, m_request_body, m_include_credentials, m_proxy_data);
+                            m_client->start_revalidation_request({}, m_method, m_url, m_request_headers, m_request_body, m_include_credentials, m_proxy_data);
 
                         if (is_revalidation_request())
                             transition_to_state(State::DNSLookup);
@@ -701,7 +707,7 @@ void Request::handle_read_cache_state()
     m_bytes_transferred_to_client = file.size;
     m_curl_result_code = CURLE_OK;
 
-    m_client.async_request_body_file_available(m_request_id, IPC::File::adopt_fd(file.fd), file.offset, file.size);
+    m_client->async_request_body_file_available(m_request_id, IPC::File::adopt_fd(file.fd), file.offset, file.size);
     m_cache_entry_reader.clear();
 
     transition_to_state(State::Complete);
@@ -832,7 +838,7 @@ void Request::handle_retrieve_cookie_state()
 
     if (auto connection = ConnectionFromClient::primary_connection(); connection.has_value()) {
         mark_lifecycle_event(this, &WireStats::cookie_started_at);
-        connection->async_retrieve_http_cookie(m_client.client_id(), m_request_id, m_type, m_url);
+        connection->async_retrieve_http_cookie(m_client->client_id(), m_request_id, m_type, m_url);
     } else {
         m_network_error = Requests::NetworkError::RequestServerDied;
         transition_to_state(State::Error);
@@ -874,6 +880,7 @@ void Request::handle_connect_state()
     mark_lifecycle_event(this, &WireStats::curl_added_at);
     auto result = curl_multi_add_handle(m_curl_multi_handle, m_curl_easy_handle);
     VERIFY(result == CURLM_OK);
+    m_curl_easy_handle_is_in_multi = true;
 }
 
 void Request::handle_fetch_state()
@@ -1000,6 +1007,7 @@ void Request::handle_fetch_state()
     mark_lifecycle_event(this, &WireStats::curl_added_at);
     auto result = curl_multi_add_handle(m_curl_multi_handle, m_curl_easy_handle);
     VERIFY(result == CURLM_OK);
+    m_curl_easy_handle_is_in_multi = true;
 }
 
 void Request::handle_complete_state()
@@ -1045,9 +1053,9 @@ void Request::handle_complete_state()
         }
 
         if (cached_body_file.has_value())
-            m_client.async_request_cached_body_file_available(m_request_id, IPC::File::adopt_fd(cached_body_file->fd), cached_body_file->offset, cached_body_file->size);
+            m_client->async_request_cached_body_file_available(m_request_id, IPC::File::adopt_fd(cached_body_file->fd), cached_body_file->offset, cached_body_file->size);
 
-        m_client.async_request_finished(m_request_id, m_bytes_transferred_to_client, timing_info, m_network_error);
+        m_client->async_request_finished(m_request_id, m_bytes_transferred_to_client, timing_info, m_network_error);
     }
 
     if (m_cache_entry_writer.has_value()) {
@@ -1055,17 +1063,17 @@ void Request::handle_complete_state()
         m_cache_entry_writer.clear();
     }
 
-    m_client.request_complete({}, *this);
+    m_client->request_complete({}, *this);
 }
 
 void Request::handle_error_state()
 {
     if (m_type == RequestType::Fetch) {
         // FIXME: Implement timing info for failed requests.
-        m_client.async_request_finished(m_request_id, m_bytes_transferred_to_client, {}, m_network_error.value_or(Requests::NetworkError::Unknown));
+        m_client->async_request_finished(m_request_id, m_bytes_transferred_to_client, {}, m_network_error.value_or(Requests::NetworkError::Unknown));
     }
 
-    m_client.request_complete({}, *this);
+    m_client->request_complete({}, *this);
 }
 
 size_t Request::on_header_received(void* buffer, size_t size, size_t nmemb, void* user_data)
@@ -1144,6 +1152,58 @@ size_t Request::on_data_received(void* buffer, size_t size, size_t nmemb, void* 
     return total_size;
 }
 
+ErrorOr<void> Request::detach_curl_handle_from_multi()
+{
+    if (!m_curl_easy_handle)
+        return {};
+
+    if (!m_curl_easy_handle_is_in_multi)
+        return {};
+
+    auto remove_result = curl_multi_remove_handle(m_curl_multi_handle, m_curl_easy_handle);
+    if (remove_result != CURLM_OK)
+        return Error::from_string_literal("Failed to remove curl easy handle from multi handle");
+
+    m_curl_easy_handle_is_in_multi = false;
+    return {};
+}
+
+ErrorOr<void> Request::transfer_to_client(ConnectionFromClient& client, u64 request_id)
+{
+    if (m_type == RequestType::BackgroundRevalidation)
+        return Error::from_string_literal("Cannot transfer background revalidation requests");
+
+    auto was_complete = is_complete();
+    auto& previous_client = *m_client;
+    auto previous_request_id = m_request_id;
+
+    if (was_complete)
+        TRY(detach_curl_handle_from_multi());
+    else if (&previous_client != &client)
+        m_network_connection_keep_alive = &previous_client;
+
+    m_client = &client;
+    m_request_id = request_id;
+    m_keep_alive_for_transfer = false;
+
+    if (m_client_request_pipe.has_value())
+        TRY(send_request_pipe_to_client());
+
+    if (m_sent_response_headers_to_client)
+        send_headers_to_client();
+
+    if (was_complete) {
+        if (m_state == State::Complete)
+            m_client->async_request_finished(m_request_id, m_bytes_transferred_to_client, acquire_timing_info(), m_network_error);
+        else
+            m_client->async_request_finished(m_request_id, m_bytes_transferred_to_client, {}, m_network_error.value_or(Requests::NetworkError::Unknown));
+    } else {
+        previous_client.async_request_transferred(previous_request_id);
+    }
+
+    return {};
+}
+
 ErrorOr<void> Request::inform_client_request_started()
 {
     if (m_type == RequestType::BackgroundRevalidation)
@@ -1157,8 +1217,16 @@ ErrorOr<void> Request::inform_client_request_started()
     }
 
     m_client_request_pipe = request_pipe.release_value();
-    m_client.async_request_started(m_request_id, IPC::File::adopt_fd(m_client_request_pipe->reader_fd()));
+    TRY(send_request_pipe_to_client());
 
+    return {};
+}
+
+ErrorOr<void> Request::send_request_pipe_to_client()
+{
+    VERIFY(m_client_request_pipe.has_value());
+    auto reader_fd = TRY(Core::System::dup(m_client_request_pipe->reader_fd()));
+    m_client->async_request_started(m_request_id, IPC::File::adopt_fd(reader_fd));
     return {};
 }
 
@@ -1214,7 +1282,12 @@ void Request::transfer_headers_to_client_if_needed()
         javascript_bytecode_cache_vary_key = m_cache_entry_writer->vary_key();
     }
 
-    m_client.async_headers_became_available(m_request_id, m_response_headers->headers(), m_status_code, m_reason_phrase, move(javascript_bytecode), javascript_bytecode_size, javascript_bytecode_cache_vary_key);
+    send_headers_to_client(move(javascript_bytecode), javascript_bytecode_size, javascript_bytecode_cache_vary_key);
+}
+
+void Request::send_headers_to_client(Optional<IPC::File> javascript_bytecode, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key)
+{
+    m_client->async_headers_became_available(m_request_id, m_response_headers->headers(), m_status_code, m_reason_phrase, move(javascript_bytecode), javascript_bytecode_size, javascript_bytecode_cache_vary_key);
 }
 
 ErrorOr<void> Request::write_queued_bytes_without_blocking()

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -87,6 +87,18 @@ public:
     void notify_fetch_complete(Badge<ConnectionFromClient>, int result_code);
 
 private:
+    struct TransferredBodyFile {
+        TransferredBodyFile() = default;
+        ~TransferredBodyFile();
+
+        TransferredBodyFile(TransferredBodyFile const&) = delete;
+        TransferredBodyFile& operator=(TransferredBodyFile const&) = delete;
+
+        int fd { -1 };
+        u64 offset { 0 };
+        u64 size { 0 };
+    };
+
     enum class State : u8 {
         Init,              // Decide whether to service this request from cache or the network.
         ReadCache,         // Read the cached response from disk.
@@ -174,6 +186,7 @@ private:
     ErrorOr<void> detach_curl_handle_from_multi();
     ErrorOr<void> inform_client_request_started();
     ErrorOr<void> send_request_pipe_to_client();
+    ErrorOr<void> send_transferred_body_file_to_client();
     void transfer_headers_to_client_if_needed();
     void send_headers_to_client(Optional<IPC::File> javascript_bytecode = {}, u64 javascript_bytecode_size = 0, Optional<u64> javascript_bytecode_cache_vary_key = {});
     ErrorOr<void> write_queued_bytes_without_blocking();
@@ -225,6 +238,7 @@ private:
     AllocatingMemoryStream m_response_buffer;
     RefPtr<Core::Notifier> m_client_writer_notifier;
     Optional<RequestPipe> m_client_request_pipe;
+    Optional<TransferredBodyFile> m_transferred_body_file;
     size_t m_bytes_transferred_to_client { 0 };
 
     Optional<Requests::NetworkError> m_network_error;

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -10,6 +10,7 @@
 #include <AK/ByteString.h>
 #include <AK/MemoryStream.h>
 #include <AK/Optional.h>
+#include <AK/RefPtr.h>
 #include <AK/Time.h>
 #include <LibCore/Proxy.h>
 #include <LibDNS/Resolver.h>
@@ -17,6 +18,7 @@
 #include <LibHTTP/Cache/CacheRequest.h>
 #include <LibHTTP/Cookie/IncludeCredentials.h>
 #include <LibHTTP/HeaderList.h>
+#include <LibIPC/File.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
@@ -44,7 +46,8 @@ public:
         ByteBuffer request_body,
         HTTP::Cookie::IncludeCredentials include_credentials,
         ByteString alt_svc_cache_path,
-        Core::ProxyData proxy_data);
+        Core::ProxyData proxy_data,
+        bool keep_alive_for_transfer);
 
     static NonnullOwnPtr<Request> connect(
         u64 request_id,
@@ -73,6 +76,11 @@ public:
     u64 request_id() const { return m_request_id; }
     RequestType type() const { return m_type; }
     URL::URL const& url() const { return m_url; }
+    bool is_complete() const { return m_state == State::Complete || m_state == State::Error; }
+    bool keep_alive_for_transfer() const { return m_keep_alive_for_transfer; }
+
+    ErrorOr<void> transfer_to_client(ConnectionFromClient&, u64 request_id);
+    void release_for_transfer() { m_keep_alive_for_transfer = false; }
 
     virtual void notify_request_unblocked(Badge<HTTP::DiskCache>) override;
     void notify_retrieved_http_cookie(Badge<ConnectionFromClient>, StringView cookie);
@@ -136,7 +144,8 @@ private:
         ByteBuffer request_body,
         HTTP::Cookie::IncludeCredentials include_credentials,
         ByteString alt_svc_cache_path,
-        Core::ProxyData proxy_data);
+        Core::ProxyData proxy_data,
+        bool keep_alive_for_transfer = false);
 
     Request(
         u64 request_id,
@@ -162,8 +171,11 @@ private:
     static size_t on_header_received(void* buffer, size_t size, size_t nmemb, void* user_data);
     static size_t on_data_received(void* buffer, size_t size, size_t nmemb, void* user_data);
 
+    ErrorOr<void> detach_curl_handle_from_multi();
     ErrorOr<void> inform_client_request_started();
+    ErrorOr<void> send_request_pipe_to_client();
     void transfer_headers_to_client_if_needed();
+    void send_headers_to_client(Optional<IPC::File> javascript_bytecode = {}, u64 javascript_bytecode_size = 0, Optional<u64> javascript_bytecode_cache_vary_key = {});
     ErrorOr<void> write_queued_bytes_without_blocking();
 
     virtual bool is_revalidation_request() const override;
@@ -180,10 +192,11 @@ private:
 
     Optional<HTTP::DiskCache&> m_disk_cache;
     HTTP::CacheMode m_cache_mode { HTTP::CacheMode::Default };
-    ConnectionFromClient& m_client;
+    ConnectionFromClient* m_client { nullptr };
 
     void* m_curl_multi_handle { nullptr };
     void* m_curl_easy_handle { nullptr };
+    bool m_curl_easy_handle_is_in_multi { false };
     Vector<curl_slist*> m_curl_string_lists;
     Optional<int> m_curl_result_code;
 
@@ -215,6 +228,8 @@ private:
     size_t m_bytes_transferred_to_client { 0 };
 
     Optional<Requests::NetworkError> m_network_error;
+    bool m_keep_alive_for_transfer { false };
+    RefPtr<ConnectionFromClient> m_network_connection_keep_alive;
 };
 
 }

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -12,6 +12,7 @@ endpoint RequestClient
     request_cached_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
     request_finished(u64 request_id, u64 total_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|
     headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key) =|
+    request_transferred(u64 request_id) =|
 
     retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, URL::URL url) =|
 

--- a/Services/RequestServer/RequestPipe.cpp
+++ b/Services/RequestServer/RequestPipe.cpp
@@ -37,6 +37,8 @@ RequestPipe& RequestPipe::operator=(RequestPipe&& other)
 
 RequestPipe::~RequestPipe()
 {
+    if (m_reader_fd != -1)
+        MUST(Core::System::close(m_reader_fd));
     if (m_writer_fd != -1)
         MUST(Core::System::close(m_writer_fd));
 }

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -24,8 +24,11 @@ endpoint RequestServer
 
     // Test if a specific protocol is supported, e.g "http"
     is_supported_protocol(ByteString protocol) => (bool supported)
+    get_client_id() => (int client_id)
 
-    start_request(u64 request_id, ByteString method, URL::URL url, Vector<HTTP::Header> request_headers, ByteBuffer request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data) =|
+    start_request(u64 request_id, ByteString method, URL::URL url, Vector<HTTP::Header> request_headers, ByteBuffer request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData proxy_data, bool keep_alive_for_transfer) =|
+    adopt_request(int source_client_id, u64 source_request_id, u64 target_request_id) =|
+    release_request_for_transfer(u64 request_id) =|
     stop_request(u64 request_id) => (bool success)
     set_certificate(u64 request_id, ByteString certificate, ByteString key) => (bool success)
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -306,6 +306,12 @@ void ConnectionFromClient::reload(u64 page_id)
         page->page().reload();
 }
 
+void ConnectionFromClient::cancel_download(u64 page_id, u64 download_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->cancel_download(download_id);
+}
+
 void ConnectionFromClient::traverse_the_history_by_delta(u64 page_id, i32 delta)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -90,6 +90,7 @@ private:
     virtual void load_html(u64 page_id, ByteString) override;
     virtual void load_html_with_url(u64 page_id, ByteString, URL::URL) override;
     virtual void reload(u64 page_id) override;
+    virtual void cancel_download(u64 page_id, u64 download_id) override;
     virtual void run_iframe_load_event_steps(u64 page_id, String frame_id) override;
     virtual void set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId>) override;
     virtual void set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId>) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -535,6 +535,12 @@ Optional<u64> PageClient::page_did_start_download(URL::URL const& url, ByteStrin
     return response->download_id();
 }
 
+Optional<u64> PageClient::page_did_start_download(URL::URL const& url, ByteString const& suggested_filename, Optional<u64> total_size)
+{
+    auto response = client().send_sync<Messages::WebContentClient::DidStartDownloadWithoutRequest>(m_id, url, suggested_filename, total_size);
+    return response->download_id();
+}
+
 void PageClient::page_did_receive_download_data(u64 download_id, ByteBuffer data)
 {
     if (m_canceled_downloads.contains(download_id))

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -30,6 +30,8 @@
 #include <LibWeb/DOM/MutationType.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NodeList.h>
+#include <LibWeb/Fetch/Infrastructure/FetchController.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
@@ -42,6 +44,7 @@
 #include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Streams/ReadableStreamDefaultReader.h>
 #include <LibWeb/WebIDL/Promise.h>
 #include <LibWebView/SiteIsolation.h>
 #include <LibWebView/ViewImplementation.h>
@@ -58,6 +61,7 @@ namespace WebContent {
 static bool s_is_headless { false };
 static bool s_async_scrolling_enabled { false };
 static bool s_should_report_session_history_updates_in_test_mode { false };
+static constexpr size_t s_max_download_data_ipc_chunk_size = 16 * MiB;
 
 GC_DEFINE_ALLOCATOR(PageClient);
 
@@ -118,6 +122,10 @@ void PageClient::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_top_level_document_console_client);
     for (auto& promise : m_pending_delete_all_cookies_promises)
         visitor.visit(promise.value);
+    for (auto& controller : m_download_controllers)
+        visitor.visit(controller.value);
+    for (auto& reader : m_download_readers)
+        visitor.visit(reader.value);
     m_pending_dom_mutations.for_each([&](auto& pending_mutation) {
         visitor.visit(pending_mutation.target);
     });
@@ -519,6 +527,74 @@ void PageClient::page_did_change_active_document_in_top_level_browsing_context(W
 void PageClient::page_did_finish_loading(URL::URL const& url)
 {
     client().async_did_finish_loading(m_id, url);
+}
+
+Optional<u64> PageClient::page_did_start_download(URL::URL const& url, ByteString const& suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data)
+{
+    auto response = client().send_sync<Messages::WebContentClient::DidStartDownload>(m_id, url, suggested_filename, total_size, request_server_client_id, request_server_request_id, move(initial_data));
+    return response->download_id();
+}
+
+void PageClient::page_did_receive_download_data(u64 download_id, ByteBuffer data)
+{
+    if (m_canceled_downloads.contains(download_id))
+        return;
+
+    auto bytes = data.bytes();
+    for (size_t offset = 0; offset < bytes.size(); offset += s_max_download_data_ipc_chunk_size) {
+        auto chunk_size = min(bytes.size() - offset, s_max_download_data_ipc_chunk_size);
+        client().async_did_receive_download_data(m_id, download_id, bytes.slice(offset, chunk_size));
+    }
+}
+
+void PageClient::page_did_finish_download(u64 download_id)
+{
+    page_did_unregister_download(download_id);
+    client().async_did_finish_download(m_id, download_id);
+}
+
+void PageClient::page_did_fail_download(u64 download_id, String const& error)
+{
+    page_did_unregister_download(download_id);
+    client().async_did_fail_download(m_id, download_id, error);
+}
+
+void PageClient::page_did_register_download_controller(u64 download_id, GC::Ref<Web::Fetch::Infrastructure::FetchController> controller)
+{
+    m_download_controllers.set(download_id, controller);
+}
+
+void PageClient::page_did_register_download_reader(u64 download_id, GC::Ref<Web::Streams::ReadableStreamDefaultReader> reader)
+{
+    m_download_readers.set(download_id, reader);
+}
+
+void PageClient::page_did_unregister_download(u64 download_id)
+{
+    m_download_controllers.remove(download_id);
+    m_download_readers.remove(download_id);
+    m_canceled_downloads.remove(download_id);
+}
+
+bool PageClient::page_is_download_canceled(u64 download_id) const
+{
+    return m_canceled_downloads.contains(download_id);
+}
+
+void PageClient::cancel_download(u64 download_id)
+{
+    auto controller = m_download_controllers.take(download_id);
+    auto reader = m_download_readers.take(download_id);
+    if (!controller.has_value() && !reader.has_value())
+        return;
+
+    m_canceled_downloads.set(download_id);
+
+    if (controller.has_value())
+        controller.value()->stop_fetch();
+
+    if (reader.has_value())
+        Web::Fetch::Infrastructure::cancel_incremental_read(*reader.value());
 }
 
 void PageClient::wait_for_webdriver_navigation_completion(Optional<u64> page_load_timeout, Function<void(Web::WebDriver::Response)> on_complete)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -10,6 +10,7 @@
 
 #include <AK/Function.h>
 #include <AK/HashMap.h>
+#include <AK/HashTable.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/AudioPlayState.h>
@@ -130,6 +131,7 @@ public:
     void did_complete_webdriver_navigation_completion(u64 request_id, Web::WebDriver::Response);
     void run_iframe_load_event_steps(String const& frame_id);
     void set_remote_child_frame_compositor_context(String, Optional<Web::Compositor::CompositorContextId>);
+    void cancel_download(u64 download_id);
     void clear_pending_dom_mutations();
     void did_delete_all_cookies(u64 request_id);
 
@@ -189,6 +191,14 @@ private:
     virtual void page_did_create_new_document(Web::DOM::Document&) override;
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) override;
     virtual void page_did_finish_loading(URL::URL const&) override;
+    virtual Optional<u64> page_did_start_download(URL::URL const&, ByteString const& suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) override;
+    virtual void page_did_receive_download_data(u64 download_id, ByteBuffer data) override;
+    virtual void page_did_finish_download(u64 download_id) override;
+    virtual void page_did_fail_download(u64 download_id, String const& error) override;
+    virtual void page_did_register_download_controller(u64 download_id, GC::Ref<Web::Fetch::Infrastructure::FetchController>) override;
+    virtual void page_did_register_download_reader(u64 download_id, GC::Ref<Web::Streams::ReadableStreamDefaultReader>) override;
+    virtual void page_did_unregister_download(u64 download_id) override;
+    virtual bool page_is_download_canceled(u64 download_id) const override;
     virtual void page_did_request_alert(String const&) override;
     virtual void page_did_request_confirm(String const&) override;
     virtual void page_did_request_prompt(String const&, String const&) override;
@@ -273,6 +283,9 @@ private:
     u64 m_id { 0 };
     u64 m_next_delete_all_cookies_request_id { 1 };
     HashMap<u64, GC::Ref<Web::WebIDL::Promise>> m_pending_delete_all_cookies_promises;
+    HashMap<u64, GC::Ref<Web::Fetch::Infrastructure::FetchController>> m_download_controllers;
+    HashMap<u64, GC::Ref<Web::Streams::ReadableStreamDefaultReader>> m_download_readers;
+    HashTable<u64> m_canceled_downloads;
     bool m_has_focus { true };
 
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -192,6 +192,7 @@ private:
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) override;
     virtual void page_did_finish_loading(URL::URL const&) override;
     virtual Optional<u64> page_did_start_download(URL::URL const&, ByteString const& suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) override;
+    virtual Optional<u64> page_did_start_download(URL::URL const&, ByteString const& suggested_filename, Optional<u64> total_size) override;
     virtual void page_did_receive_download_data(u64 download_id, ByteBuffer data) override;
     virtual void page_did_finish_download(u64 download_id) override;
     virtual void page_did_fail_download(u64 download_id, String const& error) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -55,6 +55,7 @@ endpoint WebContentClient
     did_start_loading(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     did_cancel_loading(u64 page_id, URL::URL url) =|
     did_finish_loading(u64 page_id, URL::URL url) =|
+    did_start_download_without_request(u64 page_id, URL::URL url, ByteString suggested_filename, Optional<u64> total_size) => (Optional<u64> download_id)
     did_start_download(u64 page_id, URL::URL url, ByteString suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) => (Optional<u64> download_id)
     did_receive_download_data(u64 page_id, u64 download_id, ByteBuffer data) =|
     did_finish_download(u64 page_id, u64 download_id) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -55,6 +55,10 @@ endpoint WebContentClient
     did_start_loading(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     did_cancel_loading(u64 page_id, URL::URL url) =|
     did_finish_loading(u64 page_id, URL::URL url) =|
+    did_start_download(u64 page_id, URL::URL url, ByteString suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) => (Optional<u64> download_id)
+    did_receive_download_data(u64 page_id, u64 download_id, ByteBuffer data) =|
+    did_finish_download(u64 page_id, u64 download_id) =|
+    did_fail_download(u64 page_id, u64 download_id, String error) =|
     did_request_refresh(u64 page_id) =|
     did_request_cursor_change(u64 page_id, Gfx::Cursor cursor) =|
     did_change_title(u64 page_id, Utf16String title) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -59,6 +59,7 @@ endpoint WebContentServer
     load_html(u64 page_id, ByteString html) =|
     load_html_with_url(u64 page_id, ByteString html, URL::URL url) =|
     reload(u64 page_id) =|
+    cancel_download(u64 page_id, u64 download_id) =|
     run_iframe_load_event_steps(u64 page_id, String frame_id) =|
     set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id) =|
     set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId> context_id) =|

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -47,4 +47,7 @@ private:
 }
 
 @interface Application : NSApplication
+
+- (BOOL)confirmCancelActiveDownloads;
+
 @end

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -24,7 +24,7 @@ private:
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
     virtual void open_url_in_new_window(URL::URL const& url) override;
 
-    virtual Optional<ByteString> ask_user_for_download_path(StringView file) const override;
+    virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -8,6 +8,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/ThreadEventQueue.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/ViewImplementation.h>
 #include <Utilities/Conversions.h>
@@ -395,8 +396,31 @@ void Application::on_devtools_disabled() const
 
 #pragma mark - NSApplication
 
+- (BOOL)confirmCancelActiveDownloads
+{
+    auto& downloader = WebView::Application::the().file_downloader();
+    if (!downloader.has_active_downloads())
+        return YES;
+
+    auto* dialog = [[NSAlert alloc] init];
+    [dialog setMessageText:@"Downloads are still in progress."];
+    [dialog setInformativeText:@"Quitting will cancel active downloads."];
+    [dialog setAlertStyle:NSAlertStyleWarning];
+    [[dialog addButtonWithTitle:@"Quit and Cancel Downloads"] setTag:NSModalResponseOK];
+    [[dialog addButtonWithTitle:@"Cancel"] setTag:NSModalResponseCancel];
+
+    if ([dialog runModal] != NSModalResponseOK)
+        return NO;
+
+    downloader.cancel_active_downloads();
+    return YES;
+}
+
 - (void)terminate:(id)sender
 {
+    if (![self confirmCancelActiveDownloads])
+        return;
+
     Core::EventLoop::current().quit(0);
 }
 

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -66,7 +66,7 @@ void Application::open_url_in_new_window(URL::URL const& url)
     (void)[delegate createNewTab:url fromTab:nil activateTab:Web::HTML::ActivateTab::Yes];
 }
 
-Optional<ByteString> Application::ask_user_for_download_path(StringView file) const
+Optional<ByteString> Application::ask_user_for_download_path(ByteString const& file) const
 {
     auto* panel = [NSSavePanel savePanel];
     [panel setNameFieldStringValue:Ladybird::string_to_ns_string(file)];

--- a/UI/AppKit/Application/ApplicationDelegate.h
+++ b/UI/AppKit/Application/ApplicationDelegate.h
@@ -36,6 +36,7 @@
 - (nullable Tab*)activeTab;
 
 - (void)removeTab:(nonnull TabController*)controller;
+- (NSUInteger)tabCount;
 
 - (void)rebuildBookmarksMenu;
 

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -6,6 +6,7 @@
 
 #include <LibWebView/Application.h>
 
+#import <Application/Application.h>
 #import <Application/ApplicationDelegate.h>
 #import <Interface/InfoBar.h>
 #import <Interface/LadybirdWebView.h>
@@ -134,6 +135,11 @@
 - (void)removeTab:(TabController*)controller
 {
     [self.managed_tabs removeObject:controller];
+}
+
+- (NSUInteger)tabCount
+{
+    return self.managed_tabs.count;
 }
 
 - (void)rebuildBookmarksMenu
@@ -408,7 +414,7 @@
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender
 {
-    return YES;
+    return [(Application*)sender confirmCancelActiveDownloads];
 }
 
 - (void)applicationDidChangeScreenParameters:(NSNotification*)notification

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -11,6 +11,7 @@
 #include <LibWebView/URL.h>
 #include <LibWebView/ViewImplementation.h>
 
+#import <Application/Application.h>
 #import <Application/ApplicationDelegate.h>
 #import <Interface/Autocomplete.h>
 #import <Interface/LadybirdWebView.h>
@@ -994,7 +995,17 @@ static NSImage* location_field_globe_icon()
 
 - (BOOL)windowShouldClose:(NSWindow*)sender
 {
+    auto* delegate = (ApplicationDelegate*)[NSApp delegate];
+    auto confirm_canceling_downloads = [&]() {
+        if ([delegate tabCount] > 1)
+            return true;
+        return [(Application*)NSApp confirmCancelActiveDownloads];
+    };
+
     if (![[[self tab] web_view] needsBeforeUnloadCheck]) {
+        if (!confirm_canceling_downloads())
+            return false;
+
         m_pending_immediate_close = [[[self tab] web_view] prepareForImmediateClose];
         return true;
     }
@@ -1009,6 +1020,9 @@ static NSImage* location_field_globe_icon()
 
     // If the user has already requested a close, then respect the user's request and just close the tab.
     // For example, the WebContent process may not be responding.
+    if (!confirm_canceling_downloads())
+        return false;
+
     return true;
 }
 

--- a/UI/Gtk/Application.cpp
+++ b/UI/Gtk/Application.cpp
@@ -126,6 +126,18 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls)
     }),
         nullptr);
 
+    g_signal_connect(window_ref.gtk_window(), "close-request", G_CALLBACK(+[](GtkWindow* gtk_window, gpointer) -> gboolean {
+        auto& app = Application::the();
+        size_t window_count = 0;
+        app.for_each_window([&](auto&) { ++window_count; });
+
+        if (window_count <= 1 && !app.confirm_cancel_active_downloads(gtk_window))
+            return GDK_EVENT_STOP;
+
+        return GDK_EVENT_PROPAGATE;
+    }),
+        nullptr);
+
     // Clean up when window is destroyed — defer removal to avoid mutating m_windows during iteration
     g_signal_connect(window_ref.gtk_window(), "destroy", G_CALLBACK(+[](GtkWidget* gtk_window, gpointer) {
         auto& app = Application::the();
@@ -140,7 +152,7 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls)
             app.remove_window(*to_remove);
             bool has_windows = false;
             app.for_each_window([&](auto&) { has_windows = true; });
-            if (!has_windows)
+            if (!has_windows && !app.file_downloader().has_active_downloads())
                 Core::EventLoop::current().quit(0);
         }
     }),
@@ -149,6 +161,40 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls)
     window_ref.present();
     m_windows.append(move(window));
     return window_ref;
+}
+
+bool Application::confirm_cancel_active_downloads(GtkWindow* parent)
+{
+    auto& downloader = file_downloader();
+    if (!downloader.has_active_downloads())
+        return true;
+
+    auto* dialog = adw_alert_dialog_new("Downloads are still in progress.", "Quitting will cancel active downloads.");
+    adw_alert_dialog_add_response(ADW_ALERT_DIALOG(dialog), "cancel", "Cancel");
+    adw_alert_dialog_add_response(ADW_ALERT_DIALOG(dialog), "quit", "Quit and Cancel Downloads");
+    adw_alert_dialog_set_response_appearance(ADW_ALERT_DIALOG(dialog), "quit", ADW_RESPONSE_DESTRUCTIVE);
+    adw_alert_dialog_set_default_response(ADW_ALERT_DIALOG(dialog), "cancel");
+    adw_alert_dialog_set_close_response(ADW_ALERT_DIALOG(dialog), "cancel");
+
+    struct ConfirmCancelDownloadsResult {
+        bool done { false };
+        bool accepted { false };
+    } result;
+
+    g_signal_connect(dialog, "response", G_CALLBACK(+[](AdwAlertDialog*, char const* response, gpointer user_data) {
+        auto* result = static_cast<ConfirmCancelDownloadsResult*>(user_data);
+        result->accepted = StringView(response, strlen(response)) == "quit"sv;
+        result->done = true;
+    }),
+        &result);
+    adw_dialog_present(ADW_DIALOG(dialog), GTK_WIDGET(parent));
+
+    Core::EventLoop::current().spin_until([&] { return result.done; });
+    if (!result.accepted)
+        return false;
+
+    downloader.cancel_active_downloads();
+    return true;
 }
 
 void Application::remove_window(BrowserWindow& window)

--- a/UI/Gtk/Application.cpp
+++ b/UI/Gtk/Application.cpp
@@ -180,7 +180,7 @@ Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML
     return static_cast<WebView::ViewImplementation&>(tab.view());
 }
 
-Optional<ByteString> Application::ask_user_for_download_path(StringView file) const
+Optional<ByteString> Application::ask_user_for_download_path(ByteString const& file) const
 {
     if (!m_active_window)
         return {};
@@ -193,7 +193,7 @@ Optional<ByteString> Application::ask_user_for_download_path(StringView file) co
         GObjectPtr initial_folder { g_file_new_for_path(downloads_dir) };
         gtk_file_dialog_set_initial_folder(GTK_FILE_DIALOG(dialog.ptr()), G_FILE(initial_folder.ptr()));
     }
-    gtk_file_dialog_set_initial_name(GTK_FILE_DIALOG(dialog.ptr()), ByteString(file).characters());
+    gtk_file_dialog_set_initial_name(GTK_FILE_DIALOG(dialog.ptr()), file.characters());
 
     struct FileDialogSaveResult {
         bool done { false };

--- a/UI/Gtk/Application.h
+++ b/UI/Gtk/Application.h
@@ -33,6 +33,7 @@ public:
     Tab* active_tab() const;
 
     AdwApplication* adw_application() const { return m_adw_application; }
+    bool confirm_cancel_active_downloads(GtkWindow* parent);
 
     template<typename Callback>
     void for_each_window(Callback callback)

--- a/UI/Gtk/Application.h
+++ b/UI/Gtk/Application.h
@@ -49,7 +49,7 @@ private:
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
 
-    virtual Optional<ByteString> ask_user_for_download_path(StringView file) const override;
+    virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 

--- a/UI/Gtk/BrowserWindow.cpp
+++ b/UI/Gtk/BrowserWindow.cpp
@@ -118,7 +118,11 @@ void BrowserWindow::register_actions()
         if (auto* tab = self.current_tab())
             tab->view().find_in_page_previous_match(); });
 
-    add_action("quit", [](BrowserWindow&) { Core::EventLoop::current().quit(0); });
+    add_action("quit", [](BrowserWindow& self) {
+        if (!Application::the().confirm_cancel_active_downloads(self.gtk_window()))
+            return;
+        Core::EventLoop::current().quit(0);
+    });
 
     add_action("fullscreen", [](BrowserWindow& self) {
         if (gtk_window_is_fullscreen(GTK_WINDOW(self.m_window)))

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -358,6 +358,9 @@ void Application::open_file()
 
 void Application::quit()
 {
+    if (!confirm_cancel_active_downloads(active_window_if_any()))
+        return;
+
     QApplication::closeAllWindows();
 
     for (auto* widget : QApplication::topLevelWidgets()) {
@@ -366,6 +369,29 @@ void Application::quit()
     }
 
     QApplication::quit();
+}
+
+bool Application::confirm_cancel_active_downloads(QWidget* parent)
+{
+    auto& downloader = file_downloader();
+    if (!downloader.has_active_downloads())
+        return true;
+
+    QMessageBox dialog(parent ? parent : active_window_if_any());
+    dialog.setWindowTitle("Ladybird");
+    dialog.setIcon(QMessageBox::Warning);
+    dialog.setText("Downloads are still in progress.");
+    dialog.setInformativeText("Quitting will cancel active downloads.");
+    auto* quit_button = dialog.addButton("Quit and Cancel Downloads", QMessageBox::DestructiveRole);
+    dialog.addButton(QMessageBox::Cancel);
+    dialog.setDefaultButton(QMessageBox::Cancel);
+    dialog.exec();
+
+    if (dialog.clickedButton() != quit_button)
+        return false;
+
+    downloader.cancel_active_downloads();
+    return true;
 }
 
 void Application::initialize_macos_application_menu()

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -425,14 +425,14 @@ void Application::open_url_in_new_window(URL::URL const& url)
     this->new_window({ url });
 }
 
-Optional<ByteString> Application::ask_user_for_download_path(StringView file) const
+Optional<ByteString> Application::ask_user_for_download_path(ByteString const& file) const
 {
     auto default_path = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
 
     if (default_path.isNull() || default_path.isEmpty())
-        default_path = qstring_from_ak_string(file);
+        default_path = qstring_from_ak_string(file.view());
     else
-        default_path = QDir { default_path }.filePath(qstring_from_ak_string(file));
+        default_path = QDir { default_path }.filePath(qstring_from_ak_string(file.view()));
 
     auto path = QFileDialog::getSaveFileName(nullptr, "Select save location", default_path);
     if (path.isNull())

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -163,6 +163,8 @@ public:
             Application::the().open_file();
         });
 
+        file_menu->addAction(create_application_action(*file_menu, application.open_downloads_page_action(), IncludeActionIcon::No));
+
         auto* open_location_action = add_application_menu_action(*file_menu, "Open &Location", { QKeySequence("Ctrl+L"), QKeySequence("Alt+D") });
         QObject::connect(open_location_action, &QAction::triggered, this, [] {
             Application::the().focus_location_editor();
@@ -461,6 +463,16 @@ void Application::display_download_confirmation_dialog(StringView download_name,
 void Application::display_error_dialog(StringView error_message) const
 {
     QMessageBox::warning(active_tab(), "Ladybird", qstring_from_ak_string(error_message));
+}
+
+void Application::open_download(WebView::FileDownloader::Download const& download) const
+{
+    QDesktopServices::openUrl(QUrl::fromLocalFile(qstring_from_ak_string(download.destination.string())));
+}
+
+void Application::show_download_in_folder(WebView::FileDownloader::Download const& download) const
+{
+    QDesktopServices::openUrl(QUrl::fromLocalFile(qstring_from_ak_string(download.destination.dirname())));
 }
 
 static QClipboard::Mode clipboard_mode(QClipboard const& clipboard, Application::ClipboardType type)

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -493,12 +493,24 @@ void Application::display_error_dialog(StringView error_message) const
 
 void Application::open_download(WebView::FileDownloader::Download const& download) const
 {
-    QDesktopServices::openUrl(QUrl::fromLocalFile(qstring_from_ak_string(download.destination.string())));
+    auto path = download_file_path_for_frontend_action(download);
+    if (path.is_error()) {
+        display_error_dialog("Unable to open downloaded file: path cannot be represented by this frontend"sv);
+        return;
+    }
+
+    QDesktopServices::openUrl(QUrl::fromLocalFile(qstring_from_ak_string(path.release_value())));
 }
 
 void Application::show_download_in_folder(WebView::FileDownloader::Download const& download) const
 {
-    QDesktopServices::openUrl(QUrl::fromLocalFile(qstring_from_ak_string(download.destination.dirname())));
+    auto path = download_directory_path_for_frontend_action(download);
+    if (path.is_error()) {
+        display_error_dialog("Unable to show downloaded file: path cannot be represented by this frontend"sv);
+        return;
+    }
+
+    QDesktopServices::openUrl(QUrl::fromLocalFile(qstring_from_ak_string(path.release_value())));
 }
 
 static QClipboard::Mode clipboard_mode(QClipboard const& clipboard, Application::ClipboardType type)

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -14,6 +14,7 @@
 #include <QApplication>
 
 class QMenu;
+class QWidget;
 
 namespace Ladybird {
 
@@ -39,6 +40,7 @@ public:
     void reopen_recently_closed_tab();
     void open_file();
     void quit();
+    bool confirm_cancel_active_downloads(QWidget* parent = nullptr);
     void initialize_macos_application_menu();
     QMenu* qt_bookmarks_menu() const;
 

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -64,6 +64,8 @@ private:
     virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
+    virtual void open_download(WebView::FileDownloader::Download const&) const override;
+    virtual void show_download_in_folder(WebView::FileDownloader::Download const&) const override;
 
     virtual bool supports_clipboard_type(ClipboardType) const override;
     virtual Utf16String clipboard_text(ClipboardType) const override;

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -61,7 +61,7 @@ private:
     virtual bool activate_tab_with_url(URL::URL const&) const override;
     virtual void open_url_in_new_window(URL::URL const& url) override;
 
-    virtual Optional<ByteString> ask_user_for_download_path(StringView file) const override;
+    virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -101,6 +101,16 @@ static Vector<URL::URL> recently_closed_urls_for_window(TabWidget const& tabs_co
     return urls;
 }
 
+static int visible_browser_window_count()
+{
+    int count = 0;
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (as_if<BrowserWindow>(widget) && widget->isVisible())
+            ++count;
+    }
+    return count;
+}
+
 FullscreenMode::FullscreenMode(BrowserWindow* window, ExitFullscreenButton* exit_button)
     : QObject(window)
     , m_window(window)
@@ -724,8 +734,13 @@ bool BrowserWindow::activate_tab_with_url(URL::URL const& url)
     return false;
 }
 
-void BrowserWindow::definitely_close_tab(int index)
+bool BrowserWindow::definitely_close_tab(int index)
 {
+    if (m_tabs_container->count() == 1 && Application::the().file_downloader().has_active_downloads() && visible_browser_window_count() <= 1) {
+        if (!Application::the().confirm_cancel_active_downloads(this))
+            return false;
+    }
+
     auto* tab = m_tabs_container->tab(index);
     auto url = tab->view().url();
     m_tabs_container->remove_tab(index);
@@ -737,6 +752,8 @@ void BrowserWindow::definitely_close_tab(int index)
         m_should_record_closed_window_on_close = false;
         close();
     }
+
+    return true;
 }
 
 void BrowserWindow::update_reopen_recently_closed_action()
@@ -1575,6 +1592,15 @@ void BrowserWindow::wheelEvent(QWheelEvent* event)
 
 void BrowserWindow::closeEvent(QCloseEvent* event)
 {
+    if (Application::the().file_downloader().has_active_downloads()) {
+        if (visible_browser_window_count() <= 1) {
+            if (!Application::the().confirm_cancel_active_downloads(this)) {
+                event->ignore();
+                return;
+            }
+        }
+    }
+
     clear_resize_cursor();
 
     Optional<Vector<URL::URL>> recently_closed_window_urls;

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -291,6 +291,9 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     m_hamburger_menu->addAction(open_file_action);
     file_menu->addAction(open_file_action);
 
+    m_hamburger_menu->addAction(create_application_action(*this, application.open_downloads_page_action(), IncludeActionIcon::No));
+    file_menu->addAction(create_application_action(*this, application.open_downloads_page_action(), IncludeActionIcon::No));
+
     m_hamburger_menu->addSeparator();
 
     auto* edit_menu = m_hamburger_menu->addMenu("&Edit");

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -138,7 +138,7 @@ public slots:
     Tab& new_tab_from_url(URL::URL const&, Web::HTML::ActivateTab);
     Tab& new_child_tab(Web::HTML::ActivateTab, Tab& parent, Optional<u64> page_index);
     void activate_tab(int index);
-    void definitely_close_tab(int index);
+    bool definitely_close_tab(int index);
     void move_tab(int old_index, int new_index);
     void request_to_close_tab(int index);
     void request_to_close_current_tab();

--- a/UI/Qt/Icon.cpp
+++ b/UI/Qt/Icon.cpp
@@ -299,6 +299,23 @@ static QPixmap create_chrome_icon_pixmap(ChromeIcon icon, QColor color, qreal de
         painter.drawPath(path);
         break;
     }
+    case ChromeIcon::Download:
+    case ChromeIcon::DownloadActive: {
+        painter.setPen(chrome_icon_pen(color, 1.75));
+        painter.drawLine(QPointF(10.0, 3.4), QPointF(10.0, 12.0));
+        painter.drawLine(QPointF(6.6, 8.7), QPointF(10.0, 12.1));
+        painter.drawLine(QPointF(13.4, 8.7), QPointF(10.0, 12.1));
+
+        QPainterPath tray;
+        tray.moveTo(4.0, 13.4);
+        tray.lineTo(4.0, 15.7);
+        tray.quadTo(4.0, 16.6, 4.9, 16.6);
+        tray.lineTo(15.1, 16.6);
+        tray.quadTo(16.0, 16.6, 16.0, 15.7);
+        tray.lineTo(16.0, 13.4);
+        painter.drawPath(tray);
+        break;
+    }
     case ChromeIcon::Volume:
         draw_volume_icon(painter, color, false);
         break;
@@ -379,7 +396,10 @@ QIcon create_chrome_icon(ChromeIcon icon, QPalette const& palette)
 {
     auto normal = ChromeStyle::chrome_button_text(palette);
     auto normal_alpha = 216;
-    if (icon == ChromeIcon::Close || icon == ChromeIcon::TabClose)
+    if (icon == ChromeIcon::DownloadActive) {
+        normal = ChromeStyle::chrome_accent(palette);
+        normal_alpha = 244;
+    } else if (icon == ChromeIcon::Close || icon == ChromeIcon::TabClose)
         normal_alpha = 172;
     else if (icon == ChromeIcon::Star)
         normal_alpha = 204;

--- a/UI/Qt/Icon.h
+++ b/UI/Qt/Icon.h
@@ -30,6 +30,8 @@ enum class ChromeIcon {
     Search,
     Globe,
     Folder,
+    Download,
+    DownloadActive,
     Volume,
     VolumeMuted,
     ChevronUp,

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -164,6 +164,9 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
             qaction.setIcon(create_chrome_icon(ChromeIcon::Reload, palette));
         qaction.setShortcuts({ QKeySequence(Qt::CTRL | Qt::Key_R), QKeySequence(Qt::Key_F5) });
         break;
+    case WebView::ActionID::ViewDownloads:
+        qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::Key_J));
+        break;
 
     case WebView::ActionID::CopySelection:
         qaction.setShortcut(QKeySequence::StandardKey::Copy);

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -165,6 +165,8 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
         qaction.setShortcuts({ QKeySequence(Qt::CTRL | Qt::Key_R), QKeySequence(Qt::Key_F5) });
         break;
     case WebView::ActionID::ViewDownloads:
+        if (include_action_icon == IncludeActionIcon::Yes)
+            qaction.setIcon(create_chrome_icon(ChromeIcon::Download, palette));
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::Key_J));
         break;
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -12,6 +12,7 @@
 #include <LibWebView/Application.h>
 #include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
+#include <UI/Qt/Application.h>
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/ChromeLayout.h>
 #include <UI/Qt/ChromeStyle.h>
@@ -27,6 +28,8 @@
 #include <QFileDialog>
 #include <QFont>
 #include <QFontMetrics>
+#include <QFrame>
+#include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QImage>
 #include <QInputDialog>
@@ -35,8 +38,13 @@
 #include <QMimeData>
 #include <QMimeDatabase>
 #include <QPainter>
+#include <QProgressBar>
+#include <QPushButton>
 #include <QResizeEvent>
+#include <QScreen>
+#include <QScrollArea>
 #include <QTimer>
+#include <QVBoxLayout>
 
 namespace Ladybird {
 
@@ -101,6 +109,12 @@ public:
         update();
     }
 
+    void set_progress_icon(QIcon icon)
+    {
+        m_progress_icon = icon;
+        update();
+    }
+
 protected:
     virtual void paintEvent(QPaintEvent* event) override
     {
@@ -115,8 +129,6 @@ protected:
         if (progress > 1.0)
             progress = 1.0;
 
-        constexpr qreal bar_height = 3.0;
-        constexpr qreal bar_bottom_margin = 2.0;
         auto const icon_size = this->iconSize();
         auto icon_rect = QRectF {
             (static_cast<qreal>(width()) - icon_size.width()) / 2.0,
@@ -124,33 +136,22 @@ protected:
             static_cast<qreal>(icon_size.width()),
             static_cast<qreal>(icon_size.height())
         };
-        auto bar_rect = QRectF {
+        auto fill_rect = QRectF {
             icon_rect.left(),
-            static_cast<qreal>(height()) - bar_bottom_margin - bar_height,
+            icon_rect.top(),
             icon_rect.width(),
-            bar_height
+            icon_rect.height() * progress
         };
-        auto fill_rect = bar_rect;
-        fill_rect.setWidth(bar_rect.width() * progress);
-
-        auto track_color = ChromeStyle::chrome_control_border(palette());
-        track_color.setAlpha(112);
-        auto fill_color = ChromeStyle::chrome_accent(palette());
 
         QPainter painter(this);
-        painter.setRenderHint(QPainter::Antialiasing, true);
-        painter.setPen(Qt::NoPen);
-        painter.setBrush(track_color);
-        painter.drawRoundedRect(bar_rect, 1.5, 1.5);
-
-        if (fill_rect.width() > 0.0) {
-            painter.setBrush(fill_color);
-            painter.drawRoundedRect(fill_rect, 1.5, 1.5);
-        }
+        painter.setClipRect(fill_rect);
+        auto pixmap = m_progress_icon.pixmap(icon_size, devicePixelRatioF(), isEnabled() ? QIcon::Normal : QIcon::Disabled);
+        painter.drawPixmap(icon_rect.toRect(), pixmap);
     }
 
 private:
     Optional<double> m_progress;
+    QIcon m_progress_icon;
 };
 
 static QToolButton* create_toolbar_button(QWidget& parent, QAction& action)
@@ -212,6 +213,9 @@ static constexpr int TOOLBAR_MACOS_TRAFFIC_LIGHTS_CONTROL_GAP = 22;
 static constexpr int TOOLBAR_SIDEBAR_TOGGLE_NAVIGATION_GAP = 8;
 static constexpr int TOOLBAR_LOCATION_EDIT_SIDE_GAP = 32;
 static constexpr int TOOLBAR_WINDOW_CONTROLS_RIGHT_MARGIN = 4;
+static constexpr int DOWNLOADS_POPOVER_WIDTH = 380;
+static constexpr int DOWNLOADS_POPOVER_MAX_HEIGHT = 360;
+static constexpr int DOWNLOADS_POPOVER_MAX_VISIBLE_DOWNLOADS = 5;
 
 static QString download_count_text(size_t count, char const* singular, char const* plural)
 {
@@ -228,6 +232,381 @@ static QString download_percent_text(double progress)
     auto percent = static_cast<int>(progress * 100.0);
     return QString("%1%").arg(percent);
 }
+
+static QString download_size_text(u64 size)
+{
+    constexpr double kibibyte = 1024.0;
+    constexpr double mebibyte = kibibyte * 1024.0;
+    constexpr double gibibyte = mebibyte * 1024.0;
+
+    auto size_as_double = static_cast<double>(size);
+    if (size_as_double < kibibyte)
+        return QString("%1 B").arg(size);
+    if (size_as_double < mebibyte)
+        return QString("%1 KB").arg(size_as_double / kibibyte, 0, 'f', 1);
+    if (size_as_double < gibibyte)
+        return QString("%1 MB").arg(size_as_double / mebibyte, 0, 'f', 1);
+    return QString("%1 GB").arg(size_as_double / gibibyte, 0, 'f', 1);
+}
+
+static Optional<double> download_progress(WebView::FileDownloader::Download const& download)
+{
+    if (!download.total_size.has_value() || *download.total_size == 0)
+        return {};
+
+    return static_cast<double>(min(download.downloaded_size, *download.total_size)) / static_cast<double>(*download.total_size);
+}
+
+static QString download_status_text(WebView::FileDownloader::Download const& download)
+{
+    using DownloadStatus = WebView::FileDownloader::DownloadStatus;
+
+    switch (download.status) {
+    case DownloadStatus::InProgress:
+        if (auto progress = download_progress(download); progress.has_value()) {
+            return QString("%1 of %2 - %3")
+                .arg(download_size_text(download.downloaded_size))
+                .arg(download_size_text(*download.total_size))
+                .arg(download_percent_text(*progress));
+        }
+        return QString("%1 downloaded").arg(download_size_text(download.downloaded_size));
+    case DownloadStatus::Completed:
+        return QString("Completed - %1").arg(download_size_text(download.downloaded_size));
+    case DownloadStatus::Canceled:
+        return "Canceled";
+    case DownloadStatus::Failed:
+        if (download.error.has_value() && !download.error->is_empty())
+            return QString("Failed - %1").arg(qstring_from_ak_string(*download.error));
+        return "Failed";
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static QString downloads_popover_style_sheet(QPalette const& palette)
+{
+    auto surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface(palette));
+    auto recessed_surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface_recessed(palette));
+    auto hover_surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface_hover(palette));
+    auto border = ChromeStyle::style_sheet_color(ChromeStyle::chrome_border(palette));
+    auto text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_text(palette));
+    auto muted_text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_muted_text(palette));
+    auto accent = ChromeStyle::style_sheet_color(ChromeStyle::chrome_accent(palette));
+
+    return qformatted(R"(
+QFrame#LadybirdDownloadsPopover {{
+    color: {4};
+    background: {0};
+    border: 1px solid {3};
+    border-radius: 8px;
+}}
+
+QScrollArea#LadybirdDownloadsPopoverScroll,
+QWidget#LadybirdDownloadsPopoverRows {{
+    background: transparent;
+    border: 0;
+}}
+
+QLabel#LadybirdDownloadsPopoverTitle,
+QLabel#LadybirdDownloadFileName {{
+    color: {4};
+    font-weight: 600;
+}}
+
+QLabel#LadybirdDownloadStatus,
+QLabel#LadybirdDownloadsEmpty {{
+    color: {5};
+}}
+
+QFrame#LadybirdDownloadRow {{
+    background: {0};
+    border: 1px solid {3};
+    border-radius: 6px;
+}}
+
+QFrame#LadybirdDownloadRow:hover {{
+    background: {2};
+}}
+
+QProgressBar#LadybirdDownloadProgress {{
+    background: {1};
+    border: 0;
+    border-radius: 2px;
+    min-height: 4px;
+    max-height: 4px;
+}}
+
+QProgressBar#LadybirdDownloadProgress::chunk {{
+    background: {6};
+    border-radius: 2px;
+}}
+)",
+        surface, recessed_surface, hover_surface, border, text, muted_text, accent);
+}
+
+class ElidedLabel final : public QLabel {
+public:
+    explicit ElidedLabel(QString text, Qt::TextElideMode elide_mode, QWidget* parent = nullptr)
+        : QLabel(text, parent)
+        , m_elide_mode(elide_mode)
+    {
+        setMinimumWidth(0);
+        setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    }
+
+    virtual QSize sizeHint() const override
+    {
+        auto size = QLabel::sizeHint();
+        size.setWidth(0);
+        return size;
+    }
+
+    virtual QSize minimumSizeHint() const override
+    {
+        return { 0, QLabel::minimumSizeHint().height() };
+    }
+
+protected:
+    virtual void paintEvent(QPaintEvent*) override
+    {
+        QPainter painter(this);
+        painter.setFont(font());
+        painter.setPen(palette().color(foregroundRole()));
+        painter.drawText(rect(), alignment() | Qt::TextSingleLine, fontMetrics().elidedText(text(), m_elide_mode, width()));
+    }
+
+private:
+    Qt::TextElideMode m_elide_mode { Qt::ElideRight };
+};
+
+class DownloadRow final : public QFrame {
+public:
+    explicit DownloadRow(WebView::FileDownloader::Download const& download, QWidget* parent)
+        : QFrame(parent)
+        , m_download_id(download.id)
+    {
+        setObjectName("LadybirdDownloadRow");
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+        auto* row_layout = new QHBoxLayout(this);
+        row_layout->setContentsMargins(10, 8, 10, 8);
+        row_layout->setSpacing(8);
+
+        auto* details_layout = new QVBoxLayout;
+        details_layout->setContentsMargins(0, 0, 0, 0);
+        details_layout->setSpacing(4);
+
+        m_file_name_label = new ElidedLabel({}, Qt::ElideRight, this);
+        m_file_name_label->setObjectName("LadybirdDownloadFileName");
+        details_layout->addWidget(m_file_name_label);
+
+        m_status_label = new ElidedLabel({}, Qt::ElideRight, this);
+        m_status_label->setObjectName("LadybirdDownloadStatus");
+        details_layout->addWidget(m_status_label);
+
+        m_progress_bar = new QProgressBar(this);
+        m_progress_bar->setObjectName("LadybirdDownloadProgress");
+        m_progress_bar->setRange(0, 1000);
+        m_progress_bar->setTextVisible(false);
+        details_layout->addWidget(m_progress_bar);
+
+        row_layout->addLayout(details_layout, 1);
+
+        m_cancel_button = new QPushButton("Cancel", this);
+        m_cancel_button->setFocusPolicy(Qt::NoFocus);
+        QObject::connect(m_cancel_button, &QPushButton::clicked, this, [this] {
+            if (on_cancel_download)
+                on_cancel_download(m_download_id);
+        });
+        row_layout->addWidget(m_cancel_button, 0, Qt::AlignTop);
+
+        (void)update_download(download);
+    }
+
+    u64 id() const { return m_download_id; }
+
+    bool update_download(WebView::FileDownloader::Download const& download)
+    {
+        VERIFY(download.id == m_download_id);
+
+        m_file_name_label->setText(qstring_from_ak_string(download.destination.basename()));
+        m_file_name_label->setToolTip(qstring_from_ak_string(download.destination.string()));
+
+        auto status_text = download_status_text(download);
+        m_status_label->setText(status_text);
+        m_status_label->setToolTip(status_text);
+
+        bool geometry_changed = false;
+        auto progress = download_progress(download);
+        auto show_progress = download.status == WebView::FileDownloader::DownloadStatus::InProgress && progress.has_value();
+        auto progress_bar_is_visible = !m_progress_bar->isHidden();
+        if (progress_bar_is_visible != show_progress) {
+            m_progress_bar->setVisible(show_progress);
+            geometry_changed = true;
+        }
+        if (progress.has_value())
+            m_progress_bar->setValue(static_cast<int>(*progress * 1000.0));
+
+        auto should_show_cancel = download.status == WebView::FileDownloader::DownloadStatus::InProgress;
+        auto cancel_button_is_visible = !m_cancel_button->isHidden();
+        if (cancel_button_is_visible != should_show_cancel) {
+            m_cancel_button->setVisible(should_show_cancel);
+            geometry_changed = true;
+        }
+
+        return geometry_changed;
+    }
+
+    Function<void(u64)> on_cancel_download;
+
+private:
+    u64 m_download_id { 0 };
+    ElidedLabel* m_file_name_label { nullptr };
+    ElidedLabel* m_status_label { nullptr };
+    QProgressBar* m_progress_bar { nullptr };
+    QPushButton* m_cancel_button { nullptr };
+};
+
+class DownloadsPopover final : public QFrame {
+public:
+    explicit DownloadsPopover(QWidget* parent)
+        : QFrame(parent, Qt::Popup | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint)
+    {
+        setObjectName("LadybirdDownloadsPopover");
+#if defined(AK_OS_MACOS)
+        setAttribute(Qt::WA_NativeWindow);
+#endif
+        setFrameShape(QFrame::StyledPanel);
+        setFrameShadow(QFrame::Raised);
+        setAutoFillBackground(true);
+        setFixedWidth(DOWNLOADS_POPOVER_WIDTH);
+
+        auto* layout = new QVBoxLayout(this);
+        layout->setContentsMargins(12, 10, 12, 12);
+        layout->setSpacing(8);
+
+        auto* title = new QLabel("Downloads", this);
+        title->setObjectName("LadybirdDownloadsPopoverTitle");
+        layout->addWidget(title);
+
+        m_empty_label = new QLabel("No downloads", this);
+        m_empty_label->setObjectName("LadybirdDownloadsEmpty");
+        m_empty_label->setAlignment(Qt::AlignCenter);
+        m_empty_label->setMinimumHeight(80);
+        layout->addWidget(m_empty_label);
+
+        m_scroll_area = new QScrollArea(this);
+        m_scroll_area->setObjectName("LadybirdDownloadsPopoverScroll");
+        m_scroll_area->setFrameShape(QFrame::NoFrame);
+        m_scroll_area->setWidgetResizable(true);
+        m_scroll_area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        m_scroll_area->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+
+        m_rows_widget = new QWidget(m_scroll_area);
+        m_rows_widget->setObjectName("LadybirdDownloadsPopoverRows");
+        m_rows_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        m_rows_layout = new QVBoxLayout(m_rows_widget);
+        m_rows_layout->setContentsMargins(0, 0, 0, 0);
+        m_rows_layout->setSpacing(6);
+        m_scroll_area->setWidget(m_rows_widget);
+        layout->addWidget(m_scroll_area);
+
+        auto* show_all_button = new QPushButton("Show All Downloads", this);
+        QObject::connect(show_all_button, &QPushButton::clicked, this, [this] {
+            if (on_open_all_downloads)
+                on_open_all_downloads();
+        });
+        layout->addWidget(show_all_button);
+    }
+
+    void update_chrome_style(QPalette const& palette)
+    {
+        setPalette(palette);
+        setStyleSheet(downloads_popover_style_sheet(palette));
+    }
+
+    bool set_downloads(ReadonlySpan<WebView::FileDownloader::Download> downloads)
+    {
+        bool geometry_changed = false;
+        Vector<WebView::FileDownloader::Download const*> visible_downloads;
+        visible_downloads.ensure_capacity(min(downloads.size(), DOWNLOADS_POPOVER_MAX_VISIBLE_DOWNLOADS));
+
+        for (size_t i = downloads.size(); i > 0 && visible_downloads.size() < DOWNLOADS_POPOVER_MAX_VISIBLE_DOWNLOADS; --i)
+            visible_downloads.append(&downloads[i - 1]);
+
+        if (!rows_match(visible_downloads)) {
+            rebuild_rows(visible_downloads);
+            geometry_changed = true;
+        } else {
+            for (size_t i = 0; i < visible_downloads.size(); ++i) {
+                if (m_download_rows[i]->update_download(*visible_downloads[i]))
+                    geometry_changed = true;
+            }
+        }
+
+        auto is_empty = visible_downloads.is_empty();
+        auto empty_label_is_visible = !m_empty_label->isHidden();
+        if (empty_label_is_visible != is_empty) {
+            m_empty_label->setVisible(is_empty);
+            geometry_changed = true;
+        }
+        auto scroll_area_is_visible = !m_scroll_area->isHidden();
+        if (scroll_area_is_visible == is_empty) {
+            m_scroll_area->setVisible(!is_empty);
+            geometry_changed = true;
+        }
+
+        return geometry_changed;
+    }
+
+    Function<void(u64)> on_cancel_download;
+    Function<void()> on_open_all_downloads;
+
+private:
+    bool rows_match(Vector<WebView::FileDownloader::Download const*> const& downloads) const
+    {
+        if (m_download_rows.size() != downloads.size())
+            return false;
+
+        for (size_t i = 0; i < downloads.size(); ++i) {
+            if (m_download_rows[i]->id() != downloads[i]->id)
+                return false;
+        }
+
+        return true;
+    }
+
+    void rebuild_rows(Vector<WebView::FileDownloader::Download const*> const& downloads)
+    {
+        clear_rows();
+        m_download_rows.ensure_capacity(downloads.size());
+
+        for (auto* download : downloads) {
+            auto* row = new DownloadRow(*download, m_rows_widget);
+            row->on_cancel_download = [this](u64 id) {
+                if (on_cancel_download)
+                    on_cancel_download(id);
+            };
+            m_rows_layout->addWidget(row);
+            m_download_rows.append(row);
+        }
+    }
+
+    void clear_rows()
+    {
+        while (auto* item = m_rows_layout->takeAt(0)) {
+            if (auto* widget = item->widget())
+                delete widget;
+            delete item;
+        }
+        m_download_rows.clear();
+    }
+
+    QLabel* m_empty_label { nullptr };
+    QScrollArea* m_scroll_area { nullptr };
+    QWidget* m_rows_widget { nullptr };
+    QVBoxLayout* m_rows_layout { nullptr };
+    Vector<DownloadRow*> m_download_rows;
+};
 
 Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
     : QWidget(window)
@@ -372,12 +751,15 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_right_toggle_vertical_tabs_expanded_button = create_toolbar_button(*m_toolbar, *m_toggle_vertical_tabs_expanded_action);
     toolbar_layout->addWidget(m_right_toggle_vertical_tabs_expanded_button, 0, Qt::AlignTop);
     m_downloads_button = new DownloadsButton(m_toolbar);
-    m_downloads_button->setDefaultAction(m_open_downloads_page_action);
+    m_downloads_button->setText("Downloads");
     m_downloads_button->setAutoRaise(true);
     m_downloads_button->setFocusPolicy(Qt::NoFocus);
     m_downloads_button->setIconSize({ 20, 20 });
     m_downloads_button->setFixedSize(36, 36);
     m_downloads_button->setVisible(m_open_downloads_page_action->isVisible());
+    QObject::connect(m_downloads_button, &QToolButton::clicked, this, [this] {
+        show_downloads_popover();
+    });
     toolbar_layout->addWidget(m_downloads_button, 0, Qt::AlignTop);
     toolbar_layout->addWidget(m_hamburger_button, 0, Qt::AlignTop);
     if (use_right_custom_window_controls()) {
@@ -962,6 +1344,8 @@ void Tab::update_chrome_style()
     auto hover_text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_text(palette()));
     m_hover_label->setStyleSheet(qformatted("background: {}; color: {}; border: 1px solid {}; border-radius: 6px;",
         hover_surface, hover_text, hover_border));
+    if (m_downloads_popover)
+        m_downloads_popover->update_chrome_style(palette());
     m_is_updating_chrome_style = false;
 }
 
@@ -1021,16 +1405,25 @@ void Tab::update_downloads_button()
     }
 
     m_downloads_button->setVisible(!downloads.is_empty());
-
-    auto downloads_icon = active_download_count > 0 ? ChromeIcon::DownloadActive : ChromeIcon::Download;
-    if (!m_downloads_button_icon.has_value() || *m_downloads_button_icon != downloads_icon) {
-        m_open_downloads_page_action->setIcon(create_chrome_icon(downloads_icon, palette()));
-        m_downloads_button_icon = downloads_icon;
+    if (downloads.is_empty()) {
+        static_cast<DownloadsButton*>(m_downloads_button)->set_progress({});
+        if (m_downloads_popover)
+            m_downloads_popover->close();
     }
 
     Optional<double> active_download_progress;
     if (known_total_size > 0.0)
         active_download_progress = known_downloaded_size / known_total_size;
+
+    auto downloads_icon = active_download_count > 0 && !active_download_progress.has_value() ? ChromeIcon::DownloadActive : ChromeIcon::Download;
+    if (!m_downloads_button_icon.has_value() || *m_downloads_button_icon != downloads_icon) {
+        auto icon = create_chrome_icon(downloads_icon, palette());
+        m_open_downloads_page_action->setIcon(icon);
+        m_downloads_button->setIcon(icon);
+        static_cast<DownloadsButton*>(m_downloads_button)->set_progress_icon(create_chrome_icon(ChromeIcon::DownloadActive, palette()));
+        m_downloads_button_icon = downloads_icon;
+    }
+
     static_cast<DownloadsButton*>(m_downloads_button)->set_progress(active_download_count > 0 ? active_download_progress : Optional<double> {});
 
     QString tooltip;
@@ -1060,19 +1453,91 @@ void Tab::update_downloads_button()
     }
 }
 
+void Tab::update_downloads_popover()
+{
+    if (!m_downloads_popover || !m_downloads_popover->isVisible())
+        return;
+
+    if (m_downloads_popover->set_downloads(WebView::Application::the().file_downloader().downloads()))
+        position_downloads_popover();
+}
+
+void Tab::show_downloads_popover()
+{
+    if (!m_downloads_button || !m_downloads_button->isVisible())
+        return;
+
+    if (!m_downloads_popover) {
+        m_downloads_popover = new DownloadsPopover(this);
+        m_downloads_popover->on_cancel_download = [this](u64 id) {
+            auto& file_downloader = WebView::Application::the().file_downloader();
+            if (auto download = file_downloader.download(id); download.has_value() && download->status == WebView::FileDownloader::DownloadStatus::InProgress)
+                file_downloader.cancel_download(id);
+            update_downloads_popover();
+        };
+        m_downloads_popover->on_open_all_downloads = [this] {
+            if (m_downloads_popover)
+                m_downloads_popover->close();
+            m_open_downloads_page_action->trigger();
+        };
+    }
+
+    m_downloads_popover->update_chrome_style(palette());
+    (void)m_downloads_popover->set_downloads(WebView::Application::the().file_downloader().downloads());
+    position_downloads_popover();
+    m_downloads_popover->show();
+    position_downloads_popover();
+    m_downloads_popover->raise();
+}
+
+void Tab::position_downloads_popover()
+{
+    if (!m_downloads_popover || !m_downloads_button)
+        return;
+
+    m_downloads_popover->adjustSize();
+    auto size = m_downloads_popover->sizeHint();
+    size.setWidth(DOWNLOADS_POPOVER_WIDTH);
+    if (size.height() > DOWNLOADS_POPOVER_MAX_HEIGHT)
+        size.setHeight(DOWNLOADS_POPOVER_MAX_HEIGHT);
+    m_downloads_popover->setFixedSize(size);
+
+    auto anchor_position = m_downloads_button->mapToGlobal(m_downloads_button->rect().bottomRight());
+    auto popup_position = QPoint(anchor_position.x() - m_downloads_popover->width(), anchor_position.y() + 4);
+
+    if (auto* screen = QGuiApplication::screenAt(anchor_position)) {
+        auto available_geometry = screen->availableGeometry();
+        if (popup_position.x() < available_geometry.left())
+            popup_position.setX(available_geometry.left());
+        if (popup_position.x() + m_downloads_popover->width() > available_geometry.right())
+            popup_position.setX(available_geometry.right() - m_downloads_popover->width() + 1);
+        if (popup_position.y() + m_downloads_popover->height() > available_geometry.bottom())
+            popup_position.setY(m_downloads_button->mapToGlobal(m_downloads_button->rect().topRight()).y() - m_downloads_popover->height() - 4);
+    }
+
+    m_downloads_popover->move(popup_position);
+}
+
 void Tab::download_added(WebView::FileDownloader::Download const&)
 {
     update_downloads_button();
+    if (Application::the().active_tab() == this && m_window->isActiveWindow()) {
+        show_downloads_popover();
+        return;
+    }
+    update_downloads_popover();
 }
 
 void Tab::download_updated(WebView::FileDownloader::Download const&)
 {
     update_downloads_button();
+    update_downloads_popover();
 }
 
 void Tab::download_removed(u64)
 {
     update_downloads_button();
+    update_downloads_popover();
 }
 
 void Tab::update_vertical_tabs_toolbar_button_placement()

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -82,7 +82,22 @@ public:
 
     void set_progress(Optional<double> progress)
     {
-        m_progress = AK::move(progress);
+        auto normalized_progress = progress.map([](auto value) {
+            if (value < 0.0)
+                return 0.0;
+            if (value > 1.0)
+                return 1.0;
+            return value;
+        });
+
+        if (m_progress.has_value() == normalized_progress.has_value()) {
+            if (!normalized_progress.has_value())
+                return;
+            if (AK::abs(*m_progress - *normalized_progress) < 0.005)
+                return;
+        }
+
+        m_progress = AK::move(normalized_progress);
         update();
     }
 
@@ -101,7 +116,7 @@ protected:
             progress = 1.0;
 
         constexpr qreal bar_height = 3.0;
-        constexpr qreal bar_bottom_margin = 1.0;
+        constexpr qreal bar_bottom_margin = 2.0;
         auto const icon_size = this->iconSize();
         auto icon_rect = QRectF {
             (static_cast<qreal>(width()) - icon_size.width()) / 2.0,
@@ -111,7 +126,7 @@ protected:
         };
         auto bar_rect = QRectF {
             icon_rect.left(),
-            icon_rect.top() + icon_rect.height() - bar_bottom_margin - bar_height,
+            static_cast<qreal>(height()) - bar_bottom_margin - bar_height,
             icon_rect.width(),
             bar_height
         };
@@ -960,6 +975,7 @@ void Tab::recreate_toolbar_icons()
     m_navigate_back_action->setIcon(create_chrome_icon(ChromeIcon::Back, palette()));
     m_navigate_forward_action->setIcon(create_chrome_icon(ChromeIcon::Forward, palette()));
     m_reload_action->setIcon(create_chrome_icon(ChromeIcon::Reload, palette()));
+    m_downloads_button_icon = {};
     update_downloads_button();
     m_hamburger_button->setIcon(create_chrome_icon(ChromeIcon::Menu, palette()));
     update_window_control_icons();
@@ -1005,7 +1021,12 @@ void Tab::update_downloads_button()
     }
 
     m_downloads_button->setVisible(!downloads.is_empty());
-    m_open_downloads_page_action->setIcon(create_chrome_icon(active_download_count > 0 ? ChromeIcon::DownloadActive : ChromeIcon::Download, palette()));
+
+    auto downloads_icon = active_download_count > 0 ? ChromeIcon::DownloadActive : ChromeIcon::Download;
+    if (!m_downloads_button_icon.has_value() || *m_downloads_button_icon != downloads_icon) {
+        m_open_downloads_page_action->setIcon(create_chrome_icon(downloads_icon, palette()));
+        m_downloads_button_icon = downloads_icon;
+    }
 
     Optional<double> active_download_progress;
     if (known_total_size > 0.0)
@@ -1032,8 +1053,11 @@ void Tab::update_downloads_button()
         tooltip = "Downloads";
     }
 
-    m_open_downloads_page_action->setToolTip(tooltip);
-    m_downloads_button->setToolTip(tooltip);
+    if (m_downloads_button_tooltip != tooltip) {
+        m_downloads_button_tooltip = tooltip;
+        m_open_downloads_page_action->setToolTip(tooltip);
+        m_downloads_button->setToolTip(tooltip);
+    }
 }
 
 void Tab::download_added(WebView::FileDownloader::Download const&)
@@ -1042,6 +1066,11 @@ void Tab::download_added(WebView::FileDownloader::Download const&)
 }
 
 void Tab::download_updated(WebView::FileDownloader::Download const&)
+{
+    update_downloads_button();
+}
+
+void Tab::download_removed(u64)
 {
     update_downloads_button();
 }

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -1077,8 +1077,8 @@ void Tab::request_close()
 {
     if (!view().needs_beforeunload_check()) {
         auto request_close = view().prepare_for_immediate_close();
-        m_window->definitely_close_tab(tab_index());
-        Core::deferred_invoke(AK::move(request_close));
+        if (m_window->definitely_close_tab(tab_index()))
+            Core::deferred_invoke(AK::move(request_close));
         return;
     }
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -34,6 +34,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QMimeDatabase>
+#include <QPainter>
 #include <QResizeEvent>
 #include <QTimer>
 
@@ -73,6 +74,68 @@ private:
 
         menu->popup(QPoint { bottom_right.x() - menu_width, bottom_right.y() });
     }
+};
+
+class DownloadsButton final : public QToolButton {
+public:
+    using QToolButton::QToolButton;
+
+    void set_progress(Optional<double> progress)
+    {
+        m_progress = AK::move(progress);
+        update();
+    }
+
+protected:
+    virtual void paintEvent(QPaintEvent* event) override
+    {
+        QToolButton::paintEvent(event);
+
+        if (!m_progress.has_value())
+            return;
+
+        auto progress = *m_progress;
+        if (progress < 0.0)
+            progress = 0.0;
+        if (progress > 1.0)
+            progress = 1.0;
+
+        constexpr qreal bar_height = 3.0;
+        constexpr qreal bar_bottom_margin = 1.0;
+        auto const icon_size = this->iconSize();
+        auto icon_rect = QRectF {
+            (static_cast<qreal>(width()) - icon_size.width()) / 2.0,
+            (static_cast<qreal>(height()) - icon_size.height()) / 2.0,
+            static_cast<qreal>(icon_size.width()),
+            static_cast<qreal>(icon_size.height())
+        };
+        auto bar_rect = QRectF {
+            icon_rect.left(),
+            icon_rect.top() + icon_rect.height() - bar_bottom_margin - bar_height,
+            icon_rect.width(),
+            bar_height
+        };
+        auto fill_rect = bar_rect;
+        fill_rect.setWidth(bar_rect.width() * progress);
+
+        auto track_color = ChromeStyle::chrome_control_border(palette());
+        track_color.setAlpha(112);
+        auto fill_color = ChromeStyle::chrome_accent(palette());
+
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(track_color);
+        painter.drawRoundedRect(bar_rect, 1.5, 1.5);
+
+        if (fill_rect.width() > 0.0) {
+            painter.setBrush(fill_color);
+            painter.drawRoundedRect(fill_rect, 1.5, 1.5);
+        }
+    }
+
+private:
+    Optional<double> m_progress;
 };
 
 static QToolButton* create_toolbar_button(QWidget& parent, QAction& action)
@@ -134,6 +197,22 @@ static constexpr int TOOLBAR_MACOS_TRAFFIC_LIGHTS_CONTROL_GAP = 22;
 static constexpr int TOOLBAR_SIDEBAR_TOGGLE_NAVIGATION_GAP = 8;
 static constexpr int TOOLBAR_LOCATION_EDIT_SIDE_GAP = 32;
 static constexpr int TOOLBAR_WINDOW_CONTROLS_RIGHT_MARGIN = 4;
+
+static QString download_count_text(size_t count, char const* singular, char const* plural)
+{
+    return QString("%1 %2").arg(count).arg(count == 1 ? singular : plural);
+}
+
+static QString download_percent_text(double progress)
+{
+    if (progress < 0.0)
+        progress = 0.0;
+    if (progress > 1.0)
+        progress = 1.0;
+
+    auto percent = static_cast<int>(progress * 100.0);
+    return QString("%1%").arg(percent);
+}
 
 Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
     : QWidget(window)
@@ -214,6 +293,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_navigate_forward_action = create_application_action(*this, view().navigate_forward_action());
     m_reload_action = create_application_action(*this, application.reload_action());
     m_toggle_vertical_tabs_expanded_action = create_application_action(*this, application.toggle_vertical_tabs_expanded_action());
+    m_open_downloads_page_action = create_application_action(*this, application.open_downloads_page_action());
 
     m_toolbar_window_controls_separator = new QWidget(m_toolbar);
     m_toolbar_window_controls_separator->setObjectName("LadybirdToolbarWindowControlsSeparator");
@@ -276,6 +356,14 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     toolbar_layout->addWidget(location_edit_container, 1);
     m_right_toggle_vertical_tabs_expanded_button = create_toolbar_button(*m_toolbar, *m_toggle_vertical_tabs_expanded_action);
     toolbar_layout->addWidget(m_right_toggle_vertical_tabs_expanded_button, 0, Qt::AlignTop);
+    m_downloads_button = new DownloadsButton(m_toolbar);
+    m_downloads_button->setDefaultAction(m_open_downloads_page_action);
+    m_downloads_button->setAutoRaise(true);
+    m_downloads_button->setFocusPolicy(Qt::NoFocus);
+    m_downloads_button->setIconSize({ 20, 20 });
+    m_downloads_button->setFixedSize(36, 36);
+    m_downloads_button->setVisible(m_open_downloads_page_action->isVisible());
+    toolbar_layout->addWidget(m_downloads_button, 0, Qt::AlignTop);
     toolbar_layout->addWidget(m_hamburger_button, 0, Qt::AlignTop);
     if (use_right_custom_window_controls()) {
         toolbar_layout->addWidget(m_toolbar_window_controls_separator, 0, Qt::AlignVCenter);
@@ -283,6 +371,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     }
 
     update_chrome_style();
+    update_downloads_button();
     set_toolbar_window_controls_visible(false);
 
     view().on_activate_tab = [this] {
@@ -871,6 +960,7 @@ void Tab::recreate_toolbar_icons()
     m_navigate_back_action->setIcon(create_chrome_icon(ChromeIcon::Back, palette()));
     m_navigate_forward_action->setIcon(create_chrome_icon(ChromeIcon::Forward, palette()));
     m_reload_action->setIcon(create_chrome_icon(ChromeIcon::Reload, palette()));
+    update_downloads_button();
     m_hamburger_button->setIcon(create_chrome_icon(ChromeIcon::Menu, palette()));
     update_window_control_icons();
 
@@ -878,6 +968,82 @@ void Tab::recreate_toolbar_icons()
         auto icon = view().toggle_bookmark_action().engaged() ? ChromeIcon::StarFilled : ChromeIcon::Star;
         action->setIcon(create_chrome_icon(icon, palette()));
     }
+}
+
+void Tab::update_downloads_button()
+{
+    if (!m_downloads_button)
+        return;
+
+    auto downloads = WebView::Application::the().file_downloader().downloads();
+    using DownloadStatus = WebView::FileDownloader::DownloadStatus;
+
+    size_t active_download_count = 0;
+    size_t unknown_active_download_count = 0;
+    size_t failed_download_count = 0;
+    double known_downloaded_size = 0.0;
+    double known_total_size = 0.0;
+    for (auto const& download : downloads) {
+        switch (download.status) {
+        case DownloadStatus::InProgress:
+            ++active_download_count;
+            if (download.total_size.has_value() && *download.total_size > 0) {
+                known_downloaded_size += min(download.downloaded_size, *download.total_size);
+                known_total_size += *download.total_size;
+            } else {
+                ++unknown_active_download_count;
+            }
+            break;
+        case DownloadStatus::Completed:
+            break;
+        case DownloadStatus::Canceled:
+            break;
+        case DownloadStatus::Failed:
+            ++failed_download_count;
+            break;
+        }
+    }
+
+    m_downloads_button->setVisible(!downloads.is_empty());
+    m_open_downloads_page_action->setIcon(create_chrome_icon(active_download_count > 0 ? ChromeIcon::DownloadActive : ChromeIcon::Download, palette()));
+
+    Optional<double> active_download_progress;
+    if (known_total_size > 0.0)
+        active_download_progress = known_downloaded_size / known_total_size;
+    static_cast<DownloadsButton*>(m_downloads_button)->set_progress(active_download_count > 0 ? active_download_progress : Optional<double> {});
+
+    QString tooltip;
+    if (active_download_count > 0) {
+        if (active_download_progress.has_value() && unknown_active_download_count == 0) {
+            if (active_download_count == 1) {
+                tooltip = QString("Downloading - %1")
+                              .arg(download_percent_text(*active_download_progress));
+            } else {
+                tooltip = QString("%1 downloads - %2")
+                              .arg(active_download_count)
+                              .arg(download_percent_text(*active_download_progress));
+            }
+        } else {
+            tooltip = download_count_text(active_download_count, "download in progress", "downloads in progress");
+        }
+    } else if (failed_download_count > 0) {
+        tooltip = download_count_text(failed_download_count, "download failed", "downloads failed");
+    } else {
+        tooltip = "Downloads";
+    }
+
+    m_open_downloads_page_action->setToolTip(tooltip);
+    m_downloads_button->setToolTip(tooltip);
+}
+
+void Tab::download_added(WebView::FileDownloader::Download const&)
+{
+    update_downloads_button();
+}
+
+void Tab::download_updated(WebView::FileDownloader::Download const&)
+{
+    update_downloads_button();
 }
 
 void Tab::update_vertical_tabs_toolbar_button_placement()

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -27,6 +27,7 @@ class QTimer;
 namespace Ladybird {
 
 class BrowserWindow;
+enum class ChromeIcon;
 class WindowControlButton;
 
 class HyperlinkLabel final : public QLabel {
@@ -124,6 +125,7 @@ private:
 
     virtual void download_added(WebView::FileDownloader::Download const&) override;
     virtual void download_updated(WebView::FileDownloader::Download const&) override;
+    virtual void download_removed(u64) override;
 
     QWidget* m_toolbar_container { nullptr };
     QWidget* m_toolbar { nullptr };
@@ -165,6 +167,8 @@ private:
     QAction* m_navigate_forward_action { nullptr };
     QAction* m_reload_action { nullptr };
     QAction* m_open_downloads_page_action { nullptr };
+    Optional<ChromeIcon> m_downloads_button_icon;
+    QString m_downloads_button_tooltip;
 
     QPointer<QDialog> m_dialog;
 

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibWeb/HTML/AudioPlayState.h>
+#include <LibWebView/FileDownloader.h>
 #include <LibWebView/Settings.h>
 #include <UI/Qt/BookmarksBar.h>
 #include <UI/Qt/FindInPageWidget.h>
@@ -49,6 +50,7 @@ signals:
 
 class Tab final
     : public QWidget
+    , public WebView::FileDownloaderObserver
     , public WebView::SettingsObserver {
     Q_OBJECT
 
@@ -115,9 +117,13 @@ private:
     void update_hamburger_menu();
     void update_chrome_style();
     void update_tab_title();
+    void update_downloads_button();
     void set_loading(bool);
     void update_tab_icon();
     int tab_index();
+
+    virtual void download_added(WebView::FileDownloader::Download const&) override;
+    virtual void download_updated(WebView::FileDownloader::Download const&) override;
 
     QWidget* m_toolbar_container { nullptr };
     QWidget* m_toolbar { nullptr };
@@ -132,6 +138,7 @@ private:
     WindowControlButton* m_close_window_button { nullptr };
     BookmarksBar* m_bookmarks_bar { nullptr };
     QToolButton* m_hamburger_button { nullptr };
+    QToolButton* m_downloads_button { nullptr };
     LocationEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
     FindInPageWidget* m_find_in_page { nullptr };
@@ -157,6 +164,7 @@ private:
     QAction* m_navigate_back_action { nullptr };
     QAction* m_navigate_forward_action { nullptr };
     QAction* m_reload_action { nullptr };
+    QAction* m_open_downloads_page_action { nullptr };
 
     QPointer<QDialog> m_dialog;
 

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -23,11 +23,11 @@
 #include <QWidget>
 
 class QTimer;
-
 namespace Ladybird {
 
 class BrowserWindow;
 enum class ChromeIcon;
+class DownloadsPopover;
 class WindowControlButton;
 
 class HyperlinkLabel final : public QLabel {
@@ -119,6 +119,9 @@ private:
     void update_chrome_style();
     void update_tab_title();
     void update_downloads_button();
+    void update_downloads_popover();
+    void show_downloads_popover();
+    void position_downloads_popover();
     void set_loading(bool);
     void update_tab_icon();
     int tab_index();
@@ -141,6 +144,7 @@ private:
     BookmarksBar* m_bookmarks_bar { nullptr };
     QToolButton* m_hamburger_button { nullptr };
     QToolButton* m_downloads_button { nullptr };
+    QPointer<DownloadsPopover> m_downloads_popover;
     LocationEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
     FindInPageWidget* m_find_in_page { nullptr };

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -32,6 +32,7 @@ list(TRANSFORM INTERNAL_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladyb
 set(ABOUT_PAGES
     about.html
     bookmarks.html
+    downloads.html
     history.html
     newtab.html
     processes.html


### PR DESCRIPTION
This adds UI-process download management for Ladybird, including active download tracking, cancellation, failure handling, completed-download session state, and the about:downloads WebUI.

Navigation responses that become downloads are transferred from WebContent to the UI process when they have a RequestServer request, so downloads can continue independently of the tab that started them. Synthetic responses without a transferable RequestServer request stream their body data from WebContent instead.

Notable pieces:

- Transfer top-level navigation downloads to the UI process after content-disposition handling or MIME sniffing.
- Keep RequestServer requests alive long enough to adopt them for download, while still resuming normal document body delivery correctly.
- Add byte-string filename/path handling so arbitrary filesystem paths do not require UTF-8.
- Add destination conflict handling, unique temporary paths, cancellation, failure cleanup, and atomic finalization by rename.
- Add Qt download UI surfaces, including the toolbar indicator, downloads popover, about:downloads, and quit confirmation for active downloads.
- Keep the shared download state and behavior in LibWebView so other frontends can catch up without duplicating most of the logic.

Toolbar icon with popover:

<img width="1219" height="761" alt="Screenshot 2026-06-29 at 20 16 47" src="https://github.com/user-attachments/assets/ec53290c-abc4-43d7-88d0-89d1fa401cea" />

about:downloads page:

<img width="1252" height="797" alt="Screenshot 2026-06-29 at 20 16 54" src="https://github.com/user-attachments/assets/cfd40751-b189-4961-a87c-d32e78dcadb9" />
