### PR TITLE
LibGC+LibJS+LibWasm: Cage primitive byte storage

### DIFF
--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -162,6 +162,22 @@ ErrorOr<void> commit_memory(void* address, size_t size)
     return {};
 }
 
+ErrorOr<void> decommit_memory(void* address, size_t size)
+{
+    if (size == 0)
+        return {};
+
+    int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED;
+#ifdef MAP_NORESERVE
+    flags |= MAP_NORESERVE;
+#endif
+    auto* ptr = ::mmap(address, size, PROT_NONE, flags, -1, 0);
+    if (ptr == MAP_FAILED)
+        return Error::from_syscall("mmap"sv, errno);
+    VERIFY(ptr == address);
+    return {};
+}
+
 ErrorOr<void> release_address_space(void* address, size_t size)
 {
     if (::munmap(address, size) < 0)

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -80,6 +80,7 @@ ErrorOr<void*> mmap(void* address, size_t, int protection, int flags, int fd, of
 ErrorOr<void> munmap(void* address, size_t);
 CORE_API ErrorOr<void*> reserve_address_space(size_t size);
 CORE_API ErrorOr<void> commit_memory(void* address, size_t size);
+CORE_API ErrorOr<void> decommit_memory(void* address, size_t size);
 CORE_API ErrorOr<void> release_address_space(void* address, size_t size);
 ErrorOr<int> anon_create(size_t size, int options);
 CORE_API ErrorOr<int> open(StringView path, int options, mode_t mode = 0);

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -223,6 +223,15 @@ ErrorOr<void> commit_memory(void* address, size_t size)
     return {};
 }
 
+ErrorOr<void> decommit_memory(void* address, size_t size)
+{
+    if (size == 0)
+        return {};
+    if (!VirtualFree(address, size, MEM_DECOMMIT))
+        return Error::from_windows_error();
+    return {};
+}
+
 ErrorOr<void> release_address_space(void* address, size_t size)
 {
     // VirtualFree with MEM_RELEASE requires size == 0 and frees the entire reservation.

--- a/Libraries/LibGC/CMakeLists.txt
+++ b/Libraries/LibGC/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     Heap.cpp
     HeapGroup.cpp
     HeapBlock.cpp
+    PrimitiveStorage.cpp
     Timer.cpp
     WeakBlock.cpp
     WeakContainer.cpp

--- a/Libraries/LibGC/PrimitiveStorage.cpp
+++ b/Libraries/LibGC/PrimitiveStorage.cpp
@@ -384,7 +384,7 @@ u8* PrimitiveStorage::Allocator::data(Allocation const& allocation, size_t byte_
 {
     VERIFY(m_cage_base);
     VERIFY(allocation.offset != invalid_offset);
-    return m_cage_base + allocation.offset + byte_offset;
+    return m_cage_base + PrimitiveStorage::mask_offset(allocation.offset + byte_offset);
 }
 
 ErrorOr<PrimitiveStorageHandle> PrimitiveStorage::try_allocate(size_t size, ZeroFillNewBytes zero_fill_new_bytes)
@@ -473,17 +473,15 @@ u8 const* PrimitiveStorage::data(PrimitiveStorageHandle handle) const
     return const_cast<PrimitiveStorage&>(*this).data(handle);
 }
 
-Bytes PrimitiveStorage::bytes(PrimitiveStorageHandle handle)
+u8* PrimitiveStorage::data(PrimitiveStorageHandle handle, size_t byte_offset)
 {
     auto* entry = entry_for(handle);
-    if (!entry)
-        return {};
-    return { data_unchecked(*entry), entry->size };
+    return entry ? m_allocator.data(entry->allocation, byte_offset) : nullptr;
 }
 
-ReadonlyBytes PrimitiveStorage::bytes(PrimitiveStorageHandle handle) const
+u8 const* PrimitiveStorage::data(PrimitiveStorageHandle handle, size_t byte_offset) const
 {
-    return const_cast<PrimitiveStorage&>(*this).bytes(handle);
+    return const_cast<PrimitiveStorage&>(*this).data(handle, byte_offset);
 }
 
 ErrorOr<void> PrimitiveStorage::try_resize(PrimitiveStorageHandle handle, size_t new_size, ZeroFillNewBytes zero_fill_new_bytes)

--- a/Libraries/LibGC/PrimitiveStorage.cpp
+++ b/Libraries/LibGC/PrimitiveStorage.cpp
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Checked.h>
+#include <AK/NeverDestroyed.h>
+#include <LibCore/System.h>
+#include <LibGC/PrimitiveStorage.h>
+
+extern "C" {
+GC_API FlatPtr js_primitive_storage_cage_base = 0;
+}
+
+namespace GC {
+
+static size_t round_up_to_page(size_t value)
+{
+    auto page = static_cast<size_t>(PAGE_SIZE);
+    return align_up_to(value, page);
+}
+
+PrimitiveStorage& PrimitiveStorage::the()
+{
+    static NeverDestroyed<PrimitiveStorage> storage;
+    return *storage;
+}
+
+size_t PrimitiveStorage::Allocator::page_size()
+{
+    return static_cast<size_t>(PAGE_SIZE);
+}
+
+ErrorOr<void> PrimitiveStorage::Allocator::ensure_cage()
+{
+    if (m_cage_base)
+        return {};
+
+    if constexpr (sizeof(FlatPtr) < sizeof(u64))
+        return Error::from_errno(ENOMEM);
+
+    m_cage_size = PrimitiveStorage::default_cage_size;
+    Checked<size_t> reservation_size = m_cage_size;
+    reservation_size += page_size();
+    if (reservation_size.has_overflow())
+        return Error::from_errno(ENOMEM);
+
+    // Leave an inaccessible page after the logical cage so a masked fixed-width
+    // access at the top edge cannot cross into an unrelated mapping.
+    auto mapping = TRY(Core::System::reserve_address_space(reservation_size.value()));
+    m_cage_base = static_cast<u8*>(mapping);
+    js_primitive_storage_cage_base = bit_cast<FlatPtr>(m_cage_base);
+    return {};
+}
+
+ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::allocate(size_t size, size_t capacity, ZeroFillNewBytes zero_fill_new_bytes, size_t guard_size, bool)
+{
+    VERIFY(size <= capacity);
+    return allocate_large_storage(size, capacity, zero_fill_new_bytes, guard_size);
+}
+
+ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::allocate_large_storage(size_t size, size_t capacity, ZeroFillNewBytes zero_fill_new_bytes, size_t guard_size)
+{
+    TRY(ensure_cage());
+
+    auto rounded_capacity = round_up_to_page(capacity);
+    auto rounded_guard_size = round_up_to_page(guard_size);
+    Checked<size_t> reservation_size = rounded_capacity;
+    reservation_size += rounded_guard_size;
+    if (reservation_size.has_overflow())
+        return Error::from_errno(ENOMEM);
+
+    auto offset = TRY(allocate_cage_range(reservation_size.value()));
+    auto committed_size = round_up_to_page(size);
+    if (committed_size > 0) {
+        auto commit_result = Core::System::commit_memory(m_cage_base + offset, committed_size);
+        if (commit_result.is_error()) {
+            release_cage_range(offset, reservation_size.value());
+            return commit_result.release_error();
+        }
+    }
+    if (zero_fill_new_bytes == ZeroFillNewBytes::Yes && size > 0)
+        __builtin_memset(m_cage_base + offset, 0, size);
+
+    return Allocation {
+        .offset = offset,
+        .capacity = capacity,
+        .reservation_size = reservation_size.value(),
+        .committed_size = committed_size,
+    };
+}
+
+ErrorOr<size_t> PrimitiveStorage::Allocator::allocate_cage_range(size_t reservation_size)
+{
+    VERIFY(m_cage_base);
+    reservation_size = round_up_to_page(reservation_size);
+    if (reservation_size == 0)
+        return m_next_offset;
+
+    for (size_t i = 0; i < m_free_ranges.size(); ++i) {
+        auto range = m_free_ranges[i];
+        if (range.size < reservation_size)
+            continue;
+
+        auto offset = range.offset;
+        m_free_ranges[i].offset += reservation_size;
+        m_free_ranges[i].size -= reservation_size;
+        if (m_free_ranges[i].size == 0)
+            m_free_ranges.remove(i);
+        return offset;
+    }
+
+    auto next_offset = align_up_to(m_next_offset, page_size());
+    Checked<size_t> new_next_offset = next_offset;
+    new_next_offset += reservation_size;
+    if (new_next_offset.has_overflow() || new_next_offset.value() > m_cage_size)
+        return Error::from_errno(ENOMEM);
+
+    m_next_offset = new_next_offset.value();
+    return next_offset;
+}
+
+ErrorOr<void> PrimitiveStorage::Allocator::resize(Allocation& allocation, size_t old_size, size_t new_size, ZeroFillNewBytes zero_fill_new_bytes)
+{
+    VERIFY(new_size <= allocation.capacity);
+
+    TRY(commit_large_storage(allocation, new_size));
+
+    if (zero_fill_new_bytes == ZeroFillNewBytes::Yes && new_size > old_size)
+        __builtin_memset(data(allocation, old_size), 0, new_size - old_size);
+
+    return {};
+}
+
+ErrorOr<void> PrimitiveStorage::Allocator::commit_large_storage(Allocation& allocation, size_t new_size)
+{
+    VERIFY(new_size <= allocation.capacity);
+
+    auto new_committed_size = round_up_to_page(new_size);
+    if (new_committed_size > allocation.committed_size) {
+        TRY(Core::System::commit_memory(m_cage_base + allocation.offset + allocation.committed_size, new_committed_size - allocation.committed_size));
+        allocation.committed_size = new_committed_size;
+    }
+
+    return {};
+}
+
+void PrimitiveStorage::Allocator::decommit_large_storage(Allocation const& allocation)
+{
+    if (allocation.committed_size == 0)
+        return;
+    MUST(Core::System::decommit_memory(m_cage_base + allocation.offset, allocation.committed_size));
+}
+
+ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::reallocate(Allocation const& old_allocation, size_t old_size, size_t new_size, size_t new_capacity, ZeroFillNewBytes zero_fill_new_bytes, bool force_large)
+{
+    VERIFY(new_size <= new_capacity);
+
+    auto allocation = TRY(allocate(new_size, new_capacity, ZeroFillNewBytes::No, 0, force_large));
+    auto bytes_to_copy = min(old_size, new_size);
+    if (bytes_to_copy > 0)
+        __builtin_memcpy(m_cage_base + allocation.offset, m_cage_base + old_allocation.offset, bytes_to_copy);
+    if (zero_fill_new_bytes == ZeroFillNewBytes::Yes && new_size > old_size)
+        __builtin_memset(m_cage_base + allocation.offset + old_size, 0, new_size - old_size);
+
+    return allocation;
+}
+
+void PrimitiveStorage::Allocator::deallocate(Allocation& allocation)
+{
+    if (allocation.reservation_size > 0) {
+        decommit_large_storage(allocation);
+        release_cage_range(allocation.offset, allocation.reservation_size);
+    }
+    allocation = {};
+}
+
+void PrimitiveStorage::Allocator::release_cage_range(size_t offset, size_t size)
+{
+    size = round_up_to_page(size);
+    if (size == 0)
+        return;
+
+    if (offset <= m_next_offset && size == m_next_offset - offset) {
+        m_next_offset = offset;
+        reclaim_free_ranges_at_top();
+        return;
+    }
+
+    free_cage_range(offset, size);
+}
+
+void PrimitiveStorage::Allocator::free_cage_range(size_t offset, size_t size)
+{
+    size = round_up_to_page(size);
+    if (size == 0)
+        return;
+
+    size_t insert_before = 0;
+    while (insert_before < m_free_ranges.size() && m_free_ranges[insert_before].offset < offset)
+        ++insert_before;
+
+    m_free_ranges.insert(insert_before, FreeRange { offset, size });
+
+    if (insert_before > 0) {
+        auto& previous = m_free_ranges[insert_before - 1];
+        auto& current = m_free_ranges[insert_before];
+        if (previous.offset + previous.size == current.offset) {
+            previous.size += current.size;
+            m_free_ranges.remove(insert_before);
+            --insert_before;
+        }
+    }
+
+    if (insert_before + 1 < m_free_ranges.size()) {
+        auto& current = m_free_ranges[insert_before];
+        auto& next = m_free_ranges[insert_before + 1];
+        if (current.offset + current.size == next.offset) {
+            current.size += next.size;
+            m_free_ranges.remove(insert_before + 1);
+        }
+    }
+
+    reclaim_free_ranges_at_top();
+}
+
+void PrimitiveStorage::Allocator::reclaim_free_ranges_at_top()
+{
+    while (!m_free_ranges.is_empty()) {
+        auto range = m_free_ranges.last();
+        if (range.offset > m_next_offset || range.size != m_next_offset - range.offset)
+            return;
+
+        m_next_offset = range.offset;
+        m_free_ranges.remove(m_free_ranges.size() - 1);
+    }
+}
+
+bool PrimitiveStorage::Allocator::contains(void const* address, size_t size) const
+{
+    if (!m_cage_base || !address)
+        return false;
+    auto address_value = bit_cast<FlatPtr>(address);
+    auto base = bit_cast<FlatPtr>(m_cage_base);
+    if (address_value < base)
+        return false;
+    auto offset = address_value - base;
+    return offset <= m_cage_size && size <= m_cage_size - offset;
+}
+
+bool PrimitiveStorage::Allocator::contains(Allocation const& allocation, void const* address, size_t size) const
+{
+    if (!address || allocation.offset == invalid_offset)
+        return false;
+    auto address_value = bit_cast<FlatPtr>(address);
+    auto base = bit_cast<FlatPtr>(m_cage_base);
+    if (!m_cage_base || address_value < base)
+        return false;
+    auto offset = address_value - base;
+    if (offset < allocation.offset)
+        return false;
+    auto allocation_offset = offset - allocation.offset;
+    return allocation_offset <= allocation.reservation_size && size <= allocation.reservation_size - allocation_offset;
+}
+
+u8* PrimitiveStorage::Allocator::data(Allocation const& allocation, size_t byte_offset) const
+{
+    VERIFY(m_cage_base);
+    VERIFY(allocation.offset != invalid_offset);
+    return m_cage_base + allocation.offset + byte_offset;
+}
+
+ErrorOr<PrimitiveStorageHandle> PrimitiveStorage::try_allocate(size_t size, ZeroFillNewBytes zero_fill_new_bytes)
+{
+    auto allocation = TRY(m_allocator.allocate(size, size, zero_fill_new_bytes, 0, false));
+    return install_allocation(move(allocation), size);
+}
+
+ErrorOr<PrimitiveStorageHandle> PrimitiveStorage::try_reserve(size_t size, size_t capacity, ZeroFillNewBytes zero_fill_new_bytes, size_t guard_size)
+{
+    if (size > capacity)
+        return Error::from_errno(ENOMEM);
+
+    auto allocation = TRY(m_allocator.allocate(size, capacity, zero_fill_new_bytes, guard_size, true));
+    return install_allocation(move(allocation), size);
+}
+
+PrimitiveStorageHandle PrimitiveStorage::install_allocation(Allocator::Allocation allocation, size_t size)
+{
+    u32 index;
+    if (m_free_entry_indices.is_empty()) {
+        VERIFY(m_entries.size() < PrimitiveStorageHandle::invalid_index);
+        index = static_cast<u32>(m_entries.size());
+        m_entries.append({});
+    } else {
+        index = m_free_entry_indices.take_last();
+    }
+
+    auto& entry = m_entries[index];
+    VERIFY(!entry.allocated);
+    entry.allocated = true;
+    entry.size = size;
+    entry.allocation = move(allocation);
+
+    return PrimitiveStorageHandle { index, entry.generation };
+}
+
+bool PrimitiveStorage::is_valid(PrimitiveStorageHandle handle) const
+{
+    return entry_for(handle) != nullptr;
+}
+
+bool PrimitiveStorage::contains(void const* address, size_t size) const
+{
+    return m_allocator.contains(address, size);
+}
+
+bool PrimitiveStorage::contains(PrimitiveStorageHandle handle, void const* address, size_t size) const
+{
+    auto const* entry = entry_for(handle);
+    return entry && m_allocator.contains(entry->allocation, address, size);
+}
+
+size_t PrimitiveStorage::offset(PrimitiveStorageHandle handle) const
+{
+    auto const* entry = entry_for(handle);
+    return entry ? entry->allocation.offset : invalid_offset;
+}
+
+size_t PrimitiveStorage::size(PrimitiveStorageHandle handle) const
+{
+    auto const* entry = entry_for(handle);
+    return entry ? entry->size : 0;
+}
+
+size_t PrimitiveStorage::capacity(PrimitiveStorageHandle handle) const
+{
+    auto const* entry = entry_for(handle);
+    return entry ? entry->allocation.capacity : 0;
+}
+
+size_t PrimitiveStorage::committed_size(PrimitiveStorageHandle handle) const
+{
+    auto const* entry = entry_for(handle);
+    return entry ? entry->allocation.committed_size : 0;
+}
+
+u8* PrimitiveStorage::data(PrimitiveStorageHandle handle)
+{
+    auto* entry = entry_for(handle);
+    return entry ? data_unchecked(*entry) : nullptr;
+}
+
+u8 const* PrimitiveStorage::data(PrimitiveStorageHandle handle) const
+{
+    return const_cast<PrimitiveStorage&>(*this).data(handle);
+}
+
+Bytes PrimitiveStorage::bytes(PrimitiveStorageHandle handle)
+{
+    auto* entry = entry_for(handle);
+    if (!entry)
+        return {};
+    return { data_unchecked(*entry), entry->size };
+}
+
+ReadonlyBytes PrimitiveStorage::bytes(PrimitiveStorageHandle handle) const
+{
+    return const_cast<PrimitiveStorage&>(*this).bytes(handle);
+}
+
+ErrorOr<void> PrimitiveStorage::try_resize(PrimitiveStorageHandle handle, size_t new_size, ZeroFillNewBytes zero_fill_new_bytes)
+{
+    auto* entry = entry_for(handle);
+    if (!entry)
+        return Error::from_errno(EINVAL);
+
+    if (new_size <= entry->allocation.capacity) {
+        TRY(m_allocator.resize(entry->allocation, entry->size, new_size, zero_fill_new_bytes));
+        entry->size = new_size;
+        return {};
+    }
+
+    return reallocate_entry(*entry, new_size, new_size, zero_fill_new_bytes, false);
+}
+
+ErrorOr<void> PrimitiveStorage::try_reserve(PrimitiveStorageHandle handle, size_t new_capacity)
+{
+    auto* entry = entry_for(handle);
+    if (!entry)
+        return Error::from_errno(EINVAL);
+    if (new_capacity <= entry->allocation.capacity)
+        return {};
+
+    return reallocate_entry(*entry, entry->size, new_capacity, ZeroFillNewBytes::No, true);
+}
+
+ErrorOr<void> PrimitiveStorage::try_resize_and_reserve(PrimitiveStorageHandle handle, size_t new_size, size_t new_capacity, ZeroFillNewBytes zero_fill_new_bytes)
+{
+    if (new_size > new_capacity)
+        return Error::from_errno(ENOMEM);
+
+    auto* entry = entry_for(handle);
+    if (!entry)
+        return Error::from_errno(EINVAL);
+
+    if (new_capacity <= entry->allocation.capacity) {
+        TRY(m_allocator.resize(entry->allocation, entry->size, new_size, zero_fill_new_bytes));
+        entry->size = new_size;
+        return {};
+    }
+
+    return reallocate_entry(*entry, new_size, new_capacity, zero_fill_new_bytes, true);
+}
+
+ErrorOr<void> PrimitiveStorage::reallocate_entry(Entry& entry, size_t new_size, size_t new_capacity, ZeroFillNewBytes zero_fill_new_bytes, bool force_large)
+{
+    VERIFY(new_size <= new_capacity);
+    auto allocation = TRY(m_allocator.reallocate(entry.allocation, entry.size, new_size, new_capacity, zero_fill_new_bytes, force_large));
+    m_allocator.deallocate(entry.allocation);
+    entry.allocation = move(allocation);
+    entry.size = new_size;
+    return {};
+}
+
+void PrimitiveStorage::free(PrimitiveStorageHandle handle)
+{
+    auto* entry = entry_for(handle);
+    if (!entry)
+        return;
+
+    m_allocator.deallocate(entry->allocation);
+    entry->allocated = false;
+    entry->size = 0;
+    ++entry->generation;
+    if (entry->generation == 0)
+        ++entry->generation;
+    m_free_entry_indices.append(handle.index);
+}
+
+PrimitiveStorage::Entry* PrimitiveStorage::entry_for(PrimitiveStorageHandle handle)
+{
+    if (!handle.is_valid() || handle.index >= m_entries.size())
+        return nullptr;
+    auto& entry = m_entries[handle.index];
+    if (!entry.allocated || entry.generation != handle.generation)
+        return nullptr;
+    return &entry;
+}
+
+PrimitiveStorage::Entry const* PrimitiveStorage::entry_for(PrimitiveStorageHandle handle) const
+{
+    return const_cast<PrimitiveStorage&>(*this).entry_for(handle);
+}
+
+u8* PrimitiveStorage::data_unchecked(Entry const& entry) const
+{
+    return m_allocator.data(entry.allocation);
+}
+
+}

--- a/Libraries/LibGC/PrimitiveStorage.cpp
+++ b/Libraries/LibGC/PrimitiveStorage.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Checked.h>
 #include <AK/NeverDestroyed.h>
+#include <AK/ScopeGuard.h>
 #include <LibCore/System.h>
 #include <LibGC/PrimitiveStorage.h>
 
@@ -15,10 +16,34 @@ GC_API FlatPtr js_primitive_storage_cage_base = 0;
 
 namespace GC {
 
+static constexpr size_t small_slab_size = 64 * KiB;
+static constexpr size_t minimum_small_slot_size = 16;
+static constexpr size_t maximum_small_slot_size = 64 * KiB;
+
 static size_t round_up_to_page(size_t value)
 {
     auto page = static_cast<size_t>(PAGE_SIZE);
     return align_up_to(value, page);
+}
+
+static Optional<u16> small_size_class_index(size_t size)
+{
+    auto slot_size = max(size, minimum_small_slot_size);
+    if (slot_size > maximum_small_slot_size)
+        return {};
+
+    size_t class_size = minimum_small_slot_size;
+    u16 index = 0;
+    while (class_size < slot_size) {
+        class_size <<= 1;
+        ++index;
+    }
+    return index;
+}
+
+static size_t small_slot_size_for_class(u16 index)
+{
+    return minimum_small_slot_size << index;
 }
 
 PrimitiveStorage& PrimitiveStorage::the()
@@ -54,10 +79,85 @@ ErrorOr<void> PrimitiveStorage::Allocator::ensure_cage()
     return {};
 }
 
-ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::allocate(size_t size, size_t capacity, ZeroFillNewBytes zero_fill_new_bytes, size_t guard_size, bool)
+ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::allocate(size_t size, size_t capacity, ZeroFillNewBytes zero_fill_new_bytes, size_t guard_size, bool force_large)
 {
     VERIFY(size <= capacity);
+    if (!force_large && guard_size == 0 && size == capacity && small_size_class_index(size).has_value())
+        return allocate_small_storage(size, zero_fill_new_bytes);
     return allocate_large_storage(size, capacity, zero_fill_new_bytes, guard_size);
+}
+
+ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::allocate_small_storage(size_t size, ZeroFillNewBytes zero_fill_new_bytes)
+{
+    auto size_class_index = small_size_class_index(size);
+    VERIFY(size_class_index.has_value());
+
+    TRY(ensure_cage());
+
+    auto slot_size = small_slot_size_for_class(*size_class_index);
+    auto& slabs = m_small_slabs[*size_class_index];
+
+    for (u32 slab_index = 0; slab_index < slabs.size(); ++slab_index) {
+        auto& slab = slabs[slab_index];
+        if (slab.free_slots.is_empty())
+            continue;
+
+        auto slot_index = slab.free_slots.take_last();
+        ++slab.used_slot_count;
+        auto offset = slab.offset + slot_index * slot_size;
+        if (zero_fill_new_bytes == ZeroFillNewBytes::Yes)
+            __builtin_memset(m_cage_base + offset, 0, size);
+        return Allocation {
+            .offset = offset,
+            .capacity = slot_size,
+            .reservation_size = slot_size,
+            .committed_size = slot_size,
+            .small_allocation = SmallAllocation { *size_class_index, static_cast<u16>(slab_index), slot_index },
+        };
+    }
+
+    return allocate_from_new_slab(*size_class_index, slot_size, zero_fill_new_bytes, size);
+}
+
+ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::allocate_from_new_slab(u16 size_class_index, size_t slot_size, ZeroFillNewBytes zero_fill_new_bytes, size_t requested_size)
+{
+    auto& slabs = m_small_slabs[size_class_index];
+    if (slabs.size() >= NumericLimits<u16>::max())
+        return Error::from_errno(ENOMEM);
+
+    auto slab_offset = TRY(allocate_cage_range(small_slab_size));
+    auto commit_result = Core::System::commit_memory(m_cage_base + slab_offset, small_slab_size);
+    if (commit_result.is_error()) {
+        release_cage_range(slab_offset, small_slab_size);
+        return commit_result.release_error();
+    }
+    auto release_slab_on_error = ArmedScopeGuard([&] {
+        release_cage_range(slab_offset, small_slab_size);
+    });
+
+    Slab slab;
+    slab.offset = slab_offset;
+    slab.slot_size = slot_size;
+    slab.slot_count = static_cast<u32>(small_slab_size / slot_size);
+    slab.used_slot_count = 1;
+    slab.free_slots.ensure_capacity(slab.slot_count);
+    for (u32 slot = slab.slot_count - 1; slot > 0; --slot)
+        slab.free_slots.unchecked_append(slot);
+
+    auto slab_index = static_cast<u16>(slabs.size());
+    slabs.append(move(slab));
+    release_slab_on_error.disarm();
+
+    if (zero_fill_new_bytes == ZeroFillNewBytes::Yes)
+        __builtin_memset(m_cage_base + slab_offset, 0, requested_size);
+
+    return Allocation {
+        .offset = slab_offset,
+        .capacity = slot_size,
+        .reservation_size = slot_size,
+        .committed_size = slot_size,
+        .small_allocation = SmallAllocation { size_class_index, slab_index, 0 },
+    };
 }
 
 ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::allocate_large_storage(size_t size, size_t capacity, ZeroFillNewBytes zero_fill_new_bytes, size_t guard_size)
@@ -88,6 +188,7 @@ ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::al
         .capacity = capacity,
         .reservation_size = reservation_size.value(),
         .committed_size = committed_size,
+        .small_allocation = {},
     };
 }
 
@@ -125,7 +226,8 @@ ErrorOr<void> PrimitiveStorage::Allocator::resize(Allocation& allocation, size_t
 {
     VERIFY(new_size <= allocation.capacity);
 
-    TRY(commit_large_storage(allocation, new_size));
+    if (!allocation.small_allocation.has_value())
+        TRY(commit_large_storage(allocation, new_size));
 
     if (zero_fill_new_bytes == ZeroFillNewBytes::Yes && new_size > old_size)
         __builtin_memset(data(allocation, old_size), 0, new_size - old_size);
@@ -135,6 +237,7 @@ ErrorOr<void> PrimitiveStorage::Allocator::resize(Allocation& allocation, size_t
 
 ErrorOr<void> PrimitiveStorage::Allocator::commit_large_storage(Allocation& allocation, size_t new_size)
 {
+    VERIFY(!allocation.small_allocation.has_value());
     VERIFY(new_size <= allocation.capacity);
 
     auto new_committed_size = round_up_to_page(new_size);
@@ -148,6 +251,7 @@ ErrorOr<void> PrimitiveStorage::Allocator::commit_large_storage(Allocation& allo
 
 void PrimitiveStorage::Allocator::decommit_large_storage(Allocation const& allocation)
 {
+    VERIFY(!allocation.small_allocation.has_value());
     if (allocation.committed_size == 0)
         return;
     MUST(Core::System::decommit_memory(m_cage_base + allocation.offset, allocation.committed_size));
@@ -169,6 +273,18 @@ ErrorOr<PrimitiveStorage::Allocator::Allocation> PrimitiveStorage::Allocator::re
 
 void PrimitiveStorage::Allocator::deallocate(Allocation& allocation)
 {
+    if (auto small_allocation = allocation.small_allocation; small_allocation.has_value()) {
+        auto& slabs = m_small_slabs[small_allocation->size_class_index];
+        VERIFY(small_allocation->slab_index < slabs.size());
+        auto& slab = slabs[small_allocation->slab_index];
+        VERIFY(slab.free_slots.size() < slab.slot_count);
+        slab.free_slots.unchecked_append(small_allocation->slot_index);
+        VERIFY(slab.used_slot_count > 0);
+        --slab.used_slot_count;
+        allocation = {};
+        return;
+    }
+
     if (allocation.reservation_size > 0) {
         decommit_large_storage(allocation);
         release_cage_range(allocation.offset, allocation.reservation_size);

--- a/Libraries/LibGC/PrimitiveStorage.h
+++ b/Libraries/LibGC/PrimitiveStorage.h
@@ -74,11 +74,18 @@ public:
 private:
     class Allocator {
     public:
+        struct SmallAllocation {
+            u16 size_class_index { 0 };
+            u16 slab_index { 0 };
+            u32 slot_index { 0 };
+        };
+
         struct Allocation {
             size_t offset { invalid_offset };
             size_t capacity { 0 };
             size_t reservation_size { 0 };
             size_t committed_size { 0 };
+            Optional<SmallAllocation> small_allocation;
         };
 
         ErrorOr<Allocation> allocate(size_t size, size_t capacity, ZeroFillNewBytes, size_t guard_size, bool force_large);
@@ -100,8 +107,18 @@ private:
             size_t size { 0 };
         };
 
+        struct Slab {
+            size_t offset { 0 };
+            size_t slot_size { 0 };
+            u32 slot_count { 0 };
+            u32 used_slot_count { 0 };
+            Vector<u32> free_slots;
+        };
+
         ErrorOr<void> ensure_cage();
+        ErrorOr<Allocation> allocate_small_storage(size_t size, ZeroFillNewBytes);
         ErrorOr<Allocation> allocate_large_storage(size_t size, size_t capacity, ZeroFillNewBytes, size_t guard_size);
+        ErrorOr<Allocation> allocate_from_new_slab(u16 size_class_index, size_t slot_size, ZeroFillNewBytes, size_t requested_size);
         ErrorOr<size_t> allocate_cage_range(size_t reservation_size);
         ErrorOr<void> commit_large_storage(Allocation&, size_t new_size);
         void decommit_large_storage(Allocation const&);
@@ -115,6 +132,7 @@ private:
         size_t m_cage_size { 0 };
         size_t m_next_offset { 0 };
         Vector<FreeRange> m_free_ranges;
+        Vector<Slab> m_small_slabs[13];
     };
 
     struct Entry {

--- a/Libraries/LibGC/PrimitiveStorage.h
+++ b/Libraries/LibGC/PrimitiveStorage.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Error.h>
+#include <AK/Noncopyable.h>
+#include <AK/Optional.h>
+#include <AK/StdLibExtras.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibGC/Export.h>
+
+namespace GC {
+
+struct PrimitiveStorageHandle {
+    static constexpr u32 invalid_index = NumericLimits<u32>::max();
+
+    u32 index { invalid_index };
+    u32 generation { 0 };
+
+    bool is_valid() const { return index != invalid_index && generation != 0; }
+};
+
+class GC_API PrimitiveStorage {
+    AK_MAKE_NONCOPYABLE(PrimitiveStorage);
+    AK_MAKE_NONMOVABLE(PrimitiveStorage);
+
+public:
+    enum class ZeroFillNewBytes {
+        No,
+        Yes,
+    };
+
+    static constexpr size_t default_cage_size = 64ull * GiB;
+    static_assert(is_power_of_two(default_cage_size));
+    static constexpr size_t cage_offset_mask = default_cage_size - 1;
+    static constexpr size_t invalid_offset = NumericLimits<size_t>::max();
+
+    static PrimitiveStorage& the();
+
+    ErrorOr<PrimitiveStorageHandle> try_allocate(size_t size, ZeroFillNewBytes = ZeroFillNewBytes::Yes);
+    ErrorOr<PrimitiveStorageHandle> try_reserve(size_t size, size_t capacity, ZeroFillNewBytes = ZeroFillNewBytes::Yes, size_t guard_size = 0);
+
+    bool is_valid(PrimitiveStorageHandle) const;
+    bool contains(void const* address, size_t size = 1) const;
+    bool contains(PrimitiveStorageHandle, void const* address, size_t size = 1) const;
+
+    size_t offset(PrimitiveStorageHandle) const;
+    size_t size(PrimitiveStorageHandle) const;
+    size_t capacity(PrimitiveStorageHandle) const;
+    size_t committed_size(PrimitiveStorageHandle) const;
+
+    u8* data(PrimitiveStorageHandle);
+    u8 const* data(PrimitiveStorageHandle) const;
+    Bytes bytes(PrimitiveStorageHandle);
+    ReadonlyBytes bytes(PrimitiveStorageHandle) const;
+
+    ErrorOr<void> try_resize(PrimitiveStorageHandle, size_t new_size, ZeroFillNewBytes = ZeroFillNewBytes::No);
+    ErrorOr<void> try_reserve(PrimitiveStorageHandle, size_t new_capacity);
+    ErrorOr<void> try_resize_and_reserve(PrimitiveStorageHandle, size_t new_size, size_t new_capacity, ZeroFillNewBytes = ZeroFillNewBytes::No);
+    void free(PrimitiveStorageHandle);
+
+    u8* cage_base() { return m_allocator.cage_base(); }
+    u8 const* cage_base() const { return m_allocator.cage_base(); }
+    size_t cage_size() const { return m_allocator.cage_size(); }
+
+    PrimitiveStorage() = default;
+
+private:
+    class Allocator {
+    public:
+        struct Allocation {
+            size_t offset { invalid_offset };
+            size_t capacity { 0 };
+            size_t reservation_size { 0 };
+            size_t committed_size { 0 };
+        };
+
+        ErrorOr<Allocation> allocate(size_t size, size_t capacity, ZeroFillNewBytes, size_t guard_size, bool force_large);
+        ErrorOr<void> resize(Allocation&, size_t old_size, size_t new_size, ZeroFillNewBytes);
+        ErrorOr<Allocation> reallocate(Allocation const&, size_t old_size, size_t new_size, size_t new_capacity, ZeroFillNewBytes, bool force_large);
+        void deallocate(Allocation&);
+
+        bool contains(void const* address, size_t size = 1) const;
+        bool contains(Allocation const&, void const* address, size_t size = 1) const;
+        u8* data(Allocation const&, size_t byte_offset = 0) const;
+
+        u8* cage_base() { return m_cage_base; }
+        u8 const* cage_base() const { return m_cage_base; }
+        size_t cage_size() const { return m_cage_size; }
+
+    private:
+        struct FreeRange {
+            size_t offset { 0 };
+            size_t size { 0 };
+        };
+
+        ErrorOr<void> ensure_cage();
+        ErrorOr<Allocation> allocate_large_storage(size_t size, size_t capacity, ZeroFillNewBytes, size_t guard_size);
+        ErrorOr<size_t> allocate_cage_range(size_t reservation_size);
+        ErrorOr<void> commit_large_storage(Allocation&, size_t new_size);
+        void decommit_large_storage(Allocation const&);
+        void release_cage_range(size_t offset, size_t size);
+        void free_cage_range(size_t offset, size_t size);
+        void reclaim_free_ranges_at_top();
+
+        static size_t page_size();
+
+        u8* m_cage_base { nullptr };
+        size_t m_cage_size { 0 };
+        size_t m_next_offset { 0 };
+        Vector<FreeRange> m_free_ranges;
+    };
+
+    struct Entry {
+        u32 generation { 1 };
+        bool allocated { false };
+        size_t size { 0 };
+        Allocator::Allocation allocation;
+    };
+
+    PrimitiveStorageHandle install_allocation(Allocator::Allocation, size_t size);
+    Entry* entry_for(PrimitiveStorageHandle);
+    Entry const* entry_for(PrimitiveStorageHandle) const;
+    u8* data_unchecked(Entry const&) const;
+    ErrorOr<void> reallocate_entry(Entry&, size_t new_size, size_t new_capacity, ZeroFillNewBytes, bool force_large);
+
+    Allocator m_allocator;
+    Vector<Entry> m_entries;
+    Vector<u32> m_free_entry_indices;
+};
+
+}
+
+extern "C" GC_API FlatPtr js_primitive_storage_cage_base;

--- a/Libraries/LibGC/PrimitiveStorage.h
+++ b/Libraries/LibGC/PrimitiveStorage.h
@@ -42,6 +42,7 @@ public:
     static constexpr size_t invalid_offset = NumericLimits<size_t>::max();
 
     static PrimitiveStorage& the();
+    static constexpr size_t mask_offset(size_t offset) { return offset & cage_offset_mask; }
 
     ErrorOr<PrimitiveStorageHandle> try_allocate(size_t size, ZeroFillNewBytes = ZeroFillNewBytes::Yes);
     ErrorOr<PrimitiveStorageHandle> try_reserve(size_t size, size_t capacity, ZeroFillNewBytes = ZeroFillNewBytes::Yes, size_t guard_size = 0);
@@ -57,8 +58,8 @@ public:
 
     u8* data(PrimitiveStorageHandle);
     u8 const* data(PrimitiveStorageHandle) const;
-    Bytes bytes(PrimitiveStorageHandle);
-    ReadonlyBytes bytes(PrimitiveStorageHandle) const;
+    u8* data(PrimitiveStorageHandle, size_t byte_offset);
+    u8 const* data(PrimitiveStorageHandle, size_t byte_offset) const;
 
     ErrorOr<void> try_resize(PrimitiveStorageHandle, size_t new_size, ZeroFillNewBytes = ZeroFillNewBytes::No);
     ErrorOr<void> try_reserve(PrimitiveStorageHandle, size_t new_capacity);

--- a/Libraries/LibJS/AsmIntGen/src/allocator.rs
+++ b/Libraries/LibJS/AsmIntGen/src/allocator.rs
@@ -1561,6 +1561,41 @@ end
     }
 
     #[test]
+    fn and_immediate_keeps_live_temps_off_x86_scratch_registers() {
+        // x86_64 lowers large `and` immediates through rax, or through r11
+        // when the destination is rax. Temps live across the instruction
+        // must avoid both scratch registers.
+        let src = "
+handler Test
+    temp base, index
+    mov base, 100
+    mov index, 0x123456789
+    and index, 0x3ffffffff
+    add index, base
+    store_operand m_dst, index
+    dispatch_next
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        for insn in &out {
+            if insn.mnemonic == "mov" && insn.operands.len() == 2 {
+                if let Operand::Immediate(100) = insn.operands[1] {
+                    if let Operand::Register(name) = &insn.operands[0] {
+                        assert_ne!(name, "rax", "live temp must avoid rax");
+                        assert_ne!(name, "r11", "live temp must avoid r11");
+                    }
+                }
+            }
+            if insn.mnemonic == "and" {
+                if let Some(Operand::Register(name)) = insn.operands.first() {
+                    assert_ne!(name, "rax", "and dst must avoid rax");
+                    assert_ne!(name, "r11", "and dst must avoid r11");
+                }
+            }
+        }
+    }
+
+    #[test]
     fn macro_local_temps_can_share_a_physical_register_across_invocations() {
         // Two non-overlapping invocations of the same macro should be
         // free to put their private `tmp` in the same physical register.

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -2292,6 +2292,31 @@ fn emit_instruction(
             }
         }
 
+        // load_c_symbol_address dst, symbol - Load the address of an external C symbol.
+        "load_c_symbol_address" => {
+            if insn.operands.len() == 2 {
+                let dst = resolve_op(&insn.operands[0], handler, program);
+                let symbol = match &insn.operands[1] {
+                    Operand::Register(symbol) | Operand::Constant(symbol) | Operand::Label(symbol) => symbol,
+                    _ => panic!("load_c_symbol_address expects a symbol operand"),
+                };
+                let symbol = format!("CSYM({symbol})");
+                match program.object_format {
+                    ObjectFormat::MachO => {
+                        w!(out, "    adrp {dst}, {symbol}@GOTPAGE");
+                        w!(out, "    ldr {dst}, [{dst}, {symbol}@GOTPAGEOFF]");
+                    }
+                    ObjectFormat::Elf => {
+                        w!(out, "    adrp {dst}, :got:{symbol}");
+                        w!(out, "    ldr {dst}, [{dst}, :got_lo12:{symbol}]");
+                    }
+                    ObjectFormat::Coff => {
+                        emit_symbol_addr(out, &dst, &symbol, program.object_format);
+                    }
+                }
+            }
+        }
+
         // Floating point instructions
         "fp_add" => {
             if insn.operands.len() == 2 {

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -1502,9 +1502,12 @@ fn emit_instruction(
                         // Use mov to 32-bit register to zero upper bits
                         let dst32 = to_32bit_reg(&dst);
                         w!(out, "    mov {dst32}, {dst32}");
+                    } else if val >= i32::MIN as i64 && val <= i32::MAX as i64 {
+                        w!(out, "    and {dst}, {val}");
                     } else {
-                        let src = resolve_op(&insn.operands[1], handler, program);
-                        w!(out, "    and {dst}, {src}");
+                        let scratch = if dst == "rax" { "r11" } else { "rax" };
+                        w!(out, "    movabs {scratch}, {val}");
+                        w!(out, "    and {dst}, {scratch}");
                     }
                 } else {
                     let src = resolve_op(&insn.operands[1], handler, program);
@@ -1558,7 +1561,7 @@ fn emit_instruction(
                         w!(out, "    mov {dst}, QWORD PTR [rip + CSYM({symbol})@GOTPCREL]");
                     }
                     ObjectFormat::Coff => {
-                        w!(out, "    lea {dst}, [rip + CSYM({symbol})]");
+                        w!(out, "    mov {dst}, QWORD PTR [rip + __imp_{symbol}]");
                     }
                 }
             }
@@ -1921,6 +1924,67 @@ mod tests {
         assert!(out.contains("bt rdx, 32"));
         assert!(out.contains("jnc .Lasm_Call.slow"));
         assert!(!out.contains("test rdx, 4294967296"));
+    }
+
+    #[test]
+    fn lowers_large_and_mask_through_scratch_register() {
+        let mut program = test_program();
+        program
+            .constants
+            .insert("CAGE_MASK".into(), 0x0000_003f_ffff_ffff);
+        let handler = call_handler();
+        let instruction = AsmInstruction {
+            mnemonic: "and".into(),
+            operands: vec![
+                Operand::Register("rdx".into()),
+                Operand::Constant("CAGE_MASK".into()),
+            ],
+        };
+        let mut out = String::new();
+        let mut state = HandlerState::new();
+
+        emit_instruction(
+            &mut out,
+            &instruction,
+            &handler,
+            &program,
+            &mut state,
+            X86_64Abi::SysV,
+        );
+
+        assert!(out.contains("movabs rax, 274877906943"));
+        assert!(out.contains("and rdx, rax"));
+        assert!(!out.contains("and rdx, 274877906943"));
+    }
+
+    #[test]
+    fn lowers_large_and_mask_on_rax_through_r11() {
+        let mut program = test_program();
+        program
+            .constants
+            .insert("CAGE_MASK".into(), 0x0000_003f_ffff_ffff);
+        let handler = call_handler();
+        let instruction = AsmInstruction {
+            mnemonic: "and".into(),
+            operands: vec![
+                Operand::Register("rax".into()),
+                Operand::Constant("CAGE_MASK".into()),
+            ],
+        };
+        let mut out = String::new();
+        let mut state = HandlerState::new();
+
+        emit_instruction(
+            &mut out,
+            &instruction,
+            &handler,
+            &program,
+            &mut state,
+            X86_64Abi::SysV,
+        );
+
+        assert!(out.contains("movabs r11, 274877906943"));
+        assert!(out.contains("and rax, r11"));
     }
 
     #[test]

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -1545,6 +1545,25 @@ fn emit_instruction(
             }
         }
 
+        // load_c_symbol_address dst, symbol - Load the address of an external C symbol.
+        "load_c_symbol_address" => {
+            if insn.operands.len() == 2 {
+                let dst = resolve_op(&insn.operands[0], handler, program);
+                let symbol = match &insn.operands[1] {
+                    Operand::Register(symbol) | Operand::Constant(symbol) | Operand::Label(symbol) => symbol,
+                    _ => panic!("load_c_symbol_address expects a symbol operand"),
+                };
+                match program.object_format {
+                    ObjectFormat::MachO | ObjectFormat::Elf => {
+                        w!(out, "    mov {dst}, QWORD PTR [rip + CSYM({symbol})@GOTPCREL]");
+                    }
+                    ObjectFormat::Coff => {
+                        w!(out, "    lea {dst}, [rip + CSYM({symbol})]");
+                    }
+                }
+            }
+        }
+
         // Unconditional jump - resolve local labels
         "jmp" => {
             if let Some(Operand::Label(label)) = insn.operands.first() {

--- a/Libraries/LibJS/AsmIntGen/src/instructions.rs
+++ b/Libraries/LibJS/AsmIntGen/src/instructions.rs
@@ -635,7 +635,7 @@ pub const INSTRUCTIONS: &[InstructionInfo] = &[
         None,
         false,
         false,
-        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["rax", "r11"], ..ArchSpec::NONE },
         ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
     ),
     info(
@@ -1160,6 +1160,13 @@ mod tests {
     fn table_entries_are_unique() {
         // Force the lazy index to build, which asserts uniqueness.
         let _ = index();
+    }
+
+    #[test]
+    fn and_declares_x86_large_immediate_scratch_registers() {
+        let info = lookup("and").expect("and instruction should exist");
+        assert!(info.x86_64.clobbers_gpr.contains(&"rax"));
+        assert!(info.x86_64.clobbers_gpr.contains(&"r11"));
     }
 
     #[test]

--- a/Libraries/LibJS/AsmIntGen/src/instructions.rs
+++ b/Libraries/LibJS/AsmIntGen/src/instructions.rs
@@ -552,6 +552,7 @@ pub const INSTRUCTIONS: &[InstructionInfo] = &[
         // Large offsets / non-power-of-two scales go through x9.
         ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
     ),
+    plain("load_c_symbol_address", &[GprOut, FuncSymbol]),
 
     // ------------------------------------------------------------------
     // Integer ALU

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmSlowPaths.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmSlowPaths.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Types.h>
 #include <LibJS/Bytecode/Builtins.h>
@@ -2812,34 +2813,38 @@ i64 asm_try_get_by_value_typed_array(VM* vm, u32, Op::GetByValue const* instruct
     }
 
     auto* buffer = typed_array.viewed_array_buffer();
-    auto const* data = buffer->data() + typed_array.byte_offset();
+    Checked<size_t> byte_index = index;
+    byte_index *= typed_array.element_size();
+    byte_index += typed_array.byte_offset();
+    if (byte_index.has_overflow()) [[unlikely]]
+        return 1;
 
     Value result;
     switch (typed_array.kind()) {
     case TypedArrayBase::Kind::Uint8Array:
     case TypedArrayBase::Kind::Uint8ClampedArray:
-        result = Value(static_cast<i32>(data[index]));
+        result = buffer->get_value<u8>(byte_index.value(), true, ArrayBuffer::Order::Unordered);
         break;
     case TypedArrayBase::Kind::Int8Array:
-        result = Value(static_cast<i32>(reinterpret_cast<i8 const*>(data)[index]));
+        result = buffer->get_value<i8>(byte_index.value(), true, ArrayBuffer::Order::Unordered);
         break;
     case TypedArrayBase::Kind::Uint16Array:
-        result = Value(static_cast<i32>(reinterpret_cast<u16 const*>(data)[index]));
+        result = buffer->get_value<u16>(byte_index.value(), true, ArrayBuffer::Order::Unordered);
         break;
     case TypedArrayBase::Kind::Int16Array:
-        result = Value(static_cast<i32>(reinterpret_cast<i16 const*>(data)[index]));
+        result = buffer->get_value<i16>(byte_index.value(), true, ArrayBuffer::Order::Unordered);
         break;
     case TypedArrayBase::Kind::Uint32Array:
-        result = Value(static_cast<double>(reinterpret_cast<u32 const*>(data)[index]));
+        result = buffer->get_value<u32>(byte_index.value(), true, ArrayBuffer::Order::Unordered);
         break;
     case TypedArrayBase::Kind::Int32Array:
-        result = Value(reinterpret_cast<i32 const*>(data)[index]);
+        result = buffer->get_value<i32>(byte_index.value(), true, ArrayBuffer::Order::Unordered);
         break;
     case TypedArrayBase::Kind::Float32Array:
-        result = Value(static_cast<double>(reinterpret_cast<float const*>(data)[index]));
+        result = buffer->get_value<float>(byte_index.value(), true, ArrayBuffer::Order::Unordered);
         break;
     case TypedArrayBase::Kind::Float64Array:
-        result = Value(reinterpret_cast<double const*>(data)[index]);
+        result = buffer->get_value<double>(byte_index.value(), true, ArrayBuffer::Order::Unordered);
         break;
     default:
         return 1;
@@ -2883,32 +2888,36 @@ i64 asm_try_put_by_value_typed_array(VM* vm, u32, Op::PutByValue const* instruct
         return 1;
 
     auto* buffer = typed_array.viewed_array_buffer();
-    auto* data = buffer->data() + typed_array.byte_offset();
+    Checked<size_t> byte_index = index;
+    byte_index *= typed_array.element_size();
+    byte_index += typed_array.byte_offset();
+    if (byte_index.has_overflow()) [[unlikely]]
+        return 1;
     auto value = vm->get(instruction->src());
 
     if (value.is_int32()) {
         auto int_val = value.as_i32();
         switch (typed_array.kind()) {
         case TypedArrayBase::Kind::Uint8Array:
-            data[index] = static_cast<u8>(int_val);
+            buffer->set_value<u8>(byte_index.value(), value, true, ArrayBuffer::Order::Unordered);
             return 0;
         case TypedArrayBase::Kind::Uint8ClampedArray:
-            data[index] = static_cast<u8>(clamp(int_val, 0, 255));
+            buffer->set_value<ClampedU8>(byte_index.value(), Value { clamp(int_val, 0, 255) }, true, ArrayBuffer::Order::Unordered);
             return 0;
         case TypedArrayBase::Kind::Int8Array:
-            reinterpret_cast<i8*>(data)[index] = static_cast<i8>(int_val);
+            buffer->set_value<i8>(byte_index.value(), value, true, ArrayBuffer::Order::Unordered);
             return 0;
         case TypedArrayBase::Kind::Uint16Array:
-            reinterpret_cast<u16*>(data)[index] = static_cast<u16>(int_val);
+            buffer->set_value<u16>(byte_index.value(), value, true, ArrayBuffer::Order::Unordered);
             return 0;
         case TypedArrayBase::Kind::Int16Array:
-            reinterpret_cast<i16*>(data)[index] = static_cast<i16>(int_val);
+            buffer->set_value<i16>(byte_index.value(), value, true, ArrayBuffer::Order::Unordered);
             return 0;
         case TypedArrayBase::Kind::Uint32Array:
-            reinterpret_cast<u32*>(data)[index] = static_cast<u32>(int_val);
+            buffer->set_value<u32>(byte_index.value(), value, true, ArrayBuffer::Order::Unordered);
             return 0;
         case TypedArrayBase::Kind::Int32Array:
-            reinterpret_cast<i32*>(data)[index] = int_val;
+            buffer->set_value<i32>(byte_index.value(), value, true, ArrayBuffer::Order::Unordered);
             return 0;
         default:
             break;
@@ -2917,10 +2926,10 @@ i64 asm_try_put_by_value_typed_array(VM* vm, u32, Op::PutByValue const* instruct
         auto dbl_val = value.as_double();
         switch (typed_array.kind()) {
         case TypedArrayBase::Kind::Float32Array:
-            reinterpret_cast<float*>(data)[index] = static_cast<float>(dbl_val);
+            buffer->set_value<float>(byte_index.value(), Value { dbl_val }, true, ArrayBuffer::Order::Unordered);
             return 0;
         case TypedArrayBase::Kind::Float64Array:
-            reinterpret_cast<double*>(data)[index] = dbl_val;
+            buffer->set_value<double>(byte_index.value(), Value { dbl_val }, true, ArrayBuffer::Order::Unordered);
             return 0;
         default:
             break;

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -624,6 +624,14 @@ macro load_global_variable_cache(cache)
     add cache, caches
 end
 
+macro caged_primitive_storage_address(dst, cage_base, cached_offset, index, shift)
+    mov dst, index
+    shl dst, shift
+    add dst, cached_offset
+    and dst, PRIMITIVE_STORAGE_CAGE_OFFSET_MASK
+    add dst, cage_base
+end
+
 # ============================================================================
 # Simple data movement
 # ============================================================================
@@ -1842,7 +1850,6 @@ handler PutByValue
     load_c_symbol_address elements, js_primitive_storage_cage_base
     load64 elements, [elements, 0]
     branch_zero elements, .try_typed_array_slow
-    add elements, cached_offset
     assert_nonzero elements
     # Cached pointers only exist for fixed-length typed arrays, so array_length
     # is known to hold a concrete u32 value here.
@@ -1856,16 +1863,12 @@ handler PutByValue
     branch_eq kind_byte, TYPED_ARRAY_KIND_FLOAT32, .ta_store_float32
     branch_ne kind_byte, TYPED_ARRAY_KIND_FLOAT64, .try_typed_array_slow
     # Compute store address before check_is_double mangles its argument.
-    mov addr, index
-    shl addr, 3
-    add addr, elements
+    caged_primitive_storage_address addr, elements, cached_offset, index, 3
     check_is_double src, .try_typed_array_slow
     store64 [addr, 0], src
     dispatch_next
 .ta_store_float32:
-    mov addr, index
-    shl addr, 2
-    add addr, elements
+    caged_primitive_storage_address addr, elements, cached_offset, index, 2
     check_is_double src, .try_typed_array_slow
     fp_mov src_dbl, src
     double_to_float src_dbl, src_dbl
@@ -1880,37 +1883,36 @@ handler PutByValue
     branch_any_eq kind_byte, TYPED_ARRAY_KIND_UINT16, TYPED_ARRAY_KIND_INT16, .ta_put_uint16
     jmp .try_typed_array_slow
 .ta_put_int32:
-    store32 [elements, index, 4], src_int32
+    caged_primitive_storage_address addr, elements, cached_offset, index, 2
+    store32 [addr, 0], src_int32
     dispatch_next
 .ta_put_float32:
     int_to_double src_dbl, src_int32
     double_to_float src_dbl, src_dbl
-    mov addr, index
-    shl addr, 2
-    add addr, elements
+    caged_primitive_storage_address addr, elements, cached_offset, index, 2
     storef32 [addr, 0], src_dbl
     dispatch_next
 .ta_put_uint8_clamped:
+    caged_primitive_storage_address addr, elements, cached_offset, index, 0
     branch_negative src_int32, .ta_put_uint8_clamped_zero
     mov max, 255
     branch_ge_unsigned src_int32, max, .ta_put_uint8_clamped_max
-    store8 [elements, index], src_int32
+    store8 [addr, 0], src_int32
     dispatch_next
 .ta_put_uint8_clamped_zero:
     mov src_int32, 0
-    store8 [elements, index], src_int32
+    store8 [addr, 0], src_int32
     dispatch_next
 .ta_put_uint8_clamped_max:
     mov src_int32, 255
-    store8 [elements, index], src_int32
+    store8 [addr, 0], src_int32
     dispatch_next
 .ta_put_uint8:
-    store8 [elements, index], src_int32
+    caged_primitive_storage_address addr, elements, cached_offset, index, 0
+    store8 [addr, 0], src_int32
     dispatch_next
 .ta_put_uint16:
-    mov addr, index
-    add addr, index
-    add addr, elements
+    caged_primitive_storage_address addr, elements, cached_offset, index, 1
     store16 [addr, 0], src_int32
     dispatch_next
 .try_typed_array_slow:
@@ -2072,7 +2074,6 @@ handler GetByValue
     load_c_symbol_address elements, js_primitive_storage_cage_base
     load64 elements, [elements, 0]
     branch_zero elements, .try_typed_array_slow
-    add elements, cached_offset
     assert_nonzero elements
     # Cached pointers only exist for fixed-length typed arrays, so array_length
     # is known to hold a concrete u32 value here.
@@ -2089,28 +2090,27 @@ handler GetByValue
     branch_eq kind_byte, TYPED_ARRAY_KIND_FLOAT64, .ta_float64
     jmp .try_typed_array_slow
 .ta_int32:
-    load32 raw, [elements, index, 4]
+    caged_primitive_storage_address addr, elements, cached_offset, index, 2
+    load32 raw, [addr, 0]
     jmp .ta_box_int32
 .ta_uint8:
-    load8 raw, [elements, index]
+    caged_primitive_storage_address addr, elements, cached_offset, index, 0
+    load8 raw, [addr, 0]
     jmp .ta_box_int32
 .ta_uint16:
-    mov addr, index
-    add addr, index
-    load16 raw, [elements, addr]
+    caged_primitive_storage_address addr, elements, cached_offset, index, 1
+    load16 raw, [addr, 0]
     jmp .ta_box_int32
 .ta_int8:
-    load8s raw, [elements, index]
+    caged_primitive_storage_address addr, elements, cached_offset, index, 0
+    load8s raw, [addr, 0]
     jmp .ta_box_int32
 .ta_int16:
-    mov addr, index
-    add addr, index
-    load16s raw, [elements, addr]
+    caged_primitive_storage_address addr, elements, cached_offset, index, 1
+    load16s raw, [addr, 0]
     jmp .ta_box_int32
 .ta_float32:
-    mov addr, index
-    shl addr, 2
-    add addr, elements
+    caged_primitive_storage_address addr, elements, cached_offset, index, 2
     loadf32 slot_dbl, [addr, 0]
     float_to_double slot_dbl, slot_dbl
     fp_mov slot, slot_dbl
@@ -2120,9 +2120,7 @@ handler GetByValue
     branch_nonzero raw, .ta_f64_as_int
     jmp .ta_f64_as_int
 .ta_float64:
-    mov addr, index
-    shl addr, 3
-    add addr, elements
+    caged_primitive_storage_address addr, elements, cached_offset, index, 3
     load64 slot, [addr, 0]
     fp_mov slot_dbl, slot
     # Exclude negative zero early (slot gets clobbered by double_to_int32).
@@ -2140,7 +2138,8 @@ handler GetByValue
     store_operand m_dst, dst
     dispatch_next
 .ta_uint32:
-    load32 raw, [elements, index, 4]
+    caged_primitive_storage_address addr, elements, cached_offset, index, 2
+    load32 raw, [addr, 0]
     branch_bit_set raw, 31, .ta_uint32_to_double
     jmp .ta_box_int32
 .ta_uint32_to_double:
@@ -2357,7 +2356,7 @@ handler Call
     #   3. Reserve an InterpreterStack frame and populate ExecutionContext.
     #   4. Materialize [registers | locals | constants | arguments].
     #   5. Swap VM state over to the callee frame and dispatch at pc = 0.
-    temp callee, callee_value, flags, shared_data, exec_ptr, meta, this_value, tag, scratch, formal_count, passed_count, arg_count, total_slots, regs_locals_count, frame_bytes, vm_ptr, stack_limit, frame_base, value_tail, realm, lex_env, priv_env, empty_tag, som_src, som_lo, som_hi, return_pc, return_dst, base_pc, slot_offset, slot_end, const_count, const_data, const_idx, const_value, write_idx, arg_idx, arg_ops, arg_value, undef_slot, fill_end, native_func, variant, native_return, helper_arg, native_pc, exception_pc, native_total_bytes, after_pc, dst_offset, after_offset, result
+    temp callee, callee_value, flags, shared_data, exec_ptr, meta, this_value, tag, scratch, formal_count, passed_count, arg_count, total_slots, regs_locals_count, frame_bytes, vm_ptr, stack_limit, frame_base, value_tail, realm, lex_env, priv_env, empty_tag, som_src, som_lo, som_hi, return_pc, return_dst, base_pc, slot_offset, slot_end, const_count, const_data, const_idx, const_value, write_idx, arg_idx, arg_ops, arg_value, undef_slot, fill_end, native_func, variant, native_return, native_payload, helper_arg, native_pc, exception_pc, native_total_bytes, after_pc, dst_offset, after_offset, result
     load_operand callee_value, m_callee
     extract_tag tag, callee_value
     branch_ne tag, OBJECT_TAG, .call_slow
@@ -2726,6 +2725,7 @@ handler Call
     load64 native_func, [callee, RAW_NATIVE_FUNCTION_NATIVE_FUNCTION]
     assert_nonzero native_func
     call_raw_native native_func, native_return, variant
+    mov native_payload, native_return
     and variant, 0xFF
     assert_lt_unsigned variant, 2
     branch_nonzero variant, .call_raw_native_exception
@@ -2740,7 +2740,7 @@ handler Call
     store64 [vm_ptr, VM_INTERPRETER_STACK_TOP], exec_ctx
     mov exec_ctx, frame_base
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
-    store_operand m_dst, native_return
+    store_operand m_dst, native_payload
     load32 after_offset, [pb, pc, m_length]
     dispatch_variable after_offset
 
@@ -2753,10 +2753,10 @@ handler Call
     #          program counter to resume at inside the (post-unwind)
     #          running execution context.
     #    < 0 : no handler; bail out of the asm dispatch loop entirely.
-    # native_return is pinned to rax by call_raw_native; helper_arg is
-    # pinned to rcx by call_helper, so this mov is the explicit bridge
-    # between the two ABIs.
-    mov helper_arg, native_return
+    # native_payload carries the rax-pinned call_raw_native payload.
+    # helper_arg is pinned to rcx by call_helper, so this mov is the
+    # explicit bridge between the two ABIs.
+    mov helper_arg, native_payload
     call_helper asm_helper_handle_raw_native_exception, helper_arg, exception_pc
     branch_negative exception_pc, .call_exit_asm
     # Reload exec_ctx/values/pb/pc from the caller frame the helper left

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1781,7 +1781,7 @@ end
 
 # Fast path for array[int32_index] = value with Packed/Holey indexed storage.
 handler PutByValue
-    temp kind, base, prop, base_tag, prop_tag, index, obj, flags, storage_kind, size, elements, src, capacity_addr, capacity, slot, empty_tag, kind_byte, addr, src_int32, max, result
+    temp kind, base, prop, base_tag, prop_tag, index, obj, flags, storage_kind, size, elements, src, capacity_addr, capacity, slot, empty_tag, kind_byte, addr, src_int32, max, result, cached_offset, invalid_offset
     ftemp src_dbl
     # Only fast-path Normal puts (not Getter/Setter/Own)
     load8 kind, [pb, pc, m_kind]
@@ -1834,10 +1834,15 @@ handler PutByValue
     branch_nonzero result, .slow
     dispatch_next
 .try_typed_array:
-    # Load cached data pointer (pre-computed: buffer.data() + byte_offset)
-    # nullptr means uncached -> C++ helper will resolve the access.
-    load64 elements, [obj, TYPED_ARRAY_CACHED_DATA_PTR]
+    # Load cached cage offset (pre-computed: buffer.data_offset() + byte_offset)
+    # invalid means uncached -> C++ helper will resolve the access.
+    load64 cached_offset, [obj, TYPED_ARRAY_CACHED_DATA_OFFSET]
+    mov invalid_offset, TYPED_ARRAY_CACHED_DATA_OFFSET_INVALID
+    branch_eq cached_offset, invalid_offset, .try_typed_array_slow
+    load_c_symbol_address elements, js_primitive_storage_cage_base
+    load64 elements, [elements, 0]
     branch_zero elements, .try_typed_array_slow
+    add elements, cached_offset
     assert_nonzero elements
     # Cached pointers only exist for fixed-length typed arrays, so array_length
     # is known to hold a concrete u32 value here.
@@ -2016,7 +2021,7 @@ end
 
 # Fast path for array[int32_index] with Packed/Holey indexed storage.
 handler GetByValue
-    temp base, prop, base_tag, prop_tag, index, obj, flags, storage_kind, size, elements, slot, capacity_addr, capacity, kind_byte, raw, addr, neg_zero, dst, result
+    temp base, prop, base_tag, prop_tag, index, obj, flags, storage_kind, size, elements, slot, capacity_addr, capacity, kind_byte, raw, addr, neg_zero, dst, result, cached_offset, invalid_offset
     ftemp slot_dbl
     load_operand base, m_base
     load_operand prop, m_property
@@ -2061,8 +2066,13 @@ handler GetByValue
     store_operand m_dst, slot
     dispatch_next
 .try_typed_array:
-    load64 elements, [obj, TYPED_ARRAY_CACHED_DATA_PTR]
+    load64 cached_offset, [obj, TYPED_ARRAY_CACHED_DATA_OFFSET]
+    mov invalid_offset, TYPED_ARRAY_CACHED_DATA_OFFSET_INVALID
+    branch_eq cached_offset, invalid_offset, .try_typed_array_slow
+    load_c_symbol_address elements, js_primitive_storage_cage_base
+    load64 elements, [elements, 0]
     branch_zero elements, .try_typed_array_slow
+    add elements, cached_offset
     assert_nonzero elements
     # Cached pointers only exist for fixed-length typed arrays, so array_length
     # is known to hold a concrete u32 value here.

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -10,6 +10,7 @@
 #include <AK/Format.h>
 #include <AK/StringBase.h>
 #include <AK/Utf16StringData.h>
+#include <LibGC/PrimitiveStorage.h>
 #include <LibJS/Bytecode/Builtins.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/PropertyNameIterator.h>
@@ -359,7 +360,8 @@ int main()
     EMIT_OFFSET(TYPED_ARRAY_BYTE_OFFSET, TypedArrayBase, m_byte_offset);
     EMIT_OFFSET(TYPED_ARRAY_KIND, TypedArrayBase, m_kind);
     EMIT_OFFSET(TYPED_ARRAY_CACHED_DATA_OFFSET, TypedArrayBase, m_cached_data_offset);
-    outln("const TYPED_ARRAY_CACHED_DATA_OFFSET_INVALID = 0x{:X}", TypedArrayBase::invalid_cached_data_offset);
+    outln("const TYPED_ARRAY_CACHED_DATA_OFFSET_INVALID = 0x{:X}", static_cast<size_t>(TypedArrayBase::invalid_cached_data_offset));
+    outln("const PRIMITIVE_STORAGE_CAGE_OFFSET_MASK = 0x{:X}", static_cast<size_t>(GC::PrimitiveStorage::cage_offset_mask));
 
     // ByteLength (Variant<Auto, Detached, u32>) layout
     outln("\n# ByteLength layout");

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -358,7 +358,8 @@ int main()
     EMIT_OFFSET(TYPED_ARRAY_ARRAY_LENGTH, TypedArrayBase, m_array_length);
     EMIT_OFFSET(TYPED_ARRAY_BYTE_OFFSET, TypedArrayBase, m_byte_offset);
     EMIT_OFFSET(TYPED_ARRAY_KIND, TypedArrayBase, m_kind);
-    EMIT_OFFSET(TYPED_ARRAY_CACHED_DATA_PTR, TypedArrayBase, m_data);
+    EMIT_OFFSET(TYPED_ARRAY_CACHED_DATA_OFFSET, TypedArrayBase, m_cached_data_offset);
+    outln("const TYPED_ARRAY_CACHED_DATA_OFFSET_INVALID = 0x{:X}", TypedArrayBase::invalid_cached_data_offset);
 
     // ByteLength (Variant<Auto, Detached, u32>) layout
     outln("\n# ByteLength layout");

--- a/Libraries/LibJS/Print.cpp
+++ b/Libraries/LibJS/Print.cpp
@@ -422,7 +422,7 @@ ErrorOr<void> print_array_buffer(JS::PrintContext& print_context, JS::ArrayBuffe
     if (byte_length == 0)
         return {};
 
-    auto const* buffer_data = array_buffer.data();
+    auto buffer_data = TRY(array_buffer.copy_to_byte_buffer());
     TRY(js_out(print_context, "\n"));
     for (size_t i = 0; i < byte_length; ++i) {
         TRY(js_out(print_context, "{:02x}", buffer_data[i]));
@@ -486,27 +486,20 @@ ErrorOr<void> print_typed_array(JS::PrintContext& print_context, JS::TypedArrayB
     TRY(js_out(print_context, "\n"));
     // FIXME: Find a better way to print typed arrays to the console.
     // The current solution is limited to 100 lines, is hard to read, and hampers debugging.
-#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
-    if (is<JS::ClassName>(typed_array_base)) {                                           \
-        TRY(js_out(print_context, "[ "));                                                \
-        auto& typed_array = static_cast<JS::ClassName const&>(typed_array_base);         \
-        auto data = typed_array.data();                                                  \
-        size_t printed_count = 0;                                                        \
-        for (size_t i = 0; i < length; ++i) {                                            \
-            if (i > 0)                                                                   \
-                TRY(js_out(print_context, ", "));                                        \
-            TRY(print_number(print_context, data[i]));                                   \
-            if (++printed_count > 100 && i < length) {                                   \
-                TRY(js_out(print_context, ", ..."));                                     \
-                break;                                                                   \
-            }                                                                            \
-        }                                                                                \
-        TRY(js_out(print_context, " ]"));                                                \
-        return {};                                                                       \
+    TRY(js_out(print_context, "[ "));
+    size_t printed_count = 0;
+    for (size_t i = 0; i < length; ++i) {
+        if (i > 0)
+            TRY(js_out(print_context, ", "));
+        auto byte_index = typed_array_base.byte_offset() + i * typed_array_base.element_size();
+        TRY(print_value(print_context, typed_array_base.get_value_from_buffer(byte_index, JS::ArrayBuffer::Order::Unordered), seen_objects));
+        if (++printed_count > 100 && i < length) {
+            TRY(js_out(print_context, ", ..."));
+            break;
+        }
     }
-    JS_ENUMERATE_TYPED_ARRAYS
-#undef __JS_ENUMERATE
-    VERIFY_NOT_REACHED();
+    TRY(js_out(print_context, " ]"));
+    return {};
 }
 
 ErrorOr<void> print_data_view(JS::PrintContext& print_context, JS::DataView const& data_view, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)

--- a/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -322,7 +322,7 @@ ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM& vm, ArrayBuffer
     // 12. Let toBlock be newBuffer.[[ArrayBufferData]].
     // 13. Perform CopyDataBlockBytes(toBlock, 0, fromBlock, 0, copyLength).
     // 14. NOTE: Neither creation of the new Data Block nor copying from the old Data Block are observable. Implementations may implement this method as a zero-copy move or a realloc.
-    new_buffer->overwrite(0, array_buffer.data(), copy_length);
+    array_buffer.copy_data_to(*new_buffer, 0, 0, copy_length);
 
     // 15. Perform ! DetachArrayBuffer(arrayBuffer).
     MUST(detach_array_buffer(vm, array_buffer));
@@ -393,11 +393,9 @@ ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(VM& vm, ArrayBuffer& source_b
     auto* target_buffer = TRY(allocate_array_buffer(vm, realm.intrinsics().array_buffer_constructor(), source_length));
 
     // 3. Let srcBlock be srcBuffer.[[ArrayBufferData]].
-    auto source_block = source_buffer.bytes().slice(source_byte_offset, source_length);
-
     // 4. Let targetBlock be targetBuffer.[[ArrayBufferData]].
     // 5. Perform CopyDataBlockBytes(targetBlock, 0, srcBlock, srcByteOffset, srcLength).
-    target_buffer->overwrite(0, source_block.data(), source_length);
+    source_buffer.copy_data_to(*target_buffer, source_byte_offset, 0, source_length);
 
     // 6. Return targetBuffer.
     return target_buffer;

--- a/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -82,7 +82,10 @@ void ArrayBuffer::account_external_memory_change(size_t old_external_memory_size
 void ArrayBuffer::set_data_block(DataBlock block)
 {
     auto old_external_memory_size = external_memory_size();
+    auto old_data_offset = m_data_block.offset();
     m_data_block = move(block);
+    if (m_data_block.offset() != old_data_offset)
+        invalidate_cached_typed_array_view_offsets();
     account_external_memory_change(old_external_memory_size, external_memory_size());
 }
 
@@ -94,7 +97,10 @@ void ArrayBuffer::did_change_data_block_capacity(size_t old_external_memory_size
 ErrorOr<void> ArrayBuffer::try_resize(size_t new_size, DataBlock::ZeroFillNewBytes zero_fill_new_bytes)
 {
     auto old_external_memory_size = external_memory_size();
+    auto old_data_offset = m_data_block.offset();
     TRY(m_data_block.try_resize(new_size, zero_fill_new_bytes));
+    if (m_data_block.offset() != old_data_offset)
+        invalidate_cached_typed_array_view_offsets();
     did_change_data_block_capacity(old_external_memory_size);
     return {};
 }
@@ -102,7 +108,10 @@ ErrorOr<void> ArrayBuffer::try_resize(size_t new_size, DataBlock::ZeroFillNewByt
 ErrorOr<void> ArrayBuffer::try_ensure_capacity(size_t new_capacity)
 {
     auto old_external_memory_size = external_memory_size();
+    auto old_data_offset = m_data_block.offset();
     TRY(m_data_block.try_ensure_capacity(new_capacity));
+    if (m_data_block.offset() != old_data_offset)
+        invalidate_cached_typed_array_view_offsets();
     did_change_data_block_capacity(old_external_memory_size);
     return {};
 }
@@ -115,18 +124,32 @@ void ArrayBuffer::visit_edges(Cell::Visitor& visitor)
         visitor.visit(external->owner);
 }
 
+void ArrayBuffer::invalidate_cached_typed_array_view_offsets()
+{
+    for (auto& cached_view : m_cached_views) {
+        auto& view = static_cast<TypedArrayBase&>(cached_view);
+        if (view.viewed_array_buffer() == this)
+            view.set_cached_data_offset(TypedArrayBase::invalid_cached_data_offset);
+    }
+    m_cached_views.clear();
+}
+
 // 6.2.9.1 CreateByteDataBlock ( size ), https://tc39.es/ecma262/#sec-createbytedatablock
-ThrowCompletionOr<DataBlock> create_byte_data_block(VM& vm, size_t size)
+ThrowCompletionOr<DataBlock> create_byte_data_block(VM& vm, size_t size, Optional<size_t> capacity)
 {
     // 1. If size > 2^53 - 1, throw a RangeError exception.
     if (size > MAX_ARRAY_LIKE_INDEX)
         return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "array buffer");
+    if (capacity.has_value() && *capacity > MAX_ARRAY_LIKE_INDEX)
+        return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "array buffer");
 
     // 2. Let db be a new Data Block value consisting of size bytes. If it is impossible to create such a Data Block, throw a RangeError exception.
     // 3. Set all of the bytes of db to 0.
-    auto data_block = DataBlock::OwnedBackingStore::create_zeroed(size);
+    auto data_block = capacity.has_value()
+        ? DataBlock::OwnedBackingStore::create_zeroed_with_capacity(size, *capacity)
+        : DataBlock::OwnedBackingStore::create_zeroed(size);
     if (data_block.is_error())
-        return vm.throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, size);
+        return vm.throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, capacity.value_or(size));
 
     // 4. Return db.
     return DataBlock { data_block.release_value(), DataBlock::Shared::No };
@@ -134,12 +157,15 @@ ThrowCompletionOr<DataBlock> create_byte_data_block(VM& vm, size_t size)
 
 // FIXME: The returned DataBlock is not shared in the sense that the standard specifies it.
 // 6.2.9.2 CreateSharedByteDataBlock ( size ), https://tc39.es/ecma262/#sec-createsharedbytedatablock
-static ThrowCompletionOr<DataBlock> create_shared_byte_data_block(VM& vm, size_t size)
+static ThrowCompletionOr<DataBlock> create_shared_byte_data_block(VM& vm, size_t size, Optional<size_t> capacity = {})
 {
+    if (!capacity.has_value())
+        capacity = size;
+
     // 1. Let db be a new Shared Data Block value consisting of size bytes. If it is impossible to create such a Shared Data Block, throw a RangeError exception.
-    auto data_block = DataBlock::OwnedBackingStore::create_zeroed(size);
+    auto data_block = DataBlock::OwnedBackingStore::create_zeroed_with_capacity(size, *capacity);
     if (data_block.is_error())
-        return vm.throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, size);
+        return vm.throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, *capacity);
 
     // 2. Let execution be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
     // 3. Let eventsRecord be the Agent Events Record of execution.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().
@@ -229,7 +255,7 @@ ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM& vm, FunctionObject& co
     auto obj = TRY(ordinary_create_from_constructor<ArrayBuffer>(vm, constructor, &Intrinsics::array_buffer_prototype, static_cast<ByteBuffer*>(nullptr), DataBlock::Shared::No));
 
     // 5. Let block be ? CreateByteDataBlock(byteLength).
-    auto block = TRY(create_byte_data_block(vm, byte_length));
+    auto block = TRY(create_byte_data_block(vm, byte_length, max_byte_length));
 
     // 6. Set obj.[[ArrayBufferData]] to block.
     obj->set_data_block(move(block));
@@ -240,8 +266,6 @@ ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM& vm, FunctionObject& co
     if (allocating_resizable_buffer) {
         // a. If it is not possible to create a Data Block block consisting of maxByteLength bytes, throw a RangeError exception.
         // b. NOTE: Resizable ArrayBuffers are designed to be implementable with in-place growth. Implementations may throw if, for example, virtual memory cannot be reserved up front.
-        if (auto result = obj->try_ensure_capacity(*max_byte_length); result.is_error())
-            return vm.throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, *max_byte_length);
 
         // c. Set obj.[[ArrayBufferMaxByteLength]] to maxByteLength.
         obj->set_max_byte_length(*max_byte_length);
@@ -310,12 +334,7 @@ ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM& vm, ArrayBuffer
 void ArrayBuffer::detach_buffer()
 {
     auto old_external_memory_size = external_memory_size();
-    for (auto& cached_view : m_cached_views) {
-        auto& view = static_cast<TypedArrayBase&>(cached_view);
-        if (view.viewed_array_buffer() == this)
-            view.set_cached_data_ptr(nullptr);
-    }
-    m_cached_views.clear();
+    invalidate_cached_typed_array_view_offsets();
     m_data_block.byte_buffer = Empty {};
     account_external_memory_change(old_external_memory_size, 0);
 }
@@ -329,12 +348,7 @@ ThrowCompletionOr<DataBlock> ArrayBuffer::detach_and_take_data_block(VM& vm)
 
     auto old_external_memory_size = external_memory_size();
     auto block = move(m_data_block);
-    for (auto& cached_view : m_cached_views) {
-        auto& view = static_cast<TypedArrayBase&>(cached_view);
-        if (view.viewed_array_buffer() == this)
-            view.set_cached_data_ptr(nullptr);
-    }
-    m_cached_views.clear();
+    invalidate_cached_typed_array_view_offsets();
     m_data_block.byte_buffer = Empty {};
     account_external_memory_change(old_external_memory_size, 0);
     return block;
@@ -434,9 +448,9 @@ ThrowCompletionOr<GC::Ref<ArrayBuffer>> allocate_shared_array_buffer(VM& vm, Fun
     auto alloc_length = allocating_growable_buffer ? *max_byte_length : byte_length;
 
     // 7. Let block be ? CreateSharedByteDataBlock(allocLength).
-    // AD-HOC: We track [[ArrayBufferByteLength(Data)]] via the length of the Data Block, so shrink it down to byteLength.
-    auto block = TRY(create_shared_byte_data_block(vm, alloc_length));
-    block.set_size(byte_length);
+    // AD-HOC: We track [[ArrayBufferByteLength(Data)]] via the length of the Data Block, so reserve allocLength
+    //         up front and expose byteLength as the current length.
+    auto block = TRY(create_shared_byte_data_block(vm, byte_length, alloc_length));
 
     // 8. Set obj.[[ArrayBufferData]] to block.
     obj->set_data_block(move(block));

--- a/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -125,6 +125,8 @@ void ArrayBuffer::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_detach_key);
     if (auto* external = m_data_block.byte_buffer.get_pointer<DataBlock::UnownedExternalBuffer>())
         visitor.visit(external->owner);
+    if (auto* external = m_data_block.byte_buffer.get_pointer<DataBlock::ExternalPrimitiveStorage>())
+        visitor.visit(external->owner);
 }
 
 // 6.2.9.1 CreateByteDataBlock ( size ), https://tc39.es/ecma262/#sec-createbytedatablock

--- a/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -55,11 +55,6 @@ GC::Ref<ArrayBuffer> ArrayBuffer::create(Realm& realm, DataBlock block)
     return array_buffer;
 }
 
-GC::Ref<ArrayBuffer> ArrayBuffer::create(Realm& realm, DataBlock::UnownedExternalBuffer buffer, DataBlock::Shared is_shared)
-{
-    return realm.create<ArrayBuffer>(buffer, is_shared, prototype_for_shared_state(realm, is_shared));
-}
-
 ArrayBuffer::ArrayBuffer(DataBlock::OwnedBackingStore buffer, DataBlock::Shared is_shared, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_data_block(DataBlock { move(buffer), is_shared })
@@ -70,13 +65,6 @@ ArrayBuffer::ArrayBuffer(DataBlock::OwnedBackingStore buffer, DataBlock::Shared 
 ArrayBuffer::ArrayBuffer(ByteBuffer* buffer, DataBlock::Shared is_shared, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_data_block(DataBlock { DataBlock::UnownedFixedLengthByteBuffer(buffer), is_shared })
-    , m_detach_key(js_undefined())
-{
-}
-
-ArrayBuffer::ArrayBuffer(DataBlock::UnownedExternalBuffer buffer, DataBlock::Shared is_shared, Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
-    , m_data_block(DataBlock { move(buffer), is_shared })
     , m_detach_key(js_undefined())
 {
 }
@@ -123,8 +111,6 @@ void ArrayBuffer::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_detach_key);
-    if (auto* external = m_data_block.byte_buffer.get_pointer<DataBlock::UnownedExternalBuffer>())
-        visitor.visit(external->owner);
     if (auto* external = m_data_block.byte_buffer.get_pointer<DataBlock::ExternalPrimitiveStorage>())
         visitor.visit(external->owner);
 }

--- a/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -11,6 +11,7 @@
 #include <AK/IntrusiveList.h>
 #include <AK/Variant.h>
 #include <AK/kmalloc.h>
+#include <LibGC/PrimitiveStorage.h>
 #include <LibJS/Export.h>
 #include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/Completion.h>
@@ -157,6 +158,40 @@ struct DataBlock {
         size_t size = 0;
     };
 
+    struct DynamicPrimitiveStorageSize {
+    };
+
+    struct ExternalPrimitiveStorage {
+        explicit ExternalPrimitiveStorage(GC::Ref<GC::Cell> owner, GC::PrimitiveStorageHandle handle)
+            : handle(handle)
+            , size(DynamicPrimitiveStorageSize {})
+            , owner(owner)
+        {
+        }
+
+        explicit ExternalPrimitiveStorage(GC::Ref<GC::Cell> owner, GC::PrimitiveStorageHandle handle, size_t fixed_size)
+            : handle(handle)
+            , size(fixed_size)
+            , owner(owner)
+        {
+        }
+
+        u8* data() { return GC::PrimitiveStorage::the().data(handle); }
+        u8 const* data() const { return GC::PrimitiveStorage::the().data(handle); }
+        size_t byte_length() const
+        {
+            return size.visit(
+                [&](DynamicPrimitiveStorageSize) { return GC::PrimitiveStorage::the().size(handle); },
+                [](size_t fixed_size) { return fixed_size; });
+        }
+        size_t capacity() const { return GC::PrimitiveStorage::the().capacity(handle); }
+        size_t offset() const { return GC::PrimitiveStorage::the().offset(handle); }
+
+        GC::PrimitiveStorageHandle handle;
+        Variant<DynamicPrimitiveStorageSize, size_t> size;
+        GC::Ref<GC::Cell> owner;
+    };
+
     // AD-HOC: ECMA-262 models ArrayBuffer backing storage as a Data Block. We additionally allow
     //         host code to provide an external byte store via callbacks so engine-independent
     //         consumers like LibWeb can project spec-defined host objects onto ArrayBuffer without
@@ -193,7 +228,8 @@ struct DataBlock {
             [](Empty) -> u8* { VERIFY_NOT_REACHED(); },
             [](OwnedBackingStore& value) -> u8* { return value.data(); },
             [](UnownedFixedLengthByteBuffer& value) -> u8* { return value.buffer->data(); },
-            [](UnownedExternalBuffer& value) -> u8* { return value.data ? value.data(value.context) : nullptr; });
+            [](UnownedExternalBuffer& value) -> u8* { return value.data ? value.data(value.context) : nullptr; },
+            [](ExternalPrimitiveStorage& value) -> u8* { return value.data(); });
     }
     u8 const* data() const { return const_cast<DataBlock*>(this)->data(); }
 
@@ -217,7 +253,8 @@ struct DataBlock {
             [&](Empty) { VERIFY_NOT_REACHED(); },
             [&](OwnedBackingStore& value) { value.set_size(new_size, zero_fill_new_bytes); },
             [&](UnownedFixedLengthByteBuffer& value) { value.buffer->set_size(new_size, byte_buffer_zero_fill); },
-            [&](UnownedExternalBuffer&) { VERIFY_NOT_REACHED(); });
+            [&](UnownedExternalBuffer&) { VERIFY_NOT_REACHED(); },
+            [&](ExternalPrimitiveStorage&) { VERIFY_NOT_REACHED(); });
     }
 
     ErrorOr<void> try_resize(size_t new_size, ZeroFillNewBytes zero_fill_new_bytes = ZeroFillNewBytes::No)
@@ -229,7 +266,8 @@ struct DataBlock {
             [&](Empty) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
             [&](OwnedBackingStore& value) { return value.try_resize(new_size, zero_fill_new_bytes); },
             [&](UnownedFixedLengthByteBuffer& value) { return value.buffer->try_resize(new_size, byte_buffer_zero_fill); },
-            [&](UnownedExternalBuffer&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); });
+            [&](UnownedExternalBuffer&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
+            [&](ExternalPrimitiveStorage&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); });
     }
 
     ErrorOr<void> try_ensure_capacity(size_t new_capacity)
@@ -238,7 +276,8 @@ struct DataBlock {
             [&](Empty) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
             [&](OwnedBackingStore& value) { return value.try_ensure_capacity(new_capacity); },
             [&](UnownedFixedLengthByteBuffer& value) { return value.buffer->try_ensure_capacity(new_capacity); },
-            [&](UnownedExternalBuffer&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); });
+            [&](UnownedExternalBuffer&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
+            [&](ExternalPrimitiveStorage&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); });
     }
 
     size_t size() const
@@ -251,7 +290,42 @@ struct DataBlock {
                 return value.size.visit(
                     [](size_t size) { return size; },
                     [&](auto& fn) { return fn ? fn(value.context) : 0zu; });
-            });
+            },
+            [](ExternalPrimitiveStorage const& value) { return value.byte_length(); });
+    }
+
+    size_t capacity() const
+    {
+        return byte_buffer.visit(
+            [](Empty) -> size_t { return 0; },
+            [](OwnedBackingStore const& buffer) { return buffer.capacity(); },
+            [](UnownedFixedLengthByteBuffer const& value) { return value.size; },
+            [](UnownedExternalBuffer const& value) {
+                return value.size.visit(
+                    [](size_t size) { return size; },
+                    [&](auto& fn) { return fn ? fn(value.context) : 0zu; });
+            },
+            [](ExternalPrimitiveStorage const& value) { return value.capacity(); });
+    }
+
+    size_t offset() const
+    {
+        return byte_buffer.visit(
+            [](Empty) -> size_t { return GC::PrimitiveStorage::invalid_offset; },
+            [](OwnedBackingStore const&) { return GC::PrimitiveStorage::invalid_offset; },
+            [](UnownedFixedLengthByteBuffer const&) { return GC::PrimitiveStorage::invalid_offset; },
+            [](UnownedExternalBuffer const&) { return GC::PrimitiveStorage::invalid_offset; },
+            [](ExternalPrimitiveStorage const& value) { return value.offset(); });
+    }
+
+    bool is_caged() const
+    {
+        return byte_buffer.visit(
+            [](Empty) { return false; },
+            [](OwnedBackingStore const&) { return false; },
+            [](UnownedFixedLengthByteBuffer const&) { return false; },
+            [](UnownedExternalBuffer const&) { return false; },
+            [](ExternalPrimitiveStorage const& value) { return value.handle.is_valid(); });
     }
 
     size_t external_memory_size() const
@@ -260,12 +334,13 @@ struct DataBlock {
             [](Empty) -> size_t { return 0; },
             [](OwnedBackingStore const& buffer) { return buffer.capacity(); },
             [](UnownedFixedLengthByteBuffer const&) -> size_t { return 0; },
-            [](UnownedExternalBuffer const&) -> size_t { return 0; });
+            [](UnownedExternalBuffer const&) -> size_t { return 0; },
+            [](ExternalPrimitiveStorage const&) -> size_t { return 0; });
     }
 
-    bool is_external() const { return byte_buffer.has<UnownedExternalBuffer>(); }
+    bool is_external() const { return byte_buffer.has<UnownedExternalBuffer>() || byte_buffer.has<ExternalPrimitiveStorage>(); }
 
-    Variant<Empty, OwnedBackingStore, UnownedFixedLengthByteBuffer, UnownedExternalBuffer> byte_buffer;
+    Variant<Empty, OwnedBackingStore, UnownedFixedLengthByteBuffer, UnownedExternalBuffer, ExternalPrimitiveStorage> byte_buffer;
     Shared is_shared = { Shared::No };
 };
 

--- a/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -10,7 +10,6 @@
 #include <AK/Function.h>
 #include <AK/IntrusiveList.h>
 #include <AK/Variant.h>
-#include <AK/kmalloc.h>
 #include <LibGC/PrimitiveStorage.h>
 #include <LibJS/Export.h>
 #include <LibJS/Runtime/BigInt.h>
@@ -62,7 +61,11 @@ struct DataBlock {
     class OwnedBackingStore {
     public:
         OwnedBackingStore() = default;
-        ~OwnedBackingStore() { kfree(m_data); }
+        ~OwnedBackingStore()
+        {
+            if (m_handle.is_valid())
+                GC::PrimitiveStorage::the().free(m_handle);
+        }
 
         OwnedBackingStore(OwnedBackingStore&& other)
         {
@@ -72,7 +75,8 @@ struct DataBlock {
         OwnedBackingStore& operator=(OwnedBackingStore&& other)
         {
             if (this != &other) {
-                kfree(m_data);
+                if (m_handle.is_valid())
+                    GC::PrimitiveStorage::the().free(m_handle);
                 move_from(move(other));
             }
             return *this;
@@ -84,67 +88,76 @@ struct DataBlock {
         static ErrorOr<OwnedBackingStore> create_zeroed(size_t size)
         {
             OwnedBackingStore buffer;
-            TRY(buffer.try_resize(size, ZeroFillNewBytes::Yes));
+            if (size > 0)
+                buffer.m_handle = TRY(GC::PrimitiveStorage::the().try_allocate(size, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
             return buffer;
         }
 
         static ErrorOr<OwnedBackingStore> create_uninitialized(size_t size)
         {
             OwnedBackingStore buffer;
-            TRY(buffer.try_resize(size, ZeroFillNewBytes::No));
+            if (size > 0)
+                buffer.m_handle = TRY(GC::PrimitiveStorage::the().try_allocate(size, GC::PrimitiveStorage::ZeroFillNewBytes::No));
             return buffer;
         }
 
-        u8* data() { return m_data; }
-        u8 const* data() const { return m_data; }
-        size_t size() const { return m_size; }
-        size_t capacity() const { return m_capacity; }
+        static ErrorOr<OwnedBackingStore> create_zeroed_with_capacity(size_t size, size_t capacity)
+        {
+            OwnedBackingStore buffer;
+            if (capacity > 0)
+                buffer.m_handle = TRY(GC::PrimitiveStorage::the().try_reserve(size, capacity, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+            return buffer;
+        }
+
+        u8* data() { return GC::PrimitiveStorage::the().data(m_handle); }
+        u8 const* data() const { return GC::PrimitiveStorage::the().data(m_handle); }
+        size_t size() const { return GC::PrimitiveStorage::the().size(m_handle); }
+        size_t capacity() const { return GC::PrimitiveStorage::the().capacity(m_handle); }
+        size_t offset() const { return GC::PrimitiveStorage::the().offset(m_handle); }
+        GC::PrimitiveStorageHandle handle() const { return m_handle; }
         Bytes bytes() { return { data(), size() }; }
         ReadonlyBytes bytes() const { return { data(), size() }; }
 
         void set_size(size_t new_size, ZeroFillNewBytes zero_fill_new_bytes = ZeroFillNewBytes::No)
         {
             VERIFY(new_size <= capacity());
-            if (zero_fill_new_bytes == ZeroFillNewBytes::Yes && new_size > m_size)
-                __builtin_memset(data() + m_size, 0, new_size - m_size);
-            m_size = new_size;
+            MUST(try_resize(new_size, zero_fill_new_bytes));
         }
 
         ErrorOr<void> try_resize(size_t new_size, ZeroFillNewBytes zero_fill_new_bytes = ZeroFillNewBytes::No)
         {
-            if (new_size <= m_size) {
-                m_size = new_size;
+            auto primitive_zero_fill = zero_fill_new_bytes == ZeroFillNewBytes::Yes
+                ? GC::PrimitiveStorage::ZeroFillNewBytes::Yes
+                : GC::PrimitiveStorage::ZeroFillNewBytes::No;
+
+            if (!m_handle.is_valid()) {
+                if (new_size == 0)
+                    return {};
+                m_handle = TRY(GC::PrimitiveStorage::the().try_allocate(new_size, primitive_zero_fill));
                 return {};
             }
-            if (new_size > capacity())
-                TRY(try_ensure_capacity(new_size));
-            set_size(new_size, zero_fill_new_bytes);
-            return {};
+
+            return GC::PrimitiveStorage::the().try_resize(m_handle, new_size, primitive_zero_fill);
         }
 
         ErrorOr<void> try_ensure_capacity(size_t new_capacity)
         {
             if (new_capacity <= capacity())
                 return {};
-            auto* new_data = static_cast<u8*>(krealloc(HeapPartition::ArrayBuffer, m_data, new_capacity));
-            if (!new_data)
-                return AK::Error::from_errno(ENOMEM);
-            m_data = new_data;
-            m_capacity = new_capacity;
-            return {};
+            if (!m_handle.is_valid()) {
+                m_handle = TRY(GC::PrimitiveStorage::the().try_reserve(0, new_capacity, GC::PrimitiveStorage::ZeroFillNewBytes::No));
+                return {};
+            }
+            return GC::PrimitiveStorage::the().try_reserve(m_handle, new_capacity);
         }
 
     private:
         void move_from(OwnedBackingStore&& other)
         {
-            m_data = exchange(other.m_data, nullptr);
-            m_size = exchange(other.m_size, 0);
-            m_capacity = exchange(other.m_capacity, 0);
+            m_handle = exchange(other.m_handle, {});
         }
 
-        u8* m_data { nullptr };
-        size_t m_size { 0 };
-        size_t m_capacity { 0 };
+        GC::PrimitiveStorageHandle m_handle;
     };
 
     struct UnownedFixedLengthByteBuffer {
@@ -272,7 +285,7 @@ struct DataBlock {
     {
         return byte_buffer.visit(
             [](Empty) -> size_t { return GC::PrimitiveStorage::invalid_offset; },
-            [](OwnedBackingStore const&) { return GC::PrimitiveStorage::invalid_offset; },
+            [](OwnedBackingStore const& buffer) { return buffer.offset(); },
             [](UnownedFixedLengthByteBuffer const&) { return GC::PrimitiveStorage::invalid_offset; },
             [](ExternalPrimitiveStorage const& value) { return value.offset(); });
     }
@@ -281,7 +294,7 @@ struct DataBlock {
     {
         return byte_buffer.visit(
             [](Empty) { return false; },
-            [](OwnedBackingStore const&) { return false; },
+            [](OwnedBackingStore const& buffer) { return buffer.handle().is_valid() || buffer.size() == 0; },
             [](UnownedFixedLengthByteBuffer const&) { return false; },
             [](ExternalPrimitiveStorage const& value) { return value.handle.is_valid(); });
     }
@@ -325,6 +338,7 @@ public:
     ReadonlyBytes bytes() const { return m_data_block.bytes(); }
     void overwrite(size_t offset, void const* source, size_t count) { m_data_block.overwrite(offset, source, count); }
     bool is_external() const { return m_data_block.is_external(); }
+    size_t data_offset() const { return m_data_block.offset(); }
 
     // Detaches this ArrayBuffer and returns its underlying DataBlock for use in a TransferArrayBuffer-like operation.
     // If detach fails, the underlying storage is left untouched.
@@ -367,9 +381,9 @@ public:
         return true;
     }
 
-    bool can_cache_typed_array_view_data_pointer() const
+    bool can_cache_typed_array_view_data_offset() const
     {
-        return !is_detached() && is_fixed_length() && m_data_block.byte_buffer.has<DataBlock::OwnedBackingStore>();
+        return !is_detached() && is_fixed_length() && m_data_block.is_caged();
     }
 
     // 25.2.2.2 IsSharedArrayBuffer ( obj ), https://tc39.es/ecma262/#sec-issharedarraybuffer
@@ -408,6 +422,7 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     void account_external_memory_change(size_t old_external_memory_size, size_t new_external_memory_size);
+    void invalidate_cached_typed_array_view_offsets();
 
     DataBlock m_data_block;
     Optional<size_t> m_max_byte_length;
@@ -421,7 +436,7 @@ private:
 template<>
 inline bool Object::fast_is<ArrayBuffer>() const { return is_array_buffer(); }
 
-JS_API ThrowCompletionOr<DataBlock> create_byte_data_block(VM& vm, size_t size);
+JS_API ThrowCompletionOr<DataBlock> create_byte_data_block(VM& vm, size_t size, Optional<size_t> capacity = {});
 JS_API void copy_data_block_bytes(Bytes to_block, u64 to_index, ReadonlyBytes from_block, u64 from_index, u64 count);
 ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM&, FunctionObject& constructor, size_t byte_length, Optional<size_t> const& max_byte_length = {});
 ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM&, ArrayBuffer& array_buffer, Value new_length, PreserveResizability preserve_resizability);

--- a/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -115,8 +115,6 @@ struct DataBlock {
         size_t capacity() const { return GC::PrimitiveStorage::the().capacity(m_handle); }
         size_t offset() const { return GC::PrimitiveStorage::the().offset(m_handle); }
         GC::PrimitiveStorageHandle handle() const { return m_handle; }
-        Bytes bytes() { return { data(), size() }; }
-        ReadonlyBytes bytes() const { return { data(), size() }; }
 
         void set_size(size_t new_size, ZeroFillNewBytes zero_fill_new_bytes = ZeroFillNewBytes::No)
         {
@@ -209,6 +207,7 @@ struct DataBlock {
         GC::Ref<GC::Cell> owner;
     };
 
+private:
     u8* data()
     {
         return byte_buffer.visit(
@@ -219,15 +218,159 @@ struct DataBlock {
     }
     u8 const* data() const { return const_cast<DataBlock*>(this)->data(); }
 
-    Bytes span() { return { data(), size() }; }
-    ReadonlyBytes span() const { return { data(), size() }; }
-    Bytes bytes() { return { data(), size() }; }
-    ReadonlyBytes bytes() const { return { data(), size() }; }
+public:
+    u8* data_at(size_t byte_offset)
+    {
+        return byte_buffer.visit(
+            [](Empty) -> u8* { VERIFY_NOT_REACHED(); },
+            [byte_offset](OwnedBackingStore& value) -> u8* {
+                if (!value.handle().is_valid()) {
+                    VERIFY(byte_offset == 0);
+                    return nullptr;
+                }
+                return GC::PrimitiveStorage::the().data(value.handle(), byte_offset);
+            },
+            [byte_offset](UnownedFixedLengthByteBuffer& value) -> u8* { return value.buffer->data() + byte_offset; },
+            [byte_offset](ExternalPrimitiveStorage& value) -> u8* { return GC::PrimitiveStorage::the().data(value.handle, byte_offset); });
+    }
+    u8 const* data_at(size_t byte_offset) const { return const_cast<DataBlock*>(this)->data_at(byte_offset); }
+
+    size_t contiguous_bytes_from(size_t byte_offset, size_t count) const
+    {
+        if (!is_caged() || count == 0)
+            return count;
+
+        auto data_offset = offset();
+        if (data_offset == GC::PrimitiveStorage::invalid_offset)
+            return count;
+
+        auto caged_offset = GC::PrimitiveStorage::mask_offset(data_offset + byte_offset);
+        return min(count, GC::PrimitiveStorage::default_cage_size - caged_offset);
+    }
+
+    size_t contiguous_bytes_before(size_t byte_offset, size_t count) const
+    {
+        if (!is_caged() || count == 0)
+            return count;
+
+        VERIFY(byte_offset > 0);
+
+        auto data_offset = offset();
+        if (data_offset == GC::PrimitiveStorage::invalid_offset)
+            return count;
+
+        auto caged_offset = GC::PrimitiveStorage::mask_offset(data_offset + byte_offset - 1);
+        return min(count, caged_offset + 1);
+    }
+
+    void copy_to(size_t offset, Bytes destination) const
+    {
+        VERIFY(offset <= size());
+        VERIFY(destination.size() <= size() - offset);
+        size_t copied = 0;
+        while (copied < destination.size()) {
+            auto chunk_size = contiguous_bytes_from(offset + copied, destination.size() - copied);
+            __builtin_memcpy(destination.data() + copied, data_at(offset + copied), chunk_size);
+            copied += chunk_size;
+        }
+    }
+
+    void copy_to(DataBlock& destination, size_t source_offset, size_t destination_offset, size_t count) const
+    {
+        VERIFY(source_offset <= size());
+        VERIFY(count <= size() - source_offset);
+        VERIFY(destination_offset <= destination.size());
+        VERIFY(count <= destination.size() - destination_offset);
+
+        size_t copied = 0;
+        while (copied < count) {
+            auto source_chunk_size = contiguous_bytes_from(source_offset + copied, count - copied);
+            auto destination_chunk_size = destination.contiguous_bytes_from(destination_offset + copied, count - copied);
+            auto chunk_size = min(source_chunk_size, destination_chunk_size);
+            __builtin_memcpy(destination.data_at(destination_offset + copied), data_at(source_offset + copied), chunk_size);
+            copied += chunk_size;
+        }
+    }
+
+    ErrorOr<ByteBuffer> copy_to_byte_buffer(size_t offset, size_t count) const
+    {
+        VERIFY(offset <= size());
+        VERIFY(count <= size() - offset);
+
+        auto destination = TRY(ByteBuffer::create_uninitialized(count));
+        copy_to(offset, destination);
+        return destination;
+    }
+
+    ErrorOr<ByteBuffer> copy_to_byte_buffer() const
+    {
+        return copy_to_byte_buffer(0, size());
+    }
+
+    template<typename Callback>
+    decltype(auto) with_readonly_bytes(size_t offset, size_t count, Callback callback) const
+    {
+        VERIFY(offset <= size());
+        VERIFY(count <= size() - offset);
+
+        if (count == 0)
+            return callback({});
+
+        if (contiguous_bytes_from(offset, count) == count)
+            return callback({ data_at(offset), count });
+
+        auto storage = MUST(copy_to_byte_buffer(offset, count));
+        return callback(storage.bytes());
+    }
+
     void overwrite(size_t offset, void const* source, size_t count)
     {
         VERIFY(offset <= size());
         VERIFY(count <= size() - offset);
-        __builtin_memcpy(data() + offset, source, count);
+        auto const* source_bytes = static_cast<u8 const*>(source);
+        size_t copied = 0;
+        while (copied < count) {
+            auto chunk_size = contiguous_bytes_from(offset + copied, count - copied);
+            __builtin_memcpy(data_at(offset + copied), source_bytes + copied, chunk_size);
+            copied += chunk_size;
+        }
+    }
+
+    void move_data(size_t destination_offset, size_t source_offset, size_t count)
+    {
+        VERIFY(destination_offset <= size());
+        VERIFY(count <= size() - destination_offset);
+        VERIFY(source_offset <= size());
+        VERIFY(count <= size() - source_offset);
+
+        if (count == 0 || destination_offset == source_offset)
+            return;
+
+        if (!is_caged()) {
+            __builtin_memmove(data_at(destination_offset), data_at(source_offset), count);
+            return;
+        }
+
+        if (source_offset < destination_offset && destination_offset < source_offset + count) {
+            size_t remaining = count;
+            while (remaining > 0) {
+                auto source_chunk_size = contiguous_bytes_before(source_offset + remaining, remaining);
+                auto destination_chunk_size = contiguous_bytes_before(destination_offset + remaining, remaining);
+                auto chunk_size = min(source_chunk_size, destination_chunk_size);
+                remaining -= chunk_size;
+                __builtin_memmove(data_at(destination_offset + remaining), data_at(source_offset + remaining), chunk_size);
+            }
+            return;
+        }
+
+        size_t copied = 0;
+        while (copied < count) {
+            auto source_chunk_size = contiguous_bytes_from(source_offset + copied, count - copied);
+            auto destination_chunk_size = contiguous_bytes_from(destination_offset + copied, count - copied);
+            auto chunk_size = min(source_chunk_size, destination_chunk_size);
+            __builtin_memmove(data_at(destination_offset + copied), data_at(source_offset + copied), chunk_size);
+            copied += chunk_size;
+        }
     }
 
     void set_size(size_t new_size, ZeroFillNewBytes zero_fill_new_bytes = ZeroFillNewBytes::No)
@@ -310,6 +453,13 @@ struct DataBlock {
 
     bool is_external() const { return byte_buffer.has<ExternalPrimitiveStorage>(); }
 
+    bool shares_storage_with(DataBlock const& other) const
+    {
+        if (byte_buffer.has<Empty>() || other.byte_buffer.has<Empty>())
+            return false;
+        return data() == other.data();
+    }
+
     Variant<Empty, OwnedBackingStore, UnownedFixedLengthByteBuffer, ExternalPrimitiveStorage> byte_buffer;
     Shared is_shared = { Shared::No };
 };
@@ -330,14 +480,20 @@ public:
     virtual size_t external_memory_size() const override { return m_data_block.external_memory_size(); }
 
     // [[ArrayBufferData]]
-    u8* data() { return m_data_block.data(); }
-    u8 const* data() const { return m_data_block.data(); }
-    Bytes span() { return m_data_block.span(); }
-    ReadonlyBytes span() const { return m_data_block.span(); }
-    Bytes bytes() { return m_data_block.bytes(); }
-    ReadonlyBytes bytes() const { return m_data_block.bytes(); }
+    u8* data_at(size_t byte_index) { return m_data_block.data_at(byte_index); }
+    u8 const* data_at(size_t byte_index) const { return m_data_block.data_at(byte_index); }
+    void copy_to(size_t offset, Bytes destination) const { m_data_block.copy_to(offset, destination); }
+    ErrorOr<ByteBuffer> copy_to_byte_buffer(size_t offset, size_t count) const { return m_data_block.copy_to_byte_buffer(offset, count); }
+    ErrorOr<ByteBuffer> copy_to_byte_buffer() const { return m_data_block.copy_to_byte_buffer(); }
+    template<typename Callback>
+    decltype(auto) with_readonly_bytes(size_t offset, size_t count, Callback callback) const { return m_data_block.with_readonly_bytes(offset, count, move(callback)); }
+    void copy_data_to(ArrayBuffer& destination, size_t source_offset, size_t destination_offset, size_t count) const { m_data_block.copy_to(destination.m_data_block, source_offset, destination_offset, count); }
+    void copy_data_to(DataBlock& destination, size_t source_offset, size_t destination_offset, size_t count) const { m_data_block.copy_to(destination, source_offset, destination_offset, count); }
     void overwrite(size_t offset, void const* source, size_t count) { m_data_block.overwrite(offset, source, count); }
+    void move_data(size_t destination_offset, size_t source_offset, size_t count) { m_data_block.move_data(destination_offset, source_offset, count); }
     bool is_external() const { return m_data_block.is_external(); }
+    bool is_caged() const { return m_data_block.is_caged(); }
+    bool shares_storage_with(ArrayBuffer const& other) const { return m_data_block.shares_storage_with(other.m_data_block); }
     size_t data_offset() const { return m_data_block.offset(); }
 
     // Detaches this ArrayBuffer and returns its underlying DataBlock for use in a TransferArrayBuffer-like operation.
@@ -557,11 +713,10 @@ Value ArrayBuffer::get_value(size_t byte_index, [[maybe_unused]] bool is_typed_a
     VERIFY(!is_detached());
 
     // 2. Assert: There are sufficient bytes in arrayBuffer starting at byteIndex to represent a value of type.
-    VERIFY(m_data_block.bytes().slice(byte_index).size() >= sizeof(T));
+    VERIFY(byte_index <= m_data_block.size());
+    VERIFY(sizeof(T) <= m_data_block.size() - byte_index);
 
     // 3. Let block be arrayBuffer.[[ArrayBufferData]].
-    auto block = m_data_block.bytes();
-
     // 4. Let elementSize be the Element Size value specified in Table 70 for Element Type type.
     auto element_size = sizeof(T);
 
@@ -581,7 +736,7 @@ Value ArrayBuffer::get_value(size_t byte_index, [[maybe_unused]] bool is_typed_a
     // 6. Else,
     else {
         // a. Let rawValue be a List whose elements are bytes from block at indices in the interval from byteIndex (inclusive) to byteIndex + elementSize (exclusive).
-        block.slice(byte_index, element_size).copy_to(raw_value);
+        m_data_block.copy_to(byte_index, raw_value.span());
     }
 
     // 7. Assert: The number of elements in rawValue is elementSize.
@@ -675,16 +830,14 @@ void ArrayBuffer::set_value(size_t byte_index, Value value, [[maybe_unused]] boo
     VERIFY(!is_detached());
 
     // 2. Assert: There are sufficient bytes in arrayBuffer starting at byteIndex to represent a value of type.
-    VERIFY(m_data_block.bytes().slice(byte_index).size() >= sizeof(T));
+    VERIFY(byte_index <= m_data_block.size());
+    VERIFY(sizeof(T) <= m_data_block.size() - byte_index);
 
     // 3. Assert: value is a BigInt if IsBigIntElementType(type) is true; otherwise, value is a Number.
     if constexpr (IsIntegral<T> && sizeof(T) == 8)
         VERIFY(value.is_bigint());
     else
         VERIFY(value.is_number());
-
-    // 4. Let block be arrayBuffer.[[ArrayBufferData]].
-    auto block = m_data_block.span();
 
     // FIXME: 5. Let elementSize be the Element Size value specified in Table 70 for Element Type type.
 
@@ -705,7 +858,7 @@ void ArrayBuffer::set_value(size_t byte_index, Value value, [[maybe_unused]] boo
     // 9. Else,
     else {
         // a. Store the individual bytes of rawBytes into block, starting at block[byteIndex].
-        raw_bytes.span().copy_to(block.slice(byte_index));
+        m_data_block.overwrite(byte_index, raw_bytes.data(), raw_bytes.size());
     }
 
     // 10. Return unused.
@@ -723,9 +876,9 @@ Value ArrayBuffer::get_modify_set_value(size_t byte_index, Value value, ReadWrit
     // FIXME: Check for shared buffer
 
     auto raw_bytes_read = MUST(ByteBuffer::create_uninitialized(sizeof(T)));
-    m_data_block.bytes().slice(byte_index, sizeof(T)).copy_to(raw_bytes_read);
+    m_data_block.copy_to(byte_index, raw_bytes_read);
     auto raw_bytes_modified = operation(raw_bytes_read, raw_bytes);
-    raw_bytes_modified.span().copy_to(m_data_block.span().slice(byte_index));
+    m_data_block.overwrite(byte_index, raw_bytes_modified.data(), raw_bytes_modified.size());
 
     return raw_bytes_to_numeric<T>(vm, raw_bytes_read, is_little_endian);
 }

--- a/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -161,6 +161,10 @@ struct DataBlock {
     struct DynamicPrimitiveStorageSize {
     };
 
+    // AD-HOC: ECMA-262 models ArrayBuffer backing storage as a Data Block. We additionally allow
+    //         host code to provide an external caged primitive store, so engine-independent
+    //         consumers like LibWeb can project spec-defined host objects onto ArrayBuffer without
+    //         teaching LibJS about those hosts.
     struct ExternalPrimitiveStorage {
         explicit ExternalPrimitiveStorage(GC::Ref<GC::Cell> owner, GC::PrimitiveStorageHandle handle)
             : handle(handle)
@@ -192,43 +196,12 @@ struct DataBlock {
         GC::Ref<GC::Cell> owner;
     };
 
-    // AD-HOC: ECMA-262 models ArrayBuffer backing storage as a Data Block. We additionally allow
-    //         host code to provide an external byte store via callbacks so engine-independent
-    //         consumers like LibWeb can project spec-defined host objects onto ArrayBuffer without
-    //         teaching LibJS about those hosts.
-    struct UnownedExternalBuffer {
-        using DataFunction = u8* (*)(void*);
-        using SizeFunction = size_t (*)(void*);
-
-        explicit UnownedExternalBuffer(GC::Ref<GC::Cell> owner, void* context, DataFunction data, SizeFunction size)
-            : context(context)
-            , data(data)
-            , size(size)
-            , owner(owner)
-        {
-        }
-
-        explicit UnownedExternalBuffer(GC::Ref<GC::Cell> owner, void* context, DataFunction data, size_t fixed_size)
-            : context(context)
-            , data(data)
-            , size(fixed_size)
-            , owner(owner)
-        {
-        }
-
-        void* context { nullptr };
-        DataFunction data { nullptr };
-        Variant<SizeFunction, size_t> size;
-        GC::Ref<GC::Cell> owner;
-    };
-
     u8* data()
     {
         return byte_buffer.visit(
             [](Empty) -> u8* { VERIFY_NOT_REACHED(); },
             [](OwnedBackingStore& value) -> u8* { return value.data(); },
             [](UnownedFixedLengthByteBuffer& value) -> u8* { return value.buffer->data(); },
-            [](UnownedExternalBuffer& value) -> u8* { return value.data ? value.data(value.context) : nullptr; },
             [](ExternalPrimitiveStorage& value) -> u8* { return value.data(); });
     }
     u8 const* data() const { return const_cast<DataBlock*>(this)->data(); }
@@ -253,7 +226,6 @@ struct DataBlock {
             [&](Empty) { VERIFY_NOT_REACHED(); },
             [&](OwnedBackingStore& value) { value.set_size(new_size, zero_fill_new_bytes); },
             [&](UnownedFixedLengthByteBuffer& value) { value.buffer->set_size(new_size, byte_buffer_zero_fill); },
-            [&](UnownedExternalBuffer&) { VERIFY_NOT_REACHED(); },
             [&](ExternalPrimitiveStorage&) { VERIFY_NOT_REACHED(); });
     }
 
@@ -266,7 +238,6 @@ struct DataBlock {
             [&](Empty) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
             [&](OwnedBackingStore& value) { return value.try_resize(new_size, zero_fill_new_bytes); },
             [&](UnownedFixedLengthByteBuffer& value) { return value.buffer->try_resize(new_size, byte_buffer_zero_fill); },
-            [&](UnownedExternalBuffer&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
             [&](ExternalPrimitiveStorage&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); });
     }
 
@@ -276,7 +247,6 @@ struct DataBlock {
             [&](Empty) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
             [&](OwnedBackingStore& value) { return value.try_ensure_capacity(new_capacity); },
             [&](UnownedFixedLengthByteBuffer& value) { return value.buffer->try_ensure_capacity(new_capacity); },
-            [&](UnownedExternalBuffer&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); },
             [&](ExternalPrimitiveStorage&) -> ErrorOr<void> { VERIFY_NOT_REACHED(); });
     }
 
@@ -286,11 +256,6 @@ struct DataBlock {
             [](Empty) -> size_t { return 0u; },
             [](OwnedBackingStore const& buffer) { return buffer.size(); },
             [](UnownedFixedLengthByteBuffer const& value) { return value.size; },
-            [](UnownedExternalBuffer const& value) {
-                return value.size.visit(
-                    [](size_t size) { return size; },
-                    [&](auto& fn) { return fn ? fn(value.context) : 0zu; });
-            },
             [](ExternalPrimitiveStorage const& value) { return value.byte_length(); });
     }
 
@@ -300,11 +265,6 @@ struct DataBlock {
             [](Empty) -> size_t { return 0; },
             [](OwnedBackingStore const& buffer) { return buffer.capacity(); },
             [](UnownedFixedLengthByteBuffer const& value) { return value.size; },
-            [](UnownedExternalBuffer const& value) {
-                return value.size.visit(
-                    [](size_t size) { return size; },
-                    [&](auto& fn) { return fn ? fn(value.context) : 0zu; });
-            },
             [](ExternalPrimitiveStorage const& value) { return value.capacity(); });
     }
 
@@ -314,7 +274,6 @@ struct DataBlock {
             [](Empty) -> size_t { return GC::PrimitiveStorage::invalid_offset; },
             [](OwnedBackingStore const&) { return GC::PrimitiveStorage::invalid_offset; },
             [](UnownedFixedLengthByteBuffer const&) { return GC::PrimitiveStorage::invalid_offset; },
-            [](UnownedExternalBuffer const&) { return GC::PrimitiveStorage::invalid_offset; },
             [](ExternalPrimitiveStorage const& value) { return value.offset(); });
     }
 
@@ -324,7 +283,6 @@ struct DataBlock {
             [](Empty) { return false; },
             [](OwnedBackingStore const&) { return false; },
             [](UnownedFixedLengthByteBuffer const&) { return false; },
-            [](UnownedExternalBuffer const&) { return false; },
             [](ExternalPrimitiveStorage const& value) { return value.handle.is_valid(); });
     }
 
@@ -334,13 +292,12 @@ struct DataBlock {
             [](Empty) -> size_t { return 0; },
             [](OwnedBackingStore const& buffer) { return buffer.capacity(); },
             [](UnownedFixedLengthByteBuffer const&) -> size_t { return 0; },
-            [](UnownedExternalBuffer const&) -> size_t { return 0; },
             [](ExternalPrimitiveStorage const&) -> size_t { return 0; });
     }
 
-    bool is_external() const { return byte_buffer.has<UnownedExternalBuffer>() || byte_buffer.has<ExternalPrimitiveStorage>(); }
+    bool is_external() const { return byte_buffer.has<ExternalPrimitiveStorage>(); }
 
-    Variant<Empty, OwnedBackingStore, UnownedFixedLengthByteBuffer, UnownedExternalBuffer, ExternalPrimitiveStorage> byte_buffer;
+    Variant<Empty, OwnedBackingStore, UnownedFixedLengthByteBuffer, ExternalPrimitiveStorage> byte_buffer;
     Shared is_shared = { Shared::No };
 };
 
@@ -353,7 +310,6 @@ public:
     static GC::Ref<ArrayBuffer> create(Realm&, ByteBuffer, DataBlock::Shared = DataBlock::Shared::No);
     static GC::Ref<ArrayBuffer> create(Realm&, ByteBuffer*, DataBlock::Shared = DataBlock::Shared::No);
     static GC::Ref<ArrayBuffer> create(Realm&, DataBlock);
-    static GC::Ref<ArrayBuffer> create(Realm&, DataBlock::UnownedExternalBuffer, DataBlock::Shared = DataBlock::Shared::No);
 
     virtual ~ArrayBuffer() override = default;
 
@@ -446,7 +402,6 @@ public:
 private:
     ArrayBuffer(DataBlock::OwnedBackingStore buffer, DataBlock::Shared, Object& prototype);
     ArrayBuffer(ByteBuffer* buffer, DataBlock::Shared, Object& prototype);
-    ArrayBuffer(DataBlock::UnownedExternalBuffer buffer, DataBlock::Shared, Object& prototype);
 
     virtual bool is_array_buffer() const final { return true; }
 

--- a/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -163,9 +163,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::resize)
     auto copy_length = min(new_byte_length, array_buffer_object->byte_length());
 
     // 12. Perform CopyDataBlockBytes(newBlock, 0, oldBlock, 0, copyLength).
-    auto new_block_bytes = new_block.bytes();
-    auto old_block_bytes = array_buffer_object->bytes();
-    copy_data_block_bytes(new_block_bytes, 0, old_block_bytes, 0, copy_length);
+    array_buffer_object->copy_data_to(new_block, 0, 0, copy_length);
 
     // 13. NOTE: Neither creation of the new Data Block nor copying from the old Data Block are observable. Implementations may implement this method as in-place growth or shrinkage.
 
@@ -277,14 +275,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
         // a. Let count be min(newLen, currentLen - first).
         auto count = min(new_length, current_length - first);
 
-        // Let fromBuf be O.[[ArrayBufferData]].
-        auto from_buf = array_buffer_object->bytes();
-
-        // Let toBuf be new.[[ArrayBufferData]].
-        auto to_buf = new_array_buffer_object->bytes();
-
         // b. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, count).
-        copy_data_block_bytes(to_buf, 0, from_buf, first, count);
+        array_buffer_object->copy_data_to(*new_array_buffer_object, first, 0, count);
     }
 
     // 28. Return new.

--- a/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -319,9 +319,6 @@ static ThrowCompletionOr<Value> atomic_compare_exchange_impl(VM& vm, TypedArrayB
     // 2. Let buffer be typedArray.[[ViewedArrayBuffer]].
     auto* buffer = typed_array.viewed_array_buffer();
 
-    // 3. Let block be buffer.[[ArrayBufferData]].
-    auto block = buffer->bytes();
-
     // 7. Let elementType be TypedArrayElementType(typedArray).
     // 8. Let elementSize be TypedArrayElementSize(typedArray).
 
@@ -342,7 +339,8 @@ static ThrowCompletionOr<Value> atomic_compare_exchange_impl(VM& vm, TypedArrayB
     // 13. Else,
 
     // a. Let rawBytesRead be a List of length elementSize whose elements are the sequence of elementSize bytes starting with block[byteIndexInBuffer].
-    auto raw_bytes_read = MUST(ByteBuffer::copy(block.slice(byte_index_in_buffer, sizeof(T))));
+    auto raw_bytes_read = MUST(ByteBuffer::create_uninitialized(sizeof(T)));
+    buffer->copy_to(byte_index_in_buffer, raw_bytes_read);
 
     // b. If ByteListEqual(rawBytesRead, expectedBytes) is true, then
     //    i. Store the individual bytes of replacementBytes into block, starting at block[byteIndexInBuffer].
@@ -351,7 +349,7 @@ static ThrowCompletionOr<Value> atomic_compare_exchange_impl(VM& vm, TypedArrayB
     } else {
         using U = Conditional<IsSame<ClampedU8, T>, u8, T>;
 
-        auto* v = reinterpret_cast<U*>(block.slice(byte_index_in_buffer).data());
+        auto* v = reinterpret_cast<U*>(buffer->data_at(byte_index_in_buffer));
         auto* e = reinterpret_cast<U*>(expected_bytes.data());
         auto* r = reinterpret_cast<U*>(replacement_bytes.data());
         (void)AK::atomic_compare_exchange_strong(v, *e, *r);
@@ -455,9 +453,6 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::notify)
     // 4. Let buffer be typedArray.[[ViewedArrayBuffer]].
     auto* buffer = typed_array->viewed_array_buffer();
 
-    // 5. Let block be buffer.[[ArrayBufferData]].
-    auto block = buffer->bytes();
-
     // 6. If IsSharedArrayBuffer(buffer) is false, return +0𝔽.
     if (!buffer->is_shared_array_buffer())
         return Value { 0 };
@@ -465,7 +460,6 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::notify)
     // FIXME: Implement the remaining steps when we support SharedArrayBuffer.
     (void)byte_index_in_buffer;
     (void)count;
-    (void)block;
 
     return vm.throw_completion<InternalError>(ErrorType::NotImplemented, "SharedArrayBuffer"sv);
 }

--- a/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
+++ b/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
@@ -219,14 +219,8 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::slice)
     if (new_array_buffer_object->byte_length() < new_length)
         return vm.throw_completion<TypeError>(ErrorType::SpeciesConstructorReturned, "an ArrayBuffer smaller than requested");
 
-    // 20. Let fromBuf be O.[[ArrayBufferData]].
-    auto from_buf = array_buffer_object->bytes();
-
-    // 21. Let toBuf be new.[[ArrayBufferData]].
-    auto to_buf = new_array_buffer_object->bytes();
-
     // 22. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, newLen).
-    copy_data_block_bytes(to_buf, 0, from_buf, first, new_length);
+    array_buffer_object->copy_data_to(*new_array_buffer_object, first, 0, new_length);
 
     // 23. Return new.
     return new_array_buffer_object;

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -45,24 +45,25 @@ public:
     ContentType content_type() const { return m_content_type; }
     ArrayBuffer* viewed_array_buffer() const { return m_viewed_array_buffer; }
 
-    // Cached raw pointer: viewed_array_buffer->data() + byte_offset.
-    // nullptr means "not cached, use slow path". This is only safe for
-    // fixed-length ArrayBuffers that own stable backing storage.
-    u8* cached_data_ptr() const { return m_data; }
-    void set_cached_data_ptr(u8* ptr) { m_data = ptr; }
+    static constexpr size_t invalid_cached_data_offset = GC::PrimitiveStorage::invalid_offset;
+
+    // Cached cage offset: viewed_array_buffer->data_offset() + byte_offset.
+    // invalid_cached_data_offset means "not cached, use slow path".
+    size_t cached_data_offset() const { return m_cached_data_offset; }
+    void set_cached_data_offset(size_t offset) { m_cached_data_offset = offset; }
 
     void set_array_length(ByteLength length) { m_array_length = move(length); }
     void set_byte_length(ByteLength length) { m_byte_length = move(length); }
     void set_byte_offset(u32 offset)
     {
         m_byte_offset = offset;
-        update_cached_data_ptr();
+        update_cached_data_offset();
     }
 
     void set_viewed_array_buffer(ArrayBuffer* array_buffer)
     {
         m_viewed_array_buffer = array_buffer;
-        update_cached_data_ptr();
+        update_cached_data_offset();
     }
 
     [[nodiscard]] Kind kind() const { return m_kind; }
@@ -98,16 +99,27 @@ protected:
         set_is_typed_array();
     }
 
-    void update_cached_data_ptr()
+    void update_cached_data_offset()
     {
-        if (!m_viewed_array_buffer || !m_viewed_array_buffer->can_cache_typed_array_view_data_pointer()) {
+        if (!m_viewed_array_buffer || !m_viewed_array_buffer->can_cache_typed_array_view_data_offset()) {
             remove_from_cached_view_list();
-            m_data = nullptr;
+            m_cached_data_offset = invalid_cached_data_offset;
             return;
         }
 
+        auto data_offset = m_viewed_array_buffer->data_offset();
+        if (data_offset == invalid_cached_data_offset) {
+            remove_from_cached_view_list();
+            m_cached_data_offset = invalid_cached_data_offset;
+            return;
+        }
+
+        Checked<size_t> cached_data_offset = data_offset;
+        cached_data_offset += m_byte_offset;
+        VERIFY(!cached_data_offset.has_overflow());
+
         m_viewed_array_buffer->register_cached_typed_array_view(*this);
-        m_data = m_viewed_array_buffer->data() + m_byte_offset;
+        m_cached_data_offset = cached_data_offset.value();
     }
 
     u32 m_element_size { 0 };
@@ -117,7 +129,7 @@ protected:
     ContentType m_content_type { ContentType::Number };
     Kind m_kind {};
     GC::Ptr<ArrayBuffer> m_viewed_array_buffer;
-    u8* m_data { nullptr };
+    size_t m_cached_data_offset { invalid_cached_data_offset };
 
 private:
     virtual bool is_typed_array_base() const final { return true; }

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -508,32 +508,6 @@ public:
         return { move(keys) };
     }
 
-    ReadonlySpan<UnderlyingBufferDataType> data() const
-    {
-        auto typed_array_record = make_typed_array_with_buffer_witness_record(*this, ArrayBuffer::Order::SeqCst);
-
-        if (is_typed_array_out_of_bounds(typed_array_record)) {
-            // FIXME: Propagate this as an error?
-            return {};
-        }
-
-        auto length = typed_array_length(typed_array_record);
-        return { reinterpret_cast<UnderlyingBufferDataType const*>(m_viewed_array_buffer->data() + m_byte_offset), length };
-    }
-
-    Span<UnderlyingBufferDataType> data()
-    {
-        auto typed_array_record = make_typed_array_with_buffer_witness_record(*this, ArrayBuffer::Order::SeqCst);
-
-        if (is_typed_array_out_of_bounds(typed_array_record)) {
-            // FIXME: Propagate this as an error?
-            return {};
-        }
-
-        auto length = typed_array_length(typed_array_record);
-        return { reinterpret_cast<UnderlyingBufferDataType*>(m_viewed_array_buffer->data() + m_byte_offset), length };
-    }
-
     bool is_unclamped_integer_element_type() const override
     {
         constexpr bool is_unclamped_integer = IsSame<T, i8> || IsSame<T, u8> || IsSame<T, i16> || IsSame<T, u16> || IsSame<T, i32> || IsSame<T, u32>;
@@ -557,7 +531,7 @@ protected:
         VERIFY(!Checked<u32>::multiplication_would_overflow(array_length, sizeof(UnderlyingBufferDataType)));
         set_viewed_array_buffer(&array_buffer);
         if (array_length)
-            VERIFY(!data().is_null());
+            VERIFY(m_viewed_array_buffer->data_at(0));
         m_array_length = array_length;
         m_byte_length = m_viewed_array_buffer->byte_length();
     }

--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -373,26 +373,14 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
             return typed_array;
         }
 
-        // OPTIMIZATION: Fast path for non-shared ArrayBuffers that are not detached and have enough space to perform the copy with memmove.
         if (!buffer->is_shared_array_buffer()) {
-            Checked<size_t> from_end = from_byte_index;
-            from_end += count_bytes;
-
-            Checked<size_t> to_end = to_byte_index;
-            to_end += count_bytes;
-
-            if (!from_end.has_overflow() && !to_end.has_overflow()) {
-                auto* base = buffer->data();
-                void const* src = base + from_byte_index;
-                void* dst = base + to_byte_index;
-                memmove(dst, src, count_bytes);
-                return typed_array;
-            }
+            buffer->move_data(to_byte_index, from_byte_index, count_bytes);
+            return typed_array;
         }
 
         i8 direction;
 
-        // l. If fromByteIndex < toByteIndex and toByteIndex < fromByteIndex + countBytes, then
+        // m. If fromByteIndex < toByteIndex and toByteIndex < fromByteIndex + countBytes, then
         if (from_byte_index < to_byte_index && to_byte_index < from_plus_count.value()) {
             // i. Let direction be -1.
             direction = -1;
@@ -410,7 +398,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
             // iii. Set toByteIndex to toByteIndex + countBytes - 1.
             to_byte_index = to_plus_count.value() - 1;
         }
-        // m. Else,
+        // n. Else,
         else {
             // i. Let direction be 1.
             direction = 1;
@@ -517,9 +505,11 @@ inline void fast_typed_array_fill(TypedArrayBase& typed_array, u32 begin, u32 en
     }
 
     auto& array_buffer = *typed_array.viewed_array_buffer();
-    auto* slot = reinterpret_cast<T*>(array_buffer.data() + computed_begin.value());
-    for (auto i = begin; i < end; ++i)
-        *(slot++) = value;
+    auto byte_index = computed_begin.value();
+    for (auto i = begin; i < end; ++i) {
+        array_buffer.overwrite(byte_index, &value, sizeof(T));
+        byte_index += sizeof(T);
+    }
 }
 
 // 23.2.3.9 %TypedArray%.prototype.fill ( value [ , start [ , end ] ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.fill
@@ -1479,7 +1469,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArr
     auto same_shared_array_buffer = false;
 
     // 18. If IsSharedArrayBuffer(srcBuffer) is true, IsSharedArrayBuffer(targetBuffer) is true, and srcBuffer.[[ArrayBufferData]] is targetBuffer.[[ArrayBufferData]], let sameSharedArrayBuffer be true; otherwise, let sameSharedArrayBuffer be false.
-    if (source_buffer->is_shared_array_buffer() && target_buffer->is_shared_array_buffer() && (source_buffer->data() == target_buffer->data()))
+    if (source_buffer->is_shared_array_buffer() && target_buffer->is_shared_array_buffer() && source_buffer->shares_storage_with(*target_buffer))
         same_shared_array_buffer = true;
 
     size_t source_byte_index = 0;
@@ -1527,7 +1517,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArr
         //     ii. Perform SetValueInBuffer(targetBuffer, targetByteIndex, Uint8, value, true, Unordered).
         //     iii. Set srcByteIndex to srcByteIndex + 1.
         //     iv. Set targetByteIndex to targetByteIndex + 1.
-        target_buffer->overwrite(target_byte_index, source_buffer->data() + source_byte_index, limit - target_byte_index);
+        source_buffer->copy_data_to(*target_buffer, source_byte_index, target_byte_index, limit - target_byte_index);
     }
     // 24. Else,
     else {
@@ -1767,8 +1757,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
             // OPTIMIZATION: If the buffers are not detached and not shared, we can do a single bulk copy.
             if (!target_buffer.is_detached() && !target_buffer.is_shared_array_buffer()
                 && !source_buffer.is_detached() && !source_buffer.is_shared_array_buffer()
-                && target_buffer.data() != source_buffer.data()) {
-                target_buffer.overwrite(target_byte_index, source_buffer.data() + source_byte_index.value(), limit.value() - target_byte_index);
+                && !target_buffer.shares_storage_with(source_buffer)) {
+                source_buffer.copy_data_to(target_buffer, source_byte_index.value(), target_byte_index, limit.value() - target_byte_index);
             } else {
                 // ix. Repeat, while targetByteIndex < limit,
                 while (target_byte_index < limit) {

--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/TypeCasts.h>
 #include <AK/Utf16StringBuilder.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -506,6 +507,22 @@ inline void fast_typed_array_fill(TypedArrayBase& typed_array, u32 begin, u32 en
 
     auto& array_buffer = *typed_array.viewed_array_buffer();
     auto byte_index = computed_begin.value();
+    if (!array_buffer.is_shared_array_buffer()) {
+        constexpr size_t pattern_byte_size = 256;
+        constexpr size_t pattern_element_count = max<size_t>(1, pattern_byte_size / sizeof(T));
+        AK::Array<T, pattern_element_count> pattern;
+        pattern.fill(value);
+
+        auto remaining_bytes = (end - begin) * sizeof(T);
+        while (remaining_bytes > 0) {
+            auto chunk_size = min(remaining_bytes, pattern.size() * sizeof(T));
+            array_buffer.overwrite(byte_index, pattern.data(), chunk_size);
+            byte_index += chunk_size;
+            remaining_bytes -= chunk_size;
+        }
+        return;
+    }
+
     for (auto i = begin; i < end; ++i) {
         array_buffer.overwrite(byte_index, &value, sizeof(T));
         byte_index += sizeof(T);

--- a/Libraries/LibJS/Runtime/Uint8Array.cpp
+++ b/Libraries/LibJS/Runtime/Uint8Array.cpp
@@ -187,10 +187,7 @@ JS_DEFINE_NATIVE_FUNCTION(Uint8ArrayConstructorHelpers::from_hex)
 
     // 7. Set the value at each index of ta.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding
     //    index of result.[[Bytes]].
-    auto* array_buffer_data = typed_array->viewed_array_buffer()->data();
-
-    for (size_t index = 0; index < result_length; ++index)
-        array_buffer_data[index] = result.bytes[index];
+    typed_array->viewed_array_buffer()->overwrite(0, result.bytes.data(), result.bytes.size());
 
     // 8. Return ta.
     return typed_array;
@@ -357,20 +354,16 @@ JS_DEFINE_NATIVE_FUNCTION(Uint8ArrayPrototypeHelpers::to_base64)
     }
 
     // 8. Let toEncode be ? GetUint8ArrayBytes(O).
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(*typed_array, ArrayBuffer::Order::SeqCst);
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    auto length = typed_array_length(typed_array_record);
+    auto byte_offset = typed_array->byte_offset();
+
     Utf16String out_ascii;
 
-    // OPTIMIZATION: If the ArrayBuffer is not shared, we can avoid copying the bytes.
-    if (!typed_array->viewed_array_buffer()->is_shared_array_buffer()
-        && !typed_array->viewed_array_buffer()->is_detached()) {
-        auto to_encode = TRY(get_uint8_array_bytes_view(vm, typed_array));
-        if (alphabet == Alphabet::Base64) {
-            out_ascii = MUST(encode_base64_to_utf16(to_encode, omit_padding));
-        } else {
-            out_ascii = MUST(encode_base64url_to_utf16(to_encode, omit_padding));
-        }
-    } else {
-        auto to_encode = TRY(get_uint8_array_bytes(vm, typed_array));
-
+    typed_array->viewed_array_buffer()->with_readonly_bytes(byte_offset, length, [&](ReadonlyBytes to_encode) {
         // 9. If alphabet is "base64", then
         if (alphabet == Alphabet::Base64) {
             // a. Let outAscii be the sequence of code points which results from encoding toEncode according to the base64
@@ -384,7 +377,7 @@ JS_DEFINE_NATIVE_FUNCTION(Uint8ArrayPrototypeHelpers::to_base64)
             //    encoding specified in section 5 of RFC 4648. Padding is included if and only if omitPadding is false.
             out_ascii = MUST(encode_base64url_to_utf16(to_encode, omit_padding));
         }
-    }
+    });
 
     // 11. Return CodePointsToString(outAscii).
     return PrimitiveString::create(vm, move(out_ascii));
@@ -398,18 +391,25 @@ JS_DEFINE_NATIVE_FUNCTION(Uint8ArrayPrototypeHelpers::to_hex)
     auto typed_array = TRY(validate_uint8_array(vm));
 
     // 3. Let toEncode be ? GetUint8ArrayBytes(O).
-    auto to_encode = TRY(get_uint8_array_bytes(vm, typed_array));
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(*typed_array, ArrayBuffer::Order::SeqCst);
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    auto length = typed_array_length(typed_array_record);
+    auto byte_offset = typed_array->byte_offset();
 
     // 4. Let out be the empty String.
-    Utf16StringBuilder out(to_encode.bytes().size() * 2);
+    Utf16StringBuilder out(static_cast<size_t>(length) * 2);
 
-    // 5. For each byte byte of toEncode, do
-    for (auto byte : to_encode.bytes()) {
-        // a. Let hex be Number::toString(𝔽(byte), 16).
-        // b. Set hex to StringPad(hex, 2, "0", START).
-        // c. Set out to the string-concatenation of out and hex.
-        append_lowercase_hex_byte(out, byte);
-    }
+    typed_array->viewed_array_buffer()->with_readonly_bytes(byte_offset, length, [&](ReadonlyBytes to_encode) {
+        // 5. For each byte byte of toEncode, do
+        for (auto byte : to_encode) {
+            // a. Let hex be Number::toString(𝔽(byte), 16).
+            // b. Set hex to StringPad(hex, 2, "0", START).
+            // c. Set out to the string-concatenation of out and hex.
+            append_lowercase_hex_byte(out, byte);
+        }
+    });
 
     // 6. Return out.
     return PrimitiveString::create(vm, out.to_string());
@@ -452,45 +452,12 @@ ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM& vm, TypedArrayBase const
     auto byte_offset = typed_array.byte_offset();
 
     // 6. Let bytes be a new empty List.
-    ByteBuffer bytes;
-
     // 7. Let index be 0.
     // 8. Repeat, while index < len,
-    for (u32 index = 0; index < length; ++index) {
-        // a. Let byteIndex be byteOffset + index.
-        auto byte_index = byte_offset + index;
-
-        // b. Let byte be ℝ(GetValueFromBuffer(buffer, byteIndex, UINT8, true, UNORDERED)).
-        auto byte = typed_array.get_value_from_buffer(byte_index, ArrayBuffer::Order::Unordered);
-
-        // c. Append byte to bytes.
-        bytes.append(MUST(byte.to_u8(vm)));
-
-        // d. Set index to index + 1.
-    }
+    auto bytes = MUST(typed_array.viewed_array_buffer()->copy_to_byte_buffer(byte_offset, length));
 
     // 9. Return bytes.
     return bytes;
-}
-
-// 23.3.3.2 GetUint8ArrayBytes ( ta ), https://tc39.es/ecma262/#sec-getuint8arraybytes
-// NOTE: This is an optimized version that returns a view into the underlying buffer when possible.
-//       It's only safe to use when the ArrayBuffer is known to not be shared or detached.
-ThrowCompletionOr<ReadonlyBytes> get_uint8_array_bytes_view(VM& vm, TypedArrayBase const& typed_array)
-{
-    VERIFY(typed_array.kind() == TypedArrayBase::Kind::Uint8Array);
-    VERIFY(!typed_array.viewed_array_buffer()->is_shared_array_buffer());
-    VERIFY(!typed_array.viewed_array_buffer()->is_detached());
-    auto typed_array_record = make_typed_array_with_buffer_witness_record(typed_array, ArrayBuffer::Order::SeqCst);
-    if (is_typed_array_out_of_bounds(typed_array_record))
-        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
-    auto length = typed_array_length(typed_array_record);
-    auto byte_offset = typed_array.byte_offset();
-
-    return ReadonlyBytes {
-        typed_array.viewed_array_buffer()->data() + byte_offset,
-        length
-    };
 }
 
 // 23.3.3.3 SetUint8ArrayBytes ( into, bytes ), https://tc39.es/ecma262/#sec-setuint8arraybytes

--- a/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Libraries/LibJS/Runtime/Uint8Array.h
@@ -51,7 +51,6 @@ struct DecodeResult {
 
 ThrowCompletionOr<GC::Ref<TypedArrayBase>> validate_uint8_array(VM&);
 ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM&, TypedArrayBase const&);
-ThrowCompletionOr<ReadonlyBytes> get_uint8_array_bytes_view(VM&, TypedArrayBase const&);
 void set_uint8_array_bytes(TypedArrayBase&, ReadonlyBytes);
 DecodeResult from_base64(VM&, Utf16View string, Alphabet alphabet, AK::LastChunkHandling last_chunk_handling, Optional<size_t> max_length = {});
 DecodeResult from_hex(VM&, Utf16View string, Optional<size_t> max_length = {});

--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
 #include <AK/Enumerate.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/SaturatingMath.h>
-#include <LibCore/System.h>
 #include <LibGC/Heap.h>
 #include <LibSync/MutexProtected.h>
 #include <LibWasm/AbstractMachine/AbstractMachine.h>
@@ -173,11 +173,8 @@ MemoryBuffer::~MemoryBuffer()
 MemoryBuffer::MemoryBuffer(MemoryBuffer&& other)
     : m_size(exchange(other.m_size, 0))
     , m_reserved_capacity(exchange(other.m_reserved_capacity, 0))
-    , m_mapping_size(exchange(other.m_mapping_size, 0))
-    , m_host_page_size(exchange(other.m_host_page_size, 0))
-    , m_mapping_base(exchange(other.m_mapping_base, nullptr))
-    , m_data(exchange(other.m_data, nullptr))
-    , m_fallback(move(other.m_fallback))
+    , m_handle(exchange(other.m_handle, {}))
+    , m_storage_offset(exchange(other.m_storage_offset, GC::PrimitiveStorage::invalid_offset))
 {
 }
 
@@ -187,91 +184,260 @@ MemoryBuffer& MemoryBuffer::operator=(MemoryBuffer&& other)
         clear();
         m_size = exchange(other.m_size, 0);
         m_reserved_capacity = exchange(other.m_reserved_capacity, 0);
-        m_mapping_size = exchange(other.m_mapping_size, 0);
-        m_host_page_size = exchange(other.m_host_page_size, 0);
-        m_mapping_base = exchange(other.m_mapping_base, nullptr);
-        m_data = exchange(other.m_data, nullptr);
-        m_fallback = move(other.m_fallback);
+        m_handle = exchange(other.m_handle, {});
+        m_storage_offset = exchange(other.m_storage_offset, GC::PrimitiveStorage::invalid_offset);
     }
     return *this;
 }
 
 void MemoryBuffer::clear()
 {
-    if (m_mapping_base) {
-        VERIFY(m_reserved_capacity);
-        VERIFY(m_mapping_size);
-        VERIFY(m_host_page_size);
-        auto reservation_size = m_mapping_size + 2 * m_host_page_size;
-        [[maybe_unused]] auto result = Core::System::release_address_space(m_mapping_base, reservation_size);
-        VERIFY(!result.is_error());
-    }
-    m_mapping_base = nullptr;
-    m_data = nullptr;
+    if (m_handle.is_valid())
+        GC::PrimitiveStorage::the().free(m_handle);
     m_reserved_capacity = 0;
-    m_mapping_size = 0;
-    m_host_page_size = 0;
     m_size = 0;
-    m_fallback.clear();
+    m_handle = {};
+    m_storage_offset = GC::PrimitiveStorage::invalid_offset;
 }
 
-void MemoryBuffer::reserve_wasm32_address_space()
+void MemoryBuffer::update_storage_offset()
 {
-    if (m_mapping_base)
-        return;
+    m_storage_offset = GC::PrimitiveStorage::the().offset(m_handle);
+}
 
-    auto host_page_size = static_cast<size_t>(PAGE_SIZE);
-    auto reserved_capacity = static_cast<size_t>(Constants::page_size) * 65536;
-    auto mapping_size = reserved_capacity * 2;
-    auto reservation_size = mapping_size + 2 * host_page_size;
+ErrorOr<void> MemoryBuffer::try_reserve(size_t capacity)
+{
+    if (m_handle.is_valid()) {
+        if (capacity <= m_reserved_capacity)
+            return {};
+        TRY(GC::PrimitiveStorage::the().try_reserve(m_handle, capacity));
+        m_reserved_capacity = GC::PrimitiveStorage::the().capacity(m_handle);
+        update_storage_offset();
+        return {};
+    }
 
-    auto mapping_or_error = MUST(Core::System::reserve_address_space(reservation_size));
-
-    m_mapping_base = mapping_or_error;
-    m_data = reinterpret_cast<u8*>(m_mapping_base) + host_page_size;
-    m_reserved_capacity = reserved_capacity;
-    m_mapping_size = mapping_size;
-    m_host_page_size = host_page_size;
+    m_handle = TRY(GC::PrimitiveStorage::the().try_reserve(0, capacity, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+    m_reserved_capacity = capacity;
+    update_storage_offset();
+    return {};
 }
 
 ErrorOr<void> MemoryBuffer::try_resize(size_t new_size)
 {
-    if (m_data) {
-        VERIFY(new_size >= m_size);
-        VERIFY(m_host_page_size);
-        if (new_size > m_reserved_capacity)
-            return Error::from_errno(ENOMEM);
-        if (new_size == m_size)
-            return {};
-
-        auto* grow_base = m_data + m_size;
-        auto grow_size = new_size - m_size;
-        TRY(Core::System::commit_memory(grow_base, grow_size));
-
+    VERIFY(new_size >= m_size);
+    if (m_handle.is_valid()) {
+        TRY(GC::PrimitiveStorage::the().try_resize(m_handle, new_size, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+        m_reserved_capacity = GC::PrimitiveStorage::the().capacity(m_handle);
         m_size = new_size;
+        update_storage_offset();
         return {};
     }
 
-    TRY(m_fallback.try_resize(new_size));
-    m_size = m_fallback.size();
+    if (new_size == 0)
+        return {};
+
+    auto capacity = max(new_size, m_reserved_capacity);
+    m_handle = TRY(GC::PrimitiveStorage::the().try_reserve(new_size, capacity, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+    m_reserved_capacity = capacity;
+    m_size = new_size;
+    update_storage_offset();
     return {};
+}
+
+ErrorOr<void> MemoryBuffer::try_resize(size_t new_size, size_t reserved_capacity)
+{
+    VERIFY(new_size >= m_size);
+    VERIFY(new_size <= reserved_capacity);
+    if (m_handle.is_valid()) {
+        TRY(GC::PrimitiveStorage::the().try_resize_and_reserve(m_handle, new_size, reserved_capacity, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+        m_reserved_capacity = GC::PrimitiveStorage::the().capacity(m_handle);
+        m_size = new_size;
+        update_storage_offset();
+        return {};
+    }
+
+    if (reserved_capacity == 0)
+        return {};
+
+    m_handle = TRY(GC::PrimitiveStorage::the().try_reserve(new_size, reserved_capacity, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+    m_reserved_capacity = reserved_capacity;
+    m_size = new_size;
+    update_storage_offset();
+    return {};
+}
+
+size_t MemoryBuffer::contiguous_bytes_from(size_t offset, size_t count) const
+{
+    if (count == 0 || m_storage_offset == GC::PrimitiveStorage::invalid_offset)
+        return count;
+    auto caged_offset = GC::PrimitiveStorage::mask_offset(m_storage_offset + offset);
+    return min(count, GC::PrimitiveStorage::default_cage_size - caged_offset);
+}
+
+size_t MemoryBuffer::contiguous_bytes_before(size_t offset, size_t count) const
+{
+    if (count == 0 || m_storage_offset == GC::PrimitiveStorage::invalid_offset)
+        return count;
+    VERIFY(offset > 0);
+    auto caged_offset = GC::PrimitiveStorage::mask_offset(m_storage_offset + offset - 1);
+    return min(count, caged_offset + 1);
+}
+
+void MemoryBuffer::copy_to(size_t offset, Bytes destination) const
+{
+    VERIFY(offset <= size());
+    VERIFY(destination.size() <= size() - offset);
+
+    size_t copied = 0;
+    while (copied < destination.size()) {
+        auto chunk_size = contiguous_bytes_from(offset + copied, destination.size() - copied);
+        __builtin_memcpy(destination.data() + copied, offset_pointer(offset + copied), chunk_size);
+        copied += chunk_size;
+    }
+}
+
+void MemoryBuffer::copy_from(MemoryBuffer const& source, size_t source_offset, size_t destination_offset, size_t count)
+{
+    VERIFY(source_offset <= source.size());
+    VERIFY(count <= source.size() - source_offset);
+    VERIFY(destination_offset <= size());
+    VERIFY(count <= size() - destination_offset);
+
+    if (&source == this) {
+        move_data(destination_offset, source_offset, count);
+        return;
+    }
+
+    size_t copied = 0;
+    while (copied < count) {
+        auto source_chunk_size = source.contiguous_bytes_from(source_offset + copied, count - copied);
+        auto destination_chunk_size = contiguous_bytes_from(destination_offset + copied, count - copied);
+        auto chunk_size = min(source_chunk_size, destination_chunk_size);
+        __builtin_memcpy(offset_pointer(destination_offset + copied), source.offset_pointer(source_offset + copied), chunk_size);
+        copied += chunk_size;
+    }
+}
+
+void MemoryBuffer::fill(size_t offset, u8 value, size_t count)
+{
+    VERIFY(offset <= size());
+    VERIFY(count <= size() - offset);
+
+    size_t filled = 0;
+    while (filled < count) {
+        auto chunk_size = contiguous_bytes_from(offset + filled, count - filled);
+        __builtin_memset(offset_pointer(offset + filled), value, chunk_size);
+        filled += chunk_size;
+    }
+}
+
+void MemoryBuffer::overwrite(size_t offset, void const* source, size_t count)
+{
+    VERIFY(offset <= size());
+    VERIFY(count <= size() - offset);
+
+    auto const* source_bytes = static_cast<u8 const*>(source);
+    size_t copied = 0;
+    while (copied < count) {
+        auto chunk_size = contiguous_bytes_from(offset + copied, count - copied);
+        __builtin_memcpy(offset_pointer(offset + copied), source_bytes + copied, chunk_size);
+        copied += chunk_size;
+    }
+}
+
+void MemoryBuffer::move_data(size_t destination_offset, size_t source_offset, size_t count)
+{
+    VERIFY(destination_offset <= size());
+    VERIFY(count <= size() - destination_offset);
+    VERIFY(source_offset <= size());
+    VERIFY(count <= size() - source_offset);
+
+    if (count == 0 || destination_offset == source_offset)
+        return;
+
+    if (source_offset < destination_offset && destination_offset < source_offset + count) {
+        size_t remaining = count;
+        while (remaining > 0) {
+            auto source_chunk_size = contiguous_bytes_before(source_offset + remaining, remaining);
+            auto destination_chunk_size = contiguous_bytes_before(destination_offset + remaining, remaining);
+            auto chunk_size = min(source_chunk_size, destination_chunk_size);
+            remaining -= chunk_size;
+            __builtin_memmove(offset_pointer(destination_offset + remaining), offset_pointer(source_offset + remaining), chunk_size);
+        }
+        return;
+    }
+
+    size_t copied = 0;
+    while (copied < count) {
+        auto source_chunk_size = contiguous_bytes_from(source_offset + copied, count - copied);
+        auto destination_chunk_size = contiguous_bytes_from(destination_offset + copied, count - copied);
+        auto chunk_size = min(source_chunk_size, destination_chunk_size);
+        __builtin_memmove(offset_pointer(destination_offset + copied), offset_pointer(source_offset + copied), chunk_size);
+        copied += chunk_size;
+    }
 }
 
 bool MemoryBuffer::contains_virtual_address(void const* address) const
 {
-    if (!m_mapping_base)
+    if (!m_handle.is_valid())
         return false;
+    return GC::PrimitiveStorage::the().contains(m_handle, address);
+}
 
-    auto fault_address = bit_cast<FlatPtr>(address);
-    auto base = bit_cast<FlatPtr>(m_data);
-    return fault_address >= base && fault_address < base + m_mapping_size;
+static ErrorOr<size_t> size_from_page_count(u64 pages)
+{
+    Checked<size_t> size { pages };
+    size *= Constants::page_size;
+    if (size.has_overflow())
+        return Error::from_errno(ENOMEM);
+    return size.value();
+}
+
+static ErrorOr<size_t> maximum_memory_size(MemoryType const& type)
+{
+    auto supported_max_pages = type.limits().address_type() == AddressType::I32 ? Constants::wasm32_max_pages : Constants::wasm64_max_pages;
+    auto max_pages = min(type.limits().max().value_or(supported_max_pages), supported_max_pages);
+    return size_from_page_count(max_pages);
+}
+
+static ErrorOr<size_t> initial_memory_reservation_size(MemoryType const& type)
+{
+    auto maximum_size = TRY(maximum_memory_size(type));
+    auto initial_size = TRY(size_from_page_count(type.limits().min()));
+    if (initial_size > maximum_size)
+        return Error::from_errno(ENOMEM);
+
+    if (type.limits().max().has_value())
+        return maximum_size;
+
+    if (type.limits().address_type() != AddressType::I32)
+        return initial_size;
+
+    return min(max(initial_size, static_cast<size_t>(Constants::wasm32_default_memory_reservation_size)), maximum_size);
+}
+
+static size_t grown_memory_reservation_size(size_t current_capacity, size_t required_size, size_t maximum_size)
+{
+    auto new_capacity = max(current_capacity, static_cast<size_t>(Constants::wasm32_default_memory_reservation_size));
+    while (new_capacity < required_size) {
+        if (new_capacity > maximum_size / 2) {
+            new_capacity = maximum_size;
+            break;
+        }
+        new_capacity *= 2;
+    }
+    return min(max(new_capacity, required_size), maximum_size);
 }
 
 ErrorOr<MemoryInstance> MemoryInstance::create(MemoryType const& type)
 {
     MemoryInstance instance { type };
 
-    if (!instance.grow(type.limits().min() * Constants::page_size, GrowType::No))
+    auto reserved_capacity = TRY(initial_memory_reservation_size(type));
+    TRY(instance.m_data.try_reserve(reserved_capacity));
+
+    auto initial_size = TRY(size_from_page_count(type.limits().min()));
+    if (!instance.grow(initial_size, GrowType::No))
         return Error::from_string_literal("Failed to grow to requested size");
 
     return { move(instance) };
@@ -280,28 +446,30 @@ ErrorOr<MemoryInstance> MemoryInstance::create(MemoryType const& type)
 MemoryInstance::MemoryInstance(MemoryType const& type)
     : m_type(type)
 {
-    if (type.limits().address_type() == AddressType::I32)
-        m_data.reserve_wasm32_address_space();
 }
 
 bool MemoryInstance::grow(size_t size_to_grow, GrowType grow_type, InhibitGrowCallback inhibit_callback)
 {
     if (size_to_grow == 0)
         return true;
-    u64 new_size = m_data.size() + size_to_grow;
-    if (new_size > Constants::page_size * 65536)
-        return false;
-    if (auto max = m_type.limits().max(); max.has_value()) {
-        if (max.value() * Constants::page_size < new_size)
-            return false;
-    }
 
-    auto previous_size = m_data.size();
-    if (m_data.try_resize(new_size).is_error())
+    auto maximum_size = maximum_memory_size(m_type);
+    if (maximum_size.is_error())
         return false;
-    if (!m_data.is_virtual())
-        m_data.span().slice(previous_size, size_to_grow).fill(0);
 
+    Checked<size_t> new_size { m_data.size() };
+    new_size += size_to_grow;
+    if (new_size.has_overflow() || new_size.value() > maximum_size.value())
+        return false;
+
+    auto new_capacity = m_data.capacity();
+    if (new_size.value() > new_capacity)
+        new_capacity = m_type.limits().max().has_value()
+            ? maximum_size.value()
+            : grown_memory_reservation_size(new_capacity, new_size.value(), maximum_size.value());
+
+    if (m_data.try_resize(new_size.value(), new_capacity).is_error())
+        return false;
     if (inhibit_callback == InhibitGrowCallback::No && successful_grow_hook)
         successful_grow_hook();
 
@@ -394,6 +562,10 @@ Optional<MemoryAddress> Store::allocate(MemoryType const& type)
 {
     MemoryAddress address { m_memories.size() };
     auto instance = MemoryInstance::create(type);
+    if (instance.is_error() && m_heap) {
+        m_heap->collect_garbage();
+        instance = MemoryInstance::create(type);
+    }
     if (instance.is_error())
         return {};
 

--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -612,8 +612,15 @@ public:
     ReadonlyBytes bytes() const { return { data(), size() }; }
     Bytes span() { return bytes(); }
     ReadonlyBytes span() const { return bytes(); }
-    u8* offset_pointer(size_t offset) { return GC::PrimitiveStorage::the().data(m_handle, offset); }
-    u8 const* offset_pointer(size_t offset) const { return GC::PrimitiveStorage::the().data(m_handle, offset); }
+    u8* offset_pointer(size_t offset)
+    {
+        if (m_storage_offset == GC::PrimitiveStorage::invalid_offset)
+            return nullptr;
+        auto* cage_base = GC::PrimitiveStorage::the().cage_base();
+        VERIFY(cage_base);
+        return cage_base + GC::PrimitiveStorage::mask_offset(m_storage_offset + offset);
+    }
+    u8 const* offset_pointer(size_t offset) const { return const_cast<MemoryBuffer&>(*this).offset_pointer(offset); }
     u8& operator[](size_t index) { return *offset_pointer(index); }
     u8 const& operator[](size_t index) const { return *offset_pointer(index); }
     size_t contiguous_bytes_from(size_t offset, size_t count) const;

--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
@@ -18,6 +17,7 @@
 #include <LibGC/CellAllocator.h>
 #include <LibGC/ConservativeRangeProvider.h>
 #include <LibGC/Heap.h>
+#include <LibGC/PrimitiveStorage.h>
 #include <LibWasm/Export.h>
 #include <LibWasm/TypeSystem.h>
 #include <LibWasm/Types.h>
@@ -598,39 +598,44 @@ public:
     MemoryBuffer(MemoryBuffer const&) = delete;
     MemoryBuffer& operator=(MemoryBuffer const&) = delete;
 
-    void reserve_wasm32_address_space();
+    ErrorOr<void> try_reserve(size_t capacity);
     ErrorOr<void> try_resize(size_t new_size);
+    ErrorOr<void> try_resize(size_t new_size, size_t reserved_capacity);
 
     auto size() const { return m_size; }
-    auto data() const { return m_data ? m_data : m_fallback.data(); }
-    auto data() { return m_data ? m_data : m_fallback.data(); }
+    auto capacity() const { return m_reserved_capacity; }
+    auto data() const { return GC::PrimitiveStorage::the().data(m_handle); }
+    auto data() { return GC::PrimitiveStorage::the().data(m_handle); }
+    auto storage_offset() const { return m_storage_offset; }
+    GC::PrimitiveStorageHandle primitive_storage_handle() const { return m_handle; }
     Bytes bytes() { return { data(), size() }; }
     ReadonlyBytes bytes() const { return { data(), size() }; }
     Bytes span() { return bytes(); }
     ReadonlyBytes span() const { return bytes(); }
-    u8* offset_pointer(size_t offset) { return data() + offset; }
-    u8 const* offset_pointer(size_t offset) const { return data() + offset; }
-    u8& operator[](size_t index) { return data()[index]; }
-    u8 const& operator[](size_t index) const { return data()[index]; }
-    void overwrite(size_t offset, void const* source, size_t count)
-    {
-        VERIFY(offset <= size());
-        VERIFY(count <= size() - offset);
-        __builtin_memcpy(offset_pointer(offset), source, count);
-    }
-    bool is_virtual() const { return m_data != nullptr; }
+    u8* offset_pointer(size_t offset) { return GC::PrimitiveStorage::the().data(m_handle, offset); }
+    u8 const* offset_pointer(size_t offset) const { return GC::PrimitiveStorage::the().data(m_handle, offset); }
+    u8& operator[](size_t index) { return *offset_pointer(index); }
+    u8 const& operator[](size_t index) const { return *offset_pointer(index); }
+    size_t contiguous_bytes_from(size_t offset, size_t count) const;
+    size_t contiguous_bytes_before(size_t offset, size_t count) const;
+    void copy_to(size_t offset, Bytes destination) const;
+    void copy_from(MemoryBuffer const& source, size_t source_offset, size_t destination_offset, size_t count);
+    void fill(size_t offset, u8 value, size_t count);
+    void overwrite(size_t offset, void const* source, size_t count);
+    void move_data(size_t destination_offset, size_t source_offset, size_t count);
     bool contains_virtual_address(void const* address) const;
+
+    static constexpr size_t size_offset() { return __builtin_offsetof(MemoryBuffer, m_size); }
+    static constexpr size_t storage_offset_offset() { return __builtin_offsetof(MemoryBuffer, m_storage_offset); }
 
 private:
     void clear();
+    void update_storage_offset();
 
     size_t m_size { 0 };
     size_t m_reserved_capacity { 0 };
-    size_t m_mapping_size { 0 };
-    size_t m_host_page_size { 0 };
-    void* m_mapping_base { nullptr };
-    u8* m_data { nullptr };
-    ByteBuffer m_fallback;
+    GC::PrimitiveStorageHandle m_handle;
+    size_t m_storage_offset { GC::PrimitiveStorage::invalid_offset };
 };
 
 class WASM_API MemoryInstance {
@@ -656,6 +661,8 @@ public:
     bool grow(size_t size_to_grow, GrowType grow_type = GrowType::Yes, InhibitGrowCallback inhibit_callback = InhibitGrowCallback::No);
 
     Function<void()> successful_grow_hook;
+
+    static constexpr size_t data_offset() { return __builtin_offsetof(MemoryInstance, m_data); }
 
 private:
     explicit MemoryInstance(MemoryType const& type);

--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -2971,11 +2971,7 @@ HANDLE_INSTRUCTION(memory_init)
     if (count == 0)
         TAILCALL return continue_(HANDLER_PARAMS(DECOMPOSE_PARAMS_NAME_ONLY));
 
-    for (size_t i = 0; i < (size_t)count; ++i) {
-        auto value = data.data()[source_offset + i];
-        if (interpreter.store_to_memory(*memory, destination_offset + i, value))
-            return Outcome::Return;
-    }
+    memory->data().overwrite(destination_offset, data.data().data() + source_offset, count);
     TAILCALL return continue_(HANDLER_PARAMS(DECOMPOSE_PARAMS_NAME_ONLY));
 }
 

--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -2914,10 +2914,7 @@ HANDLE_INSTRUCTION(memory_fill)
         if (count == 0)
             TAILCALL return continue_(HANDLER_PARAMS(DECOMPOSE_PARAMS_NAME_ONLY));
 
-        for (u64 i = 0; i < count; ++i) {
-            if (interpreter.store_to_memory(*instance, destination_offset + i, value))
-                return Outcome::Return;
-        }
+        instance->data().fill(destination_offset, value, count);
     }
 
     TAILCALL return continue_(HANDLER_PARAMS(DECOMPOSE_PARAMS_NAME_ONLY));
@@ -2946,19 +2943,7 @@ HANDLE_INSTRUCTION(memory_copy)
     if (count == 0)
         TAILCALL return continue_(HANDLER_PARAMS(DECOMPOSE_PARAMS_NAME_ONLY));
 
-    if (destination_offset <= source_offset) {
-        for (u64 i = 0; i < count; ++i) {
-            auto value = source_instance->data()[source_offset + i];
-            if (interpreter.store_to_memory(*destination_instance, destination_offset + i, value))
-                return Outcome::Return;
-        }
-    } else {
-        for (u64 i = count; i > 0; --i) {
-            auto value = source_instance->data()[source_offset + i - 1];
-            if (interpreter.store_to_memory(*destination_instance, destination_offset + i - 1, value))
-                return Outcome::Return;
-        }
-    }
+    destination_instance->data().copy_from(source_instance->data(), source_offset, destination_offset, count);
 
     TAILCALL return continue_(HANDLER_PARAMS(DECOMPOSE_PARAMS_NAME_ONLY));
 }
@@ -6509,8 +6494,7 @@ bool BytecodeInterpreter::load_and_push(Configuration& configuration, Instructio
         dbgln_if(WASM_TRACE_DEBUG, "LibWasm: load_and_push - Memory access out of bounds (expected {} to be less than or equal to {})", instance_address + sizeof(ReadType), memory->size());
         return true;
     }
-    auto slice = memory->data().bytes().slice(instance_address, sizeof(ReadType));
-    entry = Value(static_cast<PushType>(read_value<ReadType>(slice)));
+    entry = Value(static_cast<PushType>(read_value<ReadType>({ memory->data().offset_pointer(instance_address), sizeof(ReadType) })));
     dbgln_if(WASM_TRACE_DEBUG, "  loaded value: {}", entry.value());
     return false;
 }
@@ -6538,15 +6522,15 @@ bool BytecodeInterpreter::load_and_push_mxn(Configuration& configuration, Instru
         m_trap = Trap::from_string("Memory access out of bounds");
         return true;
     }
-    auto slice = memory->data().bytes().slice(instance_address, M * N / 8);
+    auto const* data = memory->data().offset_pointer(instance_address);
     using V64 = NativeVectorType<M, N, SetSign>;
     using V128 = NativeVectorType<M * 2, N, SetSign>;
 
     V64 bytes { 0 };
-    if (bit_cast<FlatPtr>(slice.data()) % sizeof(V64) == 0)
-        bytes = *bit_cast<V64*>(slice.data());
+    if (bit_cast<FlatPtr>(data) % sizeof(V64) == 0)
+        bytes = *bit_cast<V64 const*>(data);
     else
-        ByteReader::load(slice.data(), bytes);
+        ByteReader::load(data, bytes);
 
     entry = Value(bit_cast<u128>(convert_vector<V128>(bytes)));
     dbgln_if(WASM_TRACE_DEBUG, "  loaded value: {}", entry.value());
@@ -6571,9 +6555,8 @@ bool BytecodeInterpreter::load_and_push_lane_n(Configuration& configuration, Ins
         m_trap = Trap::from_string("Memory access out of bounds");
         return true;
     }
-    auto slice = memory->data().bytes().slice(instance_address, N / 8);
     auto dst = bit_cast<u8*>(&vector) + memarg_and_lane.lane * N / 8;
-    memcpy(dst, slice.data(), N / 8);
+    memory->data().copy_to(instance_address, { dst, N / 8 });
     dbgln_if(WASM_TRACE_DEBUG, "  loaded value: {}", vector);
     configuration.push_to_destination<SourceAddressMix::Any>(Value(vector), addresses.destination);
     return false;
@@ -6596,9 +6579,8 @@ bool BytecodeInterpreter::load_and_push_zero_n(Configuration& configuration, Ins
         m_trap = Trap::from_string("Memory access out of bounds");
         return true;
     }
-    auto slice = memory->data().bytes().slice(instance_address, N / 8);
     u128 vector = 0;
-    memcpy(&vector, slice.data(), N / 8);
+    memory->data().copy_to(instance_address, { bit_cast<u8*>(&vector), N / 8 });
     dbgln_if(WASM_TRACE_DEBUG, "  loaded value: {}", vector);
     configuration.push_to_destination<SourceAddressMix::Any>(Value(vector), addresses.destination);
     return false;
@@ -6621,8 +6603,7 @@ bool BytecodeInterpreter::load_and_push_m_splat(Configuration& configuration, In
         m_trap = Trap::from_string("Memory access out of bounds");
         return true;
     }
-    auto slice = memory->data().bytes().slice(instance_address, M / 8);
-    auto value = read_value<NativeIntegralType<M>>(slice);
+    auto value = read_value<NativeIntegralType<M>>({ memory->data().offset_pointer(instance_address), M / 8 });
     dbgln_if(WASM_TRACE_DEBUG, "  loaded value: {}", value);
     set_top_m_splat<M, NativeIntegralType>(configuration, value, addresses);
     return false;
@@ -6870,9 +6851,9 @@ bool BytecodeInterpreter::store_to_memory(MemoryInstance& memory, u64 address, T
 
     dbgln_if(WASM_TRACE_DEBUG, "temporary({}b) -> store({})", data_size, address);
     if constexpr (IsSame<ReadonlyBytes, T>)
-        (void)value.copy_to(memory.data().bytes().slice(address, data_size));
+        memory.data().overwrite(address, value.data(), data_size);
     else
-        memcpy(memory.data().bytes().offset_pointer(address), &value, data_size);
+        memory.data().overwrite(address, &value, data_size);
     return false;
 }
 

--- a/Libraries/LibWasm/AbstractMachine/Configuration.cpp
+++ b/Libraries/LibWasm/AbstractMachine/Configuration.cpp
@@ -24,11 +24,9 @@ void Configuration::unwind_impl()
     m_locals_base = m_frame_stack.is_empty() ? nullptr : m_frame_stack.last().locals_data();
     if (m_frame_stack.is_empty()) {
         m_default_memory = nullptr;
-        m_default_memory_base = nullptr;
     } else {
         auto const& memories = m_frame_stack.last().module().memories();
         m_default_memory = memories.is_empty() ? nullptr : m_store.unsafe_get(memories[0]);
-        m_default_memory_base = m_default_memory ? m_default_memory->data().data() : nullptr;
     }
 
     if (!last_frame.owns_locals()) {

--- a/Libraries/LibWasm/AbstractMachine/Configuration.h
+++ b/Libraries/LibWasm/AbstractMachine/Configuration.h
@@ -49,7 +49,6 @@ public:
         m_locals_base = frame.locals_data();
         auto const& memories = frame.module().memories();
         m_default_memory = memories.is_empty() ? nullptr : m_store.unsafe_get(memories[0]);
-        m_default_memory_base = m_default_memory ? m_default_memory->data().data() : nullptr;
         frame.set_compiled_fn_table(&frame.module().compiled_fn_table(m_store));
 
         auto continuation = frame.expression().instructions().size() - 1;
@@ -84,7 +83,6 @@ public:
         m_locals_base = locals_ptr;
         auto const& memories = module.memories();
         m_default_memory = memories.is_empty() ? nullptr : m_store.unsafe_get(memories[0]);
-        m_default_memory_base = m_default_memory ? m_default_memory->data().data() : nullptr;
         // Skip capacity hints and label push (Cranelift uses its own structured control flow).
     }
 
@@ -114,8 +112,6 @@ public:
     ALWAYS_INLINE auto& store() const { return m_store; }
     ALWAYS_INLINE auto& store() { return m_store; }
     ALWAYS_INLINE MemoryInstance* default_memory() const { return m_default_memory; }
-    ALWAYS_INLINE u8* default_memory_base() const { return m_default_memory_base; }
-    ALWAYS_INLINE void refresh_default_memory_base() { m_default_memory_base = m_default_memory ? m_default_memory->data().data() : nullptr; }
     ALWAYS_INLINE Value& compiled_call_result_scratch() { return m_compiled_call_result_scratch; }
     ALWAYS_INLINE Value const& compiled_call_result_scratch() const { return m_compiled_call_result_scratch; }
 
@@ -128,7 +124,7 @@ public:
     size_t m_compiled_direct_call_depth { 0 };
 
     static constexpr size_t locals_base_offset() { return __builtin_offsetof(Configuration, m_locals_base); }
-    static constexpr size_t default_memory_base_offset() { return __builtin_offsetof(Configuration, m_default_memory_base); }
+    static constexpr size_t default_memory_offset() { return __builtin_offsetof(Configuration, m_default_memory); }
     static constexpr size_t compiled_call_result_scratch_offset() { return __builtin_offsetof(Configuration, m_compiled_call_result_scratch); }
 
     ALWAYS_INLINE Value& call_record_entry(size_t index) { return m_call_record_base[index]; }
@@ -355,7 +351,6 @@ public:
     Value* m_locals_base { nullptr };
     Value* m_call_record_base { nullptr };
     MemoryInstance* m_default_memory { nullptr };
-    u8* m_default_memory_base { nullptr };
     Value m_compiled_call_result_scratch;
 };
 

--- a/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -491,7 +491,7 @@ ErrorOr<void, ValidationError> Validator::validate(TableType const& type)
 
 ErrorOr<void, ValidationError> Validator::validate(MemoryType const& type)
 {
-    u64 bound = type.limits().address_type() == AddressType::I64 ? 1ull << 48 : 1ull << 16;
+    u64 bound = type.limits().address_type() == AddressType::I64 ? 1ull << 48 : Constants::wasm32_max_pages;
     return validate(type.limits(), bound);
 }
 

--- a/Libraries/LibWasm/Constants.h
+++ b/Libraries/LibWasm/Constants.h
@@ -64,6 +64,13 @@ static constexpr auto extern_global_tag = 0x03;
 static constexpr auto extern_tag_tag = 0x04; // Proposal "exception-handling"
 
 static constexpr auto page_size = 64 * KiB;
+static constexpr u64 wasm32_max_pages = 1ull << 16;
+// FIXME: The compiled memory access path currently narrows memory64 addresses
+//        to i32 before adding the memarg offset. Keep memory64 memories within
+//        the currently supported address width until 64-bit memory accesses are
+//        implemented there.
+static constexpr u64 wasm64_max_pages = wasm32_max_pages;
+static constexpr auto wasm32_default_memory_reservation_size = 16 * MiB;
 
 // Implementation-defined limits
 // These are not concretely defined by the spec, so the values are only defined by us.

--- a/Libraries/LibWasm/CraneliftBridge.cpp
+++ b/Libraries/LibWasm/CraneliftBridge.cpp
@@ -97,7 +97,7 @@ struct BatchInput {
 // any rebuild that changes those will simply miss the cache rather than try to
 // execute incompatible bytes.
 constexpr u64 cache_blob_magic = 0x4354494A4D534157ULL; // "WASMJITC" little-endian
-constexpr u32 cache_blob_format_version = 3;
+constexpr u32 cache_blob_format_version = 5;
 
 struct CacheBlobHeader {
     u64 magic;
@@ -165,8 +165,12 @@ static u64 compute_layout_hash(RuntimeHelpers const& h)
     hash = fnv1a(hash, h.regs_offset);
     hash = fnv1a(hash, h.value_size);
     hash = fnv1a(hash, h.locals_base_offset);
-    hash = fnv1a(hash, h.default_memory_base_offset);
+    hash = fnv1a(hash, h.default_memory_offset);
+    hash = fnv1a(hash, h.memory_instance_data_offset);
+    hash = fnv1a(hash, h.memory_buffer_size_offset);
+    hash = fnv1a(hash, h.memory_buffer_storage_offset_offset);
     hash = fnv1a(hash, h.compiled_call_result_scratch_offset);
+    hash = fnv1a(hash, h.primitive_storage_cage_offset_mask);
     return hash;
 }
 
@@ -174,7 +178,8 @@ static u64 compute_layout_hash(RuntimeHelpers const& h)
 // so the helper address for id N is simply the N-th `size_t` field of the struct.
 static_assert(offsetof(RuntimeHelpers, call_function) == 0);
 static_assert(offsetof(RuntimeHelpers, memory_fill) == sizeof(size_t) * 30);
-static_assert(HELPER_COUNT == 31);
+static_assert(offsetof(RuntimeHelpers, primitive_storage_cage_base) == sizeof(size_t) * 31);
+static_assert(HELPER_COUNT == 32);
 
 static bool apply_helper_relocs(u8* code_bytes, size_t code_size, HelperReloc const* relocs, size_t reloc_count, RuntimeHelpers const& helpers)
 {
@@ -601,8 +606,6 @@ i32 wasm_cl_memory_grow(void* config_ptr, i32 mem_idx, i32 pages)
     auto old_pages = memory->size() / Constants::page_size;
     if (!memory->grow(pages * Constants::page_size))
         return -1;
-    if (mem_idx == 0)
-        config.refresh_default_memory_base();
     return static_cast<i32>(old_pages);
 }
 
@@ -680,7 +683,7 @@ i32 wasm_cl_memory_copy(void* interp_ptr, void* config_ptr, i32 dst_mem, i32 src
         return interpreter.set_trap(Trap::from_string("Memory access out of bounds"));
 
     if (count > 0)
-        __builtin_memmove(dst_instance->data().data() + static_cast<u32>(dst_offset), src_instance->data().data() + static_cast<u32>(src_offset), static_cast<u32>(count));
+        dst_instance->data().copy_from(src_instance->data(), static_cast<u32>(src_offset), static_cast<u32>(dst_offset), static_cast<u32>(count));
 
     return 0;
 }
@@ -699,7 +702,7 @@ i32 wasm_cl_memory_fill(void* interp_ptr, void* config_ptr, i32 mem_idx, i32 off
         return interpreter.set_trap(Trap::from_string("Memory access out of bounds"));
 
     if (count > 0)
-        __builtin_memset(instance->data().data() + static_cast<u32>(offset), static_cast<u8>(value), static_cast<u32>(count));
+        instance->data().fill(static_cast<u32>(offset), static_cast<u8>(value), static_cast<u32>(count));
 
     return 0;
 }
@@ -966,10 +969,15 @@ static RuntimeHelpers make_runtime_helpers()
         .call_indirect = bit_cast<uintptr_t>(&wasm_cl_call_indirect),
         .memory_copy = bit_cast<uintptr_t>(&wasm_cl_memory_copy),
         .memory_fill = bit_cast<uintptr_t>(&wasm_cl_memory_fill),
+        .primitive_storage_cage_base = bit_cast<uintptr_t>(&js_primitive_storage_cage_base),
+        .primitive_storage_cage_offset_mask = GC::PrimitiveStorage::cage_offset_mask,
         .regs_offset = static_cast<u32>(offsetof(Configuration, regs)),
         .value_size = static_cast<u32>(sizeof(Value)),
         .locals_base_offset = static_cast<u32>(Configuration::locals_base_offset()),
-        .default_memory_base_offset = static_cast<u32>(Configuration::default_memory_base_offset()),
+        .default_memory_offset = static_cast<u32>(Configuration::default_memory_offset()),
+        .memory_instance_data_offset = static_cast<u32>(MemoryInstance::data_offset()),
+        .memory_buffer_size_offset = static_cast<u32>(MemoryBuffer::size_offset()),
+        .memory_buffer_storage_offset_offset = static_cast<u32>(MemoryBuffer::storage_offset_offset()),
         .compiled_call_result_scratch_offset = static_cast<u32>(Configuration::compiled_call_result_scratch_offset()),
     };
 }
@@ -1056,7 +1064,7 @@ static CraneliftInsn serialize_insn(Dispatch const& dispatch, SourcesAndDestinat
     } else if (opc >= Instructions::i32_load.value() && opc <= Instructions::i64_store32.value()) {
         auto const& mem_arg = args.get<Instruction::MemoryArgument>();
         out.imm1 = static_cast<i64>(mem_arg.offset);
-        out.imm3 = static_cast<u32>(mem_arg.memory_index.value()) | (mem_arg.memory_index.value() == 0 ? (1u << 31) : 0);
+        out.imm3 = static_cast<u32>(mem_arg.memory_index.value());
     } else if (opc == Instructions::memory_size.value()
         || opc == Instructions::memory_grow.value()) {
         auto const& mem_idx_arg = args.get<Instruction::MemoryIndexArgument>();
@@ -1093,7 +1101,7 @@ static CraneliftInsn serialize_insn(Dispatch const& dispatch, SourcesAndDestinat
             auto const& mem_arg = args.get<Instruction::MemoryArgument>();
             out.imm1 = static_cast<i64>(mem_arg.offset);
             out.imm2 = static_cast<i64>(insn->local_index().value());
-            out.imm3 = static_cast<u32>(mem_arg.memory_index.value()) | (mem_arg.memory_index.value() == 0 ? (1u << 31) : 0);
+            out.imm3 = static_cast<u32>(mem_arg.memory_index.value());
         } else if (is_syn(Instructions::synthetic_local_seti32_const)) {
             out.imm1 = static_cast<i64>(args.get<i32>());
             out.imm2 = static_cast<i64>(insn->local_index().value());

--- a/Libraries/LibWasm/Rust/build.rs
+++ b/Libraries/LibWasm/Rust/build.rs
@@ -46,6 +46,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");
+    println!("cargo:rerun-if-changed=src/lib.rs");
 
     generate_opcodes(&manifest_dir, &out_dir)?;
 

--- a/Libraries/LibWasm/Rust/src/compiler.rs
+++ b/Libraries/LibWasm/Rust/src/compiler.rs
@@ -152,6 +152,7 @@ impl CraneliftCompiler {
 
         let epilogue_block = builder.create_block();
         let trap_block = builder.create_block();
+        let memory_oob_block = builder.create_block();
 
         // Build helper call signatures. We import them as indirect calls via function pointers.
         macro_rules! sig {
@@ -186,6 +187,7 @@ impl CraneliftCompiler {
             memory_fill_sig:   i32 fn(ptr, ptr, i32, i32, i32, i32);
             mem_load_sig:      i32 fn(ptr, ptr, i32, i64, ptr);
             mem_store_sig:     i32 fn(ptr, ptr, i32, i64, i64);
+            cage_base_sig:     i64 fn();
             mem_size_sig:      i64 fn(ptr, i32);
             mem_grow_sig:      i32 fn(ptr, i32, i32);
             read_global_sig:   i64 fn(ptr, i32);
@@ -248,9 +250,15 @@ impl CraneliftCompiler {
         let h_call_indirect = decl_helper!(call_indirect_sig, HelperId::call_indirect);
         let h_memory_copy = decl_helper!(memory_copy_sig, HelperId::memory_copy);
         let h_memory_fill = decl_helper!(memory_fill_sig, HelperId::memory_fill);
+        let h_primitive_storage_cage_base = decl_helper!(cage_base_sig, HelperId::primitive_storage_cage_base);
         let locals_base_offset = helpers.locals_base_offset as i32;
-        let default_memory_base_offset = helpers.default_memory_base_offset as i32;
+        let default_memory_offset = helpers.default_memory_offset as i32;
+        let memory_instance_data_offset = helpers.memory_instance_data_offset as i32;
+        let memory_buffer_size_offset = helpers.memory_buffer_size_offset as i32;
+        let memory_buffer_storage_offset_offset = helpers.memory_buffer_storage_offset_offset as i32;
+        let primitive_storage_cage_offset_mask = helpers.primitive_storage_cage_offset_mask as i64;
         let compiled_call_result_scratch_offset = helpers.compiled_call_result_scratch_offset as i32;
+        let wasm_memory_flags = MemFlags::new().with_notrap();
         let interp_var = Variable::from_u32(8);
         builder.declare_var(interp_var, ptr_type);
         builder.def_var(interp_var, interpreter_val);
@@ -264,15 +272,6 @@ impl CraneliftCompiler {
                 .ins()
                 .load(ptr_type, MemFlags::trusted(), configuration_val, locals_base_offset);
         builder.def_var(locals_base_var, initial_locals_base);
-        let default_memory_base_var = Variable::from_u32(11);
-        builder.declare_var(default_memory_base_var, ptr_type);
-        let initial_default_memory_base = builder.ins().load(
-            ptr_type,
-            MemFlags::trusted(),
-            configuration_val,
-            default_memory_base_offset,
-        );
-        builder.def_var(default_memory_base_var, initial_default_memory_base);
 
         let mut control_stack: Vec<ControlFrame> = Vec::new();
 
@@ -288,7 +287,7 @@ impl CraneliftCompiler {
         let mut is_unreachable = false;
         let mut dirty_regs = [false; REG_COUNT];
         let mut stack_vars: Vec<Variable> = Vec::with_capacity(max_stack_depth);
-        const VSTACK_VAR_BASE: u32 = 12;
+        const VSTACK_VAR_BASE: u32 = 11;
 
         for i in 0..max_stack_depth {
             let var = Variable::from_u32(VSTACK_VAR_BASE + i as u32);
@@ -558,12 +557,12 @@ impl CraneliftCompiler {
                 $builder.ins().brif(is_trap, trap_block, &[], cont, &[]);
                 $builder.switch_to_block(cont);
                 $builder.seal_block(cont);
-                // Reload locals_base (frame_stack may have reallocated) and default_memory_base (callee may have grown memory).
+                // Reload locals_base; frame_stack may have reallocated.
                 let _cfg_for_lb = $builder.use_var(config_var);
-                let new_lb = $builder.ins().load(ptr_type, MemFlags::trusted(), _cfg_for_lb, locals_base_offset);
+                let new_lb = $builder
+                    .ins()
+                    .load(ptr_type, MemFlags::trusted(), _cfg_for_lb, locals_base_offset);
                 $builder.def_var(locals_base_var, new_lb);
-                let new_default_memory_base = $builder.ins().load(ptr_type, MemFlags::trusted(), _cfg_for_lb, default_memory_base_offset);
-                $builder.def_var(default_memory_base_var, new_default_memory_base);
             }};
         }
         macro_rules! set_trap {
@@ -585,6 +584,64 @@ impl CraneliftCompiler {
                 $builder
                     .ins()
                     .call_indirect(set_trap_sig, st_ptr, &[interp, msg_ptr, msg_len]);
+            }};
+        }
+        macro_rules! inline_default_memory_address {
+            ($builder:expr, $addr:expr, $access_size:expr) => {{
+                let cfg = $builder.use_var(config_var);
+                let memory = $builder
+                    .ins()
+                    .load(ptr_type, MemFlags::trusted(), cfg, default_memory_offset);
+                let memory_buffer_offset = memory_instance_data_offset;
+                let memory_size = $builder.ins().load(
+                    types::I64,
+                    MemFlags::trusted(),
+                    memory,
+                    memory_buffer_offset + memory_buffer_size_offset,
+                );
+
+                let addr_too_large = $builder
+                    .ins()
+                    .icmp(IntCC::UnsignedGreaterThan, $addr, memory_size);
+                let addr_in_bounds = $builder.create_block();
+                $builder
+                    .ins()
+                    .brif(addr_too_large, memory_oob_block, &[], addr_in_bounds, &[]);
+                $builder.switch_to_block(addr_in_bounds);
+                $builder.seal_block(addr_in_bounds);
+
+                let remaining = $builder.ins().isub(memory_size, $addr);
+                let access_too_large = $builder
+                    .ins()
+                    .icmp_imm(IntCC::UnsignedLessThan, remaining, $access_size);
+                let access_in_bounds = $builder.create_block();
+                $builder
+                    .ins()
+                    .brif(access_too_large, memory_oob_block, &[], access_in_bounds, &[]);
+                $builder.switch_to_block(access_in_bounds);
+                $builder.seal_block(access_in_bounds);
+
+                let storage_offset = $builder.ins().load(
+                    types::I64,
+                    MemFlags::trusted(),
+                    memory,
+                    memory_buffer_offset + memory_buffer_storage_offset_offset,
+                );
+                let unmasked_caged_offset = $builder.ins().iadd(storage_offset, $addr);
+                let cage_offset_mask = $builder
+                    .ins()
+                    .iconst(types::I64, primitive_storage_cage_offset_mask);
+                let caged_offset = $builder.ins().band(unmasked_caged_offset, cage_offset_mask);
+                let cage_base_storage = $builder.ins().func_addr(ptr_type, h_primitive_storage_cage_base);
+                let cage_base = $builder
+                    .ins()
+                    .load(ptr_type, MemFlags::trusted(), cage_base_storage, 0);
+                let caged_offset = if ptr_type == types::I64 {
+                    caged_offset
+                } else {
+                    $builder.ins().ireduce(ptr_type, caged_offset)
+                };
+                $builder.ins().iadd(cage_base, caged_offset)
             }};
         }
 
@@ -1440,19 +1497,6 @@ impl CraneliftCompiler {
                 | op::I64_LOAD16_U
                 | op::I64_LOAD32_S
                 | op::I64_LOAD32_U => {
-                    let use_direct_memory = (insn.imm3 & (1u32 << 31)) != 0;
-                    let memory_load_helper = match opc {
-                        op::I32_LOAD | op::F32_LOAD => h_mem_load32_u,
-                        op::I64_LOAD | op::F64_LOAD => h_mem_load64,
-                        op::I32_LOAD8_S | op::I64_LOAD8_S => h_mem_load8_s,
-                        op::I32_LOAD8_U | op::I64_LOAD8_U => h_mem_load8_u,
-                        op::I32_LOAD16_S | op::I64_LOAD16_S => h_mem_load16_s,
-                        op::I32_LOAD16_U | op::I64_LOAD16_U => h_mem_load16_u,
-                        op::I64_LOAD32_S => h_mem_load32_s,
-                        op::I64_LOAD32_U => h_mem_load32_u,
-                        _ => unreachable!(),
-                    };
-
                     // addr = base (from source reg as u32) + offset.
                     let base_raw = read_src!(builder, insn.sources[0]);
                     let base_u32 = builder.ins().ireduce(types::I32, base_raw);
@@ -1460,49 +1504,63 @@ impl CraneliftCompiler {
                     let offset = builder.ins().iconst(types::I64, insn.imm1);
                     let addr = builder.ins().iadd(base_u64, offset);
 
-                    let result = if use_direct_memory {
-                        let memory_base = builder.use_var(default_memory_base_var);
-                        let addr_offset = if ptr_type == types::I64 {
-                            addr
-                        } else {
-                            builder.ins().ireduce(ptr_type, addr)
+                    let mem_idx = insn.imm3 & 0x7fff_ffff;
+                    if mem_idx == 0 {
+                        let access_size = match opc {
+                            op::I32_LOAD8_S | op::I32_LOAD8_U | op::I64_LOAD8_S | op::I64_LOAD8_U => 1,
+                            op::I32_LOAD16_S | op::I32_LOAD16_U | op::I64_LOAD16_S | op::I64_LOAD16_U => 2,
+                            op::I32_LOAD | op::F32_LOAD | op::I64_LOAD32_S | op::I64_LOAD32_U => 4,
+                            op::I64_LOAD | op::F64_LOAD => 8,
+                            _ => unreachable!(),
                         };
-                        let native_addr = builder.ins().iadd(memory_base, addr_offset);
-                        match opc {
+                        let address = inline_default_memory_address!(builder, addr, access_size);
+                        let result = match opc {
                             op::I32_LOAD | op::F32_LOAD | op::I64_LOAD32_U => {
-                                let loaded = builder.ins().load(types::I32, MemFlags::new(), native_addr, 0);
-                                builder.ins().uextend(types::I64, loaded)
+                                let value = builder.ins().load(types::I32, wasm_memory_flags, address, 0);
+                                builder.ins().uextend(types::I64, value)
                             }
                             op::I64_LOAD | op::F64_LOAD => {
-                                builder.ins().load(types::I64, MemFlags::new(), native_addr, 0)
+                                builder.ins().load(types::I64, wasm_memory_flags, address, 0)
                             }
                             op::I32_LOAD8_S | op::I64_LOAD8_S => {
-                                let loaded = builder.ins().load(types::I8, MemFlags::new(), native_addr, 0);
-                                builder.ins().sextend(types::I64, loaded)
+                                let value = builder.ins().load(types::I8, wasm_memory_flags, address, 0);
+                                builder.ins().sextend(types::I64, value)
                             }
                             op::I32_LOAD8_U | op::I64_LOAD8_U => {
-                                let loaded = builder.ins().load(types::I8, MemFlags::new(), native_addr, 0);
-                                builder.ins().uextend(types::I64, loaded)
+                                let value = builder.ins().load(types::I8, wasm_memory_flags, address, 0);
+                                builder.ins().uextend(types::I64, value)
                             }
                             op::I32_LOAD16_S | op::I64_LOAD16_S => {
-                                let loaded = builder.ins().load(types::I16, MemFlags::new(), native_addr, 0);
-                                builder.ins().sextend(types::I64, loaded)
+                                let value = builder.ins().load(types::I16, wasm_memory_flags, address, 0);
+                                builder.ins().sextend(types::I64, value)
                             }
                             op::I32_LOAD16_U | op::I64_LOAD16_U => {
-                                let loaded = builder.ins().load(types::I16, MemFlags::new(), native_addr, 0);
-                                builder.ins().uextend(types::I64, loaded)
+                                let value = builder.ins().load(types::I16, wasm_memory_flags, address, 0);
+                                builder.ins().uextend(types::I64, value)
                             }
                             op::I64_LOAD32_S => {
-                                let loaded = builder.ins().load(types::I32, MemFlags::new(), native_addr, 0);
-                                builder.ins().sextend(types::I64, loaded)
+                                let value = builder.ins().load(types::I32, wasm_memory_flags, address, 0);
+                                builder.ins().sextend(types::I64, value)
                             }
                             _ => unreachable!(),
-                        }
+                        };
+                        write_dst!(builder, insn.destination, result);
                     } else {
+                        let memory_load_helper = match opc {
+                            op::I32_LOAD | op::F32_LOAD => h_mem_load32_u,
+                            op::I64_LOAD | op::F64_LOAD => h_mem_load64,
+                            op::I32_LOAD8_S | op::I64_LOAD8_S => h_mem_load8_s,
+                            op::I32_LOAD8_U | op::I64_LOAD8_U => h_mem_load8_u,
+                            op::I32_LOAD16_S | op::I64_LOAD16_S => h_mem_load16_s,
+                            op::I32_LOAD16_U | op::I64_LOAD16_U => h_mem_load16_u,
+                            op::I64_LOAD32_S => h_mem_load32_s,
+                            op::I64_LOAD32_U => h_mem_load32_u,
+                            _ => unreachable!(),
+                        };
                         let result_slot =
                             builder.create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 8, 0));
                         let result_ptr = builder.ins().stack_addr(ptr_type, result_slot, 0);
-                        let mem_idx = builder.ins().iconst(types::I32, i64::from(insn.imm3 & 0x7fff_ffff));
+                        let mem_idx = builder.ins().iconst(types::I32, i64::from(mem_idx));
                         let interp = builder.use_var(interp_var);
                         let config = builder.use_var(config_var);
                         let _xc_0 = builder.ins().func_addr(ptr_type, memory_load_helper);
@@ -1517,9 +1575,9 @@ impl CraneliftCompiler {
                         builder.ins().brif(is_trap, trap_block, &[], cont, &[]);
                         builder.switch_to_block(cont);
                         builder.seal_block(cont);
-                        builder.ins().stack_load(types::I64, result_slot, 0)
-                    };
-                    write_dst!(builder, insn.destination, result);
+                        let result = builder.ins().stack_load(types::I64, result_slot, 0);
+                        write_dst!(builder, insn.destination, result);
+                    }
                 }
 
                 op::I32_STORE
@@ -1531,15 +1589,6 @@ impl CraneliftCompiler {
                 | op::I64_STORE8
                 | op::I64_STORE16
                 | op::I64_STORE32 => {
-                    let use_direct_memory = (insn.imm3 & (1u32 << 31)) != 0;
-                    let memory_store_helper = match opc {
-                        op::I32_STORE | op::F32_STORE | op::I64_STORE32 => h_mem_store32,
-                        op::I64_STORE | op::F64_STORE => h_mem_store64,
-                        op::I32_STORE8 | op::I64_STORE8 => h_mem_store8,
-                        op::I32_STORE16 | op::I64_STORE16 => h_mem_store16,
-                        _ => unreachable!(),
-                    };
-
                     let val = read_src!(builder, insn.sources[0]);
                     let base_raw = read_src!(builder, insn.sources[1]);
                     let base_u32 = builder.ins().ireduce(types::I32, base_raw);
@@ -1547,34 +1596,33 @@ impl CraneliftCompiler {
                     let offset = builder.ins().iconst(types::I64, insn.imm1);
                     let addr = builder.ins().iadd(base_u64, offset);
 
-                    if use_direct_memory {
-                        let memory_base = builder.use_var(default_memory_base_var);
-                        let addr_offset = if ptr_type == types::I64 {
-                            addr
-                        } else {
-                            builder.ins().ireduce(ptr_type, addr)
-                        };
-                        let native_addr = builder.ins().iadd(memory_base, addr_offset);
-                        match opc {
-                            op::I32_STORE | op::F32_STORE | op::I64_STORE32 => {
-                                let narrowed = builder.ins().ireduce(types::I32, val);
-                                builder.ins().store(MemFlags::new(), narrowed, native_addr, 0);
-                            }
-                            op::I64_STORE | op::F64_STORE => {
-                                builder.ins().store(MemFlags::new(), val, native_addr, 0);
-                            }
-                            op::I32_STORE8 | op::I64_STORE8 => {
-                                let narrowed = builder.ins().ireduce(types::I8, val);
-                                builder.ins().store(MemFlags::new(), narrowed, native_addr, 0);
-                            }
-                            op::I32_STORE16 | op::I64_STORE16 => {
-                                let narrowed = builder.ins().ireduce(types::I16, val);
-                                builder.ins().store(MemFlags::new(), narrowed, native_addr, 0);
-                            }
+                    let mem_idx = insn.imm3 & 0x7fff_ffff;
+                    if mem_idx == 0 {
+                        let access_size = match opc {
+                            op::I32_STORE8 | op::I64_STORE8 => 1,
+                            op::I32_STORE16 | op::I64_STORE16 => 2,
+                            op::I32_STORE | op::F32_STORE | op::I64_STORE32 => 4,
+                            op::I64_STORE | op::F64_STORE => 8,
                             _ => unreachable!(),
-                        }
+                        };
+                        let address = inline_default_memory_address!(builder, addr, access_size);
+                        let value = match access_size {
+                            1 => builder.ins().ireduce(types::I8, val),
+                            2 => builder.ins().ireduce(types::I16, val),
+                            4 => builder.ins().ireduce(types::I32, val),
+                            8 => val,
+                            _ => unreachable!(),
+                        };
+                        builder.ins().store(wasm_memory_flags, value, address, 0);
                     } else {
-                        let mem_idx = builder.ins().iconst(types::I32, i64::from(insn.imm3 & 0x7fff_ffff));
+                        let memory_store_helper = match opc {
+                            op::I32_STORE | op::F32_STORE | op::I64_STORE32 => h_mem_store32,
+                            op::I64_STORE | op::F64_STORE => h_mem_store64,
+                            op::I32_STORE8 | op::I64_STORE8 => h_mem_store8,
+                            op::I32_STORE16 | op::I64_STORE16 => h_mem_store16,
+                            _ => unreachable!(),
+                        };
+                        let mem_idx = builder.ins().iconst(types::I32, i64::from(mem_idx));
                         let interp = builder.use_var(interp_var);
                         let _xv_config_var = builder.use_var(config_var);
                         let _xc_0 = builder.ins().func_addr(ptr_type, memory_store_helper);
@@ -1613,13 +1661,6 @@ impl CraneliftCompiler {
                         .ins()
                         .call_indirect(mem_grow_sig, _xc_0, &[_xv_config_var, mem_idx, pages_i32]);
                     let result = builder.inst_results(call)[0];
-                    let refreshed_memory_base = builder.ins().load(
-                        ptr_type,
-                        MemFlags::trusted(),
-                        _xv_config_var,
-                        default_memory_base_offset,
-                    );
-                    builder.def_var(default_memory_base_var, refreshed_memory_base);
                     let result = builder.ins().sextend(types::I64, result);
                     write_dst!(builder, insn.destination, result);
                 }
@@ -1862,29 +1903,25 @@ impl CraneliftCompiler {
                 }
 
                 op::SYNTHETIC_I32_STORELOCAL | op::SYNTHETIC_I64_STORELOCAL => {
-                    let use_direct_memory = (insn.imm3 & (1u32 << 31)) != 0;
                     let base_raw = read_src!(builder, insn.sources[0]);
                     let val = read_local_inline!(builder, insn.imm2);
                     let base_u32 = builder.ins().ireduce(types::I32, base_raw);
                     let base_u64 = builder.ins().uextend(types::I64, base_u32);
                     let offset = builder.ins().iconst(types::I64, insn.imm1);
                     let addr = builder.ins().iadd(base_u64, offset);
-                    if use_direct_memory {
-                        let memory_base = builder.use_var(default_memory_base_var);
-                        let addr_offset = if ptr_type == types::I64 {
-                            addr
+
+                    let mem_idx = insn.imm3 & 0x7fff_ffff;
+                    if mem_idx == 0 {
+                        let access_size = if opc == op::SYNTHETIC_I32_STORELOCAL { 4 } else { 8 };
+                        let address = inline_default_memory_address!(builder, addr, access_size);
+                        let value = if opc == op::SYNTHETIC_I32_STORELOCAL {
+                            builder.ins().ireduce(types::I32, val)
                         } else {
-                            builder.ins().ireduce(ptr_type, addr)
+                            val
                         };
-                        let native_addr = builder.ins().iadd(memory_base, addr_offset);
-                        if opc == op::SYNTHETIC_I32_STORELOCAL {
-                            let narrowed = builder.ins().ireduce(types::I32, val);
-                            builder.ins().store(MemFlags::new(), narrowed, native_addr, 0);
-                        } else {
-                            builder.ins().store(MemFlags::new(), val, native_addr, 0);
-                        }
+                        builder.ins().store(wasm_memory_flags, value, address, 0);
                     } else {
-                        let mem_idx = builder.ins().iconst(types::I32, i64::from(insn.imm3 & 0x7fff_ffff));
+                        let mem_idx = builder.ins().iconst(types::I32, i64::from(mem_idx));
                         let memory_store_helper = if opc == op::SYNTHETIC_I32_STORELOCAL {
                             h_mem_store32
                         } else {
@@ -1945,9 +1982,14 @@ impl CraneliftCompiler {
             builder.seal_block(body_start);
         }
 
+        builder.switch_to_block(memory_oob_block);
+        builder.seal_block(memory_oob_block);
+        set_trap!(builder, "Memory access out of bounds");
+        builder.ins().jump(trap_block, &[]);
+
         builder.switch_to_block(trap_block);
         builder.seal_block(trap_block);
-        // Helper already set the trap for us.
+        // The helper or the inline trap block already set the trap for us.
         let trap_ret = builder.ins().iconst(types::I64, outcome_return_value as i64);
         builder.ins().return_(&[trap_ret]);
 

--- a/Libraries/LibWasm/Rust/src/lib.rs
+++ b/Libraries/LibWasm/Rust/src/lib.rs
@@ -79,11 +79,18 @@ pub struct RuntimeHelpers {
     pub memory_copy: usize,
     // i32 fn(interp, config, mem_idx, offset, value, count)
     pub memory_fill: usize,
+    // Address of the process-global primitive storage cage base.
+    pub primitive_storage_cage_base: usize,
+
+    pub primitive_storage_cage_offset_mask: usize,
 
     pub regs_offset: u32,
     pub value_size: u32,
     pub locals_base_offset: u32,
-    pub default_memory_base_offset: u32,
+    pub default_memory_offset: u32,
+    pub memory_instance_data_offset: u32,
+    pub memory_buffer_size_offset: u32,
+    pub memory_buffer_storage_offset_offset: u32,
     pub compiled_call_result_scratch_offset: u32,
 }
 
@@ -125,9 +132,10 @@ pub enum HelperId {
     call_indirect = 28,
     memory_copy = 29,
     memory_fill = 30,
+    primitive_storage_cage_base = 31,
 }
 
-pub const HELPER_COUNT: u32 = 31;
+pub const HELPER_COUNT: u32 = 32;
 
 /// One relocation slot in the generated machine code. `code_offset` is the byte offset
 /// from the start of the function where 8 contiguous bytes hold the absolute helper

--- a/Libraries/LibWasm/Tests/Executor/test-cranelift-default-memory-access.js
+++ b/Libraries/LibWasm/Tests/Executor/test-cranelift-default-memory-access.js
@@ -1,0 +1,57 @@
+test("compiled default memory loads and stores use checked caged addresses", () => {
+    // prettier-ignore
+    const binary = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x60,
+        0x01, 0x7f, 0x01, 0x7f, 0x03, 0x05, 0x04, 0x00, 0x00, 0x00, 0x00, 0x05,
+        0x03, 0x01, 0x00, 0x01, 0x07, 0x34, 0x04, 0x09, 0x72, 0x6f, 0x75, 0x6e,
+        0x64, 0x74, 0x72, 0x69, 0x70, 0x00, 0x00, 0x07, 0x6c, 0x6f, 0x61, 0x64,
+        0x5f, 0x61, 0x74, 0x00, 0x01, 0x08, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x5f,
+        0x61, 0x74, 0x00, 0x02, 0x0f, 0x6c, 0x6f, 0x61, 0x64, 0x5f, 0x6d, 0x61,
+        0x78, 0x5f, 0x6f, 0x66, 0x66, 0x73, 0x65, 0x74, 0x00, 0x03, 0x0a, 0x30,
+        0x04, 0x0e, 0x00, 0x41, 0x20, 0x20, 0x00, 0x36, 0x02, 0x00, 0x41, 0x20,
+        0x28, 0x02, 0x00, 0x0b, 0x07, 0x00, 0x20, 0x00, 0x28, 0x02, 0x00, 0x0b,
+        0x0b, 0x00, 0x20, 0x00, 0x41, 0x2a, 0x36, 0x02, 0x00, 0x41, 0x01, 0x0b,
+        0x0b, 0x00, 0x20, 0x00, 0x28, 0x02, 0xff, 0xff, 0xff, 0xff, 0x0f, 0x0b
+    ]);
+
+    const module = parseWebAssemblyModule(binary);
+    const roundtrip = module.getExport("roundtrip");
+    const loadAt = module.getExport("load_at");
+    const storeAt = module.getExport("store_at");
+    const loadMaxOffset = module.getExport("load_max_offset");
+
+    const roundtripEligible = isCraneliftEligible(roundtrip);
+    const loadAtEligible = isCraneliftEligible(loadAt);
+    const storeAtEligible = isCraneliftEligible(storeAt);
+    const loadMaxOffsetEligible = isCraneliftEligible(loadMaxOffset);
+
+    if (!roundtripEligible && !loadAtEligible && !storeAtEligible && !loadMaxOffsetEligible) return;
+
+    expect(roundtripEligible).toBe(true);
+    expect(loadAtEligible).toBe(true);
+    expect(storeAtEligible).toBe(true);
+    expect(loadMaxOffsetEligible).toBe(true);
+
+    const roundtripCompiled = isCraneliftCompiled(roundtrip);
+    const loadAtCompiled = isCraneliftCompiled(loadAt);
+    const storeAtCompiled = isCraneliftCompiled(storeAt);
+    const loadMaxOffsetCompiled = isCraneliftCompiled(loadMaxOffset);
+
+    expect(roundtripCompiled).toBe(true);
+    expect(loadAtCompiled).toBe(true);
+    expect(storeAtCompiled).toBe(true);
+    expect(loadMaxOffsetCompiled).toBe(true);
+    expect(module.invoke(roundtrip, 0x12345678)).toBe(0x12345678);
+    expect(() => module.invoke(loadAt, 65534)).toThrowWithMessage(
+        TypeError,
+        "Execution trapped: Memory access out of bounds"
+    );
+    expect(() => module.invoke(storeAt, 65534)).toThrowWithMessage(
+        TypeError,
+        "Execution trapped: Memory access out of bounds"
+    );
+    expect(() => module.invoke(loadMaxOffset, 1)).toThrowWithMessage(
+        TypeError,
+        "Execution trapped: Memory access out of bounds"
+    );
+});

--- a/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Libraries/LibWasm/WASI/Wasi.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/ByteReader.h>
+#include <AK/Checked.h>
 #include <AK/Debug.h>
 #include <AK/FlyString.h>
 #include <AK/Random.h>
@@ -72,6 +73,29 @@ CompatibleValue<T> to_compatible_value(Wasm::Value const& value)
 }
 
 namespace Wasm::Wasi {
+
+static ErrorOr<size_t> checked_byte_count(size_t element_size, Size count)
+{
+    Checked<size_t> byte_count { static_cast<u32>(count) };
+    byte_count *= element_size;
+    if (byte_count.has_overflow())
+        return Error::from_errno(ENOBUFS);
+    return byte_count.value();
+}
+
+static bool memory_range_is_in_bounds(MemoryInstance const& memory, size_t address, size_t byte_count)
+{
+    return address <= memory.size() && byte_count <= memory.size() - address;
+}
+
+static Optional<Bytes> contiguous_memory_bytes(MemoryInstance& memory, size_t address, size_t byte_count)
+{
+    if (!memory_range_is_in_bounds(memory, address, byte_count))
+        return {};
+    if (memory.data().contiguous_bytes_from(address, byte_count) < byte_count)
+        return {};
+    return Bytes { memory.data().offset_pointer(address), byte_count };
+}
 
 void ArgsSizes::serialize_into(Array<Bytes, 2> bytes) const
 {
@@ -230,15 +254,16 @@ ErrorOr<Vector<T>> copy_typed_array(Configuration& configuration, Pointer<T> sou
     if (!memory)
         return Error::from_errno(ENOMEM);
 
-    UnderlyingPointerType address = source.value();
-    auto size = sizeof(T);
-    if (memory->size() < address || memory->size() <= address + (size * count)) {
+    size_t address = source.value();
+    auto byte_count = TRY(checked_byte_count(sizeof(T), count));
+    if (!memory_range_is_in_bounds(*memory, address, byte_count))
         return Error::from_errno(ENOBUFS);
-    }
 
     for (Size i = 0; i < count; i += 1) {
-        values.unchecked_append(T::read_from(Array { ReadonlyBytes { memory->data().bytes().slice(address, size) } }));
-        address += size;
+        u8 bytes[sizeof(T)];
+        memory->data().copy_to(address, { bytes, sizeof(bytes) });
+        values.unchecked_append(T::read_from(Array { ReadonlyBytes { bytes, sizeof(bytes) } }));
+        address += sizeof(T);
     }
 
     return values;
@@ -251,13 +276,13 @@ ErrorOr<void> copy_typed_value_to(Configuration& configuration, T const& value, 
     if (!memory)
         return Error::from_errno(ENOMEM);
 
-    UnderlyingPointerType address = destination.value();
-    auto size = sizeof(T);
-    if (memory->size() < address || memory->size() <= address + size) {
+    size_t address = destination.value();
+    if (!memory_range_is_in_bounds(*memory, address, sizeof(T)))
         return Error::from_errno(ENOBUFS);
-    }
 
-    ABI::serialize(value, Array { Bytes { memory->data().bytes().slice(address, size) } });
+    u8 bytes[sizeof(T)];
+    ABI::serialize(value, Array { Bytes { bytes, sizeof(bytes) } });
+    memory->data().overwrite(address, bytes, sizeof(bytes));
     return {};
 }
 
@@ -268,13 +293,13 @@ ErrorOr<Span<T>> slice_typed_memory(Configuration& configuration, Pointer<T> sou
     if (!memory)
         return Error::from_errno(ENOMEM);
 
-    auto address = source.value();
-    auto size = sizeof(T);
-    if (memory->size() < address || memory->size() <= address + (size * count))
+    size_t address = source.value();
+    auto byte_count = TRY(checked_byte_count(sizeof(T), count));
+    auto bytes = contiguous_memory_bytes(*memory, address, byte_count);
+    if (!bytes.has_value())
         return Error::from_errno(ENOBUFS);
 
-    auto untyped_slice = memory->data().bytes().slice(address, size * count);
-    return Span<T>(untyped_slice.data(), count);
+    return Span<T>(reinterpret_cast<T*>(bytes->data()), static_cast<size_t>(count));
 }
 
 template<typename T>
@@ -284,13 +309,13 @@ ErrorOr<Span<T const>> slice_typed_memory(Configuration& configuration, ConstPoi
     if (!memory)
         return Error::from_errno(ENOMEM);
 
-    auto address = source.value();
-    auto size = sizeof(T);
-    if (memory->size() < address || memory->size() <= address + (size * count))
+    size_t address = source.value();
+    auto byte_count = TRY(checked_byte_count(sizeof(T), count));
+    auto bytes = contiguous_memory_bytes(*memory, address, byte_count);
+    if (!bytes.has_value())
         return Error::from_errno(ENOBUFS);
 
-    auto untyped_slice = memory->data().bytes().slice(address, size * count);
-    return Span<T const>(untyped_slice.data(), count);
+    return Span<T const>(reinterpret_cast<T const*>(bytes->data()), static_cast<size_t>(count));
 }
 
 static ErrorOr<size_t> copy_string_including_terminating_null(Configuration& configuration, StringView string, Pointer<u8> target)
@@ -849,10 +874,12 @@ ErrorOr<Result<void>> Implementation::impl$sock_shutdown(Configuration&, FD fd, 
 template<size_t N>
 static Array<Bytes, N> address_spans(Span<Value> values, Configuration& configuration)
 {
-    Array<Bytes, N> result;
-    auto memory = configuration.store().get(MemoryAddress { 0 })->data().span();
-    for (size_t i = 0; i < N; ++i)
-        result[i] = memory.slice(values[i].to<i32>());
+    Array<Bytes, N> result {};
+    auto& memory = configuration.store().get(MemoryAddress { 0 })->data();
+    for (size_t i = 0; i < N; ++i) {
+        if (auto address = static_cast<size_t>(values[i].to<i32>()); address <= memory.size())
+            result[i] = Bytes { memory.offset_pointer(address), memory.contiguous_bytes_from(address, memory.size() - address) };
+    }
     return result;
 }
 

--- a/Libraries/LibWeb/Bindings/HostDefined.h
+++ b/Libraries/LibWeb/Bindings/HostDefined.h
@@ -8,11 +8,12 @@
 
 #include <LibGC/Ptr.h>
 #include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Bindings {
 
-struct HostDefined : public JS::Realm::HostDefined {
+struct WEB_API HostDefined : public JS::Realm::HostDefined {
     explicit HostDefined(GC::Ref<Intrinsics> intrinsics)
         : intrinsics(intrinsics)
     {

--- a/Libraries/LibWeb/Bindings/Intrinsics.h
+++ b/Libraries/LibWeb/Bindings/Intrinsics.h
@@ -42,7 +42,7 @@ struct UnforgeableKey {
     bool operator==(UnforgeableKey const&) const = default;
 };
 
-class Intrinsics final : public JS::Cell {
+class WEB_API Intrinsics final : public JS::Cell {
     GC_CELL(Intrinsics, JS::Cell);
     GC_DECLARE_ALLOCATOR(Intrinsics);
 

--- a/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <AK/Random.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Crypto.h>
@@ -72,7 +73,9 @@ WebIDL::ExceptionOr<WebIDL::ArrayBufferViewVariant> Crypto::get_random_values(We
         return WebIDL::QuotaExceededError::create(realm(), "array's byteLength may not be greater than 65536"_utf16);
 
     // 3. Overwrite all elements of array with cryptographically strong random values of the appropriate type.
-    fill_with_random(array_view.viewed_array_buffer()->bytes().slice(array_view.byte_offset(), array_view.byte_length()));
+    auto random_bytes = MUST(ByteBuffer::create_uninitialized(array_view.byte_length()));
+    fill_with_random(random_bytes);
+    array_view.viewed_array_buffer()->overwrite(array_view.byte_offset(), random_bytes.data(), random_bytes.size());
 
     // 4. Return array.
     return array;

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -870,7 +870,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::derive_key(AlgorithmIdentifier algorithm,
         }
 
         // 15. Let result be the result of performing the import key operation specified by normalizedDerivedKeyAlgorithmImport using "raw" as format, secret as keyData, derivedKeyType as algorithm and using extractable and usages.
-        auto secret_bytes = MUST(ByteBuffer::copy(secret.release_value()->bytes()));
+        auto secret_bytes = MUST(secret.release_value()->copy_to_byte_buffer());
         auto result_or_error = normalized_derived_key_algorithm_import.methods->import_key(*normalized_derived_key_algorithm_import.parameter, Bindings::KeyFormat::Raw, move(secret_bytes), extractable, key_usages);
         if (result_or_error.is_error()) {
             WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result_or_error.release_error()).release_value());
@@ -1001,7 +1001,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::wrap_key(Bindings::KeyFormat format, GC::
             || format == Bindings::KeyFormat::Pkcs8
             || format == Bindings::KeyFormat::Spki) {
             // Let bytes be exportedKey.
-            bytes = MUST(ByteBuffer::copy(as<JS::ArrayBuffer>(*exported_key).bytes()));
+            bytes = MUST(as<JS::ArrayBuffer>(*exported_key).copy_to_byte_buffer());
         } else {
             VERIFY_NOT_REACHED();
         }
@@ -1147,7 +1147,8 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::unwrap_key(Bindings::KeyFormat format, We
         // 15. If format is equal to the string "jwk":
         if (format == Bindings::KeyFormat::Jwk) {
             // Let key be the result of executing the parse a JWK algorithm, with bytes as the data to be parsed.
-            auto maybe_parsed = JsonWebKey::parse(realm, bytes->bytes());
+            auto bytes_data = MUST(bytes->copy_to_byte_buffer());
+            auto maybe_parsed = JsonWebKey::parse(realm, bytes_data);
             if (maybe_parsed.is_error()) {
                 WebIDL::reject_promise(realm, promise, maybe_parsed.release_error().release_value());
                 return;
@@ -1165,7 +1166,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::unwrap_key(Bindings::KeyFormat format, We
             || format == Bindings::KeyFormat::Pkcs8
             || format == Bindings::KeyFormat::Spki) {
             // Let key be bytes.
-            key = MUST(ByteBuffer::copy(bytes->bytes()));
+            key = MUST(bytes->copy_to_byte_buffer());
         } else {
             VERIFY_NOT_REACHED();
         }
@@ -1479,7 +1480,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::decapsulate_key(AlgorithmIdentifier decap
         auto maybe_shared_key = normalized_shared_key_algorithm.methods->import_key(
             *normalized_shared_key_algorithm.parameter,
             Bindings::KeyFormat::RawSecret,
-            MUST(ByteBuffer::copy(decapsulated_bits->bytes())),
+            MUST(decapsulated_bits->copy_to_byte_buffer()),
             extractable,
             usages);
         if (maybe_shared_key.is_error()) {

--- a/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -59,7 +59,10 @@ Bindings::TextEncoderEncodeIntoResult TextEncoder::encode_into(String const& sou
     if (destination->viewed_array_buffer()->is_detached())
         return { 0, 0 };
 
-    auto data = destination->data();
+    auto destination_record = JS::make_typed_array_with_buffer_witness_record(*destination, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(destination_record))
+        return { 0, 0 };
+    auto destination_byte_length = JS::typed_array_byte_length(destination_record);
 
     // 1. Let read be 0.
     WebIDL::UnsignedLongLong read = 0;
@@ -85,7 +88,7 @@ Bindings::TextEncoderEncodeIntoResult TextEncoder::encode_into(String const& sou
 
         // 6.4. Otherwise:
         // 6.4.1. If destination’s byte length − written is greater than or equal to the number of bytes in result, then:
-        if (data.size() - written >= result.size()) {
+        if (destination_byte_length - written >= result.size()) {
             // 6.4.1.1. If item is greater than U+FFFF, then increment read by 2.
             if (item > 0xffff) {
                 read += 2;
@@ -98,8 +101,8 @@ Bindings::TextEncoderEncodeIntoResult TextEncoder::encode_into(String const& sou
             // 6.4.1.3. Write the bytes in result into destination, with startingOffset set to written.
             // 6.4.1.4. Increment written by the number of bytes in result.
             // WARNING: See the warning for SharedArrayBuffer objects at https://encoding.spec.whatwg.org/#sharedarraybuffer-warning.
-            for (auto byte : result)
-                data[written++] = byte;
+            destination->viewed_array_buffer()->overwrite(destination->byte_offset() + written, result.data(), result.size());
+            written += result.size();
         }
         // 6.4.2. Otherwise, break.
         else {

--- a/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
@@ -30,7 +30,10 @@ void IncrementalReadLoopReadRequest::on_chunk(JS::Value chunk)
     else {
         // 1. Let bytes be a copy of chunk.
         // NOTE: Implementations are strongly encouraged to use an implementation strategy that avoids this copy where possible.
-        auto bytes = MUST(ByteBuffer::copy(uint8_array->data()));
+        auto record = JS::make_typed_array_with_buffer_witness_record(*uint8_array, JS::ArrayBuffer::Order::SeqCst);
+        auto bytes = JS::is_typed_array_out_of_bounds(record)
+            ? ByteBuffer {}
+            : MUST(uint8_array->viewed_array_buffer()->copy_to_byte_buffer(uint8_array->byte_offset(), JS::typed_array_byte_length(record)));
         // 2. Set continueAlgorithm to these steps:
         continue_algorithm = GC::create_function(realm.heap(), [bytes = move(bytes), body = m_body, reader = m_reader, task_destination = m_task_destination, process_body_chunk = m_process_body_chunk, process_end_of_body = m_process_end_of_body, process_body_error = m_process_body_error] {
             HTML::TemporaryExecutionContext execution_context { reader->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };

--- a/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -398,7 +398,8 @@ GC::Ref<WebIDL::Promise> Blob::text()
         auto const& array_buffer = static_cast<JS::ArrayBuffer const&>(object);
 
         auto decoder = TextCodec::decoder_for("UTF-8"sv);
-        auto utf8_text = TRY_OR_THROW_OOM(vm, TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, array_buffer.bytes()));
+        auto buffer_data = MUST(array_buffer.copy_to_byte_buffer());
+        auto utf8_text = TRY_OR_THROW_OOM(vm, TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, buffer_data));
         return JS::PrimitiveString::create(vm, Utf16String::from_utf8(utf8_text));
     }));
 }
@@ -426,7 +427,7 @@ GC::Ref<WebIDL::Promise> Blob::array_buffer()
         VERIFY(is<JS::ArrayBuffer>(object));
         auto const& array_buffer = static_cast<JS::ArrayBuffer const&>(object);
 
-        return JS::ArrayBuffer::create(realm, MUST(ByteBuffer::copy(array_buffer.bytes())));
+        return JS::ArrayBuffer::create(realm, MUST(array_buffer.copy_to_byte_buffer()));
     }));
 }
 

--- a/Libraries/LibWeb/FileAPI/FileReader.cpp
+++ b/Libraries/LibWeb/FileAPI/FileReader.cpp
@@ -240,7 +240,11 @@ WebIDL::ExceptionOr<void> FileReader::read_operation(Blob& blob, Type type, Opti
                     auto const& byte_sequence = as<JS::Uint8Array>(value.as_object());
 
                     // 2. Append bs to bytes.
-                    state->bytes.append(byte_sequence.data());
+                    auto byte_sequence_record = JS::make_typed_array_with_buffer_witness_record(byte_sequence, JS::ArrayBuffer::Order::SeqCst);
+                    if (!JS::is_typed_array_out_of_bounds(byte_sequence_record)) {
+                        auto bytes = MUST(byte_sequence.viewed_array_buffer()->copy_to_byte_buffer(byte_sequence.byte_offset(), JS::typed_array_byte_length(byte_sequence_record)));
+                        state->bytes.append(bytes);
+                    }
 
                     // 3. If roughly 50ms have passed since these steps were last invoked, queue a task to fire a progress event called progress at fr.
                     auto now = MonotonicTime::now();

--- a/Libraries/LibWeb/FileAPI/FileReaderSync.cpp
+++ b/Libraries/LibWeb/FileAPI/FileReaderSync.cpp
@@ -94,7 +94,7 @@ WebIDL::ExceptionOr<Result> FileReaderSync::read_as(Blob& blob, FileReader::Type
     if (promise->state() == JS::Promise::State::Fulfilled && array_buffer) {
         // AD-HOC: This diverges from the spec as wrritten, where the type argument is specified explicitly for each caller.
         // 1. Return the result of package data given bytes, type, blob’s type, and encoding.
-        auto result = TRY(FileReader::blob_package_data(realm(), MUST(ByteBuffer::copy(array_buffer->bytes())), type, blob.type(), encoding));
+        auto result = TRY(FileReader::blob_package_data(realm(), MUST(array_buffer->copy_to_byte_buffer()), type, blob.type(), encoding));
         return result.get<Result>();
     }
 

--- a/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -170,18 +170,20 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float32_array(JS::VM& vm
     if (element_count != 6 && element_count != 16)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float32Array argument with 6 or 16 elements"_string };
 
-    auto elements = array->data();
+    return array->viewed_array_buffer()->with_readonly_bytes(array->byte_offset(), element_count * sizeof(float), [&](ReadonlyBytes bytes) -> WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> {
+        auto elements = bytes.reinterpret<float const>();
 
-    // If array32 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
-    if (element_count == 6)
-        return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
+        // If array32 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
+        if (element_count == 6)
+            return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
 
-    // If array32 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
-    VERIFY(element_count == 16);
-    return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
-        elements.at(4), elements.at(5), elements.at(6), elements.at(7),
-        elements.at(8), elements.at(9), elements.at(10), elements.at(11),
-        elements.at(12), elements.at(13), elements.at(14), elements.at(15));
+        // If array32 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
+        VERIFY(element_count == 16);
+        return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
+            elements.at(4), elements.at(5), elements.at(6), elements.at(7),
+            elements.at(8), elements.at(9), elements.at(10), elements.at(11),
+            elements.at(12), elements.at(13), elements.at(14), elements.at(15));
+    });
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrix-fromfloat64array
@@ -196,18 +198,20 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float64_array(JS::VM& vm
     if (element_count != 6 && element_count != 16)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float64Array argument with 6 or 16 elements"_string };
 
-    auto elements = array->data();
+    return array->viewed_array_buffer()->with_readonly_bytes(array->byte_offset(), element_count * sizeof(double), [&](ReadonlyBytes bytes) -> WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> {
+        auto elements = bytes.reinterpret<double const>();
 
-    // If array64 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
-    if (element_count == 6)
-        return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
+        // If array64 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
+        if (element_count == 6)
+            return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
 
-    // If array64 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
-    VERIFY(element_count == 16);
-    return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
-        elements.at(4), elements.at(5), elements.at(6), elements.at(7),
-        elements.at(8), elements.at(9), elements.at(10), elements.at(11),
-        elements.at(12), elements.at(13), elements.at(14), elements.at(15));
+        // If array64 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
+        VERIFY(element_count == 16);
+        return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
+            elements.at(4), elements.at(5), elements.at(6), elements.at(7),
+            elements.at(8), elements.at(9), elements.at(10), elements.at(11),
+            elements.at(12), elements.at(13), elements.at(14), elements.at(15));
+    });
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m11

--- a/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -162,42 +162,52 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_matrix(JS::VM& vm, Bindi
 WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float32_array(JS::VM& vm, GC::Ref<JS::Float32Array> array)
 {
     auto& realm = *vm.current_realm();
-    ReadonlySpan<float> elements = array->data();
+    auto record = JS::make_typed_array_with_buffer_witness_record(*array, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(record))
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float32Array argument with 6 or 16 elements"_string };
+
+    auto element_count = JS::typed_array_length(record);
+    if (element_count != 6 && element_count != 16)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float32Array argument with 6 or 16 elements"_string };
+
+    auto elements = array->data();
 
     // If array32 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
-    if (elements.size() == 6)
+    if (element_count == 6)
         return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
 
     // If array32 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
-    if (elements.size() == 16)
-        return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
-            elements.at(4), elements.at(5), elements.at(6), elements.at(7),
-            elements.at(8), elements.at(9), elements.at(10), elements.at(11),
-            elements.at(12), elements.at(13), elements.at(14), elements.at(15));
-
-    // Otherwise, throw a TypeError exception.
-    return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float32Array argument with 6 or 16 elements"_string };
+    VERIFY(element_count == 16);
+    return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
+        elements.at(4), elements.at(5), elements.at(6), elements.at(7),
+        elements.at(8), elements.at(9), elements.at(10), elements.at(11),
+        elements.at(12), elements.at(13), elements.at(14), elements.at(15));
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrix-fromfloat64array
 WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float64_array(JS::VM& vm, GC::Ref<JS::Float64Array> array)
 {
     auto& realm = *vm.current_realm();
-    ReadonlySpan<double> elements = array->data();
+    auto record = JS::make_typed_array_with_buffer_witness_record(*array, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(record))
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float64Array argument with 6 or 16 elements"_string };
+
+    auto element_count = JS::typed_array_length(record);
+    if (element_count != 6 && element_count != 16)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float64Array argument with 6 or 16 elements"_string };
+
+    auto elements = array->data();
 
     // If array64 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
-    if (elements.size() == 6)
+    if (element_count == 6)
         return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
 
     // If array64 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
-    if (elements.size() == 16)
-        return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
-            elements.at(4), elements.at(5), elements.at(6), elements.at(7),
-            elements.at(8), elements.at(9), elements.at(10), elements.at(11),
-            elements.at(12), elements.at(13), elements.at(14), elements.at(15));
-
-    // Otherwise, throw a TypeError exception.
-    return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float64Array argument with 6 or 16 elements"_string };
+    VERIFY(element_count == 16);
+    return realm.create<DOMMatrix>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
+        elements.at(4), elements.at(5), elements.at(6), elements.at(7),
+        elements.at(8), elements.at(9), elements.at(10), elements.at(11),
+        elements.at(12), elements.at(13), elements.at(14), elements.at(15));
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m11

--- a/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -241,18 +241,20 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float32_
     if (element_count != 6 && element_count != 16)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float32Array argument with 6 or 16 elements"_string };
 
-    auto elements = array->data();
+    return array->viewed_array_buffer()->with_readonly_bytes(array->byte_offset(), element_count * sizeof(float), [&](ReadonlyBytes bytes) -> WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> {
+        auto elements = bytes.reinterpret<float const>();
 
-    // If array32 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
-    if (element_count == 6)
-        return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
+        // If array32 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
+        if (element_count == 6)
+            return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
 
-    // If array32 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
-    VERIFY(element_count == 16);
-    return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
-        elements.at(4), elements.at(5), elements.at(6), elements.at(7),
-        elements.at(8), elements.at(9), elements.at(10), elements.at(11),
-        elements.at(12), elements.at(13), elements.at(14), elements.at(15));
+        // If array32 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
+        VERIFY(element_count == 16);
+        return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
+            elements.at(4), elements.at(5), elements.at(6), elements.at(7),
+            elements.at(8), elements.at(9), elements.at(10), elements.at(11),
+            elements.at(12), elements.at(13), elements.at(14), elements.at(15));
+    });
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-fromfloat64array
@@ -267,18 +269,20 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float64_
     if (element_count != 6 && element_count != 16)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float64Array argument with 6 or 16 elements"_string };
 
-    auto elements = array->data();
+    return array->viewed_array_buffer()->with_readonly_bytes(array->byte_offset(), element_count * sizeof(double), [&](ReadonlyBytes bytes) -> WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> {
+        auto elements = bytes.reinterpret<double const>();
 
-    // If array64 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
-    if (element_count == 6)
-        return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
+        // If array64 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
+        if (element_count == 6)
+            return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
 
-    // If array64 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
-    VERIFY(element_count == 16);
-    return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
-        elements.at(4), elements.at(5), elements.at(6), elements.at(7),
-        elements.at(8), elements.at(9), elements.at(10), elements.at(11),
-        elements.at(12), elements.at(13), elements.at(14), elements.at(15));
+        // If array64 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
+        VERIFY(element_count == 16);
+        return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
+            elements.at(4), elements.at(5), elements.at(6), elements.at(7),
+            elements.at(8), elements.at(9), elements.at(10), elements.at(11),
+            elements.at(12), elements.at(13), elements.at(14), elements.at(15));
+    });
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-isidentity

--- a/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -233,42 +233,52 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_matrix(J
 WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float32_array(JS::VM& vm, GC::Ref<JS::Float32Array> array)
 {
     auto& realm = *vm.current_realm();
-    ReadonlySpan<float> elements = array->data();
+    auto record = JS::make_typed_array_with_buffer_witness_record(*array, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(record))
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float32Array argument with 6 or 16 elements"_string };
+
+    auto element_count = JS::typed_array_length(record);
+    if (element_count != 6 && element_count != 16)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float32Array argument with 6 or 16 elements"_string };
+
+    auto elements = array->data();
 
     // If array32 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
-    if (elements.size() == 6)
+    if (element_count == 6)
         return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
 
     // If array32 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array32 in the provided order.
-    if (elements.size() == 16)
-        return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
-            elements.at(4), elements.at(5), elements.at(6), elements.at(7),
-            elements.at(8), elements.at(9), elements.at(10), elements.at(11),
-            elements.at(12), elements.at(13), elements.at(14), elements.at(15));
-
-    // Otherwise, throw a TypeError exception.
-    return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float32Array argument with 6 or 16 elements"_string };
+    VERIFY(element_count == 16);
+    return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
+        elements.at(4), elements.at(5), elements.at(6), elements.at(7),
+        elements.at(8), elements.at(9), elements.at(10), elements.at(11),
+        elements.at(12), elements.at(13), elements.at(14), elements.at(15));
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-fromfloat64array
 WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::from_float64_array(JS::VM& vm, GC::Ref<JS::Float64Array> array)
 {
     auto& realm = *vm.current_realm();
-    ReadonlySpan<double> elements = array->data();
+    auto record = JS::make_typed_array_with_buffer_witness_record(*array, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(record))
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float64Array argument with 6 or 16 elements"_string };
+
+    auto element_count = JS::typed_array_length(record);
+    if (element_count != 6 && element_count != 16)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float64Array argument with 6 or 16 elements"_string };
+
+    auto elements = array->data();
 
     // If array64 has 6 elements, return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
-    if (elements.size() == 6)
+    if (element_count == 6)
         return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3), elements.at(4), elements.at(5));
 
     // If array64 has 16 elements, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers taking the values from array64 in the provided order.
-    if (elements.size() == 16)
-        return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
-            elements.at(4), elements.at(5), elements.at(6), elements.at(7),
-            elements.at(8), elements.at(9), elements.at(10), elements.at(11),
-            elements.at(12), elements.at(13), elements.at(14), elements.at(15));
-
-    // Otherwise, throw a TypeError exception.
-    return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Expected a Float64Array argument with 6 or 16 elements"_string };
+    VERIFY(element_count == 16);
+    return realm.create<DOMMatrixReadOnly>(realm, elements.at(0), elements.at(1), elements.at(2), elements.at(3),
+        elements.at(4), elements.at(5), elements.at(6), elements.at(7),
+        elements.at(8), elements.at(9), elements.at(10), elements.at(11),
+        elements.at(12), elements.at(13), elements.at(14), elements.at(15));
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-isidentity

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -757,11 +757,12 @@ WebIDL::ExceptionOr<GC::Ptr<ImageData>> CanvasRenderingContext2D::get_image_data
     // NOTE: Internally we must use premultiplied alpha, but ImageData should hold unpremultiplied alpha. This conversion
     //       might result in a loss of precision, but is according to spec.
     //       See: https://html.spec.whatwg.org/multipage/canvas.html#premultiplied-alpha-and-the-2d-rendering-context
+    auto image_data_bitmap = TRY_OR_THROW_OOM(realm().vm(), image_data->bitmap());
     VERIFY(snapshot.bitmap().alpha_type() == Gfx::AlphaType::Premultiplied);
-    VERIFY(image_data->bitmap().alpha_type() == Gfx::AlphaType::Unpremultiplied);
+    VERIFY(image_data_bitmap->alpha_type() == Gfx::AlphaType::Unpremultiplied);
 
-    auto painter = Gfx::Painter::create(image_data->bitmap());
-    painter->draw_bitmap(image_data->bitmap().rect().to_type<float>(), snapshot, snapshot.rect(), Gfx::ScalingMode::NearestNeighbor, {}, 1, Gfx::CompositingAndBlendingOperator::SourceOver);
+    auto painter = Gfx::Painter::create(*image_data_bitmap);
+    painter->draw_bitmap(image_data_bitmap->rect().to_type<float>(), snapshot, snapshot.rect(), Gfx::ScalingMode::NearestNeighbor, {}, 1, Gfx::CompositingAndBlendingOperator::SourceOver);
 
     // 7. Set the pixels values of imageData for areas of the source rectangle that are outside of the output bitmap to transparent black.
     // NOTE: No-op, already done during creation.
@@ -854,10 +855,13 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::put_pixels_from_an_image_dat
     //       snapshot is shareable so that flushing to the Compositor passes the pixels
     //       by file descriptor instead of copying them again.
     auto source_rect = Gfx::IntRect { dirty_x, dirty_y, dirty_width, dirty_height };
-    auto const& source_bitmap = image_data.bitmap();
-    auto bitmap_snapshot = MUST(Gfx::Bitmap::create_shareable(source_bitmap.format(), source_bitmap.alpha_type(), source_rect.size()));
+    auto source_bitmap_or_error = image_data.bitmap();
+    if (source_bitmap_or_error.is_error())
+        return WebIDL::InvalidStateError::create(image_data.realm(), "ImageData's underlying buffer is detached or out-of-bounds"_utf16);
+    auto source_bitmap = source_bitmap_or_error.release_value();
+    auto bitmap_snapshot = MUST(Gfx::Bitmap::create_shareable(source_bitmap->format(), source_bitmap->alpha_type(), source_rect.size()));
     for (int y = 0; y < source_rect.height(); ++y)
-        __builtin_memcpy(bitmap_snapshot->scanline(y), source_bitmap.scanline(source_rect.y() + y) + source_rect.x(), static_cast<size_t>(source_rect.width()) * sizeof(Gfx::RawPixel));
+        __builtin_memcpy(bitmap_snapshot->scanline(y), source_bitmap->scanline(source_rect.y() + y) + source_rect.x(), static_cast<size_t>(source_rect.width()) * sizeof(Gfx::RawPixel));
     canvas_command_list.append(Gfx::CanvasCommands::Save {});
     canvas_command_list.append(Gfx::CanvasCommands::SetTransform { .transform = {} });
     canvas_command_list.append(Gfx::CanvasCommands::DrawBitmap {

--- a/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Libraries/LibWeb/HTML/ImageData.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
 #include <LibGfx/Bitmap.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/ImageData.h>
@@ -19,9 +20,28 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(ImageData);
 
-[[nodiscard]] static auto create_bitmap_backed_by_uint8_clamped_array(u32 const width, u32 const height, JS::Uint8ClampedArray& data)
+[[nodiscard]] static ErrorOr<void> validate_uint8_clamped_array_can_back_bitmap(u32 const width, u32 const height, JS::Uint8ClampedArray const& data)
 {
-    return Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::RGBA8888, Gfx::AlphaType::Unpremultiplied, Gfx::IntSize(width, height), width * sizeof(u32), data.data().data());
+    auto data_record = JS::make_typed_array_with_buffer_witness_record(data, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(data_record))
+        return Error::from_errno(EINVAL);
+
+    Checked<size_t> expected_byte_length = width;
+    expected_byte_length *= height;
+    expected_byte_length *= sizeof(u32);
+    if (expected_byte_length.has_overflow())
+        return Error::from_errno(EINVAL);
+
+    if (JS::typed_array_byte_length(data_record) < expected_byte_length.value())
+        return Error::from_errno(EINVAL);
+
+    return {};
+}
+
+[[nodiscard]] static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> create_bitmap_backed_by_uint8_clamped_array(u32 const width, u32 const height, JS::Uint8ClampedArray& data)
+{
+    TRY(validate_uint8_clamped_array_can_back_bitmap(width, height, data));
+    return Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::RGBA8888, Gfx::AlphaType::Unpremultiplied, Gfx::IntSize(width, height), width * sizeof(u32), data.viewed_array_buffer()->data_at(data.byte_offset()));
 }
 
 GC::Ref<ImageData> ImageData::create(JS::Realm& realm)
@@ -49,8 +69,12 @@ WebIDL::ExceptionOr<GC::Ref<ImageData>> ImageData::construct_impl(JS::Realm& rea
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-with-data
 WebIDL::ExceptionOr<GC::Ref<ImageData>> ImageData::create(JS::Realm& realm, GC::Ref<JS::Uint8ClampedArray> uint8_clamped_array_data, u32 sw, Optional<u32> sh, Optional<Bindings::ImageDataSettings> const& settings)
 {
+    auto data_record = JS::make_typed_array_with_buffer_witness_record(*uint8_clamped_array_data, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(data_record))
+        return WebIDL::InvalidStateError::create(realm, "Source data must not be out-of-bounds."_utf16);
+
     // 1. Let length be the number of bytes in data.
-    auto length = uint8_clamped_array_data->byte_length().length();
+    auto length = JS::typed_array_length(data_record);
 
     // 2. If length is not a nonzero integral multiple of four, then throw an "InvalidStateError" DOMException.
     if (length == 0 || length % 4 != 0)
@@ -105,8 +129,9 @@ WebIDL::ExceptionOr<GC::Ref<ImageData>> ImageData::initialize(JS::Realm& realm, 
         return TRY(JS::Uint8ClampedArray::create(realm, sizeof(u32) * rows * pixels_per_row));
     }());
 
-    // AD-HOC: Create the bitmap backed by the Uint8ClampedArray.
-    auto bitmap = TRY_OR_THROW_OOM(realm.vm(), create_bitmap_backed_by_uint8_clamped_array(pixels_per_row, rows, *data));
+    // AD-HOC: Validate that the bitmap can be backed by the Uint8ClampedArray.
+    if (validate_uint8_clamped_array_can_back_bitmap(pixels_per_row, rows, *data).is_error())
+        return WebIDL::InvalidStateError::create(realm, "Source data must not be detached or out-of-bounds."_utf16);
 
     // 4. Initialize the width attribute of imageData to pixelsPerRow.
     // 5. Initialize the height attribute of imageData to rows.
@@ -122,7 +147,7 @@ WebIDL::ExceptionOr<GC::Ref<ImageData>> ImageData::initialize(JS::Realm& realm, 
     else
         color_space = Bindings::PredefinedColorSpace::Srgb;
 
-    return realm.create<ImageData>(realm, move(bitmap), data, color_space);
+    return realm.create<ImageData>(realm, pixels_per_row, rows, data, color_space);
 }
 
 ImageData::ImageData(JS::Realm& realm)
@@ -130,9 +155,10 @@ ImageData::ImageData(JS::Realm& realm)
 {
 }
 
-ImageData::ImageData(JS::Realm& realm, NonnullRefPtr<Gfx::Bitmap> bitmap, GC::Ref<JS::Uint8ClampedArray> data, Bindings::PredefinedColorSpace color_space)
+ImageData::ImageData(JS::Realm& realm, u32 width, u32 height, GC::Ref<JS::Uint8ClampedArray> data, Bindings::PredefinedColorSpace color_space)
     : PlatformObject(realm)
-    , m_bitmap(move(bitmap))
+    , m_width(width)
+    , m_height(height)
     , m_color_space(color_space)
     , m_data(move(data))
 {
@@ -157,12 +183,18 @@ void ImageData::visit_edges(Cell::Visitor& visitor)
 
 WebIDL::UnsignedLong ImageData::width() const
 {
-    return m_bitmap->width();
+    return m_width;
 }
 
 WebIDL::UnsignedLong ImageData::height() const
 {
-    return m_bitmap->height();
+    return m_height;
+}
+
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> ImageData::bitmap()
+{
+    VERIFY(m_data);
+    return create_bitmap_backed_by_uint8_clamped_array(m_width, m_height, *m_data);
 }
 
 JS::Uint8ClampedArray* ImageData::data()
@@ -185,10 +217,10 @@ WebIDL::ExceptionOr<void> ImageData::serialization_steps(HTML::TransferDataEncod
     serialized.append(move(serialized_data));
 
     // 2. Set serialized.[[Width]] to the value of value's width attribute.
-    serialized.encode(m_bitmap->width());
+    serialized.encode(m_width);
 
     // 3. Set serialized.[[Height]] to the value of value's height attribute.
-    serialized.encode(m_bitmap->height());
+    serialized.encode(m_height);
 
     // 4. Set serialized.[[ColorSpace]] to the value of value's colorSpace attribute.
     serialized.encode(m_color_space);
@@ -209,18 +241,19 @@ WebIDL::ExceptionOr<void> ImageData::deserialization_steps(HTML::TransferDataDec
     m_data = as<JS::Uint8ClampedArray>(deserialized.as_object());
 
     // 2. Initialize value's width attribute to serialized.[[Width]].
-    auto width = serialized.decode<int>();
+    m_width = serialized.decode<u32>();
 
     // 3. Initialize value's height attribute to serialized.[[Height]].
-    auto height = serialized.decode<int>();
+    m_height = serialized.decode<u32>();
 
     // 4. Initialize value's colorSpace attribute to serialized.[[ColorSpace]].
     m_color_space = serialized.decode<Bindings::PredefinedColorSpace>();
 
     // FIXME: 5. Initialize value's pixelFormat attribute to serialized.[[PixelFormat]].
 
-    // AD-HOC: Create the bitmap backed by the Uint8ClampedArray.
-    m_bitmap = TRY_OR_THROW_OOM(vm, create_bitmap_backed_by_uint8_clamped_array(width, height, *m_data));
+    // AD-HOC: Validate that the bitmap can be backed by the Uint8ClampedArray.
+    if (validate_uint8_clamped_array_can_back_bitmap(m_width, m_height, *m_data).is_error())
+        return WebIDL::InvalidStateError::create(realm, "Image data must not be detached or out-of-bounds."_utf16);
 
     define_direct_property("data"_utf16_fly_string, m_data, JS::Attribute::Enumerable);
 

--- a/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Libraries/LibWeb/HTML/ImageData.cpp
@@ -194,6 +194,7 @@ WebIDL::UnsignedLong ImageData::height() const
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> ImageData::bitmap()
 {
     VERIFY(m_data);
+    // The wrapper aliases mutable ImageData storage. Use it synchronously only.
     return create_bitmap_backed_by_uint8_clamped_array(m_width, m_height, *m_data);
 }
 

--- a/Libraries/LibWeb/HTML/ImageData.h
+++ b/Libraries/LibWeb/HTML/ImageData.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <AK/Error.h>
+#include <AK/NonnullRefPtr.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/Bindings/ImageData.h>
 #include <LibWeb/Bindings/PlatformObject.h>
@@ -24,7 +26,7 @@ class ImageData final
 public:
     [[nodiscard]] static GC::Ref<ImageData> create(JS::Realm&);
     [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<ImageData>> create(JS::Realm&, u32 sw, u32 sh, Optional<Bindings::ImageDataSettings> const& settings = {});
-    [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<ImageData>> create(JS::Realm&, GC::Ref<JS::Uint8ClampedArray> data, u32 sw, Optional<u32> sh = {}, Optional<Bindings::ImageDataSettings> const& settings = {});
+    [[nodiscard]] static WEB_API WebIDL::ExceptionOr<GC::Ref<ImageData>> create(JS::Realm&, GC::Ref<JS::Uint8ClampedArray> data, u32 sw, Optional<u32> sh = {}, Optional<Bindings::ImageDataSettings> const& settings = {});
 
     [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<ImageData>> construct_impl(JS::Realm&, u32 sw, u32 sh, Optional<Bindings::ImageDataSettings> const& settings = {});
     [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<ImageData>> construct_impl(JS::Realm&, GC::Ref<JS::Uint8ClampedArray> data, u32 sw, Optional<u32> sh = {}, Optional<Bindings::ImageDataSettings> const& settings = {});
@@ -34,8 +36,7 @@ public:
     WebIDL::UnsignedLong width() const;
     WebIDL::UnsignedLong height() const;
 
-    Gfx::Bitmap& bitmap() { return *m_bitmap; }
-    Gfx::Bitmap const& bitmap() const { return *m_bitmap; }
+    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap();
 
     JS::Uint8ClampedArray* data();
     JS::Uint8ClampedArray const* data() const;
@@ -49,12 +50,13 @@ private:
     [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<ImageData>> initialize(JS::Realm&, u32 rows, u32 pixels_per_row, Optional<Bindings::ImageDataSettings> const&, GC::Ptr<JS::Uint8ClampedArray> = {}, Optional<Bindings::PredefinedColorSpace> = {});
 
     explicit ImageData(JS::Realm&);
-    ImageData(JS::Realm&, NonnullRefPtr<Gfx::Bitmap>, GC::Ref<JS::Uint8ClampedArray>, Bindings::PredefinedColorSpace);
+    ImageData(JS::Realm&, u32 width, u32 height, GC::Ref<JS::Uint8ClampedArray>, Bindings::PredefinedColorSpace);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    u32 m_width { 0 };
+    u32 m_height { 0 };
     Bindings::PredefinedColorSpace m_color_space { Bindings::PredefinedColorSpace::Srgb };
     GC::Ptr<JS::Uint8ClampedArray> m_data;
 };

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -144,14 +144,14 @@ static WebIDL::ExceptionOr<void> serialize_array_buffer(JS::VM& vm, TransferData
             //           [[ArrayBufferMaxByteLength]]: value.[[ArrayBufferMaxByteLength]],
             //           FIXME: [[AgentCluster]]: the surrounding agent's agent cluster }.
             data_holder.encode(ValueTag::GrowableSharedArrayBuffer);
-            data_holder.encode(MUST(ByteBuffer::copy(array_buffer.bytes())));
+            data_holder.encode(MUST(array_buffer.copy_to_byte_buffer()));
             data_holder.encode(array_buffer.max_byte_length());
         } else {
             // 4. Otherwise, set serialized to { [[Type]]: "SharedArrayBuffer", [[ArrayBufferData]]: value.[[ArrayBufferData]],
             //           [[ArrayBufferByteLength]]: value.[[ArrayBufferByteLength]],
             //           FIXME: [[AgentCluster]]: the surrounding agent's agent cluster }.
             data_holder.encode(ValueTag::SharedArrayBuffer);
-            data_holder.encode(MUST(ByteBuffer::copy(array_buffer.bytes())));
+            data_holder.encode(MUST(array_buffer.copy_to_byte_buffer()));
         }
     }
     // 2. Otherwise:
@@ -168,21 +168,19 @@ static WebIDL::ExceptionOr<void> serialize_array_buffer(JS::VM& vm, TransferData
         auto data_copy = TRY(JS::create_byte_data_block(vm, size));
 
         // 4. Perform CopyDataBlockBytes(dataCopy, 0, value.[[ArrayBufferData]], 0, size).
-        auto data_copy_bytes = data_copy.bytes();
-        auto array_buffer_bytes = array_buffer.bytes();
-        JS::copy_data_block_bytes(data_copy_bytes, 0, array_buffer_bytes, 0, size);
+        array_buffer.copy_data_to(data_copy, 0, 0, size);
 
         // 5. If value has an [[ArrayBufferMaxByteLength]] internal slot, then set serialized to { [[Type]]: "ResizableArrayBuffer",
         //    [[ArrayBufferData]]: dataCopy, [[ArrayBufferByteLength]]: size, [[ArrayBufferMaxByteLength]]: value.[[ArrayBufferMaxByteLength]] }.
         if (!array_buffer.is_fixed_length()) {
             data_holder.encode(ValueTag::ResizeableArrayBuffer);
-            data_holder.encode(MUST(ByteBuffer::copy(data_copy.bytes())));
+            data_holder.encode(MUST(data_copy.copy_to_byte_buffer()));
             data_holder.encode(array_buffer.max_byte_length());
         }
         // 6. Otherwise, set serialized to { [[Type]]: "ArrayBuffer", [[ArrayBufferData]]: dataCopy, [[ArrayBufferByteLength]]: size }.
         else {
             data_holder.encode(ValueTag::ArrayBuffer);
-            data_holder.encode(MUST(ByteBuffer::copy(data_copy.bytes())));
+            data_holder.encode(MUST(data_copy.copy_to_byte_buffer()));
         }
     }
     return {};
@@ -1049,7 +1047,7 @@ WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer
         // 4. If transferable has an [[ArrayBufferData]] internal slot, then:
         if (array_buffer) {
             // 1. If transferable has an [[ArrayBufferMaxByteLength]] internal slot, then:
-            auto buffer_data = MUST(ByteBuffer::copy(array_buffer->bytes()));
+            auto buffer_data = MUST(array_buffer->copy_to_byte_buffer());
 
             if (!array_buffer->is_fixed_length()) {
                 // 1. Set dataHolder.[[Type]] to "ResizableArrayBuffer".

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -377,8 +377,14 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
                 return;
             }
 
+            auto bitmap_or_error = image_data->bitmap();
+            if (bitmap_or_error.is_error()) {
+                WebIDL::reject_promise(realm, *p, WebIDL::InvalidStateError::create(image_bitmap->realm(), "Image data is detached or out-of-bounds"_utf16));
+                return;
+            }
+
             // 3. Set imageBitmap's bitmap data to image's image data, cropped to the source rectangle with formatting.
-            auto cropped_bitmap_or_error = crop_to_the_source_rectangle_with_formatting(image_data->bitmap(), sx, sy, sw, sh, options);
+            auto cropped_bitmap_or_error = crop_to_the_source_rectangle_with_formatting(bitmap_or_error.release_value(), sx, sy, sw, sh, options);
             // AD-HOC: Reject promise with an "InvalidStateError" DOMException on allocation failure
             // Spec issue: https://github.com/whatwg/html/issues/3323
             if (cropped_bitmap_or_error.is_error()) {

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibMedia/PlaybackManager.h>
 #include <LibWeb/Bindings/Intrinsics.h>
@@ -334,7 +335,8 @@ WebIDL::ExceptionOr<void> SourceBuffer::append_buffer(WebIDL::BufferSource data)
 
     // 2. Add data to the end of the [[input buffer]].
     if (auto array_buffer = data.viewed_array_buffer(); array_buffer && !array_buffer->is_detached() && !data.is_out_of_bounds()) {
-        auto bytes = array_buffer->bytes().slice(data.byte_offset(), data.byte_length());
+        auto bytes = MUST(ByteBuffer::create_uninitialized(data.byte_length()));
+        array_buffer->copy_to(data.byte_offset(), bytes);
         m_processor->append_to_input_buffer(bytes);
     }
 

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
@@ -333,7 +333,7 @@ WebIDL::ExceptionOr<void> SourceBuffer::append_buffer(WebIDL::BufferSource data)
     TRY(prepare_append(data.byte_length(), m_media_source->media_element_assigned_to()->playback_manager().current_time()));
 
     // 2. Add data to the end of the [[input buffer]].
-    if (auto array_buffer = data.viewed_array_buffer(); array_buffer && !array_buffer->is_detached()) {
+    if (auto array_buffer = data.viewed_array_buffer(); array_buffer && !array_buffer->is_detached() && !data.is_out_of_bounds()) {
         auto bytes = array_buffer->bytes().slice(data.byte_offset(), data.byte_length());
         m_processor->append_to_input_buffer(bytes);
     }

--- a/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -27,6 +27,7 @@
 #include <LibWeb/Streams/WritableStream.h>
 #include <LibWeb/Streams/WritableStreamOperations.h>
 #include <LibWeb/WebIDL/Buffers.h>
+#include <LibWeb/WebIDL/DOMException.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Streams {
@@ -309,7 +310,8 @@ WebIDL::ExceptionOr<void> ReadableStream::pull_from_bytes(ByteBuffer bytes)
     // 8. If stream’s current BYOB request view is non-null, then:
     if (auto byob_view = current_byob_request_view(); byob_view.has_value()) {
         // 1. Write pulled into stream’s current BYOB request view.
-        byob_view->write(pulled);
+        if (byob_view->write_checked(pulled).is_error())
+            return WebIDL::InvalidStateError::create(realm, "BYOB request view is detached or out-of-bounds"_utf16);
 
         // 2. Perform ? ReadableByteStreamControllerRespond(stream.[[controller]], pullSize).
         TRY(readable_byte_stream_controller_respond(controller, pull_size));

--- a/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -89,7 +89,11 @@ void ReadLoopReadRequest::on_chunk(JS::Value chunk)
     auto const& array = static_cast<JS::Uint8Array const&>(chunk.as_object());
 
     // 2. Append the bytes represented by chunk to bytes.
-    m_bytes.append(array.data());
+    auto record = JS::make_typed_array_with_buffer_witness_record(array, JS::ArrayBuffer::Order::SeqCst);
+    if (!JS::is_typed_array_out_of_bounds(record)) {
+        auto bytes = MUST(array.viewed_array_buffer()->copy_to_byte_buffer(array.byte_offset(), JS::typed_array_byte_length(record)));
+        m_bytes.append(bytes);
+    }
 
     // FIXME: As the spec suggests, implement this non-recursively - instead of directly. It is not too big of a deal currently
     //        as we enqueue the entire blob buffer in one go, meaning that we only recurse a single time. Once we begin queuing

--- a/Libraries/LibWeb/Streams/ReadableStreamOperations.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamOperations.cpp
@@ -2105,10 +2105,7 @@ bool readable_byte_stream_controller_fill_pull_into_descriptor_from_queue(Readab
         VERIFY(can_copy_data_block_bytes_buffer(descriptor_buffer, dest_start, queue_buffer, queue_byte_offset, bytes_to_copy));
 
         // 8. Perform ! CopyDataBlockBytes(pullIntoDescriptor’s buffer.[[ArrayBufferData]], destStart, headOfQueue’s buffer.[[ArrayBufferData]], headOfQueue’s byte offset, bytesToCopy).
-        // NOTE: Stream buffers are never externally backed, so copy_data_block_bytes is safe here.
-        auto descriptor_buffer_bytes = pull_into_descriptor.buffer->bytes();
-        auto queue_buffer_bytes = head_of_queue.buffer->bytes();
-        JS::copy_data_block_bytes(descriptor_buffer_bytes, dest_start, queue_buffer_bytes, head_of_queue.byte_offset, bytes_to_copy);
+        head_of_queue.buffer->copy_data_to(*descriptor_buffer, head_of_queue.byte_offset, dest_start, bytes_to_copy);
 
         // 9. If headOfQueue’s byte length is bytesToCopy,
         if (head_of_queue.byte_length == bytes_to_copy) {

--- a/Libraries/LibWeb/WebAssembly/Memory.cpp
+++ b/Libraries/LibWeb/WebAssembly/Memory.cpp
@@ -18,16 +18,6 @@ namespace Web::WebAssembly {
 
 GC_DEFINE_ALLOCATOR(Memory);
 
-static u8* wasm_memory_buffer_data(void* context)
-{
-    return static_cast<Wasm::MemoryBuffer*>(context)->data();
-}
-
-static size_t wasm_memory_buffer_size(void* context)
-{
-    return static_cast<Wasm::MemoryBuffer*>(context)->size();
-}
-
 WebIDL::ExceptionOr<GC::Ref<Memory>> Memory::construct_impl(JS::Realm& realm, Bindings::MemoryDescriptor& descriptor)
 {
     auto& vm = realm.vm();
@@ -233,7 +223,10 @@ void Memory::refresh_the_memory_buffer(JS::VM& vm, JS::Realm& realm, Wasm::Memor
         buffer = create_a_fixed_length_memory_buffer(vm, realm, address, memory.value()->m_shared, *memory.value());
     } else {
         // 1. Let block be a Data Block which is identified with the underlying memory of memaddr.
-        auto& bytes = cache.abstract_machine().store().get(address)->data();
+        auto* wasm_memory = cache.abstract_machine().store().get(address);
+        VERIFY(wasm_memory);
+        auto handle = wasm_memory->data().primitive_storage_handle();
+        VERIFY(handle.is_valid());
 
         // AD-HOC: Neither the main spec nor the threads proposal specify that the Data Block should be Shared for
         //         shared Wasm memories, but we do in fact want a Shared Data Block in that case.
@@ -241,7 +234,7 @@ void Memory::refresh_the_memory_buffer(JS::VM& vm, JS::Realm& realm, Wasm::Memor
 
         // 2. Set buffer.[[ArrayBufferData]] to block.
         // 3. Set buffer.[[ArrayBufferByteLength]] to the length of block.
-        buffer->set_data_block({ JS::DataBlock::UnownedExternalBuffer(*memory.value(), &bytes, wasm_memory_buffer_data, wasm_memory_buffer_size), is_shared });
+        buffer->set_data_block({ JS::DataBlock::ExternalPrimitiveStorage(*memory.value(), handle), is_shared });
     }
 }
 
@@ -282,7 +275,11 @@ GC::Ref<JS::ArrayBuffer> Memory::create_a_fixed_length_memory_buffer(JS::VM& vm,
     auto* memory = context.abstract_machine().store().get(address);
     VERIFY(memory);
 
-    JS::ArrayBuffer* array_buffer;
+    auto data_block = JS::DataBlock {
+        JS::DataBlock::ExternalPrimitiveStorage(owner, memory->data().primitive_storage_handle(), memory->size()),
+        shared == Shared::Yes ? JS::DataBlock::Shared::Yes : JS::DataBlock::Shared::No,
+    };
+    auto array_buffer = JS::ArrayBuffer::create(realm, move(data_block));
     // https://webassembly.github.io/threads/js-api/index.html#create-a-fixed-length-memory-buffer
     // 3. If share is shared,
     if (shared == Shared::Yes) {
@@ -291,7 +288,6 @@ GC::Ref<JS::ArrayBuffer> Memory::create_a_fixed_length_memory_buffer(JS::VM& vm,
         // 3. Set buffer.[[ArrayBufferData]] to block.
         // 4. Set buffer.[[ArrayBufferByteLength]] to the length of block.
         // NOTE: ArrayBufferByteLength should contain the original size regardless of growth.
-        array_buffer = JS::ArrayBuffer::create(realm, JS::DataBlock::UnownedExternalBuffer(owner, &memory->data(), wasm_memory_buffer_data, memory->size()), JS::DataBlock::Shared::Yes);
         VERIFY(array_buffer->byte_length() == memory->size());
 
         // 5. Perform ! SetIntegrityLevel(buffer, "frozen").
@@ -300,11 +296,10 @@ GC::Ref<JS::ArrayBuffer> Memory::create_a_fixed_length_memory_buffer(JS::VM& vm,
 
     // 4. Otherwise,
     else {
-        array_buffer = JS::ArrayBuffer::create(realm, JS::DataBlock::UnownedExternalBuffer(owner, &memory->data(), wasm_memory_buffer_data, wasm_memory_buffer_size));
         array_buffer->set_detach_key(JS::PrimitiveString::create(vm, "WebAssembly.Memory"_utf16_fly_string));
     }
 
-    return GC::Ref(*array_buffer);
+    return array_buffer;
 }
 
 // https://webassembly.github.io/spec/js-api/#create-a-resizable-memory-buffer
@@ -327,7 +322,11 @@ JS::ThrowCompletionOr<GC::Ref<JS::ArrayBuffer>> Memory::create_a_resizable_memor
         // 1. Let block be a Shared Data Block which is identified with the underlying memory of memaddr.
         // 2. Let buffer be a new SharedArrayBuffer with the internal slots [[ArrayBufferData]], [[ArrayBufferByteLength]], and [[ArrayBufferMaxByteLength]].
         // 3. Set buffer.[[ArrayBufferData]] to block.
-        auto buffer = JS::ArrayBuffer::create(realm, JS::DataBlock::UnownedExternalBuffer(owner, &memory->data(), wasm_memory_buffer_data, wasm_memory_buffer_size), JS::DataBlock::Shared::Yes);
+        auto data_block = JS::DataBlock {
+            JS::DataBlock::ExternalPrimitiveStorage(owner, memory->data().primitive_storage_handle()),
+            JS::DataBlock::Shared::Yes,
+        };
+        auto buffer = JS::ArrayBuffer::create(realm, move(data_block));
 
         // AD-HOC: The threads proposal uses the memory type's minimum for both shared and
         //         non-shared memories, but the upstream spec uses the memory instance's current
@@ -354,7 +353,11 @@ JS::ThrowCompletionOr<GC::Ref<JS::ArrayBuffer>> Memory::create_a_resizable_memor
         // 1. Let block be a Data Block which is identified with the underlying memory of memaddr.
         // 4. Let buffer be a new ArrayBuffer with the internal slots [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferMaxByteLength]], and [[ArrayBufferDetachKey]].
         // 5. Set buffer.[[ArrayBufferData]] to block.
-        auto buffer = JS::ArrayBuffer::create(realm, JS::DataBlock::UnownedExternalBuffer(owner, &memory->data(), wasm_memory_buffer_data, wasm_memory_buffer_size));
+        auto data_block = JS::DataBlock {
+            JS::DataBlock::ExternalPrimitiveStorage(owner, memory->data().primitive_storage_handle()),
+            JS::DataBlock::Shared::No,
+        };
+        auto buffer = JS::ArrayBuffer::create(realm, move(data_block));
 
         // 2. Let length be the length of block.
         // 6. Set buffer.[[ArrayBufferByteLength]] to length.

--- a/Libraries/LibWeb/WebAudio/AnalyserNode.cpp
+++ b/Libraries/LibWeb/WebAudio/AnalyserNode.cpp
@@ -146,11 +146,11 @@ WebIDL::ExceptionOr<void> AnalyserNode::get_float_frequency_data(GC::Ref<JS::Flo
     // quantum as a previous call, the current frequency data is not updated with the same data. Instead, the
     // previously computed data is returned.
 
-    auto output_data = array->data();
-    size_t floats_to_write = min(output_data.size(), static_cast<size_t>(frequency_bin_count()));
-    for (size_t i = 0; i < floats_to_write; i++) {
-        output_data[i] = frequency_data[i];
-    }
+    auto record = JS::make_typed_array_with_buffer_witness_record(*array, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(record))
+        return {};
+    auto floats_to_write = min(static_cast<size_t>(JS::typed_array_length(record)), static_cast<size_t>(frequency_bin_count()));
+    array->viewed_array_buffer()->overwrite(array->byte_offset(), frequency_data.data(), floats_to_write * sizeof(float));
 
     return {};
 }
@@ -188,11 +188,11 @@ WebIDL::ExceptionOr<void> AnalyserNode::get_byte_frequency_data(GC::Ref<JS::Uint
     // Write the current frequency data into array. If array’s byte length is less than frequencyBinCount,
     // the excess elements will be dropped. If array’s byte length is greater than the frequencyBinCount ,
     // the excess elements will be ignored. The most recent fftSize frames are used in computing the frequency data.
-    auto output_data = array->data();
-    size_t bytes_to_write = min(output_data.size(), static_cast<size_t>(frequency_bin_count()));
-
-    for (size_t i = 0; i < bytes_to_write; i++)
-        output_data[i] = byte_data[i];
+    auto record = JS::make_typed_array_with_buffer_witness_record(*array, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(record))
+        return {};
+    auto bytes_to_write = min(static_cast<size_t>(JS::typed_array_length(record)), static_cast<size_t>(frequency_bin_count()));
+    array->viewed_array_buffer()->overwrite(array->byte_offset(), byte_data.data(), bytes_to_write);
 
     return {};
 }
@@ -206,11 +206,11 @@ WebIDL::ExceptionOr<void> AnalyserNode::get_float_time_domain_data(GC::Ref<JS::F
 
     Vector<f32> time_domain_data = current_time_domain_data();
 
-    auto output_data = array->data();
-    size_t floats_to_write = min(output_data.size(), static_cast<size_t>(fft_size()));
-    for (size_t i = 0; i < floats_to_write; i++) {
-        output_data[i] = time_domain_data[i];
-    }
+    auto record = JS::make_typed_array_with_buffer_witness_record(*array, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(record))
+        return {};
+    auto floats_to_write = min(static_cast<size_t>(JS::typed_array_length(record)), static_cast<size_t>(fft_size()));
+    array->viewed_array_buffer()->overwrite(array->byte_offset(), time_domain_data.data(), floats_to_write * sizeof(float));
 
     return {};
 }
@@ -236,11 +236,11 @@ WebIDL::ExceptionOr<void> AnalyserNode::get_byte_time_domain_data(GC::Ref<JS::Ui
         byte_data.unchecked_append(static_cast<u8>(x));
     }
 
-    auto output_data = array->data();
-    size_t bytes_to_write = min(output_data.size(), static_cast<size_t>(fft_size()));
-
-    for (size_t i = 0; i < bytes_to_write; i++)
-        output_data[i] = byte_data[i];
+    auto record = JS::make_typed_array_with_buffer_witness_record(*array, JS::ArrayBuffer::Order::SeqCst);
+    if (JS::is_typed_array_out_of_bounds(record))
+        return {};
+    auto bytes_to_write = min(static_cast<size_t>(JS::typed_array_length(record)), static_cast<size_t>(fft_size()));
+    array->viewed_array_buffer()->overwrite(array->byte_offset(), byte_data.data(), bytes_to_write);
 
     return {};
 }

--- a/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
@@ -101,13 +101,26 @@ WebIDL::ExceptionOr<void> AudioBuffer::copy_from_channel(GC::Ref<JS::Float32Arra
 
     auto const channel = TRY(get_channel_data(channel_number));
 
-    auto channel_length = channel->data().size();
+    auto channel_record = JS::make_typed_array_with_buffer_witness_record(*channel, JS::ArrayBuffer::Order::SeqCst);
+    auto channel_length = JS::is_typed_array_out_of_bounds(channel_record) ? 0 : JS::typed_array_length(channel_record);
     if (buffer_offset >= channel_length)
         return {};
 
-    auto destination_data = destination->data();
-    auto count = min(destination_data.size(), channel_length - buffer_offset);
-    channel->data().slice(buffer_offset, count).copy_to(destination_data.slice(0, count));
+    auto destination_record = JS::make_typed_array_with_buffer_witness_record(*destination, JS::ArrayBuffer::Order::SeqCst);
+    auto destination_length = JS::is_typed_array_out_of_bounds(destination_record) ? 0 : JS::typed_array_length(destination_record);
+    auto count = min(destination_length, channel_length - buffer_offset);
+    if (count == 0)
+        return {};
+
+    auto byte_count = count * sizeof(float);
+    auto source_byte_offset = channel->byte_offset() + buffer_offset * sizeof(float);
+    auto destination_byte_offset = destination->byte_offset();
+    auto& source_buffer = *channel->viewed_array_buffer();
+    auto& destination_buffer = *destination->viewed_array_buffer();
+    if (source_buffer.shares_storage_with(destination_buffer))
+        destination_buffer.move_data(destination_byte_offset, source_byte_offset, byte_count);
+    else
+        source_buffer.copy_data_to(destination_buffer, source_byte_offset, destination_byte_offset, byte_count);
 
     return {};
 }
@@ -129,13 +142,26 @@ WebIDL::ExceptionOr<void> AudioBuffer::copy_to_channel(GC::Ref<JS::Float32Array>
 
     auto channel = TRY(get_channel_data(channel_number));
 
-    auto channel_length = channel->data().size();
+    auto channel_record = JS::make_typed_array_with_buffer_witness_record(*channel, JS::ArrayBuffer::Order::SeqCst);
+    auto channel_length = JS::is_typed_array_out_of_bounds(channel_record) ? 0 : JS::typed_array_length(channel_record);
     if (buffer_offset >= channel_length)
         return {};
 
-    auto source_data = source->data();
-    auto count = min(source_data.size(), channel_length - buffer_offset);
-    source_data.slice(0, count).copy_to(channel->data().slice(buffer_offset, count));
+    auto source_record = JS::make_typed_array_with_buffer_witness_record(*source, JS::ArrayBuffer::Order::SeqCst);
+    auto source_length = JS::is_typed_array_out_of_bounds(source_record) ? 0 : JS::typed_array_length(source_record);
+    auto count = min(source_length, channel_length - buffer_offset);
+    if (count == 0)
+        return {};
+
+    auto byte_count = count * sizeof(float);
+    auto source_byte_offset = source->byte_offset();
+    auto destination_byte_offset = channel->byte_offset() + buffer_offset * sizeof(float);
+    auto& source_buffer = *source->viewed_array_buffer();
+    auto& destination_buffer = *channel->viewed_array_buffer();
+    if (source_buffer.shares_storage_with(destination_buffer))
+        destination_buffer.move_data(destination_byte_offset, source_byte_offset, byte_count);
+    else
+        source_buffer.copy_data_to(destination_buffer, source_byte_offset, destination_byte_offset, byte_count);
 
     return {};
 }

--- a/Libraries/LibWeb/WebGL/RemoteWebGLTransport.h
+++ b/Libraries/LibWeb/WebGL/RemoteWebGLTransport.h
@@ -38,7 +38,7 @@ public:
     virtual void present_canvas(bool preserve_drawing_buffer) = 0;
     virtual ByteBuffer sync_call(ByteBuffer request) = 0;
     virtual ReadPixelsResult read_pixels_robust_angle(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLsizei buf_size, Core::AnonymousBuffer pixels) = 0;
-    virtual void read_buffer_sub_data(GLenum target, GLintptr offset, GLintptr size, Core::AnonymousBuffer data) = 0;
+    virtual bool read_buffer_sub_data(GLenum target, GLintptr offset, GLintptr size, Core::AnonymousBuffer data) = 0;
 
     virtual Gfx::ShareableBitmap read_back_drawing_buffer(Gfx::IntRect const&) = 0;
 };

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
+#include <AK/Checked.h>
 #include <GLES3/gl3.h>
 extern "C" {
 #include <GLES2/gl2ext.h>
@@ -59,7 +61,12 @@ void WebGL2RenderingContextImpl::get_buffer_sub_data(WebIDL::UnsignedLong target
     if (length == 0) {
         // If dstBuffer is a DataView, let copyLength be dstBuffer.byteLength - dstOffset; the typed elements in the
         // text below are bytes. Otherwise, let copyLength be dstBuffer.length - dstOffset.
-        copy_length = dst_buffer.byte_length() / element_size - dst_offset;
+        auto destination_element_count = dst_buffer.byte_length() / element_size;
+        if (dst_offset > destination_element_count) {
+            set_error(GL_INVALID_VALUE);
+            return;
+        }
+        copy_length = destination_element_count - dst_offset;
     }
 
     // Otherwise, let copyLength be length.
@@ -73,26 +80,44 @@ void WebGL2RenderingContextImpl::get_buffer_sub_data(WebIDL::UnsignedLong target
 
     // If dstOffset is greater than dstBuffer.length (or dstBuffer.byteLength in the case of DataView), generates an
     // INVALID_VALUE error.
-    size_t dst_offset_in_bytes = dst_offset * element_size;
-    if (dst_offset_in_bytes > dst_buffer.byte_length()) {
+    Checked<size_t> dst_offset_in_bytes_checked = dst_offset;
+    dst_offset_in_bytes_checked *= element_size;
+    if (dst_offset_in_bytes_checked.has_overflow() || dst_offset_in_bytes_checked.value() > dst_buffer.byte_length()) {
         set_error(GL_INVALID_VALUE);
         return;
     }
+    auto dst_offset_in_bytes = dst_offset_in_bytes_checked.value();
 
     // If dstOffset + copyLength is greater than dstBuffer.length (or dstBuffer.byteLength in the case of DataView),
     // generates an INVALID_VALUE error.
-    size_t copy_bytes = copy_length * element_size;
-    if (dst_offset_in_bytes + copy_bytes > dst_buffer.byte_length()) {
+    Checked<size_t> copy_bytes_checked = copy_length;
+    copy_bytes_checked *= element_size;
+    if (copy_bytes_checked.has_overflow()) {
         set_error(GL_INVALID_VALUE);
         return;
     }
+    Checked<size_t> end_offset_checked = dst_offset_in_bytes;
+    end_offset_checked += copy_bytes_checked.value();
+    if (end_offset_checked.has_overflow() || end_offset_checked.value() > dst_buffer.byte_length()) {
+        set_error(GL_INVALID_VALUE);
+        return;
+    }
+    auto copy_bytes = copy_bytes_checked.value();
 
     // If copyLength is greater than zero, copy copyLength typed elements (each of size elementSize) from buf into
     // dstBuffer, reading buf starting at byte index srcByteOffset and writing into dstBuffer starting at element
-    // index dstOffset. The destination span is bounds-checked above, so the readback can
-    // land directly in the JS-owned buffer without staging.
-    auto dst_span = dst_buffer.viewed_array_buffer()->span().slice(dst_buffer.byte_offset() + dst_offset_in_bytes, copy_bytes);
-    m_context->read_buffer_sub_data(target, src_byte_offset, dst_span);
+    // index dstOffset.
+    auto temporary_buffer = ByteBuffer::create_uninitialized(copy_bytes);
+    if (temporary_buffer.is_error()) {
+        set_error(GL_OUT_OF_MEMORY);
+        return;
+    }
+
+    auto bytes = temporary_buffer.release_value();
+    if (!m_context->read_buffer_sub_data(target, src_byte_offset, bytes))
+        return;
+    if (dst_buffer.write_checked(bytes, dst_offset_in_bytes).is_error()) [[unlikely]]
+        set_error(GL_INVALID_VALUE);
 }
 
 void WebGL2RenderingContextImpl::blit_framebuffer(WebIDL::Long src_x0, WebIDL::Long src_y0, WebIDL::Long src_x1, WebIDL::Long src_y1, WebIDL::Long dst_x0, WebIDL::Long dst_y0, WebIDL::Long dst_x1, WebIDL::Long dst_y1, WebIDL::UnsignedLong mask, WebIDL::UnsignedLong filter)
@@ -187,9 +212,11 @@ void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL
 {
     m_context->make_current();
 
+    ByteBuffer src_data_storage;
     ReadonlyBytes src_data_span;
     if (!src_data.has<Empty>()) {
-        src_data_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0), GL_INVALID_OPERATION);
+        src_data_storage = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
+        src_data_span = src_data_storage;
     }
 
     m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, src_data_span.size(), src_data_span.data());
@@ -199,7 +226,7 @@ void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL
 {
     m_context->make_current();
 
-    auto src_data_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset), GL_INVALID_OPERATION);
+    auto src_data_span = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset), GL_INVALID_OPERATION);
 
     m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, src_data_span.size(), src_data_span.data());
 }
@@ -208,9 +235,11 @@ void WebGL2RenderingContextImpl::tex_sub_image3d(WebIDL::UnsignedLong target, We
 {
     m_context->make_current();
 
+    ByteBuffer src_data_storage;
     ReadonlyBytes src_data_span;
     if (!src_data.has<Empty>()) {
-        src_data_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data.downcast<WebIDL::ArrayBufferViewVariant>(), src_offset), GL_INVALID_OPERATION);
+        src_data_storage = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data.downcast<WebIDL::ArrayBufferViewVariant>() }, src_offset), GL_INVALID_OPERATION);
+        src_data_span = src_data_storage;
     }
 
     m_context->tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, src_data_span.size(), src_data_span.data());
@@ -1297,7 +1326,7 @@ void WebGL2RenderingContextImpl::compressed_tex_image3d(WebIDL::UnsignedLong tar
         return;
     }
 
-    auto pixels = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, src_length_override), GL_INVALID_VALUE);
+    auto pixels = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, src_length_override), GL_INVALID_VALUE);
     m_context->compressed_tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, pixels.size(), pixels.size(), pixels.data());
 }
 
@@ -1310,7 +1339,7 @@ void WebGL2RenderingContextImpl::compressed_tex_sub_image3d(WebIDL::UnsignedLong
         return;
     }
 
-    auto pixels = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, src_length_override), GL_INVALID_VALUE);
+    auto pixels = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, src_length_override), GL_INVALID_VALUE);
     m_context->compressed_tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, pixels.size(), pixels.size(), pixels.data());
 }
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
@@ -389,6 +389,12 @@ void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y
     }
 
     WebIDL::ArrayBufferView view { pixels.downcast<WebIDL::ArrayBufferViewVariant>() };
+    auto viewed_array_buffer = view.viewed_array_buffer();
+    if (!viewed_array_buffer || viewed_array_buffer->is_detached() || view.is_out_of_bounds()) {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+
     auto bytes_or_error = ByteBuffer::create_uninitialized(view.byte_length());
     if (bytes_or_error.is_error()) {
         set_error(GL_OUT_OF_MEMORY);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
@@ -46,7 +46,7 @@ void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, W
         return;
     }
 
-    auto data = MUST(get_offset_span<u8 const>(src_data.downcast<WebIDL::BufferSourceVariant>(), /* src_offset= */ 0));
+    auto data = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data.downcast<WebIDL::BufferSourceVariant>() }, /* src_offset= */ 0), GL_INVALID_VALUE);
     m_context->buffer_data(target, static_cast<GLsizeiptr>(data.size()), data.data(), usage);
 }
 
@@ -54,7 +54,7 @@ void WebGL2RenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong targe
 {
     m_context->make_current();
 
-    auto data = MUST(get_offset_span<u8 const>(src_data, /* src_offset= */ 0));
+    auto data = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(src_data, /* src_offset= */ 0), GL_INVALID_VALUE);
     m_context->buffer_sub_data(target, dst_byte_offset, data.size(), data.data());
 }
 
@@ -62,25 +62,27 @@ void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, W
 {
     m_context->make_current();
 
-    auto span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, length), GL_INVALID_VALUE);
-    m_context->buffer_data(target, span.size(), span.data(), usage);
+    auto data = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, length), GL_INVALID_VALUE);
+    m_context->buffer_data(target, data.size(), data.data(), usage);
 }
 
 void WebGL2RenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length)
 {
     m_context->make_current();
 
-    auto span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, length), GL_INVALID_VALUE);
-    m_context->buffer_sub_data(target, dst_byte_offset, span.size(), span.data());
+    auto data = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, length), GL_INVALID_VALUE);
+    m_context->buffer_sub_data(target, dst_byte_offset, data.size(), data.data());
 }
 
 void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
 {
     m_context->make_current();
 
+    ByteBuffer pixels_storage;
     ReadonlyBytes pixels_span;
     if (!pixels.has<Empty>()) {
-        pixels_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0), GL_INVALID_OPERATION);
+        pixels_storage = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
+        pixels_span = pixels_storage;
     }
 
     m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, pixels_span.size(), pixels_span.data());
@@ -101,9 +103,11 @@ void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong targe
 {
     m_context->make_current();
 
+    ByteBuffer pixels_storage;
     ReadonlyBytes pixels_span;
     if (!pixels.has<Empty>()) {
-        pixels_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0), GL_INVALID_OPERATION);
+        pixels_storage = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
+        pixels_span = pixels_storage;
     }
 
     m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, pixels_span.size(), pixels_span.data());
@@ -142,7 +146,7 @@ void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, W
 {
     m_context->make_current();
 
-    auto pixels_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset), GL_INVALID_OPERATION);
+    auto pixels_span = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset), GL_INVALID_OPERATION);
 
     m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, pixels_span.size(), pixels_span.data());
 }
@@ -162,7 +166,7 @@ void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong targe
 {
     m_context->make_current();
 
-    auto pixels_span = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset), GL_INVALID_OPERATION);
+    auto pixels_span = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset), GL_INVALID_OPERATION);
 
     m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, pixels_span.size(), pixels_span.data());
 }
@@ -176,7 +180,7 @@ void WebGL2RenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLon
         return;
     }
 
-    auto pixels = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, src_length_override), GL_INVALID_VALUE);
+    auto pixels = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, src_length_override), GL_INVALID_VALUE);
     m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, pixels.size(), pixels.size(), pixels.data());
 }
 
@@ -189,7 +193,7 @@ void WebGL2RenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::Unsigne
         return;
     }
 
-    auto pixels = SET_ERROR_VALUE_IF_ERROR(get_offset_span<u8 const>(src_data, src_offset, src_length_override), GL_INVALID_VALUE);
+    auto pixels = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, src_length_override), GL_INVALID_VALUE);
     m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, pixels.size(), pixels.size(), pixels.data());
 }
 
@@ -384,8 +388,20 @@ void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y
         return;
     }
 
-    auto span = MUST(get_offset_span<u8>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0));
-    m_context->read_pixels_robust_angle(x, y, width, height, format, type, span.size(), nullptr, nullptr, nullptr, span.data());
+    WebIDL::ArrayBufferView view { pixels.downcast<WebIDL::ArrayBufferViewVariant>() };
+    auto bytes_or_error = ByteBuffer::create_uninitialized(view.byte_length());
+    if (bytes_or_error.is_error()) {
+        set_error(GL_OUT_OF_MEMORY);
+        return;
+    }
+    auto bytes = bytes_or_error.release_value();
+    GLsizei bytes_read = 0;
+    m_context->read_pixels_robust_angle(x, y, width, height, format, type, bytes.size(), &bytes_read, nullptr, nullptr, bytes.data());
+    if (bytes_read == 0)
+        return;
+    VERIFY(bytes_read > 0);
+    if (view.write_checked(ReadonlyBytes { bytes.data(), static_cast<size_t>(bytes_read) }).is_error()) [[unlikely]]
+        set_error(GL_INVALID_OPERATION);
 }
 
 void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height,

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
@@ -389,13 +389,14 @@ void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y
     }
 
     WebIDL::ArrayBufferView view { pixels.downcast<WebIDL::ArrayBufferViewVariant>() };
-    auto viewed_array_buffer = view.viewed_array_buffer();
-    if (!viewed_array_buffer || viewed_array_buffer->is_detached() || view.is_out_of_bounds()) {
+    auto validated_view_or_error = WebIDL::validate_array_buffer_view(view);
+    if (validated_view_or_error.is_error()) {
         set_error(GL_INVALID_OPERATION);
         return;
     }
+    auto validated_view = validated_view_or_error.release_value();
 
-    auto bytes_or_error = ByteBuffer::create_uninitialized(view.byte_length());
+    auto bytes_or_error = ByteBuffer::create_uninitialized(validated_view.byte_length);
     if (bytes_or_error.is_error()) {
         set_error(GL_OUT_OF_MEMORY);
         return;

--- a/Libraries/LibWeb/WebGL/WebGLContextProxyBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLContextProxyBase.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/StringBuilder.h>
+#include <GLES2/gl2.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/PaintingSurface.h>
@@ -138,19 +139,27 @@ void WebGLContextProxyBase::tex_sub_image2d_from_bitmap(GLenum target, GLint lev
     });
 }
 
-void WebGLContextProxyBase::read_buffer_sub_data(GLenum target, long long offset, Bytes destination)
+bool WebGLContextProxyBase::read_buffer_sub_data(GLenum target, long long offset, Bytes destination)
 {
-    if (m_lost || destination.is_empty())
-        return;
+    if (m_lost)
+        return false;
+    if (destination.is_empty())
+        return true;
 
     auto shared_data_or_error = Core::AnonymousBuffer::create_with_size(destination.size());
+    if (shared_data_or_error.is_error()) {
+        set_pending_local_error(GL_OUT_OF_MEMORY);
+        return false;
+    }
 
-    auto shared_data = shared_data_or_error.release_value_but_fixme_should_propagate_errors();
+    auto shared_data = shared_data_or_error.release_value();
     flush_commands();
-    m_transport->read_buffer_sub_data(target, static_cast<GLintptr>(offset), static_cast<GLintptr>(destination.size()), shared_data);
+    if (!m_transport->read_buffer_sub_data(target, static_cast<GLintptr>(offset), static_cast<GLintptr>(destination.size()), shared_data))
+        return false;
     if (m_lost)
-        return;
+        return false;
     __builtin_memcpy(destination.data(), shared_data.data<void>(), destination.size());
+    return true;
 }
 
 void WebGLContextProxy::shader_source(GLuint shader, GLsizei count, GLchar const* const* string, GLint const* length)
@@ -191,7 +200,12 @@ void WebGLContextProxy::read_pixels_robust_angle(GLint x, GLint y, GLsizei width
 
     Core::AnonymousBuffer shared_pixels;
     if (bufSize > 0) {
-        shared_pixels = Core::AnonymousBuffer::create_with_size(static_cast<size_t>(bufSize)).release_value_but_fixme_should_propagate_errors();
+        auto shared_pixels_or_error = Core::AnonymousBuffer::create_with_size(static_cast<size_t>(bufSize));
+        if (shared_pixels_or_error.is_error()) {
+            set_pending_local_error(GL_OUT_OF_MEMORY);
+            return;
+        }
+        shared_pixels = shared_pixels_or_error.release_value();
     }
 
     auto result = read_pixels_robust_angle_into_shared_buffer(x, y, width, height, format, type, bufSize, shared_pixels);

--- a/Libraries/LibWeb/WebGL/WebGLContextProxyBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLContextProxyBase.h
@@ -53,7 +53,7 @@ public:
     RefPtr<Gfx::Bitmap> read_back_drawing_buffer(Gfx::IntRect const&);
 
     void read_pixels_into_pixel_pack_buffer(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, long long offset);
-    void read_buffer_sub_data(GLenum target, long long offset, Bytes destination);
+    bool read_buffer_sub_data(GLenum target, long long offset, Bytes destination);
 
     void tex_image2d_from_bitmap(GLenum target, GLint level, GLint internalformat, GLenum format, GLenum type, Gfx::DecodedImageFrame, Optional<Gfx::IntSize> destination_size, bool flip_y, bool premultiply_alpha);
     void tex_sub_image2d_from_bitmap(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLenum format, GLenum type, Gfx::DecodedImageFrame, Optional<Gfx::IntSize> destination_size, bool flip_y, bool premultiply_alpha);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -227,8 +227,14 @@ Optional<WebGLRenderingContextBase::TexImageSourceFrame> WebGLRenderingContextBa
         [](GC::Ref<HTML::ImageBitmap> source) -> Optional<Gfx::DecodedImageFrame> {
             return Gfx::DecodedImageFrame { *source->bitmap() };
         },
-        [](GC::Ref<HTML::ImageData> source) -> Optional<Gfx::DecodedImageFrame> {
-            return Gfx::DecodedImageFrame { source->bitmap() };
+        [this](GC::Ref<HTML::ImageData> source) -> Optional<Gfx::DecodedImageFrame> {
+            auto bitmap = source->bitmap();
+            if (bitmap.is_error()) {
+                set_error(GL_INVALID_VALUE);
+                return OptionalNone {};
+            }
+            NonnullRefPtr<Gfx::Bitmap const> bitmap_ref = bitmap.release_value();
+            return Gfx::DecodedImageFrame { move(bitmap_ref) };
         });
     if (!frame.has_value())
         return OptionalNone {};

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
+#include <AK/Checked.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibJS/Runtime/DataView.h>
 #include <LibJS/Runtime/TypedArray.h>
@@ -102,54 +104,158 @@ protected:
         return src_span.slice(src_offset, src_length_override);
     }
 
-    template<typename T>
-    static ErrorOr<Span<T>> get_offset_span(WebIDL::BufferSource src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
+    static ErrorOr<ByteBuffer> copy_buffer_source_to_byte_buffer(WebIDL::BufferSource src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
     {
-        auto buffer_size = src_data.byte_length();
-        if (buffer_size % sizeof(T) != 0) [[unlikely]]
+        auto array_buffer = src_data.viewed_array_buffer();
+        if (!array_buffer || array_buffer->is_detached()) [[unlikely]]
             return Error::from_errno(EINVAL);
 
-        return src_data.buffer_source().visit(
-            [&](GC::Ref<JS::ArrayBuffer> array_buffer) -> ErrorOr<Span<T>> {
-                return TRY(get_offset_span(array_buffer->span(), src_offset, src_length_override)).template reinterpret<T>();
-            },
-            [&](GC::Ref<JS::DataView> data_view) -> ErrorOr<Span<T>> {
-                return TRY(get_offset_span(data_view->viewed_array_buffer()->span(), src_offset, src_length_override)).template reinterpret<T>();
-            },
-            [&](auto const& typed_array) -> ErrorOr<Span<T>> {
-                // NOTE: src_offset is the number of elements to offset by, not the number of bytes.
-                return TRY(get_offset_span(typed_array->data(), src_offset, src_length_override)).template reinterpret<T>();
-            });
+        if (src_data.is_out_of_bounds()) {
+            if (src_offset != 0 || src_length_override != 0) [[unlikely]]
+                return Error::from_errno(EINVAL);
+            return ByteBuffer::create_uninitialized(0);
+        }
+
+        auto element_size = src_data.element_size();
+        Checked<size_t> byte_offset_in_view = static_cast<size_t>(src_offset);
+        byte_offset_in_view *= element_size;
+        if (byte_offset_in_view.has_overflow() || byte_offset_in_view.value() > src_data.byte_length()) [[unlikely]]
+            return Error::from_errno(EINVAL);
+
+        auto byte_length = src_data.byte_length() - byte_offset_in_view.value();
+        if (src_length_override != 0) {
+            Checked<size_t> requested_byte_length = static_cast<size_t>(src_length_override);
+            requested_byte_length *= element_size;
+            if (requested_byte_length.has_overflow() || requested_byte_length.value() > byte_length) [[unlikely]]
+                return Error::from_errno(EINVAL);
+            byte_length = requested_byte_length.value();
+        }
+
+        Checked<size_t> byte_offset_in_buffer = src_data.byte_offset();
+        byte_offset_in_buffer += byte_offset_in_view.value();
+        if (byte_offset_in_buffer.has_overflow()) [[unlikely]]
+            return Error::from_errno(EINVAL);
+
+        if (byte_offset_in_buffer.value() > array_buffer->byte_length()) [[unlikely]]
+            return Error::from_errno(EINVAL);
+        if (byte_length > array_buffer->byte_length() - byte_offset_in_buffer.value()) [[unlikely]]
+            return Error::from_errno(EINVAL);
+
+        auto bytes = TRY(ByteBuffer::create_uninitialized(byte_length));
+        array_buffer->bytes().slice(byte_offset_in_buffer.value(), byte_length).copy_to(bytes);
+        return bytes;
     }
 
-    static ErrorOr<Span<float>> span_from_float32_list(Float32List& float32_list, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
+    template<typename T>
+    class SpanWithStorage {
+    public:
+        explicit SpanWithStorage(Span<T> span)
+            : m_span(span)
+        {
+        }
+
+        explicit SpanWithStorage(ByteBuffer storage)
+            : m_storage(move(storage))
+            , m_has_storage(true)
+            , m_span(m_storage.bytes().template reinterpret<T>())
+        {
+        }
+
+        SpanWithStorage(SpanWithStorage const&) = delete;
+        SpanWithStorage& operator=(SpanWithStorage const&) = delete;
+
+        SpanWithStorage(SpanWithStorage&& other)
+            : m_storage(move(other.m_storage))
+            , m_has_storage(exchange(other.m_has_storage, false))
+            , m_span(m_has_storage ? m_storage.bytes().template reinterpret<T>() : other.m_span)
+        {
+        }
+
+        SpanWithStorage& operator=(SpanWithStorage&& other)
+        {
+            if (this != &other) {
+                m_storage = move(other.m_storage);
+                m_has_storage = exchange(other.m_has_storage, false);
+                m_span = m_has_storage ? m_storage.bytes().template reinterpret<T>() : other.m_span;
+            }
+            return *this;
+        }
+
+        size_t size() const { return m_span.size(); }
+        T* data() { return m_span.data(); }
+        T const* data() const { return m_span.data(); }
+
+    private:
+        ByteBuffer m_storage;
+        bool m_has_storage { false };
+        Span<T> m_span;
+    };
+
+    template<typename T>
+    static ErrorOr<SpanWithStorage<T>> span_from_typed_array(JS::TypedArrayBase& typed_array, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
+    {
+        auto record = JS::make_typed_array_with_buffer_witness_record(typed_array, JS::ArrayBuffer::Order::SeqCst);
+        if (JS::is_typed_array_out_of_bounds(record)) [[unlikely]] {
+            if (src_offset == 0 && src_length_override == 0)
+                return SpanWithStorage<T> { Span<T> {} };
+            return Error::from_errno(EINVAL);
+        }
+
+        auto length = JS::typed_array_length(record);
+        Checked<size_t> end = static_cast<size_t>(src_offset);
+        end += src_length_override;
+        if (end.has_overflow() || end.value() > length) [[unlikely]]
+            return Error::from_errno(EINVAL);
+
+        auto elements_to_copy = src_length_override == 0 ? length - static_cast<size_t>(src_offset) : static_cast<size_t>(src_length_override);
+        Checked<size_t> byte_offset = static_cast<size_t>(src_offset);
+        byte_offset *= sizeof(T);
+        byte_offset += typed_array.byte_offset();
+
+        Checked<size_t> byte_length = elements_to_copy;
+        byte_length *= sizeof(T);
+        if (byte_offset.has_overflow() || byte_length.has_overflow()) [[unlikely]]
+            return Error::from_errno(EINVAL);
+
+        auto* array_buffer = typed_array.viewed_array_buffer();
+        if (byte_offset.value() > array_buffer->byte_length()) [[unlikely]]
+            return Error::from_errno(EINVAL);
+        if (byte_length.value() > array_buffer->byte_length() - byte_offset.value()) [[unlikely]]
+            return Error::from_errno(EINVAL);
+
+        auto bytes = TRY(ByteBuffer::create_uninitialized(byte_length.value()));
+        array_buffer->bytes().slice(byte_offset.value(), byte_length.value()).copy_to(bytes);
+        return SpanWithStorage<T> { move(bytes) };
+    }
+
+    static ErrorOr<SpanWithStorage<float>> span_from_float32_list(Float32List& float32_list, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
     {
         if (float32_list.has<Vector<float>>()) {
             auto& vector = float32_list.get<Vector<float>>();
-            return get_offset_span(vector.span(), src_offset, src_length_override);
+            return SpanWithStorage<float> { TRY(get_offset_span(vector.span(), src_offset, src_length_override)) };
         }
         auto& buffer = float32_list.get<GC::Ref<JS::Float32Array>>();
-        return get_offset_span(buffer->data(), src_offset, src_length_override);
+        return span_from_typed_array<float>(*buffer, src_offset, src_length_override);
     }
 
-    static ErrorOr<Span<int>> span_from_int32_list(Int32List& int32_list, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
+    static ErrorOr<SpanWithStorage<int>> span_from_int32_list(Int32List& int32_list, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
     {
         if (int32_list.has<Vector<int>>()) {
             auto& vector = int32_list.get<Vector<int>>();
-            return get_offset_span(vector.span(), src_offset, src_length_override);
+            return SpanWithStorage<int> { TRY(get_offset_span(vector.span(), src_offset, src_length_override)) };
         }
         auto& buffer = int32_list.get<GC::Ref<JS::Int32Array>>();
-        return get_offset_span(buffer->data(), src_offset, src_length_override);
+        return span_from_typed_array<int>(*buffer, src_offset, src_length_override);
     }
 
-    static ErrorOr<Span<u32>> span_from_uint32_list(Uint32List& uint32_list, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
+    static ErrorOr<SpanWithStorage<u32>> span_from_uint32_list(Uint32List& uint32_list, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
     {
         if (uint32_list.has<Vector<u32>>()) {
             auto& vector = uint32_list.get<Vector<u32>>();
-            return get_offset_span(vector.span(), src_offset, src_length_override);
+            return SpanWithStorage<u32> { TRY(get_offset_span(vector.span(), src_offset, src_length_override)) };
         }
         auto& buffer = uint32_list.get<GC::Ref<JS::Uint32Array>>();
-        return get_offset_span(buffer->data(), src_offset, src_length_override);
+        return span_from_typed_array<u32>(*buffer, src_offset, src_length_override);
     }
 
     struct TexImageSourceFrame {

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -141,9 +141,7 @@ protected:
         if (byte_length > array_buffer->byte_length() - byte_offset_in_buffer.value()) [[unlikely]]
             return Error::from_errno(EINVAL);
 
-        auto bytes = TRY(ByteBuffer::create_uninitialized(byte_length));
-        array_buffer->bytes().slice(byte_offset_in_buffer.value(), byte_length).copy_to(bytes);
-        return bytes;
+        return array_buffer->copy_to_byte_buffer(byte_offset_in_buffer.value(), byte_length);
     }
 
     template<typename T>
@@ -217,14 +215,7 @@ protected:
         if (byte_offset.has_overflow() || byte_length.has_overflow()) [[unlikely]]
             return Error::from_errno(EINVAL);
 
-        auto* array_buffer = typed_array.viewed_array_buffer();
-        if (byte_offset.value() > array_buffer->byte_length()) [[unlikely]]
-            return Error::from_errno(EINVAL);
-        if (byte_length.value() > array_buffer->byte_length() - byte_offset.value()) [[unlikely]]
-            return Error::from_errno(EINVAL);
-
-        auto bytes = TRY(ByteBuffer::create_uninitialized(byte_length.value()));
-        array_buffer->bytes().slice(byte_offset.value(), byte_length.value()).copy_to(bytes);
+        auto bytes = TRY(typed_array.viewed_array_buffer()->copy_to_byte_buffer(byte_offset.value(), byte_length.value()));
         return SpanWithStorage<T> { move(bytes) };
     }
 

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
@@ -92,6 +92,12 @@ void WebGLRenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y,
     }
 
     WebIDL::ArrayBufferView view { pixels.downcast<WebIDL::ArrayBufferViewVariant>() };
+    auto viewed_array_buffer = view.viewed_array_buffer();
+    if (!viewed_array_buffer || viewed_array_buffer->is_detached() || view.is_out_of_bounds()) {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+
     auto bytes_or_error = ByteBuffer::create_uninitialized(view.byte_length());
     if (bytes_or_error.is_error()) {
         set_error(GL_OUT_OF_MEMORY);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
@@ -92,13 +92,14 @@ void WebGLRenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y,
     }
 
     WebIDL::ArrayBufferView view { pixels.downcast<WebIDL::ArrayBufferViewVariant>() };
-    auto viewed_array_buffer = view.viewed_array_buffer();
-    if (!viewed_array_buffer || viewed_array_buffer->is_detached() || view.is_out_of_bounds()) {
+    auto validated_view_or_error = WebIDL::validate_array_buffer_view(view);
+    if (validated_view_or_error.is_error()) {
         set_error(GL_INVALID_OPERATION);
         return;
     }
+    auto validated_view = validated_view_or_error.release_value();
 
-    auto bytes_or_error = ByteBuffer::create_uninitialized(view.byte_length());
+    auto bytes_or_error = ByteBuffer::create_uninitialized(validated_view.byte_length);
     if (bytes_or_error.is_error()) {
         set_error(GL_OUT_OF_MEMORY);
         return;

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
@@ -44,16 +44,16 @@ void WebGLRenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, We
         return;
     }
 
-    auto span = MUST(get_offset_span<u8 const>(data.downcast<WebIDL::BufferSourceVariant>(), /* src_offset= */ 0));
-    m_context->buffer_data(target, static_cast<GLsizeiptr>(span.size()), span.data(), usage);
+    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { data.downcast<WebIDL::BufferSourceVariant>() }, /* src_offset= */ 0), GL_INVALID_VALUE);
+    m_context->buffer_data(target, static_cast<GLsizeiptr>(bytes.size()), bytes.data(), usage);
 }
 
 void WebGLRenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong offset, WebIDL::BufferSource data)
 {
     m_context->make_current();
 
-    auto span = MUST(get_offset_span<u8 const>(data, /* src_offset= */ 0));
-    m_context->buffer_sub_data(target, offset, span.size(), span.data());
+    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(data, /* src_offset= */ 0), GL_INVALID_VALUE);
+    m_context->buffer_sub_data(target, offset, bytes.size(), bytes.data());
 }
 
 void WebGLRenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::ArrayBufferView data)
@@ -65,8 +65,8 @@ void WebGLRenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLong
         return;
     }
 
-    auto span = MUST(get_offset_span<u8 const>(data, /* src_offset= */ 0));
-    m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, span.size(), span.size(), span.data());
+    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { data }, /* src_offset= */ 0), GL_INVALID_VALUE);
+    m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, bytes.size(), bytes.size(), bytes.data());
 }
 
 void WebGLRenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::ArrayBufferView data)
@@ -78,8 +78,8 @@ void WebGLRenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::Unsigned
         return;
     }
 
-    auto span = MUST(get_offset_span<u8 const>(data, /* src_offset= */ 0));
-    m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, span.size(), span.size(), span.data());
+    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { data }, /* src_offset= */ 0), GL_INVALID_VALUE);
+    m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, bytes.size(), bytes.size(), bytes.data());
 }
 
 void WebGLRenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -91,8 +91,20 @@ void WebGLRenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y,
         return;
     }
 
-    auto span = MUST(get_offset_span<u8>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0));
-    m_context->read_pixels_robust_angle(x, y, width, height, format, type, span.size(), nullptr, nullptr, nullptr, span.data());
+    WebIDL::ArrayBufferView view { pixels.downcast<WebIDL::ArrayBufferViewVariant>() };
+    auto bytes_or_error = ByteBuffer::create_uninitialized(view.byte_length());
+    if (bytes_or_error.is_error()) {
+        set_error(GL_OUT_OF_MEMORY);
+        return;
+    }
+    auto bytes = bytes_or_error.release_value();
+    GLsizei bytes_read = 0;
+    m_context->read_pixels_robust_angle(x, y, width, height, format, type, bytes.size(), &bytes_read, nullptr, nullptr, bytes.data());
+    if (bytes_read == 0)
+        return;
+    VERIFY(bytes_read > 0);
+    if (view.write_checked(ReadonlyBytes { bytes.data(), static_cast<size_t>(bytes_read) }).is_error()) [[unlikely]]
+        set_error(GL_INVALID_OPERATION);
 }
 
 void WebGLRenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -100,8 +112,8 @@ void WebGLRenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, We
     m_context->make_current();
 
     if (!pixels.has<Empty>()) {
-        auto span = MUST(get_offset_span<u8>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0));
-        m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, span.size(), span.data());
+        auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
+        m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, bytes.size(), bytes.data());
         return;
     }
 
@@ -183,8 +195,8 @@ void WebGLRenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target
         return;
     }
 
-    auto span = MUST(get_offset_span<u8>(pixels.downcast<WebIDL::ArrayBufferViewVariant>(), /* src_offset= */ 0));
-    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, span.size(), span.data());
+    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
+    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, bytes.size(), bytes.data());
 }
 
 void WebGLRenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)

--- a/Libraries/LibWeb/WebIDL/Buffers.cpp
+++ b/Libraries/LibWeb/WebIDL/Buffers.cpp
@@ -166,6 +166,65 @@ bool ArrayBufferView::is_out_of_bounds() const
     return BufferSource { m_array_buffer_view }.is_out_of_bounds();
 }
 
+static ErrorOr<ValidatedBufferSource> validate_buffer_source_bounds(GC::Ref<JS::ArrayBuffer> array_buffer, size_t byte_offset, size_t byte_length, size_t element_size, bool is_data_view, bool is_array_buffer)
+{
+    if (array_buffer->is_detached()) [[unlikely]]
+        return Error::from_errno(EINVAL);
+
+    Checked<size_t> byte_end = byte_offset;
+    byte_end += byte_length;
+    if (byte_end.has_overflow() || byte_end.value() > array_buffer->byte_length()) [[unlikely]]
+        return Error::from_errno(EINVAL);
+
+    return ValidatedBufferSource {
+        .buffer = array_buffer,
+        .byte_offset = byte_offset,
+        .byte_length = byte_length,
+        .element_size = element_size,
+        .is_data_view = is_data_view,
+        .is_array_buffer = is_array_buffer,
+    };
+}
+
+ErrorOr<ValidatedBufferSource> validate_buffer_source(BufferSource const& buffer_source)
+{
+    return buffer_source.buffer_source().visit(
+        [](GC::Ref<JS::ArrayBuffer> array_buffer) -> ErrorOr<ValidatedBufferSource> {
+            return validate_buffer_source_bounds(array_buffer, 0, array_buffer->byte_length(), 1, false, true);
+        },
+        [](GC::Ref<JS::DataView> data_view) -> ErrorOr<ValidatedBufferSource> {
+            auto* array_buffer = data_view->viewed_array_buffer();
+            if (!array_buffer) [[unlikely]]
+                return Error::from_errno(EINVAL);
+            if (array_buffer->is_detached()) [[unlikely]]
+                return Error::from_errno(EINVAL);
+
+            auto view_record = JS::make_data_view_with_buffer_witness_record(data_view, JS::ArrayBuffer::Order::SeqCst);
+            if (JS::is_view_out_of_bounds(view_record)) [[unlikely]]
+                return Error::from_errno(EINVAL);
+
+            return validate_buffer_source_bounds(GC::Ref { *array_buffer }, data_view->byte_offset(), JS::get_view_byte_length(view_record), 1, true, false);
+        },
+        [](auto const& typed_array) -> ErrorOr<ValidatedBufferSource> {
+            auto* array_buffer = typed_array->viewed_array_buffer();
+            if (!array_buffer) [[unlikely]]
+                return Error::from_errno(EINVAL);
+            if (array_buffer->is_detached()) [[unlikely]]
+                return Error::from_errno(EINVAL);
+
+            auto typed_array_record = JS::make_typed_array_with_buffer_witness_record(*typed_array, JS::ArrayBuffer::Order::SeqCst);
+            if (JS::is_typed_array_out_of_bounds(typed_array_record)) [[unlikely]]
+                return Error::from_errno(EINVAL);
+
+            return validate_buffer_source_bounds(GC::Ref { *array_buffer }, typed_array->byte_offset(), JS::typed_array_byte_length(typed_array_record), typed_array->element_size(), false, false);
+        });
+}
+
+ErrorOr<ValidatedBufferSource> validate_array_buffer_view(ArrayBufferView const& array_buffer_view)
+{
+    return validate_buffer_source(BufferSource { array_buffer_view });
+}
+
 ErrorOr<void> ArrayBufferView::write_checked(ReadonlyBytes bytes, u32 starting_offset)
 {
     auto view_byte_length = byte_length();
@@ -183,18 +242,16 @@ ErrorOr<void> ArrayBufferView::write_checked(ReadonlyBytes bytes, u32 starting_o
     if (bytes.is_empty())
         return {};
 
-    auto array_buffer = viewed_array_buffer();
-    if (!array_buffer || array_buffer->is_detached()) [[unlikely]]
-        return Error::from_errno(EINVAL);
+    auto validated_view = TRY(validate_array_buffer_view(*this));
 
-    Checked<size_t> write_offset = byte_offset();
+    Checked<size_t> write_offset = validated_view.byte_offset;
     write_offset += starting_offset;
-    if (write_offset.has_overflow() || write_offset.value() > array_buffer->byte_length()) [[unlikely]]
+    if (write_offset.has_overflow() || write_offset.value() > validated_view.buffer->byte_length()) [[unlikely]]
         return Error::from_errno(EINVAL);
-    if (bytes.size() > array_buffer->byte_length() - write_offset.value()) [[unlikely]]
+    if (bytes.size() > validated_view.buffer->byte_length() - write_offset.value()) [[unlikely]]
         return Error::from_errno(EINVAL);
 
-    array_buffer->overwrite(write_offset.value(), bytes.data(), bytes.size());
+    validated_view.buffer->overwrite(write_offset.value(), bytes.data(), bytes.size());
     return {};
 }
 

--- a/Libraries/LibWeb/WebIDL/Buffers.cpp
+++ b/Libraries/LibWeb/WebIDL/Buffers.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/DataView.h>
@@ -55,6 +56,8 @@ u32 BufferSource::byte_length() const
     return m_buffer_source.visit(
         [](GC::Ref<JS::DataView> data_view) {
             auto view_record = JS::make_data_view_with_buffer_witness_record(data_view, JS::ArrayBuffer::Order::SeqCst);
+            if (JS::is_view_out_of_bounds(view_record))
+                return 0u;
             return JS::get_view_byte_length(view_record);
         },
         [](GC::Ref<JS::ArrayBuffer> array_buffer) {
@@ -102,6 +105,22 @@ GC::Ptr<JS::TypedArrayBase> BufferSource::typed_array_base() const
         [](auto const& typed_array) -> GC::Ptr<JS::TypedArrayBase> { return &static_cast<JS::TypedArrayBase&>(*typed_array); });
 }
 
+bool BufferSource::is_out_of_bounds() const
+{
+    return m_buffer_source.visit(
+        [](GC::Ref<JS::DataView> data_view) {
+            auto view_record = JS::make_data_view_with_buffer_witness_record(data_view, JS::ArrayBuffer::Order::SeqCst);
+            return JS::is_view_out_of_bounds(view_record);
+        },
+        [](GC::Ref<JS::ArrayBuffer>) {
+            return false;
+        },
+        [](auto const& typed_array) {
+            auto typed_array_record = JS::make_typed_array_with_buffer_witness_record(*typed_array, JS::ArrayBuffer::Order::SeqCst);
+            return JS::is_typed_array_out_of_bounds(typed_array_record);
+        });
+}
+
 bool BufferSource::is_data_view() const
 {
     return m_buffer_source.has<GC::Ref<JS::DataView>>();
@@ -142,24 +161,41 @@ GC::Ptr<JS::TypedArrayBase> ArrayBufferView::typed_array_base() const
     return BufferSource { m_array_buffer_view }.typed_array_base();
 }
 
-// https://webidl.spec.whatwg.org/#arraybufferview-write
-void ArrayBufferView::write(ReadonlyBytes bytes, u32 starting_offset)
+bool ArrayBufferView::is_out_of_bounds() const
 {
-    // 1. Let jsView be the result of converting view to a JavaScript value.
-    // 2. Assert: bytes’s length ≤ jsView.[[ByteLength]] − startingOffset.
-    VERIFY(bytes.size() <= byte_length() - starting_offset);
+    return BufferSource { m_array_buffer_view }.is_out_of_bounds();
+}
 
-    // 3. Assert: if view is not a DataView, then bytes’s length modulo the element size of view’s type is 0.
+ErrorOr<void> ArrayBufferView::write_checked(ReadonlyBytes bytes, u32 starting_offset)
+{
+    auto view_byte_length = byte_length();
+    if (starting_offset > view_byte_length) [[unlikely]]
+        return Error::from_errno(EINVAL);
+    if (bytes.size() > view_byte_length - starting_offset) [[unlikely]]
+        return Error::from_errno(EINVAL);
+
     if (!m_array_buffer_view.has<GC::Ref<JS::DataView>>()) {
         auto element_size = typed_array_base()->element_size();
-        VERIFY(bytes.size() % element_size == 0);
+        if (bytes.size() % element_size != 0) [[unlikely]]
+            return Error::from_errno(EINVAL);
     }
 
-    // 4. Let arrayBuffer be the result of converting jsView.[[ViewedArrayBuffer]] to an IDL value of type ArrayBuffer.
-    auto array_buffer = viewed_array_buffer();
+    if (bytes.is_empty())
+        return {};
 
-    // 5. Write bytes into arrayBuffer with startingOffset set to jsView.[[ByteOffset]] + startingOffset.
-    array_buffer->overwrite(byte_offset() + starting_offset, bytes.data(), bytes.size());
+    auto array_buffer = viewed_array_buffer();
+    if (!array_buffer || array_buffer->is_detached()) [[unlikely]]
+        return Error::from_errno(EINVAL);
+
+    Checked<size_t> write_offset = byte_offset();
+    write_offset += starting_offset;
+    if (write_offset.has_overflow() || write_offset.value() > array_buffer->byte_length()) [[unlikely]]
+        return Error::from_errno(EINVAL);
+    if (bytes.size() > array_buffer->byte_length() - write_offset.value()) [[unlikely]]
+        return Error::from_errno(EINVAL);
+
+    array_buffer->overwrite(write_offset.value(), bytes.data(), bytes.size());
+    return {};
 }
 
 // https://webidl.spec.whatwg.org/#buffersource-detached

--- a/Libraries/LibWeb/WebIDL/Buffers.h
+++ b/Libraries/LibWeb/WebIDL/Buffers.h
@@ -7,10 +7,12 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Variant.h>
 #include <LibGC/CellAllocator.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::WebIDL {
@@ -35,7 +37,7 @@ using NullableArrayBufferViewVariant = FlattenVariant<ArrayBufferViewVariant, Va
 using BufferSourceVariant = FlattenVariant<ArrayBufferViewVariant, Variant<GC::Ref<JS::ArrayBuffer>>>;
 using NullableBufferSourceVariant = FlattenVariant<BufferSourceVariant, Variant<Empty>>;
 
-class BufferSource {
+class WEB_API BufferSource {
 public:
     static BufferSourceVariant from_object(GC::Ref<JS::Object>);
     static bool is_detached(JS::Value const&);
@@ -54,6 +56,7 @@ public:
     GC::Ptr<JS::ArrayBuffer> viewed_array_buffer() const;
     GC::Ptr<JS::TypedArrayBase> typed_array_base() const;
 
+    bool is_out_of_bounds() const;
     bool is_data_view() const;
     bool is_array_buffer() const;
 
@@ -62,7 +65,7 @@ private:
 };
 
 // https://webidl.spec.whatwg.org/#ArrayBufferView
-class ArrayBufferView {
+class WEB_API ArrayBufferView {
 public:
     static ArrayBufferViewVariant from_object(GC::Ref<JS::Object>);
 
@@ -78,9 +81,10 @@ public:
     GC::Ptr<JS::ArrayBuffer> viewed_array_buffer() const;
     GC::Ptr<JS::TypedArrayBase> typed_array_base() const;
 
+    bool is_out_of_bounds() const;
     bool is_data_view() const;
 
-    void write(ReadonlyBytes, u32 starting_offset = 0);
+    ErrorOr<void> write_checked(ReadonlyBytes, u32 starting_offset = 0);
 
 private:
     ArrayBufferViewVariant m_array_buffer_view;

--- a/Libraries/LibWeb/WebIDL/Buffers.h
+++ b/Libraries/LibWeb/WebIDL/Buffers.h
@@ -37,6 +37,15 @@ using NullableArrayBufferViewVariant = FlattenVariant<ArrayBufferViewVariant, Va
 using BufferSourceVariant = FlattenVariant<ArrayBufferViewVariant, Variant<GC::Ref<JS::ArrayBuffer>>>;
 using NullableBufferSourceVariant = FlattenVariant<BufferSourceVariant, Variant<Empty>>;
 
+struct WEB_API ValidatedBufferSource {
+    GC::Ref<JS::ArrayBuffer> buffer;
+    size_t byte_offset { 0 };
+    size_t byte_length { 0 };
+    size_t element_size { 1 };
+    bool is_data_view { false };
+    bool is_array_buffer { false };
+};
+
 class WEB_API BufferSource {
 public:
     static BufferSourceVariant from_object(GC::Ref<JS::Object>);
@@ -89,5 +98,8 @@ public:
 private:
     ArrayBufferViewVariant m_array_buffer_view;
 };
+
+WEB_API ErrorOr<ValidatedBufferSource> validate_buffer_source(BufferSource const&);
+WEB_API ErrorOr<ValidatedBufferSource> validate_array_buffer_view(ArrayBufferView const&);
 
 }

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -320,7 +320,7 @@ WebIDL::ExceptionOr<void> WebSocket::send(WebSocketSendData const& data)
                 auto buffer_source = WebIDL::BufferSource { buffer_source_variant };
                 ReadonlyBytes buffer;
 
-                if (auto array_buffer = buffer_source.viewed_array_buffer(); array_buffer && !array_buffer->is_detached())
+                if (auto array_buffer = buffer_source.viewed_array_buffer(); array_buffer && !array_buffer->is_detached() && !buffer_source.is_out_of_bounds())
                     buffer = array_buffer->bytes().slice(buffer_source.byte_offset(), buffer_source.byte_length());
 
                 m_websocket->send(buffer, false);

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <AK/QuickSort.h>
 #include <AK/Utf16String.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
@@ -318,10 +319,14 @@ WebIDL::ExceptionOr<void> WebSocket::send(WebSocketSendData const& data)
             },
             [this](WebIDL::BufferSourceVariant buffer_source_variant) {
                 auto buffer_source = WebIDL::BufferSource { buffer_source_variant };
+                ByteBuffer buffer_storage;
                 ReadonlyBytes buffer;
 
-                if (auto array_buffer = buffer_source.viewed_array_buffer(); array_buffer && !array_buffer->is_detached() && !buffer_source.is_out_of_bounds())
-                    buffer = array_buffer->bytes().slice(buffer_source.byte_offset(), buffer_source.byte_length());
+                if (auto array_buffer = buffer_source.viewed_array_buffer(); array_buffer && !array_buffer->is_detached() && !buffer_source.is_out_of_bounds()) {
+                    buffer_storage = MUST(ByteBuffer::create_uninitialized(buffer_source.byte_length()));
+                    array_buffer->copy_to(buffer_source.byte_offset(), buffer_storage);
+                    buffer = buffer_storage;
+                }
 
                 m_websocket->send(buffer, false);
             },

--- a/Services/Compositor/CanvasHost.cpp
+++ b/Services/Compositor/CanvasHost.cpp
@@ -168,11 +168,11 @@ Web::WebGL::ReadPixelsResult CanvasHost::webgl_read_pixels_robust_angle(Web::Pai
     return as_webgl(*context).read_pixels_robust_angle(x, y, width, height, format, type, buf_size, move(pixels));
 }
 
-void CanvasHost::webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data)
+bool CanvasHost::webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data)
 {
     auto* context = this->context(canvas_id);
     VERIFY(context);
-    as_webgl(*context).read_buffer_sub_data(target, offset, size, move(data));
+    return as_webgl(*context).read_buffer_sub_data(target, offset, size, move(data));
 }
 
 void CanvasHost::present_webgl_canvas(Web::Painting::CanvasId canvas_id, bool preserve_drawing_buffer)

--- a/Services/Compositor/CanvasHost.h
+++ b/Services/Compositor/CanvasHost.h
@@ -54,7 +54,7 @@ public:
     void execute_webgl_commands(Web::Painting::CanvasId, ReadonlyBytes, Vector<Gfx::DecodedImageFrame> const&);
     ErrorOr<ByteBuffer> execute_webgl_sync_call(Web::Painting::CanvasId, ByteBuffer request);
     Web::WebGL::ReadPixelsResult webgl_read_pixels_robust_angle(Web::Painting::CanvasId, Web::WebGL::GLint x, Web::WebGL::GLint y, Web::WebGL::GLsizei width, Web::WebGL::GLsizei height, Web::WebGL::GLenum format, Web::WebGL::GLenum type, Web::WebGL::GLsizei buf_size, Core::AnonymousBuffer pixels);
-    void webgl_read_buffer_sub_data(Web::Painting::CanvasId, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data);
+    bool webgl_read_buffer_sub_data(Web::Painting::CanvasId, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data);
 
     void present_webgl_canvas(Web::Painting::CanvasId, bool preserve_drawing_buffer);
     Gfx::ShareableBitmap read_back_pixels(Web::Painting::CanvasId, Gfx::IntRect);

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -41,7 +41,7 @@ endpoint CompositorWebContentServer
     webgl_present_canvas(Web::Painting::CanvasId canvas_id, bool preserve_drawing_buffer) =|
     webgl_sync_call(Web::Painting::CanvasId canvas_id, ByteBuffer request) => (ByteBuffer reply)
     webgl_read_pixels(Web::Painting::CanvasId canvas_id, i32 x, i32 y, i32 width, i32 height, u32 format, u32 type, i32 buf_size, Core::AnonymousBuffer pixels) => (i32 length, i32 columns, i32 rows)
-    webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data) => ()
+    webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data) => (bool success)
 
     invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) =|
     async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) => (Web::Compositor::AsyncScrollEnqueueResult result)

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -172,14 +172,14 @@ Messages::CompositorWebContentServer::WebglReadPixelsResponse ConnectionFromWebC
     return { result.length, result.columns, result.rows };
 }
 
-void ConnectionFromWebContent::webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data)
+Messages::CompositorWebContentServer::WebglReadBufferSubDataResponse ConnectionFromWebContent::webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data)
 {
     if (size < 0 || (size > 0 && (!data.is_valid() || data.size() < static_cast<size_t>(size)))) {
         did_misbehave("WebContent sent an invalid WebGL buffer readback target");
-        return;
+        return { false };
     }
 
-    m_canvas_host.webgl_read_buffer_sub_data(canvas_id, target, offset, size, move(data));
+    return { m_canvas_host.webgl_read_buffer_sub_data(canvas_id, target, offset, size, move(data)) };
 }
 
 void ConnectionFromWebContent::invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation)

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -55,7 +55,7 @@ private:
     virtual void webgl_present_canvas(Web::Painting::CanvasId canvas_id, bool preserve_drawing_buffer) override;
     virtual Messages::CompositorWebContentServer::WebglSyncCallResponse webgl_sync_call(Web::Painting::CanvasId canvas_id, ByteBuffer request) override;
     virtual Messages::CompositorWebContentServer::WebglReadPixelsResponse webgl_read_pixels(Web::Painting::CanvasId canvas_id, i32 x, i32 y, i32 width, i32 height, u32 format, u32 type, i32 buf_size, Core::AnonymousBuffer pixels) override;
-    virtual void webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data) override;
+    virtual Messages::CompositorWebContentServer::WebglReadBufferSubDataResponse webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data) override;
     virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation) override;
     virtual Messages::CompositorWebContentServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
     virtual Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScrollResponse should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) override;

--- a/Services/Compositor/HostWebGLContext.cpp
+++ b/Services/Compositor/HostWebGLContext.cpp
@@ -184,7 +184,7 @@ ReadPixelsResult HostWebGLContext::read_pixels_robust_angle(GLint x, GLint y, GL
     };
 }
 
-void HostWebGLContext::read_buffer_sub_data(GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data)
+bool HostWebGLContext::read_buffer_sub_data(GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data)
 {
     VERIFY(size >= 0);
     VERIFY(static_cast<size_t>(size) <= data.size());
@@ -194,7 +194,9 @@ void HostWebGLContext::read_buffer_sub_data(GLenum target, Web::WebGL::GLintptr 
     if (auto* mapped = m_gl_context->map_buffer_range(target, offset, size, GL_MAP_READ_BIT)) {
         __builtin_memcpy(data.data<void>(), mapped, static_cast<size_t>(size));
         m_gl_context->unmap_buffer(target);
+        return true;
     }
+    return false;
 }
 
 ErrorOr<void> HostWebGLContext::set_drawing_buffer_size(int width, int height)

--- a/Services/Compositor/HostWebGLContext.h
+++ b/Services/Compositor/HostWebGLContext.h
@@ -36,7 +36,7 @@ public:
     ErrorOr<ByteBuffer> execute_sync_call(ReadonlyBytes request);
     Gfx::ShareableBitmap read_back_drawing_buffer(Gfx::IntRect);
     Web::WebGL::ReadPixelsResult read_pixels_robust_angle(Web::WebGL::GLint x, Web::WebGL::GLint y, Web::WebGL::GLsizei width, Web::WebGL::GLsizei height, Web::WebGL::GLenum format, Web::WebGL::GLenum type, Web::WebGL::GLsizei buf_size, Core::AnonymousBuffer pixels);
-    void read_buffer_sub_data(Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data);
+    bool read_buffer_sub_data(Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data);
     ErrorOr<NonnullRefPtr<Gfx::PaintingSurface>> prepare_for_compositing(bool preserve_drawing_buffer);
     RefPtr<Gfx::PaintingSurface> surface();
 

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -239,12 +239,13 @@ Web::WebGL::ReadPixelsResult CompositorConnection::read_webgl_pixels(Web::Painti
     };
 }
 
-void CompositorConnection::read_webgl_buffer_sub_data(Web::Painting::CanvasId canvas_id, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer const& data)
+bool CompositorConnection::read_webgl_buffer_sub_data(Web::Painting::CanvasId canvas_id, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer const& data)
 {
     if (!can_send_message_to_compositor())
-        return;
+        return false;
 
-    (void)send_sync<Messages::CompositorWebContentServer::WebglReadBufferSubData>(canvas_id, target, offset, size, data);
+    auto response = send_sync<Messages::CompositorWebContentServer::WebglReadBufferSubData>(canvas_id, target, offset, size, data);
+    return response->success();
 }
 
 void CompositorConnection::request_screenshot(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -62,7 +62,7 @@ public:
     void present_webgl_canvas(Web::Painting::CanvasId, bool preserve_drawing_buffer);
     ByteBuffer webgl_sync_call(Web::Painting::CanvasId, ByteBuffer request);
     Web::WebGL::ReadPixelsResult read_webgl_pixels(Web::Painting::CanvasId, Web::WebGL::GLint x, Web::WebGL::GLint y, Web::WebGL::GLsizei width, Web::WebGL::GLsizei height, Web::WebGL::GLenum format, Web::WebGL::GLenum type, Web::WebGL::GLsizei buf_size, Core::AnonymousBuffer const& pixels);
-    void read_webgl_buffer_sub_data(Web::Painting::CanvasId, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer const& data);
+    bool read_webgl_buffer_sub_data(Web::Painting::CanvasId, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer const& data);
 
     Function<void(u64 page_id, Web::MouseEvent)> on_mouse_event;
     Function<void()> on_compositor_lost;

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -79,11 +79,11 @@ private:
         return m_connection->read_webgl_pixels(*m_canvas_id, x, y, width, height, format, type, buf_size, pixels);
     }
 
-    virtual void read_buffer_sub_data(Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data) override
+    virtual bool read_buffer_sub_data(Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data) override
     {
         if (!m_canvas_id.has_value())
-            return;
-        m_connection->read_webgl_buffer_sub_data(*m_canvas_id, target, offset, size, data);
+            return false;
+        return m_connection->read_webgl_buffer_sub_data(*m_canvas_id, target, offset, size, data);
     }
 
     virtual Gfx::ShareableBitmap read_back_drawing_buffer(Gfx::IntRect const& rect) override

--- a/Tests/LibGC/CMakeLists.txt
+++ b/Tests/LibGC/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     TestGCContainers.cpp
     TestGCHeapGroup.cpp
     TestGCIdleCollection.cpp
+    TestPrimitiveStorage.cpp
     TestGCVisitor.cpp
 )
 

--- a/Tests/LibGC/TestPrimitiveStorage.cpp
+++ b/Tests/LibGC/TestPrimitiveStorage.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGC/PrimitiveStorage.h>
+#include <LibTest/TestCase.h>
+
+#if !defined(AK_OS_WINDOWS)
+#    include <AK/Platform.h>
+#    include <signal.h>
+#    include <sys/wait.h>
+#    include <unistd.h>
+#endif
+
+TEST_CASE(allocation)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_allocate(32));
+    EXPECT(storage.is_valid(handle));
+    EXPECT_EQ(storage.size(handle), 32u);
+    EXPECT(storage.capacity(handle) >= 32u);
+    EXPECT(storage.data(handle) != nullptr);
+    EXPECT(storage.contains(storage.data(handle), 32));
+
+    storage.bytes(handle).fill(0xaa);
+    EXPECT_EQ(storage.bytes(handle)[0], 0xaa);
+
+    storage.free(handle);
+}
+
+TEST_CASE(large_allocation)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_allocate(128 * KiB));
+    EXPECT(storage.is_valid(handle));
+    EXPECT_EQ(storage.size(handle), 128u * KiB);
+    EXPECT(storage.capacity(handle) >= 128u * KiB);
+    EXPECT(storage.data(handle) != nullptr);
+    EXPECT(storage.contains(handle, storage.data(handle), storage.size(handle)));
+
+    storage.free(handle);
+}
+
+TEST_CASE(freeing_top_large_allocation_reclaims_tail_capacity)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+
+    auto first = MUST(storage.try_reserve(0, 1ull * GiB));
+    auto first_offset = storage.offset(first);
+    storage.free(first);
+
+    auto replacement_capacity = GC::PrimitiveStorage::default_cage_size - first_offset;
+    ASSUME(replacement_capacity > 1ull * GiB);
+
+    auto replacement = MUST(storage.try_reserve(0, replacement_capacity));
+    EXPECT(storage.capacity(replacement) >= replacement_capacity);
+    storage.free(replacement);
+}
+
+#if !defined(AK_OS_WINDOWS)
+TEST_CASE(freeing_large_allocation_decommits_storage)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_allocate(128 * KiB));
+    auto tail = MUST(storage.try_allocate(128 * KiB));
+    auto* data = storage.data(handle);
+    *data = 0xaa;
+
+    storage.free(handle);
+
+    auto child = fork();
+    ASSUME(child >= 0);
+
+    if (child == 0) {
+        *data = 0x55;
+        _exit(0);
+    }
+
+    int status = 0;
+    EXPECT_EQ(waitpid(child, &status, 0), child);
+
+    auto died_from_inaccessible_memory = WIFSIGNALED(status) && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS);
+#    if defined(HAS_ADDRESS_SANITIZER)
+    auto died_from_asan = (WIFEXITED(status) && WEXITSTATUS(status) != 0) || (WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT);
+    EXPECT(died_from_inaccessible_memory || died_from_asan);
+#    else
+    EXPECT(died_from_inaccessible_memory);
+#    endif
+
+    storage.free(tail);
+}
+#endif
+
+TEST_CASE(resize_and_zero_fill_growth)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_allocate(8, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+    storage.bytes(handle).fill(0x7b);
+
+    MUST(storage.try_resize(handle, 64, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+    EXPECT_EQ(storage.size(handle), 64u);
+    EXPECT_EQ(storage.bytes(handle)[0], 0x7b);
+    EXPECT_EQ(storage.bytes(handle)[7], 0x7b);
+    for (size_t i = 8; i < storage.size(handle); ++i)
+        EXPECT_EQ(storage.bytes(handle)[i], 0u);
+
+    storage.free(handle);
+}
+
+TEST_CASE(reserve_capacity)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_reserve(16, 128 * KiB));
+    auto offset = storage.offset(handle);
+
+    MUST(storage.try_resize(handle, 96 * KiB, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+    EXPECT_EQ(storage.offset(handle), offset);
+    EXPECT_EQ(storage.size(handle), 96u * KiB);
+    EXPECT(storage.capacity(handle) >= 128u * KiB);
+
+    storage.free(handle);
+}
+
+TEST_CASE(resize_and_reserve_failure_preserves_existing_storage)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_reserve(16, 64 * KiB, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
+    auto offset = storage.offset(handle);
+    auto capacity = storage.capacity(handle);
+    auto* data = storage.data(handle);
+    storage.bytes(handle)[0] = 0x42;
+    storage.bytes(handle)[15] = 0x24;
+
+    auto result = storage.try_resize_and_reserve(handle, 32, GC::PrimitiveStorage::default_cage_size + 64 * KiB, GC::PrimitiveStorage::ZeroFillNewBytes::Yes);
+
+    EXPECT(result.is_error());
+    EXPECT_EQ(storage.offset(handle), offset);
+    EXPECT_EQ(storage.size(handle), 16u);
+    EXPECT_EQ(storage.capacity(handle), capacity);
+    EXPECT_EQ(storage.data(handle), data);
+    EXPECT_EQ(storage.bytes(handle)[0], 0x42);
+    EXPECT_EQ(storage.bytes(handle)[15], 0x24);
+
+    storage.free(handle);
+}
+
+TEST_CASE(free_invalidates_generation)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_allocate(32));
+    storage.free(handle);
+
+    EXPECT(!storage.is_valid(handle));
+    EXPECT(storage.data(handle) == nullptr);
+    EXPECT_EQ(storage.offset(handle), GC::PrimitiveStorage::invalid_offset);
+    EXPECT(storage.try_resize(handle, 64).is_error());
+}
+
+TEST_CASE(invalid_handle)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    GC::PrimitiveStorageHandle handle;
+
+    EXPECT(!storage.is_valid(handle));
+    EXPECT(storage.data(handle) == nullptr);
+    EXPECT_EQ(storage.size(handle), 0u);
+    EXPECT_EQ(storage.capacity(handle), 0u);
+}
+
+TEST_CASE(cage_has_tail_guard_outside_logical_size)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_allocate(1));
+    auto* cage_base = storage.cage_base();
+    VERIFY(cage_base);
+
+    EXPECT_EQ(storage.cage_size(), GC::PrimitiveStorage::default_cage_size);
+    EXPECT(storage.contains(cage_base + GC::PrimitiveStorage::default_cage_size - 1, 1));
+    EXPECT(!storage.contains(cage_base + GC::PrimitiveStorage::default_cage_size, 1));
+
+    storage.free(handle);
+}
+
+TEST_CASE(out_of_cage_rejection)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_allocate(32));
+    u8 local = 0;
+
+    EXPECT(!storage.contains(&local, 1));
+    EXPECT(!storage.contains(handle, &local, 1));
+    EXPECT(storage.contains(handle, storage.data(handle), 32));
+    EXPECT(!storage.contains(handle, storage.data(handle), storage.capacity(handle) + 1));
+
+    storage.free(handle);
+}

--- a/Tests/LibGC/TestPrimitiveStorage.cpp
+++ b/Tests/LibGC/TestPrimitiveStorage.cpp
@@ -24,8 +24,8 @@ TEST_CASE(small_allocation)
     EXPECT(storage.data(handle) != nullptr);
     EXPECT(storage.contains(storage.data(handle), 32));
 
-    storage.bytes(handle).fill(0xaa);
-    EXPECT_EQ(storage.bytes(handle)[0], 0xaa);
+    *storage.data(handle, 0) = 0xaa;
+    EXPECT_EQ(*storage.data(handle, 0), 0xaa);
 
     storage.free(handle);
 }
@@ -105,14 +105,15 @@ TEST_CASE(resize_and_zero_fill_growth)
 {
     auto& storage = GC::PrimitiveStorage::the();
     auto handle = MUST(storage.try_allocate(8, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
-    storage.bytes(handle).fill(0x7b);
+    for (size_t i = 0; i < storage.size(handle); ++i)
+        *storage.data(handle, i) = 0x7b;
 
     MUST(storage.try_resize(handle, 64, GC::PrimitiveStorage::ZeroFillNewBytes::Yes));
     EXPECT_EQ(storage.size(handle), 64u);
-    EXPECT_EQ(storage.bytes(handle)[0], 0x7b);
-    EXPECT_EQ(storage.bytes(handle)[7], 0x7b);
+    EXPECT_EQ(*storage.data(handle, 0), 0x7b);
+    EXPECT_EQ(*storage.data(handle, 7), 0x7b);
     for (size_t i = 8; i < storage.size(handle); ++i)
-        EXPECT_EQ(storage.bytes(handle)[i], 0u);
+        EXPECT_EQ(*storage.data(handle, i), 0u);
 
     storage.free(handle);
 }

--- a/Tests/LibGC/TestPrimitiveStorage.cpp
+++ b/Tests/LibGC/TestPrimitiveStorage.cpp
@@ -14,7 +14,7 @@
 #    include <unistd.h>
 #endif
 
-TEST_CASE(allocation)
+TEST_CASE(small_allocation)
 {
     auto& storage = GC::PrimitiveStorage::the();
     auto handle = MUST(storage.try_allocate(32));
@@ -27,6 +27,14 @@ TEST_CASE(allocation)
     storage.bytes(handle).fill(0xaa);
     EXPECT_EQ(storage.bytes(handle)[0], 0xaa);
 
+    storage.free(handle);
+}
+
+TEST_CASE(free_maximum_small_allocation)
+{
+    auto& storage = GC::PrimitiveStorage::the();
+    auto handle = MUST(storage.try_allocate(64 * KiB));
+    EXPECT_EQ(storage.capacity(handle), 64u * KiB);
     storage.free(handle);
 }
 

--- a/Tests/LibGC/TestPrimitiveStorage.cpp
+++ b/Tests/LibGC/TestPrimitiveStorage.cpp
@@ -139,8 +139,8 @@ TEST_CASE(resize_and_reserve_failure_preserves_existing_storage)
     auto offset = storage.offset(handle);
     auto capacity = storage.capacity(handle);
     auto* data = storage.data(handle);
-    storage.bytes(handle)[0] = 0x42;
-    storage.bytes(handle)[15] = 0x24;
+    *storage.data(handle, 0) = 0x42;
+    *storage.data(handle, 15) = 0x24;
 
     auto result = storage.try_resize_and_reserve(handle, 32, GC::PrimitiveStorage::default_cage_size + 64 * KiB, GC::PrimitiveStorage::ZeroFillNewBytes::Yes);
 
@@ -149,8 +149,8 @@ TEST_CASE(resize_and_reserve_failure_preserves_existing_storage)
     EXPECT_EQ(storage.size(handle), 16u);
     EXPECT_EQ(storage.capacity(handle), capacity);
     EXPECT_EQ(storage.data(handle), data);
-    EXPECT_EQ(storage.bytes(handle)[0], 0x42);
-    EXPECT_EQ(storage.bytes(handle)[15], 0x24);
+    EXPECT_EQ(*storage.data(handle, 0), 0x42);
+    EXPECT_EQ(*storage.data(handle, 15), 0x24);
 
     storage.free(handle);
 }

--- a/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.copyWithin.js
+++ b/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.copyWithin.js
@@ -134,6 +134,22 @@ describe("normal behavior", () => {
         });
     });
 
+    test("SharedArrayBuffer-backed arrays", () => {
+        TYPED_ARRAYS.forEach(T => {
+            const array = new T(new SharedArrayBuffer(T.BYTES_PER_ELEMENT * 6));
+            array.set([0, 54, 999, 1000, 0, 0]);
+            expect(array.copyWithin(3, 2, 4)).toEqual(array);
+            expect(array).toEqual(new T([0, 54, 999, 999, 1000, 0]));
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            const array = new T(new SharedArrayBuffer(T.BYTES_PER_ELEMENT * 6));
+            array.set([0n, 54n, 999n, 1000n, 0n, 0n]);
+            expect(array.copyWithin(3, 2, 4)).toEqual(array);
+            expect(array).toEqual(new T([0n, 54n, 999n, 999n, 1000n, 0n]));
+        });
+    });
+
     test("resizing during copyWithin", () => {
         TYPED_ARRAYS.forEach(T => {
             let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 4, {

--- a/Tests/LibWasm/CMakeLists.txt
+++ b/Tests/LibWasm/CMakeLists.txt
@@ -1,3 +1,5 @@
+ladybird_test(TestWasmMemory.cpp LibWasm LIBS LibGC LibWasm)
+
 add_executable(test-wasm test-wasm.cpp)
 target_link_libraries(test-wasm AK LibCore LibFileSystem JavaScriptTestRunnerMain LibTest LibWasm LibJS LibCrypto LibGC)
 set(wasm_test_root "${LADYBIRD_SOURCE_DIR}")

--- a/Tests/LibWasm/TestWasmMemory.cpp
+++ b/Tests/LibWasm/TestWasmMemory.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGC/PrimitiveStorage.h>
+#include <LibTest/TestCase.h>
+#include <LibWasm/AbstractMachine/AbstractMachine.h>
+
+static size_t memory_capacity(Wasm::MemoryInstance const& memory)
+{
+    return GC::PrimitiveStorage::the().capacity(memory.data().primitive_storage_handle());
+}
+
+TEST_CASE(wasm32_memory_without_max_uses_default_reservation)
+{
+    auto memory = MUST(Wasm::MemoryInstance::create(Wasm::MemoryType { Wasm::Limits(Wasm::AddressType::I32, 1) }));
+    auto* data_before_grow = memory.data().data();
+
+    EXPECT_EQ(memory.size(), Wasm::Constants::page_size);
+    EXPECT_EQ(memory_capacity(memory), static_cast<size_t>(Wasm::Constants::wasm32_default_memory_reservation_size));
+
+    EXPECT(memory.grow(Wasm::Constants::page_size));
+
+    EXPECT_EQ(memory.size(), 2uz * Wasm::Constants::page_size);
+    EXPECT_EQ(memory_capacity(memory), static_cast<size_t>(Wasm::Constants::wasm32_default_memory_reservation_size));
+    EXPECT_EQ(memory.data().data(), data_before_grow);
+}
+
+TEST_CASE(wasm32_memory_without_max_grows_reservation_geometrically)
+{
+    constexpr auto default_reservation_size = static_cast<size_t>(Wasm::Constants::wasm32_default_memory_reservation_size);
+    constexpr auto default_reservation_pages = default_reservation_size / Wasm::Constants::page_size;
+    static_assert(default_reservation_pages * Wasm::Constants::page_size == default_reservation_size);
+
+    auto memory = MUST(Wasm::MemoryInstance::create(Wasm::MemoryType { Wasm::Limits(Wasm::AddressType::I32, default_reservation_pages) }));
+
+    EXPECT_EQ(memory.size(), default_reservation_size);
+    EXPECT_EQ(memory_capacity(memory), default_reservation_size);
+
+    EXPECT(memory.grow(Wasm::Constants::page_size));
+
+    EXPECT_EQ(memory.size(), default_reservation_size + Wasm::Constants::page_size);
+    EXPECT_EQ(memory_capacity(memory), 2uz * default_reservation_size);
+}
+
+TEST_CASE(wasm32_memory_with_max_reserves_explicit_max)
+{
+    auto memory = MUST(Wasm::MemoryInstance::create(Wasm::MemoryType { Wasm::Limits(Wasm::AddressType::I32, 1, 3) }));
+
+    EXPECT_EQ(memory.size(), Wasm::Constants::page_size);
+    EXPECT_EQ(memory_capacity(memory), 3uz * Wasm::Constants::page_size);
+}
+
+TEST_CASE(memory64_memory_without_max_can_grow)
+{
+    auto memory = MUST(Wasm::MemoryInstance::create(Wasm::MemoryType { Wasm::Limits(Wasm::AddressType::I64, 0) }));
+
+    EXPECT_EQ(memory.size(), 0u);
+
+    EXPECT(memory.grow(Wasm::Constants::page_size));
+    EXPECT_EQ(memory.size(), Wasm::Constants::page_size);
+
+    EXPECT(memory.grow(4uz * Wasm::Constants::page_size));
+    EXPECT_EQ(memory.size(), 5uz * Wasm::Constants::page_size);
+}
+
+TEST_CASE(memory64_memory_without_max_cannot_grow_past_current_compiled_address_width)
+{
+    static_assert(Wasm::Constants::wasm64_max_pages == Wasm::Constants::wasm32_max_pages);
+    constexpr auto maximum_supported_size = static_cast<size_t>(Wasm::Constants::wasm64_max_pages * Wasm::Constants::page_size);
+
+    auto memory = MUST(Wasm::MemoryInstance::create(Wasm::MemoryType { Wasm::Limits(Wasm::AddressType::I64, 0) }));
+
+    EXPECT(!memory.grow(maximum_supported_size + Wasm::Constants::page_size));
+    EXPECT_EQ(memory.size(), 0u);
+}
+
+TEST_CASE(memory64_memory_initial_size_cannot_exceed_current_compiled_address_width)
+{
+    auto memory = Wasm::MemoryInstance::create(Wasm::MemoryType { Wasm::Limits(Wasm::AddressType::I64, Wasm::Constants::wasm64_max_pages + 1) });
+    EXPECT(memory.is_error());
+}
+
+TEST_CASE(memory_buffer_failed_resize_and_reserve_preserves_backing_storage)
+{
+    Wasm::MemoryBuffer buffer;
+    MUST(buffer.try_resize(Wasm::Constants::page_size));
+    auto handle = buffer.primitive_storage_handle();
+    auto offset = GC::PrimitiveStorage::the().offset(handle);
+    auto capacity = buffer.capacity();
+    auto* data = buffer.data();
+    buffer[0] = 0x42;
+    buffer[Wasm::Constants::page_size - 1] = 0x24;
+
+    auto result = buffer.try_resize(2uz * Wasm::Constants::page_size, GC::PrimitiveStorage::default_cage_size + Wasm::Constants::page_size);
+
+    EXPECT(result.is_error());
+    EXPECT_EQ(buffer.primitive_storage_handle().index, handle.index);
+    EXPECT_EQ(buffer.primitive_storage_handle().generation, handle.generation);
+    EXPECT_EQ(GC::PrimitiveStorage::the().offset(handle), offset);
+    EXPECT_EQ(buffer.size(), Wasm::Constants::page_size);
+    EXPECT_EQ(buffer.capacity(), capacity);
+    EXPECT_EQ(buffer.data(), data);
+    EXPECT_EQ(buffer[0], 0x42);
+    EXPECT_EQ(buffer[Wasm::Constants::page_size - 1], 0x24);
+}
+
+TEST_CASE(memory_buffer_copy_fill_and_move_helpers)
+{
+    Wasm::MemoryBuffer source;
+    Wasm::MemoryBuffer destination;
+    MUST(source.try_resize(32));
+    MUST(destination.try_resize(32));
+
+    for (u8 i = 0; i < 16; ++i)
+        source[i] = i;
+
+    destination.fill(0, 0xaa, 32);
+    for (size_t i = 0; i < 32; ++i)
+        EXPECT_EQ(destination[i], 0xaa);
+
+    destination.copy_from(source, 4, 8, 8);
+    for (size_t i = 0; i < 8; ++i)
+        EXPECT_EQ(destination[8 + i], source[4 + i]);
+
+    destination.move_data(10, 8, 8);
+    EXPECT_EQ(destination[10], 4);
+    EXPECT_EQ(destination[11], 5);
+    EXPECT_EQ(destination[16], 10);
+    EXPECT_EQ(destination[17], 11);
+
+    u8 replacement[] = { 1, 2, 3, 4 };
+    destination.overwrite(28, replacement, sizeof(replacement));
+    EXPECT_EQ(destination[28], 1);
+    EXPECT_EQ(destination[29], 2);
+    EXPECT_EQ(destination[30], 3);
+    EXPECT_EQ(destination[31], 4);
+}

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <AK/MemoryStream.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibTest/JavaScriptTestRunner.h>
@@ -34,9 +35,11 @@ TESTJS_GLOBAL_FUNCTION(read_binary_wasm_file, readBinaryWasmFile)
 
     auto array = TRY(JS::Uint8Array::create(realm, file_size.value()));
 
-    auto read = file.value()->read_until_filled(array->data());
+    auto bytes = MUST(ByteBuffer::create_uninitialized(file_size.value()));
+    auto read = file.value()->read_until_filled(bytes);
     if (read.is_error())
         return vm.throw_completion<JS::TypeError>(Utf16String::from_utf8(error_code_to_string(read.error().code())));
+    array->viewed_array_buffer()->overwrite(array->byte_offset(), bytes.data(), bytes.size());
 
     return JS::Value(array);
 }
@@ -171,7 +174,9 @@ TESTJS_GLOBAL_FUNCTION(parse_webassembly_module, parseWebAssemblyModule)
     if (!is<JS::Uint8Array>(*object))
         return vm.throw_completion<JS::TypeError>("Expected a Uint8Array argument to parse_webassembly_module"_utf16);
     auto& array = static_cast<JS::Uint8Array&>(*object);
-    FixedMemoryStream stream { array.data() };
+    auto record = JS::make_typed_array_with_buffer_witness_record(array, JS::ArrayBuffer::Order::SeqCst);
+    auto bytes = MUST(array.viewed_array_buffer()->copy_to_byte_buffer(array.byte_offset(), JS::typed_array_byte_length(record)));
+    FixedMemoryStream stream { ReadonlyBytes { bytes.data(), bytes.size() } };
     auto result = Wasm::Module::parse(stream);
     if (result.is_error())
         return vm.throw_completion<JS::SyntaxError>(Utf16String::from_utf8(Wasm::parse_error_to_byte_string(result.error())));
@@ -199,7 +204,9 @@ TESTJS_GLOBAL_FUNCTION(validate_webassembly_module, validateWebAssemblyModule)
     if (!is<JS::Uint8Array>(*object))
         return vm.throw_completion<JS::TypeError>("Expected a Uint8Array argument to validate_webassembly_module"_utf16);
     auto& array = static_cast<JS::Uint8Array&>(*object);
-    FixedMemoryStream stream { array.data() };
+    auto record = JS::make_typed_array_with_buffer_witness_record(array, JS::ArrayBuffer::Order::SeqCst);
+    auto bytes = MUST(array.viewed_array_buffer()->copy_to_byte_buffer(array.byte_offset(), JS::typed_array_byte_length(record)));
+    FixedMemoryStream stream { ReadonlyBytes { bytes.data(), bytes.size() } };
     auto result = Wasm::Module::parse(stream);
     if (result.is_error())
         return vm.throw_completion<JS::SyntaxError>(Utf16String::from_utf8(Wasm::parse_error_to_byte_string(result.error())));
@@ -250,9 +257,13 @@ TESTJS_GLOBAL_FUNCTION(compare_typed_arrays, compareTypedArrays)
     auto& rhs_array = static_cast<JS::TypedArrayBase&>(*rhs);
     auto lhs_record = JS::make_typed_array_with_buffer_witness_record(lhs_array, JS::ArrayBuffer::Order::SeqCst);
     auto rhs_record = JS::make_typed_array_with_buffer_witness_record(rhs_array, JS::ArrayBuffer::Order::SeqCst);
-    auto lhs_bytes = lhs_array.viewed_array_buffer()->bytes().slice(lhs_array.byte_offset(), JS::typed_array_byte_length(lhs_record));
-    auto rhs_bytes = rhs_array.viewed_array_buffer()->bytes().slice(rhs_array.byte_offset(), JS::typed_array_byte_length(rhs_record));
-    return JS::Value(lhs_bytes == rhs_bytes);
+    auto lhs_byte_length = JS::typed_array_byte_length(lhs_record);
+    auto rhs_byte_length = JS::typed_array_byte_length(rhs_record);
+    if (lhs_byte_length != rhs_byte_length)
+        return JS::Value(false);
+    auto lhs_bytes = MUST(lhs_array.viewed_array_buffer()->copy_to_byte_buffer(lhs_array.byte_offset(), lhs_byte_length));
+    auto rhs_bytes = MUST(rhs_array.viewed_array_buffer()->copy_to_byte_buffer(rhs_array.byte_offset(), rhs_byte_length));
+    return JS::Value(lhs_bytes.bytes() == rhs_bytes.bytes());
 }
 
 static bool _is_canonical_nan32(u32 value)
@@ -461,9 +472,12 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::wasm_invoke)
             if (!is<JS::TypedArrayBase>(*object))
                 return vm.throw_completion<JS::TypeError>("Expected typed array"_utf16);
             auto& array = static_cast<JS::TypedArrayBase&>(*object);
+            auto record = JS::make_typed_array_with_buffer_witness_record(array, JS::ArrayBuffer::Order::SeqCst);
+            if (JS::typed_array_byte_length(record) < sizeof(u128))
+                return vm.throw_completion<JS::TypeError>("Expected at least 16 bytes"_utf16);
             u128 bits = 0;
             auto* ptr = bit_cast<u8*>(&bits);
-            memcpy(ptr, array.viewed_array_buffer()->data(), 16);
+            array.viewed_array_buffer()->copy_to(array.byte_offset(), { ptr, sizeof(u128) });
             arguments.append(Wasm::Value(bits));
             break;
         }
@@ -547,7 +561,8 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::wasm_invoke)
             u128 val = value.to<u128>();
             // FIXME: remove the MUST here
             auto buf = MUST(JS::ArrayBuffer::create(*vm.current_realm(), 16));
-            memcpy(buf->data(), val.bytes().data(), 16);
+            auto bytes = val.bytes();
+            buf->overwrite(0, bytes.data(), bytes.size());
             return JS::Value(buf);
         }
         case Wasm::ValueType::FunctionReference:

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -208,6 +208,36 @@ TESTJS_GLOBAL_FUNCTION(validate_webassembly_module, validateWebAssemblyModule)
     return JS::js_undefined();
 }
 
+TESTJS_GLOBAL_FUNCTION(is_cranelift_compiled, isCraneliftCompiled)
+{
+    auto address = static_cast<unsigned long>(TRY(vm.argument(0).to_double(vm)));
+    auto function_instance = WebAssemblyModule::machine().store().get(Wasm::FunctionAddress { address });
+    if (!function_instance)
+        return vm.throw_completion<JS::TypeError>("Invalid function address"_utf16);
+
+    auto* wasm_function = function_instance->get_pointer<Wasm::WasmFunction>();
+    if (!wasm_function)
+        return JS::Value(false);
+
+    auto const& compiled_instructions = wasm_function->code().func().body().compiled_instructions;
+    return JS::Value(Wasm::cranelift_entry_acquire(compiled_instructions) != 0);
+}
+
+TESTJS_GLOBAL_FUNCTION(is_cranelift_eligible, isCraneliftEligible)
+{
+    auto address = static_cast<unsigned long>(TRY(vm.argument(0).to_double(vm)));
+    auto function_instance = WebAssemblyModule::machine().store().get(Wasm::FunctionAddress { address });
+    if (!function_instance)
+        return vm.throw_completion<JS::TypeError>("Invalid function address"_utf16);
+
+    auto* wasm_function = function_instance->get_pointer<Wasm::WasmFunction>();
+    if (!wasm_function)
+        return JS::Value(false);
+
+    auto const& compiled_instructions = wasm_function->code().func().body().compiled_instructions;
+    return JS::Value(compiled_instructions.cranelift_eligible);
+}
+
 TESTJS_GLOBAL_FUNCTION(compare_typed_arrays, compareTypedArrays)
 {
     auto lhs = TRY(vm.argument(0).to_object(vm));

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_SOURCES
     TestFetchResponse.cpp
     TestFetchURL.cpp
     TestHTMLTokenizer.cpp
+    TestImageData.cpp
     TestMicrosyntax.cpp
     TestMimeSniff.cpp
     TestNumbers.cpp
@@ -21,6 +22,7 @@ set(TEST_SOURCES
     TestSessionHistoryEntry.cpp
     TestSourceHighlighter.cpp
     TestStrings.cpp
+    TestWebIDLBuffers.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)
@@ -34,10 +36,12 @@ target_link_libraries(TestControlMessageQueue PRIVATE LibSync)
 target_link_libraries(TestFetchResponse PRIVATE LibGC LibHTTP LibJS)
 target_link_libraries(TestFetchURL PRIVATE LibURL)
 target_link_libraries(TestAccumulatedVisualContext PRIVATE LibGfx)
+target_link_libraries(TestImageData PRIVATE LibGC LibJS)
 target_link_libraries(TestPage PRIVATE LibGC LibJS)
 target_link_libraries(TestSecureContexts PRIVATE LibURL)
 target_link_libraries(TestSessionHistoryEntry PRIVATE LibJS LibURL)
 target_link_libraries(TestSourceHighlighter PRIVATE LibURL LibWebView)
+target_link_libraries(TestWebIDLBuffers PRIVATE LibGC LibJS)
 
 if (NOT WIN32)
     add_custom_target(test-css-tokenizer ALL DEPENDS css-tokenizer "${CMAKE_BINARY_DIR}/bin/test-css-tokenizer")

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_SOURCES
     TestSourceHighlighter.cpp
     TestStrings.cpp
     TestWebIDLBuffers.cpp
+    TestWebGLSpanWithStorage.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)
@@ -42,6 +43,7 @@ target_link_libraries(TestSecureContexts PRIVATE LibURL)
 target_link_libraries(TestSessionHistoryEntry PRIVATE LibJS LibURL)
 target_link_libraries(TestSourceHighlighter PRIVATE LibURL LibWebView)
 target_link_libraries(TestWebIDLBuffers PRIVATE LibGC LibJS)
+target_link_libraries(TestWebGLSpanWithStorage PRIVATE LibGC LibJS)
 
 if (NOT WIN32)
     add_custom_target(test-css-tokenizer ALL DEPENDS css-tokenizer "${CMAKE_BINARY_DIR}/bin/test-css-tokenizer")

--- a/Tests/LibWeb/TestImageData.cpp
+++ b/Tests/LibWeb/TestImageData.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/FlyString.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/Bindings/HostDefined.h>
+#include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/HTML/ImageData.h>
+#include <LibWeb/WebIDL/DOMException.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
+
+namespace {
+
+struct TestVM {
+    TestVM()
+        : vm(JS::VM::create())
+        , execution_context(MUST(JS::Realm::initialize_host_defined_realm(*vm, nullptr, nullptr)))
+    {
+        auto& realm = *vm->current_realm();
+        auto intrinsics = realm.create<Web::Bindings::Intrinsics>(realm);
+        realm.set_host_defined(make<Web::Bindings::HostDefined>(intrinsics));
+    }
+
+    ~TestVM()
+    {
+        vm->pop_execution_context();
+    }
+
+    NonnullRefPtr<JS::VM> vm;
+    NonnullOwnPtr<JS::ExecutionContext> execution_context;
+};
+
+GC::Ref<JS::Uint8ClampedArray> create_out_of_bounds_uint8_clamped_array(JS::Realm& realm)
+{
+    auto array_buffer = MUST(JS::ArrayBuffer::create(realm, 16));
+    array_buffer->set_max_byte_length(16);
+    MUST(array_buffer->try_resize(4));
+
+    auto typed_array = JS::Uint8ClampedArray::create(realm, 0, array_buffer);
+    typed_array->set_viewed_array_buffer(array_buffer.ptr());
+    typed_array->set_array_length(4);
+    typed_array->set_byte_length(4);
+    typed_array->set_byte_offset(8);
+
+    return typed_array;
+}
+
+}
+
+TEST_CASE(create_rejects_out_of_bounds_uint8_clamped_array)
+{
+    TestVM test_vm;
+    auto& realm = *test_vm.vm->current_realm();
+    auto data = create_out_of_bounds_uint8_clamped_array(realm);
+
+    auto result = Web::HTML::ImageData::create(realm, data, 1, 1);
+
+    EXPECT(result.is_exception());
+    auto exception = result.exception();
+    EXPECT(exception.has<GC::Ref<Web::WebIDL::DOMException>>());
+    EXPECT_EQ(exception.get<GC::Ref<Web::WebIDL::DOMException>>()->name(), "InvalidStateError"_fly_string);
+}

--- a/Tests/LibWeb/TestWebGLSpanWithStorage.cpp
+++ b/Tests/LibWeb/TestWebGLSpanWithStorage.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <AK/ByteBuffer.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/WebGL/WebGLRenderingContextBase.h>
+
+namespace {
+
+class WebGLRenderingContextBaseAccessor : public Web::WebGL::WebGLRenderingContextBase {
+    WEB_NON_IDL_PLATFORM_OBJECT(WebGLRenderingContextBaseAccessor, Web::WebGL::WebGLRenderingContextBase);
+
+public:
+    template<typename T>
+    using SpanWithStorage = Web::WebGL::WebGLRenderingContextBase::SpanWithStorage<T>;
+
+    using Web::WebGL::WebGLRenderingContextBase::span_from_float32_list;
+    using Web::WebGL::WebGLRenderingContextBase::span_from_int32_list;
+    using Web::WebGL::WebGLRenderingContextBase::span_from_uint32_list;
+
+    template<typename T>
+    static SpanWithStorage<T> make_span_with_storage(ByteBuffer storage)
+    {
+        return SpanWithStorage<T> { move(storage) };
+    }
+
+    template<typename T>
+    static SpanWithStorage<T> make_span_with_storage(Span<T> span)
+    {
+        return SpanWithStorage<T> { span };
+    }
+};
+
+struct TestVM {
+    TestVM()
+        : vm(JS::VM::create())
+        , execution_context(MUST(JS::Realm::initialize_host_defined_realm(*vm, nullptr, nullptr)))
+    {
+    }
+
+    ~TestVM()
+    {
+        vm->pop_execution_context();
+    }
+
+    NonnullRefPtr<JS::VM> vm;
+    NonnullOwnPtr<JS::ExecutionContext> execution_context;
+};
+
+static ByteBuffer make_inline_u32_buffer(ReadonlySpan<u32> values)
+{
+    auto buffer = MUST(ByteBuffer::create_uninitialized(values.size() * sizeof(u32)));
+    EXPECT(buffer.is_inline());
+    buffer.overwrite(0, values.data(), values.size() * sizeof(u32));
+    return buffer;
+}
+
+template<typename ArrayType>
+static GC::Ref<ArrayType> create_out_of_bounds_array(JS::Realm& realm)
+{
+    auto array_buffer = MUST(JS::ArrayBuffer::create(realm, 32));
+    array_buffer->set_max_byte_length(32);
+    MUST(array_buffer->try_resize(4));
+
+    auto typed_array = ArrayType::create(realm, 0, array_buffer);
+    typed_array->set_viewed_array_buffer(array_buffer.ptr());
+    typed_array->set_array_length(4);
+    typed_array->set_byte_length(4 * typed_array->element_size());
+    typed_array->set_byte_offset(16);
+
+    return typed_array;
+}
+
+}
+
+TEST_CASE(owning_span_rebuilds_storage_after_move_construction)
+{
+    Array values { 0x10203040u, 0x50607080u, 0x90a0b0c0u, 0xd0e0f000u };
+    auto original = WebGLRenderingContextBaseAccessor::make_span_with_storage<u32>(make_inline_u32_buffer(values.span()));
+    auto* original_data = original.data();
+
+    auto moved = move(original);
+
+    EXPECT_NE(moved.data(), original_data);
+    EXPECT_EQ(moved.size(), values.size());
+    for (size_t i = 0; i < values.size(); ++i)
+        EXPECT_EQ(moved.data()[i], values[i]);
+}
+
+TEST_CASE(owning_span_rebuilds_storage_after_move_assignment)
+{
+    Array values { 0x12345678u, 0x9abcdef0u, 0x0fedcba9u, 0x87654321u };
+    auto original = WebGLRenderingContextBaseAccessor::make_span_with_storage<u32>(make_inline_u32_buffer(values.span()));
+    auto* original_data = original.data();
+
+    Array other_values { 1u, 2u, 3u, 4u };
+    auto moved = WebGLRenderingContextBaseAccessor::make_span_with_storage<u32>(make_inline_u32_buffer(other_values.span()));
+    moved = move(original);
+
+    EXPECT_NE(moved.data(), original_data);
+    EXPECT_EQ(moved.size(), values.size());
+    for (size_t i = 0; i < values.size(); ++i)
+        EXPECT_EQ(moved.data()[i], values[i]);
+}
+
+TEST_CASE(non_owning_span_preserves_external_span_after_move)
+{
+    Array values { 10u, 20u, 30u, 40u };
+    auto original = WebGLRenderingContextBaseAccessor::make_span_with_storage<u32>(values.span());
+
+    auto moved = move(original);
+
+    EXPECT_EQ(moved.data(), values.data());
+    EXPECT_EQ(moved.size(), values.size());
+    for (size_t i = 0; i < values.size(); ++i)
+        EXPECT_EQ(moved.data()[i], values[i]);
+}
+
+TEST_CASE(out_of_bounds_float32_list_without_offset_is_empty)
+{
+    TestVM test_vm;
+    auto& realm = *test_vm.vm->current_realm();
+    Web::WebGL::WebGLRenderingContextBase::Float32List list { create_out_of_bounds_array<JS::Float32Array>(realm) };
+
+    auto span = MUST(WebGLRenderingContextBaseAccessor::span_from_float32_list(list, 0));
+
+    EXPECT_EQ(span.size(), 0u);
+    EXPECT(WebGLRenderingContextBaseAccessor::span_from_float32_list(list, 1).is_error());
+    EXPECT(WebGLRenderingContextBaseAccessor::span_from_float32_list(list, 0, 1).is_error());
+}
+
+TEST_CASE(out_of_bounds_int32_list_without_offset_is_empty)
+{
+    TestVM test_vm;
+    auto& realm = *test_vm.vm->current_realm();
+    Web::WebGL::WebGLRenderingContextBase::Int32List list { create_out_of_bounds_array<JS::Int32Array>(realm) };
+
+    auto span = MUST(WebGLRenderingContextBaseAccessor::span_from_int32_list(list, 0));
+
+    EXPECT_EQ(span.size(), 0u);
+    EXPECT(WebGLRenderingContextBaseAccessor::span_from_int32_list(list, 1).is_error());
+    EXPECT(WebGLRenderingContextBaseAccessor::span_from_int32_list(list, 0, 1).is_error());
+}
+
+TEST_CASE(out_of_bounds_uint32_list_without_offset_is_empty)
+{
+    TestVM test_vm;
+    auto& realm = *test_vm.vm->current_realm();
+    Web::WebGL::WebGLRenderingContextBase::Uint32List list { create_out_of_bounds_array<JS::Uint32Array>(realm) };
+
+    auto span = MUST(WebGLRenderingContextBaseAccessor::span_from_uint32_list(list, 0));
+
+    EXPECT_EQ(span.size(), 0u);
+    EXPECT(WebGLRenderingContextBaseAccessor::span_from_uint32_list(list, 1).is_error());
+    EXPECT(WebGLRenderingContextBaseAccessor::span_from_uint32_list(list, 0, 1).is_error());
+}

--- a/Tests/LibWeb/TestWebIDLBuffers.cpp
+++ b/Tests/LibWeb/TestWebIDLBuffers.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/DataView.h>
 #include <LibJS/Runtime/Realm.h>
@@ -65,7 +64,9 @@ GC::Ref<JS::DataView> create_out_of_bounds_data_view(JS::VM& vm)
 {
     auto& realm = *vm.current_realm();
     auto array_buffer = create_shrunken_resizable_array_buffer(vm);
-    return JS::DataView::create(realm, array_buffer.ptr(), JS::ByteLength { 4 }, 8);
+    auto data_view = JS::DataView::create(realm, array_buffer.ptr(), JS::ByteLength { 4 }, 8);
+
+    return data_view;
 }
 
 GC::Ref<JS::Uint16Array> create_uint16_array_view(JS::VM& vm, GC::Ref<JS::ArrayBuffer> array_buffer, u32 byte_offset, u32 element_length)
@@ -156,10 +157,11 @@ TEST_CASE(buffer_source_copy_and_checked_write_handle_in_bounds_views)
     u8 data_view_replacement[] { 0xe0, 0xe1 };
     EXPECT(!data_view_view.write_checked(data_view_replacement, 1).is_error());
 
-    EXPECT_EQ(array_buffer->bytes()[6], 0xf0);
-    EXPECT_EQ(array_buffer->bytes()[7], 0xf1);
-    EXPECT_EQ(array_buffer->bytes()[9], 0xe0);
-    EXPECT_EQ(array_buffer->bytes()[10], 0xe1);
+    auto final_bytes = MUST(array_buffer->copy_to_byte_buffer(0, 16));
+    EXPECT_EQ(final_bytes[6], 0xf0);
+    EXPECT_EQ(final_bytes[7], 0xf1);
+    EXPECT_EQ(final_bytes[9], 0xe0);
+    EXPECT_EQ(final_bytes[10], 0xe1);
 }
 
 TEST_CASE(webgl_buffer_source_copy_treats_out_of_bounds_views_as_empty)

--- a/Tests/LibWeb/TestWebIDLBuffers.cpp
+++ b/Tests/LibWeb/TestWebIDLBuffers.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibTest/TestCase.h>
+#include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 #include <LibWeb/WebIDL/Buffers.h>
 
 namespace {
@@ -29,6 +30,12 @@ struct TestVM {
 
     NonnullRefPtr<JS::VM> vm;
     NonnullOwnPtr<JS::ExecutionContext> execution_context;
+};
+
+struct ExposedWebGLRenderingContextBase : Web::WebGL::WebGLRenderingContextBase {
+    WEB_NON_IDL_PLATFORM_OBJECT(ExposedWebGLRenderingContextBase, Web::WebGL::WebGLRenderingContextBase);
+
+    using Web::WebGL::WebGLRenderingContextBase::copy_buffer_source_to_byte_buffer;
 };
 
 GC::Ref<JS::ArrayBuffer> create_shrunken_resizable_array_buffer(JS::VM& vm)
@@ -101,7 +108,7 @@ TEST_CASE(buffer_source_reports_out_of_bounds_views_as_empty)
     EXPECT_EQ(data_view_source.byte_length(), 0u);
 }
 
-TEST_CASE(array_buffer_view_checked_write_handles_in_bounds_views)
+TEST_CASE(buffer_source_copy_and_checked_write_handle_in_bounds_views)
 {
     TestVM test_vm;
     auto& realm = *test_vm.vm->current_realm();
@@ -121,6 +128,12 @@ TEST_CASE(array_buffer_view_checked_write_handles_in_bounds_views)
     Web::WebIDL::BufferSource typed_array_source { typed_array_view };
     EXPECT_EQ(typed_array_source.byte_length(), 4u);
 
+    auto typed_array_bytes = MUST(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 1));
+    EXPECT_EQ(typed_array_bytes.size(), 2uz);
+    EXPECT_EQ(typed_array_bytes[0], 0x16);
+    EXPECT_EQ(typed_array_bytes[1], 0x17);
+    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 3).is_error());
+
     u8 one_byte = 0xaa;
     EXPECT(typed_array_view.write_checked({ &one_byte, 1 }).is_error());
 
@@ -135,6 +148,11 @@ TEST_CASE(array_buffer_view_checked_write_handles_in_bounds_views)
     Web::WebIDL::BufferSource data_view_source { data_view_view };
     EXPECT_EQ(data_view_source.byte_length(), 4u);
 
+    auto data_view_bytes = MUST(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(data_view_source, 2, 2));
+    EXPECT_EQ(data_view_bytes.size(), 2uz);
+    EXPECT_EQ(data_view_bytes[0], 0x1a);
+    EXPECT_EQ(data_view_bytes[1], 0x1b);
+
     u8 data_view_replacement[] { 0xe0, 0xe1 };
     EXPECT(!data_view_view.write_checked(data_view_replacement, 1).is_error());
 
@@ -142,6 +160,23 @@ TEST_CASE(array_buffer_view_checked_write_handles_in_bounds_views)
     EXPECT_EQ(array_buffer->bytes()[7], 0xf1);
     EXPECT_EQ(array_buffer->bytes()[9], 0xe0);
     EXPECT_EQ(array_buffer->bytes()[10], 0xe1);
+}
+
+TEST_CASE(webgl_buffer_source_copy_treats_out_of_bounds_views_as_empty)
+{
+    TestVM test_vm;
+
+    Web::WebIDL::BufferSource typed_array_source { typed_array_view(*test_vm.vm) };
+    auto typed_array_bytes = MUST(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 0));
+    EXPECT_EQ(typed_array_bytes.size(), 0uz);
+    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 1).is_error());
+    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 0, 1).is_error());
+
+    Web::WebIDL::BufferSource data_view_source { make_data_view(*test_vm.vm) };
+    auto data_view_bytes = MUST(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(data_view_source, 0));
+    EXPECT_EQ(data_view_bytes.size(), 0uz);
+    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(data_view_source, 1).is_error());
+    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(data_view_source, 0, 1).is_error());
 }
 
 TEST_CASE(array_buffer_view_checked_write_handles_out_of_bounds_views)
@@ -162,4 +197,35 @@ TEST_CASE(array_buffer_view_checked_write_handles_out_of_bounds_views)
     EXPECT(!data_view.write_checked(empty_bytes).is_error());
     EXPECT(data_view.write_checked(empty_bytes, 1).is_error());
     EXPECT(data_view.write_checked(one_byte).is_error());
+}
+
+TEST_CASE(array_buffer_view_checked_write_handles_detached_views)
+{
+    TestVM test_vm;
+    auto& realm = *test_vm.vm->current_realm();
+    auto empty_bytes = MUST(ByteBuffer::create_uninitialized(0));
+    u8 byte = 0xaa;
+    ReadonlyBytes one_byte { &byte, 1 };
+
+    auto typed_array_buffer = MUST(JS::ArrayBuffer::create(realm, 4));
+    auto typed_array = create_uint16_array_view(*test_vm.vm, typed_array_buffer, 0, 2);
+    MUST(JS::detach_array_buffer(realm.vm(), *typed_array_buffer));
+
+    Web::WebIDL::ArrayBufferViewVariant typed_array_view_variant { typed_array };
+    Web::WebIDL::ArrayBufferView typed_array_view { typed_array_view_variant };
+    EXPECT(typed_array_view.is_out_of_bounds());
+    EXPECT(!typed_array_view.write_checked(empty_bytes).is_error());
+    EXPECT(typed_array_view.write_checked(empty_bytes, 1).is_error());
+    EXPECT(typed_array_view.write_checked(one_byte).is_error());
+
+    auto data_view_buffer = MUST(JS::ArrayBuffer::create(realm, 4));
+    auto data_view = JS::DataView::create(realm, data_view_buffer.ptr(), JS::ByteLength { 4 }, 0);
+    MUST(JS::detach_array_buffer(realm.vm(), *data_view_buffer));
+
+    Web::WebIDL::ArrayBufferViewVariant data_view_variant { data_view };
+    Web::WebIDL::ArrayBufferView data_view_view { data_view_variant };
+    EXPECT(data_view_view.is_out_of_bounds());
+    EXPECT(!data_view_view.write_checked(empty_bytes).is_error());
+    EXPECT(data_view_view.write_checked(empty_bytes, 1).is_error());
+    EXPECT(data_view_view.write_checked(one_byte).is_error());
 }

--- a/Tests/LibWeb/TestWebIDLBuffers.cpp
+++ b/Tests/LibWeb/TestWebIDLBuffers.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteBuffer.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/DataView.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/WebIDL/Buffers.h>
+
+namespace {
+
+struct TestVM {
+    TestVM()
+        : vm(JS::VM::create())
+        , execution_context(MUST(JS::Realm::initialize_host_defined_realm(*vm, nullptr, nullptr)))
+    {
+    }
+
+    ~TestVM()
+    {
+        vm->pop_execution_context();
+    }
+
+    NonnullRefPtr<JS::VM> vm;
+    NonnullOwnPtr<JS::ExecutionContext> execution_context;
+};
+
+GC::Ref<JS::ArrayBuffer> create_shrunken_resizable_array_buffer(JS::VM& vm)
+{
+    auto& realm = *vm.current_realm();
+    auto array_buffer = MUST(JS::ArrayBuffer::create(realm, 16));
+    array_buffer->set_max_byte_length(16);
+    MUST(array_buffer->try_resize(4));
+    return array_buffer;
+}
+
+GC::Ref<JS::Uint8Array> create_out_of_bounds_uint8_array(JS::VM& vm)
+{
+    auto& realm = *vm.current_realm();
+    auto array_buffer = create_shrunken_resizable_array_buffer(vm);
+    auto typed_array = JS::Uint8Array::create(realm, 0, array_buffer);
+
+    typed_array->set_viewed_array_buffer(array_buffer.ptr());
+    typed_array->set_array_length(4);
+    typed_array->set_byte_length(4);
+    typed_array->set_byte_offset(8);
+
+    return typed_array;
+}
+
+GC::Ref<JS::DataView> create_out_of_bounds_data_view(JS::VM& vm)
+{
+    auto& realm = *vm.current_realm();
+    auto array_buffer = create_shrunken_resizable_array_buffer(vm);
+    return JS::DataView::create(realm, array_buffer.ptr(), JS::ByteLength { 4 }, 8);
+}
+
+GC::Ref<JS::Uint16Array> create_uint16_array_view(JS::VM& vm, GC::Ref<JS::ArrayBuffer> array_buffer, u32 byte_offset, u32 element_length)
+{
+    auto& realm = *vm.current_realm();
+    auto typed_array = JS::Uint16Array::create(realm, 0, array_buffer);
+
+    typed_array->set_viewed_array_buffer(array_buffer.ptr());
+    typed_array->set_array_length(element_length);
+    typed_array->set_byte_length(element_length * sizeof(u16));
+    typed_array->set_byte_offset(byte_offset);
+
+    return typed_array;
+}
+
+Web::WebIDL::ArrayBufferView typed_array_view(JS::VM& vm)
+{
+    Web::WebIDL::ArrayBufferViewVariant view { create_out_of_bounds_uint8_array(vm) };
+    return Web::WebIDL::ArrayBufferView { view };
+}
+
+Web::WebIDL::ArrayBufferView make_data_view(JS::VM& vm)
+{
+    Web::WebIDL::ArrayBufferViewVariant view { create_out_of_bounds_data_view(vm) };
+    return Web::WebIDL::ArrayBufferView { view };
+}
+
+}
+
+TEST_CASE(buffer_source_reports_out_of_bounds_views_as_empty)
+{
+    TestVM test_vm;
+
+    Web::WebIDL::BufferSource typed_array_source { typed_array_view(*test_vm.vm) };
+    EXPECT(typed_array_source.is_out_of_bounds());
+    EXPECT_EQ(typed_array_source.byte_length(), 0u);
+
+    Web::WebIDL::BufferSource data_view_source { make_data_view(*test_vm.vm) };
+    EXPECT(data_view_source.is_out_of_bounds());
+    EXPECT_EQ(data_view_source.byte_length(), 0u);
+}
+
+TEST_CASE(array_buffer_view_checked_write_handles_in_bounds_views)
+{
+    TestVM test_vm;
+    auto& realm = *test_vm.vm->current_realm();
+    auto array_buffer = MUST(JS::ArrayBuffer::create(realm, 16));
+    u8 initial_bytes[] {
+        0x10, 0x11, 0x12, 0x13,
+        0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b,
+        0x1c, 0x1d, 0x1e, 0x1f
+    };
+    array_buffer->overwrite(0, initial_bytes, sizeof(initial_bytes));
+
+    Web::WebIDL::ArrayBufferViewVariant typed_array_view_variant { create_uint16_array_view(*test_vm.vm, array_buffer, 4, 2) };
+    Web::WebIDL::ArrayBufferView typed_array_view { typed_array_view_variant };
+    EXPECT(!typed_array_view.is_out_of_bounds());
+
+    Web::WebIDL::BufferSource typed_array_source { typed_array_view };
+    EXPECT_EQ(typed_array_source.byte_length(), 4u);
+
+    u8 one_byte = 0xaa;
+    EXPECT(typed_array_view.write_checked({ &one_byte, 1 }).is_error());
+
+    u8 typed_array_replacement[] { 0xf0, 0xf1 };
+    EXPECT(!typed_array_view.write_checked(typed_array_replacement, 2).is_error());
+
+    auto data_view = JS::DataView::create(realm, array_buffer.ptr(), JS::ByteLength { 4 }, 8);
+    Web::WebIDL::ArrayBufferViewVariant data_view_variant { data_view };
+    Web::WebIDL::ArrayBufferView data_view_view { data_view_variant };
+    EXPECT(!data_view_view.is_out_of_bounds());
+
+    Web::WebIDL::BufferSource data_view_source { data_view_view };
+    EXPECT_EQ(data_view_source.byte_length(), 4u);
+
+    u8 data_view_replacement[] { 0xe0, 0xe1 };
+    EXPECT(!data_view_view.write_checked(data_view_replacement, 1).is_error());
+
+    EXPECT_EQ(array_buffer->bytes()[6], 0xf0);
+    EXPECT_EQ(array_buffer->bytes()[7], 0xf1);
+    EXPECT_EQ(array_buffer->bytes()[9], 0xe0);
+    EXPECT_EQ(array_buffer->bytes()[10], 0xe1);
+}
+
+TEST_CASE(array_buffer_view_checked_write_handles_out_of_bounds_views)
+{
+    TestVM test_vm;
+    auto empty_bytes = MUST(ByteBuffer::create_uninitialized(0));
+    u8 byte = 0xaa;
+    ReadonlyBytes one_byte { &byte, 1 };
+
+    auto typed_array = typed_array_view(*test_vm.vm);
+    EXPECT(typed_array.is_out_of_bounds());
+    EXPECT(!typed_array.write_checked(empty_bytes).is_error());
+    EXPECT(typed_array.write_checked(empty_bytes, 1).is_error());
+    EXPECT(typed_array.write_checked(one_byte).is_error());
+
+    auto data_view = make_data_view(*test_vm.vm);
+    EXPECT(data_view.is_out_of_bounds());
+    EXPECT(!data_view.write_checked(empty_bytes).is_error());
+    EXPECT(data_view.write_checked(empty_bytes, 1).is_error());
+    EXPECT(data_view.write_checked(one_byte).is_error());
+}

--- a/Tests/LibWeb/Text/expected/HTML/ImageData-detached-data.txt
+++ b/Tests/LibWeb/Text/expected/HTML/ImageData-detached-data.txt
@@ -1,0 +1,6 @@
+data identity before detach: true
+dimensions before detach: 1x1
+data byteLength after detach: 0
+dimensions after detach: 1x1
+putImageData with detached ImageData data: InvalidStateError
+createImageBitmap with detached ImageData data: InvalidStateError

--- a/Tests/LibWeb/Text/expected/HTML/sourcebuffer-append-out-of-bounds-view.txt
+++ b/Tests/LibWeb/Text/expected/HTML/sourcebuffer-append-out-of-bounds-view.txt
@@ -1,0 +1,1 @@
+appendBuffer threw TypeError

--- a/Tests/LibWeb/Text/expected/WebAudio/AudioBuffer-copyFromChannel.txt
+++ b/Tests/LibWeb/Text/expected/WebAudio/AudioBuffer-copyFromChannel.txt
@@ -6,4 +6,5 @@ Error calling copyFromChannel: TypeError: Not an object of type Float32Array
 5,5,5,5,5,5,5,0,0,0
 2,2,2,2,2,5,5,0,0,0
 2,2,2,2,2,5,5,0,0,0
+1,2,1,2,3,4,5
 Done.

--- a/Tests/LibWeb/Text/expected/WebAudio/AudioBuffer-copyToChannel.txt
+++ b/Tests/LibWeb/Text/expected/WebAudio/AudioBuffer-copyToChannel.txt
@@ -6,4 +6,5 @@ Error calling copyToChannel: TypeError: Not an object of type Float32Array
 1,1,1,1,1,1,1
 2,2,3,3,3,3,3
 2,2,3,3,3,3,3
+1,2,1,2,3,4,5
 Done.

--- a/Tests/LibWeb/Text/expected/WebSocket/send-out-of-bounds-buffer-source.txt
+++ b/Tests/LibWeb/Text/expected/WebSocket/send-out-of-bounds-buffer-source.txt
@@ -1,0 +1,4 @@
+open
+typed array send threw TypeError
+data view send threw TypeError
+close

--- a/Tests/LibWeb/Text/expected/canvas/webgl-detached-buffer-source.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-detached-buffer-source.txt
@@ -1,0 +1,30 @@
+webgl bufferData detached view: INVALID_VALUE
+webgl bufferSubData detached view: INVALID_VALUE
+webgl texImage2D detached view: INVALID_OPERATION
+webgl texImage2D detached ImageData data: INVALID_VALUE
+webgl texSubImage2D detached view: INVALID_OPERATION
+webgl texSubImage2D detached ImageData data: INVALID_VALUE
+webgl readPixels valid view: NO_ERROR
+webgl readPixels oversized view: NO_ERROR
+webgl readPixels oversized tail: 17,17,17,17
+webgl readPixels empty rectangle: NO_ERROR
+webgl readPixels empty rectangle destination: 21,22,23,24
+webgl readPixels detached view: INVALID_OPERATION
+webgl2 bufferData detached view: INVALID_VALUE
+webgl2 bufferSubData detached view: INVALID_VALUE
+webgl2 texImage2D detached view: INVALID_OPERATION
+webgl2 texImage2D detached ImageData data: INVALID_VALUE
+webgl2 texSubImage2D detached view: INVALID_OPERATION
+webgl2 texSubImage2D detached ImageData data: INVALID_VALUE
+webgl2 readPixels valid view: NO_ERROR
+webgl2 readPixels oversized view: NO_ERROR
+webgl2 readPixels oversized tail: 17,17,17,17
+webgl2 readPixels empty rectangle: NO_ERROR
+webgl2 readPixels empty rectangle destination: 21,22,23,24
+webgl2 readPixels detached view: INVALID_OPERATION
+webgl2 bufferData detached view with source range: INVALID_VALUE
+webgl2 bufferSubData detached view with source range: INVALID_VALUE
+webgl2 getBufferSubData dstOffset past length: INVALID_VALUE
+webgl2 getBufferSubData dstOffset past length destination: 5,6,7,8
+webgl2 getBufferSubData unbound buffer: INVALID_OPERATION
+webgl2 getBufferSubData unbound destination: 9,8,7,6

--- a/Tests/LibWeb/Text/expected/geometry/dommatrix-typed-array-validation.txt
+++ b/Tests/LibWeb/Text/expected/geometry/dommatrix-typed-array-validation.txt
@@ -1,0 +1,8 @@
+DOMMatrix Float32Array 6: 1, 2, 3, 4, 5, 6, true
+DOMMatrix Float64Array 16: 1, 2, 5, 6, 13, 14, false
+DOMMatrix Float32Array invalid: TypeError
+DOMMatrix Float64Array invalid: TypeError
+DOMMatrixReadOnly Float32Array 6: 1, 2, 3, 4, 5, 6, true
+DOMMatrixReadOnly Float64Array 16: 1, 2, 5, 6, 13, 14, false
+DOMMatrixReadOnly Float32Array invalid: TypeError
+DOMMatrixReadOnly Float64Array invalid: TypeError

--- a/Tests/LibWeb/Text/expected/geometry/dommatrix-typed-array-validation.txt
+++ b/Tests/LibWeb/Text/expected/geometry/dommatrix-typed-array-validation.txt
@@ -1,8 +1,12 @@
 DOMMatrix Float32Array 6: 1, 2, 3, 4, 5, 6, true
+DOMMatrix Float32Array 6 with byteOffset: 1, 2, 3, 4, 5, 6, true
 DOMMatrix Float64Array 16: 1, 2, 5, 6, 13, 14, false
+DOMMatrix Float64Array 16 with byteOffset: 1, 2, 5, 6, 13, 14, false
 DOMMatrix Float32Array invalid: TypeError
 DOMMatrix Float64Array invalid: TypeError
 DOMMatrixReadOnly Float32Array 6: 1, 2, 3, 4, 5, 6, true
+DOMMatrixReadOnly Float32Array 6 with byteOffset: 1, 2, 3, 4, 5, 6, true
 DOMMatrixReadOnly Float64Array 16: 1, 2, 5, 6, 13, 14, false
+DOMMatrixReadOnly Float64Array 16 with byteOffset: 1, 2, 5, 6, 13, 14, false
 DOMMatrixReadOnly Float32Array invalid: TypeError
 DOMMatrixReadOnly Float64Array invalid: TypeError

--- a/Tests/LibWeb/Text/input/HTML/ImageData-detached-data.html
+++ b/Tests/LibWeb/Text/input/HTML/ImageData-detached-data.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<script src="../include.js"></script>
+<canvas id="canvas" width="1" height="1"></canvas>
+<script>
+    asyncTest(async done => {
+        const context = canvas.getContext("2d");
+        const pixels = new Uint8ClampedArray([1, 2, 3, 4]);
+        const imageData = new ImageData(pixels, 1, 1);
+
+        println(`data identity before detach: ${imageData.data === pixels}`);
+        println(`dimensions before detach: ${imageData.width}x${imageData.height}`);
+
+        pixels.buffer.transfer();
+
+        println(`data byteLength after detach: ${imageData.data.byteLength}`);
+        println(`dimensions after detach: ${imageData.width}x${imageData.height}`);
+
+        try {
+            context.putImageData(imageData, 0, 0);
+            println("putImageData with detached ImageData data: did not throw");
+        } catch (error) {
+            println(`putImageData with detached ImageData data: ${error.name}`);
+        }
+
+        try {
+            await createImageBitmap(imageData);
+            println("createImageBitmap with detached ImageData data: resolved");
+        } catch (error) {
+            println(`createImageBitmap with detached ImageData data: ${error.name}`);
+        }
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/sourcebuffer-append-out-of-bounds-view.html
+++ b/Tests/LibWeb/Text/input/HTML/sourcebuffer-append-out-of-bounds-view.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<video id="video"></video>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const mimeType = 'video/webm;codecs="vp9,opus"';
+        const video = document.getElementById("video");
+        const mediaSource = new MediaSource();
+        video.src = URL.createObjectURL(mediaSource);
+
+        mediaSource.addEventListener("sourceopen", () => {
+            const sourceBuffer = mediaSource.addSourceBuffer(mimeType);
+            const buffer = new ArrayBuffer(200, { maxByteLength: 200 });
+            const view = new Uint8Array(buffer, 100);
+            buffer.resize(50);
+
+            try {
+                sourceBuffer.appendBuffer(view);
+                println("appendBuffer accepted out-of-bounds view as empty");
+            } catch (error) {
+                println(`appendBuffer threw ${error.name}`);
+            }
+            done();
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/WebAudio/AudioBuffer-copyFromChannel.html
+++ b/Tests/LibWeb/Text/input/WebAudio/AudioBuffer-copyFromChannel.html
@@ -57,6 +57,10 @@
         audioBuffer.copyFromChannel(biggerBuffer, 1, channel1Data.length + 1);
         println(biggerBuffer);
 
+        channel0Data.set([1, 2, 3, 4, 5, 6, 7]);
+        audioBuffer.copyFromChannel(channel0Data.subarray(2), 0, 0);
+        println(audioBuffer.getChannelData(0));
+
         // Copy channel into detached buffer (no crash)
         let detachedBuffer = new Float32Array(channel0Data.length);
         const transferred = detachedBuffer.buffer.transfer();

--- a/Tests/LibWeb/Text/input/WebAudio/AudioBuffer-copyToChannel.html
+++ b/Tests/LibWeb/Text/input/WebAudio/AudioBuffer-copyToChannel.html
@@ -67,6 +67,10 @@
         audioBuffer.copyToChannel(offsetBuffer, 1, channel1Data.length + 1);
         println(audioBuffer.getChannelData(1));
 
+        channel0Data.set([1, 2, 3, 4, 5, 6, 7]);
+        audioBuffer.copyToChannel(channel0Data.subarray(0, 5), 0, 2);
+        println(audioBuffer.getChannelData(0));
+
         // Copy buffer into detached buffer (no crash)
         let detachedBuffer = new Float32Array(channel0Data.length);
         const transferred = detachedBuffer.buffer.transfer();

--- a/Tests/LibWeb/Text/input/WebSocket/send-out-of-bounds-buffer-source.html
+++ b/Tests/LibWeb/Text/input/WebSocket/send-out-of-bounds-buffer-source.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    function makeOutOfBoundsUint8Array() {
+        const buffer = new ArrayBuffer(200, { maxByteLength: 200 });
+        const view = new Uint8Array(buffer, 100);
+        buffer.resize(50);
+        return view;
+    }
+
+    function makeOutOfBoundsDataView() {
+        const buffer = new ArrayBuffer(200, { maxByteLength: 200 });
+        const view = new DataView(buffer, 100);
+        buffer.resize(50);
+        return view;
+    }
+
+    asyncTest(done => {
+        const ws = new WebSocket(`ws://localhost:${internals.getEchoServerPort()}/`);
+
+        ws.onopen = event => {
+            println(event.type);
+            try {
+                ws.send(makeOutOfBoundsUint8Array());
+                println("sent out-of-bounds typed array as empty");
+            } catch (error) {
+                println(`typed array send threw ${error.name}`);
+            }
+            try {
+                ws.send(makeOutOfBoundsDataView());
+                println("sent out-of-bounds data view as empty");
+            } catch (error) {
+                println(`data view send threw ${error.name}`);
+            }
+            ws.close();
+        };
+        ws.onclose = event => {
+            println(event.type);
+            done();
+        };
+        ws.onerror = event => {
+            println(event.type);
+            done();
+        };
+    });
+</script>

--- a/Tests/LibWeb/Text/input/canvas/webgl-detached-buffer-source.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-detached-buffer-source.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    function detachedUint8Array(length = 4) {
+        const view = new Uint8Array(length);
+        view.buffer.transfer();
+        return view;
+    }
+
+    function errorName(gl, error) {
+        switch (error) {
+        case gl.NO_ERROR:
+            return "NO_ERROR";
+        case gl.INVALID_ENUM:
+            return "INVALID_ENUM";
+        case gl.INVALID_VALUE:
+            return "INVALID_VALUE";
+        case gl.INVALID_OPERATION:
+            return "INVALID_OPERATION";
+        case gl.OUT_OF_MEMORY:
+            return "OUT_OF_MEMORY";
+        default:
+            return `0x${error.toString(16)}`;
+        }
+    }
+
+    function clearErrors(gl) {
+        while (gl.getError() !== gl.NO_ERROR) {
+        }
+    }
+
+    function printError(label, gl) {
+        println(`${label}: ${errorName(gl, gl.getError())}`);
+    }
+
+    function byteList(bytes) {
+        return Array.from(bytes).join(",");
+    }
+
+    function runBufferUploadTests(gl, label) {
+        const buffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        gl.bufferData(gl.ARRAY_BUFFER, 16, gl.STATIC_DRAW);
+        clearErrors(gl);
+
+        gl.bufferData(gl.ARRAY_BUFFER, detachedUint8Array(), gl.STATIC_DRAW);
+        printError(`${label} bufferData detached view`, gl);
+
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, detachedUint8Array());
+        printError(`${label} bufferSubData detached view`, gl);
+    }
+
+    function runTextureUploadTests(gl, label) {
+        const texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        clearErrors(gl);
+
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, detachedUint8Array());
+        printError(`${label} texImage2D detached view`, gl);
+
+        const imageDataPixels = new Uint8ClampedArray([1, 2, 3, 4]);
+        const imageData = new ImageData(imageDataPixels, 1, 1);
+        imageDataPixels.buffer.transfer();
+
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, imageData);
+        printError(`${label} texImage2D detached ImageData data`, gl);
+
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        clearErrors(gl);
+
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, detachedUint8Array());
+        printError(`${label} texSubImage2D detached view`, gl);
+
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, imageData);
+        printError(`${label} texSubImage2D detached ImageData data`, gl);
+    }
+
+    function runReadPixelsTests(gl, label) {
+        clearErrors(gl);
+
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(4));
+        printError(`${label} readPixels valid view`, gl);
+
+        const oversizedPixels = new Uint8Array(8);
+        oversizedPixels.fill(17);
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, oversizedPixels);
+        printError(`${label} readPixels oversized view`, gl);
+        println(`${label} readPixels oversized tail: ${byteList(oversizedPixels.subarray(4))}`);
+
+        const zeroPixels = new Uint8Array([21, 22, 23, 24]);
+        gl.readPixels(0, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, zeroPixels);
+        printError(`${label} readPixels empty rectangle`, gl);
+        println(`${label} readPixels empty rectangle destination: ${byteList(zeroPixels)}`);
+
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, detachedUint8Array());
+        printError(`${label} readPixels detached view`, gl);
+    }
+
+    function runBufferReadbackTests(gl) {
+        const buffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        gl.bufferData(gl.ARRAY_BUFFER, new Uint8Array([1, 2, 3, 4]), gl.STATIC_DRAW);
+        clearErrors(gl);
+
+        const offsetPastEndDestination = new Uint8Array([5, 6, 7, 8]);
+        gl.getBufferSubData(gl.ARRAY_BUFFER, 0, offsetPastEndDestination, 5);
+        printError("webgl2 getBufferSubData dstOffset past length", gl);
+        println(`webgl2 getBufferSubData dstOffset past length destination: ${byteList(offsetPastEndDestination)}`);
+
+        const destination = new Uint8Array([9, 8, 7, 6]);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        clearErrors(gl);
+
+        gl.getBufferSubData(gl.ARRAY_BUFFER, 0, destination);
+        printError("webgl2 getBufferSubData unbound buffer", gl);
+        println(`webgl2 getBufferSubData unbound destination: ${byteList(destination)}`);
+    }
+
+    test(() => {
+        const canvas = document.createElement("canvas");
+        const canvas2 = document.createElement("canvas");
+
+        const gl = canvas.getContext("webgl");
+        runBufferUploadTests(gl, "webgl");
+        runTextureUploadTests(gl, "webgl");
+        runReadPixelsTests(gl, "webgl");
+
+        const gl2 = canvas2.getContext("webgl2");
+        runBufferUploadTests(gl2, "webgl2");
+        runTextureUploadTests(gl2, "webgl2");
+        runReadPixelsTests(gl2, "webgl2");
+
+        gl2.bufferData(gl2.ARRAY_BUFFER, detachedUint8Array(), gl2.STATIC_DRAW, 0, 0);
+        printError("webgl2 bufferData detached view with source range", gl2);
+
+        gl2.bufferSubData(gl2.ARRAY_BUFFER, 0, detachedUint8Array(), 0, 0);
+        printError("webgl2 bufferSubData detached view with source range", gl2);
+
+        runBufferReadbackTests(gl2);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/geometry/dommatrix-typed-array-validation.html
+++ b/Tests/LibWeb/Text/input/geometry/dommatrix-typed-array-validation.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function report(label, callback) {
+            try {
+                const matrix = callback();
+                println(`${label}: ${matrix.a}, ${matrix.b}, ${matrix.c}, ${matrix.d}, ${matrix.e}, ${matrix.f}, ${matrix.is2D}`);
+            } catch (e) {
+                println(`${label}: ${e.name}`);
+            }
+        }
+
+        report("DOMMatrix Float32Array 6", () => DOMMatrix.fromFloat32Array(new Float32Array([1, 2, 3, 4, 5, 6])));
+        report("DOMMatrix Float64Array 16", () => DOMMatrix.fromFloat64Array(new Float64Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])));
+        report("DOMMatrix Float32Array invalid", () => DOMMatrix.fromFloat32Array(new Float32Array(1024 * 1024)));
+        report("DOMMatrix Float64Array invalid", () => DOMMatrix.fromFloat64Array(new Float64Array(1024 * 1024)));
+
+        report("DOMMatrixReadOnly Float32Array 6", () => DOMMatrixReadOnly.fromFloat32Array(new Float32Array([1, 2, 3, 4, 5, 6])));
+        report("DOMMatrixReadOnly Float64Array 16", () => DOMMatrixReadOnly.fromFloat64Array(new Float64Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])));
+        report("DOMMatrixReadOnly Float32Array invalid", () => DOMMatrixReadOnly.fromFloat32Array(new Float32Array(1024 * 1024)));
+        report("DOMMatrixReadOnly Float64Array invalid", () => DOMMatrixReadOnly.fromFloat64Array(new Float64Array(1024 * 1024)));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/geometry/dommatrix-typed-array-validation.html
+++ b/Tests/LibWeb/Text/input/geometry/dommatrix-typed-array-validation.html
@@ -12,12 +12,32 @@
         }
 
         report("DOMMatrix Float32Array 6", () => DOMMatrix.fromFloat32Array(new Float32Array([1, 2, 3, 4, 5, 6])));
+        report("DOMMatrix Float32Array 6 with byteOffset", () => {
+            const buffer = new ArrayBuffer(8 * Float32Array.BYTES_PER_ELEMENT);
+            new Float32Array(buffer).set([99, 100, 1, 2, 3, 4, 5, 6]);
+            return DOMMatrix.fromFloat32Array(new Float32Array(buffer, 2 * Float32Array.BYTES_PER_ELEMENT, 6));
+        });
         report("DOMMatrix Float64Array 16", () => DOMMatrix.fromFloat64Array(new Float64Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])));
+        report("DOMMatrix Float64Array 16 with byteOffset", () => {
+            const buffer = new ArrayBuffer(18 * Float64Array.BYTES_PER_ELEMENT);
+            new Float64Array(buffer).set([99, 100, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+            return DOMMatrix.fromFloat64Array(new Float64Array(buffer, 2 * Float64Array.BYTES_PER_ELEMENT, 16));
+        });
         report("DOMMatrix Float32Array invalid", () => DOMMatrix.fromFloat32Array(new Float32Array(1024 * 1024)));
         report("DOMMatrix Float64Array invalid", () => DOMMatrix.fromFloat64Array(new Float64Array(1024 * 1024)));
 
         report("DOMMatrixReadOnly Float32Array 6", () => DOMMatrixReadOnly.fromFloat32Array(new Float32Array([1, 2, 3, 4, 5, 6])));
+        report("DOMMatrixReadOnly Float32Array 6 with byteOffset", () => {
+            const buffer = new ArrayBuffer(8 * Float32Array.BYTES_PER_ELEMENT);
+            new Float32Array(buffer).set([99, 100, 1, 2, 3, 4, 5, 6]);
+            return DOMMatrixReadOnly.fromFloat32Array(new Float32Array(buffer, 2 * Float32Array.BYTES_PER_ELEMENT, 6));
+        });
         report("DOMMatrixReadOnly Float64Array 16", () => DOMMatrixReadOnly.fromFloat64Array(new Float64Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])));
+        report("DOMMatrixReadOnly Float64Array 16 with byteOffset", () => {
+            const buffer = new ArrayBuffer(18 * Float64Array.BYTES_PER_ELEMENT);
+            new Float64Array(buffer).set([99, 100, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+            return DOMMatrixReadOnly.fromFloat64Array(new Float64Array(buffer, 2 * Float64Array.BYTES_PER_ELEMENT, 16));
+        });
         report("DOMMatrixReadOnly Float32Array invalid", () => DOMMatrixReadOnly.fromFloat32Array(new Float32Array(1024 * 1024)));
         report("DOMMatrixReadOnly Float64Array invalid", () => DOMMatrixReadOnly.fromFloat64Array(new Float64Array(1024 * 1024)));
     });


### PR DESCRIPTION
This adds a primitive storage cage for JS `ArrayBuffer` backing stores and Wasm linear memories.

The security goal is to kill the classic arbitrary read/write primitive where an exploit turns an out-of-bounds `ArrayBuffer`, `TypedArray`, `DataView`, or Wasm memory access into a pointer to arbitrary process memory.

Primitive byte storage now lives inside one reserved 64 GiB cage, and caged addresses are derived as `cage_base + (offset & cage_mask)`. If an attacker corrupts a backing-store offset or reaches an unchecked memory access, the resulting address is constrained to the cage instead of being able to target the GC heap, stacks, code, vtables, or other process memory.

This is a containment boundary, not full intra-cage spatial safety. An out-of-bounds primitive can still potentially read or corrupt other primitive storage inside the cage, but it no longer directly becomes a whole-process read/write primitive.

The branch adds `GC::PrimitiveStorage` with large reservations and small slab allocation, ports `ArrayBuffer` and Wasm memory storage onto it, removes broad raw `bytes()` and `span()` APIs, and routes callers through explicit copy, overwrite, move, and checked write helpers.

Wasm compiled memory accesses now go through checked helpers, stale Cranelift cache blobs are invalidated, and the dead direct-memory path is removed.

It also tightens affected Web-exposed call sites while doing the port, including WebIDL `BufferSource` handling, WebGL staging, `ImageData` backing validation, `DOMMatrix` typed-array validation, and detached or out-of-bounds resizable `ArrayBuffer` views.