### PR TITLE
LibWeb: Fix anchor() insets for fixed boxes when the page is scrolled (GitHub emoji-reaction picker)

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/FlexFormattingContext.h>
@@ -1768,8 +1769,20 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
             - CSSPixelPoint { anchor_state->border_box_left(), anchor_state->border_box_top() };
         auto containing_block_padding_box_origin = containing_block_state.cumulative_offset()
             - CSSPixelPoint { containing_block_state.padding_left, containing_block_state.padding_top };
+        auto anchor_origin = anchor_border_box_origin - containing_block_padding_box_origin;
+
+        // NB: A fixed-positioned box whose containing block is the viewport doesn't move when the document is scrolled.
+        //     So, its anchor() insets are resolved against the anchor's position within the viewport — not its position
+        //     within the document.
+        if (box.is_fixed_position() && containing_block->is_viewport()) {
+            if (auto navigable = box.navigable()) {
+                auto scroll_offset = navigable->viewport_scroll_offset();
+                anchor_origin.translate_by(-scroll_offset.x(), -scroll_offset.y());
+            }
+        }
+
         return CSSPixelRect {
-            anchor_border_box_origin - containing_block_padding_box_origin,
+            anchor_origin,
             { anchor_state->border_box_width(), anchor_state->border_box_height() },
         };
     };

--- a/Tests/LibWeb/Text/expected/anchor-positioning-fixed-scrolled.txt
+++ b/Tests/LibWeb/Text/expected/anchor-positioning-fixed-scrolled.txt
@@ -1,0 +1,5 @@
+scrollY: 900
+anchor.bottom: 130
+target.top: 130
+anchor.left: 40
+target.left: 40

--- a/Tests/LibWeb/Text/input/anchor-positioning-fixed-scrolled.html
+++ b/Tests/LibWeb/Text/input/anchor-positioning-fixed-scrolled.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #anchor {
+        anchor-name: --a;
+        position: absolute;
+        top: 1000px;
+        left: 40px;
+        width: 120px;
+        height: 30px;
+    }
+    #spacer { height: 2000px; }
+    #target {
+        position: fixed;
+        position-anchor: --a;
+        top: anchor(bottom);
+        left: anchor(left);
+        width: 50px;
+        height: 20px;
+    }
+</style>
+<div id="anchor"></div>
+<div id="spacer"></div>
+<script>
+    test(() => {
+        // A position:fixed element anchored to an element further down the page, positioned while the page is scrolled.
+        // Emulates a popup opened after the user has scrolled down. The fixed target must line up with the anchor's
+        // viewport position — not its document position. Regression test for #10387.
+        window.scrollTo(0, 900);
+
+        // Create the anchored target after scrolling, so it is laid out while scrolled.
+        const target = document.createElement("div");
+        target.id = "target";
+        document.body.appendChild(target);
+
+        const t = target.getBoundingClientRect();
+        const a = document.getElementById("anchor").getBoundingClientRect();
+        println(`scrollY: ${window.scrollY}`);
+        println(`anchor.bottom: ${a.bottom}`);
+        println(`target.top: ${t.top}`);
+        println(`anchor.left: ${a.left}`);
+        println(`target.left: ${t.left}`);
+    });
+</script>


### PR DESCRIPTION
**Problem:** Anchored popups positioned with CSS anchor positioning and `position: fixed` appear off-screen once the page has been scrolled. On GitHub issue pages, that breaks the reaction (emoji) picker behavior.

**Cause:** `resolve_anchor_rect` resolves `anchor()` insets against the anchor positions in the document. But a fixed-positioned box whose containing block is the viewport doesn’t scroll with the document. So, its inset must instead be relative to the anchor’s position within the viewport. Resolving against the document position leaves the box offset by the scroll amount — in an unexpected position: below the viewport.

**Fix:** When a box is fixed-positioned and its containing block is the viewport, subtract the viewport scroll offset from the resolved anchor rect — so the inset is viewport-relative. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10387.