### PR TITLE
LibWeb: Treat stretched flex items' cross sizes as definite

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -508,12 +508,6 @@ CSSPixels FlexFormattingContext::specified_main_max_size_for_intrinsic_contribut
     return specified_main_max_size(item);
 }
 
-bool FlexFormattingContext::is_cross_auto(Box const& box) const
-{
-    auto& cross_length = computed_cross_size(box);
-    return cross_length.is_auto();
-}
-
 void FlexFormattingContext::set_has_definite_main_size(FlexItem& item)
 {
     if (main_axis_is_horizontal())
@@ -1380,19 +1374,14 @@ void FlexFormattingContext::calculate_cross_size_of_each_flex_line()
     }
 }
 
-// https://www.w3.org/TR/css-flexbox-1/#algo-stretch
+// https://drafts.csswg.org/css-flexbox-1/#algo-stretch
 void FlexFormattingContext::determine_used_cross_size_of_each_flex_item()
 {
     for (auto& flex_line : m_flex_lines) {
         for (auto& item : flex_line.items) {
-            //  If a flex item has align-self: stretch, its computed cross size property is auto,
-            //  and neither of its cross-axis margins are auto, the used outer cross size is the used cross size of its flex line,
-            //  clamped according to the item’s used min and max cross sizes.
-            auto flex_item_alignment = alignment_for_item(item.box);
-            if ((flex_item_alignment == CSS::AlignItems::Stretch || flex_item_alignment == CSS::AlignItems::Normal)
-                && is_cross_auto(item.box)
-                && !item.margins.cross_before_is_auto
-                && !item.margins.cross_after_is_auto) {
+            // If a flex item’s cross size depends on the available space in the cross axis, recalculate its cross
+            // size using the flex line’s cross size (rather than the flex container’s) as the available space.
+            if (flex_item_is_stretched(item)) {
                 auto unclamped_cross_size = flex_line.cross_size
                     - item.margins.cross_before - item.margins.cross_after
                     - item.padding.cross_before - item.padding.cross_after
@@ -1403,6 +1392,11 @@ void FlexFormattingContext::determine_used_cross_size_of_each_flex_item()
                 auto cross_max_size = !should_treat_cross_max_size_as_none(item.box) ? specified_cross_max_size(item) : CSSPixels::max();
 
                 item.cross_size = css_clamp(unclamped_cross_size, cross_min_size, cross_max_size);
+
+                // If the flex item’s cross size changed as a result, redo layout for its contents, treating this used
+                // size as its definite cross size so that percentage-sized children can be resolved.
+                set_cross_size(item, item.cross_size.value());
+                set_has_definite_cross_size(item);
             } else {
                 // Otherwise, the used cross size is the item’s hypothetical cross size.
                 item.cross_size = item.hypothetical_cross_size;

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -139,7 +139,6 @@ private:
     CSSPixels specified_cross_max_size(FlexItem const&) const;
     CSSPixels specified_main_max_size_for_intrinsic_contribution(FlexItem const&,
         AvailableSize const&) const;
-    bool is_cross_auto(Box const&) const;
     CSSPixels specified_main_min_size(FlexItem const&) const;
     CSSPixels specified_cross_min_size(FlexItem const&) const;
     CSSPixels calculate_inner_flex_container_cross_min_size() const;

--- a/Tests/LibWeb/Ref/expected/flex/stretched-item-in-multi-line-flex-container-has-definite-cross-size-ref.html
+++ b/Tests/LibWeb/Ref/expected/flex/stretched-item-in-multi-line-flex-container-has-definite-cross-size-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+    .centered {
+        display: flex;
+        align-items: center;
+        height: 200px;
+    }
+
+    .filled {
+        height: 200px;
+        background-color: blue;
+    }
+</style>
+<div class="centered">2</div>
+<div class="filled"></div>

--- a/Tests/LibWeb/Ref/input/flex/stretched-item-in-multi-line-flex-container-has-definite-cross-size.html
+++ b/Tests/LibWeb/Ref/input/flex/stretched-item-in-multi-line-flex-container-has-definite-cross-size.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/flex/stretched-item-in-multi-line-flex-container-has-definite-cross-size-ref.html" />
+<style>
+    .outer {
+        display: flex;
+        flex-wrap: wrap;
+        height: 200px;
+    }
+
+    .centered {
+        display: flex;
+        align-items: center;
+        flex-basis: 100%;
+    }
+
+    .filled {
+        flex-basis: 100%;
+    }
+
+    .filled > div {
+        height: 100%;
+        background-color: blue;
+    }
+</style>
+<div class="outer">
+    <div class="centered">2</div>
+</div>
+<div class="outer">
+    <div class="filled">
+        <div></div>
+    </div>
+</div>


### PR DESCRIPTION
Previously, this only happened in single-line or auto-sized flex containers. In a multi-line container with a definite cross size, the contents of stretched items were laid out against an indefinite cross size, leaving nested cross-axis alignment and percentage sizes unresolved.

This fixes the vertical alignment on the numpad of https://sudoku.com:

Before:

<img width="872" height="511" alt="image" src="https://github.com/user-attachments/assets/b82b15e7-3a80-40a4-8221-04f92d5e45c1" />


After:

<img width="872" height="511" alt="image" src="https://github.com/user-attachments/assets/de829a6b-ff9e-4f7a-9008-5e0b669b0f7c" />
