### PR TITLE
LibWeb: Don't put a local storage shelf in the session storage shed

### DIFF
--- a/Libraries/LibWeb/StorageAPI/StorageShelf.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageShelf.cpp
@@ -6,7 +6,6 @@
 
 #include <LibGC/Heap.h>
 #include <LibWeb/DOM/Document.h>
-#include <LibWeb/HTML/LocalTraversableNavigable.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Page/Page.h>
@@ -64,12 +63,17 @@ GC::Ptr<StorageShelf> obtain_a_local_storage_shelf(HTML::EnvironmentSettingsObje
 
     // FIXME: This should be implemented in a way that works for Workers.
     auto& window = as<HTML::Window>(settings.global_object());
-    auto navigable = window.associated_document().navigable();
-    if (!navigable || !navigable->traversable_navigable())
+
+    auto key = obtain_a_storage_key(settings);
+    if (!key.has_value())
         return {};
 
-    auto& shed = navigable->traversable_navigable()->storage_shed();
-    return shed.obtain_a_storage_shelf(settings, StorageType::Local);
+    // AD-HOC: We have no user-agent storage shed. Our local storage is backed by StorageJar. This shelf is a transient
+    //         helper for computing estimate()'s usage and quota — so a standalone shelf is functionally equivalent to
+    //         the spec's requirement to obtain one from a shed. It must not come from the traversable navigable's
+    //         storage shed. That holds *session* storage. And we have other existing code which expects the shelves for
+    //         that to have a populated session-storage bottle — which a local shelf lacks.
+    return StorageShelf::create(window.heap(), window.page(), key.release_value(), StorageType::Local);
 }
 
 }

--- a/Tests/LibWeb/Text/expected/storage-estimate-does-not-break-session-storage.txt
+++ b/Tests/LibWeb/Text/expected/storage-estimate-does-not-break-session-storage.txt
@@ -1,0 +1,2 @@
+window.open after estimate(): ok
+sessionStorage after estimate(): value

--- a/Tests/LibWeb/Text/input/storage-estimate-does-not-break-session-storage.html
+++ b/Tests/LibWeb/Text/input/storage-estimate-does-not-break-session-storage.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    // StorageManager.estimate() must not insert a local storage shelf into the traversable navigable's session storage
+    // shed. It previously did, so window.open() (which legacy-clones that shed and assumes every shelf is a session
+    // shelf) dereferenced a null session storage bottle and crashed.
+    promiseTest(async () => {
+        await navigator.storage.estimate();
+
+        const win = window.open("about:blank");
+        println("window.open after estimate(): " + (win ? "ok" : "null"));
+        if (win) win.close();
+
+        window.sessionStorage.setItem("key", "value");
+        println("sessionStorage after estimate(): " + window.sessionStorage.getItem("key"));
+    });
+</script>


### PR DESCRIPTION
**Problem:** Very frequent CI flakes: After `estimate()` runs once, we crashed on a later `window.open()` or the first `sessionStorage` access.

**Cause:** `StorageManager::estimate()` — via `obtain_a_local_storage_shelf` — inserted a local-storage shelf in the traversable navigable's storage shed. But that shed’s expected to hold *session* storage. Legacy-cloning it on `window.open()` and obtaining a session-storage bottle both iterate/look it up expecting every shelf is a *session* shelf — with a populated session-storage bottle. A *local* shelf’s bucket has no session storage bottle — so we ended up dereferencing its null bottle-map slot.

**Fix:** `obtain_a_local_storage_shelf` now creates a standalone local-storage shelf — rather than putting one into the session-storage shed. Our local storage is backed by `StorageJar` — so the shelf’s only transiently needed to compute `estimate()`’s usage/quota; not using the session-storage shed for it matches the expectation that all its shelves are session shelves. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10385.
