### PR TITLE
LibWeb: Preserve I-beam cursor for text fragment hits

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -339,12 +339,14 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
     RefPtr<Painting::ChromeWidget> chrome_widget;
     GC::Ptr<DOM::Node> node;
     Optional<int> start_index;
+    bool hit_text_node = false;
 
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
         paintable = result->paintable;
         chrome_widget = result->chrome_widget;
         node = result->dom_node;
         start_index = result->index_in_node;
+        hit_text_node = node && node->is_text();
     }
 
     ArmedScopeGuard clear_cursor = [&] {
@@ -379,7 +381,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         bool found_parent_element = parent_element_for_event_dispatch(*paintable, node, layout_node);
 
         if (found_parent_element) {
-            update_cursor(*paintable, *node, chrome_widget);
+            update_cursor(*paintable, *node, chrome_widget, hit_text_node);
             clear_cursor.disarm();
 
             auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
@@ -809,10 +811,12 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
     RefPtr<Painting::Paintable> paintable;
     RefPtr<Painting::ChromeWidget> chrome_widget;
     GC::Ptr<DOM::Node> node;
+    bool hit_text_node = false;
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
         paintable = result->paintable;
         chrome_widget = result->chrome_widget;
         node = result->dom_node;
+        hit_text_node = node && node->is_text();
     }
 
     ArmedScopeGuard clear_hover = [&] {
@@ -841,7 +845,7 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
         return;
 
     update_hovered_chrome_widget(chrome_widget);
-    update_cursor(*paintable, *node, chrome_widget);
+    update_cursor(*paintable, *node, chrome_widget, hit_text_node);
 
     auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
     track_the_effective_position_of_the_legacy_mouse_pointer(node, DOM::HoverEventData {
@@ -2537,7 +2541,8 @@ static Gfx::Cursor resolve_cursor(Layout::NodeWithStyle const& layout_node, Read
     return Gfx::StandardCursor::None;
 }
 
-void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget> chrome_widget)
+void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<DOM::Node> host_element,
+    RefPtr<Painting::ChromeWidget> chrome_widget, bool hit_text_node)
 {
     // AD-HOC: Update the cursor image based on the CSS rules before the steps terminate if the target hasn't changed.
     auto cursor = [&] -> Gfx::Cursor {
@@ -2547,13 +2552,23 @@ void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<
         }
 
         if (paintable) {
-            auto cursor_data = paintable->computed_values().cursor();
-            auto is_selectable_text_node = paintable->layout_node().is_text_node() && paintable->layout_node().parent()->computed_values().user_select() != CSS::UserSelect::None;
+            auto* host_layout_node = host_element ? host_element->layout_node() : nullptr;
+            auto const* cursor_data = &paintable->computed_values().cursor();
+            if (hit_text_node && host_layout_node)
+                cursor_data = &host_layout_node->computed_values().cursor();
 
-            if (is_selectable_text_node || host_element->is_editable_or_editing_host())
-                return resolve_cursor(*paintable->layout_node().parent(), cursor_data, Gfx::StandardCursor::IBeam);
-            if (host_element && host_element->is_element())
-                return resolve_cursor(static_cast<Layout::NodeWithStyle&>(*host_element->layout_node()), cursor_data, Gfx::StandardCursor::Arrow);
+            auto* host_node_with_style = host_layout_node ? as_if<Layout::NodeWithStyle>(*host_layout_node) : nullptr;
+            auto is_selectable_text_node = hit_text_node
+                && host_layout_node
+                && host_layout_node->user_select_used_value() != CSS::UserSelect::None;
+
+            if (is_selectable_text_node || host_element->is_editable_or_editing_host()) {
+                if (host_node_with_style)
+                    return resolve_cursor(*host_node_with_style, *cursor_data, Gfx::StandardCursor::IBeam);
+                return resolve_cursor(*paintable->layout_node().parent(), *cursor_data, Gfx::StandardCursor::IBeam);
+            }
+            if (host_element && host_element->is_element() && host_node_with_style)
+                return resolve_cursor(*host_node_with_style, *cursor_data, Gfx::StandardCursor::Arrow);
         }
 
         return Gfx::StandardCursor::Arrow;

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -140,7 +140,7 @@ private:
     bool dispatch_chrome_widget_pointer_event(RefPtr<Painting::ChromeWidget>, FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position);
     void update_hovered_chrome_widget(RefPtr<Painting::ChromeWidget>);
 
-    void update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget> chrome_widget);
+    void update_cursor(RefPtr<Painting::Paintable>, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget>, bool hit_text_node = false);
     void record_last_known_mouse_position(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult cancel_drag_and_drop_event(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 

--- a/Tests/LibWeb/Text/expected/hit_testing/text-fragment-cursor.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/text-fragment-cursor.txt
@@ -1,0 +1,1 @@
+cursor over selectable text: IBeam

--- a/Tests/LibWeb/Text/input/hit_testing/text-fragment-cursor.html
+++ b/Tests/LibWeb/Text/input/hit_testing/text-fragment-cursor.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+        font: 20px SerenitySans, sans-serif;
+        line-height: 32px;
+    }
+
+    #cursor-target {
+        height: 40px;
+    }
+</style>
+<div id="cursor-target">Hover this selectable text</div>
+<script>
+    test(() => {
+        document.body.offsetWidth;
+
+        const cursorTarget = document.getElementById("cursor-target");
+        const range = document.createRange();
+        range.selectNodeContents(cursorTarget.firstChild);
+        const rect = range.getBoundingClientRect();
+
+        internals.mouseMove(rect.left + 5, rect.top + rect.height / 2);
+        println(`cursor over selectable text: ${internals.currentCursor()}`);
+    });
+</script>


### PR DESCRIPTION
After removing TextPaintable, hit testing ordinary text returns the owning PaintableWithLines. EventHandler::update_cursor() still looked at the hit paintable's layout node to decide whether cursor: auto should become an I-beam, so selectable text fragments fell back to the arrow cursor.

Thread whether the original hit target was a DOM text node through the cursor update path and use that only to choose the auto-cursor fallback. The cursor property is still resolved against the dispatch host layout node.