### PR TITLE
LibWeb: Guard offsetTop and offsetLeft against a boxless offsetParent

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -613,7 +613,7 @@ int HTMLElement::offset_top() const
     //    relative to the initial containing block origin,
     //    ignoring any transforms that apply to the element and its ancestors, and terminate this algorithm.
     auto offset_parent = this->offset_parent();
-    if (!offset_parent || !offset_parent->layout_node()) {
+    if (!offset_parent || !offset_parent->paintable_box()) {
         return top_border_edge_of_element.to_int();
     }
 
@@ -655,7 +655,7 @@ int HTMLElement::offset_left() const
     //    relative to the initial containing block origin,
     //    ignoring any transforms that apply to the element and its ancestors, and terminate this algorithm.
     auto offset_parent = this->offset_parent();
-    if (!offset_parent || !offset_parent->layout_node()) {
+    if (!offset_parent || !offset_parent->paintable_box()) {
         return left_border_edge_of_element.to_int();
     }
 

--- a/Tests/LibWeb/Crash/HTML/offset-top-with-boxless-offset-parent.html
+++ b/Tests/LibWeb/Crash/HTML/offset-top-with-boxless-offset-parent.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<svg>
+    <font-face-src>
+        <foreignObject style="transform: translateX(1px)">
+            <span id="target">x</span></foreignObject>
+    </font-face-src>
+</svg>
+<script>
+    const target = document.getElementById("target");
+    target.offsetTop;
+    target.offsetLeft;
+</script>


### PR DESCRIPTION
The offsetParent of an element can have a layout node without a paintable box. This made `offset_top()` and `offset_left()` dereference a null paintable box and crash.