### PR TITLE
Keep table sizing local to the wrapper/table relationship

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -51,6 +51,17 @@ CSSPixels BlockFormattingContext::automatic_content_width() const
 {
     if (root().children_are_inline())
         return m_state.get(root()).content_width();
+    if (is<TableWrapper>(root())) {
+        Optional<Box const&> table_box;
+        root().for_each_in_subtree_of_type<Box>([&](Box const& child_box) {
+            if (child_box.display().is_table_inside()) {
+                table_box = child_box;
+                return TraversalDecision::Break;
+            }
+            return TraversalDecision::Continue;
+        });
+        return m_state.get(*table_box).border_box_width();
+    }
     return greatest_child_width(root());
 }
 
@@ -1104,6 +1115,12 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         }
 
         independent_formatting_context->run(layout_input.with_available_space(inner_available_space));
+        if (is<TableWrapper>(block_container) && box.display().is_table_inside()) {
+            box_state.margin_left = max(box_state.margin_left, 0);
+            box_state.margin_right = max(box_state.margin_right, 0);
+        }
+        if (is<TableWrapper>(box) && !box.is_grid_item())
+            box_state.set_content_width(independent_formatting_context->automatic_content_width());
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
@@ -1169,7 +1186,15 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     VERIFY(!block_container.children_are_inline());
 
     auto const& available_space = available_space_for_children;
-    auto child_layout_input = layout_input_for_child_context(m_state.get(block_container), layout_input, available_space_for_children);
+    // The table wrapper is invisible to percentage resolution: percentages on the table root
+    // resolve against the wrapper's containing block, so the wrapper's own constraints pass
+    // through to the table box unchanged.
+    auto child_layout_input = [&]() -> LayoutInput {
+        if (is<TableWrapper>(block_container))
+            return LayoutInput { available_space_for_children, layout_input.containing_block_constraints };
+        else
+            return layout_input_for_child_context(m_state.get(block_container), layout_input, available_space_for_children);
+    }();
 
     CSSPixels bottom_of_lowest_margin_box = 0;
 
@@ -1403,6 +1428,10 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     }
 
     auto independent_formatting_context = layout_inside(box, m_layout_mode, layout_input.with_available_space(box_state.available_inner_space_or_constraints_from(available_space)));
+    // A floating table wrapper shrink-to-fits from cached intrinsic sizes, which may not match
+    // the width table layout just produced; the wrapper is exactly as wide as the table grid box.
+    if (is<TableWrapper>(box) && independent_formatting_context)
+        box_state.set_content_width(independent_formatting_context->automatic_content_width());
     resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints, independent_formatting_context);
 
     // Next, float to the left and/or right

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -26,6 +26,7 @@
 #include <LibWeb/Layout/SVGFormattingContext.h>
 #include <LibWeb/Layout/SVGSVGBox.h>
 #include <LibWeb/Layout/TableFormattingContext.h>
+#include <LibWeb/Layout/TableWrapper.h>
 #include <LibWeb/Layout/TextInputBox.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
@@ -644,15 +645,13 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     VERIFY(table_box.has_value());
 
     LayoutState throwaway_state(box);
-    auto& containing_block_state = throwaway_state.populate_node_from(m_state, *box.containing_block());
-    // CSS Grid lays out grid items into their grid-area containing blocks, which need not match the layout-tree
-    // containing block. Use the explicit grid-area width when measuring a table wrapper for grid alignment.
-    // NOTE: TableFormattingContext still reads the wrapper's containing block from layout state.
-    if (table_wrapper_containing_block_width.has_value())
-        containing_block_state.set_content_width(*table_wrapper_containing_block_width);
+    throwaway_state.populate_node_from(m_state, *box.containing_block());
 
-    auto const& table_wrapper_state = throwaway_state.create(box, table_wrapper_constraints.percentage_basis_width, table_wrapper_constraints.percentage_basis_height);
-    auto table_constraints = constraints_for_child_context(table_wrapper_state, table_wrapper_constraints);
+    // The table wrapper is invisible to percentage resolution, so the table box gets the
+    // wrapper's constraints unchanged. Callers measuring a table wrapper for grid alignment
+    // pass the grid-area width as the wrapper's percentage basis.
+    throwaway_state.create(box, table_wrapper_constraints.percentage_basis_width, table_wrapper_constraints.percentage_basis_height);
+    auto const& table_constraints = table_wrapper_constraints;
     auto& table_box_state = throwaway_state.create(*table_box, table_constraints.percentage_basis_width, table_constraints.percentage_basis_height);
     auto const& table_box_computed_values = table_box->computed_values();
     table_box_state.border_left = table_box_computed_values.border_left().width;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2877,13 +2877,14 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
 
     for (auto& grid_item : m_grid_items) {
         auto const grid_area_rect = get_grid_area_rect(grid_item);
+        Optional<CSSPixelSize> table_wrapper_grid_area_size;
         if (is<TableWrapper>(grid_item.box)) {
             // Track spacing can expand the final grid area after the earlier width pass. Recompute the wrapper width
-            // against that final area and store it so the real table layout resolves percentages against the grid area.
+            // against that final area so the real table layout resolves percentages against the grid area.
             resolve_table_wrapper_grid_item_width(grid_item, grid_area_rect.width());
             auto grid_area_size = grid_area_rect.size();
             grid_area_size.set_width(non_cyclic_containing_block_width_for_table_wrapper(grid_item, grid_area_size.width()));
-            grid_item.used_values.set_grid_area_size(grid_area_size);
+            table_wrapper_grid_area_size = grid_area_size;
         }
         CSSPixelPoint margin_offset = { grid_item.used_values.margin_box_left(), grid_item.used_values.margin_box_top() };
         grid_item.used_values.set_content_offset(grid_area_rect.top_left() + margin_offset);
@@ -2892,7 +2893,17 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_width()), AvailableSize::make_definite(grid_item.used_values.content_height()));
         grid_item.used_values.set_has_definite_width(true);
         grid_item.used_values.set_has_definite_height(true);
-        if (auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, LayoutInput { available_space_for_children, grid_area_constraints_for_item(grid_item) }))
+        auto child_constraints = [&] {
+            auto constraints = grid_area_constraints_for_item(grid_item);
+            // Table wrappers pass their constraints through to the table box, so hand them the
+            // grid area in both axes for the table's percentage resolution.
+            if (table_wrapper_grid_area_size.has_value()) {
+                constraints.percentage_basis_width = table_wrapper_grid_area_size->width();
+                constraints.percentage_basis_height = table_wrapper_grid_area_size->height();
+            }
+            return constraints;
+        }();
+        if (auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, LayoutInput { available_space_for_children, child_constraints }))
             independent_formatting_context->parent_context_did_dimension_child_root_box();
     }
 
@@ -3505,17 +3516,39 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
     table_wrapper_constraints.percentage_basis_width = table_wrapper_containing_block_width;
     auto table_wrapper_width = compute_table_box_width_inside_table_wrapper(
         item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
+    auto const& table_box = table_box_inside_table_wrapper(item);
     auto const& preferred_width = item.preferred_size(GridDimension::Column);
     if (!preferred_width.is_auto())
         table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.width, preferred_width, grid_area_constraints_for_item(item)));
-    if (table_box_inside_table_wrapper(item).computed_values().width().is_auto())
+    if (table_box.computed_values().width().is_auto())
         table_wrapper_width = max(table_wrapper_width, calculate_min_content_width(item.box, grid_area_constraints_for_item(item)));
     auto alignment = alignment_for_item(item.box, GridDimension::Column);
-    if (table_box_inside_table_wrapper(item).computed_values().width().is_auto()
+    if (table_box.computed_values().width().is_auto()
         && (alignment == Alignment::Normal || alignment == Alignment::Stretch)
         && !item.margin_start(GridDimension::Column).is_auto()
         && !item.margin_end(GridDimension::Column).is_auto()) {
-        table_wrapper_width = max(table_wrapper_width, table_wrapper_containing_block_width - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column));
+        // Stretching the wrapper also stretches the auto-width table inside it, so the stretched
+        // width has to respect the max-width of both the wrapper and the table box.
+        auto stretched_width = table_wrapper_containing_block_width - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
+        if (!should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints_for_item(item)))
+            stretched_width = min(stretched_width, calculate_inner_width(item.box, available_space.width, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+        if (!should_treat_max_width_as_none(table_box, available_space.width, grid_area_constraints_for_item(item))) {
+            auto const& table_max_width = table_box.computed_values().max_width();
+            if (table_max_width.is_length_percentage()) {
+                auto const& table_box_computed_values = table_box.computed_values();
+                auto table_max_border_box_width = table_max_width.to_px(table_wrapper_containing_block_width);
+                if (table_box_computed_values.box_sizing() == CSS::BoxSizing::ContentBox) {
+                    table_max_border_box_width += table_box_computed_values.border_left().width
+                        + table_box_computed_values.padding().left().to_px_or_zero(table_wrapper_containing_block_width)
+                        + table_box_computed_values.padding().right().to_px_or_zero(table_wrapper_containing_block_width)
+                        + table_box_computed_values.border_right().width;
+                }
+                stretched_width = min(stretched_width, table_max_border_box_width);
+            } else {
+                stretched_width = min(stretched_width, table_wrapper_width);
+            }
+        }
+        table_wrapper_width = max(table_wrapper_width, stretched_width);
     }
     if (!should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints_for_item(item)))
         table_wrapper_width = min(table_wrapper_width, calculate_inner_width(item.box, available_space.width, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
@@ -3571,7 +3604,11 @@ CSSPixels GridFormattingContext::non_cyclic_containing_block_width_for_table_wra
 {
     auto const& table_box = table_box_inside_table_wrapper(item);
     auto const& table_box_computed_values = table_box.computed_values();
-    if (!table_box_computed_values.width().contains_percentage()
+    auto const& table_wrapper_computed_values = item.box.computed_values();
+    if (!table_wrapper_computed_values.width().contains_percentage()
+        && !table_wrapper_computed_values.min_width().contains_percentage()
+        && !table_wrapper_computed_values.max_width().contains_percentage()
+        && !table_box_computed_values.width().contains_percentage()
         && !table_box_computed_values.min_width().contains_percentage()
         && !table_box_computed_values.max_width().contains_percentage()) {
         return containing_block_width;
@@ -3917,10 +3954,20 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
         if (minimum_size.is_max_content())
             return calculate_max_content_contribution(item, dimension);
         CSSPixels inner_minimum_size;
-        if (dimension == GridDimension::Column)
-            inner_minimum_size = calculate_inner_width(item.box, item.available_space().width, minimum_size, track_sizing_constraints_for_items());
-        else
+        if (dimension == GridDimension::Column) {
+            auto available_width = item.available_space().width;
+            // Percentage minimum sizes on a table wrapper resolve against the same non-cyclic
+            // width that the wrapper's own width resolution uses.
+            if (is<TableWrapper>(item.box) && minimum_size.contains_percentage()) {
+                auto containing_block_width = non_cyclic_containing_block_width_for_table_wrapper(
+                    item,
+                    containing_block_size_for_item(item, GridDimension::Column));
+                available_width = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_width));
+            }
+            inner_minimum_size = calculate_inner_width(item.box, available_width, minimum_size, track_sizing_constraints_for_items());
+        } else {
             inner_minimum_size = calculate_inner_height(item.box, item.available_space(), minimum_size, track_sizing_constraints_for_items());
+        }
         return item.add_margin_box_sizes(inner_minimum_size, dimension);
     }
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -320,13 +320,6 @@ struct LayoutState {
             return move(m_rare->flex_layout_data);
         }
 
-        void set_grid_area_size(CSSPixelSize grid_area_size) { ensure_rare_data().grid_area_size = grid_area_size; }
-        Optional<CSSPixelSize> const& grid_area_size() const
-        {
-            static Optional<CSSPixelSize> const empty;
-            return m_rare ? m_rare->grid_area_size : empty;
-        }
-
         void set_static_position_rect(StaticPositionRect const& static_position_rect) { ensure_rare_data().static_position_rect = static_position_rect; }
         CSSPixelPoint static_position() const
         {
@@ -358,7 +351,6 @@ struct LayoutState {
                 , computed_svg_path(other.computed_svg_path)
                 , grid_template_columns(other.grid_template_columns)
                 , grid_template_rows(other.grid_template_rows)
-                , grid_area_size(other.grid_area_size)
                 , override_borders_data(other.override_borders_data)
                 , computed_svg_transforms(other.computed_svg_transforms)
                 , static_position_rect(other.static_position_rect)
@@ -376,7 +368,6 @@ struct LayoutState {
             OwnPtr<FlexLayoutData> flex_layout_data;
             RefPtr<CSS::GridTrackSizeListStyleValue const> grid_template_columns;
             RefPtr<CSS::GridTrackSizeListStyleValue const> grid_template_rows;
-            Optional<CSSPixelSize> grid_area_size;
             Optional<Painting::PaintableBox::BordersDataWithElementKind> override_borders_data;
             Optional<Painting::SVGGraphicsPaintable::ComputedTransforms> computed_svg_transforms;
             Optional<StaticPositionRect> static_position_rect;

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/TableFormattingContext.h>
+#include <LibWeb/Layout/TableWrapper.h>
 
 namespace Web::Layout {
 
@@ -21,31 +22,6 @@ TableFormattingContext::TableFormattingContext(LayoutState& state, LayoutMode la
 }
 
 TableFormattingContext::~TableFormattingContext() = default;
-
-CSSPixels TableFormattingContext::table_wrapper_containing_block_width() const
-{
-    // CSS Grid creates a grid-area containing block for each grid item. The table wrapper is the grid item for
-    // display:table, so table-root percentages use the grid area rather than the layout-tree containing block.
-    if (auto const& grid_area_size = m_state.get(table_wrapper()).grid_area_size(); grid_area_size.has_value())
-        return grid_area_size->width();
-
-    auto const* containing_block_used_values = m_state.try_get(*table_wrapper().containing_block());
-    if (!containing_block_used_values)
-        return 0;
-    return containing_block_used_values->content_width();
-}
-
-CSSPixels TableFormattingContext::table_wrapper_containing_block_height() const
-{
-    // Keep the block-axis percentage basis consistent with the grid-area containing block stored during grid layout.
-    if (auto const& grid_area_size = m_state.get(table_wrapper()).grid_area_size(); grid_area_size.has_value())
-        return grid_area_size->height();
-
-    auto const* containing_block_used_values = m_state.try_get(*table_wrapper().containing_block());
-    if (!containing_block_used_values)
-        return 0;
-    return containing_block_used_values->content_height();
-}
 
 static inline bool is_table_column_group(Box const& box)
 {
@@ -147,8 +123,8 @@ void TableFormattingContext::compute_constrainedness()
 void TableFormattingContext::compute_cell_measures(RowMeasurement row_measurement)
 {
     // Implements https://www.w3.org/TR/css-tables-3/#computing-cell-measures.
-    auto containing_block_width = table_wrapper_containing_block_width();
-    auto containing_block_height = table_wrapper_containing_block_height();
+    auto containing_block_width = m_table_constraints.percentage_basis_width.value_or(0);
+    auto containing_block_height = m_table_constraints.percentage_basis_height.value_or(0);
 
     compute_constrainedness();
 
@@ -244,8 +220,8 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
 
 void TableFormattingContext::compute_outer_content_sizes()
 {
-    auto containing_block_width = table_wrapper_containing_block_width();
-    auto containing_block_height = table_wrapper_containing_block_height();
+    auto containing_block_width = m_table_constraints.percentage_basis_width.value_or(0);
+    auto containing_block_height = m_table_constraints.percentage_basis_height.value_or(0);
 
     size_t column_index = 0;
     TableGrid::for_each_child_box_matching(table_box(), is_table_column_group, [&](auto& column_group_box) {
@@ -279,7 +255,7 @@ void TableFormattingContext::compute_outer_content_sizes()
 template<>
 void TableFormattingContext::initialize_table_measures<TableFormattingContext::Row>()
 {
-    auto containing_block_height = table_wrapper_containing_block_height();
+    auto containing_block_height = m_table_constraints.percentage_basis_height.value_or(0);
 
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box.computed_values();
@@ -504,7 +480,7 @@ CSSPixels TableFormattingContext::compute_capmin()
     // The caption width minimum (CAPMIN) is the largest of the table captions min-content contribution:
     // https://drafts.csswg.org/css-tables-3/#computing-the-table-width
     CSSPixels capmin = 0;
-    auto width_of_table_wrapper_containing_block = table_wrapper_containing_block_width();
+    auto width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_width.value_or(0);
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
         if (!child->display().is_table_caption()) {
             continue;
@@ -538,12 +514,12 @@ CSSPixels TableFormattingContext::compute_capmin()
     return capmin;
 }
 
-static bool width_is_auto_or_indefinite_percentage(CSS::Size const& width, LayoutState::UsedValues const* containing_block_state)
+static bool width_is_auto_or_indefinite_percentage(CSS::Size const& width, bool containing_block_has_definite_width)
 {
     if (width.is_auto())
         return true;
     if (width.contains_percentage()) {
-        if (!containing_block_state || !containing_block_state->has_definite_width())
+        if (!containing_block_has_definite_width)
             return true;
     }
     return false;
@@ -561,7 +537,7 @@ void TableFormattingContext::compute_table_width()
 
     // Percentages on 'width' and 'height' on the table are relative to the table wrapper box's containing block,
     // not the table wrapper box itself.
-    CSSPixels width_of_table_wrapper_containing_block = table_wrapper_containing_block_width();
+    CSSPixels width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_width.value_or(0);
 
     // Compute undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
     auto undistributable_space = (m_columns.size() + 1) * border_spacing_horizontal();
@@ -608,31 +584,38 @@ void TableFormattingContext::compute_table_width()
     }
 
     CSSPixels used_width;
-    if (m_available_space->width.is_min_content()) {
-        used_width = grid_min;
-    } else if (m_available_space->width.is_max_content()) {
-        used_width = grid_max;
-    } else if (width_is_auto_or_indefinite_percentage(computed_values.width(), m_state.try_get(*table_wrapper().containing_block()))) {
+    if (width_is_auto_or_indefinite_percentage(computed_values.width(), m_table_constraints.percentage_basis_width.has_value())) {
         // If the table-root has 'width: auto', the used width is the greater of
         // min(GRIDMAX, the table’s containing block width), the used min-width of the table.
-        if (width_of_table_containing_block.is_definite())
+        // NOTE: In normal layout the available width already is the wrapper's used width, which the
+        //       parent context resolved with shrink-to-fit; filling it keeps the table and its
+        //       wrapper consistent without reading the wrapper's state from here.
+        if (m_available_space->width.is_min_content())
+            used_width = grid_min;
+        else if (m_available_space->width.is_max_content())
+            used_width = grid_max;
+        else if (width_of_table_containing_block.is_definite() && m_layout_mode == LayoutMode::Normal)
+            used_width = max(width_of_table_containing_block.to_px_or_zero(), used_min_width);
+        else if (width_of_table_containing_block.is_definite())
             used_width = max(min(grid_max, width_of_table_containing_block.to_px_or_zero()), used_min_width);
         else
             used_width = max(grid_max, used_min_width);
         // https://www.w3.org/TR/CSS22/tables.html#auto-table-layout
         // A percentage value for a column width is relative to the table width. If the table has 'width: auto',
         // a percentage represents a constraint on the column's width, which a UA should try to satisfy.
-        for (auto& cell : m_cells) {
-            auto const& cell_width = cell.box.computed_values().width();
-            if (cell_width.is_percentage()) {
-                CSSPixels adjusted_used_width = undistributable_space;
-                if (cell_width.percentage().value() != 0)
-                    adjusted_used_width += CSSPixels::nearest_value_for(ceil(100 / cell_width.percentage().value() * cell.outer_max_width));
+        if (!m_available_space->width.is_intrinsic_sizing_constraint()) {
+            for (auto& cell : m_cells) {
+                auto const& cell_width = cell.box.computed_values().width();
+                if (cell_width.is_percentage()) {
+                    CSSPixels adjusted_used_width = undistributable_space;
+                    if (cell_width.percentage().value() != 0)
+                        adjusted_used_width += CSSPixels::nearest_value_for(ceil(100 / cell_width.percentage().value() * cell.outer_max_width));
 
-                if (width_of_table_containing_block.is_definite())
-                    used_width = min(max(used_width, adjusted_used_width), width_of_table_containing_block.to_px_or_zero());
-                else
-                    used_width = max(used_width, adjusted_used_width);
+                    if (width_of_table_containing_block.is_definite())
+                        used_width = min(max(used_width, adjusted_used_width), width_of_table_containing_block.to_px_or_zero());
+                    else
+                        used_width = max(used_width, adjusted_used_width);
+                }
             }
         }
     } else if (computed_values.width().is_max_content()) {
@@ -647,22 +630,11 @@ void TableFormattingContext::compute_table_width()
             used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     }
 
-    auto& table_wrapper_box_state = m_state.get_mutable(table_wrapper());
-    if (computed_values.width().is_auto()
-        && table_wrapper_box_state.grid_area_size().has_value()
-        && table_wrapper_box_state.has_definite_width()) {
-        auto stretched_table_width = table_wrapper_box_state.content_width()
-            - table_box_state.border_box_left()
-            - table_box_state.border_box_right();
-        stretched_table_width = max(CSSPixels(0), stretched_table_width);
-        used_width = max(used_width, stretched_table_width);
-    }
     if (!should_treat_max_width_as_none(table_box(), m_available_space->width, m_table_constraints))
         used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     used_width = max(used_width, used_min_width);
 
     table_box_state.set_content_width(used_width);
-    table_wrapper_box_state.set_content_width(table_box_state.border_box_width());
 }
 
 CSSPixels TableFormattingContext::compute_columns_total_used_width() const
@@ -1005,8 +977,8 @@ void TableFormattingContext::compute_table_height()
         }
         auto row_computed_height = row.box.computed_values().height();
         if (row_computed_height.is_length()) {
-            auto height_of_containing_block = m_state.get(*row.box.containing_block()).content_height();
-            auto row_used_height = row_computed_height.to_px(height_of_containing_block);
+            // NOTE: A <length> height resolves without a percentage basis.
+            auto row_used_height = row_computed_height.to_px(0);
             row.base_height = max(row.base_height, row_used_height);
         }
     }
@@ -1020,8 +992,8 @@ void TableFormattingContext::compute_table_height()
         for (size_t i = 0; i < cell.column_span; ++i)
             span_width += m_columns[cell.column_index + i].used_width;
 
-        auto width_of_containing_block = cell_state.containing_block_used_values()->content_width();
-        auto height_of_containing_block = cell_state.containing_block_used_values()->content_height();
+        auto width_of_containing_block = m_participant_constraints.percentage_basis_width.value_or(0);
+        auto height_of_containing_block = m_participant_constraints.percentage_basis_height.value_or(0);
 
         cell_state.padding_top = cell.box.computed_values().padding().top().to_px_or_zero(width_of_containing_block);
         cell_state.padding_bottom = cell.box.computed_values().padding().bottom().to_px_or_zero(width_of_containing_block);
@@ -1088,7 +1060,7 @@ void TableFormattingContext::compute_table_height()
         // If the table has a height property with a value other than auto, it is treated as a minimum height for the
         // table grid, and will eventually be distributed to the height of the rows if their collective minimum height
         // ends up smaller than this number.
-        CSSPixels height_of_table_containing_block = table_wrapper_containing_block_height();
+        CSSPixels height_of_table_containing_block = m_table_constraints.percentage_basis_height.value_or(0);
         auto specified_table_height = table_box().computed_values().height().to_px(height_of_table_containing_block);
         if (table_box().computed_values().box_sizing() == CSS::BoxSizing::BorderBox) {
             auto const& table_state = m_state.get(table_box());
@@ -1822,9 +1794,15 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
     finish_grid_initialization(TableGrid::calculate_row_column_grid(context_box(), m_cells, m_rows));
 
     // The containing block of every internal table box and caption is the table wrapper;
-    // the table's own input carries the wrapper's inherited constraints.
+    // the table's own input carries the wrapper's constraints, and participant percentages
+    // resolve against those. Percentage heights of participants only resolve once the table
+    // itself has a non-auto height.
     m_table_constraints = layout_input.containing_block_constraints;
-    m_participant_constraints = constraints_for_child_context(m_state.get(table_wrapper()), layout_input.containing_block_constraints);
+    m_participant_constraints = ContainingBlockConstraints {
+        m_table_constraints.percentage_basis_width,
+        table_box().computed_values().height().is_auto() ? Optional<CSSPixels> {} : m_table_constraints.percentage_basis_height,
+        m_table_constraints.quirks_mode_percentage_basis_height,
+    };
     seed_table_participant_used_values(m_participant_constraints);
 
     border_conflict_resolution();

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -9,7 +9,6 @@
 #include <AK/Forward.h>
 #include <LibWeb/Layout/FormattingContext.h>
 #include <LibWeb/Layout/TableGrid.h>
-#include <LibWeb/Layout/TableWrapper.h>
 
 namespace Web::Layout {
 
@@ -36,10 +35,6 @@ public:
     StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     Box const& table_box() const { return context_box(); }
-    TableWrapper const& table_wrapper() const
-    {
-        return as<TableWrapper>(*table_box().containing_block());
-    }
 
     static bool border_is_less_specific(CSS::BorderData const& a, CSS::BorderData const& b);
 
@@ -84,9 +79,6 @@ private:
     bool distribute_excess_width_by_intrinsic_percentage(CSSPixels excess_width, ColumnFilter column_filter);
 
     bool use_fixed_mode_layout() const;
-
-    CSSPixels table_wrapper_containing_block_width() const;
-    CSSPixels table_wrapper_containing_block_height() const;
 
     ContainingBlockConstraints m_table_constraints;
     ContainingBlockConstraints m_participant_constraints;

--- a/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
@@ -8,7 +8,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 "1"
             TextNode <#text> (not painted)
           TableWrapper <(anonymous)> at [14.34375,8] floating [0+0+0 156.796875 0+0+0] [0+0+0 28 0+0+0] [BFC] children: not-inline
-            Box <table.middle> at [15.34375,9] table-box [0+1+0 154.796875 0+1+27.125] [0+1+0 26 0+1+0] [TFC] children: not-inline
+            Box <table.middle> at [15.34375,9] table-box [0+1+0 154.796875 0+1+0] [0+1+0 26 0+1+0] [TFC] children: not-inline
               Box <tbody> at [17.34375,11] table-row-group [0+0+0 150.796875 0+0+0] [0+0+0 22 0+0+0] children: not-inline
                 Box <tr> at [17.34375,11] table-row [0+0+0 150.796875 0+0+0] [0+0+0 22 0+0+0] children: not-inline
                   BlockContainer <td> at [19.34375,13] table-cell [0+1+1 69.59375 1+1+0] [0+1+1 18 1+1+0] [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/grid/table-wrapper-sizing-matrix.txt
+++ b/Tests/LibWeb/Layout/expected/grid/table-wrapper-sizing-matrix.txt
@@ -57,7 +57,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       Box <div.grid.stretch> at [0,130] [0+0+0 100 0+0+700] [0+0+0 20 0+0+0] [GFC] children: not-inline
         TableWrapper <(anonymous)> at [0,130] [0+0+0 60 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
-          Box <div.table.max-width> at [0,130] table-box [0+0+0 60 0+0+40] [0+0+0 20 0+0+0] [TFC] children: not-inline
+          Box <div.table.max-width> at [0,130] table-box [0+0+0 60 0+0+0] [0+0+0 20 0+0+0] [TFC] children: not-inline
             Box <(anonymous)> at [0,130] table-row [0+0+0 60 0+0+0] [0+0+0 20 0+0+0] children: not-inline
               BlockContainer <div.cell> at [0,130] table-cell [0+0+0 60 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
                 frag 0 from BlockContainer start: 0, length: 0, rect: [0,130 20x20] baseline: 20
@@ -84,7 +84,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       Box <div.grid.stretch> at [0,190] [0+0+0 100 0+0+700] [0+0+0 20 0+0+0] [GFC] children: not-inline
         TableWrapper <(anonymous)> at [0,190] [0+0+0 60 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
-          Box <div.table.border-box.max-width-border-box> at [15,190] table-box [0+10+5 30 5+10+40] [0+0+0 20 0+0+0] [TFC] children: not-inline
+          Box <div.table.border-box.max-width-border-box> at [15,190] table-box [0+10+5 30 5+10+0] [0+0+0 20 0+0+0] [TFC] children: not-inline
             Box <(anonymous)> at [15,190] table-row [0+0+0 30 0+0+0] [0+0+0 20 0+0+0] children: not-inline
               BlockContainer <div.cell> at [15,190] table-cell [0+0+0 30 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
                 frag 0 from BlockContainer start: 0, length: 0, rect: [15,190 20x20] baseline: 20
@@ -120,7 +120,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       Box <div.grid.wide-grid.stretch> at [0,270] [0+0+0 300 0+0+500] [0+0+0 24 0+0+0] [GFC] children: not-inline
         TableWrapper <(anonymous)> at [0,270] [0+0+0 256 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
-          Box <div.table.max-content-width> at [0,270] table-box [0+0+0 256 0+0+44] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          Box <div.table.max-content-width> at [0,270] table-box [0+0+0 256 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
             Box <(anonymous)> at [0,270] table-row [0+0+0 256 0+0+0] [0+0+0 24 0+0+0] children: not-inline
               BlockContainer <div.cell> at [0,270] table-cell [0+0+0 256 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
                 frag 0 from BlockContainer start: 0, length: 0, rect: [0,270 80x20] baseline: 20
@@ -139,7 +139,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       Box <div.grid.wide-grid.stretch> at [0,294] [0+0+0 300 0+0+500] [0+0+0 60 0+0+0] [GFC] children: not-inline
         TableWrapper <(anonymous)> at [0,294] [0+0+0 80 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
-          Box <div.table.min-content-width> at [0,294] table-box [0+0+0 80 0+0+220] [0+0+0 60 0+0+0] [TFC] children: not-inline
+          Box <div.table.min-content-width> at [0,294] table-box [0+0+0 80 0+0+0] [0+0+0 60 0+0+0] [TFC] children: not-inline
             Box <(anonymous)> at [0,294] table-row [0+0+0 80 0+0+0] [0+0+0 60 0+0+0] children: not-inline
               BlockContainer <div.cell> at [0,294] table-cell [0+0+0 80 0+0+0] [0+0+0 60 0+0+0] [BFC] children: inline
                 frag 0 from BlockContainer start: 0, length: 0, rect: [0,294 80x20] baseline: 20
@@ -154,7 +154,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       Box <div.grid.wide-grid.stretch> at [0,354] [0+0+0 300 0+0+500] [0+0+0 60 0+0+0] [GFC] children: not-inline
         TableWrapper <(anonymous)> at [0,354] [0+0+0 120 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
-          Box <div.table.fit-content-width> at [0,354] table-box [0+0+0 120 0+0+44] [0+0+0 60 0+0+0] [TFC] children: not-inline
+          Box <div.table.fit-content-width> at [0,354] table-box [0+0+0 120 0+0+0] [0+0+0 60 0+0+0] [TFC] children: not-inline
             Box <(anonymous)> at [0,354] table-row [0+0+0 120 0+0+0] [0+0+0 60 0+0+0] children: not-inline
               BlockContainer <div.cell> at [0,354] table-cell [0+0+0 120 0+0+0] [0+0+0 60 0+0+0] [BFC] children: inline
                 frag 0 from BlockContainer start: 0, length: 0, rect: [0,354 80x20] baseline: 20

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -7,7 +7,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [125.59375,8] floating [0+0+0 478.234375 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
-        Box <table.middle> at [125.59375,8] table-box [0+0+0 478.234375 0+0+186.515625] [0+0+0 24 0+0+0] [TFC] children: not-inline
+        Box <table.middle> at [125.59375,8] table-box [0+0+0 478.234375 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tbody> at [127.59375,10] table-row-group [0+0+0 474.234375 0+0+0] [0+0+0 20 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
@@ -3,7 +3,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 104 0+0+8] children: not-inline
       BlockContainer <center> at [8,8] [0+0+0 784 0+0+0] [0+0+0 104 0+0+0] children: not-inline
         TableWrapper <(anonymous)> at [204,8] [0+0+0 392 0+0+392] [0+0+0 104 0+0+0] [BFC] children: not-inline
-          Box <table> at [204,8] table-box [0+0+0 392 0+0+196] [0+0+0 104 0+0+0] [TFC] children: not-inline
+          Box <table> at [204,8] table-box [0+0+0 392 0+0+0] [0+0+0 104 0+0+0] [TFC] children: not-inline
             Box <tbody> at [206,10] table-row-group [0+0+0 388 0+0+0] [0+0+0 100 0+0+0] children: not-inline
               Box <tr> at [206,10] table-row [0+0+0 388 0+0+0] [0+0+0 100 0+0+0] children: not-inline
                 BlockContainer <td> at [207,60] table-cell [0+0+1 386 1+0+0] [0+0+50 0 50+0+0] [BFC] children: inline


### PR DESCRIPTION
Table layout reached outside its own root box in both directions: percentages on the table root and its internal boxes were resolved by reading the wrapper's containing block (or the wrapper's grid area) from layout state, and compute_table_width() wrote the wrapper's used width from inside the table's formatting context.

Formatting contexts should not read or write used values outside their root box, since future partial relayout support is going to depend on FC being layoutable without ancestor state.

The rebaselined layout expectations are not regressions: every box position and size in them is unchanged. The only difference is that the table box no longer carries a leftover auto-resolved right margin computed against the wrapper's tentative width, which the old wrapper write-back then made meaningless; it is now zero.