### PR TITLE
UI/Qt: Only proxy focus to the Vulkan container while visible

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -26,6 +26,7 @@ if (ENABLE_GUI_TARGETS)
     add_subdirectory(LibMedia)
     add_subdirectory(LibWeb)
     add_subdirectory(LibWebView)
+    add_subdirectory(UI)
 endif()
 
 if (ENABLE_CLANG_PLUGINS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang$")

--- a/Tests/UI/CMakeLists.txt
+++ b/Tests/UI/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Qt)

--- a/Tests/UI/Qt/CMakeLists.txt
+++ b/Tests/UI/Qt/CMakeLists.txt
@@ -1,0 +1,11 @@
+if (NOT LINUX)
+    return()
+endif()
+
+find_package(Qt6 QUIET COMPONENTS Core Gui Widgets)
+if (NOT Qt6_FOUND)
+    return()
+endif()
+
+ladybird_test("TestNativeWindowContainerFocus.cpp" UI/Qt LIBS Qt::Core Qt::Gui Qt::Widgets)
+target_sources(TestNativeWindowContainerFocus PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/NativeWindowContainer.cpp")

--- a/Tests/UI/Qt/TestNativeWindowContainerFocus.cpp
+++ b/Tests/UI/Qt/TestNativeWindowContainerFocus.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <QApplication>
+#include <QWidget>
+#include <UI/Qt/NativeWindowContainer.h>
+
+namespace {
+
+QApplication& application()
+{
+    static struct ForceOffscreenPlatform {
+        ForceOffscreenPlatform() { qputenv("QT_QPA_PLATFORM", "offscreen"); }
+    } force_offscreen_platform;
+    static int argc = 1;
+    static char program_name[] = "TestNativeWindowContainerFocus";
+    static char* argv[] = { program_name, nullptr };
+    static QApplication app(argc, argv);
+    return app;
+}
+
+struct TestWindow {
+    TestWindow()
+        : host(*new QWidget(&window))
+        , container(*new QWidget(&host))
+        , sibling(*new QWidget(&window))
+    {
+        host.setFocusPolicy(Qt::StrongFocus);
+        sibling.setFocusPolicy(Qt::StrongFocus);
+        container.setFocusPolicy(Qt::StrongFocus);
+        container.hide();
+
+        window.show();
+        window.activateWindow();
+        QApplication::processEvents();
+    }
+
+    QWidget window;
+    QWidget& host;
+    QWidget& container;
+    QWidget& sibling;
+};
+
+}
+
+TEST_CASE(focus_proxy_follows_container_visibility)
+{
+    application();
+    TestWindow widgets;
+
+    EXPECT(!widgets.host.focusProxy());
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, true);
+    EXPECT(widgets.container.isVisible());
+    EXPECT_EQ(widgets.host.focusProxy(), &widgets.container);
+    EXPECT_EQ(widgets.container.geometry(), widgets.host.rect());
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, false);
+    EXPECT(!widgets.container.isVisible());
+    EXPECT(!widgets.host.focusProxy());
+}
+
+TEST_CASE(keyboard_focus_moves_with_the_container)
+{
+    application();
+    TestWindow widgets;
+
+    widgets.host.setFocus();
+    QApplication::processEvents();
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.host);
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, true);
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.container);
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, false);
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.host);
+}
+
+TEST_CASE(focus_is_not_stolen_from_other_widgets)
+{
+    application();
+    TestWindow widgets;
+
+    widgets.sibling.setFocus();
+    QApplication::processEvents();
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.sibling);
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, true);
+    EXPECT_EQ(widgets.host.focusProxy(), &widgets.container);
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.sibling);
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, false);
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.sibling);
+}
+
+TEST_CASE(visibility_changes_are_idempotent)
+{
+    application();
+    TestWindow widgets;
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, false);
+    EXPECT(!widgets.container.isVisible());
+    EXPECT(!widgets.host.focusProxy());
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, true);
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, true);
+    EXPECT(widgets.container.isVisible());
+    EXPECT_EQ(widgets.host.focusProxy(), &widgets.container);
+}

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(ladybird PRIVATE
     Icon.cpp
     LocationEdit.cpp
     Menu.cpp
+    NativeWindowContainer.cpp
     Settings.cpp
     StringUtils.cpp
     Tab.cpp

--- a/UI/Qt/NativeWindowContainer.cpp
+++ b/UI/Qt/NativeWindowContainer.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <UI/Qt/NativeWindowContainer.h>
+
+#include <QWidget>
+
+namespace Ladybird {
+
+void set_native_window_container_visible(QWidget& host, QWidget& container, bool visible)
+{
+    if (container.isVisible() == visible)
+        return;
+
+    if (visible) {
+        bool host_had_focus = host.hasFocus();
+        container.setGeometry(host.rect());
+        container.show();
+        host.setFocusProxy(&container);
+        if (host_had_focus)
+            container.setFocus();
+    } else {
+        bool container_had_focus = container.hasFocus();
+        host.setFocusProxy(nullptr);
+        container.hide();
+        if (container_had_focus)
+            host.setFocus();
+    }
+}
+
+}

--- a/UI/Qt/NativeWindowContainer.h
+++ b/UI/Qt/NativeWindowContainer.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+class QWidget;
+
+namespace Ladybird {
+
+// Shows or hides a container widget that embeds a native window inside a host widget — keeping keyboard focus
+// consistent: The container is the host's focus proxy only while it's visible.
+void set_native_window_container_visible(QWidget& host, QWidget& container, bool visible);
+
+}

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -191,6 +191,7 @@ private:
     void update_vulkan_window_geometry();
     void set_vulkan_window_cursor(QCursor const&);
     bool handle_vulkan_window_event(QEvent*);
+    void set_vulkan_window_container_visible(bool);
 
     VulkanWindow* m_vulkan_window { nullptr };
     QWidget* m_vulkan_window_container { nullptr };

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -11,6 +11,7 @@
 #include <AK/Math.h>
 #include <AK/Optional.h>
 #include <LibGfx/SharedImageBuffer.h>
+#include <UI/Qt/NativeWindowContainer.h>
 #include <UI/Qt/WebContentView.h>
 
 #include <QByteArrayList>
@@ -805,8 +806,7 @@ struct WebContentView::VulkanWindowRenderer final : public QVulkanWindowRenderer
             && m_renderer.prepare(m_window)
             && m_renderer.can_render(*paintable->shared_image_buffer);
         if (!can_render) {
-            if (m_view.m_vulkan_window_container)
-                m_view.m_vulkan_window_container->hide();
+            m_view.set_vulkan_window_container_visible(false);
             m_view.update();
             m_window.frameReady();
             return;
@@ -847,8 +847,7 @@ struct WebContentView::VulkanWindowRenderer final : public QVulkanWindowRenderer
 
         vkCmdEndRenderPass(command_buffer);
         if (!rendered) {
-            if (m_view.m_vulkan_window_container)
-                m_view.m_vulkan_window_container->hide();
+            m_view.set_vulkan_window_container_visible(false);
             m_view.update();
         }
         m_window.frameReady();
@@ -907,7 +906,12 @@ void WebContentView::create_vulkan_window()
     m_vulkan_window_container->setMouseTracking(true);
     m_vulkan_window_container->setGeometry(rect());
     m_vulkan_window_container->hide();
-    setFocusProxy(m_vulkan_window_container);
+}
+
+void WebContentView::set_vulkan_window_container_visible(bool visible)
+{
+    if (m_vulkan_window_container)
+        set_native_window_container_visible(*this, *m_vulkan_window_container, visible);
 }
 
 void WebContentView::destroy_vulkan_window()
@@ -940,16 +944,12 @@ void WebContentView::schedule_vulkan_window_update()
 {
     if (m_vulkan_window) {
         if (!current_paintable_can_use_vulkan_window()) {
-            if (m_vulkan_window_container)
-                m_vulkan_window_container->hide();
+            set_vulkan_window_container_visible(false);
             update();
             return;
         }
 
-        if (m_vulkan_window_container && !m_vulkan_window_container->isVisible()) {
-            m_vulkan_window_container->setGeometry(rect());
-            m_vulkan_window_container->show();
-        }
+        set_vulkan_window_container_visible(true);
         m_vulkan_window->requestUpdate();
         return;
     }


### PR DESCRIPTION
**Problem:** With the Vulkan/DMABUF presentation path built in, keyboard input in web content never reaches the web view on machines where frames end up being rendered through the bitmap fallback.

**Cause:** `create_vulkan_window()` made the Vulkan window container the view’s focus proxy right away — but the container starts hidden and is only shown once frames actually render through the DMABUF path. While the bitmap fallback is active, clicking the page redirects focus to a hidden widget — so, key events never reach the view.

**Fix:** Tie the focus proxy to container visibility. A new helper shows/hides the container, sets/clears the focus proxy to match, and hands keyboard focus across. So whichever side was focused stays focused. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10313.
