### PR TITLE
LibWeb: Populate ancestor filter when recomputing pseudo-element styles

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -986,6 +986,15 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
 
     auto& style_computer = document().style_computer();
 
+    auto did_push_ancestors = false;
+    auto push_ancestors_if_needed = [&] {
+        if (did_push_ancestors)
+            return;
+        for (auto const* ancestor = this; ancestor; ancestor = ancestor->parent_or_shadow_host_element())
+            style_computer.push_ancestor(*ancestor);
+        did_push_ancestors = true;
+    };
+
     // Any document change that can cause this element's style to change, could also affect its pseudo-elements.
     auto recompute_pseudo_element_style = [&](CSS::PseudoElement pseudo_element, bool has_implicit_style = false) {
         auto pseudo_element_style = computed_properties(pseudo_element);
@@ -996,7 +1005,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
         if (!should_recompute)
             return;
 
-        style_computer.push_ancestor(*this);
+        push_ancestors_if_needed();
 
         auto new_pseudo_element_style = style_computer.compute_pseudo_element_style_if_needed({ *this, pseudo_element }, did_change_custom_properties);
 
@@ -1009,7 +1018,6 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
         }
 
         set_computed_properties(pseudo_element, move(new_pseudo_element_style));
-        style_computer.pop_ancestor(*this);
     };
 
     recompute_pseudo_element_style(CSS::PseudoElement::Before);
@@ -1020,6 +1028,11 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
         recompute_pseudo_element_style(CSS::PseudoElement::Backdrop);
     if (had_list_marker || m_computed_properties->display().is_list_item())
         recompute_pseudo_element_style(CSS::PseudoElement::Marker, true);
+
+    if (did_push_ancestors) {
+        for (auto const* ancestor = this; ancestor; ancestor = ancestor->parent_or_shadow_host_element())
+            style_computer.pop_ancestor(*ancestor);
+    }
 
     return invalidation;
 }

--- a/Tests/LibWeb/Text/expected/css/transition-visibility-pseudo-element-with-ancestor-selector.txt
+++ b/Tests/LibWeb/Text/expected/css/transition-visibility-pseudo-element-with-ancestor-selector.txt
@@ -1,0 +1,2 @@
+::before box present while hidden? true
+::before box still present after reveal transition? true

--- a/Tests/LibWeb/Text/input/css/transition-visibility-pseudo-element-with-ancestor-selector.html
+++ b/Tests/LibWeb/Text/input/css/transition-visibility-pseudo-element-with-ancestor-selector.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    ul.sub {
+        visibility: hidden;
+        opacity: 0;
+        transition: opacity 100ms ease-in, visibility 100ms ease-in;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .open ul.sub {
+        visibility: visible;
+        opacity: 1;
+    }
+
+    li#item > a.link::before {
+        content: "";
+        display: inline-block;
+        width: 45px;
+        height: 45px;
+        background: green;
+    }
+</style>
+<div id="wrap">
+    <ul class="sub">
+        <li id="item"><a class="link">item text</a></li>
+    </ul>
+</div>
+<script>
+    asyncTest(async done => {
+        const item = document.getElementById("item");
+        const heightBeforeReveal = item.getBoundingClientRect().height;
+        println(`::before box present while hidden? ${heightBeforeReveal >= 45}`);
+
+        document.getElementById("wrap").classList.add("open");
+        setTimeout(() => {
+            const heightAfterReveal = item.getBoundingClientRect().height;
+            println(`::before box still present after reveal transition? ${heightAfterReveal >= 45}`);
+            done();
+        }, 300);
+    });
+</script>


### PR DESCRIPTION
When pseudo-element styles were recomputed outside of a full style update pass, for example while propagating an animated inherited property to descendants, selector matching behaved as if the element had no ancestors. Any pseudo-element rule that matched through an ancestor was wrongly rejected, so the pseudo-element lost its computed style.

Fixes missing images in the menus on https://thinkbroadband.com:

Before:

<img width="1240" height="734" alt="image" src="https://github.com/user-attachments/assets/0045a565-15cf-4872-88ca-da6c8a3dde22" />


After:
<img width="1240" height="734" alt="image" src="https://github.com/user-attachments/assets/e817d7bc-1ee8-4f00-92ed-7d5dff2d3b9b" />
