### PR TITLE
LibJS: Avoid negative-count UB in `TypedArray.prototype.copyWithin`

### DIFF
--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -323,6 +323,11 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
         // g. Set count to min(count, len - startIndex, len - targetIndex).
         count = min(count, min(length - start_index, length - target_index));
 
+        // NB: If a coercion side effect shrank the buffer, count may be non-positive. Return before attempting
+        //     conversion to an unsigned type.
+        if (count <= 0)
+            return typed_array;
+
         // h. Let elementSize be TypedArrayElementSize(O).
         auto element_size = typed_array->element_size();
 

--- a/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.copyWithin.js
+++ b/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.copyWithin.js
@@ -155,4 +155,23 @@ describe("normal behavior", () => {
             expect(typedArray).toEqual(new T([1, 2, 2]));
         });
     });
+
+    test("shrinking the buffer to a non-positive copy count during copyWithin is a no-op", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 8, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 8,
+            });
+
+            let typedArray = new T(arrayBuffer);
+            let start = {
+                valueOf() {
+                    arrayBuffer.resize(0);
+                    return 4;
+                },
+            };
+
+            expect(typedArray.copyWithin(0, start, 8)).toEqual(typedArray);
+            expect(typedArray.length).toBe(0);
+        });
+    });
 });


### PR DESCRIPTION
If a side effect during argument coercion shrinks a resizable ArrayBuffer, the number of elements left to copy can become negative. Converting that negative count to an unsigned type was undefined behavior. Treat a non-positive count as a no-op, matching other engines.

The included regression test fails when run on `master` with UBSAN.