### PR TITLE
LibWeb: Use correct `LocalTraversableNavigable` include

### DIFF
--- a/Libraries/LibWeb/StorageAPI/StorageShelf.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageShelf.cpp
@@ -6,8 +6,8 @@
 
 #include <LibGC/Heap.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/LocalTraversableNavigable.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
-#include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/StorageAPI/StorageShed.h>


### PR DESCRIPTION
This fixes a build error caused by an undetected conflict between #10325 and #10308. 