### PR TITLE
LibWeb: Initialize layout used values explicitly

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1890,13 +1890,13 @@ void Document::update_layout(UpdateLayoutReason reason)
 
         {
             auto& viewport = static_cast<Layout::Viewport&>(*m_layout_root);
-            auto& viewport_state = layout_state.get_mutable(viewport);
+            auto& viewport_state = layout_state.create(viewport);
             viewport_state.set_content_width(viewport_rect.width());
             viewport_state.set_content_height(viewport_rect.height());
 
             // NB: Called during layout update.
             if (document_element && document_element->unsafe_layout_node()) {
-                auto& icb_state = layout_state.get_mutable(as<Layout::NodeWithStyleAndBoxModelMetrics>(*document_element->unsafe_layout_node()));
+                auto& icb_state = layout_state.create(as<Layout::NodeWithStyleAndBoxModelMetrics>(*document_element->unsafe_layout_node()));
                 icb_state.set_content_width(viewport_rect.width());
             }
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -957,7 +957,15 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     if (box.is_absolutely_positioned()) {
         if (m_layout_mode == LayoutMode::Normal) {
-            auto& box_state = m_state.get_mutable(box);
+            // Absolutely positioned boxes enter layout here, in the context that contains them.
+            // Two kinds of boxes already have used values: list item markers, whose used values
+            // were created together with the ListItemBox that places them, and the document
+            // element, which was created by the layout entry point (and can end up absolutely
+            // positioned, e.g. as a popover).
+            auto box_is_document_element = box.dom_node() && box.dom_node() == box.document().document_element();
+            auto& box_state = is<ListItemMarkerBox>(box) || box_is_document_element
+                ? m_state.get_mutable(box)
+                : m_state.create(box);
             StaticPositionRect static_position;
             auto static_position_x = CSSPixels(0);
             auto static_position_y = m_y_offset_of_current_block_container.value();
@@ -965,10 +973,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
                 auto sibling_ref = box.previous_sibling();
                 auto const* sibling = as_if<Box>(sibling_ref.ptr());
                 if (sibling && sibling->is_anonymous() && sibling->children_are_inline()) {
-                    auto const& sibling_state = m_state.get(*sibling);
-                    if (auto const& inline_end_static_position_rect = sibling_state.inline_end_static_position_rect(); inline_end_static_position_rect.has_value()) {
-                        static_position_x = sibling_state.offset.x() + inline_end_static_position_rect->rect.x();
-                        static_position_y = sibling_state.offset.y() + inline_end_static_position_rect->rect.y();
+                    // The sibling may have been skipped by layout entirely (e.g. a whitespace-only
+                    // anonymous container), in which case it has no state to derive a position from.
+                    if (auto const* sibling_state = m_state.try_get(*sibling)) {
+                        if (auto const& inline_end_static_position_rect = sibling_state->inline_end_static_position_rect(); inline_end_static_position_rect.has_value()) {
+                            static_position_x = sibling_state->offset.x() + inline_end_static_position_rect->rect.x();
+                            static_position_y = sibling_state->offset.y() + inline_end_static_position_rect->rect.y();
+                        }
                     }
                 }
             }
@@ -978,11 +989,27 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         return;
     }
 
-    auto& box_state = m_state.get_mutable(box);
-
-    // NOTE: ListItemMarkerBoxes are placed by their corresponding ListItemBox.
+    // NOTE: ListItemMarkerBoxes are placed by their corresponding ListItemBox, and their used
+    //       values were created together with its own.
     if (is<ListItemMarkerBox>(box))
         return;
+
+    // NOTE: It is possible to encounter SVGMaskBox and SVGClipBox nodes while doing layout of the
+    //       formatting context established by a <foreignObject> that references them. Skip them
+    //       before creating any used values; SVGFormattingContext lays them out on behalf of the
+    //       referencing element.
+    if (box.is_svg_mask_box() || box.is_svg_clip_box())
+        return;
+
+    auto& box_state = [&]() -> LayoutState::UsedValues& {
+        auto const* document_element = box.document().document_element();
+        if (!m_state.has_subtree_root()
+            && document_element && document_element->unsafe_layout_node()
+            && box.is_inclusive_ancestor_of(*document_element->unsafe_layout_node())) {
+            return m_state.get_mutable(box);
+        }
+        return m_state.create(box);
+    }();
 
     resolve_vertical_box_model_metrics(box, m_state.get(block_container).content_width());
 
@@ -1012,11 +1039,6 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         resolve_used_height_if_treated_as_auto(box, available_space);
 
     auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, box);
-
-    // NOTE: It is possible to encounter SVGMaskBox nodes while doing layout of formatting context established by <foreignObject> with a mask.
-    //       We should skip and let SVGFormattingContext take care of them.
-    if (box.is_svg_mask_box())
-        return;
 
     if (!independent_formatting_context && !is<BlockContainer>(box)) {
         dbgln("FIXME: Block-level box is not BlockContainer but does not create formatting context: {}", box.debug_description());
@@ -1106,6 +1128,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
                 throwaway_state.populate_node_from(m_state, *cb);
             }
 
+            throwaway_state.create(box);
             auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
             measuring_context->run(LayoutInput { inner_available_space });
             auto content_height = measuring_context->automatic_content_height();
@@ -1594,8 +1617,10 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
         }
     } else {
         box.for_each_child_of_type<Box>([&](Box const& child) {
-            if (!child.is_absolutely_positioned())
-                max_width = max(max_width, m_state.get(child).margin_box_width());
+            if (child.is_absolutely_positioned())
+                return IterationDecision::Continue;
+            if (auto const* child_state = m_state.try_get(child))
+                max_width = max(max_width, child_state->margin_box_width());
             return IterationDecision::Continue;
         });
     }

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -260,7 +260,7 @@ void FlexFormattingContext::parent_context_did_dimension_child_root_box()
 
     flex_container().for_each_child_of_type<Box>([&](Layout::Box& box) {
         if (box.is_absolutely_positioned()) {
-            m_state.get_mutable(box).set_static_position_rect(calculate_static_position_rect(box));
+            m_state.create(box).set_static_position_rect(calculate_static_position_rect(box));
         }
         return IterationDecision::Continue;
     });
@@ -378,7 +378,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
             return IterationDecision::Continue;
 
         child_box.set_flex_item(true);
-        FlexItem item = { child_box, m_state.get_mutable(child_box) };
+        FlexItem item = { child_box, m_state.create(child_box) };
         populate_specified_margins(item, m_flex_direction);
 
         auto& order_bucket = order_item_bucket.ensure(child_box.computed_values().order());

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -582,9 +582,12 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
             if ((root.computed_values().overflow_y() == CSS::Overflow::Visible) && child_box.is_floating())
                 return IterationDecision::Continue;
 
-            auto const& child_box_state = m_state.get(child_box);
+            // Children that have not been laid out yet contribute nothing to the auto height.
+            auto const* child_box_state = m_state.try_get(child_box);
+            if (!child_box_state)
+                return IterationDecision::Continue;
 
-            CSSPixels child_box_bottom = child_box_state.offset.y() + child_box_state.content_height() + child_box_state.margin_box_bottom();
+            CSSPixels child_box_bottom = child_box_state->offset.y() + child_box_state->content_height() + child_box_state->margin_box_bottom();
 
             if (!bottom.has_value() || child_box_bottom > bottom.value())
                 bottom = child_box_bottom;
@@ -646,7 +649,8 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     if (table_wrapper_containing_block_width.has_value())
         containing_block_state.set_content_width(*table_wrapper_containing_block_width);
 
-    auto& table_box_state = throwaway_state.get_mutable(*table_box);
+    throwaway_state.create(box);
+    auto& table_box_state = throwaway_state.create(*table_box);
     auto const& table_box_computed_values = table_box->computed_values();
     table_box_state.border_left = table_box_computed_values.border_left().width;
     table_box_state.border_right = table_box_computed_values.border_right().width;
@@ -655,7 +659,7 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
 
     auto context = make<TableFormattingContext>(throwaway_state, LayoutMode::IntrinsicSizing, *table_box, this);
     context->run_until_width_calculation(
-        LayoutInput { m_state.get(*table_box).available_inner_space_or_constraints_from(available_space) },
+        LayoutInput { table_box_state.available_inner_space_or_constraints_from(available_space) },
         TableFormattingContext::RowMeasurement::Skip);
 
     auto table_used_width = throwaway_state.get(*table_box).border_box_width();
@@ -686,6 +690,7 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
 
     LayoutState throwaway_state(box);
     throwaway_state.populate_node_from(m_state, *box.containing_block());
+    throwaway_state.create(box);
 
     auto context = create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
     VERIFY(context);
@@ -1682,14 +1687,18 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
             return {};
 
         auto const& anchor_box = as<Box>(*anchor_layout_node);
-        auto const& anchor_state = m_state.get(anchor_box);
-        auto anchor_border_box_origin = anchor_state.cumulative_offset()
-            - CSSPixelPoint { anchor_state.border_box_left(), anchor_state.border_box_top() };
+        // The anchor element may not have been laid out (it must be laid out strictly before
+        // the positioned element to be an acceptable anchor).
+        auto const* anchor_state = m_state.try_get(anchor_box);
+        if (!anchor_state)
+            return {};
+        auto anchor_border_box_origin = anchor_state->cumulative_offset()
+            - CSSPixelPoint { anchor_state->border_box_left(), anchor_state->border_box_top() };
         auto containing_block_padding_box_origin = containing_block_state.cumulative_offset()
             - CSSPixelPoint { containing_block_state.padding_left, containing_block_state.padding_top };
         return CSSPixelRect {
             anchor_border_box_origin - containing_block_padding_box_origin,
-            { anchor_state.border_box_width(), anchor_state.border_box_height() },
+            { anchor_state->border_box_width(), anchor_state->border_box_height() },
         };
     };
 
@@ -1853,6 +1862,8 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     // SVG elements cannot be absolutely positioned.
     VERIFY(!box.is_svg_box());
 
+    auto& box_state = m_state.get_mutable(box);
+
     resolve_anchor_insets(box);
 
     auto containing_block_info = resolve_abspos_containing_block_info(box);
@@ -1866,7 +1877,6 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     containing_block_state.set_has_definite_width(true);
     containing_block_state.set_has_definite_height(true);
 
-    auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
     // The border computed values are not changed by the compute_height & width calculations below.
@@ -2215,7 +2225,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
     LayoutState throwaway_state(box);
     throwaway_state.populate_node_from(m_state, *box.containing_block());
 
-    auto& box_state = throwaway_state.get_mutable(box);
+    auto& box_state = throwaway_state.create(box);
     box_state.width_constraint = SizeConstraint::MinContent;
     box_state.set_indefinite_content_width();
 
@@ -2306,7 +2316,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
 
     auto const& actual_box_state = m_state.get(box);
 
-    auto& box_state = throwaway_state.get_mutable(box);
+    auto& box_state = throwaway_state.create(box);
     box_state.width_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_width();
 
@@ -2355,7 +2365,7 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     LayoutState throwaway_state(box);
     throwaway_state.populate_node_from(m_state, *box.containing_block());
 
-    auto& box_state = throwaway_state.get_mutable(box);
+    auto& box_state = throwaway_state.create(box);
     box_state.height_constraint = SizeConstraint::MinContent;
     box_state.set_indefinite_content_height();
     box_state.set_content_width(width);
@@ -2391,7 +2401,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
     LayoutState throwaway_state(box);
     throwaway_state.populate_node_from(m_state, *box.containing_block());
 
-    auto& box_state = throwaway_state.get_mutable(box);
+    auto& box_state = throwaway_state.create(box);
     box_state.height_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_height();
     box_state.set_content_width(width);
@@ -2679,7 +2689,7 @@ Box const* FormattingContext::box_child_to_derive_baseline_from(Box const& box, 
             continue;
         if (child_box->is_out_of_flow(*this))
             continue;
-        if (!m_state.get(*child_box).line_boxes.is_empty())
+        if (auto const* child_state = m_state.try_get(*child_box); child_state && !child_state->line_boxes.is_empty())
             return child_box;
         if (box_child_to_derive_baseline_from(*child_box, baseline_set))
             return child_box;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1968,6 +1968,9 @@ void GridFormattingContext::place_grid_items()
 
         child_box.set_grid_item(true);
 
+        if (!m_state.try_get(child_box))
+            m_state.create(child_box);
+
         auto& order_bucket = order_item_bucket.ensure(child_box.computed_values().order());
         order_bucket.append(child_box);
 
@@ -3054,7 +3057,7 @@ void GridFormattingContext::parent_context_did_dimension_child_root_box()
 
     grid_container().for_each_child_of_type<Box>([&](Layout::Box& box) {
         if (box.is_absolutely_positioned()) {
-            m_state.get_mutable(box).set_static_position_rect(calculate_static_position_rect(box));
+            m_state.create(box).set_static_position_rect(calculate_static_position_rect(box));
         }
         return IterationDecision::Continue;
     });

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/InlineLevelIterator.h>
 #include <LibWeb/Layout/LineBuilder.h>
+#include <LibWeb/Layout/ListItemMarkerBox.h>
 
 namespace Web::Layout {
 
@@ -418,6 +419,8 @@ void InlineFormattingContext::generate_line_boxes()
 
         case InlineLevelIterator::Item::Type::FloatingElement:
             if (auto* box = as_if<Box>(*item.node)) {
+                if (!is<ListItemMarkerBox>(*box))
+                    m_state.create(*box);
                 (void)parent().clear_floating_boxes(*item.node, *this);
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
@@ -521,7 +524,9 @@ void InlineFormattingContext::generate_line_boxes()
                 if (found_static_position_marker)
                     break;
             }
-            auto& box_state = m_state.get_mutable(*box);
+            auto& box_state = is<ListItemMarkerBox>(*box)
+                ? m_state.get_mutable(*box)
+                : m_state.create(*box);
             box_state.set_static_position_rect(static_position_rect);
         }
     }

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/InlineLevelIterator.h>
 #include <LibWeb/Layout/InlineNode.h>
+#include <LibWeb/Layout/ListItemBox.h>
 #include <LibWeb/Layout/ListItemMarkerBox.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 
@@ -53,7 +54,10 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
 
     // FIXME: It's really weird that *this* is where we assign box model metrics for these layout nodes..
 
-    auto& used_values = m_layout_state.get_mutable(node);
+    auto& used_values = is<ListItemMarkerBox>(node)
+        ? m_layout_state.get_mutable(node)
+        : m_layout_state.create(node);
+
     auto const& computed_values = node.computed_values();
 
     used_values.margin_top = computed_values.margin().top().to_px_or_zero(m_containing_block_used_values.content_width());
@@ -397,7 +401,11 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
     }
 
     auto const& box = as<Layout::Box>(*m_current_node);
-    auto const& box_state = m_layout_state.get(box);
+    auto const& box_state = [&]() -> LayoutState::UsedValues const& {
+        if (!m_box_model_node_stack.is_empty() && m_box_model_node_stack.last() == &box)
+            return m_layout_state.get_mutable(box);
+        return m_layout_state.create(box);
+    }();
     m_inline_formatting_context.dimension_box_on_line(box, m_layout_mode);
 
     auto item = Item {

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -14,6 +14,8 @@
 #include <LibWeb/Layout/AvailableSpace.h>
 #include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/LayoutState.h>
+#include <LibWeb/Layout/ListItemBox.h>
+#include <LibWeb/Layout/ListItemMarkerBox.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
@@ -65,12 +67,31 @@ void LayoutState::ensure_capacity(u32 node_count)
 
 LayoutState::UsedValues& LayoutState::get_mutable(NodeWithStyle const& node)
 {
-    return ensure_used_values_for(node);
+    auto* used_values = m_used_values_store.get(node.layout_index());
+    if (!used_values) {
+        dbgln("LayoutState::get_mutable: no used values for {}; boxes must be created before their state is read", node.debug_description());
+        VERIFY_NOT_REACHED();
+    }
+    return *used_values;
 }
 
 LayoutState::UsedValues const& LayoutState::get(NodeWithStyle const& node) const
 {
-    return const_cast<LayoutState*>(this)->ensure_used_values_for(node);
+    auto const* used_values = m_used_values_store.get(node.layout_index());
+    if (!used_values) {
+        dbgln("LayoutState::get: no used values for {}; boxes must be created before their state is read", node.debug_description());
+        VERIFY_NOT_REACHED();
+    }
+    return *used_values;
+}
+
+LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node)
+{
+    if (m_used_values_store.get(node.layout_index())) {
+        dbgln("LayoutState::create: used values for {} already exist", node.debug_description());
+        VERIFY_NOT_REACHED();
+    }
+    return ensure_used_values_for(node);
 }
 
 LayoutState::UsedValues& LayoutState::populate_from_paintable(NodeWithStyle const& node, Painting::PaintableBox const& paintable)
@@ -113,11 +134,15 @@ LayoutState::UsedValues& LayoutState::ensure_used_values_for(NodeWithStyle const
         // For the subtree root, ancestor values are not available in the throwaway state.
         containing_block_used_values = try_get(*node.containing_block());
     } else if (!node.is_viewport()) {
-        containing_block_used_values = &get(*node.containing_block());
+        containing_block_used_values = &ensure_used_values_for(*node.containing_block());
     }
 
     auto& used_values = m_used_values_store.allocate(index);
     used_values.set_node(node, containing_block_used_values);
+
+    if (auto const* list_item_box = as_if<ListItemBox>(node); list_item_box && list_item_box->marker())
+        ensure_used_values_for(*list_item_box->marker());
+
     return used_values;
 }
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -418,12 +418,16 @@ struct LayoutState {
     UsedValues& get_mutable(NodeWithStyle const&);
     UsedValues const& get(NodeWithStyle const&) const;
 
+    UsedValues& create(NodeWithStyle const&);
+
     UsedValues& populate_from_paintable(NodeWithStyle const&, Painting::PaintableBox const&);
     UsedValues& populate_node_from(LayoutState const& source, NodeWithStyle const& node);
 
     UsedValues const* try_get(NodeWithStyle const&) const;
     UsedValues* try_get_mutable(NodeWithStyle const&);
     UsedValues const* try_get(Node const&) const;
+
+    bool has_subtree_root() const { return m_subtree_root != nullptr; }
 
 private:
     UsedValues& ensure_used_values_for(NodeWithStyle const&);

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -44,7 +44,7 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
     if (!wrapper)
         return;
 
-    auto& wrapper_state = m_state.get_mutable(*wrapper);
+    auto& wrapper_state = m_state.create(*wrapper);
     wrapper_state.set_content_width(content_width);
     wrapper_state.set_content_offset({ 0, 0 });
 

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -329,7 +329,7 @@ void SVGFormattingContext::layout_svg_element(Box const& child, LayoutInput cons
         layout_nested_viewport(child, parent_svg_transform);
     } else if (auto* foreign_object_element = as_if<SVG::SVGForeignObjectElement>(child.dom_node()); foreign_object_element && is<BlockContainer>(child)) {
         Layout::BlockFormattingContext bfc(m_state, m_layout_mode, as<BlockContainer>(child), this);
-        auto& child_state = m_state.get_mutable(child);
+        auto& child_state = m_state.create(child);
         CSSPixelRect rect {
             {
                 child.computed_values().x().to_px(m_available_space->width.to_px_or_zero()),
@@ -366,7 +366,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
 {
     // Layout for a nested SVG viewport.
     // https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport.
-    auto& nested_viewport_state = m_state.get_mutable(viewport);
+    auto& nested_viewport_state = m_state.create(viewport);
     auto resolve_dimension = [](auto size, auto reference_value) {
         // The value auto for width and height on the ‘svg’ element is treated as 100%.
         // https://svgwg.org/svg2-draft/geometry.html#Sizing
@@ -542,7 +542,7 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
 
 void SVGFormattingContext::layout_graphics_element(SVGGraphicsBox const& graphics_box, LayoutInput const& layout_input, Gfx::AffineTransform const& parent_svg_transform)
 {
-    auto& graphics_box_state = m_state.get_mutable(graphics_box);
+    auto& graphics_box_state = m_state.create(graphics_box);
     auto svg_transform = parent_svg_transform;
     svg_transform.multiply(const_cast<SVGGraphicsBox&>(graphics_box).dom_node().element_transform());
     graphics_box_state.set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
@@ -601,7 +601,7 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
     else
         VERIFY_NOT_REACHED();
     // FIXME: Somehow limit <clipPath> contents to: shape elements, <text>, and <use>.
-    auto& layout_state = m_state.get_mutable(mask_or_clip);
+    auto& layout_state = m_state.create(mask_or_clip);
     auto parent_viewbox_transform = m_current_viewbox_transform;
 
     auto const* pattern_box = as_if<SVGPatternBox>(mask_or_clip);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1792,6 +1792,22 @@ void TableFormattingContext::finish_grid_initialization(TableGrid const& table_g
     }
 }
 
+void TableFormattingContext::seed_table_participant_used_values()
+{
+    TableGrid::for_each_child_box_matching(table_box(), TableGrid::is_table_row_group, [&](auto& row_group_box) {
+        m_state.create(row_group_box);
+    });
+    for (auto& row : m_rows)
+        m_state.create(row.box);
+    for (auto& cell : m_cells)
+        m_state.create(cell.box);
+
+    for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
+        if (child->display().is_table_caption())
+            m_state.create(as<Box>(*child));
+    }
+}
+
 void TableFormattingContext::run_until_width_calculation(LayoutInput const& layout_input, RowMeasurement row_measurement)
 {
     auto const& available_space = layout_input.available_space;
@@ -1799,6 +1815,8 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
 
     // Determine the number of rows/columns the table requires.
     finish_grid_initialization(TableGrid::calculate_row_column_grid(context_box(), m_cells, m_rows));
+
+    seed_table_participant_used_values();
 
     border_conflict_resolution();
 
@@ -1837,7 +1855,7 @@ void TableFormattingContext::parent_context_did_dimension_child_root_box()
             // FIXME: calculate_static_position_rect() is not aware of how to correctly calculate static position for
             //        a box nested inside a table, but we need to set some value, so layout_absolutely_positioned_element()
             //        won't crash trying to access it.
-            m_state.get_mutable(box).set_static_position_rect(calculate_static_position_rect(box));
+            m_state.create(box).set_static_position_rect(calculate_static_position_rect(box));
         }
 
         if (formatting_context_type_created_by_box(box).has_value()) {

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -70,6 +70,7 @@ private:
     CSSPixels border_spacing_horizontal() const;
     CSSPixels border_spacing_vertical() const;
     void finish_grid_initialization(TableGrid const&);
+    void seed_table_participant_used_values();
 
     CSSPixels compute_columns_total_used_width() const;
     void commit_candidate_column_widths(Vector<CSSPixels> const& candidate_widths);

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-empty.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-empty.txt
@@ -4,14 +4,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       frag 0 from BlockContainer start: 0, length: 0, rect: [13,19 0x0] baseline: 4
       BlockContainer <button> at [13,19] inline-block [0+1+4 0 4+1+0] [0+1+1 0 1+1+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> at [13,19] flex-container(column) [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [FFC] children: not-inline
-          BlockContainer <(anonymous)> at [13,19] inline-block [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) inline-block [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableWithLines (BlockContainer<BUTTON>) [8,17 10x4]
         PaintableWithLines (BlockContainer(anonymous)) [13,19 0x0]
-          PaintableWithLines (BlockContainer(anonymous)) [13,19 0x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x34] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex-baseline-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/flex-baseline-alignment.txt
@@ -3,7 +3,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 23 0+0+8] children: inline
       frag 0 from Box start: 0, length: 0, rect: [8,8 23.671875x23] baseline: 17.5
       Box <div.flex> at [8,8] flex-container(row) [0+0+0 23.671875 0+0+0] [0+0+0 23 0+0+0] [FFC] children: not-inline
-        BlockContainer <(anonymous)> at [8,8] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
         BlockContainer <span.tall> at [8,8] flex-item [0+0+0 17.828125 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 1, rect: [8,8 17.828125x23] baseline: 17.5
@@ -23,7 +23,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x39]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
       PaintableBox (Box<DIV>.flex) [8,8 23.671875x23]
-        PaintableWithLines (BlockContainer(anonymous)) [8,8 0x0]
         PaintableWithLines (BlockContainer<SPAN>.tall) [8,8 17.828125x23]
         PaintableWithLines (BlockContainer<SPAN>.short) [25.828125,16.5 5.84375x12]
 

--- a/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
@@ -4,7 +4,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <div.first> at [11,11] [0+1+0 778 0+1+0] [0+1+0 26.203125 0+1+0] children: inline
         frag 0 from Box start: 0, length: 0, rect: [22,22 0x0] baseline: 22
         Box <span.second> at [22,22] flex-container(row) [0+1+10 0 10+1+0] [0+1+10 0 10+1+0] [FFC] children: not-inline
-          BlockContainer <(anonymous)> at [22,22] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
@@ -12,7 +12,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x30.203125]
       PaintableWithLines (BlockContainer<DIV>.first) [10,10 780x28.203125]
         PaintableBox (Box<SPAN>.second) [11,11 22x22]
-          PaintableWithLines (BlockContainer(anonymous)) [22,22 0x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [1,1 798x46.203125] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/fit-content-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/fit-content-3.txt
@@ -5,14 +5,14 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         frag 0 from Box start: 0, length: 0, rect: [8,10 104x104] baseline: 104
         TextNode <#text> (not painted)
         Box <div.grid> at [8,10] [0+0+0 104 0+0+0] [0+0+0 104 0+0+0] [GFC] children: not-inline
-          BlockContainer <(anonymous)> at [8,10] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
           BlockContainer <div.item> at [8,10] [0+0+0 78 0+0+0] [0+0+0 104 0+0+0] [BFC] children: not-inline
             BlockContainer <(anonymous)> at [9,11] floating [0+1+0 50 0+1+0] [0+1+0 50 0+1+0] [BFC] children: inline
               GeneratedTextNode <(anonymous)> (not painted)
             BlockContainer <(anonymous)> at [9,63] floating [0+1+0 50 0+1+0] [0+1+0 50 0+1+0] [BFC] children: inline
               GeneratedTextNode <(anonymous)> (not painted)
-          BlockContainer <(anonymous)> at [8,10] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
         TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,114] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
@@ -23,11 +23,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,10 784x104]
       PaintableWithLines (BlockContainer<DIV>.container) [8,10 200x104]
         PaintableBox (Box<DIV>.grid) [8,10 104x104]
-          PaintableWithLines (BlockContainer(anonymous)) [8,10 0x0]
           PaintableWithLines (BlockContainer<DIV>.item) [8,10 78x104]
             PaintableWithLines (BlockContainer(anonymous)) [8,10 52x52]
             PaintableWithLines (BlockContainer(anonymous)) [8,62 52x52]
-          PaintableWithLines (BlockContainer(anonymous)) [8,10 0x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,114 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/pdf-viewer.txt
+++ b/Tests/LibWeb/Layout/expected/pdf-viewer.txt
@@ -20,15 +20,15 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from Box start: 0, length: 0, rect: [1,2 798x28] baseline: 27.796875
                 TextNode <#text> (not painted)
                 Box <div#toolbarViewer.toolbarHorizontalGroup> at [1,2] flex-container(row) [0+0+0 798 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                  BlockContainer <(anonymous)> at [1,2] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                  BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                     TextNode <#text> (not painted)
                   Box <div#toolbarViewerLeft.toolbarHorizontalGroup> at [9,2] flex-container(row) flex-item [8+0+0 240.359375 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                    BlockContainer <(anonymous)> at [9,2] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                       TextNode <#text> (not painted)
                     Box <button#viewsManagerToggleButton.toolbarButton> at [9,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
                       BlockContainer <(anonymous)> at [15,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
                         GeneratedTextNode <(anonymous)> (not painted)
-                      BlockContainer <(anonymous)> at [9,2] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       BlockContainer <span> at [31,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
                         frag 0 from TextNode start: 0, length: 6, rect: [31,16 56.34375x18] baseline: 13.796875
@@ -395,12 +395,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
               PaintableWithLines (BlockContainer<DIV>#toolbarContainer) [0,0 800x32]
                 PaintableBox (Box<DIV>#toolbarViewer.toolbarHorizontalGroup) [1,2 798x28]
-                  PaintableWithLines (BlockContainer(anonymous)) [1,2 0x0]
                   PaintableBox (Box<DIV>#toolbarViewerLeft.toolbarHorizontalGroup) [9,2 240.359375x28]
-                    PaintableWithLines (BlockContainer(anonymous)) [9,2 0x0]
                     PaintableBox (Box<BUTTON>#viewsManagerToggleButton.toolbarButton) [9,2 28x28]
                       PaintableWithLines (BlockContainer(anonymous)) [15,8 16x16]
-                      PaintableWithLines (BlockContainer(anonymous)) [9,2 0x0]
                       PaintableWithLines (BlockContainer<SPAN>) [31,16 0x0] overflow: [31,16 56.34375x36]
                     PaintableWithLines (BlockContainer<DIV>.toolbarButtonSpacer) [38,15.5 30x1]
                     PaintableWithLines (BlockContainer<DIV>.toolbarButtonWithContainer) [69,2 28x28]

--- a/Tests/LibWeb/Layout/expected/popovertarget-button.txt
+++ b/Tests/LibWeb/Layout/expected/popovertarget-button.txt
@@ -4,7 +4,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       frag 0 from BlockContainer start: 0, length: 0, rect: [13,19 0x0] baseline: 4
       BlockContainer <button#button> at [13,19] inline-block [0+1+4 0 4+1+0] [0+1+1 0 1+1+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> at [13,19] flex-container(column) [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [FFC] children: not-inline
-          BlockContainer <(anonymous)> at [13,19] inline-block [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) inline-block [BFC] children: not-inline
       TextNode <#text> (not painted)
       TextNode <#text> (not painted)
       TextNode <#text> (not painted)
@@ -22,7 +22,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableWithLines (BlockContainer<BUTTON>#button) [8,17 10x4]
         PaintableWithLines (BlockContainer(anonymous)) [13,19 0x0]
-          PaintableWithLines (BlockContainer(anonymous)) [13,19 0x0]
   PaintableWithLines (BlockContainer(anonymous)) [0,0 800x600]
   PaintableWithLines (BlockContainer<DIV>#pop) [351.84375,284 96.3125x32]
     PaintableWithLines (InlineNode<SPAN>) [358.84375,291 82.3125x18]

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -127,11 +127,11 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                     frag 0 from TextNode start: 0, length: 1, rect: [141.125,180 8.453125x18] baseline: 13.796875
                         "5"
                     TextNode <#text> (not painted)
-                  BlockContainer <(anonymous)> at [9,9] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: inline
+                  BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text> (not painted)
-                BlockContainer <(anonymous)> at [9,9] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: inline
+                BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> at [9,9] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: inline
+              BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
         TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,210] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
@@ -168,9 +168,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                   PaintableWithLines (BlockContainer<TD>) [9,169 56.265625x40]
                   PaintableWithLines (BlockContainer<TD>) [65.265625,169 54.546875x40]
                   PaintableWithLines (BlockContainer<TD>) [119.8125,169 51.09375x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]
-                PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]
-              PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,210 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)


### PR DESCRIPTION
LayoutState used to allocate UsedValues lazily on the first get() or get_mutable() call for a node. Because that allocation could happen at any incidental read site, it carried an implicit assumption that the node's containing block size was already definite by the time its used values came into existence. That is an awkward implication to depend on, and one that is easy to violate without noticing.

Require formatting contexts to initialize the nodes they own instead. get() and get_mutable() now only look up existing state and assert when it is missing. Beyond removing the hidden ordering dependency, explicit initialization makes such awkward problems easy to spot: a missing entry now fails loudly instead of being papered over with a default constructed, all-zero state.