### PR TITLE
LibWeb: Only place abspos boxes below lines with preceding content

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -514,10 +514,12 @@ void InlineFormattingContext::generate_line_boxes()
 
                     if (box->display_before_box_type_transformation().is_block_outside()) {
                         auto block_position = line_box.fragments().is_empty() ? marker.offset().y() : line_box.bottom();
-                        static_position_rect.rect = { { 0, block_position }, { 0, 0 } };
+                        static_position_rect.rect = { { 0, block_position }, { m_containing_block_used_values.content_width(), 0 } };
                     } else {
                         static_position_rect.rect = { marker.offset(), { 0, 0 } };
                     }
+                    if (direction == CSS::Direction::Rtl)
+                        static_position_rect.horizontal_alignment = StaticPositionRect::Alignment::End;
                     found_static_position_marker = true;
                     break;
                 }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -513,7 +513,7 @@ void InlineFormattingContext::generate_line_boxes()
                         continue;
 
                     if (box->display_before_box_type_transformation().is_block_outside()) {
-                        auto block_position = line_box.fragments().is_empty() ? marker.offset().y() : line_box.bottom();
+                        auto block_position = marker.preceded_by_in_flow_content ? line_box.bottom() : marker.offset().y();
                         static_position_rect.rect = { { 0, block_position }, { m_containing_block_used_values.content_width(), 0 } };
                     } else {
                         static_position_rect.rect = { marker.offset(), { 0, 0 } };

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -67,6 +67,7 @@ void LineBox::add_static_position_marker(Box const& box)
         .inline_offset = m_inline_length,
         .block_offset = 0,
         .writing_mode = m_writing_mode,
+        .preceded_by_in_flow_content = !m_fragments.is_empty(),
     });
 }
 

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -20,6 +20,7 @@ public:
         CSSPixels inline_offset { 0 };
         CSSPixels block_offset { 0 };
         CSS::WritingMode writing_mode { CSS::WritingMode::HorizontalTb };
+        bool preceded_by_in_flow_content { false };
 
         CSSPixelPoint offset() const
         {

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -414,11 +414,8 @@ void LineBuilder::update_last_line()
         lowermost_box_bottom = max(lowermost_box_bottom, bottom_of_inline_box);
     }
 
-    auto marker_inline_offset = line_box.fragments().is_empty()
-        ? start_inline_offset
-        : inline_offset;
     for (auto& marker : line_box.static_position_markers()) {
-        marker.inline_offset += marker_inline_offset;
+        marker.inline_offset += inline_offset;
         marker.block_offset += block_offset + m_current_block_offset;
     }
 

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/CSS2/positioning/abspos-block-level-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/CSS2/positioning/abspos-block-level-001-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+.rtl {
+  direction: rtl
+}
+.absolute {
+  position: absolute;
+}
+.green {
+  background-color: lime;
+  padding: 0 1ch;
+}
+</style>
+<body>
+  <div>
+    <span class="absolute green">Block-level abspos before inline content</span>
+    <br>
+  </div>
+  <div>
+    <div>Inline content</div>
+    <div>Block-level abspos after inline content</div>
+  </div>
+  <div class=rtl>
+    <span class="absolute green">Block-level abspos before inline content</span>
+    <br>
+  </div>
+  <div class=rtl>
+    <div>Inline content</div>
+    <div>Block-level abspos after inline content</div>
+  </div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/positioning/abspos-block-level-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/positioning/abspos-block-level-001.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>CSS Test: Static positions of block-level absolutely positioned objects</title>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#static-position">
+<link rel="match" href="../../../../../expected/wpt-import/css/CSS2/positioning/abspos-block-level-001-ref.html">
+<link rel="author" title="Koji Ishii" href="mailto:kojii@chromium.org">
+<style>
+.rtl {
+  direction: rtl
+}
+.absolute {
+  position: absolute;
+}
+.red {
+  color: red;
+  padding: 0 1ch;
+}
+.green {
+  background-color: lime;
+  padding: 0 1ch;
+}
+</style>
+<body>
+  <div>
+    <div class="absolute green">Block-level abspos before inline content</div>
+    <span class="red">Inline content</span>
+  </div>
+  <div>
+    <span>Inline content</span>
+    <div class=absolute>Block-level abspos after inline content</div>
+  </div>
+  <br>
+  <div class=rtl>
+    <div class="absolute green">Block-level abspos before inline content</div>
+    <span class="red">Inline content</span>
+  </div>
+  <div class=rtl>
+    <span>Inline content</span>
+    <div class=absolute>Block-level abspos after inline content</div>
+  </div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-002.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: ltr; text-align: center;">
+  <div id=inflow></div>
+  <div id=float style="float: left;"></div>
+  <div id=abs style="transform: translateX(-50%);"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-003.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: ltr; text-align: right;">
+  <div id=inflow></div>
+  <div id=float style="float: left;"></div>
+  <div id=abs style="transform: translateX(-100%);"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-005.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: ltr; text-align: center;">
+  <div id=inflow></div>
+  <div id=float style="float: right;"></div>
+  <div id=abs style="transform: translateX(-50%);"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-006.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: ltr; text-align: right;">
+  <div id=inflow></div>
+  <div id=float style="float: right;"></div>
+  <div id=abs style="transform: translateX(-100%);"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-008.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-008.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: rtl; text-align: center;">
+  <div id=inflow></div>
+  <div id=float style="float: left;"></div>
+  <div id=abs style="transform: translateX(50%);"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-009.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-009.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: rtl; text-align: left;">
+  <div id=inflow></div>
+  <div id=float style="float: left;"></div>
+  <div id=abs style="transform: translateX(100%);"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-011.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-011.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: rtl; text-align: center;">
+  <div id=inflow></div>
+  <div id=float style="float: right;"></div>
+  <div id=abs style="transform: translateX(50%);"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-012.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-012.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: rtl; text-align: left;">
+  <div id=inflow></div>
+  <div id=float style="float: right;"></div>
+  <div id=abs style="transform: translateX(100%);"></div>
+</div>


### PR DESCRIPTION
Previously, a block-level abspos box was placed below its line box whenever the line had any fragments, even fragments appearing after the box itself.

This fixes a regression introduced in 0d656c30273 that caused the seek bar of the BBC News video player to be vertically misaligned:

Before:

<img width="661" height="78" alt="image" src="https://github.com/user-attachments/assets/aa0051e6-0413-4fcb-8431-16af2a9fe2ef" />

After:

<img width="661" height="78" alt="image" src="https://github.com/user-attachments/assets/940836d9-1aec-4b93-b9d2-1ae610f14844" />
