### PR TITLE
LibWebView: Handle Compositor process death during context registration

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -594,16 +594,9 @@ void Application::register_compositor_context(WebContentClient& web_content_clie
 {
     if (!can_send_compositor_process_ipc(m_compositor_client))
         return;
-    VERIFY(m_compositor_client);
 
-    auto web_content_connection_id = web_content_client.compositor_connection_id({});
-    if (!web_content_connection_id.has_value()) {
-        MUST(connect_web_content_to_compositor(web_content_client));
-        web_content_connection_id = web_content_client.compositor_connection_id({});
-    }
-    VERIFY(web_content_connection_id.has_value());
-
-    m_compositor_client->create_context(context_id, page_id, *web_content_connection_id);
+    if (auto result = try_register_compositor_context(web_content_client, context_id, page_id); result.is_error())
+        dbgln("Unable to register Compositor context: {}", result.error());
 }
 
 ErrorOr<void> Application::try_register_compositor_context(WebContentClient& web_content_client, Web::Compositor::CompositorContextId context_id, Optional<u64> page_id)


### PR DESCRIPTION
**Problem:** If the Compositor process dies while the UI process is registering a page’s compositor context, the UI process crashes too — taking the whole browser down with it. But a Compositor crash for an environmental reason — an incompatible GPU driver or an out-of-memory kill — rightly shouldn’t (doesn’t need to) actually be fatal.

**Cause:** `register_compositor_context` talked to the Compositor process with the non-fallible `create_context` call, and a `MUST` on establishing the connection — so a disconnect mid-registration became a `VERIFY` failure that aborted the UI process. Every other sync UI-to-Compositor call already uses its fallible `try_` variant.

**Fix:** Route `register_compositor_context` through the existing `try_register_compositor_context`. If it fails, then log that failure and just carry on. The context stays recorded in the `WebContentClient` — and once the Compositor process is relaunched, `recover_compositor_process()` re-registers it through `recreate_compositor_contexts()`.

For more context, see https://github.com/LadybirdBrowser/ladybird/issues/10336#issuecomment-4873933576
