### PR TITLE
LibJS: Hide Set and Map backing entries from iteration

### DIFF
--- a/Libraries/LibJS/Print.cpp
+++ b/Libraries/LibJS/Print.cpp
@@ -330,7 +330,7 @@ ErrorOr<void> print_map(JS::PrintContext& print_context, JS::Map const& map, GC:
     TRY(print_type(print_context, "Map"sv));
     TRY(js_out(print_context, " {{"));
     bool first = true;
-    for (auto const& entry : map) {
+    for (auto entry : map) {
         TRY(print_separator(print_context, first));
         TRY(print_value(print_context, entry.key, seen_objects));
         TRY(js_out(print_context, " => "));

--- a/Libraries/LibJS/Print.cpp
+++ b/Libraries/LibJS/Print.cpp
@@ -347,9 +347,9 @@ ErrorOr<void> print_set(JS::PrintContext& print_context, JS::Set const& set, GC:
     TRY(print_type(print_context, "Set"sv));
     TRY(js_out(print_context, " {{"));
     bool first = true;
-    for (auto const& entry : set) {
+    for (auto value : set) {
         TRY(print_separator(print_context, first));
-        TRY(print_value(print_context, entry.key, seen_objects));
+        TRY(print_value(print_context, value, seen_objects));
     }
     if (!first)
         TRY(js_out(print_context, " "));

--- a/Libraries/LibJS/Runtime/Map.h
+++ b/Libraries/LibJS/Runtime/Map.h
@@ -39,6 +39,11 @@ public:
     struct EndIterator {
     };
 
+    struct Entry {
+        Value key;
+        Value value;
+    };
+
     template<bool IsConst>
     struct IteratorImpl {
         bool is_end() const
@@ -53,16 +58,11 @@ public:
             return *this;
         }
 
-        decltype(auto) operator*()
+        Entry operator*() const
         {
             ensure_next_element();
-            return *m_map->m_entries.find(*m_map->m_keys.begin_from(m_index));
-        }
-
-        decltype(auto) operator*() const
-        {
-            ensure_next_element();
-            return *m_map->m_entries.find(*m_map->m_keys.begin_from(m_index));
+            auto const& entry = *m_map->m_entries.find(*m_map->m_keys.begin_from(m_index));
+            return { entry.key, entry.value };
         }
 
         bool operator==(IteratorImpl const& other) const { return m_index == other.m_index && &m_map == &other.m_map; }

--- a/Libraries/LibJS/Runtime/MapPrototype.cpp
+++ b/Libraries/LibJS/Runtime/MapPrototype.cpp
@@ -110,7 +110,7 @@ JS_DEFINE_NATIVE_FUNCTION(MapPrototype::for_each)
     // 5. Let numEntries be the number of elements in entries.
     // 6. Let index be 0.
     // 7. Repeat, while index < numEntries,
-    for (auto& entry : *map) {
+    for (auto entry : *map) {
         // i. Let e be entries[index].
         // b. Set index to index + 1.
         // c. If e.[[Key]] is not empty, then

--- a/Libraries/LibJS/Runtime/Set.cpp
+++ b/Libraries/LibJS/Runtime/Set.cpp
@@ -35,8 +35,8 @@ GC::Ref<Set> Set::copy() const
     // FIXME: This is very inefficient, but there's no better way to do this at the moment, as the underlying Map
     //  implementation of m_values uses a non-copyable RedBlackTree.
     auto result = Set::create(realm);
-    for (auto const& entry : *this)
-        result->set_add(entry.key);
+    for (auto value : *this)
+        result->set_add(value);
     return *result;
 }
 

--- a/Libraries/LibJS/Runtime/Set.h
+++ b/Libraries/LibJS/Runtime/Set.h
@@ -36,9 +36,38 @@ public:
     void set_add(Value const& key) { m_values->map_set(key, js_undefined()); }
     size_t set_size() const { return m_values->map_size(); }
 
-    auto begin() const { return const_cast<Map const&>(*m_values).begin(); }
-    auto begin() { return m_values->begin(); }
-    auto end() const { return m_values->end(); }
+    struct EndIterator {
+    };
+
+    class ConstIterator {
+    public:
+        ConstIterator& operator++()
+        {
+            ++m_iterator;
+            return *this;
+        }
+
+        Value operator*() const { return (*m_iterator).key; }
+
+        bool operator==(ConstIterator const& other) const { return m_iterator == other.m_iterator; }
+        bool operator==(EndIterator const&) const { return m_iterator == Map::EndIterator {}; }
+
+        void visit_edges(Cell::Visitor& visitor) { m_iterator.visit_edges(visitor); }
+
+    private:
+        friend class Set;
+
+        explicit ConstIterator(Map::ConstIterator iterator)
+            : m_iterator(iterator)
+        {
+        }
+
+        Map::ConstIterator m_iterator;
+    };
+
+    ConstIterator begin() const { return ConstIterator { const_cast<Map const&>(*m_values).begin() }; }
+    ConstIterator begin() { return ConstIterator { const_cast<Map const&>(*m_values).begin() }; }
+    EndIterator end() const { return {}; }
 
     GC::Ref<Set> copy() const;
 

--- a/Libraries/LibJS/Runtime/SetIterator.cpp
+++ b/Libraries/LibJS/Runtime/SetIterator.cpp
@@ -58,7 +58,7 @@ ThrowCompletionOr<void> SetIterator::next(VM& vm, bool& done, Value& value)
 
     VERIFY(m_iteration_kind != Object::PropertyKind::Key);
 
-    value = (*m_iterator).key;
+    value = *m_iterator;
     ++m_iterator;
     if (m_iteration_kind == Object::PropertyKind::Value) {
         return {};

--- a/Libraries/LibJS/Runtime/SetIterator.h
+++ b/Libraries/LibJS/Runtime/SetIterator.h
@@ -36,7 +36,7 @@ private:
     GC::Ref<Set> m_set;
     bool m_done { false };
     Object::PropertyKind m_iteration_kind;
-    Map::ConstIterator m_iterator;
+    Set::ConstIterator m_iterator;
 };
 
 }

--- a/Libraries/LibJS/Runtime/SetPrototype.cpp
+++ b/Libraries/LibJS/Runtime/SetPrototype.cpp
@@ -131,8 +131,8 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::difference)
         // c. Repeat, while index < thisSize,
         GC::RootVector<Value> keys;
         keys.ensure_capacity(result->set_size());
-        for (auto const& element : *result)
-            keys.unchecked_append(element.key);
+        for (auto key : *result)
+            keys.unchecked_append(key);
 
         for (auto const& key : keys) {
             // i. Let e be resultSetData[index].
@@ -214,14 +214,14 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::for_each)
     // 5. Let numEntries be the number of elements in entries.
     // 6. Let index be 0.
     // 7. Repeat, while index < numEntries,
-    for (auto& entry : *set) {
+    for (auto value : *set) {
         // a. Let e be entries[index].
         // b. Set index to index + 1.
         // c. If e is not empty, then
         // NOTE: This is handled in Map::IteratorImpl.
 
         // i. Perform ? Call(callbackfn, thisArg, « e, e, S »).
-        TRY(call(vm, callback_fn.as_function(), this_arg, entry.key, entry.key, set));
+        TRY(call(vm, callback_fn.as_function(), this_arg, value, value, set));
 
         // ii. NOTE: The number of elements in entries may have increased during execution of callbackfn.
         // iii. Set numEntries to the number of elements in entries.
@@ -270,20 +270,21 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::intersection)
         // a. Let thisSize be the number of elements in O.[[SetData]].
         // b. Let index be 0.
         // c. Repeat, while index < thisSize,
-        for (auto const& element : *set) {
+        for (auto e : *set) {
             // i. Let e be O.[[SetData]][index].
+
             // ii. Set index to index + 1.
             // iii. If e is not empty, then
             //     1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
-            auto in_other = TRY(call(vm, *other_record.has, other_record.set_object, element.key)).to_boolean();
+            auto in_other = TRY(call(vm, *other_record.has, other_record.set_object, e)).to_boolean();
 
             //     2. If inOther is true, then
             if (in_other) {
                 // a. NOTE: It is possible for earlier calls to otherRec.[[Has]] to remove and re-add an element of O.[[SetData]], which can cause the same element to be visited twice during this iteration.
                 // b. If SetDataHas(resultSetData, e) is false, then
-                if (!set_data_has(result, element.key)) {
+                if (!set_data_has(result, e)) {
                     // i. Append e to resultSetData.
-                    result->set_add(element.key);
+                    result->set_add(e);
                 }
             }
 
@@ -348,12 +349,12 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::is_disjoint_from)
         // a. Let thisSize be the number of elements in O.[[SetData]].
         // b. Let index be 0.
         // c. Repeat, while index < thisSize,
-        for (auto const& element : *set) {
+        for (auto e : *set) {
             // i. Let e be O.[[SetData]][index].
             // ii. Set index to index + 1.
             // iii. If e is not empty, then
             //     1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
-            auto in_other = TRY(call(vm, *other_record.has, other_record.set_object, element.key)).to_boolean();
+            auto in_other = TRY(call(vm, *other_record.has, other_record.set_object, e)).to_boolean();
 
             //     2. If inOther is true, return false.
             if (in_other)
@@ -411,12 +412,12 @@ JS_DEFINE_NATIVE_FUNCTION(SetPrototype::is_subset_of)
     // 5. Let thisSize be the number of elements in O.[[SetData]].
     // 6. Let index be 0.
     // 7. Repeat, while index < thisSize,
-    for (auto const& element : *set) {
+    for (auto e : *set) {
         // a. Let e be O.[[SetData]][index].
         // b. Set index to index + 1.
         // c. If e is not empty, then
         //     i. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
-        auto in_other = TRY(call(vm, *other_record.has, other_record.set_object, element.key)).to_boolean();
+        auto in_other = TRY(call(vm, *other_record.has, other_record.set_object, e)).to_boolean();
 
         //     ii. If inOther is false, return false.
         if (!in_other)

--- a/Libraries/LibWeb/CSS/CSSFontFeatureValuesMap.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFeatureValuesMap.cpp
@@ -72,7 +72,7 @@ OrderedHashMap<FlyString, Vector<u32>> CSSFontFeatureValuesMap::to_ordered_hash_
 {
     OrderedHashMap<FlyString, Vector<u32>> result;
 
-    for (auto const& entry : *m_map_entries) {
+    for (auto entry : *m_map_entries) {
         auto key = MUST(entry.key.to_utf16_string(vm())).to_utf8_but_should_be_ported_to_utf16();
 
         auto const& array = as<JS::Array>(entry.value.as_object());

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -145,11 +145,11 @@ void FontFaceSet::clear()
     auto* window = as_if<HTML::Window>(HTML::relevant_global_object(*this));
     Vector<JS::Value> to_remove;
     for (auto font_face_value : *m_set_entries) {
-        auto& font_face = as<FontFace>(font_face_value.key.as_object());
+        auto& font_face = as<FontFace>(font_face_value.as_object());
         if (!font_face.is_css_connected()) {
             if (window && font_face.should_be_registered_with_font_computer())
                 window->associated_document().font_computer().unregister_font_face(font_face);
-            to_remove.append(font_face_value.key);
+            to_remove.append(font_face_value);
             font_face.remove_from_set(*this);
         }
     }
@@ -242,11 +242,11 @@ static WebIDL::ExceptionOr<GC::Ref<JS::Set>> find_matching_font_faces(JS::Realm&
         auto font_family_name = string_from_style_value(font_family);
 
         for (auto font_face_value : *available_font_faces) {
-            auto& font_face = as<FontFace>(font_face_value.key.as_object());
+            auto& font_face = as<FontFace>(font_face_value.as_object());
             if (font_face.family() != font_family_name)
                 continue;
 
-            matched_font_faces->set_add(font_face_value.key);
+            matched_font_faces->set_add(font_face_value);
         }
     }
 
@@ -255,8 +255,8 @@ static WebIDL::ExceptionOr<GC::Ref<JS::Set>> find_matching_font_faces(JS::Realm&
     // 8. For each font face in matched font faces, if its defined unicode-range does not include the codepoint of at
     //    least one character in text, remove it from the list.
     GC::RootVector<JS::Value> faces_to_remove;
-    for (auto entry : *matched_font_faces) {
-        auto& font_face = as<FontFace>(entry.key.as_object());
+    for (auto font_face_value : *matched_font_faces) {
+        auto& font_face = as<FontFace>(font_face_value.as_object());
         bool includes_at_least_one_text_code_point = false;
         for (auto code_point : text.code_points()) {
             for (auto const& range : font_face.unicode_ranges()) {
@@ -269,7 +269,7 @@ static WebIDL::ExceptionOr<GC::Ref<JS::Set>> find_matching_font_faces(JS::Realm&
                 break;
         }
         if (!includes_at_least_one_text_code_point)
-            faces_to_remove.append(entry.key);
+            faces_to_remove.append(font_face_value);
     }
     for (auto& key : faces_to_remove)
         matched_font_faces->set_remove(key);
@@ -306,7 +306,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> FontFaceSet::load(String const& 
 
             // 1. For all of the font faces in the font face list, call their load() method.
             for (auto font_face_value : *matched_font_faces) {
-                auto& font_face = as<FontFace>(font_face_value.key.as_object());
+                auto& font_face = as<FontFace>(font_face_value.as_object());
                 font_face.load();
 
                 promises.append(font_face.font_status_promise());
@@ -354,7 +354,7 @@ WebIDL::ExceptionOr<bool> FontFaceSet::check(String const& font, String const& t
         return true;
 
     for (auto font_face_value : *result) {
-        auto& font_face = as<FontFace>(font_face_value.key.as_object());
+        auto& font_face = as<FontFace>(font_face_value.as_object());
         // FIXME: We should check if the font face is a system font here.
         if (font_face.status() != Bindings::FontFaceLoadStatus::Loaded)
             return false;

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -517,9 +517,9 @@ public:
                 copied_list.ensure_capacity(set->set_size());
 
                 // 2. For each entry of value.[[SetData]]:
-                for (auto const& entry : *set) {
+                for (auto entry : *set) {
                     // 1. If entry is not the special value empty, append entry to copiedList.
-                    copied_list.append(entry.key);
+                    copied_list.append(entry);
                 }
 
                 serialized.encode(set->set_size());

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -490,7 +490,7 @@ public:
                 copied_list.ensure_capacity(map->map_size() * 2);
 
                 // 2. For each Record { [[Key]], [[Value]] } entry of value.[[MapData]]:
-                for (auto const& entry : *map) {
+                for (auto entry : *map) {
                     // 1. Let copiedEntry be a new Record { [[Key]]: entry.[[Key]], [[Value]]: entry.[[Value]] }.
                     // 2. If copiedEntry.[[Key]] is not the special value empty, append copiedEntry to copiedList.
                     copied_list.append(entry.key);

--- a/Meta/Generators/libweb_bindings/iterables.py
+++ b/Meta/Generators/libweb_bindings/iterables.py
@@ -508,7 +508,7 @@ JS_DEFINE_NATIVE_FUNCTION({interface.prototype_class}::for_each)
     auto this_arg = vm.argument(1);
 
     // 6. For each key → value of map:
-    for (auto& [key, value] : *map) {{
+    for (auto [key, value] : *map) {{
         // 1. Let jsKey and jsValue be key and value converted to a JavaScript value.
         // 2. Perform ? Call(callbackFn, thisArg, « jsValue, jsKey, O »).
         TRY(JS::call(vm, callback.as_function(), this_arg, value, key, this_impl));

--- a/Meta/Generators/libweb_bindings/iterables.py
+++ b/Meta/Generators/libweb_bindings/iterables.py
@@ -746,9 +746,8 @@ JS_DEFINE_NATIVE_FUNCTION({interface.prototype_class}::for_each)
     auto this_arg = vm.argument(1);
 
     // 6. For each value of set:
-    for (auto& entry : *set) {{
+    for (auto value : *set) {{
         // 1. Let jsValue be value converted to a JavaScript value.
-        auto value = entry.key;
 
         // 2. Perform ? Call(callbackFn, thisArg, « jsValue, jsValue, O»).
         TRY(JS::call(vm, callback.as_function(), this_arg, value, value, this_impl));

--- a/Tests/LibJS/Runtime/builtins/Map/Map.prototype.forEach.js
+++ b/Tests/LibJS/Runtime/builtins/Map/Map.prototype.forEach.js
@@ -53,4 +53,19 @@ describe("normal behavior", () => {
             expect(map).toBe(a);
         });
     });
+
+    test("callback can clear map during iteration", () => {
+        const map = new Map([
+            ["a", 0],
+            ["b", 1],
+        ]);
+        const visited = [];
+
+        map.forEach((value, key) => {
+            visited.push([key, value]);
+            map.clear();
+        });
+
+        expect(visited).toEqual([["a", 0]]);
+    });
 });

--- a/Tests/LibJS/Runtime/builtins/Set/Set.prototype.intersection.js
+++ b/Tests/LibJS/Runtime/builtins/Set/Set.prototype.intersection.js
@@ -18,3 +18,33 @@ test("basic functionality", () => {
         ["b", "c"].forEach(value => expect(intersectionSet.has(value)).toBeTrue());
     }
 });
+
+test("receiver mutations during other.has preserve the current key", () => {
+    const key = {};
+    const replacement = {};
+    const set = new Set([key]);
+    const visited = [];
+
+    const other = {
+        size: 10,
+        has(value) {
+            visited.push(value);
+
+            if (value === key) {
+                set.clear();
+                set.add(replacement);
+            }
+
+            return true;
+        },
+        keys() {
+            throw new Error("unexpected keys call");
+        },
+    };
+
+    const intersection = set.intersection(other);
+    expect(visited).toEqual([key, replacement]);
+    expect(intersection).toHaveSize(2);
+    expect(intersection.has(key)).toBeTrue();
+    expect(intersection.has(replacement)).toBeTrue();
+});


### PR DESCRIPTION
`Set` and `Map` iteration handed callers a reference into the backing storage. `Set.prototype.intersection` held one across `other.has()`, which can clear the receiver and free the entry before its key is read again, a use-after-free reachable from script.

Make iteration return values/entries by copy so no backing reference survives a callback. Updates all LibJS and LibWeb callers, including the generated maplike/setlike `forEach` bindings. Live iteration behavior is unchanged.

Adds regression tests for clearing the receiver during intersection and clearing a `Map` during `forEach`.

Fixes #10337 