### PR TITLE
LibWeb: Keep vertical-align ancestor walk inside the inline FC subtree

### DIFF
--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -420,7 +420,9 @@ void LineBuilder::update_last_line()
         auto const& node = fragment.layout_node().has_style()
             ? static_cast<NodeWithStyle const&>(fragment.layout_node())
             : *fragment.layout_node().parent();
-        for (auto const* ancestor = node.parent(); !own_alignment_is_line_relative && ancestor && ancestor->is_inline_node() && ancestor != &m_context.containing_block(); ancestor = ancestor->parent()) {
+        auto const* containing_block = &m_context.containing_block();
+        auto const* first_ancestor = &node == containing_block ? nullptr : node.parent();
+        for (auto const* ancestor = first_ancestor; !own_alignment_is_line_relative && ancestor && ancestor->is_inline_node() && ancestor != containing_block; ancestor = ancestor->parent()) {
             auto const& ancestor_vertical_align = ancestor->computed_values().vertical_align();
             if (ancestor_vertical_align.has<CSS::VerticalAlign>()) {
                 auto keyword = ancestor_vertical_align.get<CSS::VerticalAlign>();

--- a/Tests/LibWeb/Crash/Layout/inline-block-text-in-vertical-aligned-inline.html
+++ b/Tests/LibWeb/Crash/Layout/inline-block-text-in-vertical-aligned-inline.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<a style="vertical-align: middle">
+    <span style="display: inline-block">x</span>
+</a>


### PR DESCRIPTION
Previously, when applying an inline element's `vertical-align`, we climbed each fragment's ancestor chain up to the inline formatting context's containing block. This assumed the fragment sat strictly inside that containing block, but an unstyled text fragment that is a direct child of it resolves to the containing block itself, so the walk started one level above the inline formatting context.

During intrinsic sizing, inside layout runs in a throwaway state rooted at the box, so reaching a node above it caused a crash.

We now skip the ancestor walk when the fragment resolves to the containing block.

Fixes a regression introduced by #10316.

First spotted on https://fairershare.org.uk/.