### PR TITLE
LibWebView: Remove obsolete WebContent-managed session history path

### DIFF
--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -502,7 +502,6 @@ void LocalTraversableNavigable::reset_session_history_for_testing(GC::Ref<GC::Fu
             page().client().page_did_update_session_history(session_history_snapshot.top_level_session_history_entries, session_history_snapshot.used_session_history_steps, session_history_snapshot.current_used_step_index);
         }
 
-        page().client().page_did_update_navigation_buttons_state(false, false);
         signal->resolve({});
         on_complete->function()();
     }));
@@ -1558,9 +1557,6 @@ void ApplyHistoryStepState::complete()
         }
 
         VERIFY(m_traversable->m_session_history_entries.size() > 0);
-        auto back_enabled = m_traversable->can_go_back();
-        auto forward_enabled = m_traversable->can_go_forward();
-        m_traversable->page().client().page_did_update_navigation_buttons_state(back_enabled, forward_enabled);
         m_traversable->page().client().page_did_change_url(m_traversable->current_session_history_entry()->url());
     }
 
@@ -2455,7 +2451,6 @@ bool LocalTraversableNavigable::try_to_synchronously_commit_same_document_naviga
     }
 
     VERIFY(session_history_entries().size() > 0);
-    page().client().page_did_update_navigation_buttons_state(can_go_back(), can_go_forward());
     page().client().page_did_change_url(current_session_history_entry()->url());
     return true;
 }

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -179,11 +179,6 @@ void Page::traverse_the_history_by_delta(int delta)
     if (m_client->page_did_request_traverse_the_history_by_delta(delta, HistoryTraversalPrecheck::Needed))
         return;
 
-    traverse_the_history_by_delta_from_ui_process(delta);
-}
-
-void Page::traverse_the_history_by_delta_from_ui_process(int delta)
-{
     top_level_traversable()->traverse_the_history_by_delta(delta);
 }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -113,7 +113,6 @@ public:
     void reload();
 
     void traverse_the_history_by_delta(int delta);
-    void traverse_the_history_by_delta_from_ui_process(int delta);
 
     CSSPixelPoint device_to_css_point(DevicePixelPoint) const;
     DevicePixelPoint css_to_device_point(CSSPixelPoint) const;
@@ -414,7 +413,6 @@ enum class ContextMenuForInputEventsTarget : u8 {
 enum class HistoryTraversalPrecheck : u8 {
     Needed,
     AlreadyDone,
-    SourceDocumentSandboxingAlreadyDone,
 };
 
 enum class NavigationTarget : u8 {
@@ -563,7 +561,6 @@ public:
     virtual NewWebViewResult page_did_request_new_web_view(HTML::ActivateTab, HTML::WebViewHints, HTML::TokenizedFeature::NoOpener) { return {}; }
     virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_top_level_traversable() { }
-    virtual void page_did_update_navigation_buttons_state([[maybe_unused]] bool back_enabled, [[maybe_unused]] bool forward_enabled) { }
     virtual bool should_report_session_history_updates() const { return true; }
     virtual void page_did_update_session_history([[maybe_unused]] Vector<HTML::SessionHistoryEntryDescriptor> const& entries, [[maybe_unused]] Vector<i32> const& used_steps, [[maybe_unused]] size_t current_used_step_index) { }
     virtual String page_did_request_ui_process_session_history_for_testing() { return "{}"_string; }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -164,24 +164,20 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
     handle_resize();
 
     auto ui_session_history_already_points_to_url = false;
-    if (should_manage_session_history_in_ui_process()) {
-        if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url)
-            ui_session_history_already_points_to_url = true;
+    if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url)
+        ui_session_history_already_points_to_url = true;
 
-        if (m_pending_session_history_traversal.has_value() && m_pending_session_history_traversal->will_replace_web_content_process)
-            m_pending_session_history_traversal->stage = PendingSessionHistoryTraversal::Stage::ReplacingWebContentProcess;
-        if (m_pending_session_history_navigation.has_value())
-            m_pending_session_history_navigation->web_content_restore_mode = PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess;
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
-        m_pending_web_content_session_history_seed.waiting_for_ack = false;
-        m_pending_web_content_session_history_seed.should_send_entries = true;
-        m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
-    }
+    if (m_pending_session_history_traversal.has_value() && m_pending_session_history_traversal->will_replace_web_content_process)
+        m_pending_session_history_traversal->stage = PendingSessionHistoryTraversal::Stage::ReplacingWebContentProcess;
+    if (m_pending_session_history_navigation.has_value())
+        m_pending_session_history_navigation->web_content_restore_mode = PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess;
+    m_current_web_content_session_history_matches_mirror = false;
+    m_session_history.forget_web_content_state();
+    m_pending_web_content_session_history_seed.waiting_for_ack = false;
+    m_pending_web_content_session_history_seed.should_send_entries = true;
+    m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
 
     auto seed_replacement_process_before_load_if_possible = [&] {
-        if (!should_manage_session_history_in_ui_process())
-            return false;
         if (!m_pending_web_content_session_history_seed.should_send_entries)
             return false;
         if (m_session_history_entry_url_loading_from_ui_process.has_value())
@@ -205,7 +201,7 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
     } else {
         m_should_suppress_history_for_current_load = false;
         m_should_suppress_history_for_next_load = false;
-        if (should_manage_session_history_in_ui_process() && !m_session_history_entry_url_loading_from_ui_process.has_value()) {
+        if (!m_session_history_entry_url_loading_from_ui_process.has_value()) {
             if (m_session_history.current_entry()) {
                 m_pending_session_history_navigation = PendingSessionHistoryNavigation {
                     url,
@@ -285,7 +281,7 @@ void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHist
     auto should_defer_ui_process_history_update = false;
     if (!m_session_history_entry_url_loading_from_ui_process.has_value())
         abandon_pending_web_content_session_history_seed();
-    if (should_manage_session_history_in_ui_process() && !m_session_history_entry_url_loading_from_ui_process.has_value()) {
+    if (!m_session_history_entry_url_loading_from_ui_process.has_value()) {
         m_pending_session_history_traversal.clear();
         auto const* current_entry = m_session_history.current_entry();
         auto is_javascript_navigation = url.scheme() == "javascript"sv;
@@ -328,10 +324,8 @@ void ViewImplementation::load_html(StringView html)
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
     abandon_pending_web_content_session_history_seed();
-    if (should_manage_session_history_in_ui_process()) {
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
-    }
+    m_current_web_content_session_history_matches_mirror = false;
+    m_session_history.forget_web_content_state();
     client().async_load_html(page_id(), html);
 }
 
@@ -341,10 +335,8 @@ void ViewImplementation::load_crash_page_html(StringView html, URL::URL const& c
     m_should_suppress_history_for_current_load = true;
     m_should_suppress_history_for_next_load = true;
     abandon_pending_web_content_session_history_seed();
-    if (should_manage_session_history_in_ui_process()) {
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
-    }
+    m_current_web_content_session_history_matches_mirror = false;
+    m_session_history.forget_web_content_state();
     set_url(crashed_url);
     client().async_load_html_with_url(page_id(), html, crashed_url);
 }
@@ -362,7 +354,7 @@ void ViewImplementation::load_navigation_error_page(StringView text)
 
 void ViewImplementation::reload()
 {
-    if (should_manage_session_history_in_ui_process() && m_is_showing_crash_page) {
+    if (m_is_showing_crash_page) {
         m_is_showing_crash_page = false;
         m_should_suppress_history_for_current_load = false;
         m_should_suppress_history_for_next_load = false;
@@ -375,12 +367,10 @@ void ViewImplementation::reload()
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
     abandon_pending_web_content_session_history_seed();
-    if (should_manage_session_history_in_ui_process()) {
-        m_session_history.mark_current_entry_reload_pending();
-        m_current_web_content_session_history_matches_mirror = false;
-        update_navigation_action_state();
-        dump_session_history("reload-mark-current-entry-reload-pending"sv);
-    }
+    m_session_history.mark_current_entry_reload_pending();
+    m_current_web_content_session_history_matches_mirror = false;
+    update_navigation_action_state();
+    dump_session_history("reload-mark-current-entry-reload-pending"sv);
     client().async_reload(page_id());
 }
 
@@ -389,17 +379,6 @@ ViewImplementation::HistoryTraversalOutcome ViewImplementation::traverse_the_his
     CheckForCancelation check_for_cancelation,
     Function<void(HistoryTraversalOutcome)> on_cancelation_check_complete)
 {
-    if (!should_manage_session_history_in_ui_process()) {
-        m_should_suppress_history_for_current_load = false;
-        m_should_suppress_history_for_next_load = false;
-        m_webdriver_pending_navigation_completes_with_session_history_update = false;
-        client().async_traverse_the_history_by_delta(page_id(), delta);
-        return {
-            .status = HistoryTraversalStatus::Started,
-            .will_change_top_level_entry = true,
-        };
-    }
-
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta
     // Let allSteps be the result of getting all used history steps for traversable.
     // Let currentStepIndex be the index of traversable's current session history step within allSteps.
@@ -1299,15 +1278,6 @@ void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, We
         on_audio_play_state_changed(m_audio_play_state);
 }
 
-void ViewImplementation::did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled)
-{
-    VERIFY(!should_manage_session_history_in_ui_process());
-
-    m_navigate_back_action->set_enabled(back_enabled);
-    m_navigate_forward_action->set_enabled(forward_enabled);
-    dump_session_history("did-update-navigation-buttons-state-using-webcontent"sv);
-}
-
 static Optional<size_t> current_top_level_history_entry_index_for_step(Vector<Web::HTML::SessionHistoryEntryDescriptor> const&, Optional<i32> current_step);
 
 TraversableSessionHistory::UpdateResult ViewImplementation::update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot)
@@ -1370,9 +1340,6 @@ bool ViewImplementation::adopt_web_content_session_history_after_rejected_seed(V
 
 void ViewImplementation::did_update_session_history(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)
 {
-    if (!should_manage_session_history_in_ui_process())
-        return;
-
     if (history_debug_enabled()) {
         dbgln("[History] UI received WebContent session history snapshot page={} pid={} current_used_step={} entries={} used_steps={}",
             page_id(),
@@ -1406,9 +1373,6 @@ void ViewImplementation::did_update_session_history(Badge<WebContentClient>, Vec
 
 void ViewImplementation::did_update_session_history_for_testing(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)
 {
-    if (!should_manage_session_history_in_ui_process())
-        return;
-
     // NB: dumpUIProcessSessionHistory() first sends WebContent's current snapshot to the UI process, then returns
     //     the UI mirror. If a stale seed ack is still pending, normal async snapshots are intentionally ignored, so
     //     use the same convergence path as a rejected seed ack to make this testing hook deterministic.
@@ -1552,9 +1516,6 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
 
 void ViewImplementation::did_start_navigation(URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
-    if (!should_manage_session_history_in_ui_process())
-        return;
-
     if (m_should_suppress_history_for_next_load || m_should_suppress_history_for_current_load)
         return;
 
@@ -1679,7 +1640,7 @@ void ViewImplementation::did_finish_navigation(URL::URL const& url)
     if (m_pending_session_history_navigation.has_value() && m_pending_session_history_navigation->url == url)
         m_pending_session_history_navigation.clear();
 
-    if (should_manage_session_history_in_ui_process() && m_pending_web_content_session_history_seed.should_send_entries) {
+    if (m_pending_web_content_session_history_seed.should_send_entries) {
         if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url) {
             m_session_history.clear_current_entry_reload_pending();
             auto allow_current_entry_reconstruction = m_pending_web_content_session_history_seed.should_reseed_after_current_history_load
@@ -2074,9 +2035,6 @@ NonnullRefPtr<Core::Promise<Empty>> ViewImplementation::reset_session_history_fo
 
 void ViewImplementation::did_set_top_level_session_history(Badge<WebContentClient>, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)
 {
-    if (!should_manage_session_history_in_ui_process())
-        return;
-
     if (history_debug_enabled()) {
         dbgln("[History] UI received WebContent session history seed ack page={} pid={} accepted={} current_used_step={} entries={} used_steps={}",
             page_id(),
@@ -2166,9 +2124,6 @@ void ViewImplementation::did_set_top_level_session_history(Badge<WebContentClien
 
 void ViewImplementation::did_traverse_the_history_to_step(Badge<WebContentClient>, i32 step, bool step_was_available, Web::HTML::HistoryStepResult result)
 {
-    if (!should_manage_session_history_in_ui_process())
-        return;
-
     if (!m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()) {
         if (!m_pending_session_history_traversal.has_value() || m_pending_session_history_traversal->target_step != step) {
             dump_session_history("ignored-stale-webcontent-history-step-result"sv);
@@ -2261,9 +2216,6 @@ void ViewImplementation::did_traverse_the_history_to_step(Badge<WebContentClient
 void ViewImplementation::did_check_if_traverse_history_step_is_canceled(
     Badge<WebContentClient>, u64 request_id, i32 step, bool canceled)
 {
-    if (!should_manage_session_history_in_ui_process())
-        return;
-
     if (!m_pending_session_history_traversal.has_value()
         || m_pending_session_history_traversal->stage != PendingSessionHistoryTraversal::Stage::CheckingCancelation
         || m_pending_session_history_traversal->cancelation_check_request_id != request_id
@@ -2418,10 +2370,8 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
     // Don't keep a stale backup bitmap around.
     m_backup_shared_image_buffer = nullptr;
 
-    if (should_manage_session_history_in_ui_process()) {
-        m_session_history_entry_url_loading_from_ui_process.clear();
-        prepare_to_seed_web_content_session_history_from_ui_process();
-    }
+    m_session_history_entry_url_loading_from_ui_process.clear();
+    prepare_to_seed_web_content_session_history_from_ui_process();
 
     handle_resize();
 
@@ -2433,7 +2383,7 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
         builder.appendff("<p>The web page <a href=\"{}\">{}</a> has crashed.<br><br>You can reload the page to try again.</p>", escaped_url, escaped_url);
         builder.append(ERROR_HTML_FOOTER);
         load_crash_page_html(builder.string_view(), m_url);
-    } else if (should_manage_session_history_in_ui_process()) {
+    } else {
         m_should_suppress_history_for_current_load = false;
         m_should_suppress_history_for_next_load = false;
         restore_current_session_history_entry_from_ui_process();

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -252,7 +252,6 @@ public:
     void did_change_audio_play_state(Badge<WebContentClient>, Web::HTML::AudioPlayState);
     Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
 
-    void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled);
     void did_update_session_history(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index);
     void did_update_session_history_for_testing(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index);
     void did_set_top_level_session_history(Badge<WebContentClient>, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index);
@@ -426,7 +425,6 @@ protected:
     NonnullRefPtr<Core::Promise<Empty>> reset_session_history_for_testing();
 
     virtual void update_zoom();
-    virtual bool should_manage_session_history_in_ui_process() const { return true; }
     String current_host() const;
     void apply_zoom_for_current_host();
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1421,11 +1421,6 @@ Messages::WebContentClient::DidRequestTraverseTheHistoryByDeltaResponse WebConte
             auto check_for_cancelation = ViewImplementation::CheckForCancelation::IfWebContentCannotTraverseTarget;
             if (history_traversal_precheck == Web::HistoryTraversalPrecheck::Needed)
                 check_for_cancelation = ViewImplementation::CheckForCancelation::Yes;
-            // NB: SourceDocumentSandboxingAlreadyDone only covers the source-document sandboxing
-            //     check. If the UI process has to apply the traversal itself, WebContent still needs
-            //     to run the cancelable part of the traverse history step prechecks.
-            else if (history_traversal_precheck == Web::HistoryTraversalPrecheck::SourceDocumentSandboxingAlreadyDone)
-                check_for_cancelation = ViewImplementation::CheckForCancelation::Yes;
             (void)view->traverse_the_history_by_delta(delta, check_for_cancelation);
         });
         return true;
@@ -1703,15 +1698,6 @@ void WebContentClient::did_change_audio_play_state(u64 page_id, Web::HTML::Audio
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
         view->did_change_audio_play_state({}, play_state);
-}
-
-void WebContentClient::did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled)
-{
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->should_manage_session_history_in_ui_process())
-            return;
-        view->did_update_navigation_buttons_state({}, back_enabled, forward_enabled);
-    }
 }
 
 void WebContentClient::did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -236,7 +236,6 @@ private:
     virtual void did_request_primary_paste(u64 page_id) override;
     virtual void did_update_primary_selection(u64 page_id, String) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
-    virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual void did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index) override;
     virtual Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse did_request_ui_process_session_history_for_testing(u64 page_id) override;
     virtual Messages::WebContentClient::DidRequestSiteIsolationProcessTreeForTestingResponse did_request_site_isolation_process_tree_for_testing(u64 page_id) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -312,12 +312,6 @@ void ConnectionFromClient::cancel_download(u64 page_id, u64 download_id)
         page->cancel_download(download_id);
 }
 
-void ConnectionFromClient::traverse_the_history_by_delta(u64 page_id, i32 delta)
-{
-    if (auto page = this->page(page_id); page.has_value())
-        page->page().traverse_the_history_by_delta_from_ui_process(delta);
-}
-
 void ConnectionFromClient::traverse_the_history_to_step(u64 page_id, i32 step)
 {
     auto page = this->page(page_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -94,7 +94,6 @@ private:
     virtual void run_iframe_load_event_steps(u64 page_id, String frame_id) override;
     virtual void set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId>) override;
     virtual void set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId>) override;
-    virtual void traverse_the_history_by_delta(u64 page_id, i32 delta) override;
     virtual void traverse_the_history_to_step(u64 page_id, i32 step) override;
     virtual void check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) override;
     virtual void set_top_level_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, size_t current_top_level_entry_index, bool allow_reconstructing_current_entry) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1001,11 +1001,6 @@ void PageClient::send_current_needs_beforeunload_check()
     client().async_did_change_needs_beforeunload_check(m_id, page().needs_beforeunload_check());
 }
 
-void PageClient::page_did_update_navigation_buttons_state(bool back_enabled, bool forward_enabled)
-{
-    client().async_did_update_navigation_buttons_state(m_id, back_enabled, forward_enabled);
-}
-
 bool PageClient::should_report_session_history_updates() const
 {
     return !Web::HTML::Window::in_test_mode() || s_should_report_session_history_updates_in_test_mode;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -233,7 +233,6 @@ private:
     virtual void page_did_request_activate_tab() override;
     virtual void page_did_close_top_level_traversable() override;
     virtual void page_did_change_needs_beforeunload_check(bool needs_beforeunload_check) override;
-    virtual void page_did_update_navigation_buttons_state(bool back_enabled, bool forward_enabled) override;
     virtual bool should_report_session_history_updates() const override;
     virtual void page_did_update_session_history(Vector<Web::HTML::SessionHistoryEntryDescriptor> const&, Vector<i32> const& used_steps, size_t current_used_step_index) override;
     virtual String page_did_request_ui_process_session_history_for_testing() override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -166,7 +166,6 @@ endpoint WebContentClient
     did_request_primary_paste(u64 page_id) =|
     did_update_primary_selection(u64 page_id, String text) =|
 
-    did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
     did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index) =|
     did_request_ui_process_session_history_for_testing(u64 page_id) => (String session_history)
     did_request_site_isolation_process_tree_for_testing(u64 page_id) => (String process_tree)

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -63,7 +63,6 @@ endpoint WebContentServer
     run_iframe_load_event_steps(u64 page_id, String frame_id) =|
     set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id) =|
     set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId> context_id) =|
-    traverse_the_history_by_delta(u64 page_id, i32 delta) =|
     traverse_the_history_to_step(u64 page_id, i32 step) =|
     check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) =|
     set_top_level_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries,


### PR DESCRIPTION
UI-process session history management is now unconditional, so remove the dead should_manage_session_history_in_ui_process().

Also remove the unused navigation-button update IPC and the old UI-to- WebContent history traversal-by-delta message that only supported the removed mode.