### PR TITLE
LibRequests: Make Request::stop() reentrancy-safe

### DIFF
--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Checked.h>
 #include <AK/ScopeGuard.h>
+#include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibRequests/Request.h>
@@ -71,13 +72,7 @@ bool Request::stop()
     auto had_active_request = m_client->stop_request({}, *this);
     auto on_stop = move(m_on_stop);
 
-    on_headers_received = nullptr;
-    on_finish = nullptr;
-    on_certificate_requested = nullptr;
-
-    m_internal_buffered_data = nullptr;
-    m_internal_stream_data = nullptr;
-    m_mode = Mode::Unknown;
+    defer_teardown();
 
     if (had_active_request && on_stop)
         on_stop();
@@ -275,16 +270,24 @@ void Request::did_transfer(Badge<RequestClient>)
 {
     auto on_stop = move(m_on_stop);
 
-    on_headers_received = nullptr;
-    on_finish = nullptr;
-    on_certificate_requested = nullptr;
-
-    m_internal_buffered_data = nullptr;
-    m_internal_stream_data = nullptr;
-    m_mode = Mode::Unknown;
+    defer_teardown();
 
     if (on_stop)
         on_stop();
+}
+
+void Request::defer_teardown()
+{
+    if (m_internal_stream_data && m_internal_stream_data->read_notifier)
+        m_internal_stream_data->read_notifier->set_enabled(false);
+    m_mode = Mode::Unknown;
+    Core::deferred_invoke([self = NonnullRefPtr(*this)] {
+        self->on_headers_received = nullptr;
+        self->on_finish = nullptr;
+        self->on_certificate_requested = nullptr;
+        self->m_internal_buffered_data = nullptr;
+        self->m_internal_stream_data = nullptr;
+    });
 }
 
 void Request::set_up_internal_stream_data(DataReceived on_data_available)

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -131,6 +131,7 @@ private:
 
     void attach_read_stream();
     void set_up_internal_stream_data(DataReceived on_data_available);
+    void defer_teardown();
 
     WeakPtr<RequestClient> m_client;
     u64 m_request_id { 0 };


### PR DESCRIPTION
**Problem:** Crash on stopping a request within one of its own callbacks.

**Cause:** `Request::stop()` could destroy a callback still on the stack.

**Fix:** Move the `Request::stop()` teardown to a shared helper that disables the read notifier right away — so delivery stops, and defers clearing the callbacks and stream data behind a strong self-reference until the current call stack has unwound. By then, the request is already out of the client’s request map — `stop_request` and `request_transferred` both remove it first — so no further callback can run in the meantime.

e57d3db already hardened the one existing caller that could hit this. This closes the root cause — so no future caller can reintroduce it.
