### PR TITLE
LibWeb: Replace element within its real parent in the outerHTML setter

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2597,7 +2597,7 @@ WebIDL::ExceptionOr<void> Element::set_outer_html(TrustedTypes::TrustedHTMLOrStr
     auto fragment = TRY(as<Element>(*parent).parse_fragment(compliant_string.to_utf8_but_should_be_ported_to_utf16()));
 
     // 6. Replace this with fragment within this's parent.
-    TRY(parent->replace_child(fragment, *this));
+    TRY(this->parent()->replace_child(fragment, *this));
 
     return {};
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	outerHTML replaces element within DocumentFragment parent.

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>outerHTML: child of DocumentFragment</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#the-outerhtml-property">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  const fragment = new DocumentFragment();
+  const div = document.createElement("div");
+  div.textContent = "original";
+  fragment.appendChild(div);
+
+  div.outerHTML = "<span>replaced</span>";
+
+  assert_equals(fragment.childNodes.length, 1, "Fragment should have one child");
+  assert_equals(fragment.firstChild.tagName, "SPAN", "Child should be a SPAN");
+  assert_equals(fragment.firstChild.textContent, "replaced", "Content should be 'replaced'");
+}, "outerHTML replaces element within DocumentFragment parent.");
+</script>


### PR DESCRIPTION
Step 5 reassigns parent to a temporary body element used as the fragment parsing context when the parent is a DocumentFragment. The replacement step then used that temporary element instead of the real parent, so use this's parent directly.