### PR TITLE
LibWeb: Port over some ancestor navigable APIs to Navigable for site isolation

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5269,7 +5269,7 @@ Vector<GC::Root<HTML::LocalNavigable>> Document::inclusive_descendant_navigables
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#ancestor-navigables
-Vector<GC::Root<HTML::LocalNavigable>> Document::ancestor_navigables()
+GC::RootVector<GC::Ref<HTML::Navigable>> Document::ancestor_navigables()
 {
     // FIXME: The document's node navigable should not be null here. But we currently do not implement the "unload a
     //        document and its descendants" steps correctly, and the navigable becomes null during unloading. We are
@@ -5280,11 +5280,10 @@ Vector<GC::Root<HTML::LocalNavigable>> Document::ancestor_navigables()
         return {};
 
     // 1. Let navigable be document's node navigable's parent.
-    auto parent_navigable = document_node_navigable->parent();
-    auto* navigable = parent_navigable ? &as<HTML::LocalNavigable>(*parent_navigable) : nullptr;
+    auto navigable = document_node_navigable->parent();
 
     // 2. Let ancestors be an empty list.
-    Vector<GC::Root<HTML::LocalNavigable>> ancestors;
+    GC::RootVector<GC::Ref<HTML::Navigable>> ancestors;
 
     // 3. While navigable is not null:
     while (navigable) {
@@ -5292,21 +5291,20 @@ Vector<GC::Root<HTML::LocalNavigable>> Document::ancestor_navigables()
         ancestors.prepend(*navigable);
 
         // 2. Set navigable to navigable's parent.
-        parent_navigable = navigable->parent();
-        navigable = parent_navigable ? &as<HTML::LocalNavigable>(*parent_navigable) : nullptr;
+        navigable = navigable->parent();
     }
 
     // 4. Return ancestors.
     return ancestors;
 }
 
-Vector<GC::Root<HTML::LocalNavigable>> const Document::ancestor_navigables() const
+GC::RootVector<GC::Ref<HTML::Navigable>> const Document::ancestor_navigables() const
 {
     return const_cast<Document&>(*this).ancestor_navigables();
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#inclusive-ancestor-navigables
-Vector<GC::Root<HTML::LocalNavigable>> Document::inclusive_ancestor_navigables()
+GC::RootVector<GC::Ref<HTML::Navigable>> Document::inclusive_ancestor_navigables()
 {
     // FIXME: The document's node navigable should not be null here. But we currently do not implement the "unload a
     //        document and its descendants" steps correctly, and the navigable becomes null during unloading. We are

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -724,9 +724,9 @@ public:
     Vector<GC::Root<HTML::LocalNavigable>> descendant_navigables();
     Vector<GC::Root<HTML::LocalNavigable>> const descendant_navigables() const;
     Vector<GC::Root<HTML::LocalNavigable>> inclusive_descendant_navigables();
-    Vector<GC::Root<HTML::LocalNavigable>> ancestor_navigables();
-    Vector<GC::Root<HTML::LocalNavigable>> const ancestor_navigables() const;
-    Vector<GC::Root<HTML::LocalNavigable>> inclusive_ancestor_navigables();
+    GC::RootVector<GC::Ref<HTML::Navigable>> ancestor_navigables();
+    GC::RootVector<GC::Ref<HTML::Navigable>> const ancestor_navigables() const;
+    GC::RootVector<GC::Ref<HTML::Navigable>> inclusive_ancestor_navigables();
     Vector<GC::Root<HTML::LocalNavigable>> document_tree_child_navigables();
 
     [[nodiscard]] bool has_been_destroyed() const { return m_has_been_destroyed; }

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -463,7 +463,7 @@ bool BrowsingContext::is_ancestor_of(BrowsingContext const& potential_descendant
 
     // 3. Let ancestorBCs be the list obtained by taking the browsing context of the active document of each member of potentialDescendantDocument's ancestor navigables.
     for (auto const& ancestor : potential_descendant_document->ancestor_navigables()) {
-        auto ancestor_browsing_context = ancestor->active_browsing_context();
+        auto ancestor_browsing_context = as<HTML::LocalNavigable>(*ancestor).active_browsing_context();
 
         // 4. If ancestorBCs contains potentialAncestor, then return true.
         if (ancestor_browsing_context == this)
@@ -501,7 +501,7 @@ bool BrowsingContext::is_familiar_with(BrowsingContext const& other) const
         return false;
 
     for (auto const& ancestor : B.active_document()->ancestor_navigables()) {
-        if (ancestor->active_document()->origin().is_same_origin(A.active_document()->origin()))
+        if (as<LocalNavigable>(*ancestor).active_document()->origin().is_same_origin(A.active_document()->origin()))
             return true;
     }
 

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -501,7 +501,7 @@ bool BrowsingContext::is_familiar_with(BrowsingContext const& other) const
         return false;
 
     for (auto const& ancestor : B.active_document()->ancestor_navigables()) {
-        if (as<LocalNavigable>(*ancestor).active_document()->origin().is_same_origin(A.active_document()->origin()))
+        if (ancestor->active_document_origin()->is_same_origin(A.active_document()->origin()))
             return true;
     }
 

--- a/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
+++ b/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
@@ -43,7 +43,7 @@ void check_if_access_between_two_browsing_contexts_should_be_reported(
     auto accessor_inclusive_ancestors = accessor->active_document()->ancestor_navigables();
     accessor_inclusive_ancestor_origins.ensure_capacity(accessor_inclusive_ancestors.size());
     for (auto const& ancestor : accessor_inclusive_ancestors) {
-        accessor_inclusive_ancestor_origins.append(as<LocalNavigable>(*ancestor).active_document()->origin());
+        accessor_inclusive_ancestor_origins.append(*ancestor->active_document_origin());
     }
 
     // 5. Let accessedTopDocument be accessed's top-level browsing context's active document.
@@ -55,7 +55,7 @@ void check_if_access_between_two_browsing_contexts_should_be_reported(
     auto accessed_inclusive_ancestors = accessed->active_document()->ancestor_navigables();
     accessed_inclusive_ancestor_origins.ensure_capacity(accessed_inclusive_ancestors.size());
     for (auto const& ancestor : accessed_inclusive_ancestors) {
-        accessed_inclusive_ancestor_origins.append(as<LocalNavigable>(*ancestor).active_document()->origin());
+        accessed_inclusive_ancestor_origins.append(*ancestor->active_document_origin());
     }
 
     // 7. If any of accessorInclusiveAncestorOrigins are not same origin with accessorTopDocument's origin, or if any of accessedInclusiveAncestorOrigins are not same origin with accessedTopDocument's origin, then return.

--- a/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
+++ b/Libraries/LibWeb/HTML/CrossOrigin/Reporting.cpp
@@ -43,9 +43,7 @@ void check_if_access_between_two_browsing_contexts_should_be_reported(
     auto accessor_inclusive_ancestors = accessor->active_document()->ancestor_navigables();
     accessor_inclusive_ancestor_origins.ensure_capacity(accessor_inclusive_ancestors.size());
     for (auto const& ancestor : accessor_inclusive_ancestors) {
-        VERIFY(ancestor != nullptr);
-        VERIFY(ancestor->active_document() != nullptr);
-        accessor_inclusive_ancestor_origins.append(ancestor->active_document()->origin());
+        accessor_inclusive_ancestor_origins.append(as<LocalNavigable>(*ancestor).active_document()->origin());
     }
 
     // 5. Let accessedTopDocument be accessed's top-level browsing context's active document.
@@ -57,9 +55,7 @@ void check_if_access_between_two_browsing_contexts_should_be_reported(
     auto accessed_inclusive_ancestors = accessed->active_document()->ancestor_navigables();
     accessed_inclusive_ancestor_origins.ensure_capacity(accessed_inclusive_ancestors.size());
     for (auto const& ancestor : accessed_inclusive_ancestors) {
-        VERIFY(ancestor != nullptr);
-        VERIFY(ancestor->active_document() != nullptr);
-        accessed_inclusive_ancestor_origins.append(ancestor->active_document()->origin());
+        accessed_inclusive_ancestor_origins.append(as<LocalNavigable>(*ancestor).active_document()->origin());
     }
 
     // 7. If any of accessorInclusiveAncestorOrigins are not same origin with accessorTopDocument's origin, or if any of accessedInclusiveAncestorOrigins are not same origin with accessedTopDocument's origin, then return.

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -502,10 +502,8 @@ void HTMLDialogElement::run_dialog_focusing_steps()
     run_focusing_steps(control);
 
     // 7. Let topDocument be control's node navigable's top-level traversable's active document.
-    auto top_document = as<LocalTraversableNavigable>(*control->navigable()->top_level_traversable()).active_document();
-
     // 8. If control's node document's origin is not the same as the origin of topDocument, then return.
-    if (!control->document().origin().is_same_origin(top_document->origin()))
+    if (!control->document().origin().is_same_origin(*control->navigable()->top_level_traversable()->active_document_origin()))
         return;
 
     // FIXME: 9. Empty topDocument's autofocus candidates.

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1221,7 +1221,7 @@ GC::Ptr<LocalNavigable> LocalNavigable::find_a_navigable_by_target_name(StringVi
     // 4. For each subtreeToSearch of subtreesToSearch, in reverse order:
     for (auto const& subtree_to_search : subtrees_to_search.in_reverse()) {
         // 1. Let documentToSearch be subtreeToSearch's active document.
-        auto& document_to_search = *subtree_to_search->active_document();
+        auto& document_to_search = *as<LocalNavigable>(*subtree_to_search).active_document();
 
         // 2. For each navigable of the inclusive descendant navigables of documentToSearch:
         for (auto const& navigable : document_to_search.inclusive_descendant_navigables()) {

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -924,6 +924,20 @@ GC::Ptr<DOM::Document> LocalNavigable::active_document() const
     return m_active_document;
 }
 
+Optional<URL::URL> LocalNavigable::active_document_url() const
+{
+    if (!m_active_document)
+        return {};
+    return m_active_document->url();
+}
+
+Optional<URL::Origin> LocalNavigable::active_document_origin() const
+{
+    if (!m_active_document)
+        return {};
+    return m_active_document->origin();
+}
+
 Optional<UniqueNodeID> LocalNavigable::active_document_id() const
 {
     if (!m_active_document)

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -109,6 +109,9 @@ public:
     virtual GC::Ptr<WindowProxy> active_window_proxy() override;
     GC::Ptr<Window> active_window();
 
+    virtual Optional<URL::URL> active_document_url() const override;
+    virtual Optional<URL::Origin> active_document_origin() const override;
+
     RefPtr<SessionHistoryEntry> get_the_target_history_entry(int target_step) const;
     RefPtr<SessionHistoryEntry> get_the_target_history_entry_if_present(int target_step) const;
 

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <LibGC/Ptr.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibURL/URL.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 
@@ -31,6 +32,8 @@ public:
     virtual GC::Ptr<WindowProxy> active_window_proxy() = 0;
     virtual String target_name() const = 0;
     GC::Ref<Navigable> top_level_traversable();
+    virtual Optional<URL::URL> active_document_url() const = 0;
+    virtual Optional<URL::Origin> active_document_origin() const = 0;
 
 protected:
     Navigable() = default;

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -220,7 +220,7 @@ Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_ifr
     // 3. If the inclusive ancestor navigables of element's node navigable contains a navigable
     //    whose active document's URL equals url with exclude fragments set to true, then return null.
     for (auto const& navigable : document().inclusive_ancestor_navigables()) {
-        if (as<LocalNavigable>(*navigable).active_document()->url().equals(url, URL::ExcludeFragment::Yes))
+        if (navigable->active_document_url()->equals(url, URL::ExcludeFragment::Yes))
             return {};
     }
 

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -220,8 +220,7 @@ Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_ifr
     // 3. If the inclusive ancestor navigables of element's node navigable contains a navigable
     //    whose active document's URL equals url with exclude fragments set to true, then return null.
     for (auto const& navigable : document().inclusive_ancestor_navigables()) {
-        VERIFY(navigable->active_document());
-        if (navigable->active_document()->url().equals(url, URL::ExcludeFragment::Yes))
+        if (as<LocalNavigable>(*navigable).active_document()->url().equals(url, URL::ExcludeFragment::Yes))
             return {};
     }
 

--- a/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
+++ b/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
@@ -59,7 +59,7 @@ ProhibitsMixedSecurityContexts does_settings_prohibit_mixed_security_contexts(GC
         // 2. For each navigable navigable in document’s ancestor navigables:
         for (auto const& navigable : document->ancestor_navigables()) {
             // 1. If navigable’s active document's origin is a potentially trustworthy origin, then return "Prohibits Mixed Security Contexts".
-            if (SecureContexts::is_origin_potentially_trustworthy(navigable->active_document()->origin()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy)
+            if (SecureContexts::is_origin_potentially_trustworthy(as<HTML::LocalNavigable>(*navigable).active_document()->origin()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy)
                 return ProhibitsMixedSecurityContexts::ProhibitsMixedSecurityContexts;
         }
     }

--- a/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
+++ b/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
@@ -59,7 +59,7 @@ ProhibitsMixedSecurityContexts does_settings_prohibit_mixed_security_contexts(GC
         // 2. For each navigable navigable in document’s ancestor navigables:
         for (auto const& navigable : document->ancestor_navigables()) {
             // 1. If navigable’s active document's origin is a potentially trustworthy origin, then return "Prohibits Mixed Security Contexts".
-            if (SecureContexts::is_origin_potentially_trustworthy(as<HTML::LocalNavigable>(*navigable).active_document()->origin()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy)
+            if (SecureContexts::is_origin_potentially_trustworthy(*navigable->active_document_origin()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy)
                 return ProhibitsMixedSecurityContexts::ProhibitsMixedSecurityContexts;
         }
     }


### PR DESCRIPTION
Two very small steps for towards site isolation.

Importantly adds active_document_url and active_document_origin APIs to the base class Navigable since those are needed for various security checks, but we can't expose the actual document cross process. These URLs / Origins will eventually need to be replicated from the UI process to WebContent.