### PR TITLE
LibJS: Guard the parser against deeply-nested input

### DIFF
--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -279,6 +279,12 @@ pub struct Parser<'a> {
     pub(crate) class_has_super_class: bool,
     /// Depth counter for class bodies — used to reject `#name` outside classes.
     pub(crate) class_scope_depth: u32,
+    /// Current expression-parser recursion depth, used to guard against native
+    /// stack exhaustion from pathologically-nested expressions (see #5749).
+    recursion_depth: u32,
+    /// Set once the recursion-depth limit is hit — so parsing loops stop
+    /// spinning on unconsumed input after a placeholder node is returned.
+    recursion_limit_reached: bool,
     pub(crate) has_default_export_name: bool,
 
     /// Stack of sets tracking private names referenced inside class bodies.
@@ -354,6 +360,8 @@ impl<'a> Parser<'a> {
             allow_member_expressions: false,
             class_has_super_class: false,
             class_scope_depth: 0,
+            recursion_depth: 0,
+            recursion_limit_reached: false,
             has_default_export_name: false,
             referenced_private_names_stack: Vec::new(),
             eval_referenced_private_names: Vec::new(),
@@ -528,7 +536,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn done(&self) -> bool {
-        self.match_token(TokenType::Eof)
+        self.recursion_limit_reached || self.match_token(TokenType::Eof)
     }
 
     // === Token consumption ===
@@ -675,6 +683,31 @@ impl<'a> Parser<'a> {
     }
 
     // === Error reporting ===
+
+    /// Maximum parser recursion depth. Beyond this, the parser reports a syntax
+    /// error — rather than exhausting the native stack, which would crash the
+    /// process on pathologically-nested input (see #5749).
+    const MAX_RECURSION_DEPTH: u32 = 2000;
+
+    /// Enters a nested-parse recursion level. Returns false if the maximum depth
+    /// would be exceeded — in which case a syntax error is recorded, and the caller
+    /// must return a placeholder node instead of recursing further.
+    #[must_use]
+    fn enter_recursion(&mut self) -> bool {
+        self.recursion_depth += 1;
+        if self.recursion_depth > Self::MAX_RECURSION_DEPTH {
+            self.recursion_depth -= 1;
+            self.recursion_limit_reached = true;
+            self.syntax_error("Maximum parser recursion depth exceeded");
+            return false;
+        }
+        true
+    }
+
+    /// Leaves a recursion level previously entered via enter_recursion.
+    fn leave_recursion(&mut self) {
+        self.recursion_depth -= 1;
+    }
 
     pub(crate) fn syntax_error(&mut self, message: &str) {
         self.errors.push(ParseError {

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -1442,6 +1442,18 @@ impl Parser<'_> {
     //                      | `[` BindingElementList `]`
     //                      | `[` BindingElementList `,` Elision? BindingRestElement? `]`
     pub(crate) fn parse_binding_pattern(&mut self) -> BindingPattern {
+        if !self.enter_recursion() {
+            return BindingPattern {
+                kind: BindingPatternKind::Object,
+                entries: Vec::new(),
+            };
+        }
+        let pattern = self.parse_binding_pattern_inner();
+        self.leave_recursion();
+        pattern
+    }
+
+    fn parse_binding_pattern_inner(&mut self) -> BindingPattern {
         let is_object = self.match_token(TokenType::CurlyOpen);
         let is_array = self.match_token(TokenType::BracketOpen);
         if !is_object && !is_array {

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -162,6 +162,21 @@ impl Parser<'_> {
         associativity: Associativity,
         forbidden: ForbiddenTokens,
     ) -> Expression {
+        if !self.enter_recursion() {
+            let start = self.position();
+            return self.expression(start, ExpressionKind::Error);
+        }
+        let expression = self.parse_expression_inner(min_precedence, associativity, forbidden);
+        self.leave_recursion();
+        expression
+    }
+
+    fn parse_expression_inner(
+        &mut self,
+        min_precedence: i32,
+        associativity: Associativity,
+        forbidden: ForbiddenTokens,
+    ) -> Expression {
         if self.match_unary_prefixed_expression() {
             let start = self.position();
             let expression = self.parse_unary_prefixed_expression();

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -26,6 +26,16 @@ enum LocalForInit {
 
 impl Parser<'_> {
     pub(crate) fn parse_statement(&mut self, allow_labelled_function: bool) -> Statement {
+        if !self.enter_recursion() {
+            let start = self.position();
+            return self.statement(start, StatementKind::Error);
+        }
+        let statement = self.parse_statement_inner(allow_labelled_function);
+        self.leave_recursion();
+        statement
+    }
+
+    fn parse_statement_inner(&mut self, allow_labelled_function: bool) -> Statement {
         let start = self.position();
         let tt = self.current_token_type();
 

--- a/Tests/LibWeb/Text/expected/parser-recursion-depth-limit.txt
+++ b/Tests/LibWeb/Text/expected/parser-recursion-depth-limit.txt
@@ -1,0 +1,6 @@
+unary-deep: SyntaxError
+parens-deep: SyntaxError
+array-deep: SyntaxError
+block-deep: SyntaxError
+binding-deep: SyntaxError
+shallow: parsed

--- a/Tests/LibWeb/Text/input/parser-recursion-depth-limit.html
+++ b/Tests/LibWeb/Text/input/parser-recursion-depth-limit.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="./include.js"></script>
+<script>
+    test(() => {
+        // Deeply-nested input must throw a SyntaxError, not exhaust the native stack and crash the parser. See #5749.
+        function check(label, source) {
+            try {
+                eval(source);
+                println(`${label}: parsed`);
+            } catch (e) {
+                println(`${label}: ${e.constructor.name}`);
+            }
+        }
+
+        check("unary-deep", "!".repeat(100000) + "1");
+        check("parens-deep", "(".repeat(100000) + "1" + ")".repeat(100000));
+        check("array-deep", "[".repeat(100000) + "1" + "]".repeat(100000));
+        check("block-deep", "{".repeat(100000) + "}".repeat(100000));
+        check("binding-deep", "var " + "[".repeat(100000) + "a" + "]".repeat(100000) + "=0");
+
+        // A shallow expression must still parse successfully.
+        check("shallow", "!".repeat(50) + "1");
+    });
+</script>


### PR DESCRIPTION
**Problem:** Crash when parsing a deeply-nested JavaScript expression.

**Cause:** The recursive-descent parser had no recursion-depth limit — so there was nothing to stop deep nesting from overflowing the stack.

**Fix:** Count recursion depth — and beyond a fixed count, stop, and record a syntax error, and return a placeholder node.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/5749
