### PR TITLE
LibWebView: Add CanonicalTraversable owning top-level session history

### DIFF
--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     Attribute.cpp
     Autocomplete.cpp
     BookmarkStore.cpp
+    CanonicalTraversable.cpp
     BrowserProcess.cpp
     ConsoleOutput.cpp
     CookieJar.cpp

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -1,0 +1,743 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/CanonicalTraversable.h>
+#include <LibWebView/SiteIsolation.h>
+
+namespace WebView {
+
+static Optional<size_t> current_top_level_history_entry_index_for_step(Vector<Web::HTML::SessionHistoryEntryDescriptor> const& entries, Optional<i32> current_step)
+{
+    if (!current_step.has_value())
+        return {};
+
+    Optional<size_t> current_entry_index;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (!entries[i].document_state.navigable_target_name.is_empty())
+            continue;
+
+        if (entries[i].step <= *current_step)
+            current_entry_index = i;
+        if (entries[i].step >= *current_step)
+            break;
+    }
+    return current_entry_index;
+}
+
+void CanonicalTraversable::abandon_pending_web_content_session_history_seed()
+{
+    m_session_history_entry_url_loading_from_ui_process.clear();
+    m_pending_web_content_session_history_seed.clear();
+}
+
+void CanonicalTraversable::prepare_to_seed_web_content_session_history_from_ui_process()
+{
+    m_current_web_content_session_history_matches_mirror = false;
+    m_session_history.forget_web_content_state();
+    m_pending_session_history_navigation.clear();
+    m_pending_web_content_session_history_seed.clear();
+    m_pending_web_content_session_history_seed.step_after_loading_top_level_entry = m_session_history.current_step_to_restore_after_loading_top_level_entry();
+    m_pending_web_content_session_history_seed.should_send_entries = true;
+    m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
+}
+
+static bool can_seed_replacement_process_before_load(TraversableSessionHistory const& session_history, Optional<URL::URL> const& session_history_entry_url_loading_from_ui_process, PendingWebContentSessionHistorySeed const& pending_web_content_session_history_seed)
+{
+    if (!pending_web_content_session_history_seed.should_send_entries)
+        return false;
+    if (session_history_entry_url_loading_from_ui_process.has_value())
+        return false;
+    if (session_history.current_step_to_restore_after_loading_top_level_entry().has_value())
+        return false;
+    return true;
+}
+
+ProcessSwapNavigationPreparation CanonicalTraversable::prepare_for_process_swap_navigation(URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+{
+    ProcessSwapNavigationPreparation result;
+
+    auto ui_session_history_already_points_to_url = false;
+    if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url)
+        ui_session_history_already_points_to_url = true;
+
+    if (m_pending_session_history_traversal.has_value() && m_pending_session_history_traversal->will_replace_web_content_process)
+        m_pending_session_history_traversal->stage = PendingSessionHistoryTraversal::Stage::ReplacingWebContentProcess;
+    if (m_pending_session_history_navigation.has_value())
+        m_pending_session_history_navigation->web_content_restore_mode = PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess;
+    m_current_web_content_session_history_matches_mirror = false;
+    m_session_history.forget_web_content_state();
+    m_pending_web_content_session_history_seed.waiting_for_ack = false;
+    m_pending_web_content_session_history_seed.should_send_entries = true;
+    m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
+
+    if (!ui_session_history_already_points_to_url && !m_session_history_entry_url_loading_from_ui_process.has_value()) {
+        if (m_session_history.current_entry()) {
+            m_pending_session_history_navigation = PendingSessionHistoryNavigation {
+                url,
+                m_session_history,
+                PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess,
+            };
+        } else {
+            m_pending_session_history_navigation.clear();
+        }
+
+        if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
+            m_session_history.replace_current_entry(url, move(document_resource));
+        else
+            m_session_history.navigate(url, move(document_resource));
+        m_current_web_content_session_history_matches_mirror = false;
+        result.should_update_navigation_action_state = true;
+    }
+
+    if (!m_session_history_entry_url_loading_from_ui_process.has_value())
+        m_pending_web_content_session_history_seed.step_after_loading_top_level_entry = m_session_history.current_step_to_restore_after_loading_top_level_entry();
+
+    result.should_seed_web_content_before_load = can_seed_replacement_process_before_load(m_session_history, m_session_history_entry_url_loading_from_ui_process, m_pending_web_content_session_history_seed);
+    return result;
+}
+
+PageLoadPreparation CanonicalTraversable::prepare_for_page_load(URL::URL const& url, Web::Bindings::NavigationHistoryBehavior history_handling)
+{
+    PageLoadPreparation result;
+
+    if (m_session_history_entry_url_loading_from_ui_process.has_value())
+        return result;
+
+    abandon_pending_web_content_session_history_seed();
+    m_pending_session_history_traversal.clear();
+    auto const* current_entry = m_session_history.current_entry();
+    auto is_javascript_navigation = url.scheme() == "javascript"sv;
+    result.should_defer_ui_process_history_update = is_javascript_navigation;
+    if (current_entry && !is_javascript_navigation)
+        m_pending_session_history_navigation = PendingSessionHistoryNavigation { url, m_session_history };
+    else
+        m_pending_session_history_navigation.clear();
+
+    if (is_javascript_navigation)
+        return result;
+
+    auto ui_process_history_handling = history_handling;
+    if (ui_process_history_handling == Web::Bindings::NavigationHistoryBehavior::Auto) {
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
+        // If url equals navigable's active document's URL, and
+        // initiatorOriginSnapshot is same origin with targetNavigable's
+        // active document's origin, then set historyHandling to "replace".
+        if (current_entry && current_entry->url == url)
+            ui_process_history_handling = Web::Bindings::NavigationHistoryBehavior::Replace;
+        else
+            ui_process_history_handling = Web::Bindings::NavigationHistoryBehavior::Push;
+    }
+
+    if (ui_process_history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
+        m_session_history.replace_current_entry(url, Empty {});
+    else
+        m_session_history.navigate(url);
+    m_current_web_content_session_history_matches_mirror = false;
+    result.should_update_navigation_action_state = true;
+    return result;
+}
+
+void CanonicalTraversable::prepare_for_non_history_page_load()
+{
+    abandon_pending_web_content_session_history_seed();
+    m_current_web_content_session_history_matches_mirror = false;
+    m_session_history.forget_web_content_state();
+}
+
+void CanonicalTraversable::prepare_for_reload()
+{
+    abandon_pending_web_content_session_history_seed();
+    m_session_history.mark_current_entry_reload_pending();
+    m_current_web_content_session_history_matches_mirror = false;
+}
+
+WebContentSessionHistoryUpdateDecision CanonicalTraversable::did_receive_web_content_session_history_update(Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url)
+{
+    if (m_pending_web_content_session_history_seed.waiting_for_ack)
+        return { .ignore_reason = "ignored-session-history-before-ui-seed-ack"sv };
+
+    auto pending_step_after_fallback_load_was_restored = false;
+    if (m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()) {
+        if (current_used_step_index >= used_steps.size() || used_steps[current_used_step_index] != *m_pending_web_content_session_history_seed.step_after_loading_top_level_entry)
+            return { .ignore_reason = "ignored-partial-session-history-before-fallback-seed"sv };
+        pending_step_after_fallback_load_was_restored = true;
+    }
+
+    if (m_pending_web_content_session_history_seed.ignore_updates_until_seed)
+        return { .ignore_reason = "ignored-session-history-before-ui-seed"sv };
+
+    return {
+        .update = update_session_history_from_web_content(move(entries), move(used_steps), current_used_step_index, pending_step_after_fallback_load_was_restored, true, current_url),
+    };
+}
+
+WebContentSessionHistoryUpdateDecision CanonicalTraversable::did_receive_web_content_session_history_update_for_testing(Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url)
+{
+    // NB: dumpUIProcessSessionHistory() first sends WebContent's current snapshot to the UI process, then returns
+    //     the UI mirror. If a stale seed ack is still pending, normal async snapshots are intentionally ignored, so
+    //     use the same convergence path as a rejected seed ack to make this testing hook deterministic.
+    if (m_pending_web_content_session_history_seed.waiting_for_ack) {
+        auto update = adopt_web_content_session_history_after_rejected_seed(move(entries), move(used_steps), current_used_step_index, current_url);
+        if (update.update_result == TraversableSessionHistory::UpdateResult::InvalidSnapshot)
+            return { .ignore_reason = "ignored-session-history-for-testing-before-ui-seed-ack"sv };
+        return { .update = move(update) };
+    }
+
+    return {
+        .update = update_session_history_from_web_content(move(entries), move(used_steps), current_used_step_index, false, true, current_url),
+    };
+}
+
+WebContentSessionHistoryUpdateResult CanonicalTraversable::update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot, URL::URL const& current_url)
+{
+    auto update_result = m_session_history.update_from_web_content(move(entries), move(used_steps), current_used_step_index);
+    m_current_web_content_session_history_matches_mirror = update_result == TraversableSessionHistory::UpdateResult::CompleteSnapshot
+        && m_session_history.web_content_history_matches_mirror();
+
+    WebContentSessionHistoryUpdateResult result {
+        .update_result = update_result,
+    };
+
+    if (update_result != TraversableSessionHistory::UpdateResult::InvalidSnapshot) {
+        if (update_result == TraversableSessionHistory::UpdateResult::CompleteSnapshot)
+            m_pending_session_history_navigation.clear();
+        if (auto* current_entry = m_session_history.current_entry())
+            result.current_url = current_entry->url;
+        if (pending_step_after_fallback_load_was_restored)
+            m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.clear();
+    } else if (seed_web_content_on_invalid_snapshot) {
+        if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == current_url) {
+            prepare_to_seed_web_content_session_history_from_ui_process();
+            result.should_seed_web_content = true;
+        }
+    }
+
+    return result;
+}
+
+WebContentSessionHistoryUpdateResult CanonicalTraversable::adopt_web_content_session_history_after_rejected_seed(Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url)
+{
+    if (entries.is_empty())
+        return {};
+
+    auto entries_from_web_content = entries;
+    auto used_steps_from_web_content = used_steps;
+    auto update = update_session_history_from_web_content(move(entries), move(used_steps), current_used_step_index, false, false, current_url);
+    if (update.update_result == TraversableSessionHistory::UpdateResult::InvalidSnapshot && current_used_step_index < used_steps_from_web_content.size()) {
+        auto current_top_level_entry_index = current_top_level_history_entry_index_for_step(entries_from_web_content, used_steps_from_web_content[current_used_step_index]);
+        if (current_top_level_entry_index.has_value() && entries_from_web_content[*current_top_level_entry_index].url == current_url) {
+            m_session_history.clear();
+            update = update_session_history_from_web_content(move(entries_from_web_content), move(used_steps_from_web_content), current_used_step_index, false, false, current_url);
+        }
+    }
+    if (update.update_result == TraversableSessionHistory::UpdateResult::InvalidSnapshot)
+        return update;
+
+    m_pending_web_content_session_history_seed.clear();
+    m_pending_session_history_traversal.clear();
+    return update;
+}
+
+WebContentSessionHistorySeedAckResult CanonicalTraversable::did_receive_web_content_session_history_seed_ack(bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url)
+{
+    if (!m_pending_web_content_session_history_seed.waiting_for_ack)
+        return { .ignored = true, .dump_reason = "ignored-webcontent-session-history-seed-ack"sv };
+
+    WebContentSessionHistorySeedAckResult result;
+    result.should_update_navigation_action_state = true;
+
+    if (!accepted) {
+        auto update = adopt_web_content_session_history_after_rejected_seed(move(entries), move(used_steps), current_used_step_index, current_url);
+        if (update.update_result != TraversableSessionHistory::UpdateResult::InvalidSnapshot) {
+            result.dump_reason = "webcontent-session-history-seed-rejected-with-current-snapshot"sv;
+            result.current_url = move(update.current_url);
+            // NB: Applying the adopted snapshot's current URL already refreshes the navigation actions.
+            result.should_update_navigation_action_state = false;
+            return result;
+        }
+
+        abandon_pending_web_content_session_history_seed();
+        m_current_web_content_session_history_matches_mirror = false;
+        m_session_history.forget_web_content_state();
+        m_pending_session_history_traversal.clear();
+        result.dump_reason = "webcontent-session-history-seed-rejected"sv;
+        return result;
+    }
+
+    if (!m_session_history.did_seed_web_content_from_ui_process(move(entries), move(used_steps), current_used_step_index)) {
+        if (m_pending_web_content_session_history_seed.should_reseed_after_current_history_load) {
+            m_pending_web_content_session_history_seed.waiting_for_ack = false;
+            m_pending_web_content_session_history_seed.should_send_entries = true;
+            m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
+            m_current_web_content_session_history_matches_mirror = false;
+            result.dump_reason = "webcontent-session-history-preload-seed-ack-mismatch"sv;
+            return result;
+        }
+
+        abandon_pending_web_content_session_history_seed();
+        m_current_web_content_session_history_matches_mirror = false;
+        m_session_history.forget_web_content_state();
+        m_pending_session_history_traversal.clear();
+        result.dump_reason = "webcontent-session-history-seed-ack-mismatch"sv;
+        return result;
+    }
+
+    m_pending_web_content_session_history_seed.waiting_for_ack = false;
+    if (m_pending_web_content_session_history_seed.should_reseed_after_current_history_load) {
+        m_pending_web_content_session_history_seed.should_send_entries = true;
+        m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
+        m_current_web_content_session_history_matches_mirror = false;
+        result.dump_reason = "webcontent-session-history-preload-seed-ack"sv;
+        return result;
+    }
+
+    m_pending_web_content_session_history_seed.ignore_updates_until_seed = false;
+    m_current_web_content_session_history_matches_mirror = !m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()
+        && !m_pending_session_history_navigation.has_value();
+    if (m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()) {
+        if (m_pending_session_history_traversal.has_value())
+            m_pending_session_history_traversal->stage = PendingSessionHistoryTraversal::Stage::RestoringNestedStepAfterSeed;
+        result.step_to_traverse = *m_pending_web_content_session_history_seed.step_after_loading_top_level_entry;
+    } else {
+        auto is_waiting_for_history_step_cancelation_check = m_pending_session_history_traversal.has_value()
+            && m_pending_session_history_traversal->stage == PendingSessionHistoryTraversal::Stage::CheckingCancelation;
+        if (!is_waiting_for_history_step_cancelation_check) {
+            m_pending_session_history_traversal.clear();
+            result.should_complete_webdriver_pending_navigation = !m_pending_session_history_navigation.has_value();
+        }
+    }
+
+    result.dump_reason = "webcontent-session-history-seed-ack"sv;
+    return result;
+}
+
+NavigationStartResult CanonicalTraversable::did_start_navigation(URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling, bool is_showing_crash_page)
+{
+    if (m_session_history_entry_url_loading_from_ui_process.has_value()) {
+        if (*m_session_history_entry_url_loading_from_ui_process != url)
+            return { .dump_reason = "ignored-stale-ui-history-load-start"sv };
+
+        auto should_keep_preseeded_web_content_history = m_pending_web_content_session_history_seed.waiting_for_ack || m_session_history.web_content_uses_ui_step_coordinates();
+        m_session_history_entry_url_loading_from_ui_process.clear();
+        if (!should_keep_preseeded_web_content_history) {
+            m_current_web_content_session_history_matches_mirror = false;
+            m_session_history.forget_web_content_state();
+        }
+        return { .dump_reason = "did-start-navigation-from-ui-history-load"sv };
+    }
+
+    if (m_pending_web_content_session_history_seed.should_send_entries || m_pending_web_content_session_history_seed.ignore_updates_until_seed || m_pending_web_content_session_history_seed.waiting_for_ack) {
+        if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url != url)
+            return { .dump_reason = "ignored-navigation-start-before-ui-history-seed"sv };
+    }
+
+    if (is_showing_crash_page) {
+        if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url) {
+            prepare_to_seed_web_content_session_history_from_ui_process();
+            return { .dump_reason = "did-start-navigation-from-crash-page"sv, .did_clear_crash_page = true };
+        }
+    }
+
+    if (is_redirect) {
+        m_session_history.replace_current_entry_url(url);
+        if (m_pending_session_history_navigation.has_value())
+            m_pending_session_history_navigation->url = url;
+        m_current_web_content_session_history_matches_mirror = false;
+        return { .dump_reason = "did-start-navigation-redirect"sv, .should_update_navigation_action_state = true, .should_update_webdriver_pending_navigation_url = true, .did_clear_crash_page = is_showing_crash_page };
+    }
+
+    if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url) {
+        if (m_pending_session_history_navigation.has_value() && m_pending_session_history_navigation->url == url)
+            return { .did_clear_crash_page = is_showing_crash_page };
+
+        if (history_handling == Web::Bindings::NavigationHistoryBehavior::Push && m_current_web_content_session_history_matches_mirror)
+            m_pending_session_history_navigation = PendingSessionHistoryNavigation { url, m_session_history };
+        else
+            m_pending_session_history_navigation.clear();
+
+        if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace) {
+            m_session_history.replace_current_entry(url, move(document_resource));
+            m_current_web_content_session_history_matches_mirror = false;
+            return { .dump_reason = "did-start-navigation-replace-current-url"sv, .should_update_navigation_action_state = true, .did_clear_crash_page = is_showing_crash_page };
+        }
+        if (history_handling == Web::Bindings::NavigationHistoryBehavior::Push) {
+            m_session_history.navigate(url, move(document_resource));
+            m_current_web_content_session_history_matches_mirror = false;
+            return { .dump_reason = "did-start-navigation-push-current-url"sv, .should_update_navigation_action_state = true, .did_clear_crash_page = is_showing_crash_page };
+        }
+        return { .did_clear_crash_page = is_showing_crash_page };
+    }
+
+    if (m_session_history.current_entry())
+        m_pending_session_history_navigation = PendingSessionHistoryNavigation { url, m_session_history };
+    else
+        m_pending_session_history_navigation.clear();
+    if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
+        m_session_history.replace_current_entry(url, move(document_resource));
+    else
+        m_session_history.navigate(url, move(document_resource));
+    m_current_web_content_session_history_matches_mirror = false;
+    return { .dump_reason = "did-start-navigation"sv, .should_update_navigation_action_state = true, .did_clear_crash_page = is_showing_crash_page };
+}
+
+NavigationCancelResult CanonicalTraversable::did_cancel_navigation(URL::URL const& url, bool has_webdriver_pending_navigation)
+{
+    if (m_pending_session_history_navigation.has_value() && m_pending_session_history_navigation->url == url)
+        return { .status = NavigationCancelStatus::RestorePendingSessionHistoryNavigation };
+
+    if (m_session_history_entry_url_loading_from_ui_process.has_value() && *m_session_history_entry_url_loading_from_ui_process == url) {
+        m_session_history_entry_url_loading_from_ui_process.clear();
+        abandon_pending_web_content_session_history_seed();
+        m_current_web_content_session_history_matches_mirror = false;
+        m_session_history.forget_web_content_state();
+        return { .status = NavigationCancelStatus::CanceledUIHistoryLoad };
+    }
+
+    if (has_webdriver_pending_navigation) {
+        m_session_history.clear_current_entry_reload_pending();
+        return { .status = NavigationCancelStatus::CompleteWebdriverPendingNavigation };
+    }
+
+    return {};
+}
+
+NavigationFinishResult CanonicalTraversable::did_finish_navigation(URL::URL const& url)
+{
+    if (m_pending_session_history_navigation.has_value() && m_pending_session_history_navigation->url == url)
+        m_pending_session_history_navigation.clear();
+
+    if (!m_pending_web_content_session_history_seed.should_send_entries)
+        return {};
+
+    if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url) {
+        m_session_history.clear_current_entry_reload_pending();
+        auto allow_current_entry_reconstruction = m_pending_web_content_session_history_seed.should_reseed_after_current_history_load;
+        m_pending_web_content_session_history_seed.should_reseed_after_current_history_load = false;
+        return { .should_seed_web_content = true, .allow_current_entry_reconstruction = allow_current_entry_reconstruction };
+    }
+
+    // NB: The first finish notification from a fresh WebContent process can still report about:blank before the
+    //     traversed-to entry is ready. Keep the pending seed state intact so partial snapshots remain ignored
+    //     until we can seed the full UI-owned history.
+    return { .dump_reason = "skip-seed-webcontent-session-history"sv };
+}
+
+RestorePendingSessionHistoryNavigationResult CanonicalTraversable::restore_pending_session_history_navigation()
+{
+    if (!m_pending_session_history_navigation.has_value())
+        return {};
+
+    auto web_content_restore_mode = m_pending_session_history_navigation->web_content_restore_mode;
+    m_session_history = move(m_pending_session_history_navigation->previous_session_history);
+    m_pending_session_history_navigation.clear();
+    m_pending_session_history_traversal.clear();
+
+    RestorePendingSessionHistoryNavigationResult result { .restored = true, .web_content_restore_mode = web_content_restore_mode };
+    if (auto* current_entry = m_session_history.current_entry()) {
+        result.current_url = current_entry->url;
+        if (web_content_restore_mode == PendingSessionHistoryNavigation::WebContentRestoreMode::PreserveCurrentProcessState) {
+            m_session_history_entry_url_loading_from_ui_process.clear();
+            abandon_pending_web_content_session_history_seed();
+            m_current_web_content_session_history_matches_mirror = m_session_history.web_content_history_matches_mirror();
+        }
+    } else {
+        m_current_web_content_session_history_matches_mirror = false;
+    }
+    return result;
+}
+
+HistoryTraversalDecision CanonicalTraversable::traverse_the_history_by_delta(int delta, CheckForCancelation check_for_cancelation, URL::URL const& current_url, Function<void(HistoryTraversalOutcome)> on_cancelation_check_complete)
+{
+    auto target = m_session_history.traversal_target_for_delta(delta);
+    if (!target.has_value())
+        return { .outcome = { .status = HistoryTraversalStatus::NoEntry } };
+
+    auto will_replace_web_content_process = !is_url_suitable_for_same_process_navigation(current_url, target->target_top_level_entry->url);
+    auto pending_traversal = PendingSessionHistoryTraversal {
+        .target_step = target->target_step,
+        .target_step_index = target->target_step_index,
+        .will_change_top_level_entry = target->changes_top_level_entry,
+        .will_replace_web_content_process = will_replace_web_content_process,
+        .on_cancelation_check_complete = nullptr,
+    };
+
+    auto web_content_can_apply_traversal = !m_pending_web_content_session_history_seed.should_send_entries
+        && !m_pending_web_content_session_history_seed.ignore_updates_until_seed
+        && !m_pending_web_content_session_history_seed.waiting_for_ack
+        && !m_session_history_entry_url_loading_from_ui_process.has_value()
+        && !m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()
+        && m_session_history.web_content_can_traverse_to(*target);
+
+    if (web_content_can_apply_traversal && !will_replace_web_content_process) {
+        m_pending_session_history_traversal = move(pending_traversal);
+        auto webdriver_pending_navigation_completes_with_session_history_update = false;
+        if (auto const* current_entry = m_session_history.current_entry()) {
+            webdriver_pending_navigation_completes_with_session_history_update = current_entry->document_state.id != 0
+                && current_entry->document_state.id == target->target_top_level_entry->document_state.id;
+        }
+        return {
+            .outcome = { .status = HistoryTraversalStatus::Started, .will_replace_web_content_process = will_replace_web_content_process, .will_change_top_level_entry = target->changes_top_level_entry },
+            .action = HistoryTraversalAction::TraverseInWebContent,
+            .target_step = target->target_step,
+            .webdriver_pending_navigation_url = target->target_top_level_entry->url,
+            .webdriver_pending_navigation_completes_with_session_history_update = webdriver_pending_navigation_completes_with_session_history_update,
+        };
+    }
+
+    auto needs_cancelation_check = check_for_cancelation == CheckForCancelation::Yes
+        || (check_for_cancelation == CheckForCancelation::IfWebContentCannotTraverseTarget && !web_content_can_apply_traversal);
+    if (needs_cancelation_check) {
+        pending_traversal.stage = PendingSessionHistoryTraversal::Stage::CheckingCancelation;
+        pending_traversal.cancelation_check_request_id = m_next_traverse_history_step_cancelation_check_request_id++;
+        pending_traversal.on_cancelation_check_complete = move(on_cancelation_check_complete);
+        auto request_id = pending_traversal.cancelation_check_request_id;
+        m_pending_session_history_traversal = move(pending_traversal);
+        return {
+            .outcome = { .status = HistoryTraversalStatus::Started, .will_replace_web_content_process = will_replace_web_content_process, .will_change_top_level_entry = target->changes_top_level_entry, .waiting_for_cancelation_check = true },
+            .action = HistoryTraversalAction::CheckForCancelation,
+            .target_step = target->target_step,
+            .cancelation_check_request_id = request_id,
+        };
+    }
+
+    pending_traversal.stage = PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess;
+    m_pending_session_history_traversal = move(pending_traversal);
+    prepare_to_load_session_history_traversal_target_from_ui_process(*target, current_url);
+    return {
+        .outcome = { .status = HistoryTraversalStatus::Started, .will_replace_web_content_process = will_replace_web_content_process, .will_change_top_level_entry = target->changes_top_level_entry },
+        .action = HistoryTraversalAction::LoadCurrentEntryFromUIProcess,
+        .webdriver_pending_navigation_url = target->target_top_level_entry->url,
+        .webdriver_pending_navigation_completes_with_session_history_update = true,
+    };
+}
+
+URL::URL CanonicalTraversable::prepare_to_load_session_history_traversal_target_from_ui_process(TraversableSessionHistory::TraversalTarget const& target, URL::URL const& current_url)
+{
+    if (!m_pending_session_history_traversal.has_value() || m_pending_session_history_traversal->target_step != target.target_step) {
+        m_pending_session_history_traversal = PendingSessionHistoryTraversal {
+            .target_step = target.target_step,
+            .target_step_index = target.target_step_index,
+            .will_change_top_level_entry = target.changes_top_level_entry,
+            .will_replace_web_content_process = !is_url_suitable_for_same_process_navigation(current_url, target.target_top_level_entry->url),
+            .stage = PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess,
+            .on_cancelation_check_complete = nullptr,
+        };
+    } else {
+        m_pending_session_history_traversal->stage = PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess;
+    }
+
+    auto target_url = target.target_top_level_entry->url;
+    auto previous_session_history = m_session_history;
+    m_session_history.traverse_to(target.target_step_index);
+    prepare_to_seed_web_content_session_history_from_ui_process();
+    m_pending_session_history_navigation = PendingSessionHistoryNavigation { target_url, move(previous_session_history) };
+    return target_url;
+}
+
+WebContentHistoryStepResult CanonicalTraversable::did_traverse_the_history_to_step(i32 step, bool step_was_available, Web::HTML::HistoryStepResult result)
+{
+    if (!m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()) {
+        if (!m_pending_session_history_traversal.has_value() || m_pending_session_history_traversal->target_step != step)
+            return { .dump_reason = "ignored-stale-webcontent-history-step-result"sv };
+
+        if (!step_was_available) {
+            auto target = m_session_history.traversal_target_for_step(step);
+            if (target.has_value())
+                return { .dump_reason = "webcontent-history-step-unavailable-fallback-load"sv, .fallback_target = *target };
+            m_current_web_content_session_history_matches_mirror = false;
+            m_session_history.forget_web_content_state();
+            m_pending_session_history_traversal.clear();
+            return { .dump_reason = "webcontent-history-step-unavailable"sv, .should_update_navigation_action_state = true };
+        }
+
+        if (result != Web::HTML::HistoryStepResult::Applied) {
+            m_pending_session_history_traversal.clear();
+            return { .dump_reason = "webcontent-history-step-canceled"sv, .should_update_navigation_action_state = true, .should_complete_webdriver_pending_navigation = true, .should_update_webdriver_pending_navigation_to_current_url = true, .should_reset_webdriver_pending_navigation_completion = true };
+        }
+
+        if (!m_session_history.did_apply_web_content_traversal_to_step(step)) {
+            if (auto target = m_session_history.traversal_target_for_step(step); target.has_value())
+                return { .dump_reason = "webcontent-history-step-applied-with-stale-mirror-fallback-load"sv, .fallback_target = *target };
+            m_current_web_content_session_history_matches_mirror = false;
+            m_session_history.forget_web_content_state();
+            m_pending_session_history_traversal.clear();
+            return { .dump_reason = "webcontent-history-step-applied-without-ui-target"sv, .should_update_navigation_action_state = true };
+        }
+
+        m_current_web_content_session_history_matches_mirror = true;
+        auto should_complete_webdriver_pending_navigation = !m_pending_session_history_traversal->will_change_top_level_entry;
+        Optional<URL::URL> current_url;
+        if (auto const* current_entry = m_session_history.current_entry())
+            current_url = current_entry->url;
+        m_pending_session_history_traversal.clear();
+        return { .dump_reason = "webcontent-history-step-applied"sv, .should_update_navigation_action_state = true, .current_url = move(current_url), .should_complete_webdriver_pending_navigation = should_complete_webdriver_pending_navigation };
+    }
+
+    if (*m_pending_web_content_session_history_seed.step_after_loading_top_level_entry != step)
+        return { .dump_reason = "ignored-stale-webcontent-history-step-result"sv };
+
+    if (step_was_available && result == Web::HTML::HistoryStepResult::Applied) {
+        m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.clear();
+        m_current_web_content_session_history_matches_mirror = m_session_history.did_restore_web_content_to_current_step(step);
+        m_pending_session_history_traversal.clear();
+        return { .dump_reason = "webcontent-history-step-restored"sv, .should_update_navigation_action_state = true, .should_complete_webdriver_pending_navigation = true };
+    }
+
+    auto pending_step_dump_reason = step_was_available ? "webcontent-pending-history-step-canceled"sv : "webcontent-history-step-unavailable"sv;
+    if (m_pending_session_history_navigation.has_value())
+        return { .dump_reason = pending_step_dump_reason, .should_restore_pending_navigation = true };
+
+    m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.clear();
+    m_current_web_content_session_history_matches_mirror = false;
+    m_session_history.forget_web_content_state();
+    m_pending_session_history_traversal.clear();
+    return { .dump_reason = pending_step_dump_reason, .should_update_navigation_action_state = true };
+}
+
+HistoryStepCancelationCheckResult CanonicalTraversable::did_check_if_traverse_history_step_is_canceled(u64 request_id, i32 step, bool canceled)
+{
+    if (!m_pending_session_history_traversal.has_value()
+        || m_pending_session_history_traversal->stage != PendingSessionHistoryTraversal::Stage::CheckingCancelation
+        || m_pending_session_history_traversal->cancelation_check_request_id != request_id
+        || m_pending_session_history_traversal->target_step != step)
+        return { .dump_reason = "ignored-stale-history-step-cancelation-check-result"sv };
+
+    if (canceled) {
+        auto on_cancelation_check_complete = move(m_pending_session_history_traversal->on_cancelation_check_complete);
+        m_pending_session_history_traversal.clear();
+        return { .dump_reason = "traverse-fallback-canceled-by-webcontent"sv, .on_cancelation_check_complete = move(on_cancelation_check_complete), .outcome = { .status = HistoryTraversalStatus::Canceled }, .should_update_navigation_action_state = true, .should_complete_webdriver_pending_navigation = true, .should_update_webdriver_pending_navigation_to_current_url = true, .should_reset_webdriver_pending_navigation_completion = true };
+    }
+
+    auto target = m_session_history.traversal_target_for_step(step);
+    if (!target.has_value()) {
+        auto on_cancelation_check_complete = move(m_pending_session_history_traversal->on_cancelation_check_complete);
+        m_current_web_content_session_history_matches_mirror = false;
+        m_session_history.forget_web_content_state();
+        m_pending_session_history_traversal.clear();
+        return { .dump_reason = "traverse-fallback-cancelation-check-without-ui-target"sv, .on_cancelation_check_complete = move(on_cancelation_check_complete), .outcome = { .status = HistoryTraversalStatus::NoEntry }, .should_update_navigation_action_state = true };
+    }
+
+    auto on_cancelation_check_complete = move(m_pending_session_history_traversal->on_cancelation_check_complete);
+    return {
+        .dump_reason = "traverse-fallback-load-after-cancelation-check"sv,
+        .on_cancelation_check_complete = move(on_cancelation_check_complete),
+        .outcome = { .status = HistoryTraversalStatus::Started, .will_replace_web_content_process = m_pending_session_history_traversal->will_replace_web_content_process, .will_change_top_level_entry = m_pending_session_history_traversal->will_change_top_level_entry },
+        .target = *target,
+    };
+}
+
+Optional<WebContentSessionHistorySeed> CanonicalTraversable::prepare_web_content_session_history_seed(bool allow_current_entry_reconstruction)
+{
+    auto current_top_level_entry_index = m_session_history.current_top_level_entry_index();
+    if (!current_top_level_entry_index.has_value()) {
+        abandon_pending_web_content_session_history_seed();
+        m_current_web_content_session_history_matches_mirror = false;
+        m_session_history.forget_web_content_state();
+        return {};
+    }
+
+    auto entries = m_session_history.entries();
+    if (entries.is_empty()) {
+        abandon_pending_web_content_session_history_seed();
+        m_current_web_content_session_history_matches_mirror = false;
+        m_session_history.forget_web_content_state();
+        return {};
+    }
+
+    auto is_restoring_traversal_target = m_pending_session_history_traversal.has_value()
+        && (m_pending_session_history_traversal->stage == PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess
+            || m_pending_session_history_traversal->stage == PendingSessionHistoryTraversal::Stage::ReplacingWebContentProcess
+            || m_pending_session_history_traversal->stage == PendingSessionHistoryTraversal::Stage::RestoringNestedStepAfterSeed);
+    auto allow_reconstructing_current_entry = is_restoring_traversal_target
+        || m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()
+        || allow_current_entry_reconstruction;
+
+    return WebContentSessionHistorySeed {
+        .entries = move(entries),
+        .current_top_level_entry_index = *current_top_level_entry_index,
+        .allow_current_entry_reconstruction = allow_reconstructing_current_entry,
+    };
+}
+
+void CanonicalTraversable::did_send_web_content_session_history_seed()
+{
+    m_pending_web_content_session_history_seed.waiting_for_ack = true;
+    m_pending_web_content_session_history_seed.should_send_entries = false;
+}
+
+bool CanonicalTraversable::prepare_to_restore_current_session_history_entry_from_ui_process()
+{
+    auto should_seed = !m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value();
+    if (should_seed)
+        m_pending_web_content_session_history_seed.should_reseed_after_current_history_load = true;
+    return should_seed;
+}
+
+CurrentSessionHistoryEntryLoad CanonicalTraversable::prepare_current_session_history_entry_load(URL::URL const& current_url)
+{
+    auto const* current_entry = m_session_history.current_entry();
+    if (!current_entry) {
+        m_session_history_entry_url_loading_from_ui_process = current_url;
+        return { .url = current_url, .document_resource = Empty {}, .history_handling = Web::Bindings::NavigationHistoryBehavior::Auto };
+    }
+
+    m_session_history_entry_url_loading_from_ui_process = current_entry->url;
+    auto history_handling = m_pending_web_content_session_history_seed.waiting_for_ack || m_session_history.web_content_uses_ui_step_coordinates()
+        ? Web::Bindings::NavigationHistoryBehavior::Replace
+        : Web::Bindings::NavigationHistoryBehavior::Auto;
+    return { .url = current_entry->url, .document_resource = current_entry->document_state.resource, .history_handling = history_handling };
+}
+
+void CanonicalTraversable::did_crash_requiring_web_content_session_history_seed()
+{
+    m_session_history_entry_url_loading_from_ui_process.clear();
+    prepare_to_seed_web_content_session_history_from_ui_process();
+}
+
+void CanonicalTraversable::reset_session_history_for_testing()
+{
+    m_session_history.clear();
+    m_current_web_content_session_history_matches_mirror = false;
+    m_pending_session_history_navigation.clear();
+    m_pending_session_history_traversal.clear();
+    m_session_history_entry_url_loading_from_ui_process.clear();
+    abandon_pending_web_content_session_history_seed();
+}
+
+void CanonicalTraversable::mark_web_content_session_history_stale_for_testing()
+{
+    m_current_web_content_session_history_matches_mirror = false;
+}
+
+StringView CanonicalTraversable::pending_session_history_navigation_web_content_restore_mode_to_string(PendingSessionHistoryNavigation::WebContentRestoreMode mode)
+{
+    switch (mode) {
+    case PendingSessionHistoryNavigation::WebContentRestoreMode::PreserveCurrentProcessState:
+        return "preserve-current-process-state"sv;
+    case PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess:
+        return "restore-from-ui-process"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+StringView CanonicalTraversable::pending_session_history_traversal_stage_to_string(PendingSessionHistoryTraversal::Stage stage)
+{
+    switch (stage) {
+    case PendingSessionHistoryTraversal::Stage::ApplyingInWebContent:
+        return "applying-in-webcontent"sv;
+    case PendingSessionHistoryTraversal::Stage::CheckingCancelation:
+        return "checking-cancelation"sv;
+    case PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess:
+        return "loading-entry-from-ui-process"sv;
+    case PendingSessionHistoryTraversal::Stage::ReplacingWebContentProcess:
+        return "replacing-webcontent-process"sv;
+    case PendingSessionHistoryTraversal::Stage::RestoringNestedStepAfterSeed:
+        return "restoring-nested-step-after-seed"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibURL/URL.h>
+#include <LibWeb/Bindings/Navigation.h>
+#include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/HTML/VisibilityState.h>
+#include <LibWebView/Export.h>
+#include <LibWebView/SessionHistory.h>
+
+namespace WebView {
+
+enum class HistoryTraversalStatus : u8 {
+    Started,
+    NoEntry,
+    Canceled,
+};
+
+// NB: The HTML Standard spells this algorithm argument "checkForCancelation".
+enum class CheckForCancelation : u8 {
+    Yes,
+    No,
+    IfWebContentCannotTraverseTarget,
+};
+
+struct HistoryTraversalOutcome {
+    HistoryTraversalStatus status { HistoryTraversalStatus::NoEntry };
+    bool will_replace_web_content_process { false };
+    bool will_change_top_level_entry { false };
+    bool waiting_for_cancelation_check { false };
+};
+
+struct PendingSessionHistoryNavigation {
+    enum class WebContentRestoreMode : u8 {
+        PreserveCurrentProcessState,
+        RestoreFromUIProcess,
+    };
+
+    URL::URL url;
+    TraversableSessionHistory previous_session_history;
+    WebContentRestoreMode web_content_restore_mode { WebContentRestoreMode::PreserveCurrentProcessState };
+};
+
+struct PendingWebContentSessionHistorySeed {
+    bool should_send_entries { false };
+    bool ignore_updates_until_seed { false };
+    bool waiting_for_ack { false };
+    bool should_reseed_after_current_history_load { false };
+    Optional<i32> step_after_loading_top_level_entry;
+
+    void clear() { *this = {}; }
+};
+
+struct PendingSessionHistoryTraversal {
+    enum class Stage : u8 {
+        ApplyingInWebContent,
+        CheckingCancelation,
+        LoadingEntryFromUIProcess,
+        ReplacingWebContentProcess,
+        RestoringNestedStepAfterSeed,
+    };
+
+    i32 target_step { 0 };
+    size_t target_step_index { 0 };
+    u64 cancelation_check_request_id { 0 };
+    bool will_change_top_level_entry { false };
+    bool will_replace_web_content_process { false };
+    Stage stage { Stage::ApplyingInWebContent };
+    Function<void(HistoryTraversalOutcome)> on_cancelation_check_complete;
+};
+
+// NB: The results below tell ViewImplementation which UI-process side effects to apply. Each
+//     carries the reason string for the session-history debug dump, so the producer is the
+//     single place that decides both the state transition and how it is logged.
+
+struct WebContentSessionHistoryUpdateResult {
+    TraversableSessionHistory::UpdateResult update_result { TraversableSessionHistory::UpdateResult::InvalidSnapshot };
+    Optional<URL::URL> current_url {};
+    bool should_seed_web_content { false };
+};
+
+struct WebContentSessionHistoryUpdateDecision {
+    // When set, the snapshot was ignored and the UI mirror was left untouched.
+    Optional<StringView> ignore_reason {};
+    WebContentSessionHistoryUpdateResult update {};
+};
+
+struct WebContentSessionHistorySeedAckResult {
+    bool ignored { false };
+    StringView dump_reason;
+    Optional<URL::URL> current_url {};
+    Optional<i32> step_to_traverse {};
+    bool should_complete_webdriver_pending_navigation { false };
+    bool should_update_navigation_action_state { false };
+};
+
+struct NavigationStartResult {
+    Optional<StringView> dump_reason {};
+    bool should_update_navigation_action_state { false };
+    bool should_update_webdriver_pending_navigation_url { false };
+    bool did_clear_crash_page { false };
+};
+
+enum class NavigationCancelStatus : u8 {
+    Ignored,
+    RestorePendingSessionHistoryNavigation,
+    CanceledUIHistoryLoad,
+    CompleteWebdriverPendingNavigation,
+};
+
+struct NavigationCancelResult {
+    NavigationCancelStatus status { NavigationCancelStatus::Ignored };
+};
+
+struct NavigationFinishResult {
+    bool should_seed_web_content { false };
+    bool allow_current_entry_reconstruction { false };
+    Optional<StringView> dump_reason {};
+};
+
+struct RestorePendingSessionHistoryNavigationResult {
+    bool restored { false };
+    Optional<URL::URL> current_url {};
+    PendingSessionHistoryNavigation::WebContentRestoreMode web_content_restore_mode { PendingSessionHistoryNavigation::WebContentRestoreMode::PreserveCurrentProcessState };
+};
+
+enum class HistoryTraversalAction : u8 {
+    None,
+    TraverseInWebContent,
+    CheckForCancelation,
+    LoadCurrentEntryFromUIProcess,
+};
+
+struct HistoryTraversalDecision {
+    HistoryTraversalOutcome outcome;
+    HistoryTraversalAction action { HistoryTraversalAction::None };
+    Optional<i32> target_step {};
+    Optional<u64> cancelation_check_request_id {};
+    Optional<URL::URL> webdriver_pending_navigation_url {};
+    bool webdriver_pending_navigation_completes_with_session_history_update { false };
+};
+
+struct WebContentHistoryStepResult {
+    StringView dump_reason;
+    // When set, the UI-owned target entry must be loaded from the UI process instead.
+    Optional<TraversableSessionHistory::TraversalTarget> fallback_target {};
+    bool should_restore_pending_navigation { false };
+    bool should_update_navigation_action_state { false };
+    Optional<URL::URL> current_url {};
+    bool should_complete_webdriver_pending_navigation { false };
+    bool should_update_webdriver_pending_navigation_to_current_url { false };
+    bool should_reset_webdriver_pending_navigation_completion { false };
+};
+
+struct HistoryStepCancelationCheckResult {
+    StringView dump_reason;
+    Function<void(HistoryTraversalOutcome)> on_cancelation_check_complete {};
+    HistoryTraversalOutcome outcome {};
+    // When set, the UI-owned target entry must be loaded from the UI process after
+    // reporting the outcome.
+    Optional<TraversableSessionHistory::TraversalTarget> target {};
+    bool should_update_navigation_action_state { false };
+    bool should_complete_webdriver_pending_navigation { false };
+    bool should_update_webdriver_pending_navigation_to_current_url { false };
+    bool should_reset_webdriver_pending_navigation_completion { false };
+};
+
+struct WebContentSessionHistorySeed {
+    Vector<Web::HTML::SessionHistoryEntryDescriptor> entries;
+    size_t current_top_level_entry_index { 0 };
+    bool allow_current_entry_reconstruction { false };
+};
+
+struct CurrentSessionHistoryEntryLoad {
+    URL::URL url;
+    Variant<Empty, String, Web::HTML::POSTResource> document_resource;
+    Web::Bindings::NavigationHistoryBehavior history_handling { Web::Bindings::NavigationHistoryBehavior::Auto };
+};
+
+struct ProcessSwapNavigationPreparation {
+    bool should_update_navigation_action_state { false };
+    bool should_seed_web_content_before_load { false };
+};
+
+struct PageLoadPreparation {
+    bool should_defer_ui_process_history_update { false };
+    bool should_update_navigation_action_state { false };
+};
+
+class WEBVIEW_API CanonicalTraversable final {
+public:
+    TraversableSessionHistory const& session_history() const { return m_session_history; }
+
+    Web::HTML::VisibilityState system_visibility_state() const { return m_system_visibility_state; }
+    void set_system_visibility_state(Web::HTML::VisibilityState visibility_state) { m_system_visibility_state = visibility_state; }
+
+    bool current_web_content_session_history_matches_mirror() const { return m_current_web_content_session_history_matches_mirror; }
+
+    Optional<PendingSessionHistoryNavigation> const& pending_session_history_navigation() const { return m_pending_session_history_navigation; }
+    Optional<PendingSessionHistoryTraversal> const& pending_session_history_traversal() const { return m_pending_session_history_traversal; }
+
+    Optional<URL::URL> const& session_history_entry_url_loading_from_ui_process() const { return m_session_history_entry_url_loading_from_ui_process; }
+    PendingWebContentSessionHistorySeed const& pending_web_content_session_history_seed() const { return m_pending_web_content_session_history_seed; }
+
+    ProcessSwapNavigationPreparation prepare_for_process_swap_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior);
+    PageLoadPreparation prepare_for_page_load(URL::URL const&, Web::Bindings::NavigationHistoryBehavior);
+    void prepare_for_non_history_page_load();
+    void prepare_for_reload();
+    void prepare_to_seed_web_content_session_history_from_ui_process();
+    WebContentSessionHistoryUpdateDecision did_receive_web_content_session_history_update(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
+    WebContentSessionHistoryUpdateDecision did_receive_web_content_session_history_update_for_testing(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
+    WebContentSessionHistorySeedAckResult did_receive_web_content_session_history_seed_ack(bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
+    NavigationStartResult did_start_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, bool is_redirect, Web::Bindings::NavigationHistoryBehavior, bool is_showing_crash_page);
+    NavigationCancelResult did_cancel_navigation(URL::URL const&, bool has_webdriver_pending_navigation);
+    NavigationFinishResult did_finish_navigation(URL::URL const&);
+    RestorePendingSessionHistoryNavigationResult restore_pending_session_history_navigation();
+    HistoryTraversalDecision traverse_the_history_by_delta(int delta, CheckForCancelation, URL::URL const& current_url, Function<void(HistoryTraversalOutcome)> on_cancelation_check_complete);
+    URL::URL prepare_to_load_session_history_traversal_target_from_ui_process(TraversableSessionHistory::TraversalTarget const&, URL::URL const& current_url);
+    WebContentHistoryStepResult did_traverse_the_history_to_step(i32 step, bool step_was_available, Web::HTML::HistoryStepResult);
+    HistoryStepCancelationCheckResult did_check_if_traverse_history_step_is_canceled(u64 request_id, i32 step, bool canceled);
+    Optional<WebContentSessionHistorySeed> prepare_web_content_session_history_seed(bool allow_current_entry_reconstruction);
+    CurrentSessionHistoryEntryLoad prepare_current_session_history_entry_load(URL::URL const& current_url);
+    void did_send_web_content_session_history_seed();
+    bool prepare_to_restore_current_session_history_entry_from_ui_process();
+    void did_crash_requiring_web_content_session_history_seed();
+    void reset_session_history_for_testing();
+    void mark_web_content_session_history_stale_for_testing();
+
+    static StringView pending_session_history_navigation_web_content_restore_mode_to_string(PendingSessionHistoryNavigation::WebContentRestoreMode);
+    static StringView pending_session_history_traversal_stage_to_string(PendingSessionHistoryTraversal::Stage);
+
+private:
+    void abandon_pending_web_content_session_history_seed();
+    WebContentSessionHistoryUpdateResult update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot, URL::URL const& current_url);
+    WebContentSessionHistoryUpdateResult adopt_web_content_session_history_after_rejected_seed(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
+
+    TraversableSessionHistory m_session_history;
+    Web::HTML::VisibilityState m_system_visibility_state { Web::HTML::VisibilityState::Hidden };
+    bool m_current_web_content_session_history_matches_mirror { false };
+    Optional<PendingSessionHistoryNavigation> m_pending_session_history_navigation;
+    Optional<PendingSessionHistoryTraversal> m_pending_session_history_traversal;
+    u64 m_next_traverse_history_step_cancelation_check_request_id { 0 };
+    Optional<URL::URL> m_session_history_entry_url_loading_from_ui_process;
+    PendingWebContentSessionHistorySeed m_pending_web_content_session_history_seed;
+};
+
+}

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -16,6 +16,7 @@ class Action;
 class Application;
 class Autocomplete;
 class BookmarkStore;
+class CanonicalTraversable;
 class CompositorClient;
 class CookieJar;
 class HistoryStore;

--- a/Libraries/LibWebView/HeadlessWebView.cpp
+++ b/Libraries/LibWebView/HeadlessWebView.cpp
@@ -163,7 +163,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
         m_pending_prompt_text.clear();
     };
 
-    m_system_visibility_state = Web::HTML::VisibilityState::Visible;
+    m_top_level_traversable.set_system_visibility_state(Web::HTML::VisibilityState::Visible);
 }
 
 void HeadlessWebView::initialize_client(CreateNewClient create_new_client)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -163,69 +163,18 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
 
     handle_resize();
 
-    auto ui_session_history_already_points_to_url = false;
-    if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url)
-        ui_session_history_already_points_to_url = true;
+    auto preparation = m_top_level_traversable.prepare_for_process_swap_navigation(url, document_resource, history_handling);
+    if (preparation.should_update_navigation_action_state)
+        update_navigation_action_state();
 
-    if (m_pending_session_history_traversal.has_value() && m_pending_session_history_traversal->will_replace_web_content_process)
-        m_pending_session_history_traversal->stage = PendingSessionHistoryTraversal::Stage::ReplacingWebContentProcess;
-    if (m_pending_session_history_navigation.has_value())
-        m_pending_session_history_navigation->web_content_restore_mode = PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess;
-    m_current_web_content_session_history_matches_mirror = false;
-    m_session_history.forget_web_content_state();
-    m_pending_web_content_session_history_seed.waiting_for_ack = false;
-    m_pending_web_content_session_history_seed.should_send_entries = true;
-    m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
-
-    auto seed_replacement_process_before_load_if_possible = [&] {
-        if (!m_pending_web_content_session_history_seed.should_send_entries)
-            return false;
-        if (m_session_history_entry_url_loading_from_ui_process.has_value())
-            return false;
-        if (m_session_history.current_step_to_restore_after_loading_top_level_entry().has_value())
-            return false;
+    m_should_suppress_history_for_current_load = false;
+    m_should_suppress_history_for_next_load = false;
+    set_url(url);
+    if (preparation.should_seed_web_content_before_load)
         seed_web_content_session_history_from_ui_process();
-        return true;
-    };
-
-    if (ui_session_history_already_points_to_url) {
-        m_should_suppress_history_for_current_load = false;
-        m_should_suppress_history_for_next_load = false;
-        if (!m_session_history_entry_url_loading_from_ui_process.has_value())
-            m_pending_web_content_session_history_seed.step_after_loading_top_level_entry = m_session_history.current_step_to_restore_after_loading_top_level_entry();
-        set_url(url);
-        auto seeded_replacement_process_before_load = seed_replacement_process_before_load_if_possible();
-        auto web_content_history_handling = seeded_replacement_process_before_load ? Web::Bindings::NavigationHistoryBehavior::Replace : history_handling;
-        dump_session_history("process-swap-load-existing-ui-entry"sv);
-        client().async_load_url_with_document_resource(page_id(), url, document_resource, web_content_history_handling);
-    } else {
-        m_should_suppress_history_for_current_load = false;
-        m_should_suppress_history_for_next_load = false;
-        if (!m_session_history_entry_url_loading_from_ui_process.has_value()) {
-            if (m_session_history.current_entry()) {
-                m_pending_session_history_navigation = PendingSessionHistoryNavigation {
-                    url,
-                    m_session_history,
-                    PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess,
-                };
-            } else {
-                m_pending_session_history_navigation.clear();
-            }
-            if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
-                m_session_history.replace_current_entry(url, document_resource);
-            else
-                m_session_history.navigate(url, document_resource);
-            m_current_web_content_session_history_matches_mirror = false;
-            update_navigation_action_state();
-        }
-        if (!m_session_history_entry_url_loading_from_ui_process.has_value())
-            m_pending_web_content_session_history_seed.step_after_loading_top_level_entry = m_session_history.current_step_to_restore_after_loading_top_level_entry();
-        set_url(url);
-        auto seeded_replacement_process_before_load = seed_replacement_process_before_load_if_possible();
-        auto web_content_history_handling = seeded_replacement_process_before_load ? Web::Bindings::NavigationHistoryBehavior::Replace : history_handling;
-        dump_session_history("load"sv);
-        client().async_load_url_with_document_resource(page_id(), url, document_resource, web_content_history_handling);
-    }
+    auto web_content_history_handling = preparation.should_seed_web_content_before_load ? Web::Bindings::NavigationHistoryBehavior::Replace : history_handling;
+    dump_session_history("process-swap-load"sv);
+    client().async_load_url_with_document_resource(page_id(), url, document_resource, web_content_history_handling);
     dump_session_history("after-process-swap-load"sv);
 }
 
@@ -266,11 +215,11 @@ void ViewImplementation::did_update_window_rect()
 
 void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState visibility_state)
 {
-    if (m_system_visibility_state == visibility_state)
+    if (m_top_level_traversable.system_visibility_state() == visibility_state)
         return;
 
-    m_system_visibility_state = visibility_state;
-    client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
+    m_top_level_traversable.set_system_visibility_state(visibility_state);
+    client().async_set_system_visibility_state(m_client_state.page_index, visibility_state);
 }
 
 void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHistoryBehavior history_handling)
@@ -278,41 +227,10 @@ void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHist
     m_is_showing_crash_page = false;
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
-    auto should_defer_ui_process_history_update = false;
-    if (!m_session_history_entry_url_loading_from_ui_process.has_value())
-        abandon_pending_web_content_session_history_seed();
-    if (!m_session_history_entry_url_loading_from_ui_process.has_value()) {
-        m_pending_session_history_traversal.clear();
-        auto const* current_entry = m_session_history.current_entry();
-        auto is_javascript_navigation = url.scheme() == "javascript"sv;
-        should_defer_ui_process_history_update = is_javascript_navigation;
-        if (current_entry && !is_javascript_navigation)
-            m_pending_session_history_navigation = PendingSessionHistoryNavigation { url, m_session_history };
-        else
-            m_pending_session_history_navigation.clear();
-
-        if (!is_javascript_navigation) {
-            auto ui_process_history_handling = history_handling;
-            if (ui_process_history_handling == Web::Bindings::NavigationHistoryBehavior::Auto) {
-                // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
-                // If url equals navigable's active document's URL, and
-                // initiatorOriginSnapshot is same origin with targetNavigable's
-                // active document's origin, then set historyHandling to "replace".
-                if (current_entry && current_entry->url == url)
-                    ui_process_history_handling = Web::Bindings::NavigationHistoryBehavior::Replace;
-                else
-                    ui_process_history_handling = Web::Bindings::NavigationHistoryBehavior::Push;
-            }
-
-            if (ui_process_history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
-                m_session_history.replace_current_entry(url, Empty {});
-            else
-                m_session_history.navigate(url);
-            m_current_web_content_session_history_matches_mirror = false;
-            update_navigation_action_state();
-        }
-    }
-    if (!should_defer_ui_process_history_update)
+    auto preparation = m_top_level_traversable.prepare_for_page_load(url, history_handling);
+    if (preparation.should_update_navigation_action_state)
+        update_navigation_action_state();
+    if (!preparation.should_defer_ui_process_history_update)
         set_url(url);
     dump_session_history("load"sv);
     client().async_load_url(page_id(), url, history_handling);
@@ -323,9 +241,7 @@ void ViewImplementation::load_html(StringView html)
     m_is_showing_crash_page = false;
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
-    abandon_pending_web_content_session_history_seed();
-    m_current_web_content_session_history_matches_mirror = false;
-    m_session_history.forget_web_content_state();
+    m_top_level_traversable.prepare_for_non_history_page_load();
     client().async_load_html(page_id(), html);
 }
 
@@ -334,9 +250,7 @@ void ViewImplementation::load_crash_page_html(StringView html, URL::URL const& c
     m_is_showing_crash_page = true;
     m_should_suppress_history_for_current_load = true;
     m_should_suppress_history_for_next_load = true;
-    abandon_pending_web_content_session_history_seed();
-    m_current_web_content_session_history_matches_mirror = false;
-    m_session_history.forget_web_content_state();
+    m_top_level_traversable.prepare_for_non_history_page_load();
     set_url(crashed_url);
     client().async_load_html_with_url(page_id(), html, crashed_url);
 }
@@ -358,7 +272,7 @@ void ViewImplementation::reload()
         m_is_showing_crash_page = false;
         m_should_suppress_history_for_current_load = false;
         m_should_suppress_history_for_next_load = false;
-        prepare_to_seed_web_content_session_history_from_ui_process();
+        m_top_level_traversable.prepare_to_seed_web_content_session_history_from_ui_process();
         restore_current_session_history_entry_from_ui_process();
         return;
     }
@@ -366,114 +280,57 @@ void ViewImplementation::reload()
     m_is_showing_crash_page = false;
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
-    abandon_pending_web_content_session_history_seed();
-    m_session_history.mark_current_entry_reload_pending();
-    m_current_web_content_session_history_matches_mirror = false;
+    m_top_level_traversable.prepare_for_reload();
     update_navigation_action_state();
     dump_session_history("reload-mark-current-entry-reload-pending"sv);
     client().async_reload(page_id());
 }
 
-ViewImplementation::HistoryTraversalOutcome ViewImplementation::traverse_the_history_by_delta(
+HistoryTraversalOutcome ViewImplementation::traverse_the_history_by_delta(
     int delta,
     CheckForCancelation check_for_cancelation,
     Function<void(HistoryTraversalOutcome)> on_cancelation_check_complete)
 {
-    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta
-    // Let allSteps be the result of getting all used history steps for traversable.
-    // Let currentStepIndex be the index of traversable's current session history step within allSteps.
-    // Let targetStepIndex be currentStepIndex plus delta.
-    //
-    // AD-HOC: Browser UI calls do not pass sourceDocument. Since the UI process owns the top-level session history
-    //         mirror, it resolves targetStepIndex before asking WebContent to apply or precheck the resulting
-    //         traverse history step.
-    auto target = m_session_history.traversal_target_for_delta(delta);
-    if (!target.has_value()) {
+    auto decision = m_top_level_traversable.traverse_the_history_by_delta(delta, check_for_cancelation, m_url, move(on_cancelation_check_complete));
+    if (decision.outcome.status == HistoryTraversalStatus::NoEntry) {
         dump_session_history("traverse-no-entry"sv);
-        return { .status = HistoryTraversalStatus::NoEntry };
+        return decision.outcome;
     }
 
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
 
-    auto will_replace_web_content_process = !is_url_suitable_for_same_process_navigation(m_url, target->target_top_level_entry->url);
-    auto pending_traversal = PendingSessionHistoryTraversal {
-        .target_step = target->target_step,
-        .target_step_index = target->target_step_index,
-        .will_change_top_level_entry = target->changes_top_level_entry,
-        .will_replace_web_content_process = will_replace_web_content_process,
-        .on_cancelation_check_complete = nullptr,
-    };
+    if (decision.webdriver_pending_navigation_url.has_value()) {
+        m_webdriver_pending_navigation_url = *decision.webdriver_pending_navigation_url;
+        m_webdriver_pending_navigation_completes_with_session_history_update = decision.webdriver_pending_navigation_completes_with_session_history_update;
+    }
 
-    auto web_content_can_apply_traversal = !m_pending_web_content_session_history_seed.should_send_entries
-        && !m_pending_web_content_session_history_seed.ignore_updates_until_seed
-        && !m_pending_web_content_session_history_seed.waiting_for_ack
-        && !m_session_history_entry_url_loading_from_ui_process.has_value()
-        && !m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()
-        && m_session_history.web_content_can_traverse_to(*target);
-
-    // If WebContent already has enough state to apply the traverse history step,
-    // let it run the spec algorithm directly.
-    if (web_content_can_apply_traversal && !will_replace_web_content_process) {
-        m_pending_session_history_traversal = move(pending_traversal);
-        m_webdriver_pending_navigation_url = target->target_top_level_entry->url;
-        if (auto const* current_entry = m_session_history.current_entry()) {
-            m_webdriver_pending_navigation_completes_with_session_history_update = current_entry->document_state.id != 0
-                && current_entry->document_state.id == target->target_top_level_entry->document_state.id;
-        } else {
-            m_webdriver_pending_navigation_completes_with_session_history_update = false;
-        }
+    switch (decision.action) {
+    case HistoryTraversalAction::None:
+        return decision.outcome;
+    case HistoryTraversalAction::TraverseInWebContent:
         dump_session_history("traverse-delegate-to-webcontent"sv);
-        client().async_traverse_the_history_to_step(page_id(), target->target_step);
-        return {
-            .status = HistoryTraversalStatus::Started,
-            .will_replace_web_content_process = will_replace_web_content_process,
-            .will_change_top_level_entry = target->changes_top_level_entry,
-        };
-    }
-
-    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
-    // If checkForCancelation is true, and the result of checking if unloading is canceled given
-    // navigablesCrossingDocuments, traversable, targetStep, and userInvolvement is not "continue", then return that
-    // result.
-    //
-    // AD-HOC: If WebContent cannot apply the step itself, the UI still asks it to run that precheck before moving
-    //         the UI-owned history mirror and loading or reseeding WebContent from that state. A renderer-initiated
-    //         traversal can report that this already happened, but only trust that precheck if WebContent can
-    //         traverse to the same target step in the UI-owned history mirror.
-    auto needs_cancelation_check = check_for_cancelation == CheckForCancelation::Yes
-        || (check_for_cancelation == CheckForCancelation::IfWebContentCannotTraverseTarget && !web_content_can_apply_traversal);
-    if (needs_cancelation_check) {
-        pending_traversal.stage = PendingSessionHistoryTraversal::Stage::CheckingCancelation;
-        pending_traversal.cancelation_check_request_id = m_next_traverse_history_step_cancelation_check_request_id++;
-        pending_traversal.on_cancelation_check_complete = move(on_cancelation_check_complete);
-        auto request_id = pending_traversal.cancelation_check_request_id;
-        m_pending_session_history_traversal = move(pending_traversal);
-        client().async_check_if_traverse_history_step_is_canceled(page_id(), request_id, target->target_step);
+        client().async_traverse_the_history_to_step(page_id(), *decision.target_step);
+        return decision.outcome;
+    case HistoryTraversalAction::CheckForCancelation:
+        client().async_check_if_traverse_history_step_is_canceled(page_id(), *decision.cancelation_check_request_id, *decision.target_step);
         dump_session_history("traverse-fallback-check-cancelation"sv);
-        return {
-            .status = HistoryTraversalStatus::Started,
-            .will_replace_web_content_process = will_replace_web_content_process,
-            .will_change_top_level_entry = target->changes_top_level_entry,
-            .waiting_for_cancelation_check = true,
-        };
+        return decision.outcome;
+    case HistoryTraversalAction::LoadCurrentEntryFromUIProcess:
+        update_navigation_action_state();
+        set_url(*decision.webdriver_pending_navigation_url);
+        dump_session_history("traverse-fallback-load"sv);
+        load_current_session_history_entry_from_ui_process();
+        return decision.outcome;
     }
-
-    pending_traversal.stage = PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess;
-    m_pending_session_history_traversal = move(pending_traversal);
-    load_session_history_traversal_target_from_ui_process(*target, "traverse-fallback-load"sv);
-    return {
-        .status = HistoryTraversalStatus::Started,
-        .will_replace_web_content_process = will_replace_web_content_process,
-        .will_change_top_level_entry = target->changes_top_level_entry,
-    };
+    VERIFY_NOT_REACHED();
 }
 
 Vector<ViewImplementation::SessionHistoryTraversalMenuItem> ViewImplementation::session_history_traversal_menu_items(int direction) const
 {
     VERIFY(direction == -1 || direction == 1);
 
-    auto current_used_step_index = m_session_history.current_used_step_index();
+    auto current_used_step_index = m_top_level_traversable.session_history().current_used_step_index();
     if (!current_used_step_index.has_value())
         return {};
 
@@ -494,20 +351,20 @@ Vector<ViewImplementation::SessionHistoryTraversalMenuItem> ViewImplementation::
 
     if (direction < 0) {
         for (size_t target_step_index = *current_used_step_index; target_step_index > 0; --target_step_index) {
-            auto target_step = m_session_history.step_at(target_step_index - 1);
+            auto target_step = m_top_level_traversable.session_history().step_at(target_step_index - 1);
             if (!target_step.has_value())
                 continue;
-            auto const* target_entry = m_session_history.top_level_entry_for_step(*target_step);
+            auto const* target_entry = m_top_level_traversable.session_history().top_level_entry_for_step(*target_step);
             if (!target_entry)
                 continue;
             append_item(target_step_index - 1, *target_entry);
         }
     } else {
-        for (size_t target_step_index = *current_used_step_index + 1; target_step_index < m_session_history.used_step_count(); ++target_step_index) {
-            auto target_step = m_session_history.step_at(target_step_index);
+        for (size_t target_step_index = *current_used_step_index + 1; target_step_index < m_top_level_traversable.session_history().used_step_count(); ++target_step_index) {
+            auto target_step = m_top_level_traversable.session_history().step_at(target_step_index);
             if (!target_step.has_value())
                 continue;
-            auto const* target_entry = m_session_history.top_level_entry_for_step(*target_step);
+            auto const* target_entry = m_top_level_traversable.session_history().top_level_entry_for_step(*target_step);
             if (!target_entry)
                 continue;
             append_item(target_step_index, *target_entry);
@@ -1280,62 +1137,24 @@ void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, We
 
 static Optional<size_t> current_top_level_history_entry_index_for_step(Vector<Web::HTML::SessionHistoryEntryDescriptor> const&, Optional<i32> current_step);
 
-TraversableSessionHistory::UpdateResult ViewImplementation::update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot)
+void ViewImplementation::apply_web_content_session_history_update(WebContentSessionHistoryUpdateResult const& update)
 {
-    auto update_result = m_session_history.update_from_web_content(move(entries), move(used_steps), current_used_step_index);
-    m_current_web_content_session_history_matches_mirror = update_result == TraversableSessionHistory::UpdateResult::CompleteSnapshot
-        && m_session_history.web_content_history_matches_mirror();
-    if (update_result != TraversableSessionHistory::UpdateResult::InvalidSnapshot) {
-        // NB: A complete WebContent snapshot means the UI-owned navigation settled, including redirected navigations
-        //     whose final URL differs from the original pending navigation URL. A partial snapshot only updates the UI
-        //     mirror with the current WebContent-visible subset.
-        if (update_result == TraversableSessionHistory::UpdateResult::CompleteSnapshot)
-            m_pending_session_history_navigation.clear();
-        if (auto* current_entry = m_session_history.current_entry()) {
-            auto current_url = current_entry->url;
-            auto const url_changed = m_url != current_url;
-            set_url(current_url);
-            if (url_changed && on_url_change)
-                on_url_change(m_url);
-            if (m_webdriver_pending_navigation_url.has_value() && *m_webdriver_pending_navigation_url != current_url)
-                m_webdriver_pending_navigation_url = current_url;
-            if (m_webdriver_pending_navigation_completes_with_session_history_update)
-                complete_webdriver_pending_navigation_if_url_matches(m_url);
-        }
-        if (pending_step_after_fallback_load_was_restored)
-            m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.clear();
-    } else if (seed_web_content_on_invalid_snapshot) {
-        if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == m_url) {
-            prepare_to_seed_web_content_session_history_from_ui_process();
-            seed_web_content_session_history_from_ui_process();
-        }
+    if (update.current_url.has_value()) {
+        auto current_url = *update.current_url;
+        auto const url_changed = m_url != current_url;
+        set_url(current_url);
+        if (url_changed && on_url_change)
+            on_url_change(m_url);
+        if (m_webdriver_pending_navigation_url.has_value() && *m_webdriver_pending_navigation_url != current_url)
+            m_webdriver_pending_navigation_url = current_url;
+        if (m_webdriver_pending_navigation_completes_with_session_history_update)
+            complete_webdriver_pending_navigation_if_url_matches(m_url);
     }
+
+    if (update.should_seed_web_content)
+        seed_web_content_session_history_from_ui_process();
 
     update_navigation_action_state();
-    return update_result;
-}
-
-bool ViewImplementation::adopt_web_content_session_history_after_rejected_seed(Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)
-{
-    if (entries.is_empty())
-        return false;
-
-    auto entries_from_web_content = entries;
-    auto used_steps_from_web_content = used_steps;
-    auto update_result = update_session_history_from_web_content(move(entries), move(used_steps), current_used_step_index, false, false);
-    if (update_result == TraversableSessionHistory::UpdateResult::InvalidSnapshot && current_used_step_index < used_steps_from_web_content.size()) {
-        auto current_top_level_entry_index = current_top_level_history_entry_index_for_step(entries_from_web_content, used_steps_from_web_content[current_used_step_index]);
-        if (current_top_level_entry_index.has_value() && entries_from_web_content[*current_top_level_entry_index].url == m_url) {
-            m_session_history.clear();
-            update_result = update_session_history_from_web_content(move(entries_from_web_content), move(used_steps_from_web_content), current_used_step_index, false, false);
-        }
-    }
-    if (update_result == TraversableSessionHistory::UpdateResult::InvalidSnapshot)
-        return false;
-
-    m_pending_web_content_session_history_seed.clear();
-    m_pending_session_history_traversal.clear();
-    return true;
 }
 
 void ViewImplementation::did_update_session_history(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)
@@ -1348,43 +1167,24 @@ void ViewImplementation::did_update_session_history(Badge<WebContentClient>, Vec
             history_log_entries(entries),
             history_log_steps(used_steps, current_used_step_index));
     }
-    if (m_pending_web_content_session_history_seed.waiting_for_ack) {
-        dump_session_history("ignored-session-history-before-ui-seed-ack"sv);
+    auto update = m_top_level_traversable.did_receive_web_content_session_history_update(move(entries), move(used_steps), current_used_step_index, m_url);
+    if (update.ignore_reason.has_value()) {
+        dump_session_history(*update.ignore_reason);
         update_navigation_action_state();
         return;
     }
-    auto pending_step_after_fallback_load_was_restored = false;
-    if (m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()) {
-        if (current_used_step_index >= used_steps.size() || used_steps[current_used_step_index] != *m_pending_web_content_session_history_seed.step_after_loading_top_level_entry) {
-            dump_session_history("ignored-partial-session-history-before-fallback-seed"sv);
-            update_navigation_action_state();
-            return;
-        }
-        pending_step_after_fallback_load_was_restored = true;
-    }
-    if (m_pending_web_content_session_history_seed.ignore_updates_until_seed) {
-        dump_session_history("ignored-session-history-before-ui-seed"sv);
-        update_navigation_action_state();
-        return;
-    }
-    update_session_history_from_web_content(move(entries), move(used_steps), current_used_step_index, pending_step_after_fallback_load_was_restored, true);
+    apply_web_content_session_history_update(update.update);
     dump_session_history("did-update-session-history"sv);
 }
 
 void ViewImplementation::did_update_session_history_for_testing(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index)
 {
-    // NB: dumpUIProcessSessionHistory() first sends WebContent's current snapshot to the UI process, then returns
-    //     the UI mirror. If a stale seed ack is still pending, normal async snapshots are intentionally ignored, so
-    //     use the same convergence path as a rejected seed ack to make this testing hook deterministic.
-    if (m_pending_web_content_session_history_seed.waiting_for_ack) {
-        if (adopt_web_content_session_history_after_rejected_seed(move(entries), move(used_steps), current_used_step_index))
-            dump_session_history("did-update-session-history-for-testing-after-rejected-seed"sv);
-        else
-            dump_session_history("ignored-session-history-for-testing-before-ui-seed-ack"sv);
+    auto update = m_top_level_traversable.did_receive_web_content_session_history_update_for_testing(move(entries), move(used_steps), current_used_step_index, m_url);
+    if (update.ignore_reason.has_value()) {
+        dump_session_history(*update.ignore_reason);
         return;
     }
-
-    update_session_history_from_web_content(move(entries), move(used_steps), current_used_step_index, false, true);
+    apply_web_content_session_history_update(update.update);
     dump_session_history("did-update-session-history-for-testing"sv);
 }
 
@@ -1493,7 +1293,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     client().async_set_zoom_level(m_client_state.page_index, m_zoom_level);
     client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
     client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
-    client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
+    client().async_set_system_visibility_state(m_client_state.page_index, m_top_level_traversable.system_visibility_state());
     auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
     Application::the().update_compositor_viewport(compositor_context_id, viewport_size().to_type<int>());
     client().async_set_document_cookie_version_buffer(m_client_state.page_index, m_document_cookie_version_buffer);
@@ -1519,117 +1319,38 @@ void ViewImplementation::did_start_navigation(URL::URL const& url, Variant<Empty
     if (m_should_suppress_history_for_next_load || m_should_suppress_history_for_current_load)
         return;
 
-    if (m_session_history_entry_url_loading_from_ui_process.has_value()) {
-        if (*m_session_history_entry_url_loading_from_ui_process != url) {
-            // NB: An earlier UI-process history fallback load can start after a newer back/forward request has
-            //     superseded it. Chromium, WebKit, and Firefox all give pending history loads an identity so stale
-            //     traversals cannot consume state belonging to the current one. Keep the UI-owned history authoritative
-            //     here and wait for the load matching the latest requested entry.
-            dump_session_history("ignored-stale-ui-history-load-start"sv);
-            return;
-        }
-
-        auto should_keep_preseeded_web_content_history = m_pending_web_content_session_history_seed.waiting_for_ack || m_session_history.web_content_uses_ui_step_coordinates();
-        m_session_history_entry_url_loading_from_ui_process.clear();
-        if (!should_keep_preseeded_web_content_history) {
-            m_current_web_content_session_history_matches_mirror = false;
-            m_session_history.forget_web_content_state();
-        }
-        dump_session_history("did-start-navigation-from-ui-history-load"sv);
-        return;
-    }
-
-    if (m_pending_web_content_session_history_seed.should_send_entries || m_pending_web_content_session_history_seed.ignore_updates_until_seed || m_pending_web_content_session_history_seed.waiting_for_ack) {
-        if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url != url) {
-            dump_session_history("ignored-navigation-start-before-ui-history-seed"sv);
-            return;
-        }
-    }
-
-    if (m_is_showing_crash_page) {
+    auto result = m_top_level_traversable.did_start_navigation(url, move(document_resource), is_redirect, history_handling, m_is_showing_crash_page);
+    if (result.did_clear_crash_page)
         m_is_showing_crash_page = false;
-        if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url) {
-            prepare_to_seed_web_content_session_history_from_ui_process();
-            dump_session_history("did-start-navigation-from-crash-page"sv);
-            return;
-        }
-    }
-
-    if (is_redirect) {
-        m_session_history.replace_current_entry_url(url);
-        if (m_pending_session_history_navigation.has_value())
-            m_pending_session_history_navigation->url = url;
-        if (m_webdriver_pending_navigation_url.has_value())
-            m_webdriver_pending_navigation_url = url;
-        m_current_web_content_session_history_matches_mirror = false;
+    if (result.should_update_webdriver_pending_navigation_url && m_webdriver_pending_navigation_url.has_value())
+        m_webdriver_pending_navigation_url = url;
+    if (result.should_update_navigation_action_state)
         update_navigation_action_state();
-        dump_session_history("did-start-navigation-redirect"sv);
-        return;
-    }
-
-    if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url) {
-        if (m_pending_session_history_navigation.has_value() && m_pending_session_history_navigation->url == url)
-            return;
-
-        if (history_handling == Web::Bindings::NavigationHistoryBehavior::Push && m_current_web_content_session_history_matches_mirror)
-            m_pending_session_history_navigation = PendingSessionHistoryNavigation { url, m_session_history };
-        else
-            m_pending_session_history_navigation.clear();
-
-        if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace) {
-            m_session_history.replace_current_entry(url, move(document_resource));
-            m_current_web_content_session_history_matches_mirror = false;
-            update_navigation_action_state();
-            dump_session_history("did-start-navigation-replace-current-url"sv);
-        } else if (history_handling == Web::Bindings::NavigationHistoryBehavior::Push) {
-            m_session_history.navigate(url, move(document_resource));
-            m_current_web_content_session_history_matches_mirror = false;
-            update_navigation_action_state();
-            dump_session_history("did-start-navigation-push-current-url"sv);
-        }
-        return;
-    }
-
-    if (m_session_history.current_entry())
-        m_pending_session_history_navigation = PendingSessionHistoryNavigation { url, m_session_history };
-    else
-        m_pending_session_history_navigation.clear();
-    if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
-        m_session_history.replace_current_entry(url, move(document_resource));
-    else
-        m_session_history.navigate(url, move(document_resource));
-    m_current_web_content_session_history_matches_mirror = false;
-    update_navigation_action_state();
-    dump_session_history("did-start-navigation"sv);
+    if (result.dump_reason.has_value())
+        dump_session_history(*result.dump_reason);
 }
 
 bool ViewImplementation::did_cancel_navigation(URL::URL const& url)
 {
-    if (m_pending_session_history_navigation.has_value() && m_pending_session_history_navigation->url == url) {
+    auto result = m_top_level_traversable.did_cancel_navigation(url, m_webdriver_pending_navigation_url.has_value());
+    switch (result.status) {
+    case NavigationCancelStatus::RestorePendingSessionHistoryNavigation:
         restore_pending_session_history_navigation("did-cancel-navigation"sv);
         return true;
-    }
-
-    if (m_session_history_entry_url_loading_from_ui_process.has_value() && *m_session_history_entry_url_loading_from_ui_process == url) {
-        m_session_history_entry_url_loading_from_ui_process.clear();
-        abandon_pending_web_content_session_history_seed();
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
+    case NavigationCancelStatus::CanceledUIHistoryLoad:
         update_navigation_action_state();
         dump_session_history("did-cancel-ui-history-load"sv);
         return true;
-    }
-
-    if (m_webdriver_pending_navigation_url.has_value()) {
-        m_session_history.clear_current_entry_reload_pending();
+    case NavigationCancelStatus::CompleteWebdriverPendingNavigation:
         m_webdriver_pending_navigation_url = m_url;
         m_webdriver_pending_navigation_completes_with_session_history_update = false;
         complete_webdriver_pending_navigation_if_url_matches(m_url);
         return true;
+    case NavigationCancelStatus::Ignored:
+        dump_session_history("did-cancel-navigation-ignored"sv);
+        return false;
     }
-
-    dump_session_history("did-cancel-navigation-ignored"sv);
-    return false;
+    VERIFY_NOT_REACHED();
 }
 
 void ViewImplementation::did_finish_navigation(URL::URL const& url)
@@ -1637,99 +1358,43 @@ void ViewImplementation::did_finish_navigation(URL::URL const& url)
     if (m_webdriver_pending_navigation_url.has_value() && *m_webdriver_pending_navigation_url == url && !m_webdriver_pending_navigation_completes_with_session_history_update)
         complete_webdriver_pending_navigation_if_url_matches(url);
 
-    if (m_pending_session_history_navigation.has_value() && m_pending_session_history_navigation->url == url)
-        m_pending_session_history_navigation.clear();
-
-    if (m_pending_web_content_session_history_seed.should_send_entries) {
-        if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url) {
-            m_session_history.clear_current_entry_reload_pending();
-            auto allow_current_entry_reconstruction = m_pending_web_content_session_history_seed.should_reseed_after_current_history_load
-                ? AllowCurrentEntryReconstruction::Yes
-                : AllowCurrentEntryReconstruction::No;
-            m_pending_web_content_session_history_seed.should_reseed_after_current_history_load = false;
-            seed_web_content_session_history_from_ui_process(allow_current_entry_reconstruction);
-        } else {
-            // NB: The first finish notification from a fresh WebContent process can still report about:blank before the
-            //     traversed-to entry is ready. Keep the pending seed state intact so partial snapshots remain ignored
-            //     until we can seed the full UI-owned history.
-            dump_session_history("skip-seed-webcontent-session-history"sv);
-        }
-    }
+    auto result = m_top_level_traversable.did_finish_navigation(url);
+    if (result.should_seed_web_content)
+        seed_web_content_session_history_from_ui_process(result.allow_current_entry_reconstruction ? AllowCurrentEntryReconstruction::Yes : AllowCurrentEntryReconstruction::No);
+    else if (result.dump_reason.has_value())
+        dump_session_history(*result.dump_reason);
 }
 
 bool ViewImplementation::restore_pending_session_history_navigation(StringView reason)
 {
-    if (!m_pending_session_history_navigation.has_value())
+    auto result = m_top_level_traversable.restore_pending_session_history_navigation();
+    if (!result.restored)
         return false;
 
-    auto web_content_restore_mode = m_pending_session_history_navigation->web_content_restore_mode;
-    m_session_history = move(m_pending_session_history_navigation->previous_session_history);
-    m_pending_session_history_navigation.clear();
-    m_pending_session_history_traversal.clear();
-
-    if (auto* current_entry = m_session_history.current_entry()) {
-        auto current_url = current_entry->url;
+    if (result.current_url.has_value()) {
+        auto current_url = *result.current_url;
         auto const url_changed = m_url != current_url;
         set_url(current_url);
         if (url_changed && on_url_change)
             on_url_change(m_url);
 
-        if (web_content_restore_mode == PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess) {
-            prepare_to_seed_web_content_session_history_from_ui_process();
+        if (result.web_content_restore_mode == PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess) {
+            m_top_level_traversable.prepare_to_seed_web_content_session_history_from_ui_process();
             m_should_suppress_history_for_current_load = false;
             m_should_suppress_history_for_next_load = false;
             m_webdriver_pending_navigation_url = current_url;
             m_webdriver_pending_navigation_completes_with_session_history_update = true;
             load_current_session_history_entry_from_ui_process();
         } else {
-            m_session_history_entry_url_loading_from_ui_process.clear();
-            abandon_pending_web_content_session_history_seed();
-            m_current_web_content_session_history_matches_mirror = m_session_history.web_content_history_matches_mirror();
             m_webdriver_pending_navigation_url.clear();
             m_webdriver_pending_navigation_completes_with_session_history_update = false;
             complete_webdriver_pending_navigation_if_url_matches(current_url);
         }
-    } else {
-        m_current_web_content_session_history_matches_mirror = false;
     }
 
     update_navigation_action_state();
     dump_session_history(reason);
     return true;
-}
-
-void ViewImplementation::abandon_pending_web_content_session_history_seed()
-{
-    m_session_history_entry_url_loading_from_ui_process.clear();
-    m_pending_web_content_session_history_seed.clear();
-}
-
-StringView ViewImplementation::pending_session_history_navigation_web_content_restore_mode_to_string(PendingSessionHistoryNavigation::WebContentRestoreMode mode)
-{
-    switch (mode) {
-    case PendingSessionHistoryNavigation::WebContentRestoreMode::PreserveCurrentProcessState:
-        return "preserve-current-process-state"sv;
-    case PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess:
-        return "restore-from-ui-process"sv;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-StringView ViewImplementation::pending_session_history_traversal_stage_to_string(PendingSessionHistoryTraversal::Stage stage)
-{
-    switch (stage) {
-    case PendingSessionHistoryTraversal::Stage::ApplyingInWebContent:
-        return "applying-in-webcontent"sv;
-    case PendingSessionHistoryTraversal::Stage::CheckingCancelation:
-        return "checking-cancelation"sv;
-    case PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess:
-        return "loading-entry-from-ui-process"sv;
-    case PendingSessionHistoryTraversal::Stage::ReplacingWebContentProcess:
-        return "replacing-webcontent-process"sv;
-    case PendingSessionHistoryTraversal::Stage::RestoringNestedStepAfterSeed:
-        return "restoring-nested-step-after-seed"sv;
-    }
-    VERIFY_NOT_REACHED();
 }
 
 static Optional<size_t> current_top_level_history_entry_index_for_step(Vector<Web::HTML::SessionHistoryEntryDescriptor> const& entries, Optional<i32> current_step)
@@ -1826,17 +1491,17 @@ JsonValue ViewImplementation::webdriver_session_history() const
     serialized.set("webContentProcessID"sv, client().pid());
     serialized.set("backButtonEnabled"sv, m_navigate_back_action->enabled());
     serialized.set("forwardButtonEnabled"sv, m_navigate_forward_action->enabled());
-    serialized.set("webContentHistoryMatchesUI"sv, m_current_web_content_session_history_matches_mirror);
-    serialized.set("loadingSessionHistoryEntryFromUI"sv, m_session_history_entry_url_loading_from_ui_process.has_value());
-    serialized.set("waitingToSeedWebContent"sv, m_pending_web_content_session_history_seed.should_send_entries);
-    serialized.set("waitingForWebContentSeedAck"sv, m_pending_web_content_session_history_seed.waiting_for_ack);
-    serialized.set("ignoringWebContentUpdatesUntilSeed"sv, m_pending_web_content_session_history_seed.ignore_updates_until_seed);
-    serialized.set("reseedAfterCurrentHistoryLoad"sv, m_pending_web_content_session_history_seed.should_reseed_after_current_history_load);
-    serialized.set("hasOnlyTopLevelUsedSteps"sv, m_session_history.has_only_top_level_used_steps());
-    serialized.set("webContentUsesUIStepCoordinates"sv, m_session_history.web_content_uses_ui_step_coordinates());
-    auto web_content_known_entries = m_session_history.web_content_known_entries();
-    auto web_content_known_used_steps = m_session_history.web_content_known_used_steps();
-    auto web_content_current_step = m_session_history.web_content_current_step();
+    serialized.set("webContentHistoryMatchesUI"sv, m_top_level_traversable.current_web_content_session_history_matches_mirror());
+    serialized.set("loadingSessionHistoryEntryFromUI"sv, m_top_level_traversable.session_history_entry_url_loading_from_ui_process().has_value());
+    serialized.set("waitingToSeedWebContent"sv, m_top_level_traversable.pending_web_content_session_history_seed().should_send_entries);
+    serialized.set("waitingForWebContentSeedAck"sv, m_top_level_traversable.pending_web_content_session_history_seed().waiting_for_ack);
+    serialized.set("ignoringWebContentUpdatesUntilSeed"sv, m_top_level_traversable.pending_web_content_session_history_seed().ignore_updates_until_seed);
+    serialized.set("reseedAfterCurrentHistoryLoad"sv, m_top_level_traversable.pending_web_content_session_history_seed().should_reseed_after_current_history_load);
+    serialized.set("hasOnlyTopLevelUsedSteps"sv, m_top_level_traversable.session_history().has_only_top_level_used_steps());
+    serialized.set("webContentUsesUIStepCoordinates"sv, m_top_level_traversable.session_history().web_content_uses_ui_step_coordinates());
+    auto web_content_known_entries = m_top_level_traversable.session_history().web_content_known_entries();
+    auto web_content_known_used_steps = m_top_level_traversable.session_history().web_content_known_used_steps();
+    auto web_content_current_step = m_top_level_traversable.session_history().web_content_current_step();
     Optional<size_t> web_content_current_step_index;
     if (web_content_current_step.has_value())
         web_content_current_step_index = web_content_known_used_steps.find_first_index(*web_content_current_step);
@@ -1847,21 +1512,21 @@ JsonValue ViewImplementation::webdriver_session_history() const
     else
         serialized.set("webContentCurrentStep"sv, JsonValue {});
 
-    if (auto current_used_step_index = m_session_history.current_used_step_index(); current_used_step_index.has_value())
+    if (auto current_used_step_index = m_top_level_traversable.session_history().current_used_step_index(); current_used_step_index.has_value())
         serialized.set("currentUsedStepIndex"sv, *current_used_step_index);
     else
         serialized.set("currentUsedStepIndex"sv, JsonValue {});
 
-    if (auto pending_step = m_pending_web_content_session_history_seed.step_after_loading_top_level_entry; pending_step.has_value())
+    if (auto pending_step = m_top_level_traversable.pending_web_content_session_history_seed().step_after_loading_top_level_entry; pending_step.has_value())
         serialized.set("pendingWebContentHistoryStepAfterFallbackLoad"sv, *pending_step);
     else
         serialized.set("pendingWebContentHistoryStepAfterFallbackLoad"sv, JsonValue {});
 
-    if (m_pending_session_history_navigation.has_value()) {
+    if (m_top_level_traversable.pending_session_history_navigation().has_value()) {
         JsonObject pending_navigation;
-        pending_navigation.set("url"sv, m_pending_session_history_navigation->url.serialize());
-        pending_navigation.set("webContentRestoreMode"sv, pending_session_history_navigation_web_content_restore_mode_to_string(m_pending_session_history_navigation->web_content_restore_mode));
-        if (auto const* previous_current_entry = m_pending_session_history_navigation->previous_session_history.current_entry())
+        pending_navigation.set("url"sv, m_top_level_traversable.pending_session_history_navigation()->url.serialize());
+        pending_navigation.set("webContentRestoreMode"sv, CanonicalTraversable::pending_session_history_navigation_web_content_restore_mode_to_string(m_top_level_traversable.pending_session_history_navigation()->web_content_restore_mode));
+        if (auto const* previous_current_entry = m_top_level_traversable.pending_session_history_navigation()->previous_session_history.current_entry())
             pending_navigation.set("previousCurrentURL"sv, previous_current_entry->url.serialize());
         else
             pending_navigation.set("previousCurrentURL"sv, JsonValue {});
@@ -1870,20 +1535,20 @@ JsonValue ViewImplementation::webdriver_session_history() const
         serialized.set("pendingSessionHistoryNavigation"sv, JsonValue {});
     }
 
-    if (m_pending_session_history_traversal.has_value()) {
+    if (m_top_level_traversable.pending_session_history_traversal().has_value()) {
         JsonObject pending_traversal;
-        pending_traversal.set("targetStep"sv, m_pending_session_history_traversal->target_step);
-        pending_traversal.set("targetStepIndex"sv, m_pending_session_history_traversal->target_step_index);
-        pending_traversal.set("willChangeTopLevelEntry"sv, m_pending_session_history_traversal->will_change_top_level_entry);
-        pending_traversal.set("willReplaceWebContentProcess"sv, m_pending_session_history_traversal->will_replace_web_content_process);
-        pending_traversal.set("stage"sv, pending_session_history_traversal_stage_to_string(m_pending_session_history_traversal->stage));
+        pending_traversal.set("targetStep"sv, m_top_level_traversable.pending_session_history_traversal()->target_step);
+        pending_traversal.set("targetStepIndex"sv, m_top_level_traversable.pending_session_history_traversal()->target_step_index);
+        pending_traversal.set("willChangeTopLevelEntry"sv, m_top_level_traversable.pending_session_history_traversal()->will_change_top_level_entry);
+        pending_traversal.set("willReplaceWebContentProcess"sv, m_top_level_traversable.pending_session_history_traversal()->will_replace_web_content_process);
+        pending_traversal.set("stage"sv, CanonicalTraversable::pending_session_history_traversal_stage_to_string(m_top_level_traversable.pending_session_history_traversal()->stage));
         serialized.set("pendingSessionHistoryTraversal"sv, move(pending_traversal));
     } else {
         serialized.set("pendingSessionHistoryTraversal"sv, JsonValue {});
     }
 
-    serialized.set("entries"sv, history_json_entries(m_session_history));
-    serialized.set("usedSteps"sv, history_json_steps(m_session_history));
+    serialized.set("entries"sv, history_json_entries(m_top_level_traversable.session_history()));
+    serialized.set("usedSteps"sv, history_json_steps(m_top_level_traversable.session_history()));
     return serialized;
 }
 
@@ -1894,29 +1559,16 @@ String ViewImplementation::ui_process_session_history_for_testing(Badge<WebConte
 
 void ViewImplementation::update_navigation_action_state()
 {
-    m_navigate_back_action->set_enabled(m_session_history.can_go_back());
-    m_navigate_forward_action->set_enabled(m_session_history.can_go_forward());
+    m_navigate_back_action->set_enabled(m_top_level_traversable.session_history().can_go_back());
+    m_navigate_forward_action->set_enabled(m_top_level_traversable.session_history().can_go_forward());
 }
 
 void ViewImplementation::seed_web_content_session_history_from_ui_process(AllowCurrentEntryReconstruction allow_current_entry_reconstruction)
 {
-    auto current_top_level_entry_index = m_session_history.current_top_level_entry_index();
-    if (!current_top_level_entry_index.has_value()) {
-        abandon_pending_web_content_session_history_seed();
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
+    auto seed = m_top_level_traversable.prepare_web_content_session_history_seed(allow_current_entry_reconstruction == AllowCurrentEntryReconstruction::Yes);
+    if (!seed.has_value()) {
         update_navigation_action_state();
-        dump_session_history("skip-webcontent-session-history-seed-without-current-entry"sv);
-        return;
-    }
-
-    auto entries = m_session_history.entries();
-    if (entries.is_empty()) {
-        abandon_pending_web_content_session_history_seed();
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
-        update_navigation_action_state();
-        dump_session_history("skip-webcontent-session-history-seed-without-entries"sv);
+        dump_session_history("skip-webcontent-session-history-seed"sv);
         return;
     }
 
@@ -1924,104 +1576,45 @@ void ViewImplementation::seed_web_content_session_history_from_ui_process(AllowC
         dbgln("[History] UI seeds WebContent session history page={} pid={} current={} entries={}",
             page_id(),
             client().pid(),
-            *current_top_level_entry_index,
-            history_log_entries(entries, current_top_level_entry_index));
+            seed->current_top_level_entry_index,
+            history_log_entries(seed->entries, seed->current_top_level_entry_index));
     }
 
-    // NB: A fallback traversal or crash recovery can restore the current top-level document before WebContent has the
-    //     UI-owned session history that surrounds it. Allow WebContent to reconstruct that current entry only while the
-    //     UI process is actively restoring that authoritative history, including the follow-up child navigable step for
-    //     nested history. After crash recovery there might not be a pending traversal object anymore, but a pending
-    //     nested step still means the top-level document is only a staging point for restoring the current history
-    //     step.
-    auto is_restoring_traversal_target = m_pending_session_history_traversal.has_value()
-        && (m_pending_session_history_traversal->stage == PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess
-            || m_pending_session_history_traversal->stage == PendingSessionHistoryTraversal::Stage::ReplacingWebContentProcess
-            || m_pending_session_history_traversal->stage == PendingSessionHistoryTraversal::Stage::RestoringNestedStepAfterSeed);
-    auto allow_reconstructing_current_entry = is_restoring_traversal_target
-        || m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()
-        || allow_current_entry_reconstruction == AllowCurrentEntryReconstruction::Yes;
-    client().async_set_top_level_session_history(page_id(), move(entries), *current_top_level_entry_index, allow_reconstructing_current_entry);
-    m_pending_web_content_session_history_seed.waiting_for_ack = true;
-    m_pending_web_content_session_history_seed.should_send_entries = false;
+    client().async_set_top_level_session_history(page_id(), move(seed->entries), seed->current_top_level_entry_index, seed->allow_current_entry_reconstruction);
+    m_top_level_traversable.did_send_web_content_session_history_seed();
     update_navigation_action_state();
     dump_session_history("sent-webcontent-session-history-seed"sv);
-}
-
-void ViewImplementation::prepare_to_seed_web_content_session_history_from_ui_process()
-{
-    m_current_web_content_session_history_matches_mirror = false;
-    m_session_history.forget_web_content_state();
-    m_pending_session_history_navigation.clear();
-    m_pending_web_content_session_history_seed.clear();
-    // NB: A fresh or repaired WebContent process reaches the current top-level session history entry after loading or
-    //     reseeding m_url. If the traversable's current session history step is nested, finish restoration by
-    //     traversing to that step after seeding the top-level entries.
-    m_pending_web_content_session_history_seed.step_after_loading_top_level_entry = m_session_history.current_step_to_restore_after_loading_top_level_entry();
-    m_pending_web_content_session_history_seed.should_send_entries = true;
-    m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
 }
 
 void ViewImplementation::restore_current_session_history_entry_from_ui_process()
 {
     m_webdriver_pending_navigation_url = m_url;
-    if (!m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()) {
-        m_pending_web_content_session_history_seed.should_reseed_after_current_history_load = true;
+    auto should_seed = m_top_level_traversable.prepare_to_restore_current_session_history_entry_from_ui_process();
+    if (should_seed)
         seed_web_content_session_history_from_ui_process();
-    }
     load_current_session_history_entry_from_ui_process();
 }
 
 void ViewImplementation::load_current_session_history_entry_from_ui_process()
 {
-    auto const* current_entry = m_session_history.current_entry();
-    if (!current_entry) {
-        m_session_history_entry_url_loading_from_ui_process = m_url;
-        client().async_load_url(page_id(), m_url, Web::Bindings::NavigationHistoryBehavior::Auto);
-        return;
-    }
-
-    m_session_history_entry_url_loading_from_ui_process = current_entry->url;
-    auto history_handling = m_pending_web_content_session_history_seed.waiting_for_ack || m_session_history.web_content_uses_ui_step_coordinates()
-        ? Web::Bindings::NavigationHistoryBehavior::Replace
-        : Web::Bindings::NavigationHistoryBehavior::Auto;
-    client().async_load_url_with_document_resource(
-        page_id(),
-        current_entry->url,
-        current_entry->document_state.resource,
-        history_handling);
+    auto load = m_top_level_traversable.prepare_current_session_history_entry_load(m_url);
+    if (load.document_resource.has<Empty>())
+        client().async_load_url(page_id(), load.url, load.history_handling);
+    else
+        client().async_load_url_with_document_resource(page_id(), load.url, load.document_resource, load.history_handling);
 }
 
 void ViewImplementation::load_session_history_traversal_target_from_ui_process(TraversableSessionHistory::TraversalTarget const& target, StringView dump_reason)
 {
-    if (!m_pending_session_history_traversal.has_value() || m_pending_session_history_traversal->target_step != target.target_step) {
-        m_pending_session_history_traversal = PendingSessionHistoryTraversal {
-            .target_step = target.target_step,
-            .target_step_index = target.target_step_index,
-            .will_change_top_level_entry = target.changes_top_level_entry,
-            .will_replace_web_content_process = !is_url_suitable_for_same_process_navigation(m_url, target.target_top_level_entry->url),
-            .stage = PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess,
-            .on_cancelation_check_complete = nullptr,
-        };
-    } else {
-        m_pending_session_history_traversal->stage = PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess;
-    }
-
-    auto previous_session_history = m_session_history;
-    m_session_history.traverse_to(target.target_step_index);
+    auto target_url = m_top_level_traversable.prepare_to_load_session_history_traversal_target_from_ui_process(target, m_url);
     update_navigation_action_state();
 
-    prepare_to_seed_web_content_session_history_from_ui_process();
-    m_pending_session_history_navigation = PendingSessionHistoryNavigation {
-        target.target_top_level_entry->url,
-        move(previous_session_history),
-    };
-    m_webdriver_pending_navigation_url = target.target_top_level_entry->url;
+    m_webdriver_pending_navigation_url = target_url;
     // NB: A UI-process fallback traversal is only fully observable once the replacement WebContent process has
     //     accepted the UI-owned history seed. Completing WebDriver at load finish would let tests, and callers doing
     //     immediate history inspection, observe the fresh process before it has consumed the authoritative history.
     m_webdriver_pending_navigation_completes_with_session_history_update = true;
-    set_url(target.target_top_level_entry->url);
+    set_url(target_url);
     dump_session_history(dump_reason);
     load_current_session_history_entry_from_ui_process();
 }
@@ -2045,236 +1638,92 @@ void ViewImplementation::did_set_top_level_session_history(Badge<WebContentClien
             history_log_steps(used_steps, current_used_step_index));
     }
 
-    if (!m_pending_web_content_session_history_seed.waiting_for_ack) {
-        dump_session_history("ignored-webcontent-session-history-seed-ack"sv);
+    auto ack = m_top_level_traversable.did_receive_web_content_session_history_seed_ack(accepted, move(entries), move(used_steps), current_used_step_index, m_url);
+    if (ack.ignored) {
+        dump_session_history(ack.dump_reason);
         return;
     }
 
-    if (!accepted) {
-        // NB: WebContent can reject a stale UI-process seed without changing its live session history. In that case
-        //     the ack carries WebContent's current snapshot, so converge the UI mirror from the same path used by
-        //     normal WebContent history updates. If the snapshot itself is not usable, fall back to forgetting the
-        //     WebContent state below and wait for the next repair point.
-        if (adopt_web_content_session_history_after_rejected_seed(move(entries), move(used_steps), current_used_step_index)) {
-            dump_session_history("webcontent-session-history-seed-rejected-with-current-snapshot"sv);
-            return;
-        }
+    if (ack.current_url.has_value()) {
+        WebContentSessionHistoryUpdateResult update { .current_url = *ack.current_url };
+        apply_web_content_session_history_update(update);
+    }
 
-        abandon_pending_web_content_session_history_seed();
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
-        m_pending_session_history_traversal.clear();
+    if (ack.step_to_traverse.has_value())
+        client().async_traverse_the_history_to_step(page_id(), *ack.step_to_traverse);
+    else if (ack.should_complete_webdriver_pending_navigation)
+        complete_webdriver_pending_navigation_if_url_matches(m_url);
+
+    if (ack.should_update_navigation_action_state)
         update_navigation_action_state();
-        dump_session_history("webcontent-session-history-seed-rejected"sv);
-        return;
-    }
-
-    if (!m_session_history.did_seed_web_content_from_ui_process(move(entries), move(used_steps), current_used_step_index)) {
-        if (m_pending_web_content_session_history_seed.should_reseed_after_current_history_load) {
-            m_pending_web_content_session_history_seed.waiting_for_ack = false;
-            m_pending_web_content_session_history_seed.should_send_entries = true;
-            m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
-            m_current_web_content_session_history_matches_mirror = false;
-            update_navigation_action_state();
-            dump_session_history("webcontent-session-history-preload-seed-ack-mismatch"sv);
-            return;
-        }
-
-        abandon_pending_web_content_session_history_seed();
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
-        m_pending_session_history_traversal.clear();
-        update_navigation_action_state();
-        dump_session_history("webcontent-session-history-seed-ack-mismatch"sv);
-        return;
-    }
-
-    m_pending_web_content_session_history_seed.waiting_for_ack = false;
-    if (m_pending_web_content_session_history_seed.should_reseed_after_current_history_load) {
-        m_pending_web_content_session_history_seed.should_send_entries = true;
-        m_pending_web_content_session_history_seed.ignore_updates_until_seed = true;
-        m_current_web_content_session_history_matches_mirror = false;
-        update_navigation_action_state();
-        dump_session_history("webcontent-session-history-preload-seed-ack"sv);
-        return;
-    }
-
-    m_pending_web_content_session_history_seed.ignore_updates_until_seed = false;
-    // NB: A seed ack can arrive while a top-level navigation is still blocked. Keep the mirror provisional until that
-    //     navigation settles.
-    m_current_web_content_session_history_matches_mirror = !m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()
-        && !m_pending_session_history_navigation.has_value();
-    if (m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()) {
-        if (m_pending_session_history_traversal.has_value())
-            m_pending_session_history_traversal->stage = PendingSessionHistoryTraversal::Stage::RestoringNestedStepAfterSeed;
-        client().async_traverse_the_history_to_step(page_id(), *m_pending_web_content_session_history_seed.step_after_loading_top_level_entry);
-    } else {
-        auto is_waiting_for_history_step_cancelation_check = m_pending_session_history_traversal.has_value()
-            && m_pending_session_history_traversal->stage == PendingSessionHistoryTraversal::Stage::CheckingCancelation;
-        if (!is_waiting_for_history_step_cancelation_check) {
-            m_pending_session_history_traversal.clear();
-            if (!m_pending_session_history_navigation.has_value())
-                complete_webdriver_pending_navigation_if_url_matches(m_url);
-        }
-    }
-
-    update_navigation_action_state();
-    dump_session_history("webcontent-session-history-seed-ack"sv);
+    dump_session_history(ack.dump_reason);
 }
 
 void ViewImplementation::did_traverse_the_history_to_step(Badge<WebContentClient>, i32 step, bool step_was_available, Web::HTML::HistoryStepResult result)
 {
-    if (!m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.has_value()) {
-        if (!m_pending_session_history_traversal.has_value() || m_pending_session_history_traversal->target_step != step) {
-            dump_session_history("ignored-stale-webcontent-history-step-result"sv);
-            return;
-        }
+    auto step_result = m_top_level_traversable.did_traverse_the_history_to_step(step, step_was_available, result);
+    if (step_result.should_update_webdriver_pending_navigation_to_current_url && m_webdriver_pending_navigation_url.has_value())
+        m_webdriver_pending_navigation_url = m_url;
+    if (step_result.should_reset_webdriver_pending_navigation_completion)
+        m_webdriver_pending_navigation_completes_with_session_history_update = false;
+    if (step_result.current_url.has_value()) {
+        auto current_url = *step_result.current_url;
+        auto const url_changed = m_url != current_url;
+        set_url(current_url);
+        if (url_changed && on_url_change)
+            on_url_change(m_url);
+        if (m_webdriver_pending_navigation_url.has_value() && *m_webdriver_pending_navigation_url != current_url)
+            m_webdriver_pending_navigation_url = current_url;
+    }
 
-        if (!step_was_available) {
-            auto target = m_session_history.traversal_target_for_step(step);
-            if (target.has_value()) {
-                load_session_history_traversal_target_from_ui_process(*target, "webcontent-history-step-unavailable-fallback-load"sv);
-                return;
-            }
-
-            m_current_web_content_session_history_matches_mirror = false;
-            m_session_history.forget_web_content_state();
-            m_pending_session_history_traversal.clear();
-            update_navigation_action_state();
-            dump_session_history("webcontent-history-step-unavailable"sv);
-            return;
-        }
-
-        if (result != Web::HTML::HistoryStepResult::Applied) {
-            if (m_webdriver_pending_navigation_url.has_value())
-                m_webdriver_pending_navigation_url = m_url;
-            m_webdriver_pending_navigation_completes_with_session_history_update = false;
-            complete_webdriver_pending_navigation_if_url_matches(m_url);
-            m_pending_session_history_traversal.clear();
-            update_navigation_action_state();
-            dump_session_history("webcontent-history-step-canceled"sv);
-        } else {
-            if (!m_session_history.did_apply_web_content_traversal_to_step(step)) {
-                if (auto target = m_session_history.traversal_target_for_step(step); target.has_value()) {
-                    load_session_history_traversal_target_from_ui_process(*target, "webcontent-history-step-applied-with-stale-mirror-fallback-load"sv);
-                    return;
-                }
-
-                m_current_web_content_session_history_matches_mirror = false;
-                m_session_history.forget_web_content_state();
-                m_pending_session_history_traversal.clear();
-                update_navigation_action_state();
-                dump_session_history("webcontent-history-step-applied-without-ui-target"sv);
-                return;
-            }
-
-            m_current_web_content_session_history_matches_mirror = true;
-            if (auto const* current_entry = m_session_history.current_entry()) {
-                auto current_url = current_entry->url;
-                auto const url_changed = m_url != current_url;
-                set_url(current_url);
-                if (url_changed && on_url_change)
-                    on_url_change(m_url);
-                if (m_webdriver_pending_navigation_url.has_value() && *m_webdriver_pending_navigation_url != current_url)
-                    m_webdriver_pending_navigation_url = current_url;
-            }
-            if (!m_pending_session_history_traversal->will_change_top_level_entry)
-                complete_webdriver_pending_navigation_if_url_matches(m_url);
-            m_pending_session_history_traversal.clear();
-            update_navigation_action_state();
-            dump_session_history("webcontent-history-step-applied"sv);
-        }
+    if (step_result.fallback_target.has_value()) {
+        load_session_history_traversal_target_from_ui_process(*step_result.fallback_target, step_result.dump_reason);
         return;
     }
 
-    if (*m_pending_web_content_session_history_seed.step_after_loading_top_level_entry != step) {
-        dump_session_history("ignored-stale-webcontent-history-step-result"sv);
+    if (step_result.should_restore_pending_navigation) {
+        auto restored = restore_pending_session_history_navigation(step_result.dump_reason);
+        VERIFY(restored);
         return;
     }
 
-    if (step_was_available && result == Web::HTML::HistoryStepResult::Applied) {
-        m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.clear();
-        m_current_web_content_session_history_matches_mirror = m_session_history.did_restore_web_content_to_current_step(step);
-        m_pending_session_history_traversal.clear();
+    if (step_result.should_complete_webdriver_pending_navigation)
         complete_webdriver_pending_navigation_if_url_matches(m_url);
+    if (step_result.should_update_navigation_action_state)
         update_navigation_action_state();
-        dump_session_history("webcontent-history-step-restored"sv);
-    } else {
-        auto reason = step_was_available ? "webcontent-pending-history-step-canceled"sv : "webcontent-history-step-unavailable"sv;
-        if (restore_pending_session_history_navigation(reason))
-            return;
-
-        m_pending_web_content_session_history_seed.step_after_loading_top_level_entry.clear();
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
-        m_pending_session_history_traversal.clear();
-        update_navigation_action_state();
-        dump_session_history(reason);
-    }
+    dump_session_history(step_result.dump_reason);
 }
 
 void ViewImplementation::did_check_if_traverse_history_step_is_canceled(
     Badge<WebContentClient>, u64 request_id, i32 step, bool canceled)
 {
-    if (!m_pending_session_history_traversal.has_value()
-        || m_pending_session_history_traversal->stage != PendingSessionHistoryTraversal::Stage::CheckingCancelation
-        || m_pending_session_history_traversal->cancelation_check_request_id != request_id
-        || m_pending_session_history_traversal->target_step != step) {
-        dump_session_history("ignored-stale-history-step-cancelation-check-result"sv);
-        return;
-    }
-
-    if (canceled) {
-        auto on_cancelation_check_complete = move(m_pending_session_history_traversal->on_cancelation_check_complete);
-        if (m_webdriver_pending_navigation_url.has_value())
-            m_webdriver_pending_navigation_url = m_url;
+    auto check_result = m_top_level_traversable.did_check_if_traverse_history_step_is_canceled(request_id, step, canceled);
+    if (check_result.should_update_webdriver_pending_navigation_to_current_url && m_webdriver_pending_navigation_url.has_value())
+        m_webdriver_pending_navigation_url = m_url;
+    if (check_result.should_reset_webdriver_pending_navigation_completion)
         m_webdriver_pending_navigation_completes_with_session_history_update = false;
+
+    if (check_result.should_complete_webdriver_pending_navigation)
         complete_webdriver_pending_navigation_if_url_matches(m_url);
-        m_pending_session_history_traversal.clear();
+    if (check_result.should_update_navigation_action_state)
         update_navigation_action_state();
-        dump_session_history("traverse-fallback-canceled-by-webcontent"sv);
-        if (on_cancelation_check_complete)
-            on_cancelation_check_complete({
-                .status = HistoryTraversalStatus::Canceled,
-            });
+
+    if (check_result.target.has_value()) {
+        if (check_result.on_cancelation_check_complete)
+            check_result.on_cancelation_check_complete(move(check_result.outcome));
+        load_session_history_traversal_target_from_ui_process(*check_result.target, check_result.dump_reason);
         return;
     }
 
-    auto target = m_session_history.traversal_target_for_step(step);
-    if (!target.has_value()) {
-        auto on_cancelation_check_complete = move(m_pending_session_history_traversal->on_cancelation_check_complete);
-        m_current_web_content_session_history_matches_mirror = false;
-        m_session_history.forget_web_content_state();
-        m_pending_session_history_traversal.clear();
-        update_navigation_action_state();
-        dump_session_history("traverse-fallback-cancelation-check-without-ui-target"sv);
-        if (on_cancelation_check_complete)
-            on_cancelation_check_complete({
-                .status = HistoryTraversalStatus::NoEntry,
-            });
-        return;
-    }
-
-    auto on_cancelation_check_complete = move(m_pending_session_history_traversal->on_cancelation_check_complete);
-    if (on_cancelation_check_complete)
-        on_cancelation_check_complete({
-            .status = HistoryTraversalStatus::Started,
-            .will_replace_web_content_process = m_pending_session_history_traversal->will_replace_web_content_process,
-            .will_change_top_level_entry = m_pending_session_history_traversal->will_change_top_level_entry,
-        });
-
-    load_session_history_traversal_target_from_ui_process(*target, "traverse-fallback-load-after-cancelation-check"sv);
+    dump_session_history(check_result.dump_reason);
+    if (check_result.on_cancelation_check_complete)
+        check_result.on_cancelation_check_complete(move(check_result.outcome));
 }
 
 void ViewImplementation::did_reset_session_history_for_testing(Badge<WebContentClient>)
 {
     auto promise = move(m_pending_session_history_reset_for_testing);
-    m_session_history.clear();
-    m_current_web_content_session_history_matches_mirror = false;
-    m_pending_session_history_navigation.clear();
-    m_pending_session_history_traversal.clear();
-    m_session_history_entry_url_loading_from_ui_process.clear();
-    abandon_pending_web_content_session_history_seed();
+    m_top_level_traversable.reset_session_history_for_testing();
     m_webdriver_pending_navigation_url.clear();
     m_webdriver_pending_navigation_completes_with_session_history_update = false;
     update_navigation_action_state();
@@ -2285,7 +1734,7 @@ void ViewImplementation::did_reset_session_history_for_testing(Badge<WebContentC
 
 void ViewImplementation::mark_web_content_session_history_stale_for_testing(Badge<WebContentClient>)
 {
-    m_current_web_content_session_history_matches_mirror = false;
+    m_top_level_traversable.mark_web_content_session_history_stale_for_testing();
     update_navigation_action_state();
     dump_session_history("marked-webcontent-session-history-stale-for-testing"sv);
 }
@@ -2295,21 +1744,21 @@ void ViewImplementation::dump_session_history(StringView reason, SessionHistoryD
     if (mode == SessionHistoryDumpMode::IfDebuggingEnabled && !history_debug_enabled())
         return;
 
-    auto web_content_known_used_steps = m_session_history.web_content_known_used_steps();
-    auto web_content_current_step = m_session_history.web_content_current_step();
+    auto web_content_known_used_steps = m_top_level_traversable.session_history().web_content_known_used_steps();
+    auto web_content_current_step = m_top_level_traversable.session_history().web_content_current_step();
     Optional<size_t> web_content_current_step_index;
     if (web_content_current_step.has_value())
         web_content_current_step_index = web_content_known_used_steps.find_first_index(*web_content_current_step);
-    auto web_content_known_entries = m_session_history.web_content_known_entries();
+    auto web_content_known_entries = m_top_level_traversable.session_history().web_content_known_entries();
     auto web_content_current_top_level_entry_index = current_top_level_history_entry_index_for_step(web_content_known_entries, web_content_current_step);
 
     auto pending_navigation_url = "none"sv;
     auto pending_navigation_restore_mode = "none"sv;
     String pending_navigation_url_storage;
-    if (m_pending_session_history_navigation.has_value()) {
-        pending_navigation_url_storage = m_pending_session_history_navigation->url.serialize();
+    if (m_top_level_traversable.pending_session_history_navigation().has_value()) {
+        pending_navigation_url_storage = m_top_level_traversable.pending_session_history_navigation()->url.serialize();
         pending_navigation_url = pending_navigation_url_storage.bytes_as_string_view();
-        pending_navigation_restore_mode = pending_session_history_navigation_web_content_restore_mode_to_string(m_pending_session_history_navigation->web_content_restore_mode);
+        pending_navigation_restore_mode = CanonicalTraversable::pending_session_history_navigation_web_content_restore_mode_to_string(m_top_level_traversable.pending_session_history_navigation()->web_content_restore_mode);
     }
 
     dbgln("[History] UI session history page={} pid={} reason={} url='{}' webcontent_matches={} webcontent_uses_ui_steps={} loading_from_ui={} waiting_to_seed={} waiting_for_seed_ack={} ignore_until_seed={} reseed_after_current_load={} pending_webcontent_step={} pending_navigation_url={} pending_navigation_restore={} pending_traversal_target={} pending_traversal_stage={} webcontent_current_step={} back={} forward={} entries={} webcontent_known_entries={} webcontent_known_used_steps={}",
@@ -2317,22 +1766,22 @@ void ViewImplementation::dump_session_history(StringView reason, SessionHistoryD
         client().pid(),
         reason,
         m_url,
-        m_current_web_content_session_history_matches_mirror,
-        m_session_history.web_content_uses_ui_step_coordinates(),
-        m_session_history_entry_url_loading_from_ui_process.has_value(),
-        m_pending_web_content_session_history_seed.should_send_entries,
-        m_pending_web_content_session_history_seed.waiting_for_ack,
-        m_pending_web_content_session_history_seed.ignore_updates_until_seed,
-        m_pending_web_content_session_history_seed.should_reseed_after_current_history_load,
-        m_pending_web_content_session_history_seed.step_after_loading_top_level_entry,
+        m_top_level_traversable.current_web_content_session_history_matches_mirror(),
+        m_top_level_traversable.session_history().web_content_uses_ui_step_coordinates(),
+        m_top_level_traversable.session_history_entry_url_loading_from_ui_process().has_value(),
+        m_top_level_traversable.pending_web_content_session_history_seed().should_send_entries,
+        m_top_level_traversable.pending_web_content_session_history_seed().waiting_for_ack,
+        m_top_level_traversable.pending_web_content_session_history_seed().ignore_updates_until_seed,
+        m_top_level_traversable.pending_web_content_session_history_seed().should_reseed_after_current_history_load,
+        m_top_level_traversable.pending_web_content_session_history_seed().step_after_loading_top_level_entry,
         pending_navigation_url,
         pending_navigation_restore_mode,
-        m_pending_session_history_traversal.has_value() ? Optional<i32> { m_pending_session_history_traversal->target_step } : Optional<i32> {},
-        m_pending_session_history_traversal.has_value() ? pending_session_history_traversal_stage_to_string(m_pending_session_history_traversal->stage) : "none"sv,
+        m_top_level_traversable.pending_session_history_traversal().has_value() ? Optional<i32> { m_top_level_traversable.pending_session_history_traversal()->target_step } : Optional<i32> {},
+        m_top_level_traversable.pending_session_history_traversal().has_value() ? CanonicalTraversable::pending_session_history_traversal_stage_to_string(m_top_level_traversable.pending_session_history_traversal()->stage) : "none"sv,
         web_content_current_step,
         m_navigate_back_action->enabled(),
         m_navigate_forward_action->enabled(),
-        history_log_entries(m_session_history),
+        history_log_entries(m_top_level_traversable.session_history()),
         history_log_entries(web_content_known_entries, web_content_current_top_level_entry_index),
         history_log_steps(web_content_known_used_steps, web_content_current_step_index));
 }
@@ -2370,8 +1819,7 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
     // Don't keep a stale backup bitmap around.
     m_backup_shared_image_buffer = nullptr;
 
-    m_session_history_entry_url_loading_from_ui_process.clear();
-    prepare_to_seed_web_content_session_history_from_ui_process();
+    m_top_level_traversable.did_crash_requiring_web_content_session_history_seed();
 
     handle_resize();
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -44,6 +44,7 @@
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/WebDriver/Response.h>
 #include <LibWebView/BookmarkStore.h>
+#include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/PageInfo.h>
@@ -93,23 +94,6 @@ public:
     void load_navigation_error_page(StringView);
 
     void reload();
-    enum class HistoryTraversalStatus : u8 {
-        Started,
-        NoEntry,
-        Canceled,
-    };
-    // NB: The HTML Standard spells this algorithm argument "checkForCancelation".
-    enum class CheckForCancelation : u8 {
-        Yes,
-        No,
-        IfWebContentCannotTraverseTarget,
-    };
-    struct HistoryTraversalOutcome {
-        HistoryTraversalStatus status { HistoryTraversalStatus::NoEntry };
-        bool will_replace_web_content_process { false };
-        bool will_change_top_level_entry { false };
-        bool waiting_for_cancelation_check { false };
-    };
     struct SessionHistoryTraversalMenuItem {
         int delta { 0 };
         String title;
@@ -404,21 +388,18 @@ protected:
     void complete_webdriver_navigation_completion(u64 request_id, Web::WebDriver::Response);
     void complete_webdriver_pending_navigation_if_url_matches(URL::URL const&);
     void update_navigation_action_state();
-    TraversableSessionHistory::UpdateResult update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot);
-    bool adopt_web_content_session_history_after_rejected_seed(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index);
+    void apply_web_content_session_history_update(WebContentSessionHistoryUpdateResult const&);
     enum class SessionHistoryDumpMode {
         IfDebuggingEnabled,
         Always,
     };
     void dump_session_history(StringView reason, SessionHistoryDumpMode = SessionHistoryDumpMode::IfDebuggingEnabled) const;
     bool restore_pending_session_history_navigation(StringView reason);
-    void abandon_pending_web_content_session_history_seed();
     enum class AllowCurrentEntryReconstruction : u8 {
         No,
         Yes,
     };
     void seed_web_content_session_history_from_ui_process(AllowCurrentEntryReconstruction = AllowCurrentEntryReconstruction::No);
-    void prepare_to_seed_web_content_session_history_from_ui_process();
     void restore_current_session_history_entry_from_ui_process();
     void load_current_session_history_entry_from_ui_process();
     void load_session_history_traversal_target_from_ui_process(TraversableSessionHistory::TraversalTarget const&, StringView dump_reason);
@@ -541,61 +522,12 @@ protected:
     RefPtr<Core::Promise<LexicalPath>> m_pending_screenshot;
     RefPtr<Core::Promise<String>> m_pending_info_request;
 
-    Web::HTML::VisibilityState m_system_visibility_state { Web::HTML::VisibilityState::Hidden };
-
     Web::HTML::AudioPlayState m_audio_play_state { Web::HTML::AudioPlayState::Paused };
     size_t m_number_of_elements_playing_audio { 0 };
 
     Web::HTML::MuteState m_mute_state { Web::HTML::MuteState::Unmuted };
 
-    struct PendingSessionHistoryNavigation {
-        enum class WebContentRestoreMode : u8 {
-            PreserveCurrentProcessState,
-            RestoreFromUIProcess,
-        };
-
-        URL::URL url;
-        TraversableSessionHistory previous_session_history;
-        WebContentRestoreMode web_content_restore_mode { WebContentRestoreMode::PreserveCurrentProcessState };
-    };
-    static StringView pending_session_history_navigation_web_content_restore_mode_to_string(PendingSessionHistoryNavigation::WebContentRestoreMode);
-
-    struct PendingWebContentSessionHistorySeed {
-        bool should_send_entries { false };
-        bool ignore_updates_until_seed { false };
-        bool waiting_for_ack { false };
-        bool should_reseed_after_current_history_load { false };
-        Optional<i32> step_after_loading_top_level_entry;
-
-        void clear() { *this = {}; }
-    };
-
-    struct PendingSessionHistoryTraversal {
-        enum class Stage : u8 {
-            ApplyingInWebContent,
-            CheckingCancelation,
-            LoadingEntryFromUIProcess,
-            ReplacingWebContentProcess,
-            RestoringNestedStepAfterSeed,
-        };
-
-        i32 target_step { 0 };
-        size_t target_step_index { 0 };
-        u64 cancelation_check_request_id { 0 };
-        bool will_change_top_level_entry { false };
-        bool will_replace_web_content_process { false };
-        Stage stage { Stage::ApplyingInWebContent };
-        Function<void(HistoryTraversalOutcome)> on_cancelation_check_complete;
-    };
-    static StringView pending_session_history_traversal_stage_to_string(PendingSessionHistoryTraversal::Stage);
-
-    TraversableSessionHistory m_session_history;
-    bool m_current_web_content_session_history_matches_mirror { false };
-    Optional<PendingSessionHistoryNavigation> m_pending_session_history_navigation;
-    Optional<PendingSessionHistoryTraversal> m_pending_session_history_traversal;
-    u64 m_next_traverse_history_step_cancelation_check_request_id { 0 };
-    Optional<URL::URL> m_session_history_entry_url_loading_from_ui_process;
-    PendingWebContentSessionHistorySeed m_pending_web_content_session_history_seed;
+    CanonicalTraversable m_top_level_traversable;
     Optional<URL::URL> m_webdriver_pending_navigation_url;
     bool m_webdriver_pending_navigation_completes_with_session_history_update { false };
     RefPtr<Core::Promise<Empty>> m_pending_session_history_reset_for_testing;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1423,9 +1423,9 @@ Messages::WebContentClient::DidRequestTraverseTheHistoryByDeltaResponse WebConte
             auto view = ViewImplementation::find_view_by_id(view_id);
             if (!view.has_value())
                 return;
-            auto check_for_cancelation = ViewImplementation::CheckForCancelation::IfWebContentCannotTraverseTarget;
+            auto check_for_cancelation = CheckForCancelation::IfWebContentCannotTraverseTarget;
             if (history_traversal_precheck == Web::HistoryTraversalPrecheck::Needed)
-                check_for_cancelation = ViewImplementation::CheckForCancelation::Yes;
+                check_for_cancelation = CheckForCancelation::Yes;
             (void)view->traverse_the_history_by_delta(delta, check_for_cancelation);
         });
         return true;
@@ -1454,13 +1454,13 @@ void WebContentClient::did_request_webdriver_history_traversal(u64 page_id, u64 
                 return;
             }
 
-            auto complete = [weak_this, page_id, request_id](ViewImplementation::HistoryTraversalOutcome outcome) {
+            auto complete = [weak_this, page_id, request_id](HistoryTraversalOutcome outcome) {
                 auto self = weak_this.strong_ref();
                 if (!self)
                     return;
                 auto& client = static_cast<WebContentClient&>(*self);
 
-                auto traversal_started = outcome.status == ViewImplementation::HistoryTraversalStatus::Started;
+                auto traversal_started = outcome.status == HistoryTraversalStatus::Started;
                 client.async_complete_webdriver_history_traversal(
                     page_id,
                     request_id,
@@ -1469,14 +1469,14 @@ void WebContentClient::did_request_webdriver_history_traversal(u64 page_id, u64 
                     traversal_started && outcome.will_change_top_level_entry);
             };
 
-            auto outcome = view->traverse_the_history_by_delta(delta, ViewImplementation::CheckForCancelation::Yes,
-                [weak_this, page_id, request_id](ViewImplementation::HistoryTraversalOutcome outcome) {
+            auto outcome = view->traverse_the_history_by_delta(delta, CheckForCancelation::Yes,
+                [weak_this, page_id, request_id](HistoryTraversalOutcome outcome) {
                     auto self = weak_this.strong_ref();
                     if (!self)
                         return;
                     auto& client = static_cast<WebContentClient&>(*self);
 
-                    auto traversal_started = outcome.status == ViewImplementation::HistoryTraversalStatus::Started;
+                    auto traversal_started = outcome.status == HistoryTraversalStatus::Started;
                     client.async_complete_webdriver_history_traversal(
                         page_id,
                         request_id,
@@ -1521,7 +1521,7 @@ Messages::WebContentClient::DidRequestWebdriverTraverseHistoryFromUiResponse Web
             auto view = ViewImplementation::find_view_by_id(view_id);
             if (!view.has_value())
                 return;
-            (void)view->traverse_the_history_by_delta(delta, ViewImplementation::CheckForCancelation::Yes);
+            (void)view->traverse_the_history_by_delta(delta, CheckForCancelation::Yes);
         });
         return { JsonValue {} };
     }


### PR DESCRIPTION
See commit message for slightly more detail. This will be the UI side of LocalTraversableNavigable. Next step after this is CanonicalNavigable and building the entire navigation tree in the UI process. After that we can start replicating that state to each WebContent process so they have required information about remote frames for site isolation.