### PR TITLE
Compositor: Define EGL_EGLEXT_PROTOTYPES before the EGL headers

### DIFF
--- a/Services/Compositor/OpenGLContext.cpp
+++ b/Services/Compositor/OpenGLContext.cpp
@@ -13,9 +13,10 @@ extern "C" {
 }
 #include <GLES3/gl3.h>
 
+// Define EGL_EGLEXT_PROTOTYPES before eglext.h pulls in the ANGLE extension headers without it.
+#define EGL_EGLEXT_PROTOTYPES 1
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#define EGL_EGLEXT_PROTOTYPES 1
 extern "C" {
 #include <EGL/eglext_angle.h>
 }


### PR DESCRIPTION
**Problem:** macOS builds can fail with `use of undeclared identifier eglWaitUntilWorkScheduledANGLE` in `OpenGLContext.cpp`.

**Cause:** `EGL_EGLEXT_PROTOTYPES` was defined after including `EGL/eglext.h`, which pulls in `EGL/eglext_angle.h` at its bottom. By the time the macro was set, that header had already been processed without it — so the ANGLE extension prototype was never declared.

**Fix:** Define `EGL_EGLEXT_PROTOTYPES` before the EGL includes. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9917.
