### PR TITLE
LibWeb: Thread containing-block constraints through LayoutInput

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1890,13 +1890,20 @@ void Document::update_layout(UpdateLayoutReason reason)
 
         {
             auto& viewport = static_cast<Layout::Viewport&>(*m_layout_root);
-            auto& viewport_state = layout_state.create(viewport);
+            auto& viewport_state = layout_state.create(
+                viewport,
+                Optional<CSSPixels> { viewport_rect.width() },
+                Optional<CSSPixels> { viewport_rect.height() });
             viewport_state.set_content_width(viewport_rect.width());
             viewport_state.set_content_height(viewport_rect.height());
 
             // NB: Called during layout update.
             if (document_element && document_element->unsafe_layout_node()) {
-                auto& icb_state = layout_state.create(as<Layout::NodeWithStyleAndBoxModelMetrics>(*document_element->unsafe_layout_node()));
+                auto percentage_basis = Layout::FormattingContext::constraints_for_child_context(viewport_state, {});
+                auto& icb_state = layout_state.create(
+                    as<Layout::NodeWithStyleAndBoxModelMetrics>(*document_element->unsafe_layout_node()),
+                    percentage_basis.percentage_basis_width,
+                    percentage_basis.percentage_basis_height);
                 icb_state.set_content_width(viewport_rect.width());
             }
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -123,11 +123,10 @@ void BlockFormattingContext::run(LayoutInput const& layout_input)
         layout_fieldset_with_rendered_legend(*fieldset_box, layout_input);
         return;
     }
-
     if (root().children_are_inline())
-        layout_inline_children(root(), available_space);
+        layout_inline_children(root(), layout_input, available_space);
     else
-        layout_block_level_children(root(), layout_input);
+        layout_block_level_children(root(), layout_input, available_space);
 
     // Fieldsets without a rendered legend skip collapsed margin assignment.
     if (is<FieldSetBox>(root()))
@@ -156,7 +155,17 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
             floating_box->used_values.set_content_x(floating_box->offset_from_edge);
         } else {
             // Right-side floats: offset_from_edge is from right edge (float_containing_block_width) to the left content edge of floating_box.
-            auto float_containing_block_width = containing_block_width_for(floating_box->box);
+            auto float_containing_block_width = [&] {
+                switch (floating_box->used_values.width_constraint) {
+                case SizeConstraint::MinContent:
+                    return CSSPixels(0);
+                case SizeConstraint::MaxContent:
+                    return CSSPixels::max();
+                case SizeConstraint::None:
+                    return floating_box->percentage_basis_width.value_or(0);
+                }
+                VERIFY_NOT_REACHED();
+            }();
             floating_box->used_values.set_content_x(float_containing_block_width - floating_box->offset_from_edge);
         }
     }
@@ -192,7 +201,7 @@ bool BlockFormattingContext::box_should_avoid_floats_because_it_establishes_fc(B
         && first_is_one_of(formatting_context_type.value(), Type::Block, Type::Flex, Type::Grid);
 }
 
-void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const& available_space)
+void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     auto remaining_available_space = available_space;
 
@@ -205,8 +214,8 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         remaining_available_space.width = AvailableSize::make_definite(remaining_width);
     }
 
-    if (box_is_sized_as_replaced_element(box, available_space)) {
-        compute_width_for_block_level_replaced_element_in_normal_flow(box, available_space);
+    if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
+        compute_width_for_block_level_replaced_element_in_normal_flow(box, available_space, containing_block_constraints);
         if (box.is_floating()) {
             // 10.3.6 Floating, replaced elements:
             // https://www.w3.org/TR/CSS22/visudet.html#float-replaced-width
@@ -217,7 +226,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     if (box.is_floating()) {
         // 10.3.5 Floating, non-replaced elements:
         // https://www.w3.org/TR/CSS22/visudet.html#float-width
-        compute_width_for_floating_box(box, available_space);
+        compute_width_for_floating_box(box, available_space, containing_block_constraints);
         return;
     }
 
@@ -285,10 +294,10 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
                     }
                 } else if (available_space.width.is_min_content()) {
                     if (formatting_context_type_created_by_box(box).has_value())
-                        width = CSS::Length::make_px(calculate_min_content_width(box));
+                        width = CSS::Length::make_px(calculate_min_content_width(box, containing_block_constraints));
                 } else if (available_space.width.is_max_content()) {
                     if (formatting_context_type_created_by_box(box).has_value())
-                        width = CSS::Length::make_px(calculate_max_content_width(box));
+                        width = CSS::Length::make_px(calculate_max_content_width(box, containing_block_constraints));
                 } else {
                     VERIFY_NOT_REACHED();
                 }
@@ -311,24 +320,24 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     };
 
     auto input_width = [&] -> CSS::LengthOrAuto {
-        if (box_is_sized_as_replaced_element(box, available_space)) {
+        if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
             // NOTE: Replaced elements had their width calculated independently above.
             //       We use that width as the input here to ensure that margins get resolved.
             return CSS::Length::make_px(box_state.content_width());
         }
         if (is<TableWrapper>(box))
-            return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, remaining_available_space));
+            return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, remaining_available_space, containing_block_constraints));
 
         // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
         // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
         if (auto const* html_element = as_if<HTML::HTMLElement>(box.dom_node()); html_element
             && html_element->uses_button_layout() && computed_values.width().is_auto()) {
-            return CSS::Length::make_px(calculate_fit_content_width(box, available_space));
+            return CSS::Length::make_px(calculate_fit_content_width(box, available_space, containing_block_constraints));
         }
 
         if (should_treat_width_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width()));
+        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width(), containing_block_constraints));
     }();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
@@ -336,8 +345,8 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.width)) {
-        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width());
+    if (!should_treat_max_width_as_none(box, available_space.width, containing_block_constraints)) {
+        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() > max_width)
             used_width = try_compute_width(CSS::Length::make_px(max_width));
     }
@@ -345,12 +354,12 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto() && !used_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width());
+        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() < min_width)
             used_width = try_compute_width(CSS::Length::make_px(min_width));
     }
 
-    if (!box_is_sized_as_replaced_element(box, available_space) && !used_width.is_auto())
+    if (!box_is_sized_as_replaced_element(box, available_space, containing_block_constraints) && !used_width.is_auto())
         box_state.set_content_width(used_width.to_px_or_zero());
 
     box_state.margin_left = margin_left.to_px_or_zero();
@@ -567,7 +576,7 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
     }
 }
 
-void BlockFormattingContext::compute_width_for_floating_box(Box const& box, AvailableSpace const& available_space)
+void BlockFormattingContext::compute_width_for_floating_box(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     // 10.3.5 Floating, non-replaced elements
     auto& computed_values = box.computed_values();
@@ -597,19 +606,19 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
                     - margin_left - computed_values.border_left().width - box_state.padding_left
                     - box_state.padding_right - computed_values.border_right().width - margin_right;
                 // Then the shrink-to-fit width is: min(max(preferred minimum width, available width), preferred width).
-                auto preferred_width = calculate_max_content_width(box);
+                auto preferred_width = calculate_max_content_width(box, containing_block_constraints);
                 if (preferred_width <= available_width) {
                     width = CSS::Length::make_px(preferred_width);
                 } else {
-                    auto preferred_minimum_width = calculate_min_content_width(box);
+                    auto preferred_minimum_width = calculate_min_content_width(box, containing_block_constraints);
                     width = CSS::Length::make_px(min(max(preferred_minimum_width, available_width), preferred_width));
                 }
             } else if (available_space.width.is_indefinite() || available_space.width.is_max_content()) {
                 // Fold the formula for shrink-to-fit width for indefinite and max-content available width.
-                width = CSS::Length::make_px(calculate_max_content_width(box));
+                width = CSS::Length::make_px(calculate_max_content_width(box, containing_block_constraints));
             } else {
                 // Fold the formula for shrink-to-fit width for min-content available width.
-                width = CSS::Length::make_px(calculate_min_content_width(box));
+                width = CSS::Length::make_px(calculate_min_content_width(box, containing_block_constraints));
             }
         }
 
@@ -619,7 +628,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     auto input_width = [&] -> CSS::LengthOrAuto {
         if (should_treat_width_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width()));
+        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width(), containing_block_constraints));
     }();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
@@ -627,8 +636,8 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.width)) {
-        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width());
+    if (!should_treat_max_width_as_none(box, available_space.width, containing_block_constraints)) {
+        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width(), containing_block_constraints);
         if (width.to_px_or_zero() > max_width)
             width = compute_width(CSS::Length::make_px(max_width));
     }
@@ -636,7 +645,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width());
+        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width(), containing_block_constraints);
         if (width.to_px_or_zero() < min_width)
             width = compute_width(CSS::Length::make_px(min_width));
     }
@@ -644,7 +653,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     box_state.set_content_width(width.to_px_or_zero());
 }
 
-void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_normal_flow(Box const& box, AvailableSpace const& available_space)
+void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_normal_flow(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     // 10.3.6 Floating, replaced elements
     auto& computed_values = box.computed_values();
@@ -661,35 +670,35 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
     auto const padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
 
     auto& box_state = m_state.get_mutable(box);
-    auto width = compute_width_for_replaced_element(box, available_space);
+    auto width = compute_width_for_replaced_element(box, available_space, containing_block_constraints);
     box_state.margin_left = margin_left;
     box_state.margin_right = margin_right;
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
     box_state.padding_left = padding_left;
     box_state.padding_right = padding_right;
-    box_state.set_content_width(calculate_inner_width(box, available_space.width, CSS::Size::make_px(width)));
+    box_state.set_content_width(calculate_inner_width(box, available_space.width, CSS::Size::make_px(width), containing_block_constraints));
 }
 
-void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box const& box, AvailableSpace const& available_space)
+void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
-    if (should_treat_height_as_auto(box, available_space)) {
+    if (should_treat_height_as_auto(box, available_space, containing_block_constraints)) {
         return;
     }
 
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
 
-    auto height = calculate_inner_height(box, available_space, box.computed_values().height());
+    auto height = calculate_inner_height(box, available_space, box.computed_values().height(), containing_block_constraints);
 
-    if (!should_treat_max_height_as_none(box, available_space.height)) {
+    if (!should_treat_max_height_as_none(box, available_space.height, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
-            auto max_height = calculate_inner_height(box, available_space, computed_values.max_height());
+            auto max_height = calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints);
             height = min(height, max_height);
         }
     }
     if (!computed_values.min_height().is_auto()) {
-        height = max(height, calculate_inner_height(box, available_space, computed_values.min_height()));
+        height = max(height, calculate_inner_height(box, available_space, computed_values.min_height(), containing_block_constraints));
     }
 
     box_state.set_content_height(height);
@@ -697,9 +706,9 @@ void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box cons
         box_state.set_has_definite_height(true);
 }
 
-void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& box, AvailableSpace const& available_space, FormattingContext const* box_formatting_context)
+void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, FormattingContext const* box_formatting_context)
 {
-    if (!should_treat_height_as_auto(box, available_space)) {
+    if (!should_treat_height_as_auto(box, available_space, containing_block_constraints)) {
         return;
     }
 
@@ -707,24 +716,24 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
     auto& box_state = m_state.get_mutable(box);
 
     CSSPixels height = 0;
-    if (box_is_sized_as_replaced_element(box, available_space)) {
-        height = compute_height_for_replaced_element(box, available_space);
+    if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
+        height = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
     } else {
         if (box_formatting_context) {
             height = box_formatting_context->automatic_content_height();
         } else {
-            height = compute_auto_height_for_block_level_element(box, m_state.get(box).available_inner_space_or_constraints_from(available_space));
+            height = compute_auto_height_for_block_level_element(box, m_state.get(box).available_inner_space_or_constraints_from(available_space), containing_block_constraints);
         }
     }
 
-    if (!should_treat_max_height_as_none(box, available_space.height)) {
+    if (!should_treat_max_height_as_none(box, available_space.height, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
-            auto max_height = calculate_inner_height(box, available_space, computed_values.max_height());
+            auto max_height = calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints);
             height = min(height, max_height);
         }
     }
     if (!computed_values.min_height().is_auto()) {
-        height = max(height, calculate_inner_height(box, available_space, computed_values.min_height()));
+        height = max(height, calculate_inner_height(box, available_space, computed_values.min_height(), containing_block_constraints));
     }
 
     if (box.document().in_quirks_mode()
@@ -783,14 +792,17 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
     box_state.set_content_height(height);
 }
 
-void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, LayoutInput const& layout_input, AvailableSpace const& available_space_for_children)
 {
+    // The layout input describes block_container itself; the inline formatting context gets
+    // the input for its children derived here.
+    auto const& available_space = layout_input.available_space;
     VERIFY(block_container.children_are_inline());
 
     auto& block_container_state = m_state.get_mutable(block_container);
 
     InlineFormattingContext context(m_state, m_layout_mode, block_container, block_container_state, *this);
-    context.run(LayoutInput { available_space });
+    context.run(layout_input_for_child_context(block_container_state, layout_input, available_space_for_children));
 
     if (!block_container_state.has_definite_width()) {
         // NOTE: min-width or max-width for boxes with inline children can only be applied after inside layout
@@ -798,12 +810,10 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
         auto used_width_px = context.automatic_content_width();
         // https://www.w3.org/TR/css-sizing-3/#sizing-values
         // Percentages are resolved against the width/height, as appropriate, of the box’s containing block.
-        CSSPixels containing_block_width = 0;
-        if (auto const* containing_block_used_values = m_state.try_get(*block_container.containing_block()))
-            containing_block_width = containing_block_used_values->content_width();
+        auto containing_block_width = layout_input.containing_block_constraints.percentage_basis_width.value_or(0);
         auto available_width = AvailableSize::make_definite(containing_block_width);
-        if (!should_treat_max_width_as_none(block_container, available_space.width)) {
-            auto max_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().max_width());
+        if (!should_treat_max_width_as_none(block_container, available_space.width, layout_input.containing_block_constraints)) {
+            auto max_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().max_width(), layout_input.containing_block_constraints);
             if (used_width_px > max_width_px)
                 used_width_px = max_width_px;
         }
@@ -822,7 +832,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
             return false;
         }();
         if (!should_treat_min_width_as_auto) {
-            auto min_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().min_width());
+            auto min_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().min_width(), layout_input.containing_block_constraints);
             if (used_width_px < min_width_px)
                 used_width_px = min_width_px;
         }
@@ -831,7 +841,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
     }
 }
 
-CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Box const& box, AvailableSpace const& available_space)
+CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     if (creates_block_formatting_context(box)) {
         return compute_auto_height_for_block_formatting_context_root(box);
@@ -843,16 +853,16 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
     if (display.is_flex_inside()) {
         // https://drafts.csswg.org/css-flexbox-1/#algo-main-container
         // NOTE: The automatic block size of a block-level flex container is its max-content size.
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero());
+        return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
     }
     if (display.is_grid_inside()) {
         // https://www.w3.org/TR/css-grid-2/#intrinsic-sizes
         // In both inline and block formatting contexts, the grid container’s auto block size is its
         // max-content size.
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero());
+        return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
     }
     if (display.is_table_inside()) {
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero());
+        return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
     }
 
     // https://www.w3.org/TR/CSS22/visudet.html#normal-block
@@ -909,48 +919,6 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
     return 0;
 }
 
-static CSSPixels containing_block_height_to_resolve_percentage_in_quirks_mode(Box const& box, LayoutState const& state)
-{
-    auto content_height_of = [&](NodeWithStyleAndBoxModelMetrics const& node) -> CSSPixels {
-        auto const* node_used_values = state.try_get(node);
-        if (!node_used_values)
-            return 0;
-        return node_used_values->content_height();
-    };
-
-    // https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk
-    auto containing_block = box.containing_block();
-    while (containing_block) {
-        // 1. Let element be the nearest ancestor containing block of element, if there is one.
-        //    Otherwise, return the initial containing block.
-        if (containing_block->is_viewport()) {
-            return content_height_of(*containing_block);
-        }
-
-        // 2. If element has a computed value of the display property that is table-cell, then return a
-        //    UA-defined value.
-        if (containing_block->display().is_table_cell()) {
-            // FIXME: Likely UA-defined value should not be 0.
-            return 0;
-        }
-
-        // 3. If element has a computed value of the height property that is not auto, then return element.
-        if (!containing_block->computed_values().height().is_auto()) {
-            return content_height_of(*containing_block);
-        }
-
-        // 4. If element has a computed value of the position property that is absolute, or if element is a
-        //    not a block container or a table wrapper box, then return element.
-        if (containing_block->is_absolutely_positioned() || !is<BlockContainer>(*containing_block) || is<TableWrapper>(*containing_block)) {
-            return content_height_of(*containing_block);
-        }
-
-        // 5. Jump to the first step.
-        containing_block = containing_block->containing_block();
-    }
-    VERIFY_NOT_REACHED();
-}
-
 void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContainer const& block_container, CSSPixels& bottom_of_lowest_margin_box, LayoutInput const& layout_input)
 {
     auto const& available_space = layout_input.available_space;
@@ -963,9 +931,12 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             // element, which was created by the layout entry point (and can end up absolutely
             // positioned, e.g. as a popover).
             auto box_is_document_element = box.dom_node() && box.dom_node() == box.document().document_element();
+            // The percentage basis of an absolutely positioned box is the padding box of its
+            // absolute positioning containing block; layout_absolutely_positioned_element() pins
+            // it once that rectangle is known.
             auto& box_state = is<ListItemMarkerBox>(box) || box_is_document_element
                 ? m_state.get_mutable(box)
-                : m_state.create(box);
+                : m_state.create(box, {}, {});
             StaticPositionRect static_position;
             auto static_position_x = CSSPixels(0);
             auto static_position_y = m_y_offset_of_current_block_container.value();
@@ -1001,6 +972,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     if (box.is_svg_mask_box() || box.is_svg_clip_box())
         return;
 
+    auto const& block_container_state = m_state.get(block_container);
     auto& box_state = [&]() -> LayoutState::UsedValues& {
         auto const* document_element = box.document().document_element();
         if (!m_state.has_subtree_root()
@@ -1008,15 +980,15 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             && box.is_inclusive_ancestor_of(*document_element->unsafe_layout_node())) {
             return m_state.get_mutable(box);
         }
-        return m_state.create(box);
+        return m_state.create(box, layout_input.containing_block_constraints.percentage_basis_width, layout_input.containing_block_constraints.percentage_basis_height);
     }();
 
-    resolve_vertical_box_model_metrics(box, m_state.get(block_container).content_width());
+    resolve_vertical_box_model_metrics(box, block_container_state.content_width());
 
     if (box.is_floating()) {
         auto const y = m_y_offset_of_current_block_container.value();
         auto margin_top = !m_margin_state.has_block_container_waiting_for_final_y_position() ? m_margin_state.current_collapsed_margin() : 0;
-        layout_floating_box(box, block_container, available_space, margin_top + y);
+        layout_floating_box(box, block_container, layout_input, margin_top + y);
         bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
         return;
     }
@@ -1036,7 +1008,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     // NOTE: In quirks mode, the html element's height matches the viewport so it can be treated as definite
     if (box_state.has_definite_height() || box_is_html_element_in_quirks_mode)
-        resolve_used_height_if_treated_as_auto(box, available_space);
+        resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
 
     auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, box);
 
@@ -1054,7 +1026,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     place_block_level_element_in_normal_flow_vertically(box, y + margin_top);
 
-    compute_width(box, available_space);
+    compute_width(box, available_space, layout_input.containing_block_constraints);
     avoid_float_intrusions(box, available_space);
 
     place_block_level_element_in_normal_flow_horizontally(box, available_space);
@@ -1065,21 +1037,14 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto shadow_root = box.dom_node() ? box.dom_node()->containing_shadow_root() : nullptr;
     bool is_in_ua_internal_shadow_tree = shadow_root && shadow_root->is_user_agent_internal();
     if (box.document().in_quirks_mode() && box.computed_values().height().is_percentage() && !is_table_box && !is_in_ua_internal_shadow_tree) {
-        // In quirks mode, for the purpose of calculating the height of an element, if the
-        // computed value of the position property of element is relative or static, the specified value
-        // for the height property of element is a <percentage>, and element does not have a computed
-        // value of the display property that is table-row, table-row-group, table-header-group,
-        // table-footer-group, table-cell or table-caption, the containing block of element must be
-        // calculated using the following algorithm, aborting on the first step that returns a value:
-        auto height = containing_block_height_to_resolve_percentage_in_quirks_mode(box, m_state);
-        available_space_for_height_resolution.height = AvailableSize::make_definite(height);
+        available_space_for_height_resolution.height = AvailableSize::make_definite(layout_input.containing_block_constraints.quirks_mode_percentage_basis_height.value_or(0));
     }
 
-    resolve_used_height_if_not_treated_as_auto(box, available_space_for_height_resolution);
+    resolve_used_height_if_not_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints);
 
     // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
     if (box.has_auto_content_box_size() || box.display().is_flex_inside()) {
-        resolve_used_height_if_treated_as_auto(box, available_space_for_height_resolution);
+        resolve_used_height_if_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints);
     }
 
     // This monster basically means: "a ListItemBox that does not have specified content in the ::marker pseudo-element".
@@ -1117,7 +1082,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
         // For boxes with auto height but non-auto min-height, we need to determine if the content height is less than
         // min-height. If so, we run layout with min-height as the available height.
-        if (should_treat_height_as_auto(box, available_space) && !box.computed_values().min_height().is_auto()) {
+        if (should_treat_height_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
             LayoutState throwaway_state(box);
             // Populate the entire containing block chain: the throwaway BFC may encounter abspos
             // elements whose containing block is an ancestor above `box`. We stop when the source
@@ -1128,22 +1093,22 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
                 throwaway_state.populate_node_from(m_state, *cb);
             }
 
-            throwaway_state.create(box);
+            throwaway_state.create(box, layout_input.containing_block_constraints.percentage_basis_width, layout_input.containing_block_constraints.percentage_basis_height);
             auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
-            measuring_context->run(LayoutInput { inner_available_space });
+            measuring_context->run(layout_input.with_available_space(inner_available_space));
             auto content_height = measuring_context->automatic_content_height();
-            auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height());
+            auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
             if (content_height < min_height) {
                 inner_available_space.height = AvailableSize::make_definite(min_height);
             }
         }
 
-        independent_formatting_context->run(LayoutInput { inner_available_space });
+        independent_formatting_context->run(layout_input.with_available_space(inner_available_space));
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
         if (box.children_are_inline()) {
-            layout_inline_children(as<BlockContainer>(box), space_available_for_children);
+            layout_inline_children(as<BlockContainer>(box), layout_input, space_available_for_children);
         } else {
             auto registered_block_container_y_position_update_callback = false;
             if (box_state.border_top > 0 || box_state.padding_top > 0) {
@@ -1159,8 +1124,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
                 registered_block_container_y_position_update_callback = true;
             }
 
-            auto child_layout_input = LayoutInput { space_available_for_children };
-            layout_block_level_children(as<BlockContainer>(box), child_layout_input);
+            layout_block_level_children(as<BlockContainer>(box), layout_input, space_available_for_children);
 
             if (registered_block_container_y_position_update_callback) {
                 m_margin_state.unregister_block_container_y_position_update_callback();
@@ -1171,7 +1135,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     // Tables already set their height during the independent formatting context run. When multi-line text cells are involved, using different
     // available space here than during the independent formatting context run can result in different line breaks and thus a different height.
     if (!box.display().is_table_inside()) {
-        resolve_used_height_if_treated_as_auto(box, available_space_for_height_resolution, independent_formatting_context);
+        resolve_used_height_if_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints, independent_formatting_context);
     }
 
     // Now that our children are formatted we place the ListItemBox with the left space we remembered.
@@ -1191,7 +1155,6 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     m_margin_state.add_margin(box_state.margin_bottom);
     m_margin_state.update_block_waiting_for_final_y_position();
 
-    auto const& block_container_state = m_state.get(block_container);
     compute_inset(box, content_box_rect(block_container_state).size());
 
     bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
@@ -1200,17 +1163,19 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         independent_formatting_context->parent_context_did_dimension_child_root_box();
 }
 
-void BlockFormattingContext::layout_block_level_children(BlockContainer const& block_container, LayoutInput const& layout_input)
+void BlockFormattingContext::layout_block_level_children(BlockContainer const& block_container, LayoutInput const& layout_input, AvailableSpace const& available_space_for_children)
 {
-    auto const& available_space = layout_input.available_space;
-
+    // The layout input describes block_container itself; its children get the input derived here.
     VERIFY(!block_container.children_are_inline());
+
+    auto const& available_space = available_space_for_children;
+    auto child_layout_input = layout_input_for_child_context(m_state.get(block_container), layout_input, available_space_for_children);
 
     CSSPixels bottom_of_lowest_margin_box = 0;
 
     TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, CSSPixels(0) };
     block_container.for_each_child_of_type<Box>([&](Box& box) {
-        layout_block_level_box(box, block_container, bottom_of_lowest_margin_box, layout_input);
+        layout_block_level_box(box, block_container, bottom_of_lowest_margin_box, child_layout_input);
         return IterationDecision::Continue;
     });
 
@@ -1225,14 +1190,14 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
             //       auto size in that axis (and no minimum or maximum size in that axis) and if its containing block
             //       was zero-sized in that axis.
             if (block_container_state.width_constraint == SizeConstraint::None) {
-                if (!should_treat_max_width_as_none(block_container, available_space.width)) {
+                if (!should_treat_max_width_as_none(block_container, available_space.width, layout_input.containing_block_constraints)) {
                     auto max_width = calculate_inner_width(block_container, available_space.width,
-                        computed_values.max_width());
+                        computed_values.max_width(), layout_input.containing_block_constraints);
                     width = min(width, max_width);
                 }
                 if (!computed_values.min_width().is_auto()) {
                     auto min_width = calculate_inner_width(block_container, available_space.width,
-                        computed_values.min_width());
+                        computed_values.min_width(), layout_input.containing_block_constraints);
                     width = max(width, min_width);
                 }
             }
@@ -1245,7 +1210,9 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
 // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
 void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox const& fieldset_box, LayoutInput const& layout_input)
 {
+    // The layout input describes the fieldset itself; its children get the input derived here.
     auto const& available_space = layout_input.available_space;
+    auto child_layout_input = layout_input_for_child_context(m_state.get(fieldset_box), layout_input, available_space);
 
     auto& fieldset_state = m_state.get_mutable(fieldset_box);
 
@@ -1256,13 +1223,13 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     {
         TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, CSSPixels(0) };
         CSSPixels dummy_bottom = 0;
-        layout_block_level_box(*legend, fieldset_box, dummy_bottom, layout_input);
+        layout_block_level_box(*legend, fieldset_box, dummy_bottom, child_layout_input);
     }
 
     // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
     auto& legend_state = m_state.get_mutable(*legend);
     if (legend->computed_values().width().is_auto()) {
-        auto width = calculate_fit_content_width(*legend, available_space);
+        auto width = calculate_fit_content_width(*legend, available_space, child_layout_input.containing_block_constraints);
         legend_state.set_content_width(width);
     }
 
@@ -1281,7 +1248,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
         fieldset_box.for_each_child_of_type<Box>([&](Box& child) {
             if (&child == legend)
                 return IterationDecision::Continue;
-            layout_block_level_box(child, fieldset_box, bottom_of_lowest_margin_box, layout_input);
+            layout_block_level_box(child, fieldset_box, bottom_of_lowest_margin_box, child_layout_input);
             return IterationDecision::Continue;
         });
     }
@@ -1290,12 +1257,12 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
         auto width = greatest_child_width(fieldset_box);
         auto const& computed_values = fieldset_box.computed_values();
         if (fieldset_state.width_constraint == SizeConstraint::None) {
-            if (!should_treat_max_width_as_none(fieldset_box, available_space.width)) {
-                auto max_width = calculate_inner_width(fieldset_box, available_space.width, computed_values.max_width());
+            if (!should_treat_max_width_as_none(fieldset_box, available_space.width, layout_input.containing_block_constraints)) {
+                auto max_width = calculate_inner_width(fieldset_box, available_space.width, computed_values.max_width(), layout_input.containing_block_constraints);
                 width = min(width, max_width);
             }
             if (!computed_values.min_width().is_auto()) {
-                auto min_width = calculate_inner_width(fieldset_box, available_space.width, computed_values.min_width());
+                auto min_width = calculate_inner_width(fieldset_box, available_space.width, computed_values.min_width(), layout_input.containing_block_constraints);
                 width = max(width, min_width);
             }
         }
@@ -1415,8 +1382,9 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
     box_state.set_content_x(x);
 }
 
-void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer const& block_container, AvailableSpace const& available_space, CSSPixels y, LineBuilder* line_builder)
+void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer const& block_container, LayoutInput const& layout_input, CSSPixels y, LineBuilder* line_builder)
 {
+    auto const& available_space = layout_input.available_space;
     VERIFY(box.is_floating());
 
     auto& box_state = m_state.get_mutable(box);
@@ -1425,18 +1393,17 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     auto const& block_container_state = m_state.get(block_container);
     resolve_vertical_box_model_metrics(box, block_container_state.content_width());
 
-    compute_width(box, available_space);
+    compute_width(box, available_space, layout_input.containing_block_constraints);
 
-    resolve_used_height_if_not_treated_as_auto(box, available_space);
+    resolve_used_height_if_not_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
 
     // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
     if (box.has_auto_content_box_size() || box.display().is_flex_inside()) {
-        resolve_used_height_if_treated_as_auto(box, available_space);
+        resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
     }
 
-    auto child_layout_input = LayoutInput { box_state.available_inner_space_or_constraints_from(available_space) };
-    auto independent_formatting_context = layout_inside(box, m_layout_mode, child_layout_input);
-    resolve_used_height_if_treated_as_auto(box, available_space, independent_formatting_context);
+    auto independent_formatting_context = layout_inside(box, m_layout_mode, layout_input.with_available_space(box_state.available_inner_space_or_constraints_from(available_space)));
+    resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints, independent_formatting_context);
 
     // Next, float to the left and/or right
     // FIXME: Honor writing-mode, direction and text-orientation.
@@ -1475,6 +1442,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         .top_margin_edge = content_y - box_state.margin_box_top(),
         .bottom_margin_edge = content_y + box_state.content_height() + box_state.margin_box_bottom(),
         .margin_box_rect_in_root_coordinate_space = margin_box_rect_in_root,
+        .percentage_basis_width = layout_input.containing_block_constraints.percentage_basis_width,
     }));
     add_float_to_bands(*m_floats.last(), containing_block_rect_in_root);
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -27,7 +27,7 @@ public:
     virtual CSSPixels automatic_content_height() const override;
 
     bool box_should_avoid_floats_because_it_establishes_fc(Box const&);
-    void compute_width(Box const&, AvailableSpace const&);
+    void compute_width(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints);
     void avoid_float_intrusions(Box const&, AvailableSpace const&);
 
     // https://www.w3.org/TR/css-display/#block-formatting-context-root
@@ -35,8 +35,8 @@ public:
 
     virtual void parent_context_did_dimension_child_root_box() override;
 
-    void resolve_used_height_if_not_treated_as_auto(Box const&, AvailableSpace const&);
-    void resolve_used_height_if_treated_as_auto(Box const&, AvailableSpace const&, FormattingContext const* box_formatting_context = nullptr);
+    void resolve_used_height_if_not_treated_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints);
+    void resolve_used_height_if_treated_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, FormattingContext const* box_formatting_context = nullptr);
 
     template<typename Callback>
     void for_each_floating_box(Callback callback)
@@ -55,7 +55,7 @@ public:
 
     virtual CSSPixels greatest_child_width(Box const&) const override;
 
-    void layout_floating_box(Box const& child, BlockContainer const& containing_block, AvailableSpace const&, CSSPixels y, LineBuilder* = nullptr);
+    void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutInput const&, CSSPixels y, LineBuilder* = nullptr);
 
     void layout_block_level_box(Box const&, BlockContainer const&, CSSPixels& bottom_of_lowest_margin_box, LayoutInput const&);
 
@@ -93,17 +93,18 @@ public:
         CSSPixels bottom_margin_edge { 0 };
 
         CSSPixelRect margin_box_rect_in_root_coordinate_space;
+        Optional<CSSPixels> percentage_basis_width;
     };
 
 private:
-    CSSPixels compute_auto_height_for_block_level_element(Box const&, AvailableSpace const&);
+    CSSPixels compute_auto_height_for_block_level_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
-    void compute_width_for_floating_box(Box const&, AvailableSpace const&);
+    void compute_width_for_floating_box(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
-    void compute_width_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&);
+    void compute_width_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
-    void layout_block_level_children(BlockContainer const&, LayoutInput const&);
-    void layout_inline_children(BlockContainer const&, AvailableSpace const&);
+    void layout_block_level_children(BlockContainer const&, LayoutInput const&, AvailableSpace const& available_space_for_children);
+    void layout_inline_children(BlockContainer const&, LayoutInput const&, AvailableSpace const& available_space_for_children);
     void layout_fieldset_with_rendered_legend(FieldSetBox const&, LayoutInput const&);
 
     void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -25,7 +25,7 @@ static String serialize_flex_basis(CSS::FlexBasis const& flex_basis)
 
 CSSPixels FlexFormattingContext::get_pixel_width(FlexItem const& item, CSS::Size const& size) const
 {
-    return calculate_inner_width(item.box, m_available_space->width, size);
+    return calculate_inner_width(item.box, m_available_space->width, size, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::get_pixel_height(FlexItem const& item, CSS::Size const& size) const
@@ -37,9 +37,9 @@ CSSPixels FlexFormattingContext::get_pixel_height(FlexItem const& item, CSS::Siz
         auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
         auto available_height = AvailableSize::make_indefinite();
         auto available_space = AvailableSpace { available_width, available_height };
-        return calculate_inner_height(item.box, available_space, size);
+        return calculate_inner_height(item.box, available_space, size, item_containing_block_constraints());
     }
-    return calculate_inner_height(item.box, m_available_space.value(), size);
+    return calculate_inner_height(item.box, m_available_space.value(), size, item_containing_block_constraints());
 }
 
 FlexFormattingContext::FlexFormattingContext(LayoutState& state, LayoutMode layout_mode, Box const& flex_container, FormattingContext* parent)
@@ -50,6 +50,14 @@ FlexFormattingContext::FlexFormattingContext(LayoutState& state, LayoutMode layo
 }
 
 FlexFormattingContext::~FlexFormattingContext() = default;
+
+ContainingBlockConstraints FlexFormattingContext::item_containing_block_constraints() const
+{
+    auto constraints = constraints_for_child_context(m_flex_container_state, m_layout_input->containing_block_constraints);
+    constraints.percentage_basis_width = m_item_percentage_bases.percentage_basis_width;
+    constraints.percentage_basis_height = m_item_percentage_bases.percentage_basis_height;
+    return constraints;
+}
 
 CSSPixels FlexFormattingContext::automatic_content_width() const
 {
@@ -77,6 +85,8 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
 
     FORMATTING_CONTEXT_TRACE();
     m_available_space = available_space;
+    m_layout_input.emplace(layout_input);
+    m_item_percentage_bases = constraints_for_child_context(m_flex_container_state, layout_input.containing_block_constraints);
 
     // 1. Generate anonymous flex items
     generate_anonymous_flex_items();
@@ -239,7 +249,7 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
         // AD-HOC: Finally, layout the inside of all flex items.
         copy_dimensions_from_flex_items_to_boxes();
         for (auto& item : m_flex_items) {
-            auto item_layout_input = LayoutInput { item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space) };
+            auto item_layout_input = LayoutInput { item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space), item_containing_block_constraints() };
             if (auto independent_formatting_context = layout_inside(item.box, LayoutMode::Normal, item_layout_input))
                 independent_formatting_context->parent_context_did_dimension_child_root_box();
 
@@ -260,7 +270,7 @@ void FlexFormattingContext::parent_context_did_dimension_child_root_box()
 
     flex_container().for_each_child_of_type<Box>([&](Layout::Box& box) {
         if (box.is_absolutely_positioned()) {
-            m_state.create(box).set_static_position_rect(calculate_static_position_rect(box));
+            m_state.create(box, {}, {}).set_static_position_rect(calculate_static_position_rect(box));
         }
         return IterationDecision::Continue;
     });
@@ -378,7 +388,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
             return IterationDecision::Continue;
 
         child_box.set_flex_item(true);
-        FlexItem item = { child_box, m_state.create(child_box) };
+        FlexItem item = { child_box, m_state.create(child_box, m_item_percentage_bases.percentage_basis_width, m_item_percentage_bases.percentage_basis_height) };
         populate_specified_margins(item, m_flex_direction);
 
         auto& order_bucket = order_item_bucket.ensure(child_box.computed_values().order());
@@ -455,15 +465,15 @@ CSSPixels FlexFormattingContext::specified_cross_min_size(FlexItem const& item) 
 CSSPixels FlexFormattingContext::calculate_inner_flex_container_cross_min_size() const
 {
     return cross_axis_is_horizontal()
-        ? calculate_inner_width(flex_container(), m_available_space.value().width, computed_cross_min_size(flex_container()))
-        : calculate_inner_height(flex_container(), m_available_space.value(), computed_cross_min_size(flex_container()));
+        ? calculate_inner_width(flex_container(), m_available_space.value().width, computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints)
+        : calculate_inner_height(flex_container(), m_available_space.value(), computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints);
 }
 
 CSSPixels FlexFormattingContext::calculate_inner_flex_container_cross_max_size() const
 {
     return cross_axis_is_horizontal()
-        ? calculate_inner_width(flex_container(), m_available_space.value().width, computed_cross_max_size(flex_container()))
-        : calculate_inner_height(flex_container(), m_available_space.value(), computed_cross_max_size(flex_container()));
+        ? calculate_inner_width(flex_container(), m_available_space.value().width, computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints)
+        : calculate_inner_height(flex_container(), m_available_space.value(), computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints);
 }
 
 bool FlexFormattingContext::has_main_max_size(Box const& box) const
@@ -1334,9 +1344,9 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
     if (!cross_axis_is_horizontal()) {
         auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
         auto available_height = AvailableSize::make_indefinite();
-        fit_content_cross_size = calculate_fit_content_height(item.box, AvailableSpace(available_width, available_height));
+        fit_content_cross_size = calculate_fit_content_height(item.box, AvailableSpace(available_width, available_height), item_containing_block_constraints());
     } else {
-        fit_content_cross_size = calculate_fit_content_width(item.box, m_available_space_for_items->space);
+        fit_content_cross_size = calculate_fit_content_width(item.box, m_available_space_for_items->space, item_containing_block_constraints());
     }
     item.hypothetical_cross_size = css_clamp(fit_content_cross_size, clamp_min, clamp_max);
 }
@@ -2178,28 +2188,28 @@ bool FlexFormattingContext::should_treat_main_size_as_auto(Box const& box) const
 {
     if (main_axis_is_horizontal())
         return should_treat_width_as_auto(box, m_available_space_for_items->space);
-    return should_treat_height_as_auto(box, m_available_space_for_items->space);
+    return should_treat_height_as_auto(box, m_available_space_for_items->space, item_containing_block_constraints());
 }
 
 bool FlexFormattingContext::should_treat_cross_size_as_auto(Box const& box) const
 {
     if (cross_axis_is_horizontal())
         return should_treat_width_as_auto(box, m_available_space_for_items->space);
-    return should_treat_height_as_auto(box, m_available_space_for_items->space);
+    return should_treat_height_as_auto(box, m_available_space_for_items->space, item_containing_block_constraints());
 }
 
 bool FlexFormattingContext::should_treat_main_max_size_as_none(Box const& box) const
 {
     if (main_axis_is_horizontal())
-        return should_treat_max_width_as_none(box, m_available_space_for_items->space.width);
-    return should_treat_max_height_as_none(box, m_available_space_for_items->space.height);
+        return should_treat_max_width_as_none(box, m_available_space_for_items->space.width, item_containing_block_constraints());
+    return should_treat_max_height_as_none(box, m_available_space_for_items->space.height, item_containing_block_constraints());
 }
 
 bool FlexFormattingContext::should_treat_cross_max_size_as_none(Box const& box) const
 {
     if (cross_axis_is_horizontal())
-        return should_treat_max_width_as_none(box, m_available_space_for_items->space.width);
-    return should_treat_max_height_as_none(box, m_available_space_for_items->space.height);
+        return should_treat_max_width_as_none(box, m_available_space_for_items->space.width, item_containing_block_constraints());
+    return should_treat_max_height_as_none(box, m_available_space_for_items->space.height, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_cross_min_content_contribution(FlexItem const& item, bool resolve_percentage_min_max_sizes) const
@@ -2259,15 +2269,15 @@ CSSPixels FlexFormattingContext::calculate_width_to_use_when_determining_intrins
     bool can_resolve_percentages = m_available_space_for_items->space.width.is_definite();
 
     auto clamp_min = (!computed_min_width.is_auto() && (!computed_min_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_min_width) : 0;
-    auto clamp_max = (!should_treat_max_width_as_none(box, m_available_space_for_items->space.width) && (!computed_max_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_max_width) : CSSPixels::max();
+    auto clamp_max = (!should_treat_max_width_as_none(box, m_available_space_for_items->space.width, item_containing_block_constraints()) && (!computed_max_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_max_width) : CSSPixels::max();
 
     CSSPixels width;
     if (should_treat_width_as_auto(box, m_available_space_for_items->space) || computed_width.is_fit_content())
-        width = calculate_fit_content_width(box, m_available_space_for_items->space);
+        width = calculate_fit_content_width(box, m_available_space_for_items->space, item_containing_block_constraints());
     else if (computed_width.is_min_content())
-        width = calculate_min_content_width(box);
+        width = calculate_min_content_width(box, item_containing_block_constraints());
     else if (computed_width.is_max_content())
-        width = calculate_max_content_width(box);
+        width = calculate_max_content_width(box, item_containing_block_constraints());
 
     return css_clamp(width, clamp_min, clamp_max);
 }
@@ -2275,39 +2285,39 @@ CSSPixels FlexFormattingContext::calculate_width_to_use_when_determining_intrins
 CSSPixels FlexFormattingContext::calculate_min_content_main_size(FlexItem const& item) const
 {
     if (main_axis_is_horizontal()) {
-        return calculate_min_content_width(item.box);
+        return calculate_min_content_width(item.box, item_containing_block_constraints());
     }
     auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
     if (available_space.width.is_indefinite()) {
         available_space.width = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
     }
-    return calculate_min_content_height(item.box, available_space.width.to_px_or_zero());
+    return calculate_min_content_height(item.box, available_space.width.to_px_or_zero(), item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_max_content_main_size(FlexItem const& item) const
 {
     if (main_axis_is_horizontal()) {
-        return calculate_max_content_width(item.box);
+        return calculate_max_content_width(item.box, item_containing_block_constraints());
     }
     auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
     if (available_space.width.is_indefinite()) {
         available_space.width = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
     }
-    return calculate_max_content_height(item.box, available_space.width.to_px_or_zero());
+    return calculate_max_content_height(item.box, available_space.width.to_px_or_zero(), item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_fit_content_main_size(FlexItem const& item) const
 {
     if (main_axis_is_horizontal())
-        return calculate_fit_content_width(item.box, m_available_space_for_items->space);
-    return calculate_fit_content_height(item.box, m_available_space_for_items->space);
+        return calculate_fit_content_width(item.box, m_available_space_for_items->space, item_containing_block_constraints());
+    return calculate_fit_content_height(item.box, m_available_space_for_items->space, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_fit_content_cross_size(FlexItem const& item) const
 {
     if (cross_axis_is_horizontal())
-        return calculate_fit_content_width(item.box, m_available_space_for_items->space);
-    return calculate_fit_content_height(item.box, m_available_space_for_items->space);
+        return calculate_fit_content_width(item.box, m_available_space_for_items->space, item_containing_block_constraints());
+    return calculate_fit_content_height(item.box, m_available_space_for_items->space, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_min_content_cross_size(FlexItem const& item) const
@@ -2317,9 +2327,9 @@ CSSPixels FlexFormattingContext::calculate_min_content_cross_size(FlexItem const
         if (available_space.width.is_indefinite()) {
             available_space.width = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
         }
-        return calculate_min_content_height(item.box, available_space.width.to_px_or_zero());
+        return calculate_min_content_height(item.box, available_space.width.to_px_or_zero(), item_containing_block_constraints());
     }
-    return calculate_min_content_width(item.box);
+    return calculate_min_content_width(item.box, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_max_content_cross_size(FlexItem const& item) const
@@ -2329,9 +2339,9 @@ CSSPixels FlexFormattingContext::calculate_max_content_cross_size(FlexItem const
         if (available_space.width.is_indefinite()) {
             available_space.width = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
         }
-        return calculate_max_content_height(item.box, available_space.width.to_px_or_zero());
+        return calculate_max_content_height(item.box, available_space.width.to_px_or_zero(), item_containing_block_constraints());
     }
-    return calculate_max_content_width(item.box);
+    return calculate_max_content_width(item.box, item_containing_block_constraints());
 }
 
 // https://drafts.csswg.org/css-flexbox-1/#stretched

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -255,6 +255,9 @@ private:
     };
     Optional<AxisAgnosticAvailableSpace> m_available_space_for_items;
     Optional<AvailableSpace> m_available_space;
+    Optional<LayoutInput> m_layout_input;
+    ContainingBlockConstraints m_item_percentage_bases;
+    ContainingBlockConstraints item_containing_block_constraints() const;
 };
 
 }

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -480,25 +480,25 @@ CSSPixels FormattingContext::line_box_physical_width(Box const& box, LineBox con
     return rightmost_fragment_x - leftmost_fragment_x;
 }
 
-FormattingContext::ShrinkToFitResult FormattingContext::calculate_shrink_to_fit_widths(Box const& box)
+FormattingContext::ShrinkToFitResult FormattingContext::calculate_shrink_to_fit_widths(Box const& box, ContainingBlockConstraints const& containing_block_constraints)
 {
     return {
-        .preferred_width = calculate_max_content_width(box),
-        .preferred_minimum_width = calculate_min_content_width(box),
+        .preferred_width = calculate_max_content_width(box, containing_block_constraints),
+        .preferred_minimum_width = calculate_min_content_width(box, containing_block_constraints),
     };
 }
 
-CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const& box, AvailableSpace const& available_space) const
+CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // 10.4 Minimum and maximum widths: 'min-width' and 'max-width'
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-widths
 
-    auto min_width = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_width(box, available_space.width, box.computed_values().min_width());
-    auto specified_max_width = should_treat_max_width_as_none(box, available_space.width) ? input_width : calculate_inner_width(box, available_space.width, box.computed_values().max_width());
+    auto min_width = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_width(box, available_space.width, box.computed_values().min_width(), containing_block_constraints);
+    auto specified_max_width = should_treat_max_width_as_none(box, available_space.width, containing_block_constraints) ? input_width : calculate_inner_width(box, available_space.width, box.computed_values().max_width(), containing_block_constraints);
     auto max_width = max(min_width, specified_max_width);
 
-    auto min_height = box.computed_values().min_height().is_auto() ? 0 : calculate_inner_height(box, available_space, box.computed_values().min_height());
-    auto specified_max_height = should_treat_max_height_as_none(box, available_space.height) ? input_height : calculate_inner_height(box, available_space, box.computed_values().max_height());
+    auto min_height = box.computed_values().min_height().is_auto() ? 0 : calculate_inner_height(box, available_space, box.computed_values().min_height(), containing_block_constraints);
+    auto specified_max_height = should_treat_max_height_as_none(box, available_space.height, containing_block_constraints) ? input_height : calculate_inner_height(box, available_space, box.computed_values().max_height(), containing_block_constraints);
     auto max_height = max(min_height, specified_max_height);
 
     CSSPixelFraction aspect_ratio = *box.preferred_aspect_ratio();
@@ -533,7 +533,7 @@ CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_w
     return { input_width, input_height };
 }
 
-Optional<CSSPixels> FormattingContext::compute_auto_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, BeforeOrAfterInsideLayout before_or_after_inside_layout) const
+Optional<CSSPixels> FormattingContext::compute_auto_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout) const
 {
     // NOTE: CSS 2.2 tells us to use the "auto height for block formatting context roots" here.
     //       That's fine as long as the box is a BFC root.
@@ -546,7 +546,7 @@ Optional<CSSPixels> FormattingContext::compute_auto_height_for_absolutely_positi
     // NOTE: For anything else, we use the fit-content height.
     //       This should eventually be replaced by the new absolute positioning model:
     //       https://www.w3.org/TR/css-position-3/#abspos-layout
-    return calculate_fit_content_height(box, m_state.get(box).available_inner_space_or_constraints_from(available_space));
+    return calculate_fit_content_height(box, m_state.get(box).available_inner_space_or_constraints_from(available_space), containing_block_constraints);
 }
 
 // https://www.w3.org/TR/CSS22/visudet.html#root-height
@@ -616,6 +616,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
 CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     Box const& box,
     AvailableSpace const& available_space,
+    ContainingBlockConstraints const& table_wrapper_constraints,
     Optional<CSSPixels> table_wrapper_containing_block_width,
     TableWrapperWidthMode table_wrapper_width_mode)
 {
@@ -646,11 +647,13 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     auto& containing_block_state = throwaway_state.populate_node_from(m_state, *box.containing_block());
     // CSS Grid lays out grid items into their grid-area containing blocks, which need not match the layout-tree
     // containing block. Use the explicit grid-area width when measuring a table wrapper for grid alignment.
+    // NOTE: TableFormattingContext still reads the wrapper's containing block from layout state.
     if (table_wrapper_containing_block_width.has_value())
         containing_block_state.set_content_width(*table_wrapper_containing_block_width);
 
-    throwaway_state.create(box);
-    auto& table_box_state = throwaway_state.create(*table_box);
+    auto const& table_wrapper_state = throwaway_state.create(box, table_wrapper_constraints.percentage_basis_width, table_wrapper_constraints.percentage_basis_height);
+    auto table_constraints = constraints_for_child_context(table_wrapper_state, table_wrapper_constraints);
+    auto& table_box_state = throwaway_state.create(*table_box, table_constraints.percentage_basis_width, table_constraints.percentage_basis_height);
     auto const& table_box_computed_values = table_box->computed_values();
     table_box_state.border_left = table_box_computed_values.border_left().width;
     table_box_state.border_right = table_box_computed_values.border_right().width;
@@ -659,7 +662,7 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
 
     auto context = make<TableFormattingContext>(throwaway_state, LayoutMode::IntrinsicSizing, *table_box, this);
     context->run_until_width_calculation(
-        LayoutInput { table_box_state.available_inner_space_or_constraints_from(available_space) },
+        LayoutInput { table_box_state.available_inner_space_or_constraints_from(available_space), table_constraints },
         TableFormattingContext::RowMeasurement::Skip);
 
     auto table_used_width = throwaway_state.get(*table_box).border_box_width();
@@ -672,7 +675,7 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
 
 // 17.5.3 Table height algorithms
 // https://www.w3.org/TR/CSS22/tables.html#height-layout
-CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box const& box, AvailableSpace const& available_space)
+CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& table_wrapper_constraints)
 {
     // Table wrapper height should be equal to height of table box it contains
 
@@ -690,11 +693,11 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
 
     LayoutState throwaway_state(box);
     throwaway_state.populate_node_from(m_state, *box.containing_block());
-    throwaway_state.create(box);
+    throwaway_state.create(box, table_wrapper_constraints.percentage_basis_width, table_wrapper_constraints.percentage_basis_height);
 
     auto context = create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
     VERIFY(context);
-    context->run(LayoutInput { m_state.get(box).available_inner_space_or_constraints_from(available_space) });
+    context->run(LayoutInput { m_state.get(box).available_inner_space_or_constraints_from(available_space), table_wrapper_constraints });
 
     Optional<Box const&> table_box;
     box.for_each_in_subtree_of_type<Box>([&](Box const& child_box) {
@@ -710,20 +713,89 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
     return available_space.height.is_definite() ? min(table_used_height, available_height) : table_used_height;
 }
 
+ContainingBlockConstraints FormattingContext::constraints_for_child_context(
+    LayoutState::UsedValues const& containing_block_used_values,
+    ContainingBlockConstraints const& containing_block_constraints)
+{
+    auto const& containing_block = containing_block_used_values.node();
+    auto const* containing_block_box = as_if<Box>(containing_block);
+    // Anonymous boxes are invisible to percentage resolution: their children resolve percentages
+    // against the closest non-anonymous ancestor, so an anonymous containing block without a
+    // definite size of its own passes the constraints it was given through. Anonymous table
+    // cells are the exception: they are proper containing blocks with their own size semantics.
+    auto should_forward_indefinite_basis = containing_block_box
+        && containing_block_box->is_anonymous()
+        && !containing_block_box->display().is_table_cell()
+        && !containing_block_box->has_auto_content_box_size()
+        && containing_block_used_values.width_constraint == SizeConstraint::None
+        && containing_block_used_values.height_constraint == SizeConstraint::None;
+
+    auto percentage_basis_width = containing_block_used_values.has_definite_width()
+        ? Optional<CSSPixels> { containing_block_used_values.content_width() }
+        : should_forward_indefinite_basis ? containing_block_constraints.percentage_basis_width
+                                          : Optional<CSSPixels> {};
+    auto percentage_basis_height = containing_block_used_values.has_definite_height()
+        ? Optional<CSSPixels> { containing_block_used_values.content_height() }
+        : should_forward_indefinite_basis ? containing_block_constraints.percentage_basis_height
+                                          : Optional<CSSPixels> {};
+
+    // https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk
+    auto quirks_mode_percentage_basis_height = [&]() -> Optional<CSSPixels> {
+        // 1. Let element be the nearest ancestor containing block of element, if there is one.
+        //    Otherwise, return the initial containing block.
+        if (containing_block.is_viewport())
+            return containing_block_used_values.content_height();
+
+        // 2. If element has a computed value of the display property that is table-cell, then return a
+        //    UA-defined value.
+        if (containing_block.display().is_table_cell()) {
+            // FIXME: Likely UA-defined value should not be 0.
+            return CSSPixels(0);
+        }
+
+        // 3. If element has a computed value of the height property that is not auto, then return element.
+        if (!containing_block.computed_values().height().is_auto())
+            return containing_block_used_values.content_height();
+
+        // 4. If element has a computed value of the position property that is absolute, or if element is a
+        //    not a block container or a table wrapper box, then return element.
+        if (containing_block.is_absolutely_positioned() || !is<BlockContainer>(containing_block) || is<TableWrapper>(containing_block))
+            return containing_block_used_values.content_height();
+
+        // 5. Jump to the first step.
+        // NOTE: Evaluated incrementally: in-flow auto-height block containers pass the basis they
+        //       inherited from their own containing block through to their children.
+        return containing_block_constraints.quirks_mode_percentage_basis_height;
+    }();
+
+    return { percentage_basis_width, percentage_basis_height, quirks_mode_percentage_basis_height };
+}
+
+LayoutInput FormattingContext::layout_input_for_child_context(
+    LayoutState::UsedValues const& containing_block_used_values,
+    LayoutInput const& containing_block_layout_input,
+    AvailableSpace available_space)
+{
+    return LayoutInput {
+        available_space,
+        constraints_for_child_context(containing_block_used_values, containing_block_layout_input.containing_block_constraints),
+    };
+}
+
 // 10.3.2 Inline, replaced elements, https://www.w3.org/TR/CSS22/visudet.html#inline-replaced-width
-CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box, CSS::Size const& computed_width, AvailableSpace const& available_space) const
+CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box, CSS::Size const& computed_width, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // Treat percentages of indefinite containing block widths as 0 (the initial width).
-    if (computed_width.is_percentage() && !m_state.get(*box.containing_block()).has_definite_width())
+    if (computed_width.is_percentage() && !containing_block_constraints.percentage_basis_width.has_value())
         return 0;
 
-    auto computed_height = should_treat_height_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_height = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
     CSSPixels used_width = 0;
     if (computed_width.is_auto()) {
         used_width = computed_width.to_px(available_space.width.to_px_or_zero());
     } else {
-        used_width = calculate_inner_width(box, available_space.width, computed_width);
+        used_width = calculate_inner_width(box, available_space.width, computed_width, containing_block_constraints);
     }
 
     // If 'height' and 'width' both have computed values of 'auto' and the element also has an intrinsic width,
@@ -740,7 +812,7 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     //     (used height) * (intrinsic ratio)
     if ((computed_height.is_auto() && computed_width.is_auto() && !intrinsic.has_width() && intrinsic.has_height() && box.has_preferred_aspect_ratio())
         || (computed_width.is_auto() && !computed_height.is_auto() && box.has_preferred_aspect_ratio())) {
-        return compute_height_for_replaced_element(box, available_space) * box.preferred_aspect_ratio().value();
+        return compute_height_for_replaced_element(box, available_space, containing_block_constraints) * box.preferred_aspect_ratio().value();
     }
 
     // If 'height' and 'width' both have computed values of 'auto' and the element has an intrinsic ratio but no intrinsic height or width,
@@ -763,55 +835,55 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     return used_width;
 }
 
-void FormattingContext::compute_width_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space)
+void FormattingContext::compute_width_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
-    if (box_is_sized_as_replaced_element(box, available_space))
-        compute_width_for_absolutely_positioned_replaced_element(box, available_space);
+    if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints))
+        compute_width_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints);
     else
-        compute_width_for_absolutely_positioned_non_replaced_element(box, available_space);
+        compute_width_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints);
 }
 
-void FormattingContext::compute_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
-    if (box_is_sized_as_replaced_element(box, available_space))
-        compute_height_for_absolutely_positioned_replaced_element(box, available_space, before_or_after_inside_layout);
+    if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints))
+        compute_height_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
     else
-        compute_height_for_absolutely_positioned_non_replaced_element(box, available_space, before_or_after_inside_layout);
+        compute_height_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
 }
 
-CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, AvailableSpace const& available_space) const
+CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // 10.3.4 Block-level, replaced elements in normal flow...
     // 10.3.2 Inline, replaced elements
 
     auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
-    auto computed_height = should_treat_height_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_height = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
-    auto used_width = tentative_width_for_replaced_element(box, computed_width, available_space);
+    auto used_width = tentative_width_for_replaced_element(box, computed_width, available_space, containing_block_constraints);
 
     if (computed_width.is_auto() && computed_height.is_auto() && box.has_preferred_aspect_ratio()) {
         CSSPixels w = used_width;
-        CSSPixels h = tentative_height_for_replaced_element(box, computed_height, available_space);
-        used_width = solve_replaced_size_constraint(w, h, box, available_space).width();
+        CSSPixels h = tentative_height_for_replaced_element(box, computed_height, available_space, containing_block_constraints);
+        used_width = solve_replaced_size_constraint(w, h, box, available_space, containing_block_constraints).width();
     }
 
     // 2. If the tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.width)) {
+    if (!should_treat_max_width_as_none(box, available_space.width, containing_block_constraints)) {
         auto const& computed_max_width = box.computed_values().max_width();
-        auto max_width = calculate_inner_width(box, available_space.width, computed_max_width);
+        auto max_width = calculate_inner_width(box, available_space.width, computed_max_width, containing_block_constraints);
         if (used_width > max_width)
-            used_width = tentative_width_for_replaced_element(box, computed_max_width, available_space);
+            used_width = tentative_width_for_replaced_element(box, computed_max_width, available_space, containing_block_constraints);
     }
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     auto computed_min_width = box.computed_values().min_width();
     if (!computed_min_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.width, computed_min_width);
+        auto min_width = calculate_inner_width(box, available_space.width, computed_min_width, containing_block_constraints);
         if (used_width < min_width)
-            used_width = tentative_width_for_replaced_element(box, computed_min_width, available_space);
+            used_width = tentative_width_for_replaced_element(box, computed_min_width, available_space, containing_block_constraints);
     }
 
     return used_width;
@@ -819,12 +891,12 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
 
 // 10.6.2 Inline replaced elements, block-level replaced elements in normal flow, 'inline-block' replaced elements in normal flow and floating replaced elements
 // https://www.w3.org/TR/CSS22/visudet.html#inline-replaced-height
-CSSPixels FormattingContext::tentative_height_for_replaced_element(Box const& box, CSS::Size const& computed_height, AvailableSpace const& available_space) const
+CSSPixels FormattingContext::tentative_height_for_replaced_element(Box const& box, CSS::Size const& computed_height, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     auto intrinsic = box.auto_content_box_size();
     // If 'height' and 'width' both have computed values of 'auto' and the element also has
     // an intrinsic height, then that intrinsic height is the used value of 'height'.
-    if (should_treat_width_as_auto(box, available_space) && should_treat_height_as_auto(box, available_space) && intrinsic.has_height())
+    if (should_treat_width_as_auto(box, available_space) && should_treat_height_as_auto(box, available_space, containing_block_constraints) && intrinsic.has_height())
         return intrinsic.height.value();
 
     // Otherwise, if 'height' has a computed value of 'auto', and the element has an intrinsic ratio then the used value of 'height' is:
@@ -844,10 +916,10 @@ CSSPixels FormattingContext::tentative_height_for_replaced_element(Box const& bo
         return 150;
 
     // FIXME: Handle cases when available_space is not definite.
-    return calculate_inner_height(box, available_space, computed_height);
+    return calculate_inner_height(box, available_space, computed_height, containing_block_constraints);
 }
 
-CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box, AvailableSpace const& available_space) const
+CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // 10.6.2 Inline replaced elements
     // 10.6.4 Block-level replaced elements in normal flow
@@ -855,10 +927,10 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
     // 10.6.10 'inline-block' replaced elements in normal flow
 
     auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
-    auto computed_height = should_treat_height_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_height = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
     // 1. The tentative used height is calculated (without 'min-height' and 'max-height')
-    CSSPixels used_height = tentative_height_for_replaced_element(box, computed_height, available_space);
+    CSSPixels used_height = tentative_height_for_replaced_element(box, computed_height, available_space, containing_block_constraints);
 
     // However, for replaced elements with both 'width' and 'height' computed as 'auto',
     // use the algorithm under 'Minimum and maximum widths'
@@ -868,33 +940,33 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
         // NOTE: This is a special case where calling tentative_width_for_replaced_element() would call us right back,
         //       and we'd end up in an infinite loop. So we need to handle this case separately.
         if (auto intrinsic = box.auto_content_box_size(); intrinsic.has_width() || !intrinsic.has_height()) {
-            CSSPixels w = tentative_width_for_replaced_element(box, computed_width, available_space);
+            CSSPixels w = tentative_width_for_replaced_element(box, computed_width, available_space, containing_block_constraints);
             CSSPixels h = used_height;
-            used_height = solve_replaced_size_constraint(w, h, box, available_space).height();
+            used_height = solve_replaced_size_constraint(w, h, box, available_space, containing_block_constraints).height();
         }
     }
     // 2. If this tentative height is greater than 'max-height', the rules above are applied again,
     //    but this time using the value of 'max-height' as the computed value for 'height'.
-    if (!should_treat_max_height_as_none(box, available_space.height)) {
+    if (!should_treat_max_height_as_none(box, available_space.height, containing_block_constraints)) {
         auto const& computed_max_height = box.computed_values().max_height();
-        auto max_height = calculate_inner_height(box, available_space, computed_max_height);
+        auto max_height = calculate_inner_height(box, available_space, computed_max_height, containing_block_constraints);
         if (used_height > max_height)
-            used_height = tentative_height_for_replaced_element(box, computed_max_height, available_space);
+            used_height = tentative_height_for_replaced_element(box, computed_max_height, available_space, containing_block_constraints);
     }
 
     // 3. If the resulting height is smaller than 'min-height', the rules above are applied again,
     //    but this time using the value of 'min-height' as the computed value for 'height'.
     auto computed_min_height = box.computed_values().min_height();
     if (!computed_min_height.is_auto()) {
-        auto min_height = calculate_inner_height(box, available_space, computed_min_height);
+        auto min_height = calculate_inner_height(box, available_space, computed_min_height, containing_block_constraints);
         if (used_height < min_height)
-            used_height = tentative_height_for_replaced_element(box, computed_min_height, available_space);
+            used_height = tentative_height_for_replaced_element(box, computed_min_height, available_space, containing_block_constraints);
     }
 
     return used_height;
 }
 
-void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space)
+void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto const& computed_values = box.computed_values();
@@ -932,10 +1004,10 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
         auto calculate_shrink_to_fit_width = [&] {
             auto available_width = solve_for_width().to_px(box);
-            auto preferred_width = calculate_max_content_width(box);
+            auto preferred_width = calculate_max_content_width(box, containing_block_constraints);
             if (preferred_width <= available_width)
                 return preferred_width;
-            auto preferred_minimum_width = calculate_min_content_width(box);
+            auto preferred_minimum_width = calculate_min_content_width(box, containing_block_constraints);
             return min(max(preferred_minimum_width, available_width), preferred_width);
         };
 
@@ -1046,16 +1118,16 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = try_compute_width([&] -> CSS::LengthOrAuto {
         if (is<TableWrapper>(box))
-            return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, available_space));
+            return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (computed_values.width().is_auto())
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width()));
+        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width(), containing_block_constraints));
     }());
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.width)) {
-        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width());
+    if (!should_treat_max_width_as_none(box, available_space.width, containing_block_constraints)) {
+        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() > max_width) {
             used_width = try_compute_width(CSS::Length::make_px(max_width));
         }
@@ -1064,7 +1136,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width());
+        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() < min_width) {
             used_width = try_compute_width(CSS::Length::make_px(min_width));
         }
@@ -1078,7 +1150,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 }
 
 // https://drafts.csswg.org/css2/#abs-replaced-width
-void FormattingContext::compute_width_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space)
+void FormattingContext::compute_width_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     // 10.3.8 Absolutely positioned, replaced elements
     // In this case, section 10.3.7 applies up through and including the constraint equation,
@@ -1086,7 +1158,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
 
     // 1. The used value of 'width' is determined as for inline replaced elements.
 
-    auto width = compute_width_for_replaced_element(box, available_space);
+    auto width = compute_width_for_replaced_element(box, available_space, containing_block_constraints);
     auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
@@ -1162,7 +1234,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
 }
 
 // https://drafts.csswg.org/css-position-3/#abs-non-replaced-height
-void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     // 5.3. The Height Of Absolutely Positioned, Non-Replaced Elements
 
@@ -1173,17 +1245,17 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     //       In the before pass, if it turns out we need the automatic height of the box, we abort these steps.
     //       This allows the box to retain an indefinite height from the perspective of inside layout.
 
-    auto apply_min_max_height_constraints = [this, &box, &available_space](CSS::LengthOrAuto const& unconstrained_height) -> CSS::LengthOrAuto {
+    auto apply_min_max_height_constraints = [this, &box, &available_space, &containing_block_constraints](CSS::LengthOrAuto const& unconstrained_height) -> CSS::LengthOrAuto {
         auto const& computed_min_height = box.computed_values().min_height();
         auto const& computed_max_height = box.computed_values().max_height();
         auto constrained_height = unconstrained_height;
         if (!computed_max_height.is_none()) {
-            auto inner_max_height = calculate_inner_height(box, available_space, computed_max_height);
+            auto inner_max_height = calculate_inner_height(box, available_space, computed_max_height, containing_block_constraints);
             if (inner_max_height < constrained_height.to_px_or_zero())
                 constrained_height = CSS::Length::make_px(inner_max_height);
         }
         if (!computed_min_height.is_auto()) {
-            auto inner_min_height = calculate_inner_height(box, available_space, computed_min_height);
+            auto inner_min_height = calculate_inner_height(box, available_space, computed_min_height, containing_block_constraints);
             if (inner_min_height > constrained_height.to_px_or_zero())
                 constrained_height = CSS::Length::make_px(inner_min_height);
         }
@@ -1268,7 +1340,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             // NOTE: We actually perform these two steps in the opposite order,
             //       because the static position may depend on the height of the box (due to alignment properties).
 
-            auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, before_or_after_inside_layout);
+            auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
             if (!maybe_height.has_value())
                 return height;
             height = CSS::Length::make_px(maybe_height.value());
@@ -1319,7 +1391,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             // 1. If top and height are auto and bottom is not auto,
             if (top.is_auto() && height.is_auto() && !bottom.is_auto()) {
                 // then the height is based on the Auto heights for block formatting context roots,
-                auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, before_or_after_inside_layout);
+                auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
                 if (!maybe_height.has_value())
                     return height;
                 height = CSS::Length::make_px(maybe_height.value());
@@ -1340,7 +1412,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             // 3. If height and bottom are auto and top is not auto,
             else if (height.is_auto() && bottom.is_auto() && !top.is_auto()) {
                 // then the height is based on the Auto heights for block formatting context roots,
-                auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, before_or_after_inside_layout);
+                auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
                 if (!maybe_height.has_value())
                     return height;
                 height = CSS::Length::make_px(maybe_height.value());
@@ -1375,17 +1447,17 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // https://www.w3.org/TR/css-sizing-3/#box-sizing
     auto used_height = try_compute_height([&] -> CSS::LengthOrAuto {
         if (is<TableWrapper>(box))
-            return CSS::Length::make_px(compute_table_box_height_inside_table_wrapper(box, available_space));
-        if (should_treat_height_as_auto(box, available_space))
+            return CSS::Length::make_px(compute_table_box_height_inside_table_wrapper(box, available_space, containing_block_constraints));
+        if (should_treat_height_as_auto(box, available_space, containing_block_constraints))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_height(box, available_space, box.computed_values().height()));
+        return CSS::Length::make_px(calculate_inner_height(box, available_space, box.computed_values().height(), containing_block_constraints));
     }());
 
     // If the tentative used height is greater than 'max-height', the rules above are applied again,
     // but this time using the computed value of 'max-height' as the computed value for 'height'.
     auto const& computed_max_height = box.computed_values().max_height();
     if (!used_height.is_auto() && !computed_max_height.is_none()) {
-        auto max_height = calculate_inner_height(box, available_space, computed_max_height);
+        auto max_height = calculate_inner_height(box, available_space, computed_max_height, containing_block_constraints);
         if (used_height.to_px_or_zero() > max_height)
             used_height = try_compute_height(CSS::Length::make_px(max_height));
     }
@@ -1394,7 +1466,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // but this time using the value of 'min-height' as the computed value for 'height'.
     auto const& computed_min_height = box.computed_values().min_height();
     if (!used_height.is_auto() && !computed_min_height.is_auto()) {
-        auto min_height = calculate_inner_height(box, available_space, computed_min_height);
+        auto min_height = calculate_inner_height(box, available_space, computed_min_height, containing_block_constraints);
         if (used_height.to_px_or_zero() < min_height)
             used_height = try_compute_height(CSS::Length::make_px(min_height));
     }
@@ -1879,6 +1951,13 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
 
     auto const& computed_values = box.computed_values();
 
+    auto const containing_block_width = available_space.width.to_px_or_zero();
+    auto const containing_block_height = available_space.height.to_px_or_zero();
+    // The percentage basis of an absolutely positioned box is the padding box of its absolute
+    // positioning containing block, which need not match the basis its used values were created
+    // with (grid places absolutely positioned children into their grid area).
+    ContainingBlockConstraints const absolutely_positioned_constraints { containing_block_width, containing_block_height, {} };
+
     // The border computed values are not changed by the compute_height & width calculations below.
     // The spec only adjusts and computes sizes, insets and margins.
     box_state.border_left = computed_values.border_left().width;
@@ -1886,18 +1965,17 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     box_state.border_top = computed_values.border_top().width;
     box_state.border_bottom = computed_values.border_bottom().width;
 
-    auto const containing_block_width = available_space.width.to_px_or_zero();
     box_state.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
     box_state.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
     box_state.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
     box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
 
-    compute_width_for_absolutely_positioned_element(box, available_space);
+    compute_width_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints);
 
     // NOTE: We compute height before *and* after doing inside layout.
     //       This is done so that inside layout can resolve percentage heights.
     //       In some situations, e.g with non-auto top & bottom values, the height can be determined early.
-    compute_height_for_absolutely_positioned_element(box, available_space, BeforeOrAfterInsideLayout::Before);
+    compute_height_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, BeforeOrAfterInsideLayout::Before);
 
     // If the box width and/or height is fixed and/or or resolved from inset properties,
     // mark the size as being definite (since layout was not required to resolve it, per CSS-SIZING-3).
@@ -1925,10 +2003,10 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
             box_state.set_has_definite_height(true);
     }
 
-    auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, LayoutInput { box_state.available_inner_space_or_constraints_from(available_space) });
+    auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, LayoutInput { box_state.available_inner_space_or_constraints_from(available_space), absolutely_positioned_constraints });
 
     if (computed_values.height().is_auto()) {
-        compute_height_for_absolutely_positioned_element(box, available_space, BeforeOrAfterInsideLayout::After);
+        compute_height_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, BeforeOrAfterInsideLayout::After);
     }
 
     // Apply grid alignment for auto inset axes
@@ -2005,13 +2083,13 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
 }
 
-void FormattingContext::compute_height_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_height_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     // 10.6.5 Absolutely positioned, replaced elements
     // This situation is similar to 10.6.4, except that the element has an intrinsic height.
 
     // The used value of 'height' is determined as for inline replaced elements.
-    auto height = compute_height_for_replaced_element(box, available_space);
+    auto height = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
 
     auto height_of_containing_block = available_space.height.to_px_or_zero();
     auto const& computed_values = box.computed_values();
@@ -2151,28 +2229,28 @@ void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box
 }
 
 // https://drafts.csswg.org/css-sizing-3/#fit-content-size
-CSSPixels FormattingContext::calculate_fit_content_width(Layout::Box const& box, AvailableSpace const& available_space) const
+CSSPixels FormattingContext::calculate_fit_content_width(Layout::Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // If the available space in a given axis is definite, equal to clamp(min-content size, stretch-fit size,
     // max-content size) (i.e. max(min-content size, min(max-content size, stretch-fit size))).
     if (available_space.width.is_definite()) {
         auto stretch_fit_width = calculate_stretch_fit_width(box, available_space.width);
-        auto max_content_width = calculate_max_content_width(box);
+        auto max_content_width = calculate_max_content_width(box, containing_block_constraints);
         if (max_content_width <= stretch_fit_width)
             return max_content_width;
-        return max(calculate_min_content_width(box), stretch_fit_width);
+        return max(calculate_min_content_width(box, containing_block_constraints), stretch_fit_width);
     }
 
     // When sizing under a min-content constraint, equal to the min-content size.
     if (available_space.width.is_min_content())
-        return calculate_min_content_width(box);
+        return calculate_min_content_width(box, containing_block_constraints);
 
     // Otherwise, equal to the max-content size in that axis.
-    return calculate_max_content_width(box);
+    return calculate_max_content_width(box, containing_block_constraints);
 }
 
 // https://drafts.csswg.org/css-sizing-3/#fit-content-size
-CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box, AvailableSpace const& available_space) const
+CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // If the available space in a given axis is definite,
     // equal to clamp(min-content size, stretch-fit size, max-content size)
@@ -2180,21 +2258,21 @@ CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box
     if (available_space.height.is_definite()) {
         auto width = available_space.width.to_px_or_zero();
         auto stretch_fit_height = calculate_stretch_fit_height(box, available_space.height);
-        auto max_content_height = calculate_max_content_height(box, width);
+        auto max_content_height = calculate_max_content_height(box, width, containing_block_constraints);
         if (max_content_height <= stretch_fit_height)
             return max_content_height;
-        return max(calculate_min_content_height(box, width), stretch_fit_height);
+        return max(calculate_min_content_height(box, width, containing_block_constraints), stretch_fit_height);
     }
 
     // When sizing under a min-content constraint, equal to the min-content size.
     if (available_space.height.is_min_content())
-        return calculate_min_content_height(box, available_space.width.to_px_or_zero());
+        return calculate_min_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
 
     // Otherwise, equal to the max-content size in that axis.
-    return calculate_max_content_height(box, available_space.width.to_px_or_zero());
+    return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
 }
 
-CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box) const
+CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
 {
     if (box.is_replaced_box()) {
         // https://www.w3.org/TR/css-sizing-3/#replaced-percentage-min-contribution
@@ -2209,7 +2287,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
         if (auto const& max_width = box.computed_values().max_width(); max_width.is_percentage())
             return max_width.to_px(0);
     }
-    if (auto transferred_width = calculate_transferred_width_for_replaced_element(box); transferred_width.has_value())
+    if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
         return transferred_width.value();
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_width())
         return auto_size.width.value();
@@ -2225,7 +2303,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
     LayoutState throwaway_state(box);
     throwaway_state.populate_node_from(m_state, *box.containing_block());
 
-    auto& box_state = throwaway_state.create(box);
+    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
     box_state.width_constraint = SizeConstraint::MinContent;
     box_state.set_indefinite_content_width();
 
@@ -2237,7 +2315,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
         : AvailableSize::make_indefinite();
 
     auto available_space = AvailableSpace(available_width, available_height);
-    context->run(LayoutInput { available_space });
+    context->run(LayoutInput { available_space, containing_block_constraints });
 
     auto min_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
     cache.emplace(min_content_width);
@@ -2246,7 +2324,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
 
 // https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
 // "size constraints in the opposite dimension will transfer through and can affect the auto size in the considered one"
-Optional<CSSPixels> FormattingContext::calculate_transferred_width_for_replaced_element(Layout::Box const& box) const
+Optional<CSSPixels> FormattingContext::calculate_transferred_width_for_replaced_element(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
 {
     if (!box.is_replaced_box() || !box.has_preferred_aspect_ratio())
         return {};
@@ -2262,18 +2340,18 @@ Optional<CSSPixels> FormattingContext::calculate_transferred_width_for_replaced_
 
     auto available_space = m_state.get(box).available_inner_space_or_constraints_from(
         AvailableSpace(AvailableSize::make_max_content(), AvailableSize::make_indefinite()));
-    if (should_treat_height_as_auto(box, available_space))
+    if (should_treat_height_as_auto(box, available_space, containing_block_constraints))
         return {};
 
     // https://drafts.csswg.org/css2/#inline-replaced-width
     // "(used height) * (intrinsic ratio)"
-    return compute_width_for_replaced_element(box, available_space);
+    return compute_width_for_replaced_element(box, available_space, {});
 }
 
-CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box) const
+CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
 {
     auto auto_size = box.auto_content_box_size();
-    if (auto transferred_width = calculate_transferred_width_for_replaced_element(box); transferred_width.has_value())
+    if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
         return transferred_width.value();
     if (!auto_size.has_width()) {
         // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
@@ -2316,7 +2394,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
 
     auto const& actual_box_state = m_state.get(box);
 
-    auto& box_state = throwaway_state.create(box);
+    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
     box_state.width_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_width();
 
@@ -2334,7 +2412,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
         : AvailableSize::make_indefinite();
 
     auto available_space = AvailableSpace(available_width, available_height);
-    context->run(LayoutInput { available_space });
+    context->run(LayoutInput { available_space, containing_block_constraints });
 
     auto max_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
     cache.emplace(max_content_width);
@@ -2342,11 +2420,11 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
 }
 
 // https://www.w3.org/TR/css-sizing-3/#min-content-block-size
-CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box, CSSPixels width) const
+CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box, CSSPixels width, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // For block containers, tables, and inline boxes, this is equivalent to the max-content block size.
     if (box.is_block_container() || box.display().is_table_inside())
-        return calculate_max_content_height(box, width);
+        return calculate_max_content_height(box, width, containing_block_constraints);
 
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_height()) {
         if (auto_size.has_aspect_ratio())
@@ -2365,7 +2443,7 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     LayoutState throwaway_state(box);
     throwaway_state.populate_node_from(m_state, *box.containing_block());
 
-    auto& box_state = throwaway_state.create(box);
+    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
     box_state.height_constraint = SizeConstraint::MinContent;
     box_state.set_indefinite_content_height();
     box_state.set_content_width(width);
@@ -2373,14 +2451,14 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box);
 
     auto available_space = AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_min_content());
-    context->run(LayoutInput { available_space });
+    context->run(LayoutInput { available_space, containing_block_constraints });
 
     auto min_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
     cache.emplace(min_content_height);
     return min_content_height;
 }
 
-CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box, CSSPixels width) const
+CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box, CSSPixels width, ContainingBlockConstraints const& containing_block_constraints) const
 {
     if (box.has_preferred_aspect_ratio())
         return width / *box.preferred_aspect_ratio();
@@ -2401,7 +2479,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
     LayoutState throwaway_state(box);
     throwaway_state.populate_node_from(m_state, *box.containing_block());
 
-    auto& box_state = throwaway_state.create(box);
+    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
     box_state.height_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_height();
     box_state.set_content_width(width);
@@ -2409,60 +2487,64 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box);
 
     auto available_space = AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_max_content());
-    context->run(LayoutInput { available_space });
+    context->run(LayoutInput { available_space, containing_block_constraints });
 
     auto max_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
     cache_slot.emplace(max_content_height);
     return max_content_height;
 }
 
-CSSPixels FormattingContext::calculate_inner_width(Layout::Box const& box, AvailableSize const& available_width, CSS::Size const& width) const
+CSSPixels FormattingContext::calculate_inner_width(Layout::Box const& box, AvailableSize const& available_width, CSS::Size const& width, ContainingBlockConstraints const& containing_block_constraints) const
 {
     VERIFY(!width.is_auto());
 
-    auto width_of_containing_block = available_width.to_px_or_zero();
+    auto const& box_state = m_state.get(box);
+    auto width_of_containing_block = width.contains_percentage()
+        ? containing_block_constraints.percentage_basis_width.value_or(available_width.to_px_or_zero())
+        : available_width.to_px_or_zero();
     if (width.is_fit_content()) {
-        return calculate_fit_content_width(box, AvailableSpace { available_width, AvailableSize::make_indefinite() });
+        return calculate_fit_content_width(box, AvailableSpace { available_width, AvailableSize::make_indefinite() }, containing_block_constraints);
     }
     if (width.is_max_content()) {
-        return calculate_max_content_width(box);
+        return calculate_max_content_width(box, containing_block_constraints);
     }
     if (width.is_min_content()) {
-        return calculate_min_content_width(box);
+        return calculate_min_content_width(box, containing_block_constraints);
     }
 
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
-        auto const& state = m_state.get(box);
         auto inner_width = width.to_px(width_of_containing_block)
             - computed_values.border_left().width
-            - state.padding_left
+            - box_state.padding_left
             - computed_values.border_right().width
-            - state.padding_right;
+            - box_state.padding_right;
         return max(inner_width, 0);
     }
 
     return width.to_px(width_of_containing_block);
 }
 
-CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpace const& available_space, CSS::Size const& height) const
+CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpace const& available_space, CSS::Size const& height, ContainingBlockConstraints const& containing_block_constraints) const
 {
+    auto const& box_state = m_state.get(box);
+
     if (height.is_auto() && box.has_preferred_aspect_ratio()) {
         if (*box.preferred_aspect_ratio() == 0)
             return CSSPixels(0);
-        return m_state.get(box).content_width() / *box.preferred_aspect_ratio();
+        return box_state.content_width() / *box.preferred_aspect_ratio();
     }
 
     VERIFY(!height.is_auto());
 
     if (height.is_fit_content()) {
-        return calculate_fit_content_height(box, available_space);
+        return calculate_fit_content_height(box, available_space, containing_block_constraints);
     }
     if (height.is_max_content()) {
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero());
+        return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
     }
     if (height.is_min_content()) {
-        return calculate_min_content_height(box, available_space.width.to_px_or_zero());
+        return calculate_min_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
     }
 
     CSSPixels height_of_containing_block = available_space.height.to_px_or_zero();
@@ -2474,54 +2556,29 @@ CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpa
     //       we trust that the caller has set it up correctly (e.g., grid/flex items get
     //       their cell/area size as available space).
     if (height.contains_percentage() && available_space.height.is_indefinite()) {
-        auto containing_block = box.containing_block();
-        while (containing_block && containing_block->is_anonymous() && !containing_block->display().is_table_cell())
-            containing_block = containing_block->containing_block();
-
         // https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk
-        // In quirks mode, walk up to find an ancestor with explicit height or the viewport.
         // NOTE: Flex/grid items resolve percentage heights against their container, not via quirk.
         bool is_flex_or_grid_item = box.parent() && (box.parent()->display().is_flex_inside() || box.parent()->display().is_grid_inside());
         auto shadow_root = box.dom_node() ? box.dom_node()->containing_shadow_root() : nullptr;
         bool is_in_ua_shadow_tree = shadow_root && shadow_root->is_user_agent_internal();
         if (box.document().in_quirks_mode() && !box.is_anonymous() && !is_flex_or_grid_item && !is_in_ua_shadow_tree) {
-            while (containing_block && !containing_block->is_viewport()
-                && containing_block->computed_values().height().is_auto())
-                containing_block = containing_block->containing_block();
-        }
-
-        if (auto const* containing_block_used_values = containing_block ? m_state.try_get(*containing_block) : nullptr) {
-            if (containing_block_used_values->has_definite_height())
-                height_of_containing_block = containing_block_used_values->content_height();
+            height_of_containing_block = containing_block_constraints.quirks_mode_percentage_basis_height.value_or(0);
+        } else if (containing_block_constraints.percentage_basis_height.has_value()) {
+            height_of_containing_block = containing_block_constraints.percentage_basis_height.value();
         }
     }
     auto& computed_values = box.computed_values();
 
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
-        auto const& state = m_state.get(box);
         auto inner_height = height.to_px(height_of_containing_block)
             - computed_values.border_top().width
-            - state.padding_top
+            - box_state.padding_top
             - computed_values.border_bottom().width
-            - state.padding_bottom;
+            - box_state.padding_bottom;
         return max(inner_height, 0);
     }
 
     return height.to_px(height_of_containing_block);
-}
-
-CSSPixels FormattingContext::containing_block_width_for(NodeWithStyleAndBoxModelMetrics const& node) const
-{
-    auto const& used_values = m_state.get(node);
-    switch (used_values.width_constraint) {
-    case SizeConstraint::MinContent:
-        return 0;
-    case SizeConstraint::MaxContent:
-        return CSSPixels::max();
-    case SizeConstraint::None:
-        return used_values.containing_block_used_values()->content_width();
-    }
-    VERIFY_NOT_REACHED();
 }
 
 // https://drafts.csswg.org/css-sizing-3/#stretch-fit-size
@@ -2587,7 +2644,7 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
     return false;
 }
 
-bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpace const& available_space) const
+bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     auto computed_height = box.computed_values().height();
     if (computed_height.is_auto()) {
@@ -2630,18 +2687,7 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
                 return true;
             }();
             if (!percentage_height_quirk_applies) {
-                // NOTE: Anonymous blocks inherit height definiteness from their containing block.
-                //       However, anonymous table cells are proper containing blocks with their own
-                //       height semantics, so we must not walk past them.
-                auto containing_block = box.containing_block();
-                while (containing_block && containing_block->is_anonymous() && !containing_block->display().is_table_cell())
-                    containing_block = containing_block->containing_block();
-                if (!containing_block)
-                    return true;
-                auto const* containing_block_used_values = m_state.try_get(*containing_block);
-                if (!containing_block_used_values)
-                    return true;
-                if (!containing_block_used_values->has_definite_height())
+                if (!containing_block_constraints.percentage_basis_height.has_value())
                     return true;
             }
         }
@@ -2834,7 +2880,7 @@ CSSPixelRect FormattingContext::margin_box_rect_in_ancestor_coordinate_space(Box
     return margin_box_rect_in_ancestor_coordinate_space(m_state.get(box), ancestor_box);
 }
 
-bool FormattingContext::box_is_sized_as_replaced_element(Box const& box, AvailableSpace const& available_space) const
+bool FormattingContext::box_is_sized_as_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // When a box has a preferred aspect ratio, its automatic sizes are calculated the same as for a
     // replaced element with a natural aspect ratio and no natural size in that axis, see e.g. CSS2 §10
@@ -2855,7 +2901,7 @@ bool FormattingContext::box_is_sized_as_replaced_element(Box const& box, Availab
 
         auto auto_size = box.auto_content_box_size();
         if (should_treat_width_as_auto(box, available_space)
-            && should_treat_height_as_auto(box, available_space)
+            && should_treat_height_as_auto(box, available_space, containing_block_constraints)
             && !auto_size.has_width()
             && !auto_size.has_height()) {
             return false;
@@ -2866,7 +2912,7 @@ bool FormattingContext::box_is_sized_as_replaced_element(Box const& box, Availab
     return false;
 }
 
-bool FormattingContext::should_treat_max_width_as_none(Box const& box, AvailableSize const& available_width) const
+bool FormattingContext::should_treat_max_width_as_none(Box const& box, AvailableSize const& available_width, ContainingBlockConstraints const& containing_block_constraints) const
 {
     auto const& max_width = box.computed_values().max_width();
     if (max_width.is_none())
@@ -2882,13 +2928,7 @@ bool FormattingContext::should_treat_max_width_as_none(Box const& box, Available
                 return true;
             return false;
         }
-        auto containing_block = box.containing_block();
-        while (containing_block && containing_block->is_anonymous() && !containing_block->display().is_table_cell())
-            containing_block = containing_block->containing_block();
-        auto const* containing_block_used_values = containing_block ? m_state.try_get(*containing_block) : nullptr;
-        if (!containing_block_used_values)
-            return true;
-        if (!containing_block_used_values->has_definite_width())
+        if (!containing_block_constraints.percentage_basis_width.has_value())
             return true;
     }
     if (max_width.is_fit_content() && available_width.is_intrinsic_sizing_constraint())
@@ -2900,7 +2940,7 @@ bool FormattingContext::should_treat_max_width_as_none(Box const& box, Available
     return false;
 }
 
-bool FormattingContext::should_treat_max_height_as_none(Box const& box, AvailableSize const& available_height) const
+bool FormattingContext::should_treat_max_height_as_none(Box const& box, AvailableSize const& available_height, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-heights
     // If the height of the containing block is not specified explicitly (i.e., it depends on content height),
@@ -2912,13 +2952,7 @@ bool FormattingContext::should_treat_max_height_as_none(Box const& box, Availabl
     if (max_height.contains_percentage()) {
         if (available_height.is_min_content())
             return false;
-        auto containing_block = box.containing_block();
-        while (containing_block && containing_block->is_anonymous() && !containing_block->display().is_table_cell())
-            containing_block = containing_block->containing_block();
-        auto const* containing_block_used_values = containing_block ? m_state.try_get(*containing_block) : nullptr;
-        if (!containing_block_used_values)
-            return true;
-        if (!containing_block_used_values->has_definite_height())
+        if (!containing_block_constraints.percentage_basis_height.has_value())
             return true;
     }
     if (max_height.is_fit_content() && available_height.is_intrinsic_sizing_constraint())

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -132,28 +132,38 @@ public:
     static bool creates_block_formatting_context(Box const&);
 
     CSSPixels compute_table_box_width_inside_table_wrapper(Box const&, AvailableSpace const&,
+        ContainingBlockConstraints const& table_wrapper_constraints,
         Optional<CSSPixels> table_wrapper_containing_block_width = {},
         TableWrapperWidthMode = TableWrapperWidthMode::ClampToAvailableWidth);
-    CSSPixels compute_table_box_height_inside_table_wrapper(Box const&, AvailableSpace const&);
+    CSSPixels compute_table_box_height_inside_table_wrapper(Box const&, AvailableSpace const&, ContainingBlockConstraints const& table_wrapper_constraints);
 
-    CSSPixels compute_width_for_replaced_element(Box const&, AvailableSpace const&) const;
-    CSSPixels compute_height_for_replaced_element(Box const&, AvailableSpace const&) const;
+    CSSPixels compute_width_for_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels compute_height_for_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
     OwnPtr<FormattingContext> create_independent_formatting_context_if_needed(LayoutState&, LayoutMode, Box const& child_box);
     NonnullOwnPtr<FormattingContext> create_independent_formatting_context(LayoutState&, LayoutMode, Box const& child_box);
 
+    [[nodiscard]] static ContainingBlockConstraints constraints_for_child_context(
+        LayoutState::UsedValues const& containing_block_used_values,
+        ContainingBlockConstraints const& containing_block_constraints);
+
+    [[nodiscard]] static LayoutInput layout_input_for_child_context(
+        LayoutState::UsedValues const& containing_block_used_values,
+        LayoutInput const& containing_block_layout_input,
+        AvailableSpace available_space);
+
     virtual void parent_context_did_dimension_child_root_box() { }
 
-    CSSPixels calculate_min_content_width(Layout::Box const&) const;
-    CSSPixels calculate_max_content_width(Layout::Box const&) const;
-    CSSPixels calculate_min_content_height(Layout::Box const&, CSSPixels width) const;
-    CSSPixels calculate_max_content_height(Layout::Box const&, CSSPixels width) const;
+    CSSPixels calculate_min_content_width(Layout::Box const&, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_max_content_width(Layout::Box const&, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_min_content_height(Layout::Box const&, CSSPixels width, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_max_content_height(Layout::Box const&, CSSPixels width, ContainingBlockConstraints const&) const;
 
-    CSSPixels calculate_fit_content_height(Layout::Box const&, AvailableSpace const&) const;
-    CSSPixels calculate_fit_content_width(Layout::Box const&, AvailableSpace const&) const;
+    CSSPixels calculate_fit_content_height(Layout::Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_fit_content_width(Layout::Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
-    CSSPixels calculate_inner_width(Layout::Box const&, AvailableSize const&, CSS::Size const& width) const;
-    [[nodiscard]] CSSPixels calculate_inner_height(Box const&, AvailableSpace const&, CSS::Size const& height) const;
+    CSSPixels calculate_inner_width(Layout::Box const&, AvailableSize const&, CSS::Size const& width, ContainingBlockConstraints const&) const;
+    [[nodiscard]] CSSPixels calculate_inner_height(Box const&, AvailableSpace const&, CSS::Size const& height, ContainingBlockConstraints const&) const;
 
     virtual CSSPixels greatest_child_width(Box const&) const;
 
@@ -163,7 +173,6 @@ public:
     [[nodiscard]] CSSPixelRect content_box_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixels box_baseline(Box const&, BaselineSet) const;
-    [[nodiscard]] CSSPixels containing_block_width_for(NodeWithStyleAndBoxModelMetrics const&) const;
 
     [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;
     [[nodiscard]] CSSPixels calculate_stretch_fit_height(Box const&, AvailableSize const&) const;
@@ -176,15 +185,15 @@ protected:
     FormattingContext(Type, LayoutMode, LayoutState&, Box const&, FormattingContext* parent = nullptr);
 
     [[nodiscard]] static bool computed_height_establishes_definite_containing_block_height(CSS::Size const&);
-    [[nodiscard]] Optional<CSSPixels> calculate_transferred_width_for_replaced_element(Layout::Box const&) const;
+    [[nodiscard]] Optional<CSSPixels> calculate_transferred_width_for_replaced_element(Layout::Box const&, ContainingBlockConstraints const&) const;
 
     [[nodiscard]] bool should_treat_width_as_auto(Box const&, AvailableSpace const&) const;
-    [[nodiscard]] bool should_treat_height_as_auto(Box const&, AvailableSpace const&) const;
+    [[nodiscard]] bool should_treat_height_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
-    [[nodiscard]] bool should_treat_max_width_as_none(Box const&, AvailableSize const&) const;
-    [[nodiscard]] bool should_treat_max_height_as_none(Box const&, AvailableSize const&) const;
+    [[nodiscard]] bool should_treat_max_width_as_none(Box const&, AvailableSize const&, ContainingBlockConstraints const&) const;
+    [[nodiscard]] bool should_treat_max_height_as_none(Box const&, AvailableSize const&, ContainingBlockConstraints const&) const;
 
-    [[nodiscard]] bool box_is_sized_as_replaced_element(Box const&, AvailableSpace const&) const;
+    [[nodiscard]] bool box_is_sized_as_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
     OwnPtr<FormattingContext> layout_inside(Box const&, LayoutMode, LayoutInput const&);
 
@@ -198,14 +207,14 @@ protected:
         CSSPixels preferred_minimum_width { 0 };
     };
 
-    CSSPixels tentative_width_for_replaced_element(Box const&, CSS::Size const& computed_width, AvailableSpace const&) const;
-    CSSPixels tentative_height_for_replaced_element(Box const&, CSS::Size const& computed_height, AvailableSpace const&) const;
+    CSSPixels tentative_width_for_replaced_element(Box const&, CSS::Size const& computed_width, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels tentative_height_for_replaced_element(Box const&, CSS::Size const& computed_height, AvailableSpace const&, ContainingBlockConstraints const&) const;
     CSSPixels compute_auto_height_for_block_formatting_context_root(Box const&) const;
     static CSSPixels line_box_physical_width(Box const&, LineBox const&);
 
-    [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&, AvailableSpace const&) const;
+    [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
-    ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&);
+    ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&, ContainingBlockConstraints const&);
 
     void layout_absolutely_positioned_element(Box&);
 
@@ -215,19 +224,19 @@ protected:
     void layout_absolutely_positioned_children(Box const&);
     virtual AbsposContainingBlockInfo resolve_abspos_containing_block_info(Box const&);
     void resolve_anchor_insets(Box&) const;
-    void compute_width_for_absolutely_positioned_element(Box const&, AvailableSpace const&);
-    void compute_width_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&);
-    void compute_width_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&);
+    void compute_width_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
+    void compute_width_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
+    void compute_width_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
     enum class BeforeOrAfterInsideLayout {
         Before,
         After,
     };
-    void compute_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
-    void compute_height_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
-    void compute_height_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout);
+    void compute_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout);
+    void compute_height_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout);
+    void compute_height_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout);
 
-    [[nodiscard]] Optional<CSSPixels> compute_auto_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, BeforeOrAfterInsideLayout) const;
+    [[nodiscard]] Optional<CSSPixels> compute_auto_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout) const;
 
     [[nodiscard]] Box const* box_child_to_derive_baseline_from(Box const&, BaselineSet) const;
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -237,6 +237,29 @@ GridFormattingContext::GridFormattingContext(LayoutState& state, LayoutMode layo
 
 GridFormattingContext::~GridFormattingContext() = default;
 
+ContainingBlockConstraints GridFormattingContext::grid_area_constraints_for_item(GridItem const& item) const
+{
+    return { containing_block_size_for_item(item, GridDimension::Column), {}, item_quirks_mode_percentage_basis_height() };
+}
+
+// During track sizing the grid area is not known yet, so items have no percentage basis.
+ContainingBlockConstraints GridFormattingContext::track_sizing_constraints_for_items() const
+{
+    return { {}, {}, item_quirks_mode_percentage_basis_height() };
+}
+
+// Intrinsic contributions during track sizing measure items against the grid container's own content box, since the
+// grid area does not exist yet.
+ContainingBlockConstraints GridFormattingContext::container_derived_constraints() const
+{
+    return constraints_for_child_context(m_grid_container_used_values, m_layout_input->containing_block_constraints);
+}
+
+Optional<CSSPixels> GridFormattingContext::item_quirks_mode_percentage_basis_height() const
+{
+    return constraints_for_child_context(m_grid_container_used_values, m_layout_input->containing_block_constraints).quirks_mode_percentage_basis_height;
+}
+
 static size_t count_subgrid_line_name_lists_from_index(CSS::GridTrackSizeList const& list, size_t start_index)
 {
     size_t count = 0;
@@ -361,6 +384,7 @@ void GridFormattingContext::for_each_subgrid_item_contributing_to_track_sizing(G
     // This introspection is recursive.
     GridFormattingContext subgrid_context(m_state, LayoutMode::IntrinsicSizing, subgrid.box, this);
     subgrid_context.m_available_space = *m_available_space;
+    subgrid_context.m_layout_input.emplace(*subgrid_context.m_available_space, track_sizing_constraints_for_items());
     if (dimension == GridDimension::Row && subgrid.used_values.has_definite_width())
         subgrid_context.m_available_space->width = AvailableSize::make_definite(subgrid.used_values.content_width());
     subgrid_context.init_grid_lines(GridDimension::Column);
@@ -1707,7 +1731,7 @@ void GridFormattingContext::maximize_tracks(GridDimension dimension)
     auto const& computed_values = grid_container().computed_values();
     auto should_treat_grid_container_maximum_size_as_none = [&] {
         if (dimension == GridDimension::Column)
-            return should_treat_max_width_as_none(grid_container(), available_size);
+            return should_treat_max_width_as_none(grid_container(), available_size, m_layout_input->containing_block_constraints);
         return !computed_values.max_height().is_auto();
     }();
 
@@ -1969,7 +1993,7 @@ void GridFormattingContext::place_grid_items()
         child_box.set_grid_item(true);
 
         if (!m_state.try_get(child_box))
-            m_state.create(child_box);
+            m_state.create(child_box, {}, {});
 
         auto& order_bucket = order_item_bucket.ensure(child_box.computed_values().order());
         order_bucket.append(child_box);
@@ -2111,13 +2135,13 @@ CSSPixels GridFormattingContext::resolve_used_grid_container_height_for_second_r
     auto height = m_automatic_content_height;
     auto const& computed_values = grid_container().computed_values();
 
-    if (!should_treat_max_height_as_none(grid_container(), m_available_space->height) && !computed_values.max_height().is_auto()) {
-        auto max_height = calculate_inner_height(grid_container(), *m_available_space, computed_values.max_height());
+    if (!should_treat_max_height_as_none(grid_container(), m_available_space->height, m_layout_input->containing_block_constraints) && !computed_values.max_height().is_auto()) {
+        auto max_height = calculate_inner_height(grid_container(), *m_available_space, computed_values.max_height(), m_layout_input->containing_block_constraints);
         height = min(height, max_height);
     }
 
     if (!computed_values.min_height().is_auto())
-        height = max(height, calculate_inner_height(grid_container(), *m_available_space, computed_values.min_height()));
+        height = max(height, calculate_inner_height(grid_container(), *m_available_space, computed_values.min_height(), m_layout_input->containing_block_constraints));
 
     return height;
 }
@@ -2282,14 +2306,14 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
 
         auto calculate_inner_size = [this, &item, dimension, available_space](CSS::Size const& size) {
             if (dimension == GridDimension::Column)
-                return calculate_inner_width(item.box, available_space.width, size);
-            return calculate_inner_height(item.box, available_space, size);
+                return calculate_inner_width(item.box, available_space.width, size, grid_area_constraints_for_item(item));
+            return calculate_inner_height(item.box, available_space, size, grid_area_constraints_for_item(item));
         };
 
         auto tentative_size_for_replaced_element = [this, &item, dimension, available_space](CSS::Size const& size) {
             if (dimension == GridDimension::Column)
-                return tentative_width_for_replaced_element(item.box, size, available_space);
-            return tentative_height_for_replaced_element(item.box, size, available_space);
+                return tentative_width_for_replaced_element(item.box, size, available_space, grid_area_constraints_for_item(item));
+            return tentative_height_for_replaced_element(item.box, size, available_space, grid_area_constraints_for_item(item));
         };
 
         ItemAlignment used_alignment;
@@ -2327,22 +2351,24 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
                 // display:table, the anonymous table wrapper is the grid item, while table layout computes the inner
                 // table's border-box width, so resolve the wrapper width with the same grid-area basis used later.
                 auto table_wrapper_containing_block_width = non_cyclic_containing_block_width_for_table_wrapper(item, containing_block_size);
+                auto table_wrapper_constraints = container_derived_constraints();
+                table_wrapper_constraints.percentage_basis_width = table_wrapper_containing_block_width;
                 auto table_wrapper_width = compute_table_box_width_inside_table_wrapper(
-                    item.box, available_space, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
+                    item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
                 if (table_box_inside_table_wrapper(item).computed_values().width().is_auto())
-                    table_wrapper_width = max(table_wrapper_width, calculate_min_content_width(item.box));
+                    table_wrapper_width = max(table_wrapper_width, calculate_min_content_width(item.box, grid_area_constraints_for_item(item)));
                 used_alignment = try_compute_size(table_wrapper_width, CSS::Size::make_px(table_wrapper_width), table_wrapper_containing_block_width);
             } else if (preferred_size.is_auto() || preferred_size.is_fit_content()) {
                 CSSPixels fit_content_size;
                 if (dimension == GridDimension::Column) {
-                    fit_content_size = calculate_fit_content_width(item.box, available_space);
+                    fit_content_size = calculate_fit_content_width(item.box, available_space, grid_area_constraints_for_item(item));
                 } else if (preferred_size.is_auto() && item.box.has_preferred_aspect_ratio() && *item.box.preferred_aspect_ratio() != 0 && item.used_values.has_definite_width()) {
                     // NB: When the item has a preferred aspect ratio and a definite width, resolve the
                     //     height through the aspect ratio instead of using fit-content sizing, which would
                     //     incorrectly use the available width (grid area width) instead of the item's width.
                     fit_content_size = item.used_values.content_width() / *item.box.preferred_aspect_ratio();
                 } else {
-                    fit_content_size = calculate_fit_content_height(item.box, available_space);
+                    fit_content_size = calculate_fit_content_height(item.box, available_space, grid_area_constraints_for_item(item));
                 }
                 used_alignment = try_compute_size(fit_content_size, preferred_size);
             } else {
@@ -2351,7 +2377,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
             }
         }
 
-        bool should_treat_maximum_size_as_none = dimension == GridDimension::Column ? should_treat_max_width_as_none(item.box, available_space.width) : should_treat_max_height_as_none(item.box, available_space.height);
+        bool should_treat_maximum_size_as_none = dimension == GridDimension::Column ? should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints_for_item(item)) : should_treat_max_height_as_none(item.box, available_space.height, grid_area_constraints_for_item(item));
         if (!should_treat_maximum_size_as_none) {
             auto const& maximum_size = item.maximum_size(dimension);
             auto max_size_px = calculate_inner_size(maximum_size);
@@ -2784,6 +2810,7 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
 
     FORMATTING_CONTEXT_TRACE();
     m_available_space = available_space;
+    m_layout_input.emplace(layout_input);
 
     init_grid_lines(GridDimension::Column);
     init_grid_lines(GridDimension::Row);
@@ -2802,20 +2829,6 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
 
     collapse_auto_fit_tracks_if_needed(GridDimension::Column);
     collapse_auto_fit_tracks_if_needed(GridDimension::Row);
-
-    for (auto& item : m_grid_items) {
-        auto& computed_values = item.box.computed_values();
-
-        // NOTE: As the containing blocks of grid items are created by implicit grid areas that are not present in the
-        // layout tree, the initial value of has_definite_width/height computed by LayoutState::UsedValues::set_node
-        // will be incorrect for anything other (auto, percentage, calculated) than fixed lengths.
-        // Therefor, it becomes necessary to reset this value to indefinite.
-        // TODO: Handle this in LayoutState::UsedValues::set_node
-        if (!computed_values.width().is_length())
-            item.used_values.set_indefinite_content_width();
-        if (!computed_values.height().is_length())
-            item.used_values.set_indefinite_content_height();
-    }
 
     // Do the first pass of resolving grid items box metrics to compute values that are independent of a track width
     resolve_items_box_metrics(GridDimension::Column);
@@ -2848,7 +2861,7 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
         m_row_track_alignment_grid_container_height = resolved_grid_container_height;
         m_use_row_track_alignment_grid_container_height = true;
         m_automatic_content_height = intrinsic_grid_container_height;
-    } else if (m_layout_mode == LayoutMode::Normal && m_available_space->height.is_definite() && should_treat_height_as_auto(grid_container(), available_space)) {
+    } else if (m_layout_mode == LayoutMode::Normal && m_available_space->height.is_definite() && should_treat_height_as_auto(grid_container(), available_space, m_layout_input->containing_block_constraints)) {
         m_row_track_alignment_grid_container_height = m_available_space->height.to_px_or_zero();
         m_use_row_track_alignment_grid_container_height = true;
     }
@@ -2879,7 +2892,7 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_width()), AvailableSize::make_definite(grid_item.used_values.content_height()));
         grid_item.used_values.set_has_definite_width(true);
         grid_item.used_values.set_has_definite_height(true);
-        if (auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, LayoutInput { available_space_for_children }))
+        if (auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, LayoutInput { available_space_for_children, grid_area_constraints_for_item(grid_item) }))
             independent_formatting_context->parent_context_did_dimension_child_root_box();
     }
 
@@ -3057,7 +3070,7 @@ void GridFormattingContext::parent_context_did_dimension_child_root_box()
 
     grid_container().for_each_child_of_type<Box>([&](Layout::Box& box) {
         if (box.is_absolutely_positioned()) {
-            m_state.create(box).set_static_position_rect(calculate_static_position_rect(box));
+            m_state.create(box, {}, {}).set_static_position_rect(calculate_static_position_rect(box));
         }
         return IterationDecision::Continue;
     });
@@ -3410,16 +3423,16 @@ int GridItem::gap_adjusted_column() const
 bool GridFormattingContext::should_treat_grid_container_maximum_size_as_none(GridDimension dimension) const
 {
     if (dimension == GridDimension::Column)
-        return should_treat_max_width_as_none(grid_container(), m_available_space->width);
-    return should_treat_max_height_as_none(grid_container(), m_available_space->height);
+        return should_treat_max_width_as_none(grid_container(), m_available_space->width, m_layout_input->containing_block_constraints);
+    return should_treat_max_height_as_none(grid_container(), m_available_space->height, m_layout_input->containing_block_constraints);
 }
 
 CSSPixels GridFormattingContext::calculate_grid_container_maximum_size(GridDimension dimension) const
 {
     auto const& computed_values = grid_container().computed_values();
     if (dimension == GridDimension::Column)
-        return calculate_inner_width(grid_container(), m_available_space->width, computed_values.max_width());
-    return calculate_inner_height(grid_container(), m_available_space.value(), computed_values.max_height());
+        return calculate_inner_width(grid_container(), m_available_space->width, computed_values.max_width(), m_layout_input->containing_block_constraints);
+    return calculate_inner_height(grid_container(), m_available_space.value(), computed_values.max_height(), m_layout_input->containing_block_constraints);
 }
 
 bool GridFormattingContext::should_treat_preferred_size_as_auto_for_intrinsic_contribution(GridItem const& item, GridDimension dimension) const
@@ -3428,7 +3441,7 @@ bool GridFormattingContext::should_treat_preferred_size_as_auto_for_intrinsic_co
     auto should_treat_preferred_size_as_auto = [&] {
         if (dimension == GridDimension::Column)
             return should_treat_width_as_auto(item.box, available_space_for_item);
-        return should_treat_height_as_auto(item.box, available_space_for_item);
+        return should_treat_height_as_auto(item.box, available_space_for_item, track_sizing_constraints_for_items());
     }();
     if (should_treat_preferred_size_as_auto)
         return true;
@@ -3443,17 +3456,17 @@ bool GridFormattingContext::should_treat_preferred_size_as_auto_for_intrinsic_co
 CSSPixels GridFormattingContext::calculate_min_content_size(GridItem const& item, GridDimension dimension) const
 {
     if (dimension == GridDimension::Column) {
-        return calculate_min_content_width(item.box);
+        return calculate_min_content_width(item.box, container_derived_constraints());
     }
-    return calculate_min_content_height(item.box, item.available_space().width.to_px_or_zero());
+    return calculate_min_content_height(item.box, item.available_space().width.to_px_or_zero(), container_derived_constraints());
 }
 
 CSSPixels GridFormattingContext::calculate_max_content_size(GridItem const& item, GridDimension dimension) const
 {
     if (dimension == GridDimension::Column) {
-        return calculate_max_content_width(item.box);
+        return calculate_max_content_width(item.box, container_derived_constraints());
     }
-    return calculate_max_content_height(item.box, item.available_space().width.to_px_or_zero());
+    return calculate_max_content_height(item.box, item.available_space().width.to_px_or_zero(), container_derived_constraints());
 }
 
 CSSPixels GridFormattingContext::containing_block_size_for_item(GridItem const& item, GridDimension dimension) const
@@ -3488,13 +3501,15 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
         AvailableSize::make_definite(clamp_to_max_dimension_value(table_wrapper_containing_block_width)),
         AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)))
     };
+    auto table_wrapper_constraints = container_derived_constraints();
+    table_wrapper_constraints.percentage_basis_width = table_wrapper_containing_block_width;
     auto table_wrapper_width = compute_table_box_width_inside_table_wrapper(
-        item.box, available_space, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
+        item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
     auto const& preferred_width = item.preferred_size(GridDimension::Column);
     if (!preferred_width.is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.width, preferred_width));
+        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.width, preferred_width, grid_area_constraints_for_item(item)));
     if (table_box_inside_table_wrapper(item).computed_values().width().is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_min_content_width(item.box));
+        table_wrapper_width = max(table_wrapper_width, calculate_min_content_width(item.box, grid_area_constraints_for_item(item)));
     auto alignment = alignment_for_item(item.box, GridDimension::Column);
     if (table_box_inside_table_wrapper(item).computed_values().width().is_auto()
         && (alignment == Alignment::Normal || alignment == Alignment::Stretch)
@@ -3502,10 +3517,10 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
         && !item.margin_end(GridDimension::Column).is_auto()) {
         table_wrapper_width = max(table_wrapper_width, table_wrapper_containing_block_width - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column));
     }
-    if (!should_treat_max_width_as_none(item.box, available_space.width))
-        table_wrapper_width = min(table_wrapper_width, calculate_inner_width(item.box, available_space.width, item.maximum_size(GridDimension::Column)));
+    if (!should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints_for_item(item)))
+        table_wrapper_width = min(table_wrapper_width, calculate_inner_width(item.box, available_space.width, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
     if (!item.minimum_size(GridDimension::Column).is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.width, item.minimum_size(GridDimension::Column)));
+        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.width, item.minimum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
 
     auto const& computed_values = item.box.computed_values();
     item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(table_wrapper_containing_block_width);
@@ -3616,10 +3631,10 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
 
     auto preferred_size = item.preferred_size(dimension);
     if (dimension == GridDimension::Column) {
-        auto width = calculate_inner_width(item.box, m_available_space->width, preferred_size);
+        auto width = calculate_inner_width(item.box, m_available_space->width, preferred_size, track_sizing_constraints_for_items());
         return min(item.add_margin_box_sizes(width, dimension), maximum_size);
     }
-    auto height = calculate_inner_height(item.box, *m_available_space, preferred_size);
+    auto height = calculate_inner_height(item.box, *m_available_space, preferred_size, track_sizing_constraints_for_items());
     return min(item.add_margin_box_sizes(height, dimension), maximum_size);
 }
 
@@ -3635,7 +3650,7 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
 
     auto preferred_size = item.preferred_size(dimension);
     if (should_treat_preferred_size_as_auto || preferred_size.is_fit_content()) {
-        auto fit_content_size = dimension == GridDimension::Column ? calculate_fit_content_width(item.box, available_space_for_item) : calculate_fit_content_height(item.box, available_space_for_item);
+        auto fit_content_size = dimension == GridDimension::Column ? calculate_fit_content_width(item.box, available_space_for_item, container_derived_constraints()) : calculate_fit_content_height(item.box, available_space_for_item, container_derived_constraints());
         auto result = item.add_margin_box_sizes(fit_content_size, dimension);
         return min(result, maximum_size);
     }
@@ -3645,9 +3660,9 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
         if (dimension == GridDimension::Row) {
             auto available_height = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)));
             AvailableSpace item_available_space { available_width, available_height };
-            return calculate_inner_height(item.box, item_available_space, preferred_size);
+            return calculate_inner_height(item.box, item_available_space, preferred_size, track_sizing_constraints_for_items());
         }
-        return calculate_inner_width(item.box, available_width, preferred_size);
+        return calculate_inner_width(item.box, available_width, preferred_size, track_sizing_constraints_for_items());
     };
 
     auto result = item.add_margin_box_sizes(resolve_size(), dimension);
@@ -3903,9 +3918,9 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
             return calculate_max_content_contribution(item, dimension);
         CSSPixels inner_minimum_size;
         if (dimension == GridDimension::Column)
-            inner_minimum_size = calculate_inner_width(item.box, item.available_space().width, minimum_size);
+            inner_minimum_size = calculate_inner_width(item.box, item.available_space().width, minimum_size, track_sizing_constraints_for_items());
         else
-            inner_minimum_size = calculate_inner_height(item.box, item.available_space(), minimum_size);
+            inner_minimum_size = calculate_inner_height(item.box, item.available_space(), minimum_size, track_sizing_constraints_for_items());
         return item.add_margin_box_sizes(inner_minimum_size, dimension);
     }
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -308,6 +308,11 @@ private:
     Vector<GridItem> m_grid_items;
 
     Optional<AvailableSpace> m_available_space;
+    Optional<LayoutInput> m_layout_input;
+    ContainingBlockConstraints grid_area_constraints_for_item(GridItem const&) const;
+    ContainingBlockConstraints track_sizing_constraints_for_items() const;
+    ContainingBlockConstraints container_derived_constraints() const;
+    Optional<CSSPixels> item_quirks_mode_percentage_basis_height() const;
 
     LayoutState::UsedValues& m_grid_container_used_values;
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -71,6 +71,7 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
     FORMATTING_CONTEXT_TRACE();
     VERIFY(containing_block().children_are_inline());
     m_available_space = available_space;
+    m_layout_input.emplace(layout_input);
     generate_line_boxes();
 
     CSSPixels content_height = 0;
@@ -106,10 +107,11 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     box_state.border_bottom = computed_values.border_bottom().width;
     box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(width_of_containing_block);
 
-    if (box_is_sized_as_replaced_element(box, *m_available_space)) {
-        box_state.set_content_width(compute_width_for_replaced_element(box, *m_available_space));
-        box_state.set_content_height(compute_height_for_replaced_element(box, *m_available_space));
-        auto child_layout_input = LayoutInput { box_state.available_inner_space_or_constraints_from(*m_available_space) };
+    auto const& box_constraints = m_layout_input->containing_block_constraints;
+    if (box_is_sized_as_replaced_element(box, *m_available_space, box_constraints)) {
+        box_state.set_content_width(compute_width_for_replaced_element(box, *m_available_space, box_constraints));
+        box_state.set_content_height(compute_height_for_replaced_element(box, *m_available_space, box_constraints));
+        auto child_layout_input = m_layout_input->with_available_space(box_state.available_inner_space_or_constraints_from(*m_available_space));
         auto independent_formatting_context = layout_inside(box, layout_mode, child_layout_input);
         if (independent_formatting_context)
             independent_formatting_context->parent_context_did_dimension_child_root_box();
@@ -135,55 +137,55 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
                 - box_state.border_right
                 - box_state.margin_right;
 
-            auto preferred_width = calculate_max_content_width(box);
+            auto preferred_width = calculate_max_content_width(box, box_constraints);
             if (preferred_width <= available_width) {
                 unconstrained_width = preferred_width;
             } else {
-                auto preferred_minimum_width = calculate_min_content_width(box);
+                auto preferred_minimum_width = calculate_min_content_width(box, box_constraints);
                 unconstrained_width = min(max(preferred_minimum_width, available_width), preferred_width);
             }
         } else if (m_available_space->width.is_min_content()) {
-            unconstrained_width = calculate_min_content_width(box);
+            unconstrained_width = calculate_min_content_width(box, box_constraints);
         } else {
-            unconstrained_width = calculate_max_content_width(box);
+            unconstrained_width = calculate_max_content_width(box, box_constraints);
         }
     } else {
         if (width_value.contains_percentage() && !m_available_space->width.is_definite()) {
             // NOTE: We can't resolve percentages yet. We'll have to wait until after inner layout.
         } else {
-            auto inner_width = calculate_inner_width(box, m_available_space->width, width_value);
+            auto inner_width = calculate_inner_width(box, m_available_space->width, width_value, box_constraints);
             unconstrained_width = inner_width;
         }
     }
 
     CSSPixels width = unconstrained_width;
-    if (!should_treat_max_width_as_none(box, m_available_space->width)) {
-        auto max_width = calculate_inner_width(box, m_available_space->width, box.computed_values().max_width());
+    if (!should_treat_max_width_as_none(box, m_available_space->width, box_constraints)) {
+        auto max_width = calculate_inner_width(box, m_available_space->width, box.computed_values().max_width(), box_constraints);
         width = min(width, max_width);
     }
 
     auto computed_min_width = box.computed_values().min_width();
     if (!computed_min_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, m_available_space->width, computed_min_width);
+        auto min_width = calculate_inner_width(box, m_available_space->width, computed_min_width, box_constraints);
         width = max(width, min_width);
     }
 
     box_state.set_content_width(width);
 
-    parent().resolve_used_height_if_not_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()));
+    parent().resolve_used_height_if_not_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
 
     // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
     if (box.display().is_flex_inside())
-        parent().resolve_used_height_if_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()));
+        parent().resolve_used_height_if_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
 
-    auto child_layout_input = LayoutInput { box_state.available_inner_space_or_constraints_from(*m_available_space) };
+    auto child_layout_input = m_layout_input->with_available_space(box_state.available_inner_space_or_constraints_from(*m_available_space));
     auto independent_formatting_context = layout_inside(box, layout_mode, child_layout_input);
 
-    if (should_treat_height_as_auto(box, *m_available_space)) {
+    if (should_treat_height_as_auto(box, *m_available_space, box_constraints)) {
         // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.
-        parent().resolve_used_height_if_treated_as_auto(box, *m_available_space);
+        parent().resolve_used_height_if_treated_as_auto(box, *m_available_space, box_constraints);
     } else {
-        parent().resolve_used_height_if_not_treated_as_auto(box, *m_available_space);
+        parent().resolve_used_height_if_not_treated_as_auto(box, *m_available_space, box_constraints);
     }
 
     if (independent_formatting_context)
@@ -346,7 +348,7 @@ void InlineFormattingContext::generate_line_boxes()
     auto direction = m_context_box.computed_values().direction();
     auto writing_mode = m_context_box.computed_values().writing_mode();
 
-    InlineLevelIterator iterator(*this, m_state, containing_block(), m_containing_block_used_values, m_layout_mode);
+    InlineLevelIterator iterator(*this, m_state, containing_block(), m_containing_block_used_values, *m_layout_input, m_layout_mode);
     LineBuilder line_builder(*this, m_state, m_containing_block_used_values, direction, writing_mode);
 
     // NOTE: When we ignore collapsible whitespace chunks at the start of a line,
@@ -420,11 +422,11 @@ void InlineFormattingContext::generate_line_boxes()
         case InlineLevelIterator::Item::Type::FloatingElement:
             if (auto* box = as_if<Box>(*item.node)) {
                 if (!is<ListItemMarkerBox>(*box))
-                    m_state.create(*box);
+                    m_state.create(*box, m_layout_input->containing_block_constraints.percentage_basis_width, m_layout_input->containing_block_constraints.percentage_basis_height);
                 (void)parent().clear_floating_boxes(*item.node, *this);
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
-                parent().layout_floating_box(*box, containing_block(), *m_available_space, 0, &line_builder);
+                parent().layout_floating_box(*box, containing_block(), *m_layout_input, 0, &line_builder);
             }
             break;
 
@@ -526,7 +528,7 @@ void InlineFormattingContext::generate_line_boxes()
             }
             auto& box_state = is<ListItemMarkerBox>(*box)
                 ? m_state.get_mutable(*box)
-                : m_state.create(*box);
+                : m_state.create(*box, {}, {});
             box_state.set_static_position_rect(static_position_rect);
         }
     }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -48,6 +48,7 @@ private:
     LayoutState::UsedValues& m_containing_block_used_values;
 
     Optional<AvailableSpace> m_available_space;
+    Optional<LayoutInput> m_layout_input;
 
     CSSPixels m_automatic_content_width { 0 };
     CSSPixels m_automatic_content_height { 0 };

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -16,11 +16,12 @@
 
 namespace Web::Layout {
 
-InlineLevelIterator::InlineLevelIterator(Layout::InlineFormattingContext& inline_formatting_context, Layout::LayoutState& layout_state, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutMode layout_mode)
+InlineLevelIterator::InlineLevelIterator(Layout::InlineFormattingContext& inline_formatting_context, Layout::LayoutState& layout_state, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutInput const& layout_input, LayoutMode layout_mode)
     : m_inline_formatting_context(inline_formatting_context)
     , m_layout_state(layout_state)
     , m_containing_block(containing_block)
     , m_containing_block_used_values(containing_block_used_values)
+    , m_layout_input(layout_input)
     , m_next_node(containing_block.first_child())
     , m_layout_mode(layout_mode)
 {
@@ -56,7 +57,7 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
 
     auto& used_values = is<ListItemMarkerBox>(node)
         ? m_layout_state.get_mutable(node)
-        : m_layout_state.create(node);
+        : m_layout_state.create(node, m_layout_input.containing_block_constraints.percentage_basis_width, m_layout_input.containing_block_constraints.percentage_basis_height);
 
     auto const& computed_values = node.computed_values();
 
@@ -404,7 +405,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
     auto const& box_state = [&]() -> LayoutState::UsedValues const& {
         if (!m_box_model_node_stack.is_empty() && m_box_model_node_stack.last() == &box)
             return m_layout_state.get_mutable(box);
-        return m_layout_state.create(box);
+        return m_layout_state.create(box, m_layout_input.containing_block_constraints.percentage_basis_width, m_layout_input.containing_block_constraints.percentage_basis_height);
     }();
     m_inline_formatting_context.dimension_box_on_line(box, m_layout_mode);
 

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -51,7 +51,7 @@ public:
         }
     };
 
-    InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutMode);
+    InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutInput const&, LayoutMode);
 
     Optional<Item&> next();
     CSSPixels next_non_whitespace_sequence_width();
@@ -76,6 +76,7 @@ private:
     Layout::LayoutState& m_layout_state;
     BlockContainer const& m_containing_block;
     LayoutState::UsedValues const& m_containing_block_used_values;
+    LayoutInput const& m_layout_input;
     Layout::Node const* m_current_node { nullptr };
     Layout::Node const* m_next_node { nullptr };
     LayoutMode const m_layout_mode;

--- a/Libraries/LibWeb/Layout/LayoutInput.h
+++ b/Libraries/LibWeb/Layout/LayoutInput.h
@@ -6,17 +6,32 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <LibWeb/Layout/AvailableSpace.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web::Layout {
 
+struct ContainingBlockConstraints {
+    Optional<CSSPixels> percentage_basis_width;
+    Optional<CSSPixels> percentage_basis_height;
+    Optional<CSSPixels> quirks_mode_percentage_basis_height;
+};
+
 struct LayoutInput {
-    explicit LayoutInput(AvailableSpace new_available_space)
+    explicit LayoutInput(AvailableSpace new_available_space, ContainingBlockConstraints new_containing_block_constraints = {})
         : available_space(move(new_available_space))
+        , containing_block_constraints(move(new_containing_block_constraints))
     {
     }
 
+    [[nodiscard]] LayoutInput with_available_space(AvailableSpace new_available_space) const
+    {
+        return LayoutInput { move(new_available_space), containing_block_constraints };
+    }
+
     AvailableSpace const available_space;
+    ContainingBlockConstraints const containing_block_constraints;
 };
 
 }

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -85,13 +85,38 @@ LayoutState::UsedValues const& LayoutState::get(NodeWithStyle const& node) const
     return *used_values;
 }
 
-LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node)
+LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height)
 {
-    if (m_used_values_store.get(node.layout_index())) {
+    auto index = node.layout_index();
+    if (m_used_values_store.get(index)) {
         dbgln("LayoutState::create: used values for {} already exist", node.debug_description());
         VERIFY_NOT_REACHED();
     }
-    return ensure_used_values_for(node);
+
+    VERIFY(!m_subtree_root || m_subtree_root == &node || m_subtree_root->is_inclusive_ancestor_of(node));
+
+    UsedValues const* containing_block_used_values = nullptr;
+    if (m_subtree_root == &node) {
+        // For the subtree root, ancestor values are not available in the throwaway state.
+        containing_block_used_values = try_get(*node.containing_block());
+    } else if (!node.is_viewport()) {
+        containing_block_used_values = &ensure_used_values_for(*node.containing_block());
+    }
+
+    auto& used_values = m_used_values_store.allocate(index);
+    used_values.set_node(node, containing_block_used_values, percentage_basis_width, percentage_basis_height);
+
+    if (auto const* list_item_box = as_if<ListItemBox>(node); list_item_box && list_item_box->marker()) {
+        auto const& marker = *list_item_box->marker();
+        if (!m_used_values_store.get(marker.layout_index())) {
+            auto& marker_used_values = m_used_values_store.allocate(marker.layout_index());
+            marker_used_values.set_node(marker, &used_values,
+                used_values.has_definite_width() ? Optional<CSSPixels> { used_values.content_width() } : Optional<CSSPixels> {},
+                used_values.has_definite_height() ? Optional<CSSPixels> { used_values.content_height() } : Optional<CSSPixels> {});
+        }
+    }
+
+    return used_values;
 }
 
 LayoutState::UsedValues& LayoutState::populate_from_paintable(NodeWithStyle const& node, Painting::PaintableBox const& paintable)
@@ -138,11 +163,7 @@ LayoutState::UsedValues& LayoutState::ensure_used_values_for(NodeWithStyle const
     }
 
     auto& used_values = m_used_values_store.allocate(index);
-    used_values.set_node(node, containing_block_used_values);
-
-    if (auto const* list_item_box = as_if<ListItemBox>(node); list_item_box && list_item_box->marker())
-        ensure_used_values_for(*list_item_box->marker());
-
+    used_values.set_node(node, containing_block_used_values, {}, {});
     return used_values;
 }
 
@@ -887,7 +908,7 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
     return *this;
 }
 
-void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues const* containing_block_used_values)
+void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues const* containing_block_used_values, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height)
 {
     m_node = &node;
     m_containing_block_used_values = containing_block_used_values;
@@ -903,6 +924,10 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues con
 
     auto const& computed_values = node.computed_values();
 
+    auto containing_block_size_for_axis = [&](bool width) {
+        return width ? percentage_basis_width.value_or(0) : percentage_basis_height.value_or(0);
+    };
+
     auto adjust_for_box_sizing = [&](CSSPixels unadjusted_pixels, CSS::Size const& computed_size, bool width) -> CSSPixels {
         // box-sizing: content-box and/or automatic size don't require any adjustment.
         if (computed_values.box_sizing() == CSS::BoxSizing::ContentBox || computed_size.is_auto())
@@ -913,14 +938,14 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues con
 
         if (width) {
             border_and_padding = computed_values.border_left().width
-                + computed_values.padding().left().to_px_or_zero(containing_block_used_values->content_width())
+                + computed_values.padding().left().to_px_or_zero(percentage_basis_width.value_or(0))
                 + computed_values.border_right().width
-                + computed_values.padding().right().to_px_or_zero(containing_block_used_values->content_width());
+                + computed_values.padding().right().to_px_or_zero(percentage_basis_width.value_or(0));
         } else {
             border_and_padding = computed_values.border_top().width
-                + computed_values.padding().top().to_px_or_zero(containing_block_used_values->content_width())
+                + computed_values.padding().top().to_px_or_zero(percentage_basis_width.value_or(0))
                 + computed_values.border_bottom().width
-                + computed_values.padding().bottom().to_px_or_zero(containing_block_used_values->content_width());
+                + computed_values.padding().bottom().to_px_or_zero(percentage_basis_width.value_or(0));
         }
 
         return unadjusted_pixels - border_and_padding;
@@ -933,7 +958,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues con
         // a size of the initial containing block,
         // or a <percentage> or other formula (such as the “stretch-fit” sizing of non-replaced blocks [CSS2]) that is resolved solely against definite sizes.
 
-        auto containing_block_has_definite_size = containing_block_used_values ? (width ? containing_block_used_values->has_definite_width() : containing_block_used_values->has_definite_height()) : false;
+        auto containing_block_has_definite_size = width ? percentage_basis_width.has_value() : percentage_basis_height.has_value();
 
         if (size.is_auto()) {
             // NOTE: The width of a non-flex-item block is considered definite if it's auto and the containing block has definite width.
@@ -946,7 +971,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues con
                 && (node.parent()->display().is_flow_root_inside()
                     || node.parent()->display().is_flow_inside())) {
                 if (containing_block_has_definite_size) {
-                    CSSPixels available_width = containing_block_used_values->content_width();
+                    CSSPixels available_width = containing_block_size_for_axis(true);
                     resolved_definite_size = clamp_to_max_dimension_value(
                         available_width
                         - margin_left
@@ -966,7 +991,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues con
             if (size.contains_percentage()) {
                 if (!containing_block_has_definite_size)
                     return false;
-                auto containing_block_size_as_length = width ? containing_block_used_values->content_width() : containing_block_used_values->content_height();
+                auto containing_block_size_as_length = containing_block_size_for_axis(width);
                 resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(containing_block_size_as_length), size, width));
                 return true;
             }

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -147,7 +147,7 @@ struct LayoutState {
 
         NodeWithStyle const& node() const { return *m_node; }
         NodeWithStyle& node() { return const_cast<NodeWithStyle&>(*m_node); }
-        void set_node(NodeWithStyle const&, UsedValues const* containing_block_used_values);
+        void set_node(NodeWithStyle const&, UsedValues const* containing_block_used_values, Optional<CSSPixels> percentage_basis_width = {}, Optional<CSSPixels> percentage_basis_height = {});
 
         UsedValues const* containing_block_used_values() const { return m_containing_block_used_values; }
 
@@ -418,7 +418,7 @@ struct LayoutState {
     UsedValues& get_mutable(NodeWithStyle const&);
     UsedValues const& get(NodeWithStyle const&) const;
 
-    UsedValues& create(NodeWithStyle const&);
+    UsedValues& create(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height);
 
     UsedValues& populate_from_paintable(NodeWithStyle const&, Painting::PaintableBox const&);
     UsedValues& populate_node_from(LayoutState const& source, NodeWithStyle const& node);

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -44,12 +44,13 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
     if (!wrapper)
         return;
 
-    auto& wrapper_state = m_state.create(*wrapper);
+    auto wrapper_constraints = constraints_for_child_context(root_state, layout_input.containing_block_constraints);
+    auto& wrapper_state = m_state.create(*wrapper, wrapper_constraints.percentage_basis_width, wrapper_constraints.percentage_basis_height);
     wrapper_state.set_content_width(content_width);
     wrapper_state.set_content_offset({ 0, 0 });
 
     auto bfc = make<BlockFormattingContext>(m_state, m_layout_mode, *wrapper, this);
-    bfc->run(LayoutInput { child_available_space });
+    bfc->run(LayoutInput { child_available_space, wrapper_constraints });
 
     m_automatic_content_width = content_width;
     m_automatic_content_height = bfc->automatic_content_height();

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -296,6 +296,7 @@ void SVGFormattingContext::run(LayoutInput const& layout_input)
     }();
 
     m_available_space = available_space;
+    m_quirks_mode_percentage_basis_height = layout_input.containing_block_constraints.quirks_mode_percentage_basis_height;
     m_svg_offset = svg_box_state.offset;
     m_viewport_size = { viewport_width, viewport_height };
 
@@ -329,7 +330,9 @@ void SVGFormattingContext::layout_svg_element(Box const& child, LayoutInput cons
         layout_nested_viewport(child, parent_svg_transform);
     } else if (auto* foreign_object_element = as_if<SVG::SVGForeignObjectElement>(child.dom_node()); foreign_object_element && is<BlockContainer>(child)) {
         Layout::BlockFormattingContext bfc(m_state, m_layout_mode, as<BlockContainer>(child), this);
-        auto& child_state = m_state.create(child);
+        // SVG layout resolves percentages against the SVG viewport, not a CSS containing
+        // block, so boxes inside the SVG subtree carry no percentage basis.
+        auto& child_state = m_state.create(child, {}, {});
         CSSPixelRect rect {
             {
                 child.computed_values().x().to_px(m_available_space->width.to_px_or_zero()),
@@ -350,7 +353,7 @@ void SVGFormattingContext::layout_svg_element(Box const& child, LayoutInput cons
         child_state.set_content_height(transformed_rect.height());
 
         auto child_available_space = AvailableSpace(AvailableSize::make_definite(child_state.content_width()), AvailableSize::make_definite(child_state.content_height()));
-        bfc.run(LayoutInput { child_available_space });
+        bfc.run(LayoutInput { child_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
 
         if (auto* mask_box = child.first_child_of_type<SVGMaskBox>())
             layout_mask_or_clip(*mask_box);
@@ -366,7 +369,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
 {
     // Layout for a nested SVG viewport.
     // https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport.
-    auto& nested_viewport_state = m_state.create(viewport);
+    auto& nested_viewport_state = m_state.create(viewport, {}, {});
     auto resolve_dimension = [](auto size, auto reference_value) {
         // The value auto for width and height on the ‘svg’ element is treated as 100%.
         // https://svgwg.org/svg2-draft/geometry.html#Sizing
@@ -405,7 +408,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
     nested_viewport_state.set_has_definite_width(true);
     nested_viewport_state.set_has_definite_height(true);
     SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform, parent_svg_transform);
-    nested_context.run(LayoutInput { *m_available_space });
+    nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
 }
 
 Gfx::Path SVGFormattingContext::compute_path_for_text(SVGTextBox const& text_box) const
@@ -542,7 +545,7 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
 
 void SVGFormattingContext::layout_graphics_element(SVGGraphicsBox const& graphics_box, LayoutInput const& layout_input, Gfx::AffineTransform const& parent_svg_transform)
 {
-    auto& graphics_box_state = m_state.create(graphics_box);
+    auto& graphics_box_state = m_state.create(graphics_box, {}, {});
     auto svg_transform = parent_svg_transform;
     svg_transform.multiply(const_cast<SVGGraphicsBox&>(graphics_box).dom_node().element_transform());
     graphics_box_state.set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
@@ -601,7 +604,7 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
     else
         VERIFY_NOT_REACHED();
     // FIXME: Somehow limit <clipPath> contents to: shape elements, <text>, and <use>.
-    auto& layout_state = m_state.create(mask_or_clip);
+    auto& layout_state = m_state.create(mask_or_clip, {}, {});
     auto parent_viewbox_transform = m_current_viewbox_transform;
 
     auto const* pattern_box = as_if<SVGPatternBox>(mask_or_clip);
@@ -632,7 +635,7 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
     SVGFormattingContext nested_context(m_state, m_layout_mode, mask_or_clip, this, parent_viewbox_transform, Gfx::AffineTransform {});
     layout_state.set_has_definite_width(true);
     layout_state.set_has_definite_height(true);
-    nested_context.run(LayoutInput { *m_available_space });
+    nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
 }
 
 void SVGFormattingContext::layout_container_element(SVGBox const& container, LayoutInput const& layout_input, Gfx::AffineTransform const& container_svg_transform)

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -40,6 +40,7 @@ private:
     Optional<Gfx::AffineTransform> m_parent_svg_transform {};
 
     Optional<AvailableSpace> m_available_space {};
+    Optional<CSSPixels> m_quirks_mode_percentage_basis_height {};
     Gfx::AffineTransform m_current_viewbox_transform {};
     CSSPixelSize m_viewport_size {};
     CSSPixelPoint m_svg_offset {};

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -65,6 +65,9 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
             continue;
         }
         auto const& child_box = as<Box>(*child);
+        // Captions live inside the table wrapper, so their quirks percentage height basis derives
+        // from the wrapper, not from anything the table box inherited.
+        auto const& caption_constraints = m_participant_constraints;
         // The caption boxes are principal block-level boxes that retain their own content, padding, margin, and border areas,
         // and are rendered as normal block boxes inside the table wrapper box, as described in https://www.w3.org/TR/CSS22/tables.html#model
         if (auto caption_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, child_box)) {
@@ -73,11 +76,11 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
             if (block_context) {
                 auto available_width = caption_available_space.width.to_px_or_zero();
                 block_context->resolve_vertical_box_model_metrics(child_box, available_width);
-                block_context->compute_width(child_box, caption_available_space);
+                block_context->compute_width(child_box, caption_available_space, caption_constraints);
                 inner_available_space = m_state.get(child_box).available_inner_space_or_constraints_from(caption_available_space);
             }
 
-            caption_context->run(LayoutInput { inner_available_space });
+            caption_context->run(LayoutInput { inner_available_space, caption_constraints });
 
             if (block_context) {
                 auto& caption_state = m_state.get_mutable(child_box);
@@ -85,7 +88,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 // Adjust x offset so border-box aligns with the table wrapper.
                 caption_state.set_content_x(caption_state.offset.x() + caption_state.border_left + caption_state.padding_left);
 
-                if (should_treat_height_as_auto(child_box, caption_available_space)) {
+                if (should_treat_height_as_auto(child_box, caption_available_space, m_participant_constraints)) {
                     auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_height();
                     caption_state.set_content_height(height);
                 }
@@ -189,16 +192,16 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
                 max_content_width = width;
             }
         } else {
-            min_content_width = calculate_min_content_width(cell.box);
-            max_content_width = calculate_max_content_width(cell.box);
+            min_content_width = calculate_min_content_width(cell.box, m_participant_constraints);
+            max_content_width = calculate_max_content_width(cell.box, m_participant_constraints);
         }
 
         // The outer min-content width of a table-cell is max(min-width, min-content width) adjusted by the cell intrinsic offsets.
         cell.outer_min_width = max(min_width, min_content_width) + cell_intrinsic_width_offsets;
 
         if (row_measurement == RowMeasurement::Include) {
-            auto min_content_height = calculate_min_content_height(cell.box, max_content_width);
-            auto max_content_height = calculate_max_content_height(cell.box, min_content_width);
+            auto min_content_height = calculate_min_content_height(cell.box, max_content_width, m_participant_constraints);
+            auto max_content_height = calculate_max_content_height(cell.box, min_content_width, m_participant_constraints);
 
             // The outer min-content height of a table-cell is max(min-height, min-content height) adjusted by the cell intrinsic offsets.
             auto min_height = computed_values.min_height().to_px(containing_block_height);
@@ -524,9 +527,9 @@ CSSPixels TableFormattingContext::compute_capmin()
                 + margin_right;
         };
 
-        auto caption_min_content_contribution = outer_size_for_inner_size(calculate_min_content_width(child_box));
+        auto caption_min_content_contribution = outer_size_for_inner_size(calculate_min_content_width(child_box, m_participant_constraints));
         if (!computed_values.width().is_auto() && !computed_values.width().contains_percentage()) {
-            auto preferred_inner_width = calculate_inner_width(child_box, AvailableSize::make_definite(width_of_table_wrapper_containing_block), computed_values.width());
+            auto preferred_inner_width = calculate_inner_width(child_box, AvailableSize::make_definite(width_of_table_wrapper_containing_block), computed_values.width(), m_participant_constraints);
             caption_min_content_contribution = max(caption_min_content_contribution, outer_size_for_inner_size(preferred_inner_width));
         }
 
@@ -640,7 +643,7 @@ void TableFormattingContext::compute_table_width()
         // of resolved-table-width, and the used min-width of the table.
         CSSPixels resolved_table_width = resolve_width_constraint_to_content_box(computed_values.width());
         used_width = max(resolved_table_width, used_min_width);
-        if (!should_treat_max_width_as_none(table_box(), m_available_space->width))
+        if (!should_treat_max_width_as_none(table_box(), m_available_space->width, m_table_constraints))
             used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     }
 
@@ -654,7 +657,7 @@ void TableFormattingContext::compute_table_width()
         stretched_table_width = max(CSSPixels(0), stretched_table_width);
         used_width = max(used_width, stretched_table_width);
     }
-    if (!should_treat_max_width_as_none(table_box(), m_available_space->width))
+    if (!should_treat_max_width_as_none(table_box(), m_available_space->width, m_table_constraints))
         used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     used_width = max(used_width, used_min_width);
 
@@ -1792,19 +1795,21 @@ void TableFormattingContext::finish_grid_initialization(TableGrid const& table_g
     }
 }
 
-void TableFormattingContext::seed_table_participant_used_values()
+void TableFormattingContext::seed_table_participant_used_values(ContainingBlockConstraints const& participant_constraints)
 {
+    auto const& participant_percentage_basis = participant_constraints;
+
     TableGrid::for_each_child_box_matching(table_box(), TableGrid::is_table_row_group, [&](auto& row_group_box) {
-        m_state.create(row_group_box);
+        m_state.create(row_group_box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
     });
     for (auto& row : m_rows)
-        m_state.create(row.box);
+        m_state.create(row.box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
     for (auto& cell : m_cells)
-        m_state.create(cell.box);
+        m_state.create(cell.box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
 
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
         if (child->display().is_table_caption())
-            m_state.create(as<Box>(*child));
+            m_state.create(as<Box>(*child), participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
     }
 }
 
@@ -1816,7 +1821,11 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
     // Determine the number of rows/columns the table requires.
     finish_grid_initialization(TableGrid::calculate_row_column_grid(context_box(), m_cells, m_rows));
 
-    seed_table_participant_used_values();
+    // The containing block of every internal table box and caption is the table wrapper;
+    // the table's own input carries the wrapper's inherited constraints.
+    m_table_constraints = layout_input.containing_block_constraints;
+    m_participant_constraints = constraints_for_child_context(m_state.get(table_wrapper()), layout_input.containing_block_constraints);
+    seed_table_participant_used_values(m_participant_constraints);
 
     border_conflict_resolution();
 
@@ -1855,7 +1864,7 @@ void TableFormattingContext::parent_context_did_dimension_child_root_box()
             // FIXME: calculate_static_position_rect() is not aware of how to correctly calculate static position for
             //        a box nested inside a table, but we need to set some value, so layout_absolutely_positioned_element()
             //        won't crash trying to access it.
-            m_state.create(box).set_static_position_rect(calculate_static_position_rect(box));
+            m_state.create(box, {}, {}).set_static_position_rect(calculate_static_position_rect(box));
         }
 
         if (formatting_context_type_created_by_box(box).has_value()) {

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -70,7 +70,7 @@ private:
     CSSPixels border_spacing_horizontal() const;
     CSSPixels border_spacing_vertical() const;
     void finish_grid_initialization(TableGrid const&);
-    void seed_table_participant_used_values();
+    void seed_table_participant_used_values(ContainingBlockConstraints const&);
 
     CSSPixels compute_columns_total_used_width() const;
     void commit_candidate_column_widths(Vector<CSSPixels> const& candidate_widths);
@@ -87,6 +87,9 @@ private:
 
     CSSPixels table_wrapper_containing_block_width() const;
     CSSPixels table_wrapper_containing_block_height() const;
+
+    ContainingBlockConstraints m_table_constraints;
+    ContainingBlockConstraints m_participant_constraints;
 
     CSSPixels m_table_height { 0 };
     CSSPixels m_automatic_content_height { 0 };

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/percentage-size-quirks-002.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/percentage-size-quirks-002.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
+2 Pass
 Pass	.pct 1
-Fail	.pct 2
+Pass	.pct 2


### PR DESCRIPTION
Sizing helpers used to resolve percentages by walking containing_block() into ancestor used values at the moment of the read. That only works because the whole layout state is globally readable, which is something we need to change in order to make partial relayout possible.

Instead, containing-block constraints now travel down through LayoutInput: each formatting context derives the percentage bases and the quirks-mode percentage height basis for the boxes it lays out one containing-block hop at a time.