### PR TITLE
LibJS: Fix lexical env restore for labelled continue in for-of (Hugging Face models pages)

### DIFF
--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -1378,8 +1378,57 @@ impl Generator {
                         {
                             self.emit_mov(&tgt, &cur);
                         }
-                        self.register_jump_in_finally_context(target);
+                        let mut needs_trampoline = false;
+                        {
+                            let mut j = i;
+                            while j > 0 {
+                                j -= 1;
+                                match self.boundaries[j] {
+                                    BlockBoundaryType::LeaveLexicalEnvironment => {
+                                        needs_trampoline = true;
+                                    }
+                                    b if (!is_break && b == BlockBoundaryType::Continue)
+                                        || (is_break && b == BlockBoundaryType::Break) =>
+                                    {
+                                        break;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        if !needs_trampoline {
+                            self.register_jump_in_finally_context(target);
+                            self.current_finally_context = saved_ctx;
+                            return;
+                        }
+                        let trampoline = self.make_block();
+                        self.register_jump_in_finally_context(trampoline);
                         self.current_finally_context = saved_ctx;
+                        self.switch_to_basic_block(trampoline);
+                        let mut restore_env_offset = env_offset;
+                        {
+                            let mut j = i;
+                            while j > 0 {
+                                j -= 1;
+                                match self.boundaries[j] {
+                                    BlockBoundaryType::LeaveLexicalEnvironment => {
+                                        restore_env_offset -= 1;
+                                        let env =
+                                            self.lexical_environment_register_stack[restore_env_offset - 1].clone();
+                                        self.emit(Instruction::SetLexicalEnvironment {
+                                            environment: env.operand(),
+                                        });
+                                    }
+                                    b if (!is_break && b == BlockBoundaryType::Continue)
+                                        || (is_break && b == BlockBoundaryType::Break) =>
+                                    {
+                                        break;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        self.emit(Instruction::Jump { target });
                         return;
                     }
                     self.emit_trampoline_through_finally();
@@ -1446,8 +1495,57 @@ impl Generator {
                             {
                                 self.emit_mov(&tgt, &cur);
                             }
-                            self.register_jump_in_finally_context(*target);
+                            let mut needs_trampoline = false;
+                            {
+                                let mut j = current_boundary;
+                                while j > 0 {
+                                    j -= 1;
+                                    match self.boundaries[j] {
+                                        BlockBoundaryType::LeaveLexicalEnvironment => {
+                                            needs_trampoline = true;
+                                        }
+                                        b if (!is_break && b == BlockBoundaryType::Continue)
+                                            || (is_break && b == BlockBoundaryType::Break) =>
+                                        {
+                                            break;
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            if !needs_trampoline {
+                                self.register_jump_in_finally_context(*target);
+                                self.current_finally_context = saved_ctx;
+                                return;
+                            }
+                            let trampoline = self.make_block();
+                            self.register_jump_in_finally_context(trampoline);
                             self.current_finally_context = saved_ctx;
+                            self.switch_to_basic_block(trampoline);
+                            let mut restore_env_offset = env_offset;
+                            {
+                                let mut j = current_boundary;
+                                while j > 0 {
+                                    j -= 1;
+                                    match self.boundaries[j] {
+                                        BlockBoundaryType::LeaveLexicalEnvironment => {
+                                            restore_env_offset -= 1;
+                                            let env =
+                                                self.lexical_environment_register_stack[restore_env_offset - 1].clone();
+                                            self.emit(Instruction::SetLexicalEnvironment {
+                                                environment: env.operand(),
+                                            });
+                                        }
+                                        b if (!is_break && b == BlockBoundaryType::Continue)
+                                            || (is_break && b == BlockBoundaryType::Break) =>
+                                        {
+                                            break;
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            self.emit(Instruction::Jump { target: *target });
                             return;
                         }
                         self.emit_trampoline_through_finally();

--- a/Tests/LibJS/Runtime/loops/continue-break-restores-lexical-environment.js
+++ b/Tests/LibJS/Runtime/loops/continue-break-restores-lexical-environment.js
@@ -1,0 +1,68 @@
+// Regression test for a bytecode-generator bug where a break/continue that crossed a for-of or try/finally boundary on
+// its way to an outer loop failed to restore the lexical environment of an intervening block scope. See #9251.
+
+test("labelled continue out of a for-of nested in a block scope", () => {
+    const values = [];
+    const list = [10, 20, 30];
+    let index = 0;
+    const readIndex = () => index;
+    const readListLength = () => list.length;
+    main: for (; index < list.length; ) {
+        const current = list[index];
+        const readCurrent = () => current;
+        for (const step of [1, 2]) {
+            if (step === 2) {
+                values.push(readCurrent());
+                index++;
+                continue main;
+            }
+        }
+    }
+    expect(values).toEqual([10, 20, 30]);
+    expect(readIndex()).toBe(3);
+    expect(readListLength()).toBe(3);
+});
+
+test("unlabelled continue out of a try/finally nested in a block scope", () => {
+    const values = [];
+    const list = [10, 20, 30];
+    let index = 0;
+    const readIndex = () => index;
+    const readListLength = () => list.length;
+    for (; index < list.length; ) {
+        const current = list[index];
+        const readCurrent = () => current;
+        index++;
+        try {
+            continue;
+        } finally {
+            values.push(readCurrent());
+        }
+    }
+    expect(values).toEqual([10, 20, 30]);
+    expect(readIndex()).toBe(3);
+    expect(readListLength()).toBe(3);
+});
+
+test("labelled break out of a for-of nested in a block scope", () => {
+    const values = [];
+    const list = [10, 20, 30];
+    let index = 0;
+    const readIndex = () => index;
+    const readListLength = () => list.length;
+    main: for (; index < list.length; ) {
+        const current = list[index];
+        const readCurrent = () => current;
+        for (const step of [1, 2]) {
+            if (step === 2) {
+                values.push(readCurrent());
+                if (index === 1) break main;
+                index++;
+                continue main;
+            }
+        }
+    }
+    expect(values).toEqual([10, 20]);
+    expect(readIndex()).toBe(1);
+    expect(readListLength()).toBe(3);
+});


### PR DESCRIPTION
**Problem:** Crash when loading model pages from the Hugging Face site.

**Cause:** The Hugging Face model pages have usage snippets built with a custom tokenizer (`huggingface/jinja`) that does some stuff very unusual for frontend web-app code. And that led to our own code hitting this:

1. Inside a `for-of` body, we emit a labelled `continue` targeting an outer `for` loop. `generate_labelled_jump` crosses the `for-of`’s `ReturnToFinally` boundary, and registers a jump to the outer loop’s test block.
2. A `LeaveLexicalEnvironment` boundary, from a block scope with a `let` declaration in the outer loop body, sits between the `ReturnToFinally` and the outer `Continue` boundary — so it isn’t processed inline.
3. The dispatch thus jumps to the outer loop’s test — but did so *without restoring the lexical environment first*.
4. On the 2nd+ iteration, the test block runs with the for-body block environment as the current environment, not the function environment.
5. `GetBinding` instructions in the test were compiled against the function environment — which led them to hit out-of-bounds indices.

**Fix:** When registering a jump through a `ReturnToFinally` boundary in `generate_scoped_jump` and `generate_labelled_jump`:

1. Scan for outer `LeaveLexicalEnvironment` boundaries between the `ReturnToFinally` and the target scope’s boundary.
2. If any exist, then — before jumping to the original target — emit the missing `SetLexicalEnvironment` instructions.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/9251.
