### PR TITLE
LibGfx+LibWeb+Meta: Update Skia to milestone 148

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -64,7 +64,7 @@ if (HAS_DIRECTX)
 endif()
 
 if (HAS_VULKAN)
-    list(APPEND SOURCES VulkanContext.cpp VulkanImage.cpp)
+    list(APPEND SOURCES SkiaVulkanMemoryAllocator.cpp VulkanContext.cpp VulkanImage.cpp)
 endif()
 
 if (HAS_FONTCONFIG)
@@ -105,6 +105,7 @@ endif()
 
 if (HAS_VULKAN)
     target_link_libraries(LibCore PUBLIC Vulkan::Vulkan Vulkan::Headers)
+    target_link_libraries(LibGfx PRIVATE GPUOpen::VulkanMemoryAllocator)
 
     if (USE_VULKAN_DMABUF_IMAGES)
         pkg_check_modules(LibDRM REQUIRED libdrm)

--- a/Libraries/LibGfx/PainterSkia.cpp
+++ b/Libraries/LibGfx/PainterSkia.cpp
@@ -8,7 +8,6 @@
  */
 
 #define AK_DONT_REPLACE_STD
-#define SK_SUPPORT_UNSPANNED_APIS
 
 #include <AK/GenericShorthands.h>
 #include <AK/String.h>
@@ -24,7 +23,7 @@
 #include <core/SkPath.h>
 #include <effects/SkBlurMaskFilter.h>
 #include <effects/SkDashPathEffect.h>
-#include <effects/SkGradientShader.h>
+#include <effects/SkGradient.h>
 
 namespace Gfx {
 
@@ -40,29 +39,30 @@ static void apply_paint_style(SkPaint& paint, PaintStyle const& style)
     } else if (auto const& linear_gradient = as_if<Gfx::CanvasLinearGradientPaintStyle>(style)) {
         auto const& color_stops = linear_gradient->color_stops();
 
-        Vector<SkColor> colors;
+        Vector<SkColor4f> colors;
         colors.ensure_capacity(color_stops.size());
         Vector<SkScalar> positions;
         positions.ensure_capacity(color_stops.size());
         for (auto const& color_stop : color_stops) {
-            colors.unchecked_append(to_skia_color(color_stop.color));
+            colors.unchecked_append(to_skia_color4f(color_stop.color));
             positions.unchecked_append(color_stop.position);
         }
 
         Array points { to_skia_point(linear_gradient->start_point()), to_skia_point(linear_gradient->end_point()) };
 
         SkMatrix matrix;
-        auto shader = SkGradientShader::MakeLinear(points.data(), colors.data(), positions.data(), color_stops.size(), SkTileMode::kClamp, 0, &matrix);
+        SkGradient gradient { SkGradient::Colors { { colors.data(), colors.size() }, { positions.data(), positions.size() }, SkTileMode::kClamp }, {} };
+        auto shader = SkShaders::LinearGradient(points.data(), gradient, &matrix);
         paint.setShader(shader);
     } else if (auto const* radial_gradient = as_if<CanvasRadialGradientPaintStyle>(style)) {
         auto const& color_stops = radial_gradient->color_stops();
 
-        Vector<SkColor> colors;
+        Vector<SkColor4f> colors;
         colors.ensure_capacity(color_stops.size());
         Vector<SkScalar> positions;
         positions.ensure_capacity(color_stops.size());
         for (auto const& color_stop : color_stops) {
-            colors.unchecked_append(to_skia_color(color_stop.color));
+            colors.unchecked_append(to_skia_color4f(color_stop.color));
             positions.unchecked_append(color_stop.position);
         }
 
@@ -75,17 +75,18 @@ static void apply_paint_style(SkPaint& paint, PaintStyle const& style)
         auto end_sk_point = to_skia_point(end_center);
 
         SkMatrix matrix;
-        auto shader = SkGradientShader::MakeTwoPointConical(start_sk_point, start_radius, end_sk_point, end_radius, colors.data(), positions.data(), color_stops.size(), SkTileMode::kClamp, 0, &matrix);
+        SkGradient gradient { SkGradient::Colors { { colors.data(), colors.size() }, { positions.data(), positions.size() }, SkTileMode::kClamp }, {} };
+        auto shader = SkShaders::TwoPointConicalGradient(start_sk_point, start_radius, end_sk_point, end_radius, gradient, &matrix);
         paint.setShader(shader);
     } else if (auto const* conic_gradient = as_if<CanvasConicGradientPaintStyle>(style)) {
         auto const& color_stops = conic_gradient->color_stops();
 
-        Vector<SkColor> colors;
+        Vector<SkColor4f> colors;
         colors.ensure_capacity(color_stops.size());
         Vector<SkScalar> positions;
         positions.ensure_capacity(color_stops.size());
         for (auto const& color_stop : color_stops) {
-            colors.unchecked_append(to_skia_color(color_stop.color));
+            colors.unchecked_append(to_skia_color4f(color_stop.color));
             positions.unchecked_append(color_stop.position);
         }
 
@@ -93,7 +94,8 @@ static void apply_paint_style(SkPaint& paint, PaintStyle const& style)
         auto start_angle_degrees = AK::to_degrees(conic_gradient->start_angle());
 
         SkMatrix matrix;
-        auto shader = SkGradientShader::MakeSweep(center.x(), center.y(), colors.data(), positions.data(), color_stops.size(), SkTileMode::kClamp, start_angle_degrees, start_angle_degrees + 360, 0, &matrix);
+        SkGradient gradient { SkGradient::Colors { { colors.data(), colors.size() }, { positions.data(), positions.size() }, SkTileMode::kClamp }, {} };
+        auto shader = SkShaders::SweepGradient(to_skia_point(center), start_angle_degrees, start_angle_degrees + 360, gradient, &matrix);
         paint.setShader(shader);
     } else if (auto const* canvas_pattern = as_if<CanvasPatternPaintStyle>(style)) {
         auto frame = canvas_pattern->image();
@@ -220,7 +222,7 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::Color color, float thi
     paint.setStrokeCap(to_skia_cap(cap_style));
     paint.setStrokeJoin(to_skia_join(join_style));
     paint.setStrokeMiter(miter_limit);
-    paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), dash_offset));
+    paint.setPathEffect(SkDashPathEffect::Make({ dash_array.data(), dash_array.size() }, dash_offset));
     paint.setBlender(to_skia_blender(compositing_and_blending_operator));
     auto sk_path = to_skia_path(path);
     auto& canvas = m_painting_surface->canvas();
@@ -243,7 +245,7 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& pain
     paint.setStrokeCap(to_skia_cap(cap_style));
     paint.setStrokeJoin(to_skia_join(join_style));
     paint.setStrokeMiter(miter_limit);
-    paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), dash_offset));
+    paint.setPathEffect(SkDashPathEffect::Make({ dash_array.data(), dash_array.size() }, dash_offset));
     paint.setBlender(to_skia_blender(compositing_and_blending_operator));
     auto& canvas = m_painting_surface->canvas();
     canvas.drawPath(sk_path, paint);

--- a/Libraries/LibGfx/PathSkia.cpp
+++ b/Libraries/LibGfx/PathSkia.cpp
@@ -5,7 +5,6 @@
  */
 
 #define AK_DONT_REPLACE_STD
-#define SK_SUPPORT_UNSPANNED_APIS
 
 #include <AK/Span.h>
 #include <AK/TypeCasts.h>
@@ -18,6 +17,7 @@
 #include <LibGfx/TextLayout.h>
 #include <core/SkFont.h>
 #include <core/SkPath.h>
+#include <core/SkPathBuilder.h>
 #include <core/SkPathMeasure.h>
 #include <core/SkTextBlob.h>
 #include <pathops/SkPathOps.h>
@@ -26,79 +26,166 @@
 
 namespace Gfx {
 
+static FloatPoint to_gfx_point(SkPoint const& point)
+{
+    return { point.x(), point.y() };
+}
+
 NonnullOwnPtr<Gfx::PathImplSkia> PathImplSkia::create()
 {
     return adopt_own(*new PathImplSkia);
 }
 
 PathImplSkia::PathImplSkia()
-    : m_path(adopt_own(*new SkPath))
+    : m_path_builder(adopt_own(*new SkPathBuilder))
 {
 }
 
 PathImplSkia::PathImplSkia(PathImplSkia const& other)
     : m_last_move_to(other.m_last_move_to)
-    , m_path(adopt_own(*new SkPath(other.sk_path())))
+    , m_has_current_point(other.m_has_current_point)
+    , m_path_builder(adopt_own(*new SkPathBuilder(*other.m_path_builder)))
 {
 }
 
 PathImplSkia::~PathImplSkia() = default;
 
+SkPath const& PathImplSkia::sk_path() const
+{
+    if (!m_cached_path)
+        m_cached_path = adopt_own(*new SkPath(m_path_builder->snapshot()));
+    return *m_cached_path;
+}
+
+SkPathBuilder& PathImplSkia::sk_path_builder()
+{
+    m_cached_path = nullptr;
+    return *m_path_builder;
+}
+
+void PathImplSkia::update_state_from_builder()
+{
+    update_state_from_path(sk_path());
+}
+
+void PathImplSkia::set_path(SkPath const& path)
+{
+    sk_path_builder() = SkPathBuilder(path);
+    update_state_from_path(path);
+}
+
+void PathImplSkia::update_state_from_path(SkPath const& path)
+{
+    m_has_current_point = false;
+    m_last_move_to = {};
+
+    auto const points = path.points();
+    size_t point_index = 0;
+    for (auto verb : path.verbs()) {
+        switch (verb) {
+        case SkPathVerb::kMove:
+            m_has_current_point = true;
+            m_last_move_to = to_gfx_point(points[point_index++]);
+            break;
+        case SkPathVerb::kLine:
+            m_has_current_point = true;
+            point_index += 1;
+            break;
+        case SkPathVerb::kQuad:
+        case SkPathVerb::kConic:
+            m_has_current_point = true;
+            point_index += 2;
+            break;
+        case SkPathVerb::kCubic:
+            m_has_current_point = true;
+            point_index += 3;
+            break;
+        case SkPathVerb::kClose:
+            m_has_current_point = true;
+            break;
+        }
+    }
+}
+
 void PathImplSkia::clear()
 {
-    m_path->reset();
+    sk_path_builder().reset();
+    m_last_move_to = {};
+    m_has_current_point = false;
 }
 
 void PathImplSkia::move_to(Gfx::FloatPoint const& point)
 {
     m_last_move_to = point;
-    m_path->moveTo(point.x(), point.y());
+    m_has_current_point = true;
+    sk_path_builder().moveTo(point.x(), point.y());
 }
 
 void PathImplSkia::line_to(Gfx::FloatPoint const& point)
 {
-    m_path->lineTo(point.x(), point.y());
+    if (!m_has_current_point) {
+        move_to(point);
+        return;
+    }
+    sk_path_builder().lineTo(point.x(), point.y());
 }
 
 void PathImplSkia::close()
 {
-    m_path->close();
-    m_path->moveTo(m_last_move_to.x(), m_last_move_to.y());
+    if (!m_has_current_point)
+        return;
+    sk_path_builder().close();
+    sk_path_builder().moveTo(m_last_move_to.x(), m_last_move_to.y());
 }
 
 void PathImplSkia::elliptical_arc_to(FloatPoint point, FloatSize radii, float x_axis_rotation, bool large_arc, bool sweep)
 {
+    if (!m_has_current_point) {
+        move_to(point);
+        return;
+    }
+
     SkPoint skPoint = SkPoint::Make(point.x(), point.y());
-    SkScalar skWidth = SkFloatToScalar(radii.width());
-    SkScalar skHeight = SkFloatToScalar(radii.height());
+    SkPoint skRadii = SkPoint::Make(radii.width(), radii.height());
     SkScalar skXRotation = SkFloatToScalar(sk_float_radians_to_degrees(x_axis_rotation));
-    SkPath::ArcSize skLargeArc = large_arc ? SkPath::kLarge_ArcSize : SkPath::kSmall_ArcSize;
+    SkPathBuilder::ArcSize skLargeArc = large_arc ? SkPathBuilder::kLarge_ArcSize : SkPathBuilder::kSmall_ArcSize;
     SkPathDirection skSweep = sweep ? SkPathDirection::kCW : SkPathDirection::kCCW;
-    m_path->arcTo(skWidth, skHeight, skXRotation, skLargeArc, skSweep, skPoint.x(), skPoint.y());
+    sk_path_builder().arcTo(skRadii, skXRotation, skLargeArc, skSweep, skPoint);
 }
 
 void PathImplSkia::arc_to(FloatPoint point, float radius, bool large_arc, bool sweep)
 {
+    if (!m_has_current_point) {
+        move_to(point);
+        return;
+    }
+
     SkPoint skPoint = SkPoint::Make(point.x(), point.y());
-    SkScalar skRadius = SkFloatToScalar(radius);
-    SkPath::ArcSize skLargeArc = large_arc ? SkPath::kLarge_ArcSize : SkPath::kSmall_ArcSize;
+    SkPoint skRadii = SkPoint::Make(radius, radius);
+    SkPathBuilder::ArcSize skLargeArc = large_arc ? SkPathBuilder::kLarge_ArcSize : SkPathBuilder::kSmall_ArcSize;
     SkPathDirection skSweep = sweep ? SkPathDirection::kCW : SkPathDirection::kCCW;
-    m_path->arcTo(skRadius, skRadius, 0, skLargeArc, skSweep, skPoint.x(), skPoint.y());
+    sk_path_builder().arcTo(skRadii, 0, skLargeArc, skSweep, skPoint);
 }
 
 void PathImplSkia::quadratic_bezier_curve_to(FloatPoint through, FloatPoint point)
 {
-    m_path->quadTo(through.x(), through.y(), point.x(), point.y());
+    if (!m_has_current_point)
+        move_to(through);
+    sk_path_builder().quadTo(through.x(), through.y(), point.x(), point.y());
 }
 
 void PathImplSkia::cubic_bezier_curve_to(FloatPoint c1, FloatPoint c2, FloatPoint p2)
 {
-    m_path->cubicTo(c1.x(), c1.y(), c2.x(), c2.y(), p2.x(), p2.y());
+    if (!m_has_current_point)
+        move_to(c1);
+    sk_path_builder().cubicTo(c1.x(), c1.y(), c2.x(), c2.y(), p2.x(), p2.y());
 }
 
 void PathImplSkia::text(Utf8View const& string, Font const& font)
 {
-    SkTextUtils::GetPath(string.as_string().characters_without_null_termination(), string.as_string().length(), SkTextEncoding::kUTF8, last_point().x(), last_point().y(), font.skia_font(1), m_path.ptr());
+    SkPath text_path;
+    SkTextUtils::GetPath(string.as_string().characters_without_null_termination(), string.as_string().length(), SkTextEncoding::kUTF8, last_point().x(), last_point().y(), font.skia_font(1), &text_path);
+    set_path(text_path);
 }
 
 void PathImplSkia::text(Utf16View const& string, Font const& font)
@@ -108,26 +195,31 @@ void PathImplSkia::text(Utf16View const& string, Font const& font)
         return;
     }
 
-    SkTextUtils::GetPath(string.utf16_span().data(), string.length_in_code_units() * sizeof(char16_t), SkTextEncoding::kUTF16, last_point().x(), last_point().y(), font.skia_font(1), m_path.ptr());
+    SkPath text_path;
+    SkTextUtils::GetPath(string.utf16_span().data(), string.length_in_code_units() * sizeof(char16_t), SkTextEncoding::kUTF16, last_point().x(), last_point().y(), font.skia_font(1), &text_path);
+    set_path(text_path);
 }
 
 void PathImplSkia::glyph_run(GlyphRun const& glyph_run)
 {
     auto sk_font = glyph_run.font().skia_font(1);
-    m_path->setFillType(SkPathFillType::kWinding);
+    auto& path_builder = sk_path_builder();
+    path_builder.setFillType(SkPathFillType::kWinding);
     auto font_ascent = glyph_run.font().pixel_metrics().ascent;
     for (auto const& glyph : glyph_run.glyphs()) {
-        SkPath glyph_path;
-        if (!sk_font.getPath(static_cast<SkGlyphID>(glyph.glyph_id), &glyph_path))
+        auto glyph_path = sk_font.getPath(static_cast<SkGlyphID>(glyph.glyph_id));
+        if (!glyph_path.has_value())
             continue;
-        glyph_path.offset(glyph.position.x(), glyph.position.y() + font_ascent);
-        m_path->addPath(glyph_path);
+        path_builder.addPath(*glyph_path, glyph.position.x(), glyph.position.y() + font_ascent);
     }
+    update_state_from_path(sk_path());
 }
 
 void PathImplSkia::offset(Gfx::FloatPoint const& offset)
 {
-    m_path->offset(offset.x(), offset.y());
+    sk_path_builder().offset(offset.x(), offset.y());
+    if (m_has_current_point)
+        m_last_move_to.translate_by(offset);
 }
 
 template<typename TextToGlyphs>
@@ -149,11 +241,10 @@ static NonnullOwnPtr<PathImpl> place_text_along_impl(SkPath const& path, Font co
 
     for (size_t i = 0; i < length_in_code_points; ++i) {
         SkGlyphID glyph = run_buffer.glyphs[i];
-        SkPath glyph_path;
-        sk_font.getPath(glyph, &glyph_path);
+        auto glyph_path = sk_font.getPath(glyph);
 
-        SkScalar advance;
-        sk_font.getWidths(&glyph, 1, &advance);
+        SkScalar advance = 0;
+        sk_font.getWidths({ &glyph, 1 }, { &advance, 1 });
 
         SkPoint position;
         SkVector tangent;
@@ -169,11 +260,12 @@ static NonnullOwnPtr<PathImpl> place_text_along_impl(SkPath const& path, Font co
         matrix.setTranslate(position.x(), position.y());
         matrix.preRotate(SkRadiansToDegrees(std::atan2(tangent.y(), tangent.x())));
 
-        glyph_path.transform(matrix);
-        output_path->sk_path().addPath(glyph_path);
+        if (glyph_path.has_value())
+            output_path->sk_path_builder().addPath(*glyph_path, matrix);
 
         accumulated_distance += advance;
     }
+    output_path->update_state_from_builder();
 
     return output_path;
 }
@@ -182,8 +274,8 @@ NonnullOwnPtr<PathImpl> PathImplSkia::place_text_along(Utf8View const& text, Fon
 {
     auto length_in_code_points = text.length();
 
-    return place_text_along_impl(*m_path, font, length_in_code_points, offset, [&](auto const& sk_font, auto const& run_buffer) {
-        sk_font.textToGlyphs(text.as_string().characters_without_null_termination(), text.as_string().length(), SkTextEncoding::kUTF8, run_buffer.glyphs, length_in_code_points);
+    return place_text_along_impl(sk_path(), font, length_in_code_points, offset, [&](auto const& sk_font, auto const& run_buffer) {
+        sk_font.textToGlyphs(text.as_string().characters_without_null_termination(), text.as_string().length(), SkTextEncoding::kUTF8, { run_buffer.glyphs, length_in_code_points });
     });
 }
 
@@ -194,71 +286,78 @@ NonnullOwnPtr<PathImpl> PathImplSkia::place_text_along(Utf16View const& text, Fo
 
     auto length_in_code_points = text.length_in_code_points();
 
-    return place_text_along_impl(*m_path, font, length_in_code_points, offset, [&](auto const& sk_font, auto const& run_buffer) {
-        sk_font.textToGlyphs(text.utf16_span().data(), text.length_in_code_units() * sizeof(char16_t), SkTextEncoding::kUTF16, run_buffer.glyphs, length_in_code_points);
+    return place_text_along_impl(sk_path(), font, length_in_code_points, offset, [&](auto const& sk_font, auto const& run_buffer) {
+        sk_font.textToGlyphs(text.utf16_span().data(), text.length_in_code_units() * sizeof(char16_t), SkTextEncoding::kUTF16, { run_buffer.glyphs, length_in_code_points });
     });
 }
 
 void PathImplSkia::append_path(Gfx::Path const& other)
 {
-    m_path->addPath(static_cast<PathImplSkia const&>(other.impl()).sk_path());
+    auto const& other_impl = static_cast<PathImplSkia const&>(other.impl());
+    sk_path_builder().addPath(other_impl.sk_path());
+    if (other_impl.m_has_current_point) {
+        m_has_current_point = true;
+        m_last_move_to = other_impl.m_last_move_to;
+    }
 }
 
 void PathImplSkia::intersect(Gfx::Path const& other)
 {
-    Op(*m_path, static_cast<PathImplSkia const&>(other.impl()).sk_path(), SkPathOp::kIntersect_SkPathOp, m_path.ptr());
+    auto result = Op(sk_path(), static_cast<PathImplSkia const&>(other.impl()).sk_path(), SkPathOp::kIntersect_SkPathOp);
+    if (result.has_value())
+        set_path(*result);
 }
 
 Vector<u8> PathImplSkia::serialize_to_bytes() const
 {
-    auto path_data_size = m_path->writeToMemory(nullptr);
+    auto const& path = sk_path();
+    auto path_data_size = path.writeToMemory(nullptr);
     Vector<u8> path_data;
     path_data.resize(path_data_size);
-    m_path->writeToMemory(path_data.data());
+    path.writeToMemory(path_data.data());
     return path_data;
 }
 
 void PathImplSkia::deserialize_from_bytes(ReadonlyBytes bytes)
 {
-    m_path = adopt_own(*new SkPath(SkPath::ReadFromMemory(bytes.data(), bytes.size()).value_or(SkPath {})));
-    m_last_move_to = {};
+    set_path(SkPath::ReadFromMemory(bytes.data(), bytes.size()).value_or(SkPath {}));
 }
 
 bool PathImplSkia::is_empty() const
 {
-    return m_path->isEmpty();
+    return !m_has_current_point;
 }
 
 Gfx::FloatPoint PathImplSkia::last_point() const
 {
-    SkPoint last {};
-    if (!m_path->getLastPt(&last))
+    auto last = m_path_builder->getLastPt();
+    if (!last.has_value())
         return {};
-    return { last.fX, last.fY };
+    return { last->fX, last->fY };
 }
 
 Gfx::FloatRect PathImplSkia::bounding_box() const
 {
-    auto bounds = m_path->getBounds();
+    auto bounds = m_path_builder->computeBounds();
     return { bounds.fLeft, bounds.fTop, bounds.fRight - bounds.fLeft, bounds.fBottom - bounds.fTop };
 }
 
 float PathImplSkia::length() const
 {
-    SkPathMeasure path_measure(*m_path, false);
+    SkPathMeasure path_measure(sk_path(), false);
     return path_measure.getLength();
 }
 
 bool PathImplSkia::contains(FloatPoint point, Gfx::WindingRule winding_rule) const
 {
-    SkPath temp_path = *m_path;
+    SkPath temp_path = sk_path();
     temp_path.setFillType(to_skia_path_fill_type(winding_rule));
     return temp_path.contains(point.x(), point.y());
 }
 
 void PathImplSkia::set_fill_type(Gfx::WindingRule winding_rule)
 {
-    m_path->setFillType(to_skia_path_fill_type(winding_rule));
+    sk_path_builder().setFillType(to_skia_path_fill_type(winding_rule));
 }
 
 NonnullOwnPtr<PathImpl> PathImplSkia::clone() const
@@ -273,13 +372,15 @@ NonnullOwnPtr<PathImpl> PathImplSkia::copy_transformed(Gfx::AffineTransform cons
         transform.a(), transform.c(), transform.e(),
         transform.b(), transform.d(), transform.f(),
         0, 0, 1);
-    new_path->sk_path().transform(matrix);
+    new_path->sk_path_builder().transform(matrix);
+    if (new_path->m_has_current_point)
+        new_path->m_last_move_to = transform.map(new_path->m_last_move_to);
     return new_path;
 }
 
 String PathImplSkia::to_svg_string() const
 {
-    auto svg_string = SkParsePath::ToSVGString(*m_path);
+    auto svg_string = SkParsePath::ToSVGString(sk_path());
     return MUST(String::from_utf8(StringView { svg_string.c_str(), svg_string.size() }));
 }
 

--- a/Libraries/LibGfx/PathSkia.h
+++ b/Libraries/LibGfx/PathSkia.h
@@ -6,9 +6,11 @@
 
 #pragma once
 
+#include <AK/OwnPtr.h>
 #include <LibGfx/Path.h>
 
 class SkPath;
+class SkPathBuilder;
 
 namespace Gfx {
 
@@ -51,15 +53,21 @@ public:
 
     virtual String to_svg_string() const override;
 
-    SkPath const& sk_path() const { return *m_path; }
-    SkPath& sk_path() { return *m_path; }
+    SkPath const& sk_path() const;
+    SkPathBuilder& sk_path_builder();
+    void update_state_from_builder();
 
 private:
     PathImplSkia();
     PathImplSkia(PathImplSkia const& other);
 
+    void set_path(SkPath const&);
+    void update_state_from_path(SkPath const&);
+
     Gfx::FloatPoint m_last_move_to;
-    NonnullOwnPtr<SkPath> m_path;
+    bool m_has_current_point { false };
+    NonnullOwnPtr<SkPathBuilder> m_path_builder;
+    mutable OwnPtr<SkPath> m_cached_path;
 };
 
 }

--- a/Libraries/LibGfx/SkiaBackendContext.cpp
+++ b/Libraries/LibGfx/SkiaBackendContext.cpp
@@ -20,9 +20,11 @@
 #ifdef USE_DIRECTX
 #    include <AK/Windows.h>
 #    include <gpu/ganesh/d3d/GrD3DBackendContext.h>
+#    include <gpu/ganesh/d3d/GrD3DDirectContext.h>
 #endif
 
 #ifdef USE_VULKAN
+#    include <LibGfx/SkiaVulkanMemoryAllocator.h>
 #    include <gpu/ganesh/vk/GrVkDirectContext.h>
 #    include <gpu/vk/VulkanBackendContext.h>
 #    include <gpu/vk/VulkanExtensions.h>
@@ -208,7 +210,7 @@ RefPtr<SkiaBackendContext> SkiaBackendContext::create_direct3d_context(NonnullRe
     backend_context.fQueue.retain(direct3d_context->queue());
     backend_context.fProtectedContext = GrProtected::kNo;
 
-    auto context = GrDirectContext::MakeDirect3D(backend_context);
+    auto context = GrDirectContexts::MakeD3D(backend_context);
     if (!context) {
         dbgln("Skia Direct3D context creation failed");
         return {};
@@ -290,6 +292,9 @@ RefPtr<SkiaBackendContext> SkiaBackendContext::create_vulkan_context(VulkanConte
 
     auto extensions = make<skgpu::VulkanExtensions>();
     backend_context.fVkExtensions = extensions.ptr();
+
+    backend_context.fMemoryAllocator = create_skia_vulkan_memory_allocator(vulkan_context);
+    VERIFY(backend_context.fMemoryAllocator);
 
     sk_sp<GrDirectContext> ctx = GrDirectContexts::MakeVulkan(backend_context);
     VERIFY(ctx);

--- a/Libraries/LibGfx/SkiaVulkanMemoryAllocator.cpp
+++ b/Libraries/LibGfx/SkiaVulkanMemoryAllocator.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+// Adapted from Skia's VulkanAMDMemoryAllocator (Copyright 2018 Google LLC,
+// BSD-3-Clause), which is no longer reachable through Skia's public API.
+
+#define AK_DONT_REPLACE_STD
+
+#include <AK/Assertions.h>
+#include <LibGfx/SkiaVulkanMemoryAllocator.h>
+#include <gpu/vk/VulkanTypes.h>
+
+#define VMA_IMPLEMENTATION
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
+#include <vk_mem_alloc.h>
+
+namespace Gfx {
+
+class SkiaVulkanMemoryAllocator final : public skgpu::VulkanMemoryAllocator {
+public:
+    explicit SkiaVulkanMemoryAllocator(VmaAllocator allocator)
+        : m_allocator(allocator)
+    {
+    }
+
+    ~SkiaVulkanMemoryAllocator() override
+    {
+        vmaDestroyAllocator(m_allocator);
+    }
+
+    VkResult allocateImageMemory(VkImage image, uint32_t allocation_property_flags, skgpu::VulkanBackendMemory* backend_memory) override
+    {
+        VmaAllocationCreateInfo info = {};
+        info.usage = VMA_MEMORY_USAGE_UNKNOWN;
+        info.requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+
+        if (allocation_property_flags & kDedicatedAllocation_AllocationPropertyFlag)
+            info.flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
+        if (allocation_property_flags & kLazyAllocation_AllocationPropertyFlag)
+            info.requiredFlags |= VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
+        if (allocation_property_flags & kProtected_AllocationPropertyFlag)
+            info.requiredFlags |= VK_MEMORY_PROPERTY_PROTECTED_BIT;
+
+        VmaAllocation allocation;
+        VkResult result = vmaAllocateMemoryForImage(m_allocator, image, &info, &allocation, nullptr);
+        if (result == VK_SUCCESS)
+            *backend_memory = reinterpret_cast<skgpu::VulkanBackendMemory>(allocation);
+        return result;
+    }
+
+    VkResult allocateBufferMemory(VkBuffer buffer, BufferUsage usage, uint32_t allocation_property_flags, skgpu::VulkanBackendMemory* backend_memory) override
+    {
+        VmaAllocationCreateInfo info = {};
+        info.usage = VMA_MEMORY_USAGE_UNKNOWN;
+
+        switch (usage) {
+        case BufferUsage::kGpuOnly:
+            info.requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+            break;
+        case BufferUsage::kCpuWritesGpuReads:
+            info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+            break;
+        case BufferUsage::kTransfersFromCpuToGpu:
+            info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            break;
+        case BufferUsage::kTransfersFromGpuToCpu:
+            info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+            info.preferredFlags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+            break;
+        }
+
+        if (allocation_property_flags & kDedicatedAllocation_AllocationPropertyFlag)
+            info.flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
+        if ((allocation_property_flags & kLazyAllocation_AllocationPropertyFlag) && usage == BufferUsage::kGpuOnly)
+            info.preferredFlags |= VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
+        if (allocation_property_flags & kPersistentlyMapped_AllocationPropertyFlag) {
+            VERIFY(usage != BufferUsage::kGpuOnly);
+            info.flags |= VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        }
+        if (allocation_property_flags & kProtected_AllocationPropertyFlag)
+            info.requiredFlags |= VK_MEMORY_PROPERTY_PROTECTED_BIT;
+
+        VmaAllocation allocation;
+        VkResult result = vmaAllocateMemoryForBuffer(m_allocator, buffer, &info, &allocation, nullptr);
+        if (result == VK_SUCCESS)
+            *backend_memory = reinterpret_cast<skgpu::VulkanBackendMemory>(allocation);
+        return result;
+    }
+
+    void freeMemory(skgpu::VulkanBackendMemory const& memory_handle) override
+    {
+        auto allocation = reinterpret_cast<VmaAllocation>(memory_handle);
+        vmaFreeMemory(m_allocator, allocation);
+    }
+
+    void getAllocInfo(skgpu::VulkanBackendMemory const& memory_handle, skgpu::VulkanAlloc* alloc) const override
+    {
+        auto allocation = reinterpret_cast<VmaAllocation>(memory_handle);
+        VmaAllocationInfo vma_info;
+        vmaGetAllocationInfo(m_allocator, allocation, &vma_info);
+
+        VkMemoryPropertyFlags memory_flags;
+        vmaGetMemoryTypeProperties(m_allocator, vma_info.memoryType, &memory_flags);
+
+        uint32_t flags = 0;
+        if (memory_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+            flags |= skgpu::VulkanAlloc::kMappable_Flag;
+        if (!(memory_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
+            flags |= skgpu::VulkanAlloc::kNoncoherent_Flag;
+        if (memory_flags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
+            flags |= skgpu::VulkanAlloc::kLazilyAllocated_Flag;
+
+        alloc->fMemory = vma_info.deviceMemory;
+        alloc->fOffset = vma_info.offset;
+        alloc->fSize = vma_info.size;
+        alloc->fFlags = flags;
+        alloc->fBackendMemory = memory_handle;
+    }
+
+    VkResult mapMemory(skgpu::VulkanBackendMemory const& memory_handle, void** data) override
+    {
+        auto allocation = reinterpret_cast<VmaAllocation>(memory_handle);
+        return vmaMapMemory(m_allocator, allocation, data);
+    }
+
+    void unmapMemory(skgpu::VulkanBackendMemory const& memory_handle) override
+    {
+        auto allocation = reinterpret_cast<VmaAllocation>(memory_handle);
+        vmaUnmapMemory(m_allocator, allocation);
+    }
+
+    VkResult flushMemory(skgpu::VulkanBackendMemory const& memory_handle, VkDeviceSize offset, VkDeviceSize size) override
+    {
+        auto allocation = reinterpret_cast<VmaAllocation>(memory_handle);
+        return vmaFlushAllocation(m_allocator, allocation, offset, size);
+    }
+
+    VkResult invalidateMemory(skgpu::VulkanBackendMemory const& memory_handle, VkDeviceSize offset, VkDeviceSize size) override
+    {
+        auto allocation = reinterpret_cast<VmaAllocation>(memory_handle);
+        return vmaInvalidateAllocation(m_allocator, allocation, offset, size);
+    }
+
+    std::pair<uint64_t, uint64_t> totalAllocatedAndUsedMemory() const override
+    {
+        VmaTotalStatistics stats;
+        vmaCalculateStatistics(m_allocator, &stats);
+        return { stats.total.statistics.blockBytes, stats.total.statistics.allocationBytes };
+    }
+
+private:
+    VmaAllocator m_allocator { VK_NULL_HANDLE };
+};
+
+sk_sp<skgpu::VulkanMemoryAllocator> create_skia_vulkan_memory_allocator(VulkanContext const& vulkan_context)
+{
+    VmaVulkanFunctions functions = {};
+    functions.vkGetInstanceProcAddr = vkGetInstanceProcAddr;
+    functions.vkGetDeviceProcAddr = vkGetDeviceProcAddr;
+
+    VmaAllocatorCreateInfo info = {};
+    // Skia only ever accesses the memory allocator from the thread that owns the GrDirectContext,
+    // so internal locking can be skipped.
+    info.flags = VMA_ALLOCATOR_CREATE_EXTERNALLY_SYNCHRONIZED_BIT | VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
+    info.physicalDevice = vulkan_context.physical_device;
+    info.device = vulkan_context.logical_device;
+    info.instance = vulkan_context.instance;
+    info.vulkanApiVersion = vulkan_context.api_version;
+    // Matches the block size Skia's own allocator used: a compromise between not wasting
+    // unused allocated space and not making too many small allocations.
+    info.preferredLargeHeapBlockSize = 4 * 1024 * 1024;
+    info.pVulkanFunctions = &functions;
+
+    VmaAllocator allocator;
+    if (vmaCreateAllocator(&info, &allocator) != VK_SUCCESS)
+        return nullptr;
+
+    return sk_sp<SkiaVulkanMemoryAllocator>(new SkiaVulkanMemoryAllocator(allocator));
+}
+
+}

--- a/Libraries/LibGfx/SkiaVulkanMemoryAllocator.h
+++ b/Libraries/LibGfx/SkiaVulkanMemoryAllocator.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#ifdef USE_VULKAN
+
+#    include <LibGfx/VulkanContext.h>
+#    include <core/SkRefCnt.h>
+#    include <gpu/vk/VulkanMemoryAllocator.h>
+
+namespace Gfx {
+
+sk_sp<skgpu::VulkanMemoryAllocator> create_skia_vulkan_memory_allocator(VulkanContext const&);
+
+}
+
+#endif

--- a/Libraries/LibGfx/VulkanContext.h
+++ b/Libraries/LibGfx/VulkanContext.h
@@ -8,6 +8,7 @@
 
 #ifdef USE_VULKAN
 
+#    include <AK/Error.h>
 #    include <vulkan/vulkan.h>
 
 namespace Gfx {

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -227,7 +227,7 @@ void DisplayListPlayer::execute_impl(
                 },
                 [&](ClipPathData const& clip_path) {
                     play_command(Save {});
-                    add_clip_path(clip_path.path);
+                    add_clip_path(clip_path.path, clip_path.fill_rule);
                 });
         };
 

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -69,7 +69,7 @@ private:
     virtual void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
 
-    virtual void add_clip_path(Gfx::Path const&) = 0;
+    virtual void add_clip_path(Gfx::Path const&, Gfx::WindingRule) = 0;
 
     DisplayList const* m_active_display_list { nullptr };
     AccumulatedVisualContextTree const* m_active_visual_context_tree { nullptr };

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#define SK_SUPPORT_UNSPANNED_APIS
-
 #include <AK/TemporaryChange.h>
 #include <core/SkBitmap.h>
 #include <core/SkBlurTypes.h>
@@ -22,7 +20,7 @@
 #include <core/SkTextBlob.h>
 #include <core/SkYUVAPixmaps.h>
 #include <effects/SkDashPathEffect.h>
-#include <effects/SkGradientShader.h>
+#include <effects/SkGradient.h>
 #include <effects/SkImageFilters.h>
 #include <effects/SkLumaColorFilter.h>
 #include <gpu/ganesh/GrDirectContext.h>
@@ -383,41 +381,41 @@ void DisplayListPlayerSkia::play_command(Translate const& command)
     canvas.translate(command.delta.x(), command.delta.y());
 }
 
-static SkGradientShader::Interpolation to_skia_interpolation(Gfx::GradientInterpolationMethod interpolation_method)
+static SkGradient::Interpolation to_skia_interpolation(Gfx::GradientInterpolationMethod interpolation_method)
 {
-    SkGradientShader::Interpolation interpolation;
+    SkGradient::Interpolation interpolation;
 
     if (interpolation_method.type == Gfx::GradientInterpolationMethod::Type::Rectangular) {
         switch (interpolation_method.rectangular_color_space) {
         case Gfx::RectangularColorSpace::Srgb:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGB;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kSRGB;
             break;
         case Gfx::RectangularColorSpace::SrgbLinear:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGBLinear;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kSRGBLinear;
             break;
         case Gfx::RectangularColorSpace::Lab:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kLab;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kLab;
             break;
         case Gfx::RectangularColorSpace::Oklab:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kOKLab;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kOKLab;
             break;
         case Gfx::RectangularColorSpace::DisplayP3:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kDisplayP3;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kDisplayP3;
             break;
         case Gfx::RectangularColorSpace::A98Rgb:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kA98RGB;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kA98RGB;
             break;
         case Gfx::RectangularColorSpace::ProphotoRgb:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kProphotoRGB;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kProphotoRGB;
             break;
         case Gfx::RectangularColorSpace::Rec2020:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kRec2020;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kRec2020;
             break;
         case Gfx::RectangularColorSpace::DisplayP3Linear:
         case Gfx::RectangularColorSpace::XyzD50:
         case Gfx::RectangularColorSpace::XyzD65:
             dbgln("FIXME: Unsupported gradient color space");
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kOKLab;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kOKLab;
             break;
         case Gfx::RectangularColorSpace::Xyz:
             VERIFY_NOT_REACHED();
@@ -425,36 +423,36 @@ static SkGradientShader::Interpolation to_skia_interpolation(Gfx::GradientInterp
     } else {
         switch (interpolation_method.polar_color_space) {
         case Gfx::PolarColorSpace::Hsl:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kHSL;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kHSL;
             break;
         case Gfx::PolarColorSpace::Hwb:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kHWB;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kHWB;
             break;
         case Gfx::PolarColorSpace::Lch:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kLCH;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kLCH;
             break;
         case Gfx::PolarColorSpace::Oklch:
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kOKLCH;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kOKLCH;
             break;
         }
 
         switch (interpolation_method.hue_interpolation_method) {
         case Gfx::HueInterpolationMethod::Shorter:
-            interpolation.fHueMethod = SkGradientShader::Interpolation::HueMethod::kShorter;
+            interpolation.fHueMethod = SkGradient::Interpolation::HueMethod::kShorter;
             break;
         case Gfx::HueInterpolationMethod::Longer:
-            interpolation.fHueMethod = SkGradientShader::Interpolation::HueMethod::kLonger;
+            interpolation.fHueMethod = SkGradient::Interpolation::HueMethod::kLonger;
             break;
         case Gfx::HueInterpolationMethod::Increasing:
-            interpolation.fHueMethod = SkGradientShader::Interpolation::HueMethod::kIncreasing;
+            interpolation.fHueMethod = SkGradient::Interpolation::HueMethod::kIncreasing;
             break;
         case Gfx::HueInterpolationMethod::Decreasing:
-            interpolation.fHueMethod = SkGradientShader::Interpolation::HueMethod::kDecreasing;
+            interpolation.fHueMethod = SkGradient::Interpolation::HueMethod::kDecreasing;
             break;
         }
     }
 
-    interpolation.fInPremul = SkGradientShader::Interpolation::InPremul::kYes;
+    interpolation.fInPremul = SkGradient::Interpolation::InPremul::kYes;
     return interpolation;
 }
 
@@ -499,7 +497,8 @@ void DisplayListPlayerSkia::play_command(PaintLinearGradient const& command)
 
     auto color_space = SkColorSpace::MakeSRGB();
     auto interpolation = to_skia_interpolation(command.interpolation_method);
-    auto shader = SkGradientShader::MakeLinear(points.data(), colors.data(), color_space, color_stop_positions.data(), color_stop_positions.size(), SkTileMode::kRepeat, interpolation, &matrix);
+    SkGradient gradient { SkGradient::Colors { { colors.data(), colors.size() }, { color_stop_positions.data(), color_stop_positions.size() }, SkTileMode::kRepeat, color_space }, interpolation };
+    auto shader = SkShaders::LinearGradient(points.data(), gradient, &matrix);
 
     SkPaint paint;
     paint.setDither(true);
@@ -528,15 +527,14 @@ void DisplayListPlayerSkia::play_command(PaintInnerBoxShadow const& command)
     auto outer_rect = to_skia_rrect(command.outer_shadow_rect, command.content_corner_radii);
     auto inner_rect = to_skia_rrect(command.inner_shadow_rect, command.inner_shadow_corner_radii);
 
-    SkPath outer_path;
-    outer_path.addRRect(outer_rect);
-    SkPath inner_path;
-    inner_path.addRRect(inner_rect);
+    auto outer_path = SkPath::RRect(outer_rect);
+    auto inner_path = SkPath::RRect(inner_rect);
 
-    SkPath result_path;
-    if (!Op(outer_path, inner_path, SkPathOp::kDifference_SkPathOp, &result_path)) {
+    auto result = Op(outer_path, inner_path, SkPathOp::kDifference_SkPathOp);
+    if (!result.has_value()) {
         VERIFY_NOT_REACHED();
     }
+    auto result_path = *std::move(result);
 
     auto& canvas = surface().canvas();
     SkPaint path_paint;
@@ -609,13 +607,13 @@ static SkPaint gradient_paint_style_to_skia_paint(
 
     VERIFY(color_stop_colors.size() == color_stop_positions.size());
 
-    Vector<SkColor> colors;
+    Vector<SkColor4f> colors;
     colors.ensure_capacity(color_stop_colors.size());
     Vector<SkScalar> positions;
     positions.ensure_capacity(color_stop_positions.size());
 
     for (auto color : color_stop_colors)
-        colors.unchecked_append(to_skia_color(color));
+        colors.unchecked_append(to_skia_color4f(color));
     for (auto position : color_stop_positions)
         positions.unchecked_append(position);
 
@@ -649,18 +647,20 @@ SkPaint DisplayListPlayerSkia::paint_style_to_skia_paint(DisplayListPaintStyle c
     case DisplayListPaintStyleType::None:
         return {};
     case DisplayListPaintStyleType::LinearGradient:
-        return make_gradient_paint([&](Vector<SkColor> const& colors, Vector<SkScalar> const& positions, SkTileMode tile_mode, SkMatrix const& matrix) {
+        return make_gradient_paint([&](Vector<SkColor4f> const& colors, Vector<SkScalar> const& positions, SkTileMode tile_mode, SkMatrix const& matrix) {
             Array points {
                 to_skia_point(paint_style.linear_gradient_start_point),
                 to_skia_point(paint_style.linear_gradient_end_point),
             };
-            return SkGradientShader::MakeLinear(points.data(), colors.data(), positions.data(), colors.size(), tile_mode, 0, &matrix);
+            SkGradient gradient { SkGradient::Colors { { colors.data(), colors.size() }, { positions.data(), positions.size() }, tile_mode }, {} };
+            return SkShaders::LinearGradient(points.data(), gradient, &matrix);
         });
     case DisplayListPaintStyleType::RadialGradient:
-        return make_gradient_paint([&](Vector<SkColor> const& colors, Vector<SkScalar> const& positions, SkTileMode tile_mode, SkMatrix const& matrix) {
+        return make_gradient_paint([&](Vector<SkColor4f> const& colors, Vector<SkScalar> const& positions, SkTileMode tile_mode, SkMatrix const& matrix) {
             auto start_center = to_skia_point(paint_style.radial_gradient_start_center);
             auto end_center = to_skia_point(paint_style.radial_gradient_end_center);
-            return SkGradientShader::MakeTwoPointConical(start_center, paint_style.radial_gradient_start_radius, end_center, paint_style.radial_gradient_end_radius, colors.data(), positions.data(), colors.size(), tile_mode, 0, &matrix);
+            SkGradient gradient { SkGradient::Colors { { colors.data(), colors.size() }, { positions.data(), positions.size() }, tile_mode }, {} };
+            return SkShaders::TwoPointConicalGradient(start_center, paint_style.radial_gradient_start_radius, end_center, paint_style.radial_gradient_end_radius, gradient, &matrix);
         });
     case DisplayListPaintStyleType::Pattern: {
         auto const& tile_rect = paint_style.pattern_tile_rect;
@@ -732,7 +732,7 @@ void DisplayListPlayerSkia::play_command(StrokePath const& command)
     paint.setStrokeJoin(to_skia_join(command.join_style));
     paint.setStrokeMiter(command.miter_limit);
     auto dash_array = inline_objects<float>(command.dash_array);
-    paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), command.dash_offset));
+    paint.setPathEffect(SkDashPathEffect::Make({ dash_array.data(), dash_array.size() }, command.dash_offset));
     surface().canvas().drawPath(path, paint);
 }
 
@@ -777,7 +777,7 @@ void DisplayListPlayerSkia::play_command(DrawLine const& command)
         auto dot_count = floor(length / (static_cast<float>(command.thickness) * 2));
         auto interval = length / dot_count;
         SkScalar intervals[] = { 0, interval };
-        paint.setPathEffect(SkDashPathEffect::Make(intervals, 2, 0));
+        paint.setPathEffect(SkDashPathEffect::Make(intervals, 0));
         paint.setStrokeCap(SkPaint::Cap::kRound_Cap);
 
         // NOTE: As Skia doesn't render a dot exactly at the end of a line, we need
@@ -792,7 +792,7 @@ void DisplayListPlayerSkia::play_command(DrawLine const& command)
         auto dash_count = floor(length / static_cast<float>(command.thickness) / 4) * 2 + 1;
         auto interval = length / dash_count;
         SkScalar intervals[] = { interval, interval };
-        paint.setPathEffect(SkDashPathEffect::Make(intervals, 2, 0));
+        paint.setPathEffect(SkDashPathEffect::Make(intervals, 0));
 
         auto direction = to - from;
         direction.normalize();
@@ -859,7 +859,8 @@ void DisplayListPlayerSkia::play_command(PaintRadialGradient const& command)
 
     auto color_space = SkColorSpace::MakeSRGB();
     auto interpolation = to_skia_interpolation(command.interpolation_method);
-    auto shader = SkGradientShader::MakeRadial(center, size.height(), colors.data(), color_space, color_stop_positions.data(), color_stop_positions.size(), tile_mode, interpolation, &matrix);
+    SkGradient gradient { SkGradient::Colors { { colors.data(), colors.size() }, { color_stop_positions.data(), color_stop_positions.size() }, tile_mode, color_space }, interpolation };
+    auto shader = SkShaders::RadialGradient(center, size.height(), gradient, &matrix);
 
     SkPaint paint;
     paint.setDither(true);
@@ -883,7 +884,8 @@ void DisplayListPlayerSkia::play_command(PaintConicGradient const& command)
     matrix.setRotate(-90 + command.start_angle, center.x(), center.y());
     auto color_space = SkColorSpace::MakeSRGB();
     auto interpolation = to_skia_interpolation(command.interpolation_method);
-    auto shader = SkGradientShader::MakeSweep(center.x(), center.y(), colors.data(), color_space, color_stop_positions.data(), color_stop_positions.size(), SkTileMode::kRepeat, 0, 360, interpolation, &matrix);
+    SkGradient gradient { SkGradient::Colors { { colors.data(), colors.size() }, { color_stop_positions.data(), color_stop_positions.size() }, SkTileMode::kRepeat, color_space }, interpolation };
+    auto shader = SkShaders::SweepGradient(to_skia_point(center), 0, 360, gradient, &matrix);
 
     SkPaint paint;
     paint.setDither(true);
@@ -991,10 +993,12 @@ void DisplayListPlayerSkia::apply_transform(Gfx::FloatPoint origin, Gfx::FloatMa
     surface().canvas().concat(skia_matrix);
 }
 
-void DisplayListPlayerSkia::add_clip_path(Gfx::Path const& path)
+void DisplayListPlayerSkia::add_clip_path(Gfx::Path const& path, Gfx::WindingRule winding_rule)
 {
     auto& canvas = surface().canvas();
-    canvas.clipPath(to_skia_path(path), true);
+    auto sk_path = to_skia_path(path);
+    sk_path.setFillType(to_skia_path_fill_type(winding_rule));
+    canvas.clipPath(sk_path, true);
 }
 
 bool DisplayListPlayerSkia::would_be_fully_clipped_by_painter(Gfx::IntRect rect) const

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -49,7 +49,7 @@ private:
     void play_command(ApplyEffects const&, Gfx::Filter const*) override;
     void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 const&) override;
 
-    void add_clip_path(Gfx::Path const&) override;
+    void add_clip_path(Gfx::Path const&, Gfx::WindingRule) override;
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 

--- a/Meta/CMake/check_for_dependencies.cmake
+++ b/Meta/CMake/check_for_dependencies.cmake
@@ -53,6 +53,7 @@ if (NOT APPLE AND NOT WIN32)
     if (VulkanHeaders_FOUND AND Vulkan_FOUND)
         set(HAS_VULKAN ON CACHE BOOL "" FORCE)
         add_cxx_compile_definitions(USE_VULKAN=1)
+        find_package(VulkanMemoryAllocator CONFIG REQUIRED)
 
         # Sharable Vulkan images are currently only implemented on Linux and BSDs
         if (((LINUX AND NOT ANDROID) OR BSD) AND GLSLANG_VALIDATOR)

--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -519,8 +519,8 @@
         {
           "type": "git",
           "url": "https://skia.googlesource.com/skia.git",
-          "commit": "cd0c5f445516ea4e90e02b5f634cbc5ca23b5a44",
-          "x-branch": "chrome/m144"
+          "commit": "e7c90ecca9444fe09598f1630ab7cee2c0ee027a",
+          "x-branch": "chrome/m148"
         },
         {
           "type": "file",

--- a/Meta/CMake/flatpak/skia/skia-install.sh
+++ b/Meta/CMake/flatpak/skia/skia-install.sh
@@ -27,7 +27,7 @@ cat > "$FLATPAK_DEST/lib/pkgconfig/skia.pc" <<EOF
     Name: skia
     Description: 2D graphic library for drawing text, geometries and images.
     URL: https://skia.org/
-    Version: 144
+    Version: 148
     Libs: -L\${libdir} -lskia -lskcms
     Cflags: -I\${includedir}
 EOF

--- a/Tests/LibWeb/Screenshot/input/canvas-fillstyle-gradients.html
+++ b/Tests/LibWeb/Screenshot/input/canvas-fillstyle-gradients.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-6">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-12">
 <style>
    * {
        margin: 0;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -188,6 +188,10 @@
       "name": "vulkan-headers",
       "platform": "linux | bsd | android"
     },
+    {
+      "name": "vulkan-memory-allocator",
+      "platform": "linux | bsd | android"
+    },
     "woff2",
     "wuffs",
     "zlib"
@@ -418,7 +422,7 @@
     },
     {
       "name": "skia",
-      "version": "144#0"
+      "version": "148#0"
     },
     {
       "name": "sqlite3",
@@ -435,6 +439,10 @@
     {
       "name": "vulkan-headers",
       "version": "1.4.335.0#0"
+    },
+    {
+      "name": "vulkan-memory-allocator",
+      "version": "3.3.0#0"
     },
     {
       "name": "wayland",


### PR DESCRIPTION
Skia 148 removes the mutating SkPath API, so PathImplSkia now builds geometry with SkPathBuilder and lazily caches an SkPath snapshot that is invalidated on mutation. SkTextUtils::GetPath overwrites its output path, so text() keeps its replace semantics.

The SkGradientShader factories are gone as well; gradient shaders are now created through the SkShaders factories, which take an SkGradient description and only accept SkColor4f colors. SkFont::getPath and pathops Op() now return std::optional, and SkDashPathEffect::Make, textToGlyphs and getWidths take spans, which makes the SK_SUPPORT_UNSPANNED_APIS defines unnecessary.

Skia also no longer creates a Vulkan memory allocator internally and requires VulkanBackendContext::fMemoryAllocator to be provided by the client, otherwise GrDirectContexts::MakeVulkan() returns null, which crashed Ladybird on startup on Linux. Implement the skgpu::VulkanMemoryAllocator interface in LibGfx on top of the VulkanMemoryAllocator library, following the behavior of Skia's now-private VulkanAMDMemoryAllocator, and pass it to Skia when creating the Ganesh Vulkan context. The Flatpak manifest already builds VMA for Skia itself, so only the vcpkg dependency is new.

The new gradient rasterization shifts nine pixels in canvas-fillstyle-gradients.html by one least-significant bit, so its fuzzy tolerance grows from 6 to 12 pixels. The Flatpak manifest moves to the same milestone commit as the vcpkg port.