### PR TITLE
LibWeb: Calculate SVG translations relative to their view box

### DIFF
--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -380,6 +380,17 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
     auto nested_viewport_width = resolve_dimension(viewport.computed_values().width(), m_viewport_size.width());
     auto nested_viewport_height = resolve_dimension(viewport.computed_values().height(), m_viewport_size.height());
 
+    if (auto const* svg_svg_box = as_if<SVGSVGBox>(viewport); svg_svg_box && !nested_viewport_state.computed_svg_transforms().has_value()) {
+        // https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport
+        // Including an svg element inside SVG content creates a new SVG viewport into which all contained graphics are
+        // drawn; this implicitly establishes both a new viewport coordinate system and a new user coordinate system.
+        auto const& svg_graphics_element = as<SVG::SVGGraphicsElement>(*viewport.dom_node());
+        auto svg_transform = parent_svg_transform;
+        svg_transform.multiply(svg_graphics_element.element_transform());
+        nested_viewport_state.set_computed_svg_transforms(
+            Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
+    }
+
     CSSPixelPoint content_offset { nested_viewport_x, nested_viewport_y };
     auto content_width = nested_viewport_width;
     auto content_height = nested_viewport_height;

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -22,6 +22,9 @@
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ResolvedCSSFilter.h>
+#include <LibWeb/Painting/SVGForeignObjectPaintable.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
+#include <LibWeb/Painting/SVGSVGPaintable.h>
 #include <LibWeb/Painting/ScrollState.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 
@@ -87,6 +90,17 @@ static TransformData visual_viewport_transform_data(DOM::Document& document)
     return TransformData { matrix, { 0.f, 0.f } };
 }
 
+static Optional<Gfx::AffineTransform> svg_to_css_pixels_transform(PaintableBox const& paintable_box)
+{
+    if (auto const* svg_graphics_paintable = as_if<SVGGraphicsPaintable>(paintable_box))
+        return svg_graphics_paintable->computed_transforms().svg_to_css_pixels_transform();
+    if (auto const* svg_foreign_object_paintable = as_if<SVGForeignObjectPaintable>(paintable_box))
+        return svg_foreign_object_paintable->computed_transforms().svg_to_css_pixels_transform();
+    if (auto const* svg_svg_paintable = as_if<SVGSVGPaintable>(paintable_box))
+        return svg_svg_paintable->computed_transforms().svg_to_css_pixels_transform();
+    return {};
+}
+
 // https://drafts.csswg.org/css-transforms-2/#ctm
 Optional<TransformData> compute_transform(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, double pixel_ratio)
 {
@@ -125,6 +139,13 @@ Optional<TransformData> compute_transform(PaintableBox const& paintable_box, CSS
 
     // 8. Translate by the negated computed X, Y and Z values of transform-origin.
     matrix = matrix * Gfx::translation_matrix(Vector3 { 0.f, 0.f, -origin_z });
+
+    // https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute
+    // The presence of the viewBox attribute results in a transformation being applied to the viewport coordinate system
+    if (auto svg_to_css_pixels = svg_to_css_pixels_transform(paintable_box); svg_to_css_pixels.has_value() && !svg_to_css_pixels->is_identity()) {
+        if (auto inverse_svg_to_css_pixels = svg_to_css_pixels->inverse(); inverse_svg_to_css_pixels.has_value())
+            matrix = svg_to_css_pixels->to_matrix() * matrix * inverse_svg_to_css_pixels->to_matrix();
+    }
 
     auto origin = reference_box.location() + CSSPixelPoint { origin_x, origin_y };
     auto scale = static_cast<float>(pixel_ratio);

--- a/Tests/LibWeb/Ref/expected/svg/translate-relative-to-viewbox-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/translate-relative-to-viewbox-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewbox="0 0 1000 1000">
+    <circle cx="100" cy="250" r="25" fill="blue" />
+    <rect x="500" y="700" width="100" height="100" fill="blue"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/translate-relative-to-viewbox.html
+++ b/Tests/LibWeb/Ref/input/svg/translate-relative-to-viewbox.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/translate-relative-to-viewbox-ref.html" />
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewbox="0 0 1000 1000">
+    <circle cx="50" cy="50" r="25" fill="blue" style="translate: 50px 200px" />
+    <rect x="500" y="700" width="100" height="100" fill="red"></rect>
+    <svg x="100" y="100" width="500" height="500" viewBox="0 0 50 50" style="translate: 400px 600px">
+        <rect id="target" width="10" height="10" fill="blue"></rect>
+    </svg>
+</svg>


### PR DESCRIPTION
Within an SVG view box, `translate: 10px 20px` should move by 10 and 20 viewport units, not CSS pixels. For example, if the `<svg>` is 100px wide, but its viewbox is 1000 wide, then `translate: 100px` moves it by 100 viewport units, which is equivalent to 10 CSS pixels.

Fixes Doggo's eyes on kagi.com when the search box is selected.

Before:
<img width="913" height="410" alt="image" src="https://github.com/user-attachments/assets/05f39995-b994-4677-aa88-bb59140c0b4e" />

After:
<img width="913" height="410" alt="image" src="https://github.com/user-attachments/assets/bf34bd92-0b19-4c79-91b9-0b544dca0510" />