### PR TITLE
LibWeb: Apply default scroll shift to anchor-positioned boxes

### DIFF
--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -59,6 +59,16 @@ public:
     void clear_contained_abspos_children() { m_contained_abspos_children.clear(); }
     Vector<WeakPtr<Node>> const& contained_abspos_children() const { return m_contained_abspos_children; }
 
+    void set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_scroll_in_x, bool compensates_for_scroll_in_y)
+    {
+        m_default_scroll_shift_anchor = move(anchor);
+        m_compensates_for_scroll_in_x = compensates_for_scroll_in_x;
+        m_compensates_for_scroll_in_y = compensates_for_scroll_in_y;
+    }
+    Node* default_scroll_shift_anchor() const { return m_default_scroll_shift_anchor.ptr(); }
+    bool compensates_for_scroll_in_x() const { return m_compensates_for_scroll_in_x; }
+    bool compensates_for_scroll_in_y() const { return m_compensates_for_scroll_in_y; }
+
     IntrinsicSizes& cached_intrinsic_sizes() const
     {
         if (!m_cached_intrinsic_sizes)
@@ -77,6 +87,10 @@ private:
     virtual bool is_box() const final { return true; }
 
     Vector<WeakPtr<Node>> m_contained_abspos_children;
+
+    WeakPtr<Node> m_default_scroll_shift_anchor;
+    bool m_compensates_for_scroll_in_x { false };
+    bool m_compensates_for_scroll_in_y { false };
 
     OwnPtr<IntrinsicSizes> mutable m_cached_intrinsic_sizes;
 };

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1639,13 +1639,23 @@ static bool calculation_tree_contains_anchor(CSS::CalculationNode const& root)
     return false;
 }
 
+static Box const* nearest_scroll_container_ancestor(Box const& box)
+{
+    for (auto const* ancestor = box.containing_block(); ancestor; ancestor = ancestor->containing_block()) {
+        if (ancestor->is_scroll_container())
+            return ancestor;
+    }
+    return nullptr;
+}
+
 namespace {
 
-template<typename ResolveAnchorSide>
+template<typename ResolveAnchorSide, typename NoteResolvedAnchorFunction>
 class AnchorInsetResolver final : public CSS::AnchorResolver {
 public:
-    AnchorInsetResolver(ResolveAnchorSide const& resolve_anchor_side, bool box_is_absolutely_positioned, bool is_from_end, bool is_horizontal_axis, CSSPixels containing_block_extent)
+    AnchorInsetResolver(ResolveAnchorSide const& resolve_anchor_side, NoteResolvedAnchorFunction const& note_resolved_anchor_function, bool box_is_absolutely_positioned, bool is_from_end, bool is_horizontal_axis, CSSPixels containing_block_extent)
         : m_resolve_anchor_side(resolve_anchor_side)
+        , m_note_resolved_anchor_function(note_resolved_anchor_function)
         , m_box_is_absolutely_positioned(box_is_absolutely_positioned)
         , m_is_from_end(is_from_end)
         , m_is_horizontal_axis(is_horizontal_axis)
@@ -1662,6 +1672,8 @@ public:
         if (!side_px.has_value())
             return {};
 
+        m_note_resolved_anchor_function(anchor, m_is_horizontal_axis);
+
         // For inset properties measuring from the end edge (right, bottom), the resolved length is the distance from
         // the anchor side to the corresponding edge of the containing block's padding box.
         if (m_is_from_end)
@@ -1671,6 +1683,7 @@ public:
 
 private:
     ResolveAnchorSide const& m_resolve_anchor_side;
+    NoteResolvedAnchorFunction const& m_note_resolved_anchor_function;
     bool m_box_is_absolutely_positioned { false };
     bool m_is_from_end { false };
     bool m_is_horizontal_axis { false };
@@ -1692,6 +1705,10 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
     // NB: The first two conditions are guaranteed: this function is called from layout_absolutely_positioned_element(),
     //     and we only resolve anchor() values in inset properties.
     // FIXME: Support anchor-scope, position-try-fallbacks, anchor-size(), and other anchor positioning features.
+
+    // Cleared up front so a box that is no longer anchored does not retain a stale default scroll shift from a
+    // previous layout.
+    box.set_default_scroll_shift({}, false, false);
 
     // NB: Generated boxes for pseudo-elements are anonymous, so their anchor insets live in the generator element's
     //     computed properties for the relevant pseudo-element rather than on a DOM node of their own.
@@ -1760,6 +1777,8 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
     // https://drafts.csswg.org/css-anchor-position-1/#determining
     // Several features of this specification refer to the position and size of an anchor box. Unless otherwise
     // specified, this refers to the border box edge of the principal box of relevant anchor element.
+    // FIXME: Implement remembered scroll offsets. Anchor references are currently always resolved as if all scroll
+    //        containers were at their initial scroll position.
     auto resolve_anchor_rect = [&](CSS::AnchorStyleValue const& anchor) -> Optional<CSSPixelRect> {
         auto const& name = anchor.anchor_name().has_value() ? anchor.anchor_name() : default_anchor_name;
         if (!name.has_value())
@@ -1874,6 +1893,42 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
         return {};
     };
 
+    auto* default_anchor_box = default_anchor_name.has_value() ? target_anchor_box(default_anchor_name.value()) : nullptr;
+    bool compensates_for_scroll_in_x = false;
+    bool compensates_for_scroll_in_y = false;
+
+    // https://drafts.csswg.org/css-anchor-position-1/#compensate-for-scroll
+    // An absolutely positioned box abspos compensates for scroll in the horizontal or vertical axis if both of the
+    // following conditions are true:
+    // - abspos has a default anchor box.
+    // - abspos has an anchor reference to its default anchor box or at least to something in the same scrolling
+    //   context, aka at least one of:
+    //   - abspos's used self-alignment property value in that axis is anchor-center;
+    //   - abspos has a non-none value for position-area
+    //   - at least one anchor() function on abspos's used inset properties in the axis refers to a target anchor
+    //     element with the same nearest scroll container ancestor with that axis as a scrollable axis as abspos's
+    //     default anchor box.
+    // FIXME: Account for anchor-center and position-area once they are supported.
+    // AD-HOC: Like Blink and WebKit, we do not require the axis to be a scrollable axis of the shared scroll
+    //         container.
+    auto note_resolved_anchor_function = [&](CSS::AnchorStyleValue const& anchor, bool is_horizontal_axis) {
+        if (!default_anchor_box)
+            return;
+
+        auto const& name = anchor.anchor_name().has_value() ? anchor.anchor_name() : default_anchor_name;
+        auto const* anchor_box = name.has_value() ? target_anchor_box(name.value()) : nullptr;
+        if (!anchor_box)
+            return;
+        if (anchor_box != default_anchor_box
+            && nearest_scroll_container_ancestor(*anchor_box) != nearest_scroll_container_ancestor(*default_anchor_box))
+            return;
+
+        if (is_horizontal_axis)
+            compensates_for_scroll_in_x = true;
+        else
+            compensates_for_scroll_in_y = true;
+    };
+
     auto resolve_inset = [&](bool contains_anchor, CSS::StyleValue const& value, CSS::LengthPercentageOrAuto const& existing_value, CSS::PropertyID property_id, bool is_from_end, bool is_horizontal_axis) -> CSS::LengthPercentageOrAuto {
         if (!contains_anchor)
             return existing_value;
@@ -1882,7 +1937,7 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
             ? containing_block_state.padding_box_width()
             : containing_block_state.padding_box_height();
 
-        AnchorInsetResolver anchor_resolver { resolve_anchor_side, box.is_absolutely_positioned(), is_from_end, is_horizontal_axis, containing_block_extent };
+        AnchorInsetResolver anchor_resolver { resolve_anchor_side, note_resolved_anchor_function, box.is_absolutely_positioned(), is_from_end, is_horizontal_axis, containing_block_extent };
 
         CSS::CalculationResolutionContext resolution_context {
             .percentage_basis = CSS::Length::make_px(containing_block_extent),
@@ -1914,6 +1969,9 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
         resolve_inset(bottom_contains_anchor, bottom, existing_inset.bottom(), CSS::PropertyID::Bottom, true, false),
         resolve_inset(left_contains_anchor, left, existing_inset.left(), CSS::PropertyID::Left, false, true),
     });
+
+    if (compensates_for_scroll_in_x || compensates_for_scroll_in_y)
+        box.set_default_scroll_shift(default_anchor_box->make_weak_ptr(), compensates_for_scroll_in_x, compensates_for_scroll_in_y);
 }
 
 void FormattingContext::layout_absolutely_positioned_children()

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1736,40 +1736,47 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
     auto const& default_anchor_name = box.computed_values().position_anchor();
     auto const& containing_block_state = m_state.get(*containing_block);
 
-    // https://drafts.csswg.org/css-anchor-position-1/#determining
-    // Several features of this specification refer to the position and size of an anchor box. Unless otherwise
-    // specified, this refers to the border box edge of the principal box of relevant anchor element.
     // https://drafts.csswg.org/css-anchor-position-1/#acceptable-anchor-element
     // FIXME: An element possible anchor is an acceptable anchor element for an absolutely positioned element positioned
     //        el if all of the following are true:
     //        - possible anchor is laid out strictly before positioned el [...]
+    auto target_anchor_box = [&](FlyString const& anchor_name) -> Box* {
+        auto anchor_element = element->document().element_by_anchor_name(anchor_name, *element);
+        if (!anchor_element)
+            return nullptr;
+
+        // NB: We use unsafe_layout_node() because we are in the middle of layout.
+        auto* anchor_box = as_if<Box>(anchor_element->unsafe_layout_node());
+        if (!anchor_box)
+            return nullptr;
+
+        // The anchor element may not have been laid out (it must be laid out strictly before
+        // the positioned element to be an acceptable anchor).
+        if (!m_state.try_get(*anchor_box))
+            return nullptr;
+        return anchor_box;
+    };
+
+    // https://drafts.csswg.org/css-anchor-position-1/#determining
+    // Several features of this specification refer to the position and size of an anchor box. Unless otherwise
+    // specified, this refers to the border box edge of the principal box of relevant anchor element.
     auto resolve_anchor_rect = [&](CSS::AnchorStyleValue const& anchor) -> Optional<CSSPixelRect> {
         auto const& name = anchor.anchor_name().has_value() ? anchor.anchor_name() : default_anchor_name;
         if (!name.has_value())
             return {};
 
-        auto anchor_element = element->document().element_by_anchor_name(name.value(), *element);
-        if (!anchor_element)
+        auto const* anchor_box = target_anchor_box(name.value());
+        if (!anchor_box)
             return {};
 
-        // NB: We use unsafe_layout_node() because we are in the middle of layout.
-        auto anchor_layout_node = anchor_element->unsafe_layout_node();
-        if (!anchor_layout_node || !is<Box>(*anchor_layout_node))
-            return {};
-
-        auto const& anchor_box = as<Box>(*anchor_layout_node);
-        // The anchor element may not have been laid out (it must be laid out strictly before
-        // the positioned element to be an acceptable anchor).
-        auto const* anchor_state = m_state.try_get(anchor_box);
-        if (!anchor_state)
-            return {};
-        auto anchor_border_box_origin = anchor_state->cumulative_offset()
-            - CSSPixelPoint { anchor_state->border_box_left(), anchor_state->border_box_top() };
+        auto const& anchor_state = m_state.get(*anchor_box);
+        auto anchor_border_box_origin = anchor_state.cumulative_offset()
+            - CSSPixelPoint { anchor_state.border_box_left(), anchor_state.border_box_top() };
         auto containing_block_padding_box_origin = containing_block_state.cumulative_offset()
             - CSSPixelPoint { containing_block_state.padding_left, containing_block_state.padding_top };
         return CSSPixelRect {
             anchor_border_box_origin - containing_block_padding_box_origin,
-            { anchor_state->border_box_width(), anchor_state->border_box_height() },
+            { anchor_state.border_box_width(), anchor_state.border_box_height() },
         };
     };
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/VisualViewport.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/Layout/Box.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/Blending.h>
@@ -36,6 +37,23 @@ bool ClipData::contains(DevicePixelPoint point) const
 }
 
 static Atomic<u64> s_next_accumulated_visual_context_tree_version { 1 };
+
+static ScrollFrameIndex scroll_frame_common_ancestor(ScrollState const& scroll_state, ScrollFrameIndex a, ScrollFrameIndex b)
+{
+    Vector<ScrollFrameIndex, 8> a_and_ancestors;
+    for (auto frame = a;; frame = scroll_state.frame_at(frame).parent_index()) {
+        a_and_ancestors.append(frame);
+        if (!frame.value())
+            break;
+    }
+    for (auto frame = b;; frame = scroll_state.frame_at(frame).parent_index()) {
+        if (a_and_ancestors.contains_slow(frame))
+            return frame;
+        if (!frame.value())
+            break;
+    }
+    return {};
+}
 
 static TransformData identity_visual_viewport_transform()
 {
@@ -318,6 +336,41 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         // Build this element's own state from inherited state.
         VisualContextIndex own_state = inherited_state;
 
+        // https://drafts.csswg.org/css-anchor-position-1/#default-scroll-shift
+        // After layout has been performed for abspos, it is additionally shifted by the default scroll shift, as if
+        // affected by a transform (before any other transforms).
+        // NB: The shift is the scroll movement of the frames between the box's containing block and its default anchor
+        //     box. When the anchor is itself an anchor-positioned box, its layout position does not include its own
+        //     paint-time shift, so each chained anchor's shift is emitted as well, masked to the axes that every link
+        //     below it compensates in. The visited set and depth cap guard against malformed anchor chains.
+        if (auto const* box = as_if<Layout::Box>(&paintable_box.layout_node())) {
+            auto const& scroll_state = viewport_paintable.scroll_state();
+            bool compensate_x = true;
+            bool compensate_y = true;
+            Vector<Layout::Box const*, 8> visited;
+            constexpr size_t max_anchor_chain_depth = 32;
+            while (box && !visited.contains_slow(box) && visited.size() < max_anchor_chain_depth) {
+                auto const* anchor_box = as_if<Layout::Box>(box->default_scroll_shift_anchor());
+                if (!anchor_box)
+                    break;
+                auto box_paintable = box->paintable_box();
+                auto anchor_paintable = anchor_box->paintable_box();
+                if (!box_paintable || !anchor_paintable)
+                    break;
+                visited.append(box);
+                compensate_x = compensate_x && box->compensates_for_scroll_in_x();
+                compensate_y = compensate_y && box->compensates_for_scroll_in_y();
+                auto anchor_frame = anchor_paintable->enclosing_scroll_frame_index();
+                auto base_frame = box_paintable->enclosing_scroll_frame_index();
+                auto shared_frame = scroll_frame_common_ancestor(scroll_state, anchor_frame, base_frame);
+                for (auto frame = anchor_frame; frame.value() && frame != shared_frame; frame = scroll_state.frame_at(frame).parent_index())
+                    own_state = append_node(own_state, AnchorScrollShift { frame, false, compensate_x, compensate_y });
+                for (auto frame = base_frame; frame.value() && frame != shared_frame; frame = scroll_state.frame_at(frame).parent_index())
+                    own_state = append_node(own_state, AnchorScrollShift { frame, true, compensate_x, compensate_y });
+                box = anchor_box;
+            }
+        }
+
         // Out-of-flow descendants can skip overflow and scroll clips from intermediate ancestors. Keep their visual
         // contexts separate as we descend, and replace them with the normal descendant context only when this box
         // establishes the relevant containing block.
@@ -596,6 +649,10 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
             [&](ScrollCompensation const& compensation) -> Optional<Gfx::FloatPoint> {
                 point.translate_by(scroll_state.device_offset_for_index(compensation.scroll_frame_index));
                 return point;
+            },
+            [&](AnchorScrollShift const& shift) -> Optional<Gfx::FloatPoint> {
+                point.translate_by(-shift.masked_offset(scroll_state));
+                return point;
             });
 
         if (!result.has_value())
@@ -659,6 +716,9 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
                     auto offset = scroll_state.device_offset_for_index(compensation.scroll_frame_index);
                     rect.translate_by(-offset);
                 },
+                [&](AnchorScrollShift const& shift) {
+                    rect.translate_by(shift.masked_offset(scroll_state));
+                },
                 [&](ClipData const&) { /* clips don't affect rect coordinates */ },
                 [&](ClipPathData const&) { /* clip paths don't affect rect coordinates */ },
                 [&](EffectsData const&) { /* effects don't affect rect coordinates */ });
@@ -668,6 +728,16 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
     }
 
     return rect;
+}
+
+Gfx::FloatPoint AnchorScrollShift::masked_offset(ScrollStateSnapshot const& scroll_state) const
+{
+    auto offset = scroll_state.device_offset_for_index(scroll_frame_index);
+    if (!compensate_x)
+        offset.set_x(0);
+    if (!compensate_y)
+        offset.set_y(0);
+    return negate ? -offset : offset;
 }
 
 void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder& builder) const
@@ -723,6 +793,12 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
         },
         [&](ScrollCompensation const& compensation) {
             builder.appendff("scroll_compensation(frame_id={})", compensation.scroll_frame_index.value());
+        },
+        [&](AnchorScrollShift const& shift) {
+            builder.appendff("anchor_scroll_shift(frame_id={}{}{}{})", shift.scroll_frame_index.value(),
+                shift.negate ? ", negate"sv : ""sv,
+                shift.compensate_x ? ""sv : ", no-x"sv,
+                shift.compensate_y ? ""sv : ", no-y"sv);
         });
 }
 
@@ -846,6 +922,27 @@ ErrorOr<Web::Painting::ScrollCompensation> decode(Decoder& decoder)
 {
     return Web::Painting::ScrollCompensation {
         .scroll_frame_index = TRY(decoder.decode<Web::Painting::ScrollFrameIndex>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::AnchorScrollShift const& data)
+{
+    TRY(encoder.encode(data.scroll_frame_index));
+    TRY(encoder.encode(data.negate));
+    TRY(encoder.encode(data.compensate_x));
+    TRY(encoder.encode(data.compensate_y));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::AnchorScrollShift> decode(Decoder& decoder)
+{
+    return Web::Painting::AnchorScrollShift {
+        .scroll_frame_index = TRY(decoder.decode<Web::Painting::ScrollFrameIndex>()),
+        .negate = TRY(decoder.decode<bool>()),
+        .compensate_x = TRY(decoder.decode<bool>()),
+        .compensate_y = TRY(decoder.decode<bool>()),
     };
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -89,7 +89,18 @@ struct ScrollCompensation {
     ScrollFrameIndex scroll_frame_index;
 };
 
-using VisualContextData = Variant<ScrollData, ClipData, TransformData, PerspectiveData, ClipPathData, EffectsData, ScrollCompensation>;
+// One scroll frame's contribution to the default scroll shift of an anchor-positioned box, masked to the axes in which
+// the box compensates for scroll. Frames that move the box but not its default anchor contribute negated.
+struct AnchorScrollShift {
+    ScrollFrameIndex scroll_frame_index;
+    bool negate { false };
+    bool compensate_x { true };
+    bool compensate_y { true };
+
+    Gfx::FloatPoint masked_offset(ScrollStateSnapshot const&) const;
+};
+
+using VisualContextData = Variant<ScrollData, ClipData, TransformData, PerspectiveData, ClipPathData, EffectsData, ScrollCompensation, AnchorScrollShift>;
 
 Optional<TransformData> compute_transform(PaintableBox const&, CSS::ComputedValues const&, double pixel_ratio);
 
@@ -190,6 +201,11 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::ScrollCompensation const&);
 template<>
 WEB_API ErrorOr<Web::Painting::ScrollCompensation> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::AnchorScrollShift const&);
+template<>
+WEB_API ErrorOr<Web::Painting::AnchorScrollShift> decode(Decoder&);
 
 template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::AccumulatedVisualContextNode const&);

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -209,6 +209,12 @@ void DisplayListPlayer::execute_impl(
                     if (!offset.is_zero())
                         play_command(Translate { .delta = (-offset).to_type<int>() });
                 },
+                [&](AnchorScrollShift const& shift) {
+                    play_command(Save {});
+                    auto offset = shift.masked_offset(scroll_state);
+                    if (!offset.is_zero())
+                        play_command(Translate { .delta = offset.to_type<int>() });
+                },
                 [&](TransformData const& transform) {
                     play_command(Save {});
                     apply_transform(transform.origin, transform.matrix);
@@ -259,7 +265,8 @@ void DisplayListPlayer::execute_impl(
                 if (node.data.has<TransformData>()
                     || node.data.has<PerspectiveData>()
                     || node.data.has<ScrollData>()
-                    || node.data.has<ScrollCompensation>())
+                    || node.data.has<ScrollCompensation>()
+                    || node.data.has<AnchorScrollShift>())
                     return true;
                 if (index == VISUAL_VIEWPORT_NODE_INDEX)
                     break;

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -201,7 +201,8 @@ void Paintable::paint_with_inspector_overlay_context(DisplayListRecordingContext
                     [](PerspectiveData const&) { return true; },
                     [](ClipPathData const&) { return false; },
                     [](EffectsData const&) { return false; },
-                    [](ScrollCompensation const&) { return true; });
+                    [](ScrollCompensation const&) { return true; },
+                    [](AnchorScrollShift const&) { return true; });
                 if (should_keep)
                     relevant_indices.append(i);
             }

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/anchor-position-top-layer-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/anchor-position-top-layer-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Tests anchor positioning with top-layer elements</title>
+
+<style>
+body {
+  margin: 0;
+  height: 300vh;
+}
+
+#anchor {
+  position: fixed;
+  top: 200px;
+  left: 200px;
+  width: 100px;
+  height: 100px;
+  background: orange;
+}
+
+#target {
+  position: fixed;
+  top: 200px;
+  left: 300px;
+  width: 100px;
+  height: 100px;
+  background: lime;
+}
+</style>
+
+<div id="anchor"></div>
+<div id="target"></div>
+
+<script>
+document.scrollingElement.scrollTop = 100;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/anchor-scroll-composited-scrolling-paint-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/anchor-scroll-composited-scrolling-paint-001-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1999954">
+<style>
+.abs-cb {
+  width: 100px;
+  height: 100px;
+  position: relative;
+}
+
+.anchor {
+  anchor-name: --a;
+  width: 50px;
+  height: 50px;
+  background: blue;
+}
+
+.chain {
+  width: 25px;
+  height: 25px;
+  background: pink;
+  position: absolute;
+  left: 50px;
+  top: 50px;
+}
+
+.positioned {
+  width: 25px;
+  height: 25px;
+  background: yellow;
+  position: absolute;
+  left: 75px;
+  top: 75px;
+}
+</style>
+<div class=abs-cb>
+  <div class=anchor></div>
+  <div class=chain></div>
+  <div class=positioned></div>
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/anchor-scroll-scrollable-anchor-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/anchor-scroll-scrollable-anchor-ref.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<style>
+#scroll-container {
+  width: 400px;
+  height: 400px;
+  overflow: scroll;
+}
+
+#scroll-contents {
+  width: 1000px;
+  height: 1000px;
+  position: relative;
+}
+
+#anchor {
+  anchor-name: --anchor;
+  height: 100px;
+  width: 100px;
+  overflow: scroll;
+}
+
+#anchored {
+  background: green;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="scroll-container">
+  <div id="scroll-contents">
+    <div style="height: 400px"></div>
+    <div id="anchored"></div>
+    <div id="anchor">
+      <div style="height: 500px"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.getElementById('scroll-container').scrollTop = 300;
+document.getElementById('anchor').scrollTop = 300;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/position-area-anchor-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/position-area-anchor-002-ref.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>anchor() resolution in position-area</title>
+<style>
+.abs-cb {
+  width: 180px;
+  height: 180px;
+  position: relative;
+  border: 5px solid;
+}
+
+.scroller {
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+}
+
+.anchor {
+  width: 60px;
+  height: 60px;
+  margin-left: 60px;
+  background: pink;
+}
+
+.filler {
+  width: 1px;
+  height: 180px;
+}
+
+.positioned {
+  width: 30px;
+  height: 30px;
+  background: purple;
+  position: absolute;
+}
+
+.tl {
+  right: 120px;
+  bottom: 120px;
+}
+
+.tr {
+  left: 120px;
+  bottom: 120px;
+}
+
+.bl {
+  right: 120px;
+  top: 120px;
+}
+
+.br {
+  left: 120px;
+  top: 120px;
+}
+</style>
+<div class=abs-cb>
+  <div id=s class=scroller>
+    <div class=filler></div>
+    <div class=anchor></div>
+    <div class=filler></div>
+    <div class="positioned tl dn"></div>
+    <div class="positioned tr dn"></div>
+    <div class="positioned bl dn"></div>
+    <div class="positioned br dn"></div>
+  </div>
+</div>
+<script>
+s.scrollTop = 120;
+document.documentElement.classList.remove('reftest-wait');
+</script>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/position-visibility-no-overflow-scroll-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/position-visibility-no-overflow-scroll-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+  #scroll-container {
+    overflow: hidden scroll;
+    scrollbar-width: none;
+    width: 400px;
+    height: 150px;
+  }
+
+  .anchor {
+    width: 100px;
+    height: 100px;
+    background: orange;
+    display: inline-block;
+  }
+
+  .target {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id="scroll-container">
+  <div class="anchor">anchor1</div>
+  <div class="anchor" style="position: relative; top: 100px">anchor2</div>
+  <div id="target1" class="target" style="background: green">target1</div>
+  <div style="height: 200px"></div>
+</div>
+<script>
+document.getElementById('scroll-container').scrollTop = 50;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-chained-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-chained-001-ref.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller {
+  overflow: scroll;
+}
+
+#anchor {
+  height: 20px;
+  background: orange;
+}
+
+#anchored1 {
+  position: absolute;
+  top: 50px;
+  left: 0;
+  background: green;
+}
+
+#anchored2 {
+  position: absolute;
+  top: 150px;
+  left: 0;
+  background: lime;
+}
+
+</style>
+
+<div id="scroller">
+  <div style="height: 230px"></div>
+  <div id="anchor"></div>
+  <div style="height: 230px"></div>
+</div>
+<div id="anchored1"></div>
+<div id="anchored2"></div>
+
+<script>
+scroller.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-chained-003-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-chained-003-ref.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller1 {
+  width: 200px;
+  height: 200px;
+  position: relative;
+}
+
+#scroller1,#scroller2 {
+  overflow: scroll;
+  scrollbar-width: none;
+}
+
+#anchor {
+  height: 20px;
+  background: orange;
+}
+
+#anchored1 {
+  position: absolute;
+  top: 70px;
+  background: green;
+  z-index: 1;
+}
+
+#anchored2 {
+  position: absolute;
+  top: 170px;
+  background: lime;
+}
+
+</style>
+
+<div id="anchored2"></div>
+<div id="anchored1"></div>
+<div id="scroller1">
+  <div style="height: 100px"></div>
+  <div id="scroller2">
+    <div style="height: 230px"></div>
+    <div id="anchor"></div>
+    <div style="height: 230px"></div>
+  </div>
+  <div style="height: 100px"></div>
+</div>
+
+<script>
+scroller1.scrollTop = 80;
+scroller2.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-composited-scrolling-006-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-composited-scrolling-006-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+}
+#scroller {
+  width: 200px;
+  height: 100px;
+  overflow: scroll;
+  will-change: scroll-position;
+}
+#spacer {
+  height: 400px;
+}
+#anchor {
+  width: 100px;
+  height: 100px;
+  anchor-name: --a;
+}
+#overlap {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  top: 150px;
+  left: 0;
+  z-index: 100;
+  background: green;
+}
+</style>
+
+<div id="overlap"></div>
+<div id="scroller">
+  <div id="spacer"></div>
+  <div id="anchor"></div>
+</div>
+
+<script>
+scroller.scrollTop = 150;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-fixedpos-003-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-fixedpos-003-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  div {
+    width: 100px;
+    height: 100px;
+    font-size: 16px;
+    background: green;
+    color: white;
+  }
+
+  #anchor {
+    margin-top: 105vh;
+    background: orange;
+  }
+
+  #anchored {
+    position: absolute;
+    top: calc(105vh - 100px);
+    background: green;
+  }
+</style>
+
+<body>
+  <div id="anchor"></div>
+  <div id="anchored"></div>
+
+  <script>
+    const anchor = document.getElementById("anchor");
+    anchor.scrollIntoView(false);
+  </script>
+</body>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-fixedpos-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-fixedpos-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  margin: 300px;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  left: 400px;
+  top: 100px;
+  background: green;
+}
+
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+document.documentElement.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-001-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller {
+  overflow: scroll;
+}
+
+#anchor {
+  height: 20px;
+  background: orange;
+}
+
+#anchored {
+  position: absolute;
+  top: 20px;
+  left: 0;
+  background: green;
+}
+
+</style>
+
+<div id="scroller">
+  <div style="height: 200px"></div>
+  <div id="anchor"></div>
+  <div style="height: 150px"></div>
+</div>
+<div id="anchored"></div>
+
+<script>
+scroller.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-003-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-003-ref.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller {
+  overflow: scroll;
+  scrollbar-width: none;
+}
+
+#anchor {
+  height: 20px;
+  background: orange;
+  position: relative;
+}
+
+#anchored {
+  position: absolute;
+  top: 20px;
+  left: 0;
+  background: green;
+}
+
+</style>
+
+<div id="anchored"></div>
+<div id="scroller">
+  <div style="height: 200px"></div>
+  <div id="anchor"></div>
+  <div style="height: 150px"></div>
+</div>
+
+<script>
+scroller.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-004-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-004-ref.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller {
+  overflow: scroll;
+}
+
+#anchor {
+  height: 20px;
+  background: orange;
+  position: relative;
+}
+
+#anchored {
+  position: absolute;
+  top: 70px;
+  left: 0;
+  background: green;
+}
+
+</style>
+
+<div id="anchored"></div>
+<div id="scroller">
+  <div style="height: 250px"></div>
+  <div id="anchor"></div>
+  <div style="height: 180px"></div>
+</div>
+
+<script>
+scroller.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-005-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-005-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+  #cb {
+    position: absolute;
+    inset: 0;
+  }
+  #scroller {
+    margin-top: 300px;
+    overflow-y: scroll;
+    height: 200px;
+  }
+  #spacer { height: 400px; }
+  #anchor { anchor-name: --a; }
+  #anchored {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    top: 100px;
+    left: 0;
+  }
+</style>
+<div id="cb">
+  <div id="scroller">
+    <div id="anchor"></div>
+    <div id="spacer"></div>
+  </div>
+  <div id="anchored"></div>
+</div>
+<script>
+const scroller = document.getElementById('scroller');
+scroller.scrollTop = 200;
+</script>
+

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-006-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-006-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+  #cb {
+    position: absolute;
+    inset: 0;
+  }
+  #scroller {
+    margin-top: 300px;
+    overflow-y: scroll;
+    height: 100px;
+  }
+  #spacer { height: 300px; }
+  #anchor { anchor-name: --a; }
+  #anchored {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    top: 100px;
+    left: 0;
+  }
+</style>
+<div id="cb">
+  <div id="scroller">
+    <div id="anchor"></div>
+    <div id="spacer"></div>
+  </div>
+  <div id="anchored"></div>
+</div>
+<script>
+const scroller = document.getElementById('scroller');
+scroller.scrollTop = 200;
+</script>
+

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-009-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-009-ref.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<title>Anchored element should update when anchor's div under `contain: layout size` becomes a scroll container.</title>
+<link rel="author" href="mailto:dshin@mozilla.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<style>
+.abspos-cb {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  border: 1px solid;
+}
+
+.flex {
+  display: flex;
+}
+
+.positioned {
+  width: 15px;
+  height: 15px;
+  background: purple;
+}
+
+.scroller {
+  overflow-y: scroll;
+  height: 100%;
+}
+
+.anchor {
+  width: 15px;
+  height: 15px;
+  background: magenta;
+}
+
+.filler {
+  width: 1px;
+  height: 500px;
+}
+</style>
+<div class=abspos-cb>
+  <div id=dut class=scroller>
+    <div class=filler></div>
+    <div class=flex>
+      <div class=anchor></div>
+      <div class=positioned></div>
+    </div>
+  </div>
+</div>
+<script>
+dut.scrollTop = 315;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-010-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-010-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<title>Anchored element should update when the nearest scroll container under `contain: layout size` element changes.</title>
+<style>
+.anchor {
+  width: 20px;
+  height: 20px;
+  background: magenta;
+}
+
+.positioned {
+  background: purple;
+  width: 20px;
+  height: 20px;
+}
+
+.flex {
+  display: flex;
+}
+
+.abs-cb {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  border: 1px solid;
+}
+
+.scroll {
+  overflow: scroll;
+}
+
+.outer {
+  width: 200px;
+  height: 200px;
+}
+
+.inner {
+  width: 150px;
+  height: 150px;
+}
+
+.filler {
+  width: 1px;
+  height: 200px;
+}
+</style>
+<div class=abs-cb>
+  <div id=outer class="scroll outer">
+    <div class=filler></div>
+    <div class=flex>
+      <div class=anchor></div>
+      <div class=positioned></div>
+    </div>
+    <div class=inner>
+      <div class=anchor></div>
+    </div>
+  </div>
+</div>
+<script>
+outer.scrollTop = 100;
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed anchor()ed Box 2D</title>
+
+<link rel="stylesheet" href="../..../../fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    left: anchor(left);
+    top: anchor(top);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Reference: Scroll-to-Focus Fixed anchor()ed Box Horizontal</title>
+
+<link rel="stylesheet" href="../..../../fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in horizontal axis */
+  .fixed {
+    position: absolute;
+    position-anchor: --foo;
+    top: calc(100vh - 5em);
+    left: anchor(left);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  window.scroll(window.scrollX, 0);
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-position-top-layer-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-position-top-layer-001.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<title>Top-layer element can anchor to non-top-layer absolutely positioned element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#target-anchor-element">
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/anchor-position-top-layer-ref.html">
+
+<style>
+#anchor {
+  position: absolute;
+  top: 300px;
+  left: 200px;
+  width: 100px;
+  height: 100px;
+  background: orange;
+  anchor-name: --a;
+}
+
+#target {
+  top: anchor(top);
+  left: anchor(right);
+  width: 100px;
+  height: 100px;
+  background: lime;
+  position-anchor: --a;
+  outline: none;
+}
+
+body {
+  margin: 0;
+  height: 300vh;
+}
+
+dialog {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  inset: auto;
+}
+
+dialog::backdrop {
+  background: transparent;
+}
+</style>
+
+<div id="anchor"></div>
+<dialog id="target"></dialog>
+
+<script>
+target.showModal();
+document.scrollingElement.scrollTop = 100;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-position-top-layer-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-position-top-layer-003.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<title>Top-layer element can anchor to preceeding top-layer absolutely positioned element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#target-anchor-element">
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/anchor-position-top-layer-ref.html">
+
+<style>
+#anchor {
+  position: absolute;
+  top: 300px;
+  left: 200px;
+  width: 100px;
+  height: 100px;
+  background: orange;
+  anchor-name: --a;
+}
+
+#target {
+  top: anchor(top);
+  left: anchor(right);
+  width: 100px;
+  height: 100px;
+  background: lime;
+  position-anchor: --a;
+  outline: none;
+}
+
+body {
+  margin: 0;
+  height: 300vh;
+}
+
+dialog {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  inset: auto;
+}
+
+dialog::backdrop {
+  background: transparent;
+}
+</style>
+
+<dialog id="anchor"></dialog>
+<dialog id="target"></dialog>
+
+<script>
+anchor.showModal();
+target.showModal();
+document.scrollingElement.scrollTop = 100;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-chained-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-chained-001.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<title>Tests scroll adjustments of element anchored to another anchored element</title>
+<link rel="author" href="mailto:wangxianzhu@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-chained-001-ref.html">
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller {
+  overflow: scroll;
+}
+
+#anchor {
+  anchor-name: --a1;
+  height: 20px;
+  background: orange;
+}
+
+#anchored1 {
+  position: absolute;
+  position-anchor: --a1;
+  left: anchor(left);
+  top: anchor(bottom);
+  background: green;
+  anchor-name: --a2;
+}
+
+#anchored2 {
+  position: absolute;
+  position-anchor: --a2;
+  left: anchor(left);
+  top: anchor(bottom);
+  background: lime;
+}
+
+</style>
+
+<div id="scroller">
+  <div style="height: 230px"></div>
+  <div id="anchor"></div>
+  <div style="height: 230px"></div>
+</div>
+<div id="anchored1"></div>
+<div id="anchored2"></div>
+
+<script>
+scroller.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-chained-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-chained-003.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<title>Tests scroll adjustments of element anchored to another anchored element</title>
+<link rel="author" href="mailto:wangxianzhu@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-chained-003-ref.html">
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller1 {
+  width: 200px;
+  height: 200px;
+  position: relative;
+}
+
+#scroller1,#scroller2 {
+  /* Using visible scrollbars here tests scrollbar painting order as well, which
+     isn't related to anchor positioning. See:
+     https://github.com/web-platform-tests/wpt/pull/55022#issuecomment-3499478504 */
+overflow: scroll;
+scrollbar-width: none;
+}
+
+#anchor {
+  anchor-name: --a1;
+  height: 20px;
+  background: orange;
+}
+
+#anchored1 {
+  position: absolute;
+  position-anchor: --a1;
+  left: anchor(left);
+  top: anchor(bottom);
+  background: green;
+  anchor-name: --a2;
+  z-index: 1;
+}
+
+#anchored2 {
+  position: absolute;
+  position-anchor: --a2;
+  left: anchor(left);
+  top: anchor(bottom);
+  background: lime;
+  z-index: 1;
+}
+
+</style>
+
+<div id="anchored2"></div>
+<div id="scroller1">
+  <div id="anchored1"></div>
+  <div style="height: 100px"></div>
+  <div id="scroller2">
+    <div style="height: 230px"></div>
+    <div id="anchor"></div>
+    <div style="height: 230px"></div>
+  </div>
+  <div style="height: 100px"></div>
+</div>
+
+<script>
+scroller1.scrollTop = 80;
+scroller2.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-composited-scrolling-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-composited-scrolling-006.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Tests anchor-positioned element paint order in composited scrolling</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#scroll">
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-composited-scrolling-006-ref.html">
+<style>
+body {
+  margin: 0;
+}
+#scroller {
+  width: 200px;
+  height: 100px;
+  overflow: scroll;
+  will-change: scroll-position;
+}
+#spacer {
+  height: 400px;
+}
+#anchor {
+  width: 100px;
+  height: 100px;
+  anchor-name: --a;
+}
+#target {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: red;
+  left: 0;
+  bottom: anchor(top);
+  position-anchor: --a;
+}
+#overlap {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  top: 150px;
+  left: 0;
+  z-index: 100;
+  background: green;
+}
+</style>
+
+<div id="overlap"></div>
+<div id="scroller">
+  <div id="spacer"></div>
+  <div id="anchor"></div>
+</div>
+<div id="target"></div>
+
+<script type="module">
+function raf() { return new Promise(resolve => requestAnimationFrame(resolve)); }
+
+await raf();
+await raf();
+scroller.scrollTop = 150;
+
+document.documentElement.classList.remove('reftest-wait');
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-composited-scrolling-paint-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-composited-scrolling-paint-001.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1999954">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/anchor-scroll-composited-scrolling-paint-001-ref.html">
+<script src="../../common/reftest-wait.js"></script>
+<style>
+.abs-cb {
+  width: 100px;
+  height: 100px;
+  position: relative;
+}
+
+.scroller {
+  overflow: scroll;
+  scrollbar-width: none;
+  width: 100%;
+  height: 100%;
+}
+
+.anchor {
+  anchor-name: --a;
+  width: 50px;
+  height: 50px;
+  background: blue;
+}
+
+.chain {
+  width: 25px;
+  height: 25px;
+  background: pink;
+  position: absolute;
+  position-anchor: --a;
+  anchor-name: --b;
+  left: anchor(right);
+  top: anchor(bottom);
+}
+
+.filler {
+  width: 1px;
+  height: 50px;
+}
+
+.positioned {
+  width: 25px;
+  height: 25px;
+  background: yellow;
+  position: absolute;
+  position-anchor: --b;
+  left: anchor(right);
+  top: anchor(bottom);
+  position-visibility: always;
+}
+</style>
+<div class=abs-cb>
+  <div class=scroller>
+    <div id=s class=scroller>
+      <div class=filler></div>
+      <div class=anchor></div>
+      <div class=filler></div>
+    </div>
+    <div class=chain></div>
+  </div>
+  <div class=positioned></div>
+</div>
+<script>
+window.addEventListener("TestRendered", () => {
+  s.scrollTop = 50;
+  takeScreenshot();
+});
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-fixedpos-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-fixedpos-003.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+<title>Tests that fixed-positioned anchor-positioned elements doesn't get clipped by the viewport</title>
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-fixedpos-003-ref.html">
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  div {
+    width: 100px;
+    height: 100px;
+    font-size: 16px;
+  }
+
+  #anchor {
+    anchor-name: --a1;
+    margin-top: 105vh;
+    background: orange;
+  }
+
+  #anchored {
+    position: fixed;
+    position-anchor: --a1;
+    left: anchor(left);
+    bottom: anchor(top);
+    background: green;
+    color: white;
+  }
+</style>
+
+<body>
+  <div id="anchor"></div>
+  <div id="anchored"></div>
+
+  <script>
+    const anchor = document.getElementById("anchor");
+    anchor.scrollIntoView(false);
+  </script>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-fixedpos.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-fixedpos.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>Tests that scroll adjustments of fixed-positioned elements are applied correctly</title>
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-fixedpos-ref.html">
+<style>
+body {
+  margin: 0;
+  height: 2000px;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#anchor {
+  anchor-name: --a1;
+  margin: 300px;
+  background: orange;
+}
+
+#anchored {
+  position: fixed;
+  position-anchor: --a1;
+  left: anchor(right);
+  top: anchor(top);
+  background: green;
+}
+
+</style>
+
+<div id="anchor"></div>
+<div id="anchored"></div>
+
+<script>
+document.documentElement.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-scrollable-anchor.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-scrollable-anchor.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta name="fuzzy" content="1;0-50">
+<title>Basic of anchor positioned scrolling: scroll of a scrollable anchor should not affect anchor positioning</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/anchor-scroll-scrollable-anchor-ref.html">
+<style>
+#scroll-container {
+  width: 400px;
+  height: 400px;
+  overflow: scroll;
+  will-change: scroll-position;
+}
+
+#scroll-contents {
+  width: 1000px;
+  height: 1000px;
+  position: relative;
+}
+
+.placefiller {
+  height: 500px;
+}
+
+#anchor {
+  anchor-name: --anchor;
+  height: 100px;
+  width: 100px;
+  overflow: scroll;
+  will-change: scroll-position;
+}
+
+#anchored {
+  background: green;
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  left: anchor(left);
+  bottom: anchor(top);
+  position-anchor: --anchor;
+}
+</style>
+
+<div id="scroll-container">
+  <div id="scroll-contents">
+    <div class="placefiller"></div>
+    <div id="anchor">
+      <div class="placefiller"></div>
+    </div>
+  </div>
+</div>
+<div id="anchored"></div>
+
+<script>
+document.getElementById('scroll-container').scrollTop = 300;
+document.getElementById('anchor').scrollTop = 300;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-to-sticky-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-to-sticky-001.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>Tests scroll adjustments of element anchored to a sticky-position element</title>
+<link rel="author" href="mailto:wangxianzhu@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-001-ref.html">
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller {
+  overflow: scroll;
+}
+
+#anchor {
+  anchor-name: --a1;
+  position: sticky;
+  top: 0;
+  height: 20px;
+  background: orange;
+}
+
+#anchored {
+  position: absolute;
+  position-anchor: --a1;
+  left: anchor(left);
+  top: anchor(bottom);
+  background: green;
+}
+
+</style>
+
+<div id="scroller">
+  <div style="height: 50px"></div>
+  <div id="anchor"></div>
+  <div style="height: 300px"></div>
+</div>
+<div id="anchored"></div>
+
+<script>
+scroller.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-to-sticky-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-to-sticky-003.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<title>Tests scroll adjustments of element anchored to a sticky-position element</title>
+<link rel="author" href="mailto:wangxianzhu@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-003-ref.html">
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller {
+  overflow: scroll;
+  scrollbar-width: none;
+}
+
+#anchor {
+  anchor-name: --a1;
+  position: sticky;
+  top: 0;
+  height: 20px;
+  background: orange;
+}
+
+#anchored {
+  position: absolute;
+  position-anchor: --a1;
+  left: anchor(left);
+  top: anchor(bottom);
+  background: green;
+}
+
+</style>
+
+<!-- Anchored to later sticky-positioned. -->
+<div id="anchored"></div>
+<div id="scroller">
+  <div style="height: 50px"></div>
+  <div id="anchor"></div>
+  <div style="height: 300px"></div>
+</div>
+
+<script>
+scroller.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-to-sticky-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-to-sticky-004.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<title>Tests scroll adjustments of element anchored to a sticky-position element</title>
+<link rel="author" href="mailto:wangxianzhu@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-to-sticky-004-ref.html">
+<style>
+body {
+  margin: 0;
+}
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#scroller {
+  overflow: scroll;
+}
+
+.sticky {
+  position: sticky;
+  top: 0;
+}
+
+#anchor {
+  anchor-name: --a1;
+  height: 20px;
+  background: orange;
+}
+
+#anchored {
+  position: absolute;
+  position-anchor: --a1;
+  left: anchor(left);
+  top: anchor(bottom);
+  background: green;
+}
+
+</style>
+
+<!-- Anchored to later nested sticky elements. -->
+<div id="anchored"></div>
+<div id="scroller">
+  <div style="height: 50px"></div>
+  <div class="sticky">
+    <div style="height: 50px"></div>
+    <div id="anchor" class="sticky"></div>
+    <div style="height: 50px"></div>
+  </div>
+  <div style="height: 300px"></div>
+</div>
+
+<script>
+scroller.scrollTop = 200;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-update-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-update-005.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Tests that anchored element should update location after scroll offset changes caused by scroller resizing</title>
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-005-ref.html">
+<style>
+  #cb {
+    position: absolute;
+    inset: 0;
+  }
+  #scroller {
+    margin-top: 300px;
+    overflow-y: scroll;
+    height: 100px;
+  }
+  #scroller.changed { height: 200px; }
+  #spacer { height: 400px; }
+  #anchor { anchor-name: --a; }
+  #anchored {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    top: anchor(top);
+    left: 0;
+    position-anchor: --a;
+    position-visibility: always;
+  }
+</style>
+<div id="cb">
+  <div id="scroller">
+    <div id="anchor"></div>
+    <div id="spacer"></div>
+  </div>
+  <div id="anchored"></div>
+</div>
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+async function runTest() {
+  const scroller = document.getElementById('scroller');
+  scroller.scrollTop = 300;
+
+  await raf();
+  await raf();
+
+  scroller.classList.add('changed');
+  document.documentElement.classList.remove('reftest-wait');
+
+  // Should change scroll offset and scroll adjustment to 200.
+}
+runTest();
+</script>
+

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-update-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-update-006.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Tests that anchored element should update location after scroll offset changes caused by scroll content resizing</title>
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-006-ref.html">
+<style>
+  #cb {
+    position: absolute;
+    inset: 0;
+  }
+  #scroller {
+    margin-top: 300px;
+    overflow-y: scroll;
+    height: 100px;
+  }
+  #spacer { height: 400px; }
+  #spacer.changed { height: 300px; }
+  #anchor { anchor-name: --a; }
+  #anchored {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    top: anchor(top);
+    left: 0;
+    position-anchor: --a;
+    position-visibility: always;
+  }
+</style>
+<div id="cb">
+  <div id="scroller">
+    <div id="anchor"></div>
+    <div id="spacer"></div>
+  </div>
+  <div id="anchored"></div>
+</div>
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+async function runTest() {
+  const scroller = document.getElementById('scroller');
+  scroller.scrollTop = 300;
+
+  await raf();
+  await raf();
+
+  document.getElementById('spacer').classList.add('changed');
+  document.documentElement.classList.remove('reftest-wait');
+
+  // Should change scroll offset and scroll adjustment to 200.
+}
+runTest();
+</script>
+

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-update-009.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-update-009.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Anchored element should update when anchor's div under `contain: layout size` becomes a scroll container.</title>
+<link rel="author" href="mailto:dshin@mozilla.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-009-ref.html">
+<style>
+.abspos-cb {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  border: 1px solid;
+}
+
+.positioned {
+  width: 15px;
+  height: 15px;
+  background: purple;
+
+  position: absolute;
+  position-anchor: --a;
+  left: anchor(right);
+  top: anchor(top);
+}
+
+.scroller {
+  overflow-y: scroll;
+  height: 100%;
+}
+
+.filler {
+  width: 1px;
+  height: 500px;
+}
+
+.anchor {
+  width: 15px;
+  height: 15px;
+  background: magenta;
+  anchor-name: --a;
+}
+
+.contain {
+  contain: layout size;
+  width: 200px;
+  height: 200px;
+}
+</style>
+<div class=abspos-cb>
+  <div class=positioned></div>
+  <div class=contain><div id=dut>
+    <div class=filler></div>
+    <div class=anchor></div>
+  </div></div>
+</div>
+<script>
+dut.classList.toggle('scroller');
+dut.scrollTop = 315;
+
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+async function runTest() {
+  await raf();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-update-010.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/anchor-scroll-update-010.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Anchored element should update when the nearest scroll container under `contain: layout size` element changes.</title>
+<link rel="author" href="mailto:dshin@mozilla.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/reference/anchor-scroll-update-010-ref.html">
+<style>
+.anchor {
+  width: 20px;
+  height: 20px;
+  background: magenta;
+}
+
+.positioned {
+  position-anchor: --a;
+  position: absolute;
+  background: purple;
+  width: 20px;
+  height: 20px;
+  /* Initially not part of --a's nearest scroll container */
+  left: anchor(--b right);
+  top: anchor(--b top);
+}
+
+.abs-cb {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  border: 1px solid;
+}
+
+.scroll {
+  overflow: scroll;
+}
+
+.outer {
+  width: 200px;
+  height: 200px;
+}
+
+.inner {
+  width: 150px;
+  height: 150px;
+}
+
+.filler {
+  width: 1px;
+  height: 200px;
+}
+
+.contain {
+  contain: layout size;
+  width: 200px;
+  height: 200px;
+}
+</style>
+<div class=abs-cb>
+  <div class=contain>
+    <div id=outer class="scroll outer">
+      <div class=filler></div>
+      <div class=anchor style="anchor-name: --b"></div>
+      <div id=inner class="scroll inner">
+        <div class=anchor style="anchor-name: --a"></div>
+      </div>
+    </div>
+  </div>
+  <div class=positioned></div>
+</div>
+<script>
+inner.classList.toggle('scroll');
+outer.scrollTop = 100;
+
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+async function runTest() {
+  await raf();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/position-area-anchor-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/position-area-anchor-002.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>anchor() resolution in position-area</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/position-area-anchor-002-ref.html">
+<link rel="author" name="David Shin" href="mailto:dshin@mozilla.com">
+<style>
+.abs-cb {
+  width: 180px;
+  height: 180px;
+  position: relative;
+  border: 5px solid;
+}
+
+.scroller {
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+}
+
+.anchor {
+  width: 60px;
+  height: 60px;
+  margin-left: 60px;
+  anchor-name: --a;
+  background: pink;
+}
+
+.filler {
+  width: 1px;
+  height: 180px;
+}
+
+.positioned {
+  width: 30px;
+  height: 30px;
+  background: purple;
+  position: absolute;
+  position-anchor: --a;
+}
+
+.tl {
+  position-area: top left;
+  right: anchor(left);
+  bottom: anchor(top);
+}
+
+.tr {
+  position-area: top right;
+  left: anchor(right);
+  bottom: anchor(top);
+}
+
+.bl {
+  position-area: bottom left;
+  right: anchor(left);
+  top: anchor(bottom);
+}
+
+.br {
+  position-area: bottom right;
+  left: anchor(right);
+  top: anchor(bottom);
+}
+
+.dn {
+  display: none;
+}
+
+</style>
+<div class=abs-cb>
+  <div id=s class=scroller>
+    <div class=filler></div>
+    <div class=anchor></div>
+    <div class=filler></div>
+    <div class="positioned tl dn"></div>
+    <div class="positioned tr dn"></div>
+    <div class="positioned bl dn"></div>
+    <div class="positioned br dn"></div>
+  </div>
+</div>
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+async function runTest() {
+  s.scrollTop = 120;
+  await raf();
+  await raf();
+
+  for(const e of s.querySelectorAll('.positioned')) {
+    e.classList.remove('dn');
+  }
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/position-visibility-no-overflow-scroll.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/position-visibility-no-overflow-scroll.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Anchor Positioning Test: position-visibility: no-overflow</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-visibility">
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/position-visibility-no-overflow-scroll-ref.html">
+<style>
+  #container {
+    position: relative;
+    width: 400px;
+    height: 150px;
+    overflow: hidden;
+  }
+
+  #scroll-container {
+    overflow: hidden scroll;
+    scrollbar-width: none;
+    width: 100%;
+    height: 100%;
+  }
+
+  .anchor {
+    width: 100px;
+    height: 100px;
+    background: orange;
+    display: inline-block;
+  }
+
+  .target {
+    position: absolute;
+    position-visibility: no-overflow;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<div id="container">
+<div id="scroll-container">
+  <div class="anchor" style="anchor-name: --a1;">anchor1</div>
+  <div class="anchor" style="anchor-name: --a2; position: relative; top: 100px">anchor2</div>
+  <div id="target1" class="target" style="position-anchor: --a1; top: anchor(bottom); background: green">target1</div>
+  <div id="target2" class="target" style="position-anchor: --a2; left: anchor(left); bottom: anchor(top); background: red">target2</div>
+  <div style="height: 300px"></div>
+</div>
+</div>
+
+<script>
+requestAnimationFrame(() => {
+  requestAnimationFrame(() => {
+    document.getElementById('scroll-container').scrollTop = 50;
+    document.documentElement.classList.remove('reftest-wait');
+  });
+});
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed anchor()ed Box 2D</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#scroll">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-001-ref.html">
+<link rel="stylesheet" href="../..../../fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in both axes */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    left: anchor(left);
+    top: anchor(top);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Test: Scroll-to-Focus Fixed anchor()ed Box Horizontal</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#scroll">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-management-apis">
+
+<link rel="match" href="../../../../expected/wpt-import/css/css-anchor-position/scroll-to-anchored-fixed-005-ref.html">
+<link rel="stylesheet" href="../..../../fonts/ahem.css">
+<style>
+  /* Force scrolling. */
+  body {
+    border: solid silver;
+    height: 100vh;
+    width: 100vw;
+  }
+  .anchor {
+    position: absolute;
+    top: 100%;
+    left: 100%;
+    width: 100vw;
+    height: 100vh;
+    border: solid silver;
+    anchor-name: --foo;
+  }
+
+  /* Attach to anchor in horizontal axis */
+  .fixed {
+    position: fixed;
+    position-anchor: --foo;
+    top: calc(100vh - 5em);
+    left: anchor(left);
+    padding: 1em 2em;
+    border: solid orange 10px;
+    margin: 5px;
+  }
+
+  /* Avoid pixel differences. */
+  .fixed {
+    font-family: Ahem;
+  }
+  a:focus {
+    outline: solid blue;
+  }
+</style>
+
+<input value="Tab to the next link &rarr;"><br>
+<em>This should trigger a scroll operation...</em>
+
+<div class=anchor></div>
+<div class=fixed>
+  <p><a href="" id=test>One</a>
+  <p><a href="">Two</a>
+  <p><a href="">Three</a>
+</div>
+
+<script>
+function raf() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+async function runTest() {
+  await raf();
+  document.getElementById('test').focus();
+  await raf();
+  document.documentElement.classList.remove('reftest-wait');
+}
+runTest();
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/fonts/ahem.css.headers
+++ b/Tests/LibWeb/Ref/input/wpt-import/fonts/ahem.css.headers
@@ -1,0 +1,2 @@
+Content-Type: text/css;charset=utf-8
+Cache-Control: max-age=3600

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-anchor-position/anchor-scroll-006.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-anchor-position/anchor-scroll-006.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	#target1 is scroll-adjusted in x axis only
+Pass	#target2 is scroll-adjusted in y axis only
+Pass	#target3 is scroll-adjusted in neither axis

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-anchor-position/anchor-scroll-007.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-anchor-position/anchor-scroll-007.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	#target3 is scroll-adjusted in both axises

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-anchor-position/anchor-scroll-006.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-anchor-position/anchor-scroll-006.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<title>Tests that scroll adjustment is applied per-axis</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#needs-scroll-adjustment">
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+body {
+  margin: 0;
+}
+
+.scroller {
+  width: 150px;
+  height: 150px;
+  margin-bottom: 50px;
+  overflow: scroll;
+  position: relative;
+}
+
+.spacer {
+  width: 400px;
+  height: 400px;
+}
+
+.anchor {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  top: 50px;
+  left: 50px;
+  background: orange;
+}
+
+.target {
+  position: fixed;
+  width: 50px;
+  height: 50px;
+  background: lime;
+}
+
+#scroller1 { anchor-name: --scroller1; }
+#scroller2 { anchor-name: --scroller2; }
+#scroller3 { anchor-name: --scroller3; }
+
+#anchor1 { anchor-name: --a1; }
+#anchor2 { anchor-name: --a2; }
+#anchor3 { anchor-name: --a3; }
+
+/* Needs scroll adjustment in x axis only */
+#target1 {
+  position-anchor: --a1;
+  left: anchor(left);
+  top: anchor(--scroller1 bottom);
+}
+
+/* Needs scroll adjustment in y axis only */
+#target2 {
+  position-anchor: --a2;
+  top: anchor(top);
+  left: anchor(--scroller2 right);
+}
+
+/* No scroll adjustment needed */
+#target3 {
+  position-anchor: --a3;
+  top: anchor(--scroller3 bottom);
+  left: anchor(--scroller3 right);
+}
+</style>
+
+<div class="scroller" id="scroller1">
+  <div class="spacer"></div>
+  <div class="anchor" id="anchor1"></div>
+</div>
+<div class="target" id="target1"></div>
+
+<script>
+promise_test(async () => {
+  await waitUntilNextAnimationFrame();
+  assert_equals(target1.getBoundingClientRect().left, 50, "left initial");
+  assert_equals(target1.getBoundingClientRect().top, 150, "top initial");
+
+  scroller1.scrollLeft = 50;
+  await waitUntilNextAnimationFrame();
+  assert_equals(target1.getBoundingClientRect().left, 0, "left scroll");
+
+  scroller1.scrollTop = 50;
+  await waitUntilNextAnimationFrame();
+  assert_equals(target1.getBoundingClientRect().top, 150, "top scroll");
+}, '#target1 is scroll-adjusted in x axis only');
+</script>
+
+<div class="scroller" id="scroller2">
+  <div class="spacer"></div>
+  <div class="anchor" id="anchor2"></div>
+</div>
+<div class="target" id="target2"></div>
+
+<script>
+promise_test(async () => {
+  await waitUntilNextAnimationFrame();
+  assert_equals(target2.getBoundingClientRect().left, 150, "left initial");
+  assert_equals(target2.getBoundingClientRect().top, 250, "top initial");
+
+  scroller2.scrollLeft = 50;
+  await waitUntilNextAnimationFrame();
+  assert_equals(target2.getBoundingClientRect().left, 150, "left scroll");
+
+  scroller2.scrollTop = 50;
+  await waitUntilNextAnimationFrame();
+  assert_equals(target2.getBoundingClientRect().top, 200, "top scroll");
+}, '#target2 is scroll-adjusted in y axis only');
+</script>
+
+<div class="scroller" id="scroller3">
+  <div class="spacer"></div>
+  <div class="anchor" id="anchor3"></div>
+</div>
+<div class="target" id="target3"></div>
+
+<script>
+promise_test(async () => {
+  await waitUntilNextAnimationFrame();
+  assert_equals(target3.getBoundingClientRect().left, 150, "left initial");
+  assert_equals(target3.getBoundingClientRect().top, 550, "top initial");
+
+  scroller3.scrollLeft = 50;
+  await waitUntilNextAnimationFrame();
+  assert_equals(target3.getBoundingClientRect().left, 150, "left scroll");
+
+  scroller3.scrollTop = 50;
+  await waitUntilNextAnimationFrame();
+  assert_equals(target3.getBoundingClientRect().top, 550, "top scroll");
+}, '#target3 is scroll-adjusted in neither axis');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-anchor-position/anchor-scroll-007.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-anchor-position/anchor-scroll-007.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<title>Tests that scroll adjustment still applies when using another anchor in default anchor's scroll container</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#needs-scroll-adjustment">
+<link rel="author" href="mailto:xiaochengh@chromium.org">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+body {
+  margin: 0;
+}
+
+#scroller {
+  width: 400px;
+  height: 400px;
+  overflow: scroll;
+  position: relative;
+}
+
+#spacer {
+  width: 1000px;
+  height: 1000px;
+}
+
+.anchor {
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  background: orange;
+}
+
+#anchor1 {
+  anchor-name: --a1;
+  left: 300px;
+  top: 100px;
+}
+
+#anchor2 {
+  anchor-name: --a2;
+  left: 200px;
+  top: 200px;
+}
+
+#anchor3 {
+  anchor-name: --a3;
+  left: 100px;
+  top: 300px;
+}
+
+/* Uses different anchors in insets instead of the default anchor.
+ * Still scroll-adjusted because they are in the same scroll container. */
+#target {
+  position: fixed;
+  width: 50px;
+  height: 50px;
+  left: anchor(--a3 left);
+  top: anchor(--a1 top);
+  position-anchor: --a2;
+  background: lime;
+}
+</style>
+
+<div id="scroller">
+  <div id="spacer"></div>
+  <div class="anchor" id="anchor1"></div>
+  <div class="anchor" id="anchor2"></div>
+  <div class="anchor" id="anchor3"></div>
+</div>
+<div id="target"></div>
+
+<script>
+promise_test(async () => {
+  await waitUntilNextAnimationFrame();
+  assert_equals(target.getBoundingClientRect().left, 100);
+  assert_equals(target.getBoundingClientRect().top, 100);
+
+  scroller.scrollLeft = 50;
+  await waitUntilNextAnimationFrame();
+  assert_equals(target.getBoundingClientRect().left, 50);
+
+  scroller.scrollTop = 50;
+  await waitUntilNextAnimationFrame();
+  assert_equals(target.getBoundingClientRect().top, 50);
+}, '#target3 is scroll-adjusted in both axises');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-anchor-position/support/test-common.js
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-anchor-position/support/test-common.js
@@ -1,0 +1,44 @@
+// Asserts that the anchored element is at the top/bottom/left/right of the
+// anchor.
+function assert_fallback_position(anchored, anchor, direction) {
+  let anchoredRect = anchored.getBoundingClientRect();
+  let anchorRect = anchor.getBoundingClientRect();
+  let message = `Anchored element should be at the ${direction} of anchor`;
+  switch (direction) {
+    case 'top':
+      assert_equals(anchoredRect.bottom, anchorRect.top, message);
+      return;
+    case 'bottom':
+      assert_equals(anchoredRect.top, anchorRect.bottom, message);
+      return;
+    case 'left':
+      assert_equals(anchoredRect.right, anchorRect.left, message);
+      return;
+    case 'right':
+      assert_equals(anchoredRect.left, anchorRect.right, message);
+      return;
+    default:
+      assert_unreached('unsupported direction');
+  }
+}
+
+async function waitUntilNextAnimationFrame() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+// This function is a thin wrapper around `checkLayout` (from
+// resources/check-layout-th.js) and simply reads the `CHECK_LAYOUT_DELAY`
+// variable to optionally add a delay. This global variable is not intended
+// to be set by other tests; instead, polyfills can set it to give themselves
+// time to apply changes before proceeding with assertions about the layout.
+// Tests that call this function and then do additional work after the call
+// should `await` it to avoid race conditions.
+window.checkLayoutForAnchorPos = async function(selectorList, callDone = true) {
+  if (window.CHECK_LAYOUT_DELAY) {
+    assert_equals(window.INJECTED_SCRIPT,undefined,'CHECK_LAYOUT_DELAY is only allowed when serving WPT with --injected-script.');
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+  }
+  return window.checkLayout(selectorList, callDone);
+}


### PR DESCRIPTION
This commit implements the "compensate for scroll" mechanism from the CSS Anchor Positioning specification. A box compensates for scroll in an axis when an `anchor()` function in that axis resolves against its
default anchor box, or an anchor sharing that box's nearest scroll container ancestor.

The shift is applied at paint time, before the box's own transforms  by emitting a visual context node for each scroll frame between the box's containing block and its default anchor box. This keeps the box attached to its default anchor as any scroll container between them scrolls, including sticky and chained anchors, whose movement is not reflected in layout positions.

This fixes the gap mentioned in #10108, fixing the positioning of the "Period" dropdown on the GitHub pulse page when the page is scrolled:

Before:

<img width="879" height="518" alt="image" src="https://github.com/user-attachments/assets/a152c0a2-1fa2-4d06-b5c8-85fa72824184" />

After:

<img width="879" height="518" alt="image" src="https://github.com/user-attachments/assets/d137702d-6270-4fa4-9819-4acaf26b2e36" />

Fixes #10387