### PR TITLE
UI/Qt: Show hover-expanded vertical tabs over the Vulkan surface

### DIFF
--- a/UI/Qt/Shaders/WebContentViewLinux.frag
+++ b/UI/Qt/Shaders/WebContentViewLinux.frag
@@ -13,5 +13,7 @@ layout(location = 0) out vec4 output_color;
 
 void main()
 {
-    output_color = texture(web_content_texture, texture_coordinates);
+    // Force opaque output so the page never blends; only the strips we explicitly clear to transparent (behind
+    // hover-expanded vertical tabs) reveal the widgets composited below this window.
+    output_color = vec4(texture(web_content_texture, texture_coordinates).rgb, 1.0);
 }

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1571,6 +1571,7 @@ TabWidget::TabWidget(QWidget* parent)
         m_toolbar_container->setCurrentIndex(index);
         update_vertical_tabs_overlay_geometry();
         update_vertical_tabs_resize_handle();
+        update_vertical_tabs_content_overlay();
     });
 
     connect(m_tab_bar, &QTabBar::tabCloseRequested, this, &TabWidget::tab_close_requested);
@@ -1676,6 +1677,10 @@ void TabWidget::set_tab_bar_visible(bool visible)
         return;
 
     m_tab_bar_visible = visible;
+
+    if (!m_tab_bar_visible)
+        set_vertical_tabs_hover_expanded(false);
+
     update_tab_chrome_visibility();
     update_tab_layout();
 }
@@ -2329,7 +2334,26 @@ void TabWidget::set_vertical_tabs_hover_expanded(bool expanded)
         m_vertical_tabs_hover_collapse_timer->start();
     else
         m_vertical_tabs_hover_collapse_timer->stop();
+
     update_vertical_tabs_hover_layout();
+    update_vertical_tabs_content_overlay();
+}
+
+void TabWidget::update_vertical_tabs_content_overlay()
+{
+    auto index = current_index();
+    if (index < 0)
+        return;
+
+    int overlap = 0;
+    if (m_tab_bar_visible && m_vertical_tabs_hover_expanded && m_tab_bar->tab_layout() != TabLayout::Horizontal)
+        overlap = max(0, current_vertical_tabs_width() - vertical_tabs_layout_width());
+
+    auto left = vertical_tabs_are_on_right() ? 0 : overlap;
+    auto right = vertical_tabs_are_on_right() ? overlap : 0;
+
+    if (auto* current = tab(index))
+        current->view().set_vertical_tab_overlay_insets(left, right);
 }
 
 void TabWidget::defer_update_vertical_tabs_hover_expanded()

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -211,6 +211,7 @@ private:
     void recreate_icons();
     void update_chrome_style();
     void update_vertical_tabs_overlay_geometry();
+    void update_vertical_tabs_content_overlay();
     void set_vertical_tabs_hover_expanded(bool);
     void defer_update_vertical_tabs_hover_expanded();
     void update_vertical_tabs_hover_expanded();

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -824,6 +824,23 @@ void WebContentView::set_device_pixel_ratio(double device_pixel_ratio)
     handle_resize();
 }
 
+void WebContentView::set_vertical_tab_overlay_insets([[maybe_unused]] int left, [[maybe_unused]] int right)
+{
+#ifdef LADYBIRD_QT_USE_VULKAN_WINDOW
+    if (m_vertical_tab_overlay_left == left && m_vertical_tab_overlay_right == right)
+        return;
+
+    // While vertical tabs are hover-expanded they overlay this view. On the Vulkan presentation path, the native window
+    // would occlude them, so we clear these left/right strips (in logical pixels) to transparent, letting the tab
+    // column that paints in the widget backing store show through.
+    m_vertical_tab_overlay_left = left;
+    m_vertical_tab_overlay_right = right;
+
+    update_vulkan_window_input_region();
+    schedule_repaint();
+#endif
+}
+
 void WebContentView::set_zoom_level(double zoom_level)
 {
     m_zoom_level = zoom_level;

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -92,6 +92,7 @@ public:
     void set_zoom_level(double);
     void set_maximum_frames_per_second(double);
     void set_display_metadata(Optional<u64> display_id, double maximum_frames_per_second);
+    void set_vertical_tab_overlay_insets(int left, int right);
 
     enum class PaletteMode {
         Default,
@@ -186,6 +187,8 @@ private:
 
     void create_vulkan_window();
     void destroy_vulkan_window();
+    void update_vulkan_window_input_region();
+    void update_vulkan_alpha_blending_support();
     bool current_paintable_can_use_vulkan_window() const;
     void schedule_vulkan_window_update();
     void update_vulkan_window_geometry();
@@ -196,6 +199,10 @@ private:
 
     VulkanWindow* m_vulkan_window { nullptr };
     QWidget* m_vulkan_window_container { nullptr };
+    Optional<bool> m_vulkan_window_supports_alpha_blending;
+
+    int m_vertical_tab_overlay_left { 0 };
+    int m_vertical_tab_overlay_right { 0 };
 #endif
 };
 

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -16,6 +16,7 @@
 
 #include <QByteArrayList>
 #include <QCursor>
+#include <QRegion>
 #include <QTimer>
 #include <QVersionNumber>
 #include <QVulkanInstance>
@@ -791,6 +792,8 @@ struct WebContentView::VulkanWindowRenderer final : public QVulkanWindowRenderer
 
     virtual void startNextFrame() override
     {
+        m_view.update_vulkan_alpha_blending_support();
+
         auto command_buffer = m_window.currentCommandBuffer();
         auto target_size = m_window.swapChainImageSize();
         auto render_pass = m_window.defaultRenderPass();
@@ -845,6 +848,41 @@ struct WebContentView::VulkanWindowRenderer final : public QVulkanWindowRenderer
 
         bool rendered = m_renderer.render(command_buffer, *paintable->shared_image_buffer, paintable->bitmap_size, target_size);
 
+        if (rendered && m_view.m_vulkan_window_supports_alpha_blending.value_or(false)) {
+            // Clear the strips overlaid by hover-expanded vertical tabs to transparent so the tab column painted in the
+            // widget backing store shows through this native window.
+            auto device_pixel_ratio = m_view.device_pixel_ratio();
+
+            auto punch_transparent_strip = [&](int logical_width, bool from_right) {
+                if (logical_width <= 0)
+                    return;
+
+                auto strip_width = min(qRound(logical_width * device_pixel_ratio), target_size.width());
+                if (strip_width <= 0)
+                    return;
+
+                VkClearAttachment clear_attachment {
+                    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                    .colorAttachment = 0,
+                    .clearValue = { .color = { .float32 = { 0.0f, 0.0f, 0.0f, 0.0f } } },
+                };
+
+                VkClearRect clear_rect {
+                    .rect = {
+                        .offset = { from_right ? target_size.width() - strip_width : 0, 0 },
+                        .extent = { static_cast<u32>(strip_width), static_cast<u32>(target_size.height()) },
+                    },
+                    .baseArrayLayer = 0,
+                    .layerCount = 1,
+                };
+
+                vkCmdClearAttachments(command_buffer, 1, &clear_attachment, 1, &clear_rect);
+            };
+
+            punch_transparent_strip(m_view.m_vertical_tab_overlay_left, false);
+            punch_transparent_strip(m_view.m_vertical_tab_overlay_right, true);
+        }
+
         vkCmdEndRenderPass(command_buffer);
         m_window.frameReady();
         if (!rendered)
@@ -893,6 +931,13 @@ void WebContentView::create_vulkan_window()
     m_vulkan_window = new VulkanWindow(*this);
     m_vulkan_window->setVulkanInstance(instance);
     m_vulkan_window->setDeviceExtensions(vulkan_dmabuf_device_extensions());
+
+    // Request an alpha channel so QVulkanWindow builds a blending swapchain (pre/post-multiplied composite alpha). This
+    // lets us punch transparent holes for hover-expanded vertical tabs, which this native window would otherwise occlude.
+    auto surface_format = m_vulkan_window->requestedFormat();
+    surface_format.setAlphaBufferSize(8);
+    m_vulkan_window->setFormat(surface_format);
+
     m_vulkan_window->setPreferredColorFormats({
         VK_FORMAT_B8G8R8A8_UNORM,
         VK_FORMAT_R8G8B8A8_UNORM,
@@ -972,6 +1017,58 @@ void WebContentView::update_vulkan_window_geometry()
 {
     if (m_vulkan_window_container)
         m_vulkan_window_container->setGeometry(rect());
+    update_vulkan_window_input_region();
+}
+
+void WebContentView::update_vulkan_window_input_region()
+{
+    if (!m_vulkan_window || !m_vulkan_window_container)
+        return;
+
+    // The strips overlaid by hover-expanded vertical tabs are painted transparent, but this native window still captures
+    // the pointer there. Exclude those strips from the input region so clicks fall through to the tab column beneath.
+    auto size = m_vulkan_window_container->size();
+    QRegion input_region { QRect { QPoint { 0, 0 }, size } };
+
+    if (m_vulkan_window_supports_alpha_blending.value_or(false)) {
+        if (m_vertical_tab_overlay_left > 0)
+            input_region -= QRect { 0, 0, m_vertical_tab_overlay_left, size.height() };
+        if (m_vertical_tab_overlay_right > 0)
+            input_region -= QRect { size.width() - m_vertical_tab_overlay_right, 0, m_vertical_tab_overlay_right, size.height() };
+    }
+
+    m_vulkan_window->setMask(input_region);
+}
+
+void WebContentView::update_vulkan_alpha_blending_support()
+{
+    if (m_vulkan_window_supports_alpha_blending.has_value())
+        return;
+
+    if (!m_vulkan_window)
+        return;
+
+    auto* physical_device = m_vulkan_window->physicalDevice();
+    if (physical_device == VK_NULL_HANDLE)
+        return;
+
+    auto* surface = QVulkanInstance::surfaceForWindow(m_vulkan_window);
+    if (surface == VK_NULL_HANDLE)
+        return;
+
+    VkSurfaceCapabilitiesKHR capabilities {};
+    if (vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physical_device, surface, &capabilities) != VK_SUCCESS)
+        return;
+
+    // Our transparent tab-column holes only reach the screen if the surface is blended per-pixel. QVulkanWindow (given
+    // our alpha format) picks a pre/post-multiplied mode when offered (the Wayland case), otherwise INHERIT, which
+    // blends against the window's ARGB visual on X11 while a compositor runs. If only OPAQUE is offered there is no
+    // blending at all, so the feature stays disabled.
+    static constexpr auto blending_modes = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR | VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR | VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
+    m_vulkan_window_supports_alpha_blending = (capabilities.supportedCompositeAlpha & blending_modes) != 0;
+
+    // The input mask was computed while support was still unknown; refresh it now that any stored insets can apply.
+    update_vulkan_window_input_region();
 }
 
 void WebContentView::set_vulkan_window_cursor(QCursor const& cursor)


### PR DESCRIPTION
On Linux, web content is presented through a native `QVulkanWindow` embedded with `QWidget::createWindowContainer`. Qt always composites such an embedded window on top of the widget hierarchy, so the hover-expanded vertical tab column rendered underneath the page, and no `raise` or native-window trick could lift it above the surface (this is especially strict on Wayland).

Rather than fight the stacking order, punch the tabs through the Vulkan surface:

* Request an alpha `QSurfaceFormat` so `QVulkanWindow` builds a blending (pre-multiplied composite-alpha) swapchain, and force the page fragment output to opaque so only regions we clear become transparent.
* While the column is hover-expanded, clear the strip it overlays to transparent with `vkCmdClearAttachments`; the tab column, which paints in the ordinary widget backing store below the surface, shows through.
* Exclude that same strip from the Vulkan window's input region via `setMask` so pointer events fall through to the column. This keeps clicks and hover tracking working across the whole expanded width.

Fixes #10252