### PR TITLE
LibWeb: Use bands for BFC float intrusions

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -34,6 +34,7 @@ namespace Web::Layout {
 BlockFormattingContext::BlockFormattingContext(LayoutState& state, LayoutMode layout_mode, BlockContainer const& root, FormattingContext* parent)
     : FormattingContext(Type::Block, layout_mode, state, root, parent)
 {
+    m_bands.append({});
 }
 
 BlockFormattingContext::~BlockFormattingContext()
@@ -149,15 +150,15 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
 {
     m_was_notified_after_parent_dimensioned_my_root_box = true;
 
-    // Left-side floats: offset_from_edge is from left edge (0) to left content edge of floating_box.
-    for (auto& floating_box : m_left_floats.all_boxes) {
-        floating_box->used_values.set_content_x(floating_box->offset_from_edge);
-    }
-
-    // Right-side floats: offset_from_edge is from right edge (float_containing_block_width) to the left content edge of floating_box.
-    for (auto& floating_box : m_right_floats.all_boxes) {
-        auto float_containing_block_width = containing_block_width_for(floating_box->box);
-        floating_box->used_values.set_content_x(float_containing_block_width - floating_box->offset_from_edge);
+    for (auto& floating_box : m_floats) {
+        if (floating_box->side == FloatSide::Left) {
+            // Left-side floats: offset_from_edge is from left edge (0) to left content edge of floating_box.
+            floating_box->used_values.set_content_x(floating_box->offset_from_edge);
+        } else {
+            // Right-side floats: offset_from_edge is from right edge (float_containing_block_width) to the left content edge of floating_box.
+            auto float_containing_block_width = containing_block_width_for(floating_box->box);
+            floating_box->used_values.set_content_x(float_containing_block_width - floating_box->offset_from_edge);
+        }
     }
 
     layout_absolutely_positioned_children();
@@ -197,7 +198,9 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     // Certain formatting contexts do not allow float intrusions, so reduce the available space for them.
     if (available_space.width.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
-        auto intrusion = intrusion_by_floats_into_box(box, 0);
+        auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
+        box_in_root_rect.set_width(available_space.width.to_px_or_zero());
+        auto intrusion = intrusions_for_band_into_rect(band_at(box_in_root_rect.y()), box_in_root_rect);
         auto remaining_width = available_space.width.to_px_or_zero() - intrusion.left - intrusion.right;
         remaining_available_space.width = AvailableSize::make_definite(remaining_width);
     }
@@ -354,6 +357,181 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     box_state.margin_right = margin_right.to_px_or_zero();
 }
 
+size_t BlockFormattingContext::band_index_at(CSSPixels y) const
+{
+    VERIFY(!m_bands.is_empty());
+
+    size_t index = 0;
+    for (size_t i = 1; i < m_bands.size(); ++i) {
+        if (m_bands[i].block_start > y)
+            break;
+        index = i;
+    }
+    return index;
+}
+
+BlockFormattingContext::FloatBand const& BlockFormattingContext::band_at(CSSPixels y) const
+{
+    return m_bands[band_index_at(y)];
+}
+
+Optional<CSSPixels> BlockFormattingContext::next_float_band_block_start_after(CSSPixels y_in_root) const
+{
+    for (auto const& band : m_bands) {
+        if (band.block_start > y_in_root)
+            return band.block_start;
+    }
+    return {};
+}
+
+FormattingContext::SpaceUsedByFloats BlockFormattingContext::available_inline_space(CSSPixels block_start_in_root, CSSPixels block_end_in_root) const
+{
+    VERIFY(!m_bands.is_empty());
+
+    SpaceUsedByFloats intrusions;
+    if (block_end_in_root <= block_start_in_root) {
+        auto const& band = band_at(block_start_in_root);
+        intrusions.left = band.left_intrusion;
+        intrusions.right = band.right_intrusion;
+        return intrusions;
+    }
+
+    for (size_t i = band_index_at(block_start_in_root); i < m_bands.size(); ++i) {
+        auto const& band = m_bands[i];
+        if (band.block_start >= block_end_in_root)
+            break;
+        intrusions.left = max(intrusions.left, band.left_intrusion);
+        intrusions.right = max(intrusions.right, band.right_intrusion);
+    }
+
+    return intrusions;
+}
+
+FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusions_for_band_into_rect(FloatBand const& band, CSSPixelRect const& rect_in_root) const
+{
+    auto root_content_width = m_state.get(root()).content_width();
+    return {
+        .left = band.left_intrusion == 0 ? CSSPixels(0) : max(CSSPixels(0), band.left_intrusion - rect_in_root.x()),
+        .right = band.right_intrusion == 0 ? CSSPixels(0) : max(CSSPixels(0), band.right_intrusion - (root_content_width - rect_in_root.right())),
+    };
+}
+
+FormattingContext::SpaceUsedByFloats BlockFormattingContext::available_inline_space_in_box(LayoutState::UsedValues const& box_used_values, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
+{
+    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_used_values, root());
+    auto intrusions = available_inline_space(box_in_root_rect.y() + block_start_in_box, box_in_root_rect.y() + block_end_in_box);
+    auto root_content_width = m_state.get(root()).content_width();
+    return {
+        .left = intrusions.left == 0 ? CSSPixels(0) : max(CSSPixels(0), intrusions.left - box_in_root_rect.x()),
+        .right = intrusions.right == 0 ? CSSPixels(0) : max(CSSPixels(0), intrusions.right - (root_content_width - box_in_root_rect.right())),
+    };
+}
+
+BlockFormattingContext::FloatPlacement BlockFormattingContext::place_float(FloatSide side, LayoutState::UsedValues const& box_state, AvailableSpace const& available_space, CSSPixelRect const& containing_block_rect_in_root, CSSPixels ceiling_in_root) const
+{
+    auto const margin_box_width = box_state.margin_box_width();
+    auto candidate_block_start = ceiling_in_root;
+
+    for (;;) {
+        auto const& band = band_at(candidate_block_start);
+        auto intrusions = intrusions_for_band_into_rect(band, containing_block_rect_in_root);
+        auto available_width = available_space.width.to_px_or_zero() - intrusions.left - intrusions.right;
+        auto has_floats_present = band.left_intrusion > 0 || band.right_intrusion > 0;
+
+        if (available_space.width.is_max_content() || available_space.width.is_indefinite() || margin_box_width <= available_width || !has_floats_present) {
+            auto offset_from_edge = side == FloatSide::Left
+                ? intrusions.left + box_state.margin_box_left()
+                : intrusions.right + box_state.content_width() + box_state.margin_box_right();
+            return {
+                .block_start = candidate_block_start,
+                .offset_from_edge = offset_from_edge,
+            };
+        }
+
+        auto next_band_start = next_float_band_block_start_after(candidate_block_start);
+        if (!next_band_start.has_value())
+            return {
+                .block_start = candidate_block_start,
+                .offset_from_edge = side == FloatSide::Left
+                    ? intrusions.left + box_state.margin_box_left()
+                    : intrusions.right + box_state.content_width() + box_state.margin_box_right(),
+            };
+
+        candidate_block_start = next_band_start.value();
+    }
+}
+
+void BlockFormattingContext::ensure_band_boundary(CSSPixels block_start)
+{
+    VERIFY(!m_bands.is_empty());
+
+    for (size_t i = 0; i < m_bands.size(); ++i) {
+        if (m_bands[i].block_start == block_start)
+            return;
+        if (m_bands[i].block_start > block_start) {
+            auto new_band = i == 0 ? FloatBand {} : m_bands[i - 1];
+            new_band.block_start = block_start;
+            m_bands.insert(i, new_band);
+            return;
+        }
+    }
+
+    auto new_band = m_bands.last();
+    new_band.block_start = block_start;
+    m_bands.append(new_band);
+}
+
+void BlockFormattingContext::add_float_to_bands(FloatingBox const& floating_box, CSSPixelRect const& containing_block_rect_in_root)
+{
+    auto const& box_state = floating_box.used_values;
+    auto const root_content_width = m_state.get(root()).content_width();
+    auto const margin_box_rect_in_root = floating_box.margin_box_rect_in_root_coordinate_space;
+    auto const block_start = margin_box_rect_in_root.top();
+    auto const block_end = margin_box_rect_in_root.bottom();
+
+    if (floating_box.side == FloatSide::Left)
+        m_lowest_left_margin_edge = max(m_lowest_left_margin_edge, block_end);
+    else
+        m_lowest_right_margin_edge = max(m_lowest_right_margin_edge, block_end);
+
+    if (block_end <= block_start)
+        return;
+
+    ensure_band_boundary(block_start);
+    ensure_band_boundary(block_end);
+
+    auto intrusion = floating_box.side == FloatSide::Left
+        ? containing_block_rect_in_root.x() + floating_box.offset_from_edge + box_state.content_width() + box_state.margin_box_right()
+        : (root_content_width - containing_block_rect_in_root.right()) + floating_box.offset_from_edge + box_state.margin_box_left();
+
+    for (auto& band : m_bands) {
+        if (band.block_start < block_start)
+            continue;
+        if (band.block_start >= block_end)
+            break;
+        if (floating_box.side == FloatSide::Left)
+            band.left_intrusion = max(band.left_intrusion, intrusion);
+        else
+            band.right_intrusion = max(band.right_intrusion, intrusion);
+    }
+}
+
+void BlockFormattingContext::rebuild_float_bands()
+{
+    m_bands.clear();
+    m_bands.append({});
+    m_lowest_left_margin_edge = 0;
+    m_lowest_right_margin_edge = 0;
+
+    for (auto& floating_box : m_floats) {
+        floating_box->margin_box_rect_in_root_coordinate_space = margin_box_rect_in_ancestor_coordinate_space(floating_box->used_values, root());
+        auto const* containing_block = floating_box->used_values.containing_block_used_values();
+        VERIFY(containing_block);
+        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
+        add_float_to_bands(*floating_box, containing_block_rect_in_root);
+    }
+}
+
 void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space)
 {
     if (box.computed_values().width().is_auto())
@@ -368,28 +546,24 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
     // place it adjacent to such floats if there is sufficient space.
     auto& box_state = m_state.get_mutable(box);
     while (true) {
-        auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
-        auto space_used_by_floats = space_used_and_containing_margin_for_floats(box_in_root_rect.y());
-        auto remaining_space = available_space.width.to_px_or_zero() - space_used_by_floats.left_used_space - space_used_by_floats.right_used_space;
+        auto border_box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_state, root());
+        border_box_in_root_rect.translate_by(-box_state.border_box_left(), -box_state.border_box_top());
+        auto const* containing_block = box_state.containing_block_used_values();
+        VERIFY(containing_block);
+        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
+        containing_block_rect_in_root.set_y(border_box_in_root_rect.y());
+        containing_block_rect_in_root.set_height(box_state.border_box_height());
+        auto const& band = band_at(border_box_in_root_rect.y());
+        auto space_used_by_floats = intrusions_for_band_into_rect(band, containing_block_rect_in_root);
+        auto remaining_space = available_space.width.to_px_or_zero() - space_used_by_floats.left - space_used_by_floats.right;
         if (box_state.border_box_width() <= remaining_space)
             break;
 
-        Optional<CSSPixels> topmost_float_bottom;
-        auto find_topmost_float = [&](auto float_box) {
-            if (!float_box)
-                return;
-            auto const& float_used_values = m_state.get(*float_box);
-            auto float_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(float_used_values, root());
-            auto float_bottom = float_in_root_rect.bottom();
-            if (!topmost_float_bottom.has_value() || topmost_float_bottom.value() > float_bottom)
-                topmost_float_bottom = float_bottom;
-        };
-        find_topmost_float(space_used_by_floats.matching_left_float_box);
-        find_topmost_float(space_used_by_floats.matching_right_float_box);
-        if (!topmost_float_bottom.has_value())
+        auto next_band_start = next_float_band_block_start_after(border_box_in_root_rect.y());
+        if (!next_band_start.has_value())
             break;
 
-        box_state.set_content_y(box_state.offset.y() + topmost_float_bottom.value() - box_in_root_rect.y());
+        box_state.set_content_y(box_state.offset.y() + next_band_start.value() - border_box_in_root_rect.y());
     }
 }
 
@@ -1146,8 +1320,8 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
     auto const& computed_values = child_box.computed_values();
     auto result = DidIntroduceClearance::No;
 
-    auto clear_floating_boxes = [&](FloatSideData& float_side) {
-        if (float_side.current_boxes.is_empty())
+    auto clear_floating_boxes = [&](CSSPixels clearance_y_in_root) {
+        if (clearance_y_in_root == 0)
             return;
 
         // NOTE: Floating boxes are globally relevant within this BFC, *but* their offset coordinates
@@ -1155,16 +1329,6 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
         //       This means that we have to first convert to a root-space Y coordinate before clearing,
         //       and then convert back to a local Y coordinate when assigning the cleared offset to
         //       the `child_box` layout state.
-
-        // First, find the lowest margin box edge on this float side and calculate the Y offset just below it.
-        // NOTE: We must look at all_boxes here, not current_boxes, because current_boxes gets cleared
-        //       when floats are stacked (e.g. multiple width:100% floats). The clear property needs to
-        //       clear past ALL preceding floats, not just the ones on the current "float line".
-        CSSPixels clearance_y_in_root = 0;
-        for (auto const& floating_box : float_side.all_boxes)
-            clearance_y_in_root = max(clearance_y_in_root, floating_box->margin_box_rect_in_root_coordinate_space.bottom());
-
-        // Then, convert the clearance Y to a coordinate relative to the containing block of `child_box`.
         CSSPixels clearance_y_in_containing_block = clearance_y_in_root;
         for (auto containing_block = child_box.containing_block(); containing_block && containing_block != &root(); containing_block = containing_block->containing_block())
             clearance_y_in_containing_block -= m_state.get(*containing_block).offset.y();
@@ -1178,16 +1342,13 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
             result = DidIntroduceClearance::Yes;
             m_y_offset_of_current_block_container = clearance_y_in_containing_block;
         }
-
-        if (!child_box.is_floating())
-            float_side.clear();
     };
 
     // FIXME: Honor writing-mode, direction and text-orientation.
     if (first_is_one_of(computed_values.clear(), CSS::Clear::Left, CSS::Clear::Both, CSS::Clear::InlineStart))
-        clear_floating_boxes(m_left_floats);
+        clear_floating_boxes(m_lowest_left_margin_edge);
     if (first_is_one_of(computed_values.clear(), CSS::Clear::Right, CSS::Clear::Both, CSS::Clear::InlineEnd))
-        clear_floating_boxes(m_right_floats);
+        clear_floating_boxes(m_lowest_right_margin_edge);
 
     return result;
 }
@@ -1197,11 +1358,7 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_vertically
     auto& box_state = m_state.get_mutable(child_box);
     y += box_state.border_box_top();
     box_state.set_content_y(y);
-
-    for (auto const& float_box : m_left_floats.all_boxes)
-        float_box->margin_box_rect_in_root_coordinate_space = margin_box_rect_in_ancestor_coordinate_space(float_box->used_values, root());
-    for (auto const& float_box : m_right_floats.all_boxes)
-        float_box->margin_box_rect_in_root_coordinate_space = margin_box_rect_in_ancestor_coordinate_space(float_box->used_values, root());
+    rebuild_float_bands();
 }
 
 void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const& available_space)
@@ -1211,29 +1368,16 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
     CSSPixels x = 0;
     CSSPixels available_width_within_containing_block = available_space.width.to_px_or_zero();
 
-    if ((!m_left_floats.current_boxes.is_empty() || !m_right_floats.current_boxes.is_empty())
-        && box_should_avoid_floats_because_it_establishes_fc(child_box)) {
-        auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
-        auto space_and_containing_margin = space_used_and_containing_margin_for_floats(box_in_root_rect.y());
-        available_width_within_containing_block -= space_and_containing_margin.left_used_space + space_and_containing_margin.right_used_space;
+    if (box_should_avoid_floats_because_it_establishes_fc(child_box)) {
+        auto space_used_by_floats = intrusion_by_floats_into_box(box_state, 0);
+        available_width_within_containing_block -= space_used_by_floats.left + space_used_by_floats.right;
 
         // Since this box has a FC, it should avoid floats which means we cannot have its border box overlap with any
         // float's margin box. We start off at the right-most border of the floats, and if this box' margin-left is not
         // auto, we must overlap that margin with the floats as far as possible.
-        x = space_and_containing_margin.left_used_space;
+        x = space_used_by_floats.left;
         if (!child_box.computed_values().margin().left().is_auto())
             x = max(x - max(box_state.margin_left, 0), 0);
-
-        // All non-anonymous containing blocks that are ancestors of the child box, but are not ancestors of the left
-        // float box, might have left margins set that overlap with the used float space.
-        if (space_and_containing_margin.matching_left_float_box) {
-            Box const* current_ancestor = child_box.non_anonymous_containing_block();
-            while (!current_ancestor->is_ancestor_of(*space_and_containing_margin.matching_left_float_box)) {
-                x -= m_state.get(*current_ancestor).margin_left;
-                current_ancestor = current_ancestor->non_anonymous_containing_block();
-            }
-            x = max(x, 0);
-        }
     }
 
     if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebCenter) {
@@ -1271,234 +1415,45 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     auto independent_formatting_context = layout_inside(box, m_layout_mode, child_layout_input);
     resolve_used_height_if_treated_as_auto(box, available_space, independent_formatting_context);
 
-    // First we place the box normally (to get the right y coordinate.)
-    // If we have a LineBuilder, we're in the middle of inline layout, otherwise this is block layout.
-    if (line_builder) {
-        auto y = line_builder->y_for_float_to_be_inserted_here(box);
-        box_state.set_content_y(y + box_state.margin_box_top());
-    } else {
-        place_block_level_element_in_normal_flow_vertically(box, y + box_state.margin_top);
-        place_block_level_element_in_normal_flow_horizontally(box, available_space);
-    }
-
-    // Then we float it to the left or right.
-    // FIXME: This algorithm is fundamentally flawed. It tracks left and right floats independently,
-    //        then patches up cross-side interactions after the fact. A better approach would be to
-    //        find the first Y position where the float fits considering ALL existing floats on both
-    //        sides in a single unified pass.
-    auto float_box = [&](FloatSide side, FloatSideData& side_data) {
-        CSSPixels offset_from_edge = 0;
-        auto float_to_edge = [&] {
-            if (side == FloatSide::Left)
-                offset_from_edge = box_state.margin_box_left();
-            else
-                offset_from_edge = box_state.content_width() + box_state.margin_box_right();
-        };
-
-        auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
-        auto const initial_box_margin_y_in_root = box_in_root_rect.y();
-        CSSPixels y_in_root = box_in_root_rect.y();
-        CSSPixels y = box_state.offset.y();
-
-        auto has_clearance = false;
-        if (side == FloatSide::Left) {
-            has_clearance = computed_values.clear() == CSS::Clear::Left || computed_values.clear() == CSS::Clear::Both;
-        } else if (side == FloatSide::Right) {
-            has_clearance = computed_values.clear() == CSS::Clear::Right || computed_values.clear() == CSS::Clear::Both;
-        }
-
-        if (side_data.current_boxes.is_empty()) {
-            // This is the first floating box on this side. Go all the way to the edge.
-            float_to_edge();
-            side_data.y_offset = 0;
-        } else {
-
-            // NOTE: If we're in inline layout, the LineBuilder has already provided the right Y offset.
-            //       In block layout, we adjust by the side's current Y offset here.
-            if (!line_builder)
-                y_in_root += side_data.y_offset;
-
-            bool did_touch_preceding_float = false;
-            bool did_place_next_to_preceding_float = false;
-
-            // Walk all currently tracked floats on the side we're floating towards.
-            // We're looking for the innermost preceding float that intersects vertically with `box`.
-            for (auto& preceding_float : side_data.current_boxes.in_reverse()) {
-                if (!preceding_float.margin_box_rect_in_root_coordinate_space.contains_vertically(y_in_root))
-                    continue;
-                // We found a preceding float that intersects vertically with the current float.
-                // Now we need to find out if there's enough inline-axis space to stack them next to each other.
-                CSSPixels tentative_offset_from_edge = 0;
-                bool fits_next_to_preceding_float = false;
-                if (side == FloatSide::Left) {
-                    tentative_offset_from_edge = max(preceding_float.offset_from_edge + preceding_float.used_values.content_width() + preceding_float.used_values.margin_box_right(), 0) + box_state.margin_box_left();
-                    if (available_space.width.is_definite()) {
-                        fits_next_to_preceding_float = (tentative_offset_from_edge + box_state.content_width() + box_state.margin_box_right()) <= available_space.width.to_px_or_zero();
-                    } else if (available_space.width.is_max_content() || available_space.width.is_indefinite()) {
-                        fits_next_to_preceding_float = true;
-                    }
-                } else {
-                    tentative_offset_from_edge = preceding_float.offset_from_edge + preceding_float.used_values.margin_box_left() + box_state.margin_box_right() + box_state.content_width();
-                    if (available_space.width.is_definite()) {
-                        fits_next_to_preceding_float = (tentative_offset_from_edge + box_state.margin_box_left()) <= available_space.width.to_px_or_zero();
-                    } else if (available_space.width.is_max_content() || available_space.width.is_indefinite()) {
-                        fits_next_to_preceding_float = true;
-                    }
-                }
-                did_touch_preceding_float = true;
-                if (!fits_next_to_preceding_float)
-                    break;
-                offset_from_edge = tentative_offset_from_edge;
-                did_place_next_to_preceding_float = true;
-                break;
-            }
-
-            if (!did_touch_preceding_float || !did_place_next_to_preceding_float || has_clearance) {
-                // One of three things happened:
-                // - This box does not touch another floating box.
-                // - We ran out of horizontal space on this "float line", and need to break.
-                // - This box has clearance.
-                // Either way, we float this box all the way to the edge.
-                float_to_edge();
-                CSSPixels lowest_margin_edge = 0;
-                for (auto const& current : side_data.current_boxes) {
-                    auto current_rect = margin_box_rect_in_ancestor_coordinate_space(current.used_values, root());
-                    lowest_margin_edge = max(lowest_margin_edge, current_rect.bottom());
-                }
-
-                side_data.y_offset += max<CSSPixels>(0, lowest_margin_edge - y_in_root);
-
-                // Also, forget all previous boxes floated to this side while since they're no longer relevant.
-                side_data.clear();
-            }
-        }
-
-        // NOTE: If we're in inline layout, the LineBuilder has already provided the right Y offset.
-        //       In block layout, we adjust by the side's current Y offset here.
-        // FIXME: It's annoying that we have different behavior for inline vs block here.
-        //        Find a way to unify the behavior so we don't need to branch here.
-        if (!line_builder)
-            y += side_data.y_offset;
-
-        // NOTE: We don't set the X position here, that happens later, once we know the root block width.
-        //       See parent_context_did_dimension_child_root_box() for that logic.
-        box_state.set_content_y(y);
-
-        // CSS2 9.5.1: "If there is not enough horizontal room for the float, it is shifted downward
-        //              until either it fits or there are no more floats present."
-        // After same-side stacking, check if the float fits horizontally considering opposite-side
-        // floats. If not, push it below the shallowest blocking float and retry.
-        if (!line_builder && available_space.width.is_definite()) {
-            auto position_with_same_side_floats_after_lowering = [&](CSSPixels candidate_box_margin_y_in_root) {
-                while (true) {
-                    Vector<FloatingBox&> candidate_current_boxes;
-                    CSSPixels lowest_margin_edge = candidate_box_margin_y_in_root;
-                    for (auto const& existing_float : side_data.all_boxes) {
-                        if (!existing_float->margin_box_rect_in_root_coordinate_space.contains_vertically(candidate_box_margin_y_in_root))
-                            continue;
-                        candidate_current_boxes.append(*existing_float);
-                        lowest_margin_edge = max(lowest_margin_edge, existing_float->margin_box_rect_in_root_coordinate_space.bottom());
-                    }
-
-                    CSSPixels candidate_offset_from_edge = 0;
-                    if (side == FloatSide::Left)
-                        candidate_offset_from_edge = box_state.margin_box_left();
-                    else
-                        candidate_offset_from_edge = box_state.content_width() + box_state.margin_box_right();
-
-                    bool did_touch_preceding_float = false;
-                    bool did_place_next_to_preceding_float = false;
-                    for (auto& preceding_float : candidate_current_boxes.in_reverse()) {
-                        CSSPixels tentative_offset_from_edge = 0;
-                        bool fits_next_to_preceding_float = false;
-                        if (side == FloatSide::Left) {
-                            tentative_offset_from_edge = max(preceding_float.offset_from_edge + preceding_float.used_values.content_width() + preceding_float.used_values.margin_box_right(), 0) + box_state.margin_box_left();
-                            fits_next_to_preceding_float = (tentative_offset_from_edge + box_state.content_width() + box_state.margin_box_right()) <= available_space.width.to_px_or_zero();
-                        } else {
-                            tentative_offset_from_edge = preceding_float.offset_from_edge + preceding_float.used_values.margin_box_left() + box_state.margin_box_right() + box_state.content_width();
-                            fits_next_to_preceding_float = (tentative_offset_from_edge + box_state.margin_box_left()) <= available_space.width.to_px_or_zero();
-                        }
-
-                        did_touch_preceding_float = true;
-                        if (!fits_next_to_preceding_float)
-                            break;
-                        candidate_offset_from_edge = tentative_offset_from_edge;
-                        did_place_next_to_preceding_float = true;
-                        break;
-                    }
-
-                    if ((has_clearance && !candidate_current_boxes.is_empty()) || (did_touch_preceding_float && !did_place_next_to_preceding_float)) {
-                        candidate_box_margin_y_in_root = lowest_margin_edge;
-                        continue;
-                    }
-
-                    side_data.current_boxes.clear();
-                    for (auto& current_float : candidate_current_boxes)
-                        side_data.current_boxes.append(current_float);
-
-                    side_data.y_offset = max<CSSPixels>(0, candidate_box_margin_y_in_root - initial_box_margin_y_in_root);
-                    offset_from_edge = candidate_offset_from_edge;
-                    auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
-                    y = box_state.offset.y() + candidate_box_margin_y_in_root - box_in_root_rect.y();
-                    box_state.set_content_y(y);
-                    break;
-                }
-            };
-
-            while (true) {
-                auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
-                auto space_used_by_floats = space_used_and_containing_margin_for_floats(box_in_root_rect.y());
-                auto const* containing_block = box_state.containing_block_used_values();
-                VERIFY(containing_block);
-                auto current_containing_block_in_root_rect = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
-                auto used_by_this_side = (side == FloatSide::Left)
-                    ? offset_from_edge + box_state.content_width() + box_state.margin_box_right()
-                    : offset_from_edge + box_state.margin_box_left();
-                auto used_by_opposite_side = (side == FloatSide::Left)
-                    ? max<CSSPixels>(0, space_used_by_floats.right_used_space + space_used_by_floats.right_total_containing_margin - (m_state.get(root()).content_width() - current_containing_block_in_root_rect.right()))
-                    : max<CSSPixels>(0, space_used_by_floats.left_total_containing_margin + space_used_by_floats.left_used_space - current_containing_block_in_root_rect.x());
-                if (used_by_this_side + used_by_opposite_side <= available_space.width.to_px_or_zero())
-                    break;
-
-                // Find the shallowest (topmost) opposite-side float blocking us and move below it.
-                auto opposite_float_box = (side == FloatSide::Left)
-                    ? space_used_by_floats.matching_right_float_box
-                    : space_used_by_floats.matching_left_float_box;
-                if (!opposite_float_box)
-                    break;
-                auto const& opposite_float_used_values = m_state.get(*opposite_float_box);
-                auto opposite_float_bottom = margin_box_rect_in_ancestor_coordinate_space(opposite_float_used_values, root()).bottom();
-                position_with_same_side_floats_after_lowering(opposite_float_bottom);
-            }
-        }
-
-        auto top_margin_edge = y - box_state.margin_box_top();
-        side_data.all_boxes.append(adopt_own(*new FloatingBox {
-            .box = box,
-            .used_values = box_state,
-            .offset_from_edge = offset_from_edge,
-            .top_margin_edge = top_margin_edge,
-            .bottom_margin_edge = y + box_state.content_height() + box_state.margin_box_bottom(),
-            .margin_box_rect_in_root_coordinate_space = margin_box_rect_in_ancestor_coordinate_space(box_state, root()),
-        }));
-        side_data.current_boxes.append(*side_data.all_boxes.last());
-        m_last_inserted_float = *side_data.all_boxes.last();
-
-        if (side == FloatSide::Left) {
-            side_data.current_width = offset_from_edge + box_state.content_width() + box_state.margin_box_right();
-        } else {
-            side_data.current_width = offset_from_edge + box_state.margin_box_left();
-        }
-        side_data.max_width = max(side_data.current_width, side_data.max_width);
-    };
-
     // Next, float to the left and/or right
     // FIXME: Honor writing-mode, direction and text-orientation.
+    Optional<FloatSide> side;
     if (box.computed_values().float_() == CSS::Float::Left || box.computed_values().float_() == CSS::Float::InlineStart) {
-        float_box(FloatSide::Left, m_left_floats);
+        side = FloatSide::Left;
     } else if (box.computed_values().float_() == CSS::Float::Right || box.computed_values().float_() == CSS::Float::InlineEnd) {
-        float_box(FloatSide::Right, m_right_floats);
+        side = FloatSide::Right;
     }
+
+    if (!side.has_value())
+        return;
+
+    auto const containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(block_container_state, root());
+    auto margin_box_ceiling = line_builder ? line_builder->ceiling_for_float_to_be_inserted_here(box) : y;
+    auto clearance = computed_values.clear();
+    if (side.value() == FloatSide::Left && first_is_one_of(clearance, CSS::Clear::Left, CSS::Clear::Both, CSS::Clear::InlineStart))
+        margin_box_ceiling = max(margin_box_ceiling, m_lowest_left_margin_edge - containing_block_rect_in_root.y());
+    if (side.value() == FloatSide::Right && first_is_one_of(clearance, CSS::Clear::Right, CSS::Clear::Both, CSS::Clear::InlineEnd))
+        margin_box_ceiling = max(margin_box_ceiling, m_lowest_right_margin_edge - containing_block_rect_in_root.y());
+
+    auto ceiling_in_root = containing_block_rect_in_root.y() + margin_box_ceiling;
+    if (!m_floats.is_empty())
+        ceiling_in_root = max(ceiling_in_root, m_floats.last()->margin_box_rect_in_root_coordinate_space.top());
+
+    auto placement = place_float(side.value(), box_state, available_space, containing_block_rect_in_root, ceiling_in_root);
+    auto content_y = placement.block_start - containing_block_rect_in_root.y() + box_state.margin_box_top();
+    box_state.set_content_y(content_y);
+
+    auto margin_box_rect_in_root = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
+    m_floats.append(adopt_own(*new FloatingBox {
+        .box = box,
+        .used_values = box_state,
+        .side = side.value(),
+        .offset_from_edge = placement.offset_from_edge,
+        .top_margin_edge = content_y - box_state.margin_box_top(),
+        .bottom_margin_edge = content_y + box_state.content_height() + box_state.margin_box_bottom(),
+        .margin_box_rect_in_root_coordinate_space = margin_box_rect_in_root,
+    }));
+    add_float_to_bands(*m_floats.last(), containing_block_rect_in_root);
 
     m_state.get_mutable(root()).add_floating_descendant(box);
 
@@ -1581,48 +1536,6 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
         list_item_state.set_content_height(marker.computed_values().line_height());
 }
 
-BlockFormattingContext::SpaceUsedAndContainingMarginForFloats BlockFormattingContext::space_used_and_containing_margin_for_floats(CSSPixels y) const
-{
-    SpaceUsedAndContainingMarginForFloats space_and_containing_margin;
-
-    for (auto const& floating_box_ptr : m_left_floats.all_boxes.in_reverse()) {
-        auto const& floating_box = *floating_box_ptr;
-        // NOTE: The floating box is *not* in the final horizontal position yet, but the size and vertical position is valid.
-        auto rect = floating_box.margin_box_rect_in_root_coordinate_space;
-        if (rect.contains_vertically(y)) {
-            CSSPixels offset_from_containing_block_chain_margins_between_here_and_root = 0;
-            for (auto const* containing_block = floating_box.used_values.containing_block_used_values(); containing_block && &containing_block->node() != &root(); containing_block = containing_block->containing_block_used_values()) {
-                offset_from_containing_block_chain_margins_between_here_and_root += containing_block->margin_box_left();
-            }
-            space_and_containing_margin.left_used_space = floating_box.offset_from_edge
-                + floating_box.used_values.content_width()
-                + floating_box.used_values.margin_box_right();
-            space_and_containing_margin.left_total_containing_margin = offset_from_containing_block_chain_margins_between_here_and_root;
-            space_and_containing_margin.matching_left_float_box = &floating_box.box;
-            break;
-        }
-    }
-
-    for (auto const& floating_box_ptr : m_right_floats.all_boxes.in_reverse()) {
-        auto const& floating_box = *floating_box_ptr;
-        // NOTE: The floating box is *not* in the final horizontal position yet, but the size and vertical position is valid.
-        auto rect = floating_box.margin_box_rect_in_root_coordinate_space;
-        if (rect.contains_vertically(y)) {
-            CSSPixels offset_from_containing_block_chain_margins_between_here_and_root = 0;
-            for (auto const* containing_block = floating_box.used_values.containing_block_used_values(); containing_block && &containing_block->node() != &root(); containing_block = containing_block->containing_block_used_values()) {
-                offset_from_containing_block_chain_margins_between_here_and_root += containing_block->margin_box_right();
-            }
-            space_and_containing_margin.right_used_space = floating_box.offset_from_edge
-                + floating_box.used_values.margin_box_left();
-            space_and_containing_margin.right_total_containing_margin = offset_from_containing_block_chain_margins_between_here_and_root;
-            space_and_containing_margin.matching_right_float_box = &floating_box.box;
-            break;
-        }
-    }
-
-    return space_and_containing_margin;
-}
-
 FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_box(Box const& box, CSSPixels y_in_box) const
 {
     return intrusion_by_floats_into_box(m_state.get(box), y_in_box);
@@ -1630,45 +1543,34 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats
 
 FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_box(LayoutState::UsedValues const& box_used_values, CSSPixels y_in_box) const
 {
-    // NOTE: Floats are relative to the BFC root box, not necessarily the containing block of this IFC.
-    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_used_values, root());
-    CSSPixels y_in_root = box_in_root_rect.y() + y_in_box;
-    auto space_and_containing_margin = space_used_and_containing_margin_for_floats(y_in_root);
+    return intrusion_by_floats_into_box(box_used_values, y_in_box, y_in_box);
+}
 
-    CSSPixels left_intrusion = 0;
-    if (space_and_containing_margin.matching_left_float_box) {
-        auto left_side_floats_limit_to_right = space_and_containing_margin.left_total_containing_margin + space_and_containing_margin.left_used_space;
-        left_intrusion = max(CSSPixels(0), left_side_floats_limit_to_right - box_in_root_rect.x());
-    }
-
-    // If we did not match a right float, the right_total_containing_margin will be 0 (as its never set). Since no floats means
-    // no intrusion we would instead want it to be exactly equal to offset_from_containing_block_chain_margins_between_here_and_root.
-    // Since this is not the case we have to explicitly handle this case.
-    CSSPixels right_intrusion = 0;
-    if (space_and_containing_margin.matching_right_float_box) {
-        auto right_side_floats_limit_to_right = space_and_containing_margin.right_used_space + space_and_containing_margin.right_total_containing_margin;
-        CSSPixels offset_from_containing_block_chain_margins_between_here_and_root = 0;
-        for (auto const* containing_block = &box_used_values; containing_block && &containing_block->node() != &root(); containing_block = containing_block->containing_block_used_values()) {
-            offset_from_containing_block_chain_margins_between_here_and_root += containing_block->margin_box_right();
-        }
-        right_intrusion = max(CSSPixels(0), right_side_floats_limit_to_right - offset_from_containing_block_chain_margins_between_here_and_root);
-    }
-
-    return { left_intrusion, right_intrusion };
+FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_box(LayoutState::UsedValues const& box_used_values, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
+{
+    return available_inline_space_in_box(box_used_values, block_start_in_box, block_end_in_box);
 }
 
 CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
 {
     // Similar to FormattingContext::greatest_child_width()
     // but this one takes floats into account!
-    CSSPixels max_width = m_left_floats.max_width + m_right_floats.max_width;
+    CSSPixels max_width = 0;
+    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
+    for (auto const& band : m_bands) {
+        auto intrusions = intrusions_for_band_into_rect(band, box_in_root_rect);
+        max_width = max(max_width, intrusions.left + intrusions.right);
+    }
+
     if (box.children_are_inline()) {
         for (auto const& line_box : m_state.get(as<BlockContainer>(box)).line_boxes) {
             auto width_here = line_box_physical_width(box, line_box);
             auto line_top = line_box.bottom() - line_box.height();
             auto line_bottom = line_box.bottom();
             CSSPixels extra_width_from_left_floats = 0;
-            for (auto& left_float : m_left_floats.all_boxes) {
+            for (auto& left_float : m_floats) {
+                if (left_float->side != FloatSide::Left)
+                    continue;
                 // NOTE: Floats directly affect the automatic size of their containing block, but only indirectly anything above in the tree.
                 if (left_float->box.containing_block() != &box)
                     continue;
@@ -1677,7 +1579,9 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
                 }
             }
             CSSPixels extra_width_from_right_floats = 0;
-            for (auto& right_float : m_right_floats.all_boxes) {
+            for (auto& right_float : m_floats) {
+                if (right_float->side != FloatSide::Right)
+                    continue;
                 // NOTE: Floats directly affect the automatic size of their containing block, but only indirectly anything above in the tree.
                 if (right_float->box.containing_block() != &box)
                     continue;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -26,9 +26,6 @@ public:
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
 
-    auto const& left_side_floats() const { return m_left_floats; }
-    auto const& right_side_floats() const { return m_right_floats; }
-
     bool box_should_avoid_floats_because_it_establishes_fc(Box const&);
     void compute_width(Box const&, AvailableSpace const&);
     void avoid_float_intrusions(Box const&, AvailableSpace const&);
@@ -44,19 +41,17 @@ public:
     template<typename Callback>
     void for_each_floating_box(Callback callback)
     {
-        for (auto const& floating_box : m_left_floats.all_boxes) {
-            if (callback(*floating_box) == IterationDecision::Break)
-                return;
-        }
-        for (auto const& floating_box : m_right_floats.all_boxes) {
+        for (auto const& floating_box : m_floats) {
             if (callback(*floating_box) == IterationDecision::Break)
                 return;
         }
     }
 
-    SpaceUsedAndContainingMarginForFloats space_used_and_containing_margin_for_floats(CSSPixels y) const;
+    [[nodiscard]] SpaceUsedByFloats available_inline_space(CSSPixels block_start_in_root, CSSPixels block_end_in_root) const;
     [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(Box const&, CSSPixels y_in_box) const;
     [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(LayoutState::UsedValues const&, CSSPixels y_in_box) const;
+    [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(LayoutState::UsedValues const&, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
+    [[nodiscard]] Optional<CSSPixels> next_float_band_block_start_after(CSSPixels y_in_root) const;
 
     virtual CSSPixels greatest_child_width(Box const&) const override;
 
@@ -76,10 +71,17 @@ public:
 
     void reset_margin_state() { m_margin_state.reset(); }
 
+    enum class FloatSide {
+        Left,
+        Right,
+    };
+
     struct FloatingBox {
         Box const& box;
 
         LayoutState::UsedValues& used_values;
+
+        FloatSide side { FloatSide::Left };
 
         // Offset from left/right edge to the left content edge of `box`.
         CSSPixels offset_from_edge { 0 };
@@ -92,8 +94,6 @@ public:
 
         CSSPixelRect margin_box_rect_in_root_coordinate_space;
     };
-
-    Optional<FloatingBox&> last_inserted_float() { return m_last_inserted_float; }
 
 private:
     CSSPixels compute_auto_height_for_block_level_element(Box const&, AvailableSpace const&);
@@ -123,34 +123,25 @@ private:
     // https://www.w3.org/TR/css-align-3/#column-row-gap
     CSSPixels get_column_gap_used_value_for_multicol(CSSPixels const& U) const;
 
-    enum class FloatSide {
-        Left,
-        Right,
+    struct FloatBand {
+        CSSPixels block_start { 0 };
+        CSSPixels left_intrusion { 0 };
+        CSSPixels right_intrusion { 0 };
     };
 
-    struct FloatSideData {
-        // Floating boxes currently accumulating on this side.
-        Vector<FloatingBox&> current_boxes;
-
-        // Combined width of boxes currently accumulating on this side.
-        // This is the innermost margin of the innermost floating box.
-        CSSPixels current_width { 0 };
-
-        // Highest value of `m_current_width` we've seen.
-        CSSPixels max_width { 0 };
-
-        // All floating boxes encountered thus far within this BFC.
-        Vector<NonnullOwnPtr<FloatingBox>> all_boxes;
-
-        // Current Y offset from BFC root top.
-        CSSPixels y_offset { 0 };
-
-        void clear()
-        {
-            current_boxes.clear();
-            current_width = 0;
-        }
+    struct FloatPlacement {
+        CSSPixels block_start { 0 };
+        CSSPixels offset_from_edge { 0 };
     };
+
+    [[nodiscard]] size_t band_index_at(CSSPixels y) const;
+    [[nodiscard]] FloatBand const& band_at(CSSPixels y) const;
+    [[nodiscard]] SpaceUsedByFloats intrusions_for_band_into_rect(FloatBand const&, CSSPixelRect const& rect_in_root) const;
+    [[nodiscard]] SpaceUsedByFloats available_inline_space_in_box(LayoutState::UsedValues const&, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
+    [[nodiscard]] FloatPlacement place_float(FloatSide, LayoutState::UsedValues const&, AvailableSpace const&, CSSPixelRect const& containing_block_rect_in_root, CSSPixels ceiling_in_root) const;
+    void ensure_band_boundary(CSSPixels);
+    void add_float_to_bands(FloatingBox const&, CSSPixelRect const& containing_block_rect_in_root);
+    void rebuild_float_bands();
 
     class BlockMarginState {
     public:
@@ -212,9 +203,10 @@ private:
 
     BlockMarginState m_margin_state;
 
-    FloatSideData m_left_floats;
-    FloatSideData m_right_floats;
-    Optional<FloatingBox&> m_last_inserted_float;
+    Vector<NonnullOwnPtr<FloatingBox>> m_floats;
+    Vector<FloatBand> m_bands;
+    CSSPixels m_lowest_left_margin_edge { 0 };
+    CSSPixels m_lowest_right_margin_edge { 0 };
 
     bool m_was_notified_after_parent_dimensioned_my_root_box { false };
 };

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -193,18 +193,6 @@ protected:
         CSSPixels right { 0 };
     };
 
-    struct SpaceUsedAndContainingMarginForFloats {
-        // Width for left / right floats, including their own margins.
-        CSSPixels left_used_space;
-        CSSPixels right_used_space;
-        // Left / right total margins from the outermost containing block to the floating element.
-        // Each block in the containing chain adds its own margin and we store the total here.
-        CSSPixels left_total_containing_margin;
-        CSSPixels right_total_containing_margin;
-        Box const* matching_left_float_box { nullptr };
-        Box const* matching_right_float_box { nullptr };
-    };
-
     struct ShrinkToFitResult {
         CSSPixels preferred_width { 0 };
         CSSPixels preferred_minimum_width { 0 };

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -39,34 +39,18 @@ BlockFormattingContext const& InlineFormattingContext::parent() const
     return static_cast<BlockFormattingContext const&>(*FormattingContext::parent());
 }
 
-CSSPixels InlineFormattingContext::leftmost_inline_offset_at(CSSPixels y) const
+CSSPixels InlineFormattingContext::leftmost_inline_offset_at(CSSPixels block_offset, CSSPixels line_height) const
 {
-    // NOTE: Floats are relative to the BFC root box, not necessarily the containing block of this IFC.
-    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_containing_block_used_values, parent().root());
-    CSSPixels y_in_root = box_in_root_rect.y() + y;
-    auto space_and_containing_margin = parent().space_used_and_containing_margin_for_floats(y_in_root);
-
-    // If there's no float box to take into account, we start at the left edge of the containing block.
-    if (!space_and_containing_margin.matching_left_float_box)
-        return 0;
-
-    // If the left edge of the containing block is to the right of the rightmost left-side float, start placing inline
-    // content at the left edge of the containing block.
-    auto left_side_floats_limit_to_right = space_and_containing_margin.left_total_containing_margin + space_and_containing_margin.left_used_space;
-    if (box_in_root_rect.x() >= left_side_floats_limit_to_right)
-        return 0;
-
-    // The left edge of the containing block is to the left of the rightmost left-side float.
-    // We adjust the inline content insertion point by the overlap between the containing block and the float.
-    return left_side_floats_limit_to_right - box_in_root_rect.x();
+    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, block_offset, block_offset + line_height);
+    return intrusions.left;
 }
 
-AvailableSize InlineFormattingContext::available_space_for_line(CSSPixels y) const
+AvailableSize InlineFormattingContext::available_space_for_line(CSSPixels block_offset, CSSPixels line_height) const
 {
     if (!m_available_space->width.is_definite())
         return m_available_space->width;
 
-    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, y);
+    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, block_offset, block_offset + line_height);
     return AvailableSize::make_definite(m_available_space->width.to_px_or_zero() - intrusions.left - intrusions.right);
 }
 
@@ -546,40 +530,29 @@ void InlineFormattingContext::generate_line_boxes()
     m_containing_block_used_values.set_inline_end_static_position_rect(calculate_inline_end_static_position_rect());
 }
 
-bool InlineFormattingContext::any_floats_intrude_at_block_offset(CSSPixels block_offset) const
+bool InlineFormattingContext::any_floats_intrude_in_block_range(CSSPixels block_start, CSSPixels block_end) const
 {
-    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_containing_block_used_values, parent().root());
     // FIXME: Respect inline direction.
-    CSSPixels y_in_root = box_in_root_rect.y() + block_offset;
-    auto space_and_containing_margin = parent().space_used_and_containing_margin_for_floats(y_in_root);
-    return space_and_containing_margin.left_used_space > 0 || space_and_containing_margin.right_used_space > 0;
+    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, block_start, block_end);
+    return intrusions.left > 0 || intrusions.right > 0;
 }
 
-bool InlineFormattingContext::can_fit_new_line_at_block_offset(CSSPixels block_offset) const
+bool InlineFormattingContext::can_fit_new_line_at_block_offset(CSSPixels block_offset, CSSPixels line_height) const
 {
     // FIXME: Respect inline direction.
 
-    auto top_intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, block_offset);
-    auto bottom_intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, block_offset + containing_block().computed_values().line_height() - 1);
+    if (!m_available_space->width.is_definite())
+        return true;
+    return available_space_for_line(block_offset, line_height).to_px_or_zero() > 0;
+}
 
-    auto left_edge = [](auto& space) -> CSSPixels {
-        return space.left;
-    };
-
-    auto right_edge = [this](auto& space) -> CSSPixels {
-        return m_available_space->width.to_px_or_zero() - space.right;
-    };
-
-    auto top_left_edge = left_edge(top_intrusions);
-    auto top_right_edge = right_edge(top_intrusions);
-    auto bottom_left_edge = left_edge(bottom_intrusions);
-    auto bottom_right_edge = right_edge(bottom_intrusions);
-
-    if (top_left_edge > bottom_right_edge)
-        return false;
-    if (bottom_left_edge > top_right_edge)
-        return false;
-    return true;
+Optional<CSSPixels> InlineFormattingContext::next_float_band_block_start_after(CSSPixels block_offset) const
+{
+    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_containing_block_used_values, parent().root());
+    auto next_band_start = parent().next_float_band_block_start_after(box_in_root_rect.y() + block_offset);
+    if (!next_band_start.has_value())
+        return {};
+    return next_band_start.value() - box_in_root_rect.y();
 }
 
 CSSPixels InlineFormattingContext::vertical_float_clearance() const

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/Types.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/BlockContainer.h>
@@ -29,10 +30,11 @@ public:
 
     void dimension_box_on_line(Box const&, LayoutMode);
 
-    CSSPixels leftmost_inline_offset_at(CSSPixels y) const;
-    AvailableSize available_space_for_line(CSSPixels y) const;
-    bool any_floats_intrude_at_block_offset(CSSPixels block_offset) const;
-    bool can_fit_new_line_at_block_offset(CSSPixels block_offset) const;
+    CSSPixels leftmost_inline_offset_at(CSSPixels block_offset, CSSPixels line_height) const;
+    AvailableSize available_space_for_line(CSSPixels block_offset, CSSPixels line_height) const;
+    bool any_floats_intrude_in_block_range(CSSPixels block_start, CSSPixels block_end) const;
+    bool can_fit_new_line_at_block_offset(CSSPixels block_offset, CSSPixels line_height) const;
+    Optional<CSSPixels> next_float_band_block_start_after(CSSPixels block_offset) const;
 
     CSSPixels vertical_float_clearance() const;
     void set_vertical_float_clearance(CSSPixels);

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -41,9 +41,10 @@ void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_
         m_containing_block_used_values.line_boxes.append(LineBox(m_direction, m_writing_mode));
         begin_new_line(true, break_count == 0, forced_break);
         break_count++;
-        floats_intrude_at_current_y = m_context.any_floats_intrude_at_block_offset(m_current_block_offset);
+        auto current_line_height = max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
+        floats_intrude_at_current_y = m_context.any_floats_intrude_in_block_range(m_current_block_offset, m_current_block_offset + current_line_height);
     } while (floats_intrude_at_current_y
-        && (!m_context.can_fit_new_line_at_block_offset(m_current_block_offset)
+        && (!m_context.can_fit_new_line_at_block_offset(m_current_block_offset, m_context.containing_block().computed_values().line_height())
             || (next_item_width.value_or(0) > m_available_width_for_current_line)));
 }
 
@@ -59,15 +60,10 @@ void LineBuilder::begin_new_line(bool increment_y, bool is_first_break_in_sequen
         } else {
             // We're doing more than one break in a row.
             // This means we're trying to squeeze past intruding floats.
-            // Scan 1px at a time until we find a Y value where a new line can fit.
-            // FIXME: This is super dumb and inefficient.
-            CSSPixels candidate_block_offset = m_current_block_offset + 1;
-            while (true) {
-                if (m_context.can_fit_new_line_at_block_offset(candidate_block_offset))
-                    break;
-                ++candidate_block_offset;
-            }
-            m_current_block_offset = candidate_block_offset;
+            if (auto next_band_start = m_context.next_float_band_block_start_after(m_current_block_offset); next_band_start.has_value())
+                m_current_block_offset = next_band_start.value();
+            else
+                m_current_block_offset += max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
         }
     }
     recalculate_available_space();
@@ -130,11 +126,10 @@ void LineBuilder::append_static_position_marker(Box const& box)
     ensure_last_line_box().add_static_position_marker(box);
 }
 
-CSSPixels LineBuilder::y_for_float_to_be_inserted_here(Box const& box)
+CSSPixels LineBuilder::ceiling_for_float_to_be_inserted_here(Box const& box)
 {
     auto const& box_state = m_layout_state.get(box);
     CSSPixels const width = box_state.margin_box_width();
-    CSSPixels const height = box_state.margin_box_height();
 
     CSSPixels candidate_block_offset = m_current_block_offset;
 
@@ -148,50 +143,6 @@ CSSPixels LineBuilder::y_for_float_to_be_inserted_here(Box const& box)
     if (current_line_width > 0 && (current_line_width + width) > m_available_width_for_current_line)
         candidate_block_offset += current_line.height();
 
-    // Then, look for the next Y position where we can fit the new float.
-    auto box_in_root_rect = m_context.parent().content_box_rect_in_ancestor_coordinate_space(box_state, m_context.parent().root());
-
-    // New floats will always be placed vertically at or below the lowest float.
-    // This applies to all floats, so the last inserted float will always be the lowest.
-    auto last_float = m_context.parent().last_inserted_float();
-    if (last_float.has_value()) {
-        auto float_box_top = last_float->margin_box_rect_in_root_coordinate_space.top() - box_in_root_rect.y();
-        candidate_block_offset = max(candidate_block_offset, float_box_top);
-    }
-
-    HashMap<CSSPixels, AvailableSize> available_space_cache;
-    for (;;) {
-        Optional<CSSPixels> highest_intersection_bottom;
-        auto candidate_block_bottom = candidate_block_offset + height;
-
-        m_context.parent().for_each_floating_box([&](auto const& float_box) {
-            auto float_box_top = float_box.margin_box_rect_in_root_coordinate_space.top() - box_in_root_rect.y();
-            auto float_box_bottom = float_box.margin_box_rect_in_root_coordinate_space.bottom() - box_in_root_rect.y();
-            if (float_box_bottom <= candidate_block_offset)
-                return IterationDecision::Continue;
-
-            auto intersection_test = [&](auto y_coordinate, auto top, auto bottom) {
-                if (y_coordinate < top || y_coordinate > bottom)
-                    return;
-                auto available_space = available_space_cache.ensure(y_coordinate, [&]() {
-                    return m_context.available_space_for_line(y_coordinate);
-                });
-                if (width > available_space)
-                    highest_intersection_bottom = min(highest_intersection_bottom.value_or(float_box_bottom), float_box_bottom);
-            };
-
-            intersection_test(float_box_top, candidate_block_offset, candidate_block_bottom);
-            intersection_test(float_box_bottom, candidate_block_offset, candidate_block_bottom);
-            intersection_test(candidate_block_offset, float_box_top, float_box_bottom);
-            intersection_test(candidate_block_bottom, float_box_top, float_box_bottom);
-
-            return IterationDecision::Continue;
-        });
-        if (!highest_intersection_bottom.has_value() || highest_intersection_bottom.value() == candidate_block_offset)
-            break;
-        candidate_block_offset = highest_intersection_bottom.value();
-    }
-
     return max(candidate_block_offset, m_context.vertical_float_clearance());
 }
 
@@ -203,10 +154,9 @@ bool LineBuilder::should_break(CSSPixels next_item_width)
     auto const& line_boxes = m_containing_block_used_values.line_boxes;
     if (line_boxes.is_empty() || line_boxes.last().is_empty()) {
         // If we don't have a single line box yet *and* there are no floats intruding
-        // at this Y coordinate, we don't need to break before inserting anything.
-        if (!m_context.any_floats_intrude_at_block_offset(m_current_block_offset))
-            return false;
-        if (!m_context.any_floats_intrude_at_block_offset(m_current_block_offset + m_context.containing_block().computed_values().line_height()))
+        // into this line box, we don't need to break before inserting anything.
+        auto line_height = m_context.containing_block().computed_values().line_height();
+        if (!m_context.any_floats_intrude_in_block_range(m_current_block_offset, m_current_block_offset + line_height))
             return false;
     }
     auto current_line_width = ensure_last_line_box().width();
@@ -229,9 +179,8 @@ void LineBuilder::update_last_line()
     auto direction = m_context.containing_block().computed_values().direction();
 
     auto current_line_height = max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
-    CSSPixels inline_offset_top = m_context.leftmost_inline_offset_at(m_current_block_offset);
-    CSSPixels inline_offset_bottom = m_context.leftmost_inline_offset_at(m_current_block_offset + current_line_height - 1);
-    CSSPixels inline_offset = max(inline_offset_top, inline_offset_bottom);
+    CSSPixels start_inline_offset = m_context.leftmost_inline_offset_at(m_current_block_offset, current_line_height);
+    CSSPixels inline_offset = start_inline_offset;
     CSSPixels block_offset = 0;
 
     // FIXME: Respect inline direction.
@@ -464,7 +413,7 @@ void LineBuilder::update_last_line()
     }
 
     auto marker_inline_offset = line_box.fragments().is_empty()
-        ? max(inline_offset_top, inline_offset_bottom)
+        ? start_inline_offset
         : inline_offset;
     for (auto& marker : line_box.static_position_markers()) {
         marker.inline_offset += marker_inline_offset;
@@ -492,9 +441,7 @@ void LineBuilder::remove_last_line_if_empty()
 void LineBuilder::recalculate_available_space()
 {
     auto current_line_height = max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
-    auto available_at_top_of_line_box = m_context.available_space_for_line(m_current_block_offset);
-    auto available_at_bottom_of_line_box = m_context.available_space_for_line(m_current_block_offset + current_line_height - 1);
-    m_available_width_for_current_line = min(available_at_bottom_of_line_box, available_at_top_of_line_box);
+    m_available_width_for_current_line = m_context.available_space_for_line(m_current_block_offset, current_line_height);
     if (!m_containing_block_used_values.line_boxes.is_empty())
         m_containing_block_used_values.line_boxes.last().m_original_available_width = m_available_width_for_current_line;
 }

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -46,7 +46,7 @@ public:
     CSSPixels current_block_offset() const { return m_current_block_offset; }
 
     void recalculate_available_space();
-    CSSPixels y_for_float_to_be_inserted_here(Box const&);
+    CSSPixels ceiling_for_float_to_be_inserted_here(Box const&);
 
     void did_introduce_clearance(CSSPixels);
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-line-spans-middle-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-line-spans-middle-float.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+      BlockContainer <div.container> at [0,0] [0+0+0 300 0+0+500] [0+0+0 100 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 300 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.spacer> at [0,0] [0+0+0 300 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [0,50] [0+0+0 300 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+          BlockContainer <div.float> at [0,50] floating [0+0+0 120 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <p.probe> at [0,40] [0+0+0 300 0+0+0] [-10+0+0 60 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 20, rect: [120,40 160.296875x60] baseline: 34.796875
+              "line spans the float"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,100] [0+0+0 300 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,100] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x100]
+      PaintableWithLines (BlockContainer<DIV>.container) [0,0 300x100]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 300x0]
+        PaintableWithLines (BlockContainer<DIV>.spacer) [0,0 300x50]
+        PaintableWithLines (BlockContainer(anonymous)) [0,50 300x0]
+          PaintableWithLines (BlockContainer<DIV>.float) [0,50 120x20]
+        PaintableWithLines (BlockContainer<P>.probe) [0,40 300x60]
+        PaintableWithLines (BlockContainer(anonymous)) [0,100 300x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,100 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x100] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-line-spans-middle-float.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-line-spans-middle-float.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .container {
+        width: 300px;
+        font: 16px / 60px SerenitySans, sans-serif;
+    }
+
+    .spacer {
+        height: 50px;
+    }
+
+    .float {
+        float: left;
+        width: 120px;
+        height: 20px;
+        background: red;
+    }
+
+    .probe {
+        margin: -10px 0 0;
+    }
+</style>
+<div class="container">
+    <div class="spacer"></div>
+    <div class="float"></div>
+    <p class="probe">line spans the float</p>
+</div>


### PR DESCRIPTION
BFC kept floats in separate left/right state and let each caller re-derive the occupied space for itself. Line layout, float placement, BFC avoidance, and clearance were all asking related questions through point samples or side-specific bookkeeping instead of consulting one representation of float intrusions.

Before, each query rebuilt float state at one block offset:

    block 0  LLLLLL........  sample: left=6
             LLLLLL........
    block 8  ..............  sample: left=0

Now, floats split the block axis into bands:

    block 0  [left=6 right=0]
    block 6  [left=0 right=0]

A line query takes the maximum intrusions across every band it spans. Float placement, line layout, BFC avoidance, and clearance now share that band-backed path instead of the side-list current state, matching-float probes, and one-pixel probe loop.