### PR TITLE
LibWeb: Fix NodeIterator retargeting during removals 

### DIFF
--- a/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -15,12 +15,12 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(NodeIterator);
 
-NodeIterator::NodeIterator(JS::Realm& realm, Node& root)
+NodeIterator::NodeIterator(JS::Realm& realm, GC::Ref<Node> root, NodePointer reference)
     : PlatformObject(realm)
     , m_root(root)
-    , m_reference({ root })
+    , m_reference(reference)
 {
-    root.document().register_node_iterator({}, *this);
+    m_root->document().register_node_iterator({}, *this);
 }
 
 NodeIterator::~NodeIterator() = default;
@@ -44,17 +44,17 @@ void NodeIterator::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_root);
     visitor.visit(m_reference.node);
 
-    if (m_traversal_pointer.has_value())
-        visitor.visit(m_traversal_pointer->node);
+    if (m_candidate_reference.has_value())
+        visitor.visit(m_candidate_reference->node);
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createnodeiterator
 GC::Ref<NodeIterator> NodeIterator::create(JS::Realm& realm, Node& root, unsigned what_to_show, GC::Ptr<NodeFilter> filter)
 {
     // 1. Let iterator be a new NodeIterator object.
-    // 2. Set iterator’s root and iterator’s reference to root.
-    // 3. Set iterator’s pointer before reference to true.
-    auto iterator = realm.create<NodeIterator>(realm, root);
+    // 2. Set iterator’s root to root.
+    // 3. Set iterator’s reference to (root, true).
+    auto iterator = realm.create<NodeIterator>(realm, root, NodePointer { root, true });
 
     // 4. Set iterator’s whatToShow to whatToShow.
     iterator->m_what_to_show = what_to_show;
@@ -76,65 +76,82 @@ void NodeIterator::detach()
 // https://dom.spec.whatwg.org/#concept-nodeiterator-traverse
 JS::ThrowCompletionOr<GC::Ptr<Node>> NodeIterator::traverse(Direction direction)
 {
-    // 1. Let node be iterator’s reference.
-    // 2. Let beforeNode be iterator’s pointer before reference.
-    m_traversal_pointer = m_reference;
+    // 1. Set iterator’s candidate reference to iterator’s reference.
+    m_candidate_reference = m_reference;
 
-    GC::Ptr<Node> candidate;
+    // 2. Let result be null.
+    GC::Ptr<Node> result;
 
     // 3. While true:
     while (true) {
-        // 4. Branch on direction:
+        // 1. If type is "next":
         if (direction == Direction::Next) {
-            // next
-            // If beforeNode is false, then set node to the first node following node in iterator’s iterator collection.
-            // If there is no such node, then return null.
-            if (!m_traversal_pointer->is_before_node) {
-                auto* next_node = m_traversal_pointer->node->next_in_pre_order(m_root.ptr());
-                if (!next_node)
-                    return nullptr;
-                m_traversal_pointer->node = *next_node;
-            } else {
-                // If beforeNode is true, then set it to false.
-                m_traversal_pointer->is_before_node = false;
+            // 1. If iterator’s candidate reference’s pointer before is false:
+            if (!m_candidate_reference->pointer_before) {
+                // 1. Let following be the first node following candidate reference’s node in iterator’s iterator collection.
+                //    If there is no such node, then break.
+                auto* following = m_candidate_reference->node->next_in_pre_order(m_root);
+                if (!following)
+                    break;
+
+                // 2. Set candidate reference to (following, false).
+                m_candidate_reference = { *following, false };
             }
-        } else {
-            // previous
-            // If beforeNode is true, then set node to the first node preceding node in iterator’s iterator collection.
-            // If there is no such node, then return null.
-            if (m_traversal_pointer->is_before_node) {
-                if (m_traversal_pointer->node.ptr() == m_root.ptr())
-                    return nullptr;
-                auto* previous_node = m_traversal_pointer->node->previous_in_pre_order();
-                if (!previous_node)
-                    return nullptr;
-                m_traversal_pointer->node = *previous_node;
-            } else {
-                // If beforeNode is false, then set it to true.
-                m_traversal_pointer->is_before_node = true;
+            // 2. Otherwise, set candidate reference to (candidate reference’s node, false).
+            else {
+                m_candidate_reference = { m_candidate_reference->node, false };
+            }
+        }
+        // 2. Otherwise:
+        else {
+            // 1. If iterator’s candidate reference’s pointer before is true:
+            if (m_candidate_reference->pointer_before) {
+                // 1. Let preceding be the first node preceding candidate reference’s node in iterator’s iterator collection.
+                //    If there is no such node, then break.
+                if (m_candidate_reference->node == m_root)
+                    break;
+                auto* preceding = m_candidate_reference->node->previous_in_pre_order();
+                if (!preceding)
+                    break;
+
+                // 2. Set iterator’s candidate reference to (preceding, true).
+                m_candidate_reference = { *preceding, true };
+            }
+            // 2. Otherwise, set candidate reference to (candidate reference’s node, true).
+            else {
+                m_candidate_reference = { m_candidate_reference->node, true };
             }
         }
 
-        // NOTE: If the NodeFilter deletes the iterator's current traversal pointer,
-        //       we will automatically retarget it. However, in that case, we're expected
-        //       to return the node passed to the filter, not the adjusted traversal pointer's
-        //       node after the filter returns!
-        candidate = m_traversal_pointer->node;
+        // 3. Let node be candidate reference’s node.
+        GC::Ref<Node> node = m_candidate_reference->node;
 
-        // 2. Let result be the result of filtering node within iterator.
-        auto result = TRY(filter(*m_traversal_pointer->node));
+        // 4. Let filterResult be the result of filtering node within iterator. If this throws an exception,
+        //    then set iterator’s candidate reference to null and rethrow that exception.
+        auto filter_result = filter(node);
+        if (filter_result.is_error()) {
+            m_candidate_reference.clear();
+            return filter_result.release_error();
+        }
 
-        // 3. If result is FILTER_ACCEPT, then break.
-        if (result == NodeFilter::Result::FILTER_ACCEPT)
+        // 5. If filterResult is FILTER_ACCEPT:
+        if (filter_result.value() == NodeFilter::Result::FILTER_ACCEPT) {
+            // 1. Set iterator’s reference to iterator’s candidate reference.
+            m_reference = *m_candidate_reference;
+
+            // 2. Set result to node.
+            result = node;
+
+            // 3. Break.
             break;
+        }
     }
 
-    // 4. Set iterator’s reference to node.
-    // 5. Set iterator’s pointer before reference to beforeNode.
-    m_reference = m_traversal_pointer.release_value();
+    // 4. Set iterator’s candidate reference to null.
+    m_candidate_reference.clear();
 
-    // 6. Return node.
-    return candidate;
+    // 5. Return result.
+    return result;
 }
 
 // https://dom.spec.whatwg.org/#concept-traversal-filter
@@ -183,76 +200,60 @@ JS::ThrowCompletionOr<NodeFilter::Result> NodeIterator::filter(Node& node)
 // https://dom.spec.whatwg.org/#dom-nodeiterator-nextnode
 JS::ThrowCompletionOr<GC::Ptr<Node>> NodeIterator::next_node()
 {
+    // The nextNode() method steps are to return the result of traversing with this and "next".
     return traverse(Direction::Next);
 }
 
 // https://dom.spec.whatwg.org/#dom-nodeiterator-previousnode
 JS::ThrowCompletionOr<GC::Ptr<Node>> NodeIterator::previous_node()
 {
+    // The previousNode() method steps are to return the result of traversing with this and "previous".
     return traverse(Direction::Previous);
 }
 
-void NodeIterator::run_pre_removing_steps_with_node_pointer(Node& to_be_removed_node, NodePointer& pointer)
+// https://dom.spec.whatwg.org/#nodeiterator-adjust
+NodeIterator::NodePointer NodeIterator::adjust_node_pointer(NodePointer node_pointer, Node& to_be_removed_node)
 {
-    // NOTE: This function tries to match the behavior of other engines, but not the DOM specification
-    //       as it's a known issue that the spec doesn't match how major browsers behave.
-    //       Spec bug: https://github.com/whatwg/dom/issues/907
+    // 1. If toBeRemovedNode is not an inclusive ancestor of nodePointer’s node, or toBeRemovedNode is an inclusive
+    //    ancestor of nodeIterator’s root, then return nodePointer.
+    if (!to_be_removed_node.is_inclusive_ancestor_of(node_pointer.node) || to_be_removed_node.is_inclusive_ancestor_of(root()))
+        return node_pointer;
 
-    if (!to_be_removed_node.is_descendant_of(root()))
-        return;
+    // 2. If nodePointer’s pointer before is true:
+    if (node_pointer.pointer_before) {
+        // 1. Let next be toBeRemovedNode’s first following node that is an inclusive descendant of nodeIterator’s root
+        //    and is not an inclusive descendant of toBeRemovedNode, if there is such a node; otherwise null.
+        auto* next = to_be_removed_node.next_in_pre_order(root());
+        while (next && next->is_descendant_of(to_be_removed_node))
+            next = next->next_in_pre_order(root());
 
-    if (!to_be_removed_node.is_inclusive_ancestor_of(pointer.node))
-        return;
-
-    if (pointer.is_before_node) {
-        if (auto* node = to_be_removed_node.next_in_pre_order(root())) {
-            while (node && node->is_descendant_of(to_be_removed_node))
-                node = node->next_in_pre_order(root());
-            if (node)
-                pointer.node = *node;
-            return;
-        }
-        if (auto* node = to_be_removed_node.previous_in_pre_order()) {
-            if (to_be_removed_node.is_ancestor_of(pointer.node)) {
-                while (node && node->is_descendant_of(to_be_removed_node))
-                    node = node->previous_in_pre_order();
-            }
-            if (node) {
-                pointer = {
-                    .node = *node,
-                    .is_before_node = false,
-                };
-            }
-        }
-        return;
+        // 2. If next is non-null, then return (next, true).
+        if (next)
+            return { *next, true };
     }
 
-    if (auto* node = to_be_removed_node.previous_in_pre_order()) {
-        if (to_be_removed_node.is_ancestor_of(pointer.node)) {
-            while (node && node->is_descendant_of(to_be_removed_node))
-                node = node->previous_in_pre_order();
-        }
-        if (node)
-            pointer.node = *node;
-        return;
-    }
-    auto* node = to_be_removed_node.next_in_pre_order(root());
-    if (to_be_removed_node.is_ancestor_of(pointer.node)) {
-        while (node && node->is_descendant_of(to_be_removed_node))
-            node = node->previous_in_pre_order();
-    }
-    if (node)
-        pointer.node = *node;
+    // 3. Let newNode be toBeRemovedNode’s parent, if toBeRemovedNode’s previous sibling is null; otherwise the
+    //    inclusive descendant of toBeRemovedNode’s previous sibling that appears last in tree order.
+    // NOTE: This is exactly toBeRemovedNode’s previous node in pre-order. It is never null here, because step 1
+    //       guarantees toBeRemovedNode is a proper descendant of the root and thus has a parent.
+    auto* new_node = to_be_removed_node.previous_in_pre_order();
+    VERIFY(new_node);
+
+    // 4. Return (newNode, false).
+    return { *new_node, false };
 }
 
 // https://dom.spec.whatwg.org/#nodeiterator-pre-removing-steps
 void NodeIterator::run_pre_removing_steps(Node& to_be_removed_node)
 {
-    // NOTE: If we're in the middle of traversal, we have to adjust the traversal pointer in response to node removal.
-    if (m_traversal_pointer.has_value())
-        run_pre_removing_steps_with_node_pointer(to_be_removed_node, *m_traversal_pointer);
+    // 1. Set nodeIterator’s reference to the result of adjusting a node pointer given nodeIterator’s reference,
+    //    nodeIterator, and toBeRemovedNode.
+    m_reference = adjust_node_pointer(m_reference, to_be_removed_node);
 
-    run_pre_removing_steps_with_node_pointer(to_be_removed_node, m_reference);
+    // 2. If nodeIterator’s candidate reference is non-null, then set nodeIterator’s candidate reference to the result
+    //    of adjusting a node pointer given nodeIterator’s candidate reference, nodeIterator, and toBeRemovedNode.
+    if (m_candidate_reference.has_value())
+        m_candidate_reference = adjust_node_pointer(*m_candidate_reference, to_be_removed_node);
 }
 
 }

--- a/Libraries/LibWeb/DOM/NodeIterator.h
+++ b/Libraries/LibWeb/DOM/NodeIterator.h
@@ -25,7 +25,7 @@ public:
 
     GC::Ref<Node> root() { return m_root; }
     GC::Ref<Node> reference_node() { return m_reference.node; }
-    bool pointer_before_reference_node() const { return m_reference.is_before_node; }
+    bool pointer_before_reference_node() const { return m_reference.pointer_before; }
     unsigned what_to_show() const { return m_what_to_show; }
 
     GC::Ptr<NodeFilter> filter() const;
@@ -38,7 +38,14 @@ public:
     void run_pre_removing_steps(Node&);
 
 private:
-    explicit NodeIterator(JS::Realm&, Node& root);
+    // https://dom.spec.whatwg.org/#node-pointer
+    // A node pointer is a tuple consisting of a node (a node) and a pointer before (a boolean).
+    struct NodePointer {
+        GC::Ref<Node> node;
+        bool pointer_before { true };
+    };
+
+    explicit NodeIterator(JS::Realm&, GC::Ref<Node> root, NodePointer);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -56,21 +63,13 @@ private:
     // https://dom.spec.whatwg.org/#concept-traversal-root
     GC::Ref<Node> m_root;
 
-    struct NodePointer {
-        GC::Ref<Node> node;
-
-        // https://dom.spec.whatwg.org/#nodeiterator-pointer-before-reference
-        bool is_before_node { true };
-    };
-
-    void run_pre_removing_steps_with_node_pointer(Node&, NodePointer&);
+    NodePointer adjust_node_pointer(NodePointer, Node& to_be_removed_node);
 
     // https://dom.spec.whatwg.org/#nodeiterator-reference
     NodePointer m_reference;
 
-    // While traversal is ongoing, we keep track of the current node pointer.
-    // This allows us to adjust it during traversal if calling the filter ends up removing the node from the DOM.
-    Optional<NodePointer> m_traversal_pointer;
+    // https://dom.spec.whatwg.org/#nodeiterator-candidate-reference
+    Optional<NodePointer> m_candidate_reference;
 
     // https://dom.spec.whatwg.org/#concept-traversal-whattoshow
     unsigned m_what_to_show { 0 };

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/NodeIterator-removal-during-filtering.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/NodeIterator-removal-during-filtering.txt
@@ -2,9 +2,8 @@ Harness status: OK
 
 Found 4 tests
 
-3 Pass
-1 Fail
+4 Pass
 Pass	Removing the accepted node during its own filtering retargets the reference and returns the filtered node
 Pass	Removing an already-visited subtree during filtering does not disrupt forward traversal
 Pass	referenceNode during filtering reflects the last accepted node, not the candidate
-Fail	Removing an ancestor of the in-flight position during filtering, pointer before it, with no following node within root
+Pass	Removing an ancestor of the in-flight position during filtering, pointer before it, with no following node within root

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/NodeIterator-removal-during-filtering.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/NodeIterator-removal-during-filtering.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 4 tests
+
+3 Pass
+1 Fail
+Pass	Removing the accepted node during its own filtering retargets the reference and returns the filtered node
+Pass	Removing an already-visited subtree during filtering does not disrupt forward traversal
+Pass	referenceNode during filtering reflects the last accepted node, not the candidate
+Fail	Removing an ancestor of the in-flight position during filtering, pointer before it, with no following node within root

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/NodeIterator-removal.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/NodeIterator-removal.txt
@@ -1,0 +1,31 @@
+Harness status: OK
+
+Found 25 tests
+
+24 Pass
+1 Fail
+Pass	Test removing node paras[0]
+Pass	Test removing node paras[0].firstChild
+Pass	Test removing node paras[1].firstChild
+Pass	Test removing node paras[5].firstChild
+Pass	Test removing node foreignPara1
+Pass	Test removing node foreignPara1.firstChild
+Pass	Test removing node detachedPara1
+Pass	Test removing node detachedPara1.firstChild
+Pass	Test removing node foreignPara2
+Pass	Test removing node xmlElement
+Pass	Test removing node foreignTextNode
+Pass	Test removing node processingInstruction
+Pass	Test removing node comment
+Pass	Test removing node doctype
+Pass	Test removing node foreignDoctype
+Pass	Test removing node paras[1]
+Pass	Test removing node detachedPara2
+Pass	Test removing node detachedPara2.firstChild
+Pass	Test removing node testDiv
+Pass	Test removing node xmlTextNode
+Pass	Test removing node xmlComment
+Pass	Test removing node foreignComment
+Pass	Test removing node xmlDoctype
+Pass	Removing an inclusive ancestor of reference, pointer before reference is true, with a following node within root
+Fail	Removing an inclusive ancestor of reference, pointer before reference is true, with no following node within root

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/NodeIterator-removal.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/traversal/NodeIterator-removal.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 25 tests
 
-24 Pass
-1 Fail
+25 Pass
 Pass	Test removing node paras[0]
 Pass	Test removing node paras[0].firstChild
 Pass	Test removing node paras[1].firstChild
@@ -28,4 +27,4 @@ Pass	Test removing node xmlComment
 Pass	Test removing node foreignComment
 Pass	Test removing node xmlDoctype
 Pass	Removing an inclusive ancestor of reference, pointer before reference is true, with a following node within root
-Fail	Removing an inclusive ancestor of reference, pointer before reference is true, with no following node within root
+Pass	Removing an inclusive ancestor of reference, pointer before reference is true, with no following node within root

--- a/Tests/LibWeb/Text/input/wpt-import/dom/traversal/NodeIterator-removal-during-filtering.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/traversal/NodeIterator-removal-during-filtering.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<title>NodeIterator: removing nodes during filtering</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-nodeiterator-traverse">
+<div id=log></div>
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<script>
+"use strict";
+
+function buildTree() {
+  // Tree: root > [a, b, c]
+  const root = document.createElement("div");
+  const a = document.createElement("a-el");
+  const b = document.createElement("b-el");
+  const c = document.createElement("c-el");
+  root.append(a, b, c);
+  return { root, a, b, c };
+}
+
+test(() => {
+  const { root, a, b, c } = buildTree();
+
+  let removed = false;
+  const it = document.createNodeIterator(root, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      // Remove b from the tree while it is being filtered, i.e. while a
+      // traverse() is in flight. This runs the NodeIterator pre-remove steps
+      // against the in-progress traversal.
+      if (node === b) {
+        b.remove();
+        removed = true;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    }
+  });
+
+  assert_equals(it.nextNode(), root, "first nextNode() returns root");
+  assert_equals(it.nextNode(), a, "second nextNode() returns a");
+
+  // Advances to b and filters it; the filter removes b.
+  const returned = it.nextNode();
+  assert_true(removed, "filter removed b");
+
+  // The value returned must be the node that was passed to the filter (b),
+  // even though the traversal pointer was retargeted away from it.
+  assert_equals(returned, b, "nextNode() returns the filtered node b");
+
+  // The reference node must be retargeted to a still-attached node (a), not
+  // left pointing at the removed b.
+  assert_equals(it.referenceNode, a, "referenceNode retargeted to a");
+  assert_false(it.pointerBeforeReferenceNode, "pointer before reference is false");
+
+  // Traversal continues from the retargeted reference, reaching c rather than
+  // getting stuck on the detached b.
+  assert_equals(it.nextNode(), c, "traversal continues to c");
+}, "Removing the accepted node during its own filtering retargets the reference "
+   + "and returns the filtered node");
+
+test(() => {
+  const { root, a, b, c } = buildTree();
+
+  // Filtering c removes an earlier, already-passed subtree (a). This should
+  // not affect the outcome for c, but exercises retargeting for a node that is
+  // not the one being filtered.
+  const it = document.createNodeIterator(root, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      if (node === b) {
+        a.remove();
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    }
+  });
+
+  assert_equals(it.nextNode(), root, "root");
+  assert_equals(it.nextNode(), a, "a");
+  assert_equals(it.nextNode(), b, "b (removes a)");
+  assert_equals(it.referenceNode, b, "reference is b");
+  assert_equals(it.nextNode(), c, "c");
+}, "Removing an already-visited subtree during filtering does not disrupt "
+   + "forward traversal");
+
+test(() => {
+  const { root, a, b, c } = buildTree();
+
+  // While a node is being filtered, referenceNode still reflects the last
+  // accepted node (the reference as of the start of the current nextNode()
+  // call), not the candidate currently being filtered. A candidate only
+  // becomes the reference once it is accepted.
+  let it;
+  const observed = [];
+  it = document.createNodeIterator(root, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      observed.push([node, it.referenceNode]);
+      // Reject b so the traversal moves on without accepting it.
+      return node === b ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+    }
+  });
+
+  assert_equals(it.nextNode(), root, "root accepted");
+  assert_equals(it.nextNode(), a, "a accepted");
+  // Advances to b (rejected), then to c (accepted).
+  assert_equals(it.nextNode(), c, "c accepted after skipping b");
+
+  assert_array_equals(observed.map(([node]) => node), [root, a, b, c],
+    "each node was filtered in order");
+  // Filtering root: reference is the initial reference (root, pointer before).
+  // Filtering a: reference is root (accepted by the previous call).
+  // Filtering b and c: reference is a (accepted by the previous call).
+  assert_array_equals(observed.map(([, referenceNode]) => referenceNode),
+    [root, root, a, a],
+    "referenceNode during filtering is the last accepted node, not the candidate");
+}, "referenceNode during filtering reflects the last accepted node, not the candidate");
+
+test(() => {
+  // Tree: root > a > a1, root > b > b1 (no node after b within root).
+  const root = document.createElement("div");
+  const a = document.createElement("a-el");
+  const a1 = document.createElement("a1-el");
+  const b = document.createElement("b-el");
+  const b1 = document.createElement("b1-el");
+  a.append(a1);
+  b.append(b1);
+  root.append(a, b);
+
+  // Removing b while its descendant b1 is the in-flight (candidate) position,
+  // with the pointer before that position, exercises the pre-remove
+  // "pointer before is true" branch where there is no following node within
+  // root. The in-flight position must move to the last in-tree node before b
+  // (a1) and flip the pointer, rather than being left on the now-detached b1.
+  // WebKit and Blink get this wrong and leave it on the detached b1.
+  let armed = false;
+  const it = document.createNodeIterator(root, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      if (armed && node === b1) {
+        b.remove();
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    }
+  });
+
+  // Advance the reference forward to b1 (root, a, a1, b, b1).
+  for (let i = 0; i < 5; i++) it.nextNode();
+  assert_equals(it.referenceNode, b1, "reference advanced to b1");
+  assert_false(it.pointerBeforeReferenceNode, "pointer before reference is false");
+
+  armed = true;
+  // previousNode() puts the pointer before b1, then filters b1, whose callback
+  // removes b.
+  const returned = it.previousNode();
+
+  assert_equals(returned, b1, "previousNode() returns the filtered node b1");
+  assert_equals(it.referenceNode, a1, "reference retargeted to a1, not detached b1");
+  assert_false(it.pointerBeforeReferenceNode, "pointer before reference flipped to false");
+}, "Removing an ancestor of the in-flight position during filtering, pointer "
+   + "before it, with no following node within root");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/traversal/NodeIterator-removal.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/traversal/NodeIterator-removal.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<title>NodeIterator removal tests</title>
+<link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
+<meta name=timeout content=long>
+<div id=log></div>
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<script src=../common.js></script>
+<script>
+"use strict";
+
+for (var i = 0; i < testNodes.length; i++) {
+  var node = eval(testNodes[i]);
+  if (!node.parentNode) {
+    // Nothing to test
+    continue;
+  }
+  test(function() {
+    var iters = [];
+    var descs = [];
+    var expectedReferenceNodes = [];
+    var expectedPointers = [];
+
+    for (var j = 0; j < testNodes.length; j++) {
+      var root = eval(testNodes[j]);
+      // Add all distinct iterators with this root, calling nextNode()
+      // repeatedly until it winds up with the same iterator.
+      for (var k = 0; ; k++) {
+        var iter = document.createNodeIterator(root);
+        for (var l = 0; l < k; l++) {
+          iter.nextNode();
+        }
+        if (k && iter.referenceNode == iters[iters.length - 1].referenceNode
+            && iter.pointerBeforeReferenceNode
+               == iters[iters.length - 1].pointerBeforeReferenceNode) {
+          break;
+        } else {
+          iters.push(iter);
+          descs.push("document.createNodeIterator(" + testNodes[j]
+            + ") advanced " + k + " times");
+          expectedReferenceNodes.push(iter.referenceNode);
+          expectedPointers.push(iter.pointerBeforeReferenceNode);
+
+          var idx = iters.length - 1;
+
+          // "If the node is root or is not an inclusive ancestor of the
+          // referenceNode attribute value, terminate these steps."
+          //
+          // We also have to rule out the case where node is an ancestor of
+          // root, which is implicitly handled by the spec since such a node
+          // was not part of the iterator collection to start with.
+          if (isInclusiveAncestor(node, root)
+              || !isInclusiveAncestor(node, iter.referenceNode)) {
+            continue;
+          }
+
+          // "If the pointerBeforeReferenceNode attribute value is false, set
+          // the referenceNode attribute to the first node preceding the node
+          // that is being removed, and terminate these steps."
+          if (!iter.pointerBeforeReferenceNode) {
+            expectedReferenceNodes[idx] = previousNode(node);
+            continue;
+          }
+
+          // "If there is a node following the last inclusive descendant of the
+          // node that is being removed, set the referenceNode attribute to the
+          // first such node, and terminate these steps."
+          var next = nextNodeDescendants(node);
+          if (next) {
+            expectedReferenceNodes[idx] = next;
+            continue;
+          }
+
+          // "Set the referenceNode attribute to the first node preceding the
+          // node that is being removed and set the pointerBeforeReferenceNode
+          // attribute to false."
+          expectedReferenceNodes[idx] = previousNode(node);
+          expectedPointers[idx] = false;
+        }
+      }
+    }
+
+    var oldParent = node.parentNode;
+    var oldSibling = node.nextSibling;
+    oldParent.removeChild(node);
+
+    for (var j = 0; j < iters.length; j++) {
+      var iter = iters[j];
+      assert_equals(iter.referenceNode, expectedReferenceNodes[j],
+                    ".referenceNode of " + descs[j]);
+      assert_equals(iter.pointerBeforeReferenceNode, expectedPointers[j],
+                    ".pointerBeforeReferenceNode of " + descs[j]);
+    }
+
+    oldParent.insertBefore(node, oldSibling);
+  }, "Test removing node " + testNodes[i]);
+}
+
+testDiv.style.display = "none";
+
+
+// Targeted coverage for the pre-remove step that fires when
+// pointerBeforeReferenceNode is true and the iterator's reference is inside
+// the subtree being removed. The parametric loop above only drives iterators
+// forward with nextNode(), so pointerBeforeReferenceNode is true only when
+// referenceNode === root — a case the algorithm's first step now always
+// short-circuits. To reach the "find next within root" branch we have to back
+// the iterator up with previousNode() first.
+
+const buildScratchTree = (structure) => {
+  // structure is a string like "root[a[a1],b[b1],c]"; returns an object whose
+  // keys are the named elements.
+  const nodes = {};
+  let i = 0;
+  const parse = (parent) => {
+    let name = "";
+    while (i < structure.length && /[A-Za-z0-9]/.test(structure[i])) {
+      name += structure[i++];
+    }
+    const el = document.createElement(name);
+    nodes[name] = el;
+    if (parent) parent.appendChild(el);
+    if (structure[i] === "[") {
+      i++;
+      while (structure[i] !== "]") {
+        parse(el);
+        if (structure[i] === ",") i++;
+      }
+      i++;
+    }
+    return el;
+  };
+  const root = parse(null);
+  document.body.appendChild(root);
+  return { root, nodes };
+};
+
+test((t) => {
+  // Tree: root[a[a1], b[b1], c]
+  const { root, nodes } = buildScratchTree("root[a[a1],b[b1],c]");
+  t.add_cleanup(() => root.remove());
+
+  const iter = document.createNodeIterator(root);
+  for (let i = 0; i < 5; i++) iter.nextNode();
+  assert_equals(iter.referenceNode, nodes.b1, "advanced reference");
+  assert_false(iter.pointerBeforeReferenceNode, "advanced pointer");
+  iter.previousNode();
+  assert_equals(iter.referenceNode, nodes.b1, "backed-up reference");
+  assert_true(iter.pointerBeforeReferenceNode, "backed-up pointer");
+
+  nodes.b.remove();
+
+  // pre-remove step 2: next-within-root exists, so reference jumps to it and
+  // pointer stays true.
+  assert_equals(iter.referenceNode, nodes.c, "post-removal reference");
+  assert_true(iter.pointerBeforeReferenceNode, "post-removal pointer");
+}, "Removing an inclusive ancestor of reference, pointer before reference is true, "
+   + "with a following node within root");
+
+test((t) => {
+  // Tree: root[a[a1], b[b1]] — no node after b within root.
+  const { root, nodes } = buildScratchTree("root[a[a1],b[b1]]");
+  t.add_cleanup(() => root.remove());
+
+  const iter = document.createNodeIterator(root);
+  for (let i = 0; i < 5; i++) iter.nextNode();
+  assert_equals(iter.referenceNode, nodes.b1, "advanced reference");
+  assert_false(iter.pointerBeforeReferenceNode, "advanced pointer");
+  iter.previousNode();
+  assert_equals(iter.referenceNode, nodes.b1, "backed-up reference");
+  assert_true(iter.pointerBeforeReferenceNode, "backed-up pointer");
+
+  nodes.b.remove();
+
+  // pre-remove step 2: no next-within-root, so pointer flips to false and
+  // step 3 moves reference to the last inclusive descendant of b's previous
+  // sibling.
+  assert_equals(iter.referenceNode, nodes.a1, "post-removal reference");
+  assert_false(iter.pointerBeforeReferenceNode, "post-removal pointer");
+}, "Removing an inclusive ancestor of reference, pointer before reference is true, "
+   + "with no following node within root");
+</script>


### PR DESCRIPTION
Align NodeIterator with the current DOM spec traversal and pre-removal
algorithms. The spec now covers the cases we were previously working
around to match the behaviour of other engines. The algorithm we had
implemented to protect against removal during filtering matches
the spec algorithm quite closely, with slightly different factoring.

See:
 * https://github.com/whatwg/dom/pull/1479
 * https://github.com/whatwg/dom/pull/1477

This fixes the case where removing an ancestor of the reference or
candidate reference, with the pointer before it and no following
node inside the root, should retarget to the previous in-tree node
instead of leaving the iterator on a detached node.