### PR TITLE
LibWebView+UI/Qt: Drive location bar editing with an Omnibox model

### DIFF
--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -290,7 +290,14 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
     }
 
     if (!immediate_suggestions.is_empty() && !should_defer_intermediate_suggestions(immediate_suggestions)) {
+        auto query_before_delivery = m_query;
         invoke_autocomplete_query_complete(move(immediate_suggestions), AutocompleteResultKind::Intermediate);
+
+        // Delivering the immediate suggestions can activate one of them (pressing Enter re-queries stale results
+        // and activates once fresh results arrive). Activation clears the location bar's focus, which re-entrantly
+        // cancels or replaces this query, so bail out instead of requesting remote suggestions for it.
+        if (m_query != query_before_delivery)
+            return;
     } else if (!immediate_suggestions.is_empty()) {
         dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Deferring singleton history intermediate result for '{}' until remote autocomplete responds", trimmed_query);
     } else {

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     HSTSStore.cpp
     Menu.cpp
     Mutation.cpp
+    Omnibox.cpp
     Plugins/ImageCodecPlugin.cpp
     Process.cpp
     ProcessHandle.cpp

--- a/Libraries/LibWebView/Omnibox.cpp
+++ b/Libraries/LibWebView/Omnibox.cpp
@@ -1,0 +1,636 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StringBuilder.h>
+#include <LibWebView/Omnibox.h>
+
+namespace WebView {
+
+// Wraps the real autocomplete machinery (history store, search engine, remote suggestions).
+class AutocompleteSuggestionProvider final : public OmniboxSuggestionProvider {
+public:
+    AutocompleteSuggestionProvider()
+    {
+        m_autocomplete.on_autocomplete_query_complete = [this](auto suggestions, auto result_kind) {
+            if (on_suggestions)
+                on_suggestions(move(suggestions), result_kind);
+        };
+    }
+
+    virtual void query(String query, size_t max_suggestions) override
+    {
+        m_autocomplete.query_autocomplete_engine(move(query), max_suggestions);
+    }
+
+    virtual void cancel() override
+    {
+        m_autocomplete.cancel_pending_query();
+    }
+
+private:
+    Autocomplete m_autocomplete;
+};
+
+// "theverge.com/" completes "theverge.com" for all practical purposes, so ignore a trailing slash that
+// merely closes out a root URL.
+static StringView candidate_by_trimming_root_trailing_slash(StringView candidate)
+{
+    if (!candidate.ends_with('/'))
+        return candidate;
+
+    auto host_and_path = candidate;
+    for (auto scheme : { "https://"sv, "http://"sv }) {
+        if (host_and_path.starts_with(scheme)) {
+            host_and_path = host_and_path.substring_view(scheme.length());
+            break;
+        }
+    }
+
+    auto first_slash = host_and_path.find('/');
+    if (!first_slash.has_value() || *first_slash != host_and_path.length() - 1)
+        return candidate;
+
+    return candidate.substring_view(0, candidate.length() - 1);
+}
+
+// Users type addresses without the scheme and often without "www.", so a suggestion is matched in every
+// form the typed text could be a spelling of. Invokes the callback with each form until it returns true.
+static bool matches_any_candidate_form(String const& suggestion_text, auto callback)
+{
+    auto trimmed = candidate_by_trimming_root_trailing_slash(suggestion_text);
+
+    if (callback(trimmed))
+        return true;
+
+    if (trimmed.starts_with("www."sv) && callback(trimmed.substring_view(4)))
+        return true;
+
+    for (auto scheme : { "https://"sv, "http://"sv }) {
+        if (!trimmed.starts_with(scheme))
+            continue;
+        auto stripped = trimmed.substring_view(scheme.length());
+        if (callback(stripped))
+            return true;
+        if (stripped.starts_with("www."sv) && callback(stripped.substring_view(4)))
+            return true;
+    }
+
+    return false;
+}
+
+// NB: Prefix matching is ASCII case-insensitive only. Completion candidates are serialized URLs, so
+//     non-ASCII hosts and paths arrive punycoded or percent-encoded and never need Unicode case folding.
+static String inline_completion_for_candidate(String const& query, StringView candidate)
+{
+    auto query_view = query.bytes_as_string_view();
+    if (query_view.is_empty() || candidate.length() <= query_view.length())
+        return {};
+    if (!candidate.starts_with(query_view, CaseSensitivity::CaseInsensitive))
+        return {};
+
+    // Keep the prefix exactly as the user typed it and borrow only the completion suffix.
+    StringBuilder builder;
+    builder.append(query_view);
+    builder.append(candidate.substring_view(query_view.length()));
+    return MUST(builder.to_string());
+}
+
+static String inline_completion_for_suggestion(String const& query, String const& suggestion_text)
+{
+    String completion;
+    matches_any_candidate_form(suggestion_text, [&](StringView candidate) {
+        completion = inline_completion_for_candidate(query, candidate);
+        return !completion.is_empty();
+    });
+    return completion;
+}
+
+// NB: Unlike completion candidates, search suggestion texts are raw phrases, so the exact-match check
+//     folds Unicode case ("Muller" with a u-umlaut must match "muller" with one).
+static bool suggestion_matches_query_exactly(String const& query, String const& suggestion_text)
+{
+    return matches_any_candidate_form(suggestion_text, [&](StringView candidate) {
+        return MUST(String::from_utf8(candidate)).equals_ignoring_case(query);
+    });
+}
+
+static Optional<size_t> index_of_suggestion(String const& suggestion_text, Vector<AutocompleteSuggestion> const& suggestions)
+{
+    return suggestions.find_first_index_if([&](auto const& suggestion) {
+        return suggestion.text == suggestion_text;
+    });
+}
+
+Omnibox::Omnibox()
+    : Omnibox(make<AutocompleteSuggestionProvider>())
+{
+}
+
+Omnibox::Omnibox(NonnullOwnPtr<OmniboxSuggestionProvider> provider)
+    : m_provider(move(provider))
+{
+    m_provider->on_suggestions = [this](auto suggestions, auto result_kind) {
+        received_suggestions(move(suggestions), result_kind);
+    };
+}
+
+Omnibox::~Omnibox() = default;
+
+void Omnibox::begin_editing(String text)
+{
+    m_is_editing = true;
+    m_is_suspended = false;
+    m_provenance = TextProvenance::UserText;
+    m_query = text;
+    m_display_text = move(text);
+    m_cursor_at_end = true;
+    m_completion_suggestion = {};
+    m_completion_suppression = Empty {};
+    m_user_rejected_completion = false;
+    m_pending_activation_query = {};
+
+    // A fresh editing session must not inherit the previous session's popup rows or act on deliveries
+    // still in flight for the previous query.
+    m_provider->cancel();
+    close_popup();
+    m_suggestions.clear();
+    m_popup_query = {};
+}
+
+void Omnibox::end_editing()
+{
+    if (!m_is_editing)
+        return;
+
+    restore_query_display();
+
+    m_is_editing = false;
+    m_is_suspended = false;
+    m_completion_suppression = Empty {};
+    m_user_rejected_completion = false;
+    m_pending_activation_query = {};
+    m_provider->cancel();
+    close_popup();
+}
+
+void Omnibox::show_all_suggestions()
+{
+    if (!m_is_editing)
+        return;
+
+    // The bar holds a complete address (or nothing); suggest matches for it without completing over it.
+    // An active completion becomes part of that address, so adopt the full display text as the query
+    // instead of truncating the bar back to the typed prefix when results arrive.
+    adopt_display_text_as_query();
+    m_completion_suppression = m_query;
+    m_popup_query = {};
+    m_provider->query(m_query, default_autocomplete_suggestion_limit);
+}
+
+void Omnibox::text_edited(String text, bool cursor_at_end)
+{
+    if (!m_is_editing)
+        return;
+
+    bool had_completion = m_provenance == TextProvenance::InlineCompleted;
+    bool had_preview = m_provenance == TextProvenance::RowPreview;
+    auto previous_completion_suggestion = move(m_completion_suggestion);
+    m_completion_suggestion = {};
+
+    m_provenance = TextProvenance::UserText;
+    m_query = text;
+    m_display_text = move(text);
+    m_cursor_at_end = cursor_at_end;
+
+    if (m_pending_activation_query.has_value() && *m_pending_activation_query != m_query)
+        m_pending_activation_query = {};
+
+    if (m_completion_suppression.has<SuppressionArmedByDelete>()) {
+        // The user deleted part of the text; leave it alone until the query changes again.
+        if (had_completion || had_preview)
+            m_user_rejected_completion = true;
+        m_completion_suppression = m_query;
+    } else if (auto const* suppressed_query = m_completion_suppression.get_pointer<String>(); suppressed_query && *suppressed_query != m_query) {
+        m_completion_suppression = Empty {};
+    }
+
+    if (had_preview)
+        m_user_rejected_completion = true;
+
+    if (!completion_is_suppressed() && !m_is_suspended && previous_completion_suggestion.has_value()) {
+        if (suggestion_matches_query_exactly(m_query, *previous_completion_suggestion)) {
+            // The user typed out the whole suggestion; there is nothing left to complete.
+        } else if (auto completion = inline_completion_for_suggestion(m_query, *previous_completion_suggestion); !completion.is_empty()) {
+            // The user typed further into the completion; keep it.
+            apply_completion(previous_completion_suggestion.release_value(), move(completion));
+        } else {
+            // The user typed over the completion; Enter must now submit the text as typed.
+            m_user_rejected_completion = true;
+        }
+    }
+
+    m_provider->query(m_query, default_autocomplete_suggestion_limit);
+}
+
+void Omnibox::cursor_moved(bool cursor_at_end)
+{
+    if (!m_is_editing)
+        return;
+    m_cursor_at_end = cursor_at_end;
+}
+
+void Omnibox::set_suspended(bool suspended)
+{
+    if (!m_is_editing)
+        return;
+    m_is_suspended = suspended;
+}
+
+void Omnibox::will_delete_text()
+{
+    if (!m_is_editing)
+        return;
+    m_completion_suppression = SuppressionArmedByDelete {};
+}
+
+bool Omnibox::completion_is_suppressed() const
+{
+    auto const* suppressed_query = m_completion_suppression.get_pointer<String>();
+    return suppressed_query && *suppressed_query == m_query;
+}
+
+bool Omnibox::selection_is_user_choice() const
+{
+    return m_selection.has_value() && m_selection->origin == Selection::Origin::UserChoice;
+}
+
+void Omnibox::received_suggestions(Vector<AutocompleteSuggestion> suggestions, AutocompleteResultKind result_kind)
+{
+    if (!m_is_editing || m_is_suspended)
+        return;
+
+    bool should_activate = m_pending_activation_query.has_value() && *m_pending_activation_query == m_query;
+    bool had_row_preview = m_provenance == TextProvenance::RowPreview;
+
+    Optional<size_t> selected_suggestion;
+    if (had_row_preview)
+        selected_suggestion = index_of_suggestion(m_display_text, suggestions);
+    else
+        selected_suggestion = update_completion_for_suggestions(suggestions);
+
+    // Do not update the popup while results are still changing. Intermediate updates are triggered on
+    // every keystroke and would cause visible flicker in the suggestion list. Only final results are used
+    // to refresh the UI, except when Enter is already waiting on them.
+    if (result_kind == AutocompleteResultKind::Intermediate && m_popup_visible && !should_activate)
+        return;
+
+    // A selection that survives the refresh pointing at the same suggestion is still the user's
+    // deliberate choice; anything else the refresh picks is automatic.
+    Optional<String> user_chosen_text;
+    if (selection_is_user_choice() && m_selection->index < m_suggestions.size())
+        user_chosen_text = m_suggestions[m_selection->index].text;
+
+    m_popup_query = m_query;
+    m_suggestions = move(suggestions);
+
+    // The fresh selection is published to the chrome by the popup repaint below, not via
+    // on_selection_change, so it is assigned directly.
+    m_selection = selected_suggestion.map([&](auto index) {
+        auto is_user_choice = user_chosen_text.has_value() && m_suggestions[index].text == *user_chosen_text;
+        return Selection { index, is_user_choice ? Selection::Origin::UserChoice : Selection::Origin::Automatic };
+    });
+
+    // A previewed row that vanished from the refreshed rows must stop being displayed; the bar must not
+    // show something Enter would no longer act on.
+    if (had_row_preview && !m_selection.has_value())
+        restore_query_display();
+
+    if (m_suggestions.is_empty()) {
+        // NB: The pending activation survives this close; an empty intermediate result must not eat an
+        //     activation the final result may still satisfy.
+        if (m_popup_visible) {
+            m_popup_visible = false;
+            m_selection = {};
+            if (on_suggestions_change)
+                on_suggestions_change();
+        }
+        restore_query_display();
+    } else {
+        // Repaint even when the popup is already visible: the rows changed under it.
+        m_popup_visible = true;
+        if (on_suggestions_change)
+            on_suggestions_change();
+    }
+
+    if (should_activate) {
+        Optional<String> selected_text;
+        if (m_selection.has_value())
+            selected_text = m_suggestions[m_selection->index].text;
+
+        if (result_kind == AutocompleteResultKind::Final || (selected_text.has_value() && *selected_text != m_query)) {
+            m_pending_activation_query = {};
+            activate_selected_suggestion();
+        }
+    }
+}
+
+// Decides which row the popup should select for freshly received suggestions, and applies or clears the
+// inline completion accordingly. Row 0 drives both the highlight and (if its text prefix-matches the query)
+// the completion preview: the user-visible rule is "the top row is the default action".
+Optional<size_t> Omnibox::update_completion_for_suggestions(Vector<AutocompleteSuggestion> const& suggestions)
+{
+    if (!m_cursor_at_end)
+        return {};
+
+    if (suggestions.is_empty())
+        return {};
+
+    // A literal URL always wins: no completion, restore the typed text.
+    if (suggestions.first().source == AutocompleteSuggestionSource::LiteralURL) {
+        restore_query_display();
+        return 0;
+    }
+
+    // Backspace suppression: the user just deleted into this query, so don't re-apply a completion, but
+    // still honor the "highlight the top row" rule.
+    if (completion_is_suppressed()) {
+        restore_query_display();
+        return 0;
+    }
+
+    // Preserve an existing completion if its suggestion is still present and still extends the typed
+    // prefix. This keeps the completion stable while the user is forward-typing into a suggestion.
+    if (m_completion_suggestion.has_value()) {
+        if (auto preserved = index_of_suggestion(*m_completion_suggestion, suggestions); preserved.has_value()) {
+            if (auto completion = inline_completion_for_suggestion(m_query, *m_completion_suggestion); !completion.is_empty()) {
+                apply_completion(*m_completion_suggestion, move(completion));
+                return preserved;
+            }
+        }
+    }
+
+    if (auto completion = inline_completion_for_suggestion(m_query, suggestions.first().text); !completion.is_empty()) {
+        apply_completion(suggestions.first().text, move(completion));
+        return 0;
+    }
+
+    // Row 0 does not prefix-match the query: clear any stale completion, restore the typed text, and
+    // still highlight row 0.
+    restore_query_display();
+    return 0;
+}
+
+void Omnibox::return_pressed()
+{
+    if (!m_is_editing || m_display_text.is_empty())
+        return;
+
+    if (!m_popup_visible) {
+        commit(m_display_text);
+        return;
+    }
+
+    // The user edited or deleted a completion, so submit the text as typed instead of the popup's
+    // automatically selected row. Rows the user chose deliberately still win.
+    if (m_user_rejected_completion && !selection_is_user_choice()) {
+        Optional<String> selected_text;
+        if (m_popup_query == m_query && m_selection.has_value())
+            selected_text = m_suggestions[m_selection->index].text;
+        if (!completion_is_suppressed() && selected_text.has_value() && *selected_text != m_query) {
+            activate_selected_suggestion();
+            return;
+        }
+
+        auto query = m_query;
+        restore_query_display();
+        close_popup();
+        commit(move(query));
+        return;
+    }
+
+    if (m_popup_query == m_query) {
+        activate_selected_suggestion();
+        return;
+    }
+
+    // The visible rows belong to an older query; re-run the current one and activate once results arrive.
+    m_pending_activation_query = m_query;
+    m_provider->query(m_query, default_autocomplete_suggestion_limit);
+}
+
+// The chrome dismissed the popup without a key press (for example a click elsewhere in the window).
+void Omnibox::popup_dismissed()
+{
+    if (!m_is_editing || !m_popup_visible)
+        return;
+
+    restore_query_display();
+    abandon_popup_session();
+}
+
+Omnibox::EscapeAction Omnibox::escape_pressed()
+{
+    if (!m_is_editing || !m_popup_visible)
+        return EscapeAction::EndEditing;
+
+    if (m_provenance == TextProvenance::InlineCompleted && !selection_is_user_choice()) {
+        // Keep an automatic completion on display; only the popup goes away.
+        adopt_display_text_as_query();
+    } else {
+        restore_query_display();
+    }
+
+    abandon_popup_session();
+    return EscapeAction::ClosedPopup;
+}
+
+// The user walked away from the popup (Escape or a click elsewhere): Enter must neither submit stale
+// edited text nor fire a previously pending activation.
+void Omnibox::abandon_popup_session()
+{
+    m_user_rejected_completion = false;
+    m_pending_activation_query = {};
+    close_popup();
+    m_provider->cancel();
+}
+
+bool Omnibox::select_next_suggestion()
+{
+    return select_adjacent_suggestion(StepDirection::Next);
+}
+
+bool Omnibox::select_previous_suggestion()
+{
+    return select_adjacent_suggestion(StepDirection::Previous);
+}
+
+bool Omnibox::select_adjacent_suggestion(StepDirection direction)
+{
+    if (!m_is_editing || m_suggestions.is_empty())
+        return false;
+
+    auto count = m_suggestions.size();
+    auto step = direction == StepDirection::Next ? 1 : count - 1;
+    auto index = direction == StepDirection::Next ? 0 : count - 1;
+    if (!m_popup_visible)
+        show_popup();
+    else if (m_selection.has_value())
+        index = (m_selection->index + step) % count;
+
+    highlight_suggestion(index);
+    return true;
+}
+
+void Omnibox::suggestion_hovered(size_t suggestion_index)
+{
+    if (!m_is_editing || suggestion_index >= m_suggestions.size())
+        return;
+    if (m_selection.has_value() && m_selection->index == suggestion_index)
+        return;
+
+    highlight_suggestion(suggestion_index);
+}
+
+void Omnibox::suggestion_clicked(size_t suggestion_index)
+{
+    if (!m_is_editing || suggestion_index >= m_suggestions.size())
+        return;
+
+    commit_suggestion_text(m_suggestions[suggestion_index].text);
+}
+
+// Highlighting is always a deliberate act (arrow keys or hover); automatic row selection goes through
+// received_suggestions() instead.
+void Omnibox::highlight_suggestion(size_t suggestion_index)
+{
+    set_selection(Selection { suggestion_index, Selection::Origin::UserChoice });
+
+    auto const& suggestion_text = m_suggestions[suggestion_index].text;
+
+    if (suggestion_matches_query_exactly(m_query, suggestion_text)) {
+        restore_query_display();
+        return;
+    }
+
+    if (auto completion = inline_completion_for_suggestion(m_query, suggestion_text); !completion.is_empty()) {
+        apply_completion(suggestion_text, move(completion));
+        return;
+    }
+
+    apply_preview(suggestion_text);
+}
+
+void Omnibox::activate_selected_suggestion()
+{
+    if (m_selection.has_value()) {
+        commit_suggestion_text(m_suggestions[m_selection->index].text);
+        return;
+    }
+
+    restore_query_display();
+    close_popup();
+    commit(m_query);
+}
+
+void Omnibox::commit_suggestion_text(String text)
+{
+    m_provenance = TextProvenance::UserText;
+    m_completion_suggestion = {};
+    m_query = text;
+    set_display(text, {});
+    close_popup();
+    commit(move(text));
+}
+
+void Omnibox::adopt_display_text_as_query()
+{
+    m_provenance = TextProvenance::UserText;
+    m_completion_suggestion = {};
+    m_query = m_display_text;
+}
+
+void Omnibox::apply_completion(String suggestion_text, String completion_text)
+{
+    auto completion_start = m_query.bytes_as_string_view().length();
+
+    m_provenance = TextProvenance::InlineCompleted;
+    m_completion_suggestion = move(suggestion_text);
+
+    // A fresh automatic completion is visible from here on, so Enter must activate it instead of
+    // submitting previously edited text.
+    m_user_rejected_completion = false;
+
+    if (m_display_text == completion_text)
+        return;
+    set_display(move(completion_text), completion_start);
+}
+
+void Omnibox::apply_preview(String suggestion_text)
+{
+    m_provenance = TextProvenance::RowPreview;
+    m_completion_suggestion = {};
+
+    if (m_display_text == suggestion_text)
+        return;
+    set_display(move(suggestion_text), 0);
+}
+
+// Drops any completion or preview and puts the typed query back on display. A no-op when the user's own
+// text is already showing, so callers need not check the provenance first.
+void Omnibox::restore_query_display()
+{
+    m_provenance = TextProvenance::UserText;
+    m_completion_suggestion = {};
+
+    if (m_display_text == m_query)
+        return;
+    set_display(m_query, {});
+}
+
+void Omnibox::set_display(String text, Optional<size_t> selection_start)
+{
+    m_display_text = move(text);
+    if (on_display_change)
+        on_display_change({ .text = m_display_text, .selection_start = selection_start });
+}
+
+void Omnibox::show_popup()
+{
+    if (m_popup_visible)
+        return;
+
+    m_popup_visible = true;
+    if (on_suggestions_change)
+        on_suggestions_change();
+}
+
+// Hides the popup; the rows are kept so the arrow keys can bring it back.
+void Omnibox::close_popup()
+{
+    if (!m_popup_visible)
+        return;
+
+    m_popup_visible = false;
+    m_selection = {};
+    if (on_suggestions_change)
+        on_suggestions_change();
+}
+
+void Omnibox::set_selection(Optional<Selection> selection)
+{
+    bool index_changed = selection.map([](auto const& s) { return s.index; }) != selected_suggestion();
+    m_selection = move(selection);
+    if (index_changed && on_selection_change)
+        on_selection_change();
+}
+
+void Omnibox::commit(String text)
+{
+    if (on_commit)
+        on_commit(move(text));
+}
+
+}

--- a/Libraries/LibWebView/Omnibox.h
+++ b/Libraries/LibWebView/Omnibox.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibWebView/Autocomplete.h>
+#include <LibWebView/Export.h>
+
+namespace WebView {
+
+// Feeds autocomplete suggestions to the Omnibox. The default implementation wraps WebView::Autocomplete;
+// tests provide a scripted implementation to control delivery content and timing exactly.
+class WEBVIEW_API OmniboxSuggestionProvider {
+public:
+    virtual ~OmniboxSuggestionProvider() = default;
+
+    Function<void(Vector<AutocompleteSuggestion>, AutocompleteResultKind)> on_suggestions;
+
+    virtual void query(String, size_t max_suggestions) = 0;
+    virtual void cancel() = 0;
+};
+
+// The state machine behind a browser location bar editing session.
+//
+// The chrome forwards user events (keystrokes, popup interactions, focus changes) and renders whatever the
+// model instructs through the callbacks below. The model owns the authoritative state: the user's typed
+// query, who produced the text currently on display, the suggestion popup contents, and the handshake that
+// activates a suggestion once fresh results arrive after Enter. It lives outside any UI toolkit so the
+// behavior is unit-testable with a scripted provider and shareable between chromes.
+//
+// The text on display always has exactly one of three provenances:
+//   - UserText:        the text is exactly what the user typed (the query).
+//   - InlineCompleted: the query plus a completion suffix borrowed from one specific suggestion. The suffix
+//                      is shown selected so the next keystroke replaces it.
+//   - RowPreview:      the text of a highlighted suggestion that does not extend the query, shown fully
+//                      selected. The query is retained and restored when the popup goes away.
+//
+// The invariant that makes Enter trustworthy: whatever state we are in, on_commit carries exactly what the
+// bar displays. Enter resolves in this order: user-edited text is committed verbatim; otherwise, if the
+// visible popup rows belong to the current query, the selected row is activated; otherwise the rows are
+// stale (the user typed faster than suggestions arrive), so the query is re-run and the activation happens
+// as soon as a result worth acting on comes back. The predecessor of this model derived all of that from
+// widget selection offsets and a pile of latched booleans, and most omnibox bugs were one of those going
+// stale relative to what was actually on screen.
+class WEBVIEW_API Omnibox {
+    AK_MAKE_NONCOPYABLE(Omnibox);
+    AK_MAKE_NONMOVABLE(Omnibox);
+
+public:
+    Omnibox();
+    explicit Omnibox(NonnullOwnPtr<OmniboxSuggestionProvider>);
+    ~Omnibox();
+
+    // What the location bar should display: the full text, and, when a completion or preview is active, the
+    // start of the range that should be shown selected (through the end of the text, caret at the end).
+    struct Display {
+        String text;
+        Optional<size_t> selection_start;
+    };
+
+    enum class EscapeAction {
+        ClosedPopup,
+        EndEditing,
+    };
+
+    // Events from the chrome:
+    void begin_editing(String text);
+    void end_editing();
+    void set_suspended(bool);
+    void show_all_suggestions();
+    void text_edited(String text, bool cursor_at_end);
+    void cursor_moved(bool cursor_at_end);
+    void will_delete_text();
+    void return_pressed();
+    EscapeAction escape_pressed();
+    void popup_dismissed();
+    bool select_next_suggestion();
+    bool select_previous_suggestion();
+    void suggestion_hovered(size_t suggestion_index);
+    void suggestion_clicked(size_t suggestion_index);
+
+    // State for the chrome:
+    String const& query() const { return m_query; }
+    bool is_editing() const { return m_is_editing; }
+    bool is_popup_visible() const { return m_popup_visible; }
+    Vector<AutocompleteSuggestion> const& suggestions() const { return m_suggestions; }
+
+    Optional<size_t> selected_suggestion() const
+    {
+        return m_selection.map([](auto const& selection) { return selection.index; });
+    }
+
+    // Callbacks to the chrome:
+    Function<void(Display const&)> on_display_change;
+    Function<void()> on_suggestions_change;
+    Function<void()> on_selection_change;
+    Function<void(String)> on_commit;
+
+private:
+    enum class TextProvenance {
+        UserText,
+        InlineCompleted,
+        RowPreview,
+    };
+
+    // The selection carries its own origin, so a "user choice" verdict cannot outlive or predate the row
+    // it is about. A deliberate choice wins over m_user_rejected_completion on Enter and survives
+    // Escape's completion-preserving path.
+    struct Selection {
+        enum class Origin {
+            Automatic,
+            UserChoice,
+        };
+
+        size_t index { 0 };
+        Origin origin { Origin::Automatic };
+    };
+
+    // Suppression armed by a deleting key press, pinned to the query that the deletion produces, and
+    // lifted by any query change. This is what keeps a deleted completion from instantly growing back.
+    struct SuppressionArmedByDelete { };
+    using CompletionSuppression = Variant<Empty, SuppressionArmedByDelete, String>;
+
+    enum class StepDirection {
+        Next,
+        Previous,
+    };
+
+    void received_suggestions(Vector<AutocompleteSuggestion>, AutocompleteResultKind);
+    Optional<size_t> update_completion_for_suggestions(Vector<AutocompleteSuggestion> const&);
+    bool select_adjacent_suggestion(StepDirection);
+    void highlight_suggestion(size_t suggestion_index);
+    void activate_selected_suggestion();
+    void commit_suggestion_text(String);
+    void adopt_display_text_as_query();
+    void apply_completion(String suggestion_text, String completion_text);
+    void apply_preview(String suggestion_text);
+    void restore_query_display();
+    void set_display(String text, Optional<size_t> selection_start);
+    void show_popup();
+    void close_popup();
+    void abandon_popup_session();
+    void set_selection(Optional<Selection>);
+    void commit(String text);
+    bool selection_is_user_choice() const;
+    bool completion_is_suppressed() const;
+
+    NonnullOwnPtr<OmniboxSuggestionProvider> m_provider;
+
+    bool m_is_editing { false };
+
+    // The chrome temporarily handed input elsewhere (for example a context menu) without ending the
+    // session; suggestion deliveries are dropped and completions left alone until it resumes.
+    bool m_is_suspended { false };
+
+    TextProvenance m_provenance { TextProvenance::UserText };
+
+    // The user's typed text, surviving completions and previews. Under UserText provenance the display
+    // equals the query; the other provenances layer borrowed text over it and restore it on the way out.
+    String m_query;
+    String m_display_text;
+
+    // Completions only ever append at the end, so they are skipped while the caret is elsewhere; a late
+    // delivery must not rewrite the text under a caret the user has moved.
+    bool m_cursor_at_end { true };
+
+    // InlineCompleted: the suggestion whose text supplied the completion suffix.
+    Optional<String> m_completion_suggestion;
+
+    // The user deleted or typed over a completion, so Enter must submit the query as typed instead of
+    // activating the popup's automatically selected row. Cleared as soon as a fresh completion is applied.
+    bool m_user_rejected_completion { false };
+
+    CompletionSuppression m_completion_suppression { Empty {} };
+
+    // m_popup_query records which query produced the rows on display. Rows can lag the query, since
+    // intermediate results do not repaint a visible popup and remote results arrive late; comparing it
+    // against m_query is how Enter distinguishes "activate what the user sees" from "wait for results".
+    // The rows survive close_popup() so the arrow keys can bring a dismissed popup back.
+    bool m_popup_visible { false };
+    String m_popup_query;
+    Vector<AutocompleteSuggestion> m_suggestions;
+    Optional<Selection> m_selection;
+
+    // Enter was pressed while the popup rows were stale; activate as soon as fresh results arrive.
+    Optional<String> m_pending_activation_query;
+};
+
+}

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     TestCookieJar.cpp
     TestHistoryStore.cpp
     TestHSTSStore.cpp
+    TestOmnibox.cpp
     TestSessionHistory.cpp
     TestStorageJar.cpp
     TestWebViewURL.cpp

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -1,0 +1,780 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibWebView/Omnibox.h>
+
+namespace {
+
+using WebView::AutocompleteResultKind;
+using WebView::AutocompleteSuggestion;
+using WebView::AutocompleteSuggestionSection;
+using WebView::AutocompleteSuggestionSource;
+using WebView::Omnibox;
+
+AutocompleteSuggestion row(AutocompleteSuggestionSource source, AutocompleteSuggestionSection section, StringView text)
+{
+    return { .source = source, .section = section, .text = MUST(String::from_utf8(text)), .title = {}, .subtitle = {}, .favicon_base64_png = {} };
+}
+
+AutocompleteSuggestion history_row(StringView url)
+{
+    return row(AutocompleteSuggestionSource::History, AutocompleteSuggestionSection::History, url);
+}
+
+AutocompleteSuggestion search_row(StringView query)
+{
+    return row(AutocompleteSuggestionSource::Search, AutocompleteSuggestionSection::SearchSuggestions, query);
+}
+
+AutocompleteSuggestion literal_row(StringView url)
+{
+    return row(AutocompleteSuggestionSource::LiteralURL, AutocompleteSuggestionSection::None, url);
+}
+
+class ScriptedProvider final : public WebView::OmniboxSuggestionProvider {
+public:
+    virtual void query(String query, size_t) override
+    {
+        queries.append(move(query));
+    }
+
+    virtual void cancel() override
+    {
+        ++cancel_count;
+    }
+
+    void deliver(Vector<AutocompleteSuggestion> suggestions, AutocompleteResultKind result_kind)
+    {
+        on_suggestions(move(suggestions), result_kind);
+    }
+
+    Vector<String> queries;
+    size_t cancel_count { 0 };
+};
+
+// Emulates the line edit the way the chrome uses the model: it renders Display instructions, and user
+// keystrokes replace the selected completion range just like they would in a real text box.
+struct Harness {
+    Harness()
+        : omnibox(adopt_provider(*this))
+    {
+        omnibox.on_display_change = [this](Omnibox::Display const& display) {
+            display_text = display.text;
+            selection_start = display.selection_start;
+        };
+        omnibox.on_commit = [this](String text) {
+            commits.append(move(text));
+        };
+
+        // Mirror the popup exactly the way a real chrome does, so the tests exercise the notification
+        // contract and not just the model's internal state.
+        omnibox.on_suggestions_change = [this] {
+            ++popup_repaints;
+            visible_popup = omnibox.is_popup_visible();
+            visible_rows = omnibox.suggestions();
+            visible_selection = omnibox.selected_suggestion();
+        };
+        omnibox.on_selection_change = [this] {
+            visible_selection = omnibox.selected_suggestion();
+        };
+    }
+
+    static NonnullOwnPtr<ScriptedProvider> adopt_provider(Harness& self)
+    {
+        auto scripted_provider = make<ScriptedProvider>();
+        self.provider = scripted_provider.ptr();
+        return scripted_provider;
+    }
+
+    void begin_editing(StringView text = ""sv)
+    {
+        display_text = MUST(String::from_utf8(text));
+        selection_start = {};
+        omnibox.begin_editing(display_text);
+    }
+
+    void press_key(char code_point)
+    {
+        auto text_before_selection = selected_text_range_prefix();
+        StringBuilder builder;
+        builder.append(text_before_selection);
+        builder.append(code_point);
+        display_text = MUST(builder.to_string());
+        selection_start = {};
+        omnibox.text_edited(display_text, true);
+    }
+
+    void press_backspace()
+    {
+        omnibox.will_delete_text();
+        auto text_before_selection = selected_text_range_prefix();
+        if (!selection_start.has_value() && !text_before_selection.is_empty()) {
+            // Remove the last code point, not the last byte.
+            Utf8View code_points { text_before_selection };
+            text_before_selection = code_points.unicode_substring_view(0, code_points.length() - 1).as_string();
+        }
+        display_text = MUST(String::from_utf8(text_before_selection));
+        selection_start = {};
+        omnibox.text_edited(display_text, true);
+    }
+
+    StringView selected_text_range_prefix() const
+    {
+        auto view = display_text.bytes_as_string_view();
+        if (selection_start.has_value())
+            return view.substring_view(0, *selection_start);
+        return view;
+    }
+
+    ScriptedProvider* provider { nullptr };
+    Omnibox omnibox;
+
+    String display_text;
+    Optional<size_t> selection_start;
+    Vector<String> commits;
+
+    size_t popup_repaints { 0 };
+    bool visible_popup { false };
+    Vector<AutocompleteSuggestion> visible_rows;
+    Optional<size_t> visible_selection;
+};
+
+}
+
+TEST_CASE(fast_typing_with_top_hit_flips_activates_the_visible_completion)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    // "t" completes to the top history hit for "t".
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.twin.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "twin.example"sv);
+    EXPECT_EQ(harness.selection_start, 1u);
+    EXPECT(harness.omnibox.is_popup_visible());
+
+    // "th" no longer matches it; the completion breaks, and a different suggestion takes over.
+    harness.press_key('h');
+    EXPECT_EQ(harness.display_text, "th"sv);
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("th"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thee.example"sv);
+
+    // The user keeps typing into and past that suggestion.
+    harness.press_key('e');
+    EXPECT_EQ(harness.display_text, "thee.example"sv);
+    EXPECT_EQ(harness.selection_start, 3u);
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("the"sv) }, AutocompleteResultKind::Intermediate);
+
+    harness.press_key('v');
+    EXPECT_EQ(harness.display_text, "thev"sv);
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("thev"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+    EXPECT_EQ(harness.selection_start, 4u);
+
+    // The popup still shows rows for "t" (intermediate updates do not repaint it), so Enter re-queries and
+    // must activate the completed suggestion, not search for the typed prefix.
+    EXPECT_EQ(harness.omnibox.suggestions().first().text, "https://www.twin.example/"sv);
+    harness.omnibox.return_pressed();
+    EXPECT(harness.commits.is_empty());
+    EXPECT_EQ(harness.provider->queries.last(), "thev"sv);
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("thev"sv) }, AutocompleteResultKind::Intermediate);
+
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "https://www.thev.example/"sv);
+}
+
+TEST_CASE(editing_the_completion_submits_the_typed_text)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    // Typing something that breaks the completion means Enter takes the text literally.
+    harness.press_key('x');
+    EXPECT_EQ(harness.display_text, "tx"sv);
+    harness.provider->deliver({ search_row("tx"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "tx"sv);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "tx"sv);
+    EXPECT(!harness.omnibox.is_popup_visible());
+}
+
+TEST_CASE(backspacing_the_completion_submits_the_typed_text)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    // Backspace deletes the selected completion; the suggestion must not come back for the same query.
+    harness.press_backspace();
+    EXPECT_EQ(harness.display_text, "t"sv);
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "t"sv);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "t"sv);
+}
+
+TEST_CASE(typing_after_backspace_lifts_the_suppression)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    harness.press_backspace();
+    EXPECT_EQ(harness.display_text, "t"sv);
+
+    // A new query means the user is typing again; completion resumes and Enter activates it.
+    harness.press_key('h');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("th"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+    EXPECT_EQ(harness.selection_start, 2u);
+
+    harness.omnibox.return_pressed();
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("th"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "https://www.thev.example/"sv);
+}
+
+TEST_CASE(intermediate_results_do_not_repaint_a_visible_popup)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.twin.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.omnibox.suggestions().size(), 2u);
+    EXPECT_EQ(harness.omnibox.suggestions().first().text, "https://www.twin.example/"sv);
+
+    harness.press_key('h');
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("th"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.omnibox.suggestions().first().text, "https://www.twin.example/"sv);
+
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("th"sv), search_row("th zzz"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.omnibox.suggestions().size(), 3u);
+    EXPECT_EQ(harness.omnibox.suggestions().first().text, "https://www.thee.example/"sv);
+
+    // The popup is now fresh, so Enter activates the selected row without another engine round-trip.
+    auto queries_before_return = harness.provider->queries.size();
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.provider->queries.size(), queries_before_return);
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "https://www.thee.example/"sv);
+}
+
+TEST_CASE(pending_activation_waits_for_a_result_it_can_act_on)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    harness.press_key('h');
+    EXPECT_EQ(harness.display_text, "thee.example"sv);
+
+    // Enter with a stale popup: nothing to activate yet.
+    harness.omnibox.return_pressed();
+    EXPECT(harness.commits.is_empty());
+
+    // An intermediate whose selected row merely equals the query is not worth activating; the final
+    // result may still bring a better row.
+    harness.provider->deliver({ search_row("th"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT(harness.commits.is_empty());
+
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("th"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "https://www.thee.example/"sv);
+}
+
+TEST_CASE(escape_keeps_an_automatic_completion_but_closes_the_popup)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    auto cancels_before_escape = harness.provider->cancel_count;
+    EXPECT_EQ(harness.omnibox.escape_pressed(), Omnibox::EscapeAction::ClosedPopup);
+    EXPECT(!harness.omnibox.is_popup_visible());
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+    EXPECT_EQ(harness.provider->cancel_count, cancels_before_escape + 1);
+
+    // With the popup gone, Enter submits what is on display.
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "thev.example"sv);
+
+    EXPECT_EQ(harness.omnibox.escape_pressed(), Omnibox::EscapeAction::EndEditing);
+}
+
+TEST_CASE(escape_restores_the_query_over_a_preview)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), history_row("https://odd.example/t"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+
+    // Hovering a row that cannot extend the query previews it in full.
+    harness.omnibox.suggestion_hovered(1);
+    EXPECT_EQ(harness.display_text, "https://odd.example/t"sv);
+    EXPECT_EQ(harness.selection_start, 0u);
+
+    EXPECT_EQ(harness.omnibox.escape_pressed(), Omnibox::EscapeAction::ClosedPopup);
+    EXPECT_EQ(harness.display_text, "t"sv);
+}
+
+TEST_CASE(arrow_keys_walk_the_suggestions_and_enter_activates_the_choice)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    // Down to the search row: its text equals the query, so the display returns to the typed text.
+    EXPECT(harness.omnibox.select_next_suggestion());
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 1u);
+    EXPECT_EQ(harness.display_text, "t"sv);
+
+    // And back up to the history row.
+    EXPECT(harness.omnibox.select_previous_suggestion());
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "https://www.thev.example/"sv);
+}
+
+TEST_CASE(a_user_chosen_row_wins_over_edited_text)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+
+    // Break the completion so Enter would take the text literally...
+    harness.press_key('x');
+    harness.provider->deliver({ history_row("https://www.txt.example/"sv), search_row("tx"sv) }, AutocompleteResultKind::Final);
+
+    // ...but explicitly arrowing onto a row overrides that.
+    EXPECT(harness.omnibox.select_next_suggestion());
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 1u);
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "tx"sv);
+}
+
+TEST_CASE(a_literal_url_suggestion_never_completes)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ literal_row("t.example/path"sv), history_row("https://www.thev.example/"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "t"sv);
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "t.example/path"sv);
+}
+
+TEST_CASE(a_top_row_that_does_not_match_the_prefix_is_only_highlighted)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://odd.example/t"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "t"sv);
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+
+    // The top row is the default action even without a completion.
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "https://odd.example/t"sv);
+}
+
+TEST_CASE(a_fresh_non_prefix_top_row_wins_after_editing_a_completion)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    // The user types over the completion, and the fresh top hit is selected because it matched by title,
+    // not because its URL can inline-complete the typed query.
+    for (auto code_point : "itle match"sv)
+        harness.press_key(code_point);
+    harness.provider->deliver({ history_row("https://news.ycombinator.com/"sv), search_row("title match"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "title match"sv);
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "https://news.ycombinator.com/"sv);
+}
+
+TEST_CASE(clicking_a_suggestion_commits_it)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+
+    harness.omnibox.suggestion_clicked(1);
+    EXPECT_EQ(harness.commits.last(), "t"sv);
+    EXPECT(!harness.omnibox.is_popup_visible());
+}
+
+TEST_CASE(late_results_after_editing_ends_are_ignored)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    auto cancels_before_end = harness.provider->cancel_count;
+    harness.omnibox.end_editing();
+    EXPECT_EQ(harness.provider->cancel_count, cancels_before_end + 1);
+
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv) }, AutocompleteResultKind::Final);
+    EXPECT(!harness.omnibox.is_popup_visible());
+    EXPECT(harness.commits.is_empty());
+}
+
+TEST_CASE(showing_all_suggestions_does_not_complete_over_the_address)
+{
+    Harness harness;
+    harness.begin_editing("https://site.example/page"sv);
+    harness.omnibox.show_all_suggestions();
+    EXPECT_EQ(harness.provider->queries.last(), "https://site.example/page"sv);
+
+    harness.provider->deliver({ history_row("https://site.example/page"sv), history_row("https://site.example/page2"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "https://site.example/page"sv);
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "https://site.example/page"sv);
+}
+
+TEST_CASE(empty_results_close_the_popup_and_restore_the_query)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    harness.provider->deliver({}, AutocompleteResultKind::Final);
+    EXPECT(!harness.omnibox.is_popup_visible());
+    EXPECT_EQ(harness.display_text, "t"sv);
+}
+
+TEST_CASE(no_completion_is_applied_when_the_cursor_is_not_at_the_end)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.omnibox.text_edited("t"_string, false);
+    harness.display_text = "t"_string;
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "t"sv);
+    EXPECT(!harness.omnibox.selected_suggestion().has_value());
+
+    // With nothing selected, Enter submits the typed text.
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "t"sv);
+}
+
+TEST_CASE(dismissing_the_popup_restores_the_query)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    // A click elsewhere in the window dismisses the popup without ending the editing session.
+    harness.omnibox.popup_dismissed();
+    EXPECT(!harness.omnibox.is_popup_visible());
+    EXPECT_EQ(harness.display_text, "t"sv);
+    EXPECT(harness.omnibox.is_editing());
+}
+
+TEST_CASE(escape_cancels_a_pending_activation)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    harness.press_key('h');
+
+    // Enter with stale rows arms a pending activation; Escape must disarm it.
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.omnibox.escape_pressed(), Omnibox::EscapeAction::ClosedPopup);
+
+    // A later delivery for the same query (for example after the focus shortcut re-queries it) must not
+    // fire the navigation the user cancelled.
+    harness.omnibox.show_all_suggestions();
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("th"sv) }, AutocompleteResultKind::Final);
+    EXPECT(harness.commits.is_empty());
+}
+
+TEST_CASE(a_vanished_preview_row_stops_being_displayed)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), history_row("https://odd.example/t"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+
+    harness.omnibox.suggestion_hovered(1);
+    EXPECT_EQ(harness.display_text, "https://odd.example/t"sv);
+
+    // The previewed row is gone from the refreshed results; the bar must not keep showing text that
+    // Enter would no longer act on.
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "t"sv);
+
+    // With no selected row left, Enter submits exactly what the bar shows.
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "t"sv);
+}
+
+TEST_CASE(a_surviving_preview_row_remains_the_users_choice)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), history_row("https://odd.example/t"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+
+    // Break the completion so Enter would otherwise take the query literally, then preview a row by
+    // arrowing away and back onto it.
+    harness.press_key('x');
+    harness.provider->deliver({ history_row("https://odd.example/tx"sv), search_row("tx"sv) }, AutocompleteResultKind::Final);
+    EXPECT(harness.omnibox.select_next_suggestion());
+    EXPECT(harness.omnibox.select_previous_suggestion());
+    EXPECT_EQ(harness.display_text, "https://odd.example/tx"sv);
+
+    // A refresh that still contains the previewed row keeps it selected as the user's choice.
+    harness.provider->deliver({ history_row("https://odd.example/tx"sv), search_row("tx"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "https://odd.example/tx"sv);
+}
+
+TEST_CASE(showing_all_suggestions_adopts_an_active_completion)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    // The focus shortcut queries whatever the bar displays; results must not truncate the bar back to
+    // the typed prefix.
+    harness.omnibox.show_all_suggestions();
+    EXPECT_EQ(harness.provider->queries.last(), "thev.example"sv);
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+}
+
+TEST_CASE(arrow_keys_reopen_a_dismissed_popup)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+
+    EXPECT_EQ(harness.omnibox.escape_pressed(), Omnibox::EscapeAction::ClosedPopup);
+    EXPECT(!harness.omnibox.is_popup_visible());
+
+    EXPECT(harness.omnibox.select_next_suggestion());
+    EXPECT(harness.omnibox.is_popup_visible());
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+}
+
+TEST_CASE(a_new_editing_session_does_not_inherit_popup_rows)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    harness.omnibox.end_editing();
+
+    harness.begin_editing();
+    EXPECT(harness.omnibox.suggestions().is_empty());
+    EXPECT(!harness.omnibox.select_next_suggestion());
+}
+
+TEST_CASE(deliveries_while_suspended_are_dropped)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+
+    // A context menu borrows focus without ending the session; a late delivery must not rewrite the
+    // text or raise the popup while it is open.
+    harness.omnibox.set_suspended(true);
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "t"sv);
+    EXPECT(!harness.omnibox.is_popup_visible());
+
+    harness.omnibox.set_suspended(false);
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+}
+
+TEST_CASE(no_completion_is_applied_after_the_cursor_moves_from_the_end)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('o');
+    harness.press_key('d');
+
+    // The user clicks into the middle of the text; a late delivery must not rewrite it and yank the
+    // caret away.
+    harness.omnibox.cursor_moved(false);
+    harness.provider->deliver({ history_row("https://odd.example/"sv), search_row("od"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "od"sv);
+}
+
+TEST_CASE(final_results_repaint_a_visible_popup)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.twin.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT(harness.visible_popup);
+    EXPECT_EQ(harness.visible_rows.first().text, "https://www.twin.example/"sv);
+
+    // The final result set replaces the rows under an already-open popup; the chrome must be told.
+    harness.provider->deliver({ history_row("https://www.twin.example/"sv), search_row("t"sv), search_row("t zzz"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.visible_rows.size(), 3u);
+    EXPECT_EQ(harness.visible_rows.last().text, "t zzz"sv);
+    EXPECT_EQ(harness.visible_selection, 0u);
+}
+
+TEST_CASE(a_user_highlighted_completion_survives_a_refresh)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+
+    // Walk away and back so the highlight is a deliberate act.
+    EXPECT(harness.omnibox.select_next_suggestion());
+    EXPECT(harness.omnibox.select_previous_suggestion());
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    // A refresh that keeps the chosen row selected keeps it the user's choice, so Escape restores the
+    // typed text instead of preserving the completion.
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.omnibox.escape_pressed(), Omnibox::EscapeAction::ClosedPopup);
+    EXPECT_EQ(harness.display_text, "t"sv);
+}
+
+TEST_CASE(pending_activation_survives_an_empty_intermediate_result)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    harness.press_key('h');
+    harness.omnibox.return_pressed();
+    EXPECT(harness.commits.is_empty());
+
+    // An empty intermediate result (no local matches, remote still pending) must not eat the activation
+    // the final result may still satisfy.
+    harness.provider->deliver({}, AutocompleteResultKind::Intermediate);
+    EXPECT(harness.commits.is_empty());
+
+    harness.provider->deliver({ history_row("https://www.thee.example/"sv), search_row("th"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "https://www.thee.example/"sv);
+}
+
+TEST_CASE(restarting_the_session_cancels_in_flight_queries)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    auto cancels_before_restart = harness.provider->cancel_count;
+
+    // A programmatic text change (for example a redirect landing) restarts the session; results still in
+    // flight for the old query must not deliver into it.
+    harness.begin_editing("https://site.example/"sv);
+    EXPECT_EQ(harness.provider->cancel_count, cancels_before_restart + 1);
+    EXPECT(!harness.omnibox.is_popup_visible());
+}
+
+TEST_CASE(a_moved_cursor_blocks_completions_under_any_provenance)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Intermediate);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+
+    // The user clicks into the middle of the completed text; a late delivery must leave it alone even
+    // though a completion is currently on display.
+    harness.omnibox.cursor_moved(false);
+    harness.provider->deliver({ history_row("https://www.thevx.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "thev.example"sv);
+    EXPECT(!harness.omnibox.selected_suggestion().has_value());
+}
+
+TEST_CASE(committing_may_reentrantly_end_editing)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    // The real chrome clears focus while handling a commit, which calls back into end_editing.
+    harness.omnibox.on_commit = [&](String text) {
+        harness.commits.append(move(text));
+        harness.omnibox.end_editing();
+    };
+
+    harness.press_key('t');
+    harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "https://www.thev.example/"sv);
+    EXPECT(!harness.omnibox.is_editing());
+    EXPECT(!harness.omnibox.is_popup_visible());
+}

--- a/UI/Qt/Autocomplete.cpp
+++ b/UI/Qt/Autocomplete.cpp
@@ -220,7 +220,6 @@ public:
     }
 
     Vector<RowModel> const& rows() const { return m_rows; }
-    Vector<WebView::AutocompleteSuggestion> const& suggestions() const { return m_suggestions; }
 
     int table_row_for_suggestion_index(int suggestion_index) const
     {
@@ -367,13 +366,23 @@ public:
 Autocomplete::Autocomplete(QLineEdit* anchor)
     : QObject(anchor)
     , m_anchor(anchor)
-    , m_autocomplete(make<WebView::Autocomplete>())
+{
+    m_model = new AutocompleteModel(this);
+    m_delegate = new AutocompleteDelegate(this);
+    create_popup();
+    qApp->installEventFilter(this);
+}
+
+void Autocomplete::create_popup()
 {
     // Use a non-activating top-level window so it can stack above native web
     // content windows without moving keyboard focus away from the address bar.
     m_popup = new QFrame(m_anchor->window(), Qt::ToolTip | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint);
     connect(m_popup, &QObject::destroyed, this, [this] {
+        // The popup dies with its parent window, which can go away while this object lives on (for
+        // example when the tab is moved to another window); it is recreated on the next show.
         m_popup = nullptr;
+        m_list_view = nullptr;
     });
     m_popup->setObjectName("LadybirdAutocompletePopup");
 #if defined(AK_OS_MACOS)
@@ -397,9 +406,6 @@ Autocomplete::Autocomplete(QLineEdit* anchor)
     m_list_view->setFrameShape(QFrame::NoFrame);
     m_list_view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_list_view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-
-    m_model = new AutocompleteModel(this);
-    m_delegate = new AutocompleteDelegate(this);
     m_list_view->setModel(m_model);
     m_list_view->setItemDelegate(m_delegate);
     update_chrome_style();
@@ -412,7 +418,7 @@ Autocomplete::Autocomplete(QLineEdit* anchor)
     connect(m_list_view, &QAbstractItemView::clicked, this, [this](QModelIndex const& index) {
         if (!is_selectable_row(index.row()))
             return;
-        emit suggestion_activated(index.data(UrlRole).toString());
+        emit suggestion_clicked(index.data(SuggestionIndexRole).toInt());
     });
 
     connect(m_list_view, &QAbstractItemView::entered, this, [this](QModelIndex const& index) {
@@ -420,15 +426,8 @@ Autocomplete::Autocomplete(QLineEdit* anchor)
             return;
         if (m_list_view->currentIndex() == index)
             return;
-        select_row(index.row());
+        emit suggestion_hovered(index.data(SuggestionIndexRole).toInt());
     });
-
-    m_autocomplete->on_autocomplete_query_complete = [this](auto suggestions, auto result_kind) {
-        if (on_query_complete)
-            on_query_complete(move(suggestions), result_kind);
-    };
-
-    qApp->installEventFilter(this);
 }
 
 Autocomplete::~Autocomplete()
@@ -438,19 +437,9 @@ Autocomplete::~Autocomplete()
         delete m_popup;
 }
 
-void Autocomplete::query_autocomplete_engine(String query)
-{
-    m_autocomplete->query_autocomplete_engine(move(query), MAXIMUM_VISIBLE_AUTOCOMPLETE_SUGGESTIONS);
-}
-
-void Autocomplete::cancel_pending_query()
-{
-    m_autocomplete->cancel_pending_query();
-}
-
 void Autocomplete::update_chrome_style()
 {
-    if (m_is_updating_chrome_style)
+    if (!m_popup || m_is_updating_chrome_style)
         return;
 
     m_is_updating_chrome_style = true;
@@ -475,8 +464,11 @@ void Autocomplete::schedule_chrome_style_update()
     });
 }
 
-void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion> suggestions, int selected_suggestion_index)
+void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion> suggestions, Optional<size_t> selected_suggestion_index)
 {
+    if (!m_popup)
+        create_popup();
+
     m_model->set_suggestions(move(suggestions));
     if (m_model->rowCount() == 0) {
         close();
@@ -491,91 +483,39 @@ void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion>
     }
     m_popup->raise();
 
-    int table_row = m_model->table_row_for_suggestion_index(selected_suggestion_index);
-    if (table_row == -1)
-        clear_selection();
-    else
-        select_row(table_row, false);
+    set_selected_suggestion(selected_suggestion_index);
+}
+
+void Autocomplete::set_selected_suggestion(Optional<size_t> suggestion_index)
+{
+    if (!m_popup)
+        return;
+
+    int table_row = suggestion_index.has_value()
+        ? m_model->table_row_for_suggestion_index(static_cast<int>(*suggestion_index))
+        : -1;
+
+    if (table_row == -1) {
+        m_list_view->setCurrentIndex({});
+        return;
+    }
+
+    auto index = m_model->index(table_row, 0);
+    m_list_view->setCurrentIndex(index);
+    m_list_view->scrollTo(index);
 }
 
 bool Autocomplete::close()
 {
-    if (!m_popup->isVisible())
+    if (!m_popup || !m_popup->isVisible())
         return false;
     m_popup->hide();
-    emit did_close();
     return true;
 }
 
 bool Autocomplete::is_visible() const
 {
     return m_popup && m_popup->isVisible();
-}
-
-void Autocomplete::clear_selection()
-{
-    m_list_view->setCurrentIndex({});
-}
-
-Optional<String> Autocomplete::selected_suggestion() const
-{
-    if (!is_visible())
-        return {};
-    auto index = m_list_view->currentIndex();
-    if (!index.isValid() || !is_selectable_row(index.row()))
-        return {};
-    auto suggestion_index = index.data(SuggestionIndexRole).toInt();
-    if (suggestion_index < 0 || suggestion_index >= static_cast<int>(m_model->suggestions().size()))
-        return {};
-    return m_model->suggestions()[suggestion_index].text;
-}
-
-bool Autocomplete::select_next_suggestion()
-{
-    if (m_model->rowCount() == 0)
-        return false;
-
-    if (!m_popup->isVisible()) {
-        position_popup();
-        m_popup->show();
-        position_popup();
-        m_popup->raise();
-        int row = step_to_selectable_row(-1, 1);
-        if (row != -1)
-            select_row(row);
-        return true;
-    }
-
-    auto current = m_list_view->currentIndex();
-    int start = current.isValid() ? current.row() : -1;
-    int row = step_to_selectable_row(start, 1);
-    if (row != -1)
-        select_row(row);
-    return true;
-}
-
-bool Autocomplete::select_previous_suggestion()
-{
-    if (m_model->rowCount() == 0)
-        return false;
-
-    if (!m_popup->isVisible()) {
-        position_popup();
-        m_popup->show();
-        position_popup();
-        m_popup->raise();
-        int row = step_to_selectable_row(0, -1);
-        if (row != -1)
-            select_row(row);
-        return true;
-    }
-
-    auto current = m_list_view->currentIndex();
-    int start = current.isValid() ? current.row() : 0;
-    int row = step_to_selectable_row(start, -1);
-    if (row != -1)
-        select_row(row);
-    return true;
 }
 
 bool Autocomplete::eventFilter(QObject* watched, QEvent* event)
@@ -590,8 +530,10 @@ bool Autocomplete::eventFilter(QObject* watched, QEvent* event)
         auto global = mouse_event->globalPosition().toPoint();
         auto popup_global = QRect(m_popup->mapToGlobal(QPoint(0, 0)), m_popup->size());
         auto anchor_global = QRect(m_anchor->mapToGlobal(QPoint(0, 0)), m_anchor->size());
-        if (!popup_global.contains(global) && !anchor_global.contains(global))
-            close();
+        if (!popup_global.contains(global) && !anchor_global.contains(global)) {
+            if (close())
+                emit dismissed();
+        }
     }
     return QObject::eventFilter(watched, event);
 }
@@ -645,35 +587,6 @@ bool Autocomplete::is_selectable_row(int row) const
         return false;
     auto const& rows = m_model->rows();
     return rows[row].kind == RowKind::Suggestion;
-}
-
-int Autocomplete::step_to_selectable_row(int from, int direction) const
-{
-    int n = m_model->rowCount();
-    if (n == 0)
-        return -1;
-    int candidate = from;
-    for (int attempt = 0; attempt < n; ++attempt) {
-        candidate += direction;
-        if (candidate < 0)
-            candidate = n - 1;
-        else if (candidate >= n)
-            candidate = 0;
-        if (is_selectable_row(candidate))
-            return candidate;
-    }
-    return -1;
-}
-
-void Autocomplete::select_row(int row, bool notify)
-{
-    if (!is_selectable_row(row))
-        return;
-    auto index = m_model->index(row, 0);
-    m_list_view->setCurrentIndex(index);
-    m_list_view->scrollTo(index);
-    if (notify)
-        emit suggestion_highlighted(index.data(UrlRole).toString());
 }
 
 }

--- a/UI/Qt/Autocomplete.h
+++ b/UI/Qt/Autocomplete.h
@@ -8,10 +8,7 @@
 
 #pragma once
 
-#include <AK/Function.h>
-#include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
-#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibWebView/Autocomplete.h>
 
@@ -26,6 +23,9 @@ namespace Ladybird {
 class AutocompleteModel;
 class AutocompleteDelegate;
 
+// The suggestion popup below the location bar. This is a pure view: LocationEdit feeds it rows and a
+// selection from the WebView::Omnibox model, and it reports row hovers, clicks, and outside-click
+// dismissals back.
 class Autocomplete final : public QObject {
     Q_OBJECT
 
@@ -33,35 +33,26 @@ public:
     explicit Autocomplete(QLineEdit* anchor);
     virtual ~Autocomplete() override;
 
-    AK::Function<void(Vector<WebView::AutocompleteSuggestion>, WebView::AutocompleteResultKind)> on_query_complete;
-
-    void query_autocomplete_engine(String);
-    void cancel_pending_query();
     void update_chrome_style();
     void schedule_chrome_style_update();
 
-    void show_with_suggestions(Vector<WebView::AutocompleteSuggestion>, int selected_suggestion_index);
+    void show_with_suggestions(Vector<WebView::AutocompleteSuggestion>, Optional<size_t> selected_suggestion_index);
+    void set_selected_suggestion(Optional<size_t> suggestion_index);
     bool close();
-    bool is_visible() const;
-
-    void clear_selection();
-    Optional<String> selected_suggestion() const;
-    bool select_next_suggestion();
-    bool select_previous_suggestion();
 
 signals:
-    void suggestion_activated(QString);
-    void suggestion_highlighted(QString);
-    void did_close();
+    void suggestion_clicked(int suggestion_index);
+    void suggestion_hovered(int suggestion_index);
+    void dismissed();
 
 protected:
     virtual bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
+    void create_popup();
+    bool is_visible() const;
     void position_popup();
     bool is_selectable_row(int row) const;
-    int step_to_selectable_row(int from, int direction) const;
-    void select_row(int row, bool notify = true);
 
     QLineEdit* m_anchor { nullptr };
     QFrame* m_popup { nullptr };
@@ -70,8 +61,6 @@ private:
     AutocompleteDelegate* m_delegate { nullptr };
     bool m_is_updating_chrome_style { false };
     bool m_has_pending_chrome_style_update { false };
-
-    NonnullOwnPtr<WebView::Autocomplete> m_autocomplete;
 };
 
 }

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -5,11 +5,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/StringView.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/Autocomplete.h>
 #include <LibWebView/URL.h>
 #include <UI/Qt/Autocomplete.h>
 #include <UI/Qt/ChromeStyle.h>
@@ -23,7 +21,6 @@
 #include <QGraphicsDropShadowEffect>
 #include <QGuiApplication>
 #include <QKeyEvent>
-#include <QLatin1String>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPalette>
@@ -83,108 +80,10 @@ static QColor location_focus_glow_color(QPalette const& palette, int alpha)
     return color;
 }
 
-static QString candidate_by_trimming_root_trailing_slash(QString const& candidate)
+static int qstring_offset_for_byte_offset(String const& text, size_t byte_offset)
 {
-    if (!candidate.endsWith(QLatin1Char('/')))
-        return candidate;
-
-    QString host_and_path = candidate;
-    for (auto scheme : { QLatin1String("https://"), QLatin1String("http://") }) {
-        if (host_and_path.startsWith(scheme)) {
-            host_and_path = host_and_path.mid(scheme.size());
-            break;
-        }
-    }
-
-    int first_slash = host_and_path.indexOf(QLatin1Char('/'));
-    if (first_slash == -1 || first_slash != host_and_path.length() - 1)
-        return candidate;
-
-    return candidate.left(candidate.length() - 1);
-}
-
-static bool query_matches_candidate_exactly(QString const& query, QString const& candidate)
-{
-    auto trimmed = candidate_by_trimming_root_trailing_slash(candidate);
-    return trimmed.compare(query, Qt::CaseInsensitive) == 0;
-}
-
-static QString inline_autocomplete_text_for_candidate(QString const& query, QString const& candidate)
-{
-    if (query.isEmpty() || candidate.length() <= query.length())
-        return {};
-    if (!candidate.startsWith(query, Qt::CaseInsensitive))
-        return {};
-    return query + candidate.mid(query.length());
-}
-
-static QString inline_autocomplete_text_for_suggestion(QString const& query, QString const& suggestion_text)
-{
-    auto trimmed = candidate_by_trimming_root_trailing_slash(suggestion_text);
-
-    if (auto direct = inline_autocomplete_text_for_candidate(query, trimmed); !direct.isEmpty())
-        return direct;
-
-    if (trimmed.startsWith(QLatin1String("www."))) {
-        auto stripped = trimmed.mid(4);
-        if (auto match = inline_autocomplete_text_for_candidate(query, stripped); !match.isEmpty())
-            return match;
-    }
-
-    for (auto scheme : { QLatin1String("https://"), QLatin1String("http://") }) {
-        if (!trimmed.startsWith(scheme))
-            continue;
-        auto stripped = trimmed.mid(scheme.size());
-        if (auto match = inline_autocomplete_text_for_candidate(query, stripped); !match.isEmpty())
-            return match;
-        if (stripped.startsWith(QLatin1String("www."))) {
-            auto stripped_www = stripped.mid(4);
-            if (auto match = inline_autocomplete_text_for_candidate(query, stripped_www); !match.isEmpty())
-                return match;
-        }
-    }
-
-    return {};
-}
-
-static bool suggestion_matches_query_exactly(QString const& query, QString const& suggestion_text)
-{
-    auto trimmed = candidate_by_trimming_root_trailing_slash(suggestion_text);
-    if (query_matches_candidate_exactly(query, trimmed))
-        return true;
-
-    if (trimmed.startsWith(QLatin1String("www."))) {
-        if (query_matches_candidate_exactly(query, trimmed.mid(4)))
-            return true;
-    }
-
-    for (auto scheme : { QLatin1String("https://"), QLatin1String("http://") }) {
-        if (!trimmed.startsWith(scheme))
-            continue;
-        auto stripped = trimmed.mid(scheme.size());
-        if (query_matches_candidate_exactly(query, stripped))
-            return true;
-        if (stripped.startsWith(QLatin1String("www."))
-            && query_matches_candidate_exactly(query, stripped.mid(4)))
-            return true;
-    }
-
-    return false;
-}
-
-static int autocomplete_suggestion_index(QString const& suggestion_text, Vector<WebView::AutocompleteSuggestion> const& suggestions)
-{
-    for (size_t i = 0; i < suggestions.size(); ++i) {
-        if (qstring_from_ak_string(suggestions[i].text) == suggestion_text)
-            return static_cast<int>(i);
-    }
-    return -1;
-}
-
-static bool should_suppress_inline_autocomplete_for_key(QKeyEvent const* event)
-{
-    auto key = event->key();
-    return key == Qt::Key_Backspace || key == Qt::Key_Delete;
+    auto prefix = text.bytes_as_string_view().substring_view(0, byte_offset);
+    return static_cast<int>(qstring_from_ak_string(prefix).length());
 }
 
 static constexpr int LOCATION_TRAILING_EDGE_MARGIN = 12;
@@ -252,140 +151,79 @@ LocationEdit::LocationEdit(QWidget* parent)
     update_placeholder();
     update_location_icon();
 
-    m_autocomplete->on_query_complete = [this](auto suggestions, WebView::AutocompleteResultKind result_kind) {
-        if (!hasFocus())
-            return;
+    m_omnibox.on_display_change = [this](WebView::Omnibox::Display const& display) {
+        auto display_text = qstring_from_ak_string(display.text);
+        if (text() != display_text)
+            setText(display_text);
 
-        auto query = autocomplete_query();
-        int selected_row = -1;
-        if (!m_autocomplete_preview_query.isNull()) {
-            for (size_t i = 0; i < suggestions.size(); ++i) {
-                if (qstring_from_ak_string(suggestions[i].text) == text()) {
-                    selected_row = static_cast<int>(i);
-                    break;
-                }
-            }
-        } else if (!m_autocomplete_query_without_inline.isNull() && text() == m_autocomplete_query_without_inline) {
-            selected_row = 0;
+        if (display.selection_start.has_value()) {
+            auto selection_start = qstring_offset_for_byte_offset(display.text, *display.selection_start);
+            setSelection(selection_start, static_cast<int>(display_text.length()) - selection_start);
         } else {
-            selected_row = apply_inline_autocomplete(suggestions);
-        }
-
-        // Do not update the popup while results are still changing.
-        // Intermediate updates are triggered on every keystroke and would
-        // cause visible flicker in the suggestion list.
-        // Only final results are used to refresh the UI.
-        bool should_activate_pending_query = !m_pending_autocomplete_activation_query.isNull()
-            && m_pending_autocomplete_activation_query == query;
-        if (result_kind == WebView::AutocompleteResultKind::Intermediate && m_autocomplete->is_visible() && !should_activate_pending_query)
-            return;
-
-        m_autocomplete_popup_query = query;
-        m_autocomplete->show_with_suggestions(AK::move(suggestions), selected_row);
-        if (should_activate_pending_query) {
-            auto selected = m_autocomplete->selected_suggestion();
-            if (result_kind == WebView::AutocompleteResultKind::Final
-                || (selected.has_value() && qstring_from_ak_string(*selected) != query)) {
-                m_pending_autocomplete_activation_query = QString();
-                m_should_skip_autocomplete_cancel_on_focus_out = true;
-                activate_selected_autocomplete_suggestion();
-            }
+            deselect();
+            setCursorPosition(static_cast<int>(display_text.length()));
         }
     };
 
-    connect(m_autocomplete, &Autocomplete::suggestion_activated, this, [this](QString const& text) {
-        m_autocomplete_preview_query = QString();
-        m_current_inline_autocomplete_suggestion.clear();
-        set_text_without_inline_autocomplete(text);
-        m_autocomplete->close();
-        emit returnPressed();
-    });
-
-    connect(m_autocomplete, &Autocomplete::suggestion_highlighted, this, [this](QString const& text) {
-        m_has_highlighted_autocomplete_suggestion = true;
-        auto query = autocomplete_query();
-        apply_inline_autocomplete_suggestion_text(text, query, true);
-    });
-
-    connect(m_autocomplete, &Autocomplete::did_close, this, [this] {
-        auto should_preserve_inline_autocomplete = m_should_preserve_inline_autocomplete_on_close;
-        auto should_restore_query = should_restore_autocomplete_query();
-        m_should_preserve_inline_autocomplete_on_close = false;
-        m_has_highlighted_autocomplete_suggestion = false;
-        m_should_submit_current_text_on_return = false;
-        m_current_inline_autocomplete_suggestion.clear();
-        if (should_preserve_inline_autocomplete)
-            return;
-        if (!m_autocomplete_query_without_inline.isNull()) {
-            if (should_restore_query)
-                restore_query();
-            m_autocomplete_query_without_inline = QString();
+    m_omnibox.on_suggestions_change = [this] {
+        if (!m_omnibox.is_popup_visible()) {
+            m_autocomplete->close();
             return;
         }
-        restore_query();
-    });
+        m_autocomplete->show_with_suggestions(m_omnibox.suggestions(), m_omnibox.selected_suggestion());
+    };
 
-    connect(this, &QLineEdit::returnPressed, this, [this] {
-        if (text().isEmpty())
-            return;
+    m_omnibox.on_selection_change = [this] {
+        m_autocomplete->set_selected_suggestion(m_omnibox.selected_suggestion());
+    };
 
-        auto query = ak_string_from_qstring(text());
+    m_omnibox.on_commit = [this](String const& input) {
+        auto input_text = qstring_from_ak_string(input);
+        if (text() != input_text)
+            setText(input_text);
 
-        reset_autocomplete_state();
         clearFocus();
 
         auto ctrl_held = QApplication::keyboardModifiers() & Qt::ControlModifier;
         auto append_tld = ctrl_held ? WebView::AppendTLD::Yes : WebView::AppendTLD::No;
 
-        auto url = WebView::sanitize_url(query, WebView::Application::settings().search_engine(), append_tld);
+        auto url = WebView::sanitize_url(input, WebView::Application::settings().search_engine(), append_tld);
         set_url(AK::move(url));
+
+        emit returnPressed();
+    };
+
+    connect(m_autocomplete, &Autocomplete::suggestion_clicked, this, [this](int suggestion_index) {
+        m_omnibox.suggestion_clicked(static_cast<size_t>(suggestion_index));
+    });
+
+    connect(m_autocomplete, &Autocomplete::suggestion_hovered, this, [this](int suggestion_index) {
+        m_omnibox.suggestion_hovered(static_cast<size_t>(suggestion_index));
+    });
+
+    connect(m_autocomplete, &Autocomplete::dismissed, this, [this] {
+        m_omnibox.popup_dismissed();
     });
 
     connect(this, &QLineEdit::textEdited, this, [this] {
-        if (m_is_applying_inline_autocomplete)
-            return;
-
-        bool had_autocomplete_preview = !m_autocomplete_preview_query.isNull();
-        bool had_inline_autocomplete = !m_current_inline_autocomplete_suggestion.isEmpty();
-
-        m_autocomplete_query_without_inline = QString();
-        m_autocomplete_preview_query = QString();
-        m_has_highlighted_autocomplete_suggestion = false;
-        if (had_autocomplete_preview)
-            m_should_submit_current_text_on_return = true;
-
         if (m_url_is_hidden)
             m_has_user_edited_hidden_url = true;
 
-        auto query = current_query();
-        if (!m_pending_autocomplete_activation_query.isNull() && m_pending_autocomplete_activation_query != query)
-            m_pending_autocomplete_activation_query = QString();
-
-        if (m_should_suppress_inline_autocomplete_on_next_change) {
-            if (had_inline_autocomplete)
-                m_should_submit_current_text_on_return = true;
-            m_suppressed_inline_autocomplete_query = query;
-            m_should_suppress_inline_autocomplete_on_next_change = false;
-        } else if (!m_suppressed_inline_autocomplete_query.isNull()
-            && m_suppressed_inline_autocomplete_query != query) {
-            m_suppressed_inline_autocomplete_query = QString();
-        }
-
-        if (m_suppressed_inline_autocomplete_query.isNull()
-            && !m_current_inline_autocomplete_suggestion.isEmpty()) {
-            if (!apply_inline_autocomplete_suggestion_text(m_current_inline_autocomplete_suggestion, query)) {
-                m_current_inline_autocomplete_suggestion.clear();
-                if (had_inline_autocomplete)
-                    m_should_submit_current_text_on_return = true;
-            }
-        }
-
-        m_autocomplete->query_autocomplete_engine(ak_string_from_qstring(query));
+        bool cursor_at_end = !hasSelectedText() && cursorPosition() == text().length();
+        m_omnibox.text_edited(ak_string_from_qstring(text()), cursor_at_end);
     });
 
     connect(this, &QLineEdit::textChanged, this, [this] {
         highlight_location();
         update_location_icon();
+    });
+
+    connect(this, &QLineEdit::cursorPositionChanged, this, [this](int, int new_position) {
+        // A selection reaching the end of the text (an inline completion, select-all on focus) still
+        // counts as "at the end": replacing it appends, and completions may be applied over it.
+        bool at_end = new_position == text().length()
+            && (!hasSelectedText() || selectionEnd() == text().length());
+        m_omnibox.cursor_moved(at_end);
     });
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
@@ -433,7 +271,7 @@ void LocationEdit::set_url_is_hidden(bool url_is_hidden)
     m_has_user_edited_hidden_url = false;
 
     if (m_url_is_hidden)
-        clear();
+        set_text_and_restart_editing({});
 }
 
 void LocationEdit::show_autocomplete()
@@ -441,10 +279,7 @@ void LocationEdit::show_autocomplete()
     if (!window() || !window()->isVisible())
         return;
 
-    auto query = text();
-    m_autocomplete_popup_query = QString();
-    m_autocomplete_query_without_inline = query;
-    m_autocomplete->query_autocomplete_engine(ak_string_from_qstring(query));
+    m_omnibox.show_all_suggestions();
 }
 
 void LocationEdit::changeEvent(QEvent* event)
@@ -459,6 +294,7 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
 {
     if (event->reason() == Qt::PopupFocusReason) {
         QLineEdit::focusInEvent(event);
+        m_omnibox.set_suspended(false);
         return;
     }
 
@@ -472,6 +308,8 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
 
     if (!should_defer_full_url && m_url.has_value() && text() == display_url())
         setText(serialized_url());
+
+    m_omnibox.begin_editing(ak_string_from_qstring(text()));
 
     highlight_location();
     animate_focus_glow(58);
@@ -488,22 +326,16 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
 {
     QLineEdit::focusOutEvent(event);
 
-    if (event->reason() == Qt::PopupFocusReason)
+    // A popup (for example the context menu) borrows focus without ending the editing session; late
+    // suggestion deliveries must not rewrite the text or raise the suggestion popup while it is open.
+    if (event->reason() == Qt::PopupFocusReason) {
+        m_omnibox.set_suspended(true);
         return;
+    }
 
     animate_focus_glow(0);
 
-    if (should_restore_autocomplete_query()) {
-        auto query = current_query();
-        set_text_without_inline_autocomplete(query);
-        setCursorPosition(query.length());
-    }
-
-    auto should_cancel_pending_query = !m_should_skip_autocomplete_cancel_on_focus_out;
-    reset_autocomplete_state();
-    if (should_cancel_pending_query)
-        m_autocomplete->cancel_pending_query();
-    m_autocomplete->close();
+    m_omnibox.end_editing();
     m_should_show_full_url_on_mouse_release = false;
 
     if (m_url_is_hidden) {
@@ -516,10 +348,8 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
     }
 
     deselect();
-    if (event->reason() != Qt::PopupFocusReason) {
-        setCursorPosition(0);
-        highlight_location();
-    }
+    setCursorPosition(0);
+    highlight_location();
 }
 
 void LocationEdit::update_focus_glow(int alpha)
@@ -543,18 +373,8 @@ void LocationEdit::animate_focus_glow(int target_alpha)
 void LocationEdit::keyPressEvent(QKeyEvent* event)
 {
     if (event->key() == Qt::Key_Escape) {
-        if (m_autocomplete->is_visible()
-            && m_autocomplete_query_without_inline.isNull()
-            && m_autocomplete_preview_query.isNull()
-            && !m_has_highlighted_autocomplete_suggestion
-            && hasSelectedText()) {
-            m_should_preserve_inline_autocomplete_on_close = true;
-        }
-        if (m_autocomplete->close()) {
-            m_autocomplete->cancel_pending_query();
+        if (m_omnibox.escape_pressed() == WebView::Omnibox::EscapeAction::ClosedPopup)
             return;
-        }
-        reset_autocomplete_state();
         if (m_url.has_value())
             setText(serialized_url());
         clearFocus();
@@ -562,43 +382,23 @@ void LocationEdit::keyPressEvent(QKeyEvent* event)
     }
 
     if (event->key() == Qt::Key_Down) {
-        if (m_autocomplete->select_next_suggestion())
+        if (m_omnibox.select_next_suggestion())
             return;
     }
 
     if (event->key() == Qt::Key_Up) {
-        if (m_autocomplete->select_previous_suggestion())
+        if (m_omnibox.select_previous_suggestion())
             return;
     }
 
-    if ((event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) && m_autocomplete->is_visible()) {
-        // Manual edits to automatic completion text should submit the edited text, not the popup's automatically selected row.
-        if (m_should_submit_current_text_on_return && !m_has_highlighted_autocomplete_suggestion) {
-            auto query = current_query();
-            reset_autocomplete_state();
-            set_text_without_inline_autocomplete(query);
-            setCursorPosition(query.length());
-            m_autocomplete->close();
-            emit returnPressed();
-            event->accept();
-            return;
-        }
-
-        auto query = autocomplete_query();
-        if (m_autocomplete_popup_query == query) {
-            activate_selected_autocomplete_suggestion();
-            event->accept();
-            return;
-        } else {
-            m_pending_autocomplete_activation_query = query;
-            m_autocomplete->query_autocomplete_engine(ak_string_from_qstring(query));
-            event->accept();
-            return;
-        }
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+        m_omnibox.return_pressed();
+        event->accept();
+        return;
     }
 
-    if (should_suppress_inline_autocomplete_for_key(event))
-        m_should_suppress_inline_autocomplete_on_next_change = true;
+    if (event->key() == Qt::Key_Backspace || event->key() == Qt::Key_Delete)
+        m_omnibox.will_delete_text();
 
     QLineEdit::keyPressEvent(event);
 }
@@ -866,15 +666,30 @@ void LocationEdit::highlight_location()
     QCoreApplication::sendEvent(this, &event);
 }
 
+// Programmatic text changes bypass textEdited, so the editing session must restart for the model to act
+// on what the bar now shows.
+void LocationEdit::set_text_and_restart_editing(QString const& text)
+{
+    setText(text);
+    if (!m_omnibox.is_editing())
+        return;
+
+    // Without focus, the session is alive because a popup (for example the context menu) borrowed input;
+    // the restarted session must stay suspended behind it.
+    bool suspended = !hasFocus();
+    m_omnibox.begin_editing(ak_string_from_qstring(text));
+    m_omnibox.set_suspended(suspended);
+}
+
 void LocationEdit::set_url(Optional<URL::URL> url)
 {
     m_url = AK::move(url);
 
     if (m_url_is_hidden) {
         if (!m_has_user_edited_hidden_url)
-            clear();
+            set_text_and_restart_editing({});
     } else if (m_url.has_value()) {
-        setText(hasFocus() ? serialized_url() : display_url());
+        set_text_and_restart_editing(hasFocus() ? serialized_url() : display_url());
         setCursorPosition(0);
     }
 
@@ -894,7 +709,7 @@ void LocationEdit::show_full_url_preserving_display_selection()
     auto selection_start = selectionStart();
     auto selection_length = selectedText().length();
 
-    setText(serialized_url());
+    set_text_and_restart_editing(serialized_url());
 
     if (selection_start != -1) {
         auto serialized_selection_start = serialized_url_position_for_display_position(selection_start);
@@ -1004,241 +819,9 @@ QString LocationEdit::display_url() const
 
 QString LocationEdit::current_query() const
 {
-    if (!m_autocomplete_preview_query.isNull())
-        return m_autocomplete_preview_query;
-
-    if (!hasSelectedText())
-        return text();
-    int start = selectionStart();
-    int length = selectedText().length();
-    if (start + length != text().length())
-        return text();
-    return text().left(start);
-}
-
-int LocationEdit::apply_inline_autocomplete(Vector<WebView::AutocompleteSuggestion> const& suggestions)
-{
-    if (m_is_applying_inline_autocomplete) {
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: skipped (re-entrant)");
-        return -1;
-    }
-    if (!hasFocus()) {
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: skipped (no focus)");
-        return -1;
-    }
-
-    QString query;
-    auto current_text = text();
-    if (!hasSelectedText()) {
-        if (cursorPosition() != current_text.length()) {
-            dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: skipped (caret not at end)");
-            return -1;
-        }
-        query = current_text;
-    } else {
-        int start = selectionStart();
-        int end = start + selectedText().length();
-        if (end != current_text.length()) {
-            dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: skipped (selection not at end)");
-            return -1;
-        }
-        query = current_text.left(start);
-    }
-
-    dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: query='{}' suggestions={}",
-        ak_string_from_qstring(query),
-        suggestions.size());
-    for (size_t i = 0; i < suggestions.size(); ++i) {
-        auto const& suggestion = suggestions[i];
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History]   [{}] source={} text='{}'",
-            i,
-            suggestion.source == WebView::AutocompleteSuggestionSource::LiteralURL    ? "LiteralURL"sv
-                : suggestion.source == WebView::AutocompleteSuggestionSource::History ? "History"sv
-                                                                                      : "Search"sv,
-            suggestion.text);
-    }
-
-    if (suggestions.is_empty()) {
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: no suggestions, selected=-1");
-        return -1;
-    }
-
-    // Row 0 drives both the visible highlight and (if its text prefix-matches
-    // the query) the inline completion preview. This is a deliberate
-    // simplification over the exact/inline/fallback fan-out we used to have:
-    // the user-visible rule is "the top row is the default action".
-
-    auto row_0_text_q = qstring_from_ak_string(suggestions.first().text);
-
-    // A literal URL always wins: no preview, restore the typed text.
-    if (suggestions.first().source == WebView::AutocompleteSuggestionSource::LiteralURL) {
-        m_current_inline_autocomplete_suggestion.clear();
-        if (hasSelectedText() || current_text != query)
-            restore_query();
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: literal URL, selected=0");
-        return 0;
-    }
-
-    // Backspace suppression: the user just deleted into this query, so don't
-    // re-apply an inline preview — but still honor the "highlight the top row"
-    // rule.
-    if (!m_suppressed_inline_autocomplete_query.isNull() && m_suppressed_inline_autocomplete_query == query) {
-        m_current_inline_autocomplete_suggestion.clear();
-        if (hasSelectedText() || current_text != query)
-            restore_query();
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: suppressed query, selected=0 (no preview)");
-        return 0;
-    }
-
-    // Preserve an existing inline preview if its row is still present and
-    // still extends the typed prefix. This keeps the preview stable while the
-    // user is still forward-typing into a suggestion.
-    if (!m_current_inline_autocomplete_suggestion.isEmpty()) {
-        int preserved = autocomplete_suggestion_index(m_current_inline_autocomplete_suggestion, suggestions);
-        if (preserved != -1) {
-            auto preserved_inline = inline_autocomplete_text_for_suggestion(query, m_current_inline_autocomplete_suggestion);
-            if (!preserved_inline.isEmpty()) {
-                apply_inline_autocomplete_text(preserved_inline, query);
-                dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: preserved inline row={} text='{}'",
-                    preserved, ak_string_from_qstring(m_current_inline_autocomplete_suggestion));
-                return preserved;
-            }
-        }
-    }
-
-    // Try to inline-preview row 0 specifically.
-    auto row_0_inline = inline_autocomplete_text_for_suggestion(query, row_0_text_q);
-    if (!row_0_inline.isEmpty()) {
-        m_current_inline_autocomplete_suggestion = row_0_text_q;
-        apply_inline_autocomplete_text(row_0_inline, query);
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: row 0 inline match, inline='{}'",
-            ak_string_from_qstring(row_0_inline));
-        return 0;
-    }
-
-    // Row 0 does not prefix-match the query: clear any stale inline preview,
-    // restore the typed text, and still highlight row 0.
-    m_current_inline_autocomplete_suggestion.clear();
-    if (hasSelectedText() || current_text != query)
-        restore_query();
-    dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: row 0 not a prefix match, selected=0 (highlight only)");
-    return 0;
-}
-
-bool LocationEdit::apply_inline_autocomplete_suggestion_text(QString const& suggestion_text, QString const& query, bool allow_preview)
-{
-    if (suggestion_matches_query_exactly(query, suggestion_text)) {
-        restore_query();
-        m_current_inline_autocomplete_suggestion.clear();
-        return true;
-    }
-
-    auto inline_text = inline_autocomplete_text_for_suggestion(query, suggestion_text);
-    if (inline_text.isEmpty() && allow_preview) {
-        apply_autocomplete_preview_text(suggestion_text, query);
-        return true;
-    }
-    if (inline_text.isEmpty())
-        return false;
-
-    m_current_inline_autocomplete_suggestion = suggestion_text;
-    apply_inline_autocomplete_text(inline_text, query);
-    return true;
-}
-
-void LocationEdit::apply_inline_autocomplete_text(QString const& inline_text, QString const& query)
-{
-    if (!hasFocus())
-        return;
-
-    int completion_start = query.length();
-    int completion_length = inline_text.length() - query.length();
-    if (completion_length <= 0)
-        return;
-
-    if (text() == inline_text && hasSelectedText()
-        && selectionStart() == completion_start
-        && selectedText().length() == completion_length)
-        return;
-
-    m_autocomplete_preview_query = QString();
-    set_text_without_inline_autocomplete(inline_text);
-    setSelection(completion_start, completion_length);
-}
-
-void LocationEdit::apply_autocomplete_preview_text(QString const& suggestion_text, QString const& query)
-{
-    if (!hasFocus())
-        return;
-
-    if (text() == suggestion_text && hasSelectedText()
-        && selectionStart() == 0
-        && selectedText().length() == suggestion_text.length())
-        return;
-
-    m_current_inline_autocomplete_suggestion.clear();
-    m_autocomplete_preview_query = query;
-    set_text_without_inline_autocomplete(suggestion_text);
-    selectAll();
-}
-
-void LocationEdit::activate_selected_autocomplete_suggestion()
-{
-    if (auto selected = m_autocomplete->selected_suggestion(); selected.has_value()) {
-        m_autocomplete_preview_query = QString();
-        m_current_inline_autocomplete_suggestion.clear();
-        set_text_without_inline_autocomplete(qstring_from_ak_string(*selected));
-    }
-    m_autocomplete->close();
-    emit returnPressed();
-}
-
-void LocationEdit::restore_query()
-{
-    if (!hasFocus())
-        return;
-
-    auto query = current_query();
-    if (text() == query && !hasSelectedText())
-        return;
-
-    set_text_without_inline_autocomplete(query);
-    setCursorPosition(query.length());
-    m_autocomplete_preview_query = QString();
-}
-
-void LocationEdit::set_text_without_inline_autocomplete(QString const& text)
-{
-    m_is_applying_inline_autocomplete = true;
-    setText(text);
-    m_is_applying_inline_autocomplete = false;
-}
-
-bool LocationEdit::should_restore_autocomplete_query() const
-{
-    return !m_autocomplete_preview_query.isNull() || !m_current_inline_autocomplete_suggestion.isEmpty();
-}
-
-QString LocationEdit::autocomplete_query() const
-{
-    if (!m_autocomplete_query_without_inline.isNull())
-        return m_autocomplete_query_without_inline;
-    return current_query();
-}
-
-void LocationEdit::reset_autocomplete_state()
-{
-    m_autocomplete_popup_query = QString();
-    m_autocomplete_query_without_inline = QString();
-    m_autocomplete_preview_query = QString();
-    m_current_inline_autocomplete_suggestion.clear();
-    m_has_highlighted_autocomplete_suggestion = false;
-    m_should_submit_current_text_on_return = false;
-    m_should_preserve_inline_autocomplete_on_close = false;
-    m_should_skip_autocomplete_cancel_on_focus_out = false;
-    m_pending_autocomplete_activation_query = QString();
-    m_suppressed_inline_autocomplete_query = QString();
-    m_should_suppress_inline_autocomplete_on_next_change = false;
+    if (m_omnibox.is_editing())
+        return qstring_from_ak_string(m_omnibox.query());
+    return text();
 }
 
 }

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -7,9 +7,7 @@
 
 #pragma once
 
-#include <AK/OwnPtr.h>
-#include <AK/Vector.h>
-#include <LibWebView/Autocomplete.h>
+#include <LibWebView/Omnibox.h>
 #include <LibWebView/Settings.h>
 
 #include <QLineEdit>
@@ -71,19 +69,10 @@ private:
     bool text_matches_current_url() const;
     QString serialized_url() const;
     QString display_url() const;
-
-    int apply_inline_autocomplete(Vector<WebView::AutocompleteSuggestion> const&);
-    bool apply_inline_autocomplete_suggestion_text(QString const& suggestion_text, QString const& query, bool allow_preview = false);
-    void apply_inline_autocomplete_text(QString const& inline_text, QString const& query);
-    void apply_autocomplete_preview_text(QString const& suggestion_text, QString const& query);
-    void activate_selected_autocomplete_suggestion();
-    void restore_query();
-    void set_text_without_inline_autocomplete(QString const& text);
-    bool should_restore_autocomplete_query() const;
-    QString autocomplete_query() const;
     QString current_query() const;
-    void reset_autocomplete_state();
+    void set_text_and_restart_editing(QString const& text);
 
+    WebView::Omnibox m_omnibox;
     Autocomplete* m_autocomplete { nullptr };
     QToolButton* m_leading_icon_button { nullptr };
     QToolButton* m_trailing_action_button { nullptr };
@@ -100,19 +89,6 @@ private:
     bool m_should_show_full_url_on_mouse_release { false };
     int m_text_leading_margin { 0 };
     int m_focus_glow_alpha { 0 };
-
-    bool m_is_applying_inline_autocomplete { false };
-    bool m_should_suppress_inline_autocomplete_on_next_change { false };
-    bool m_has_highlighted_autocomplete_suggestion { false };
-    bool m_should_submit_current_text_on_return { false };
-    bool m_should_preserve_inline_autocomplete_on_close { false };
-    bool m_should_skip_autocomplete_cancel_on_focus_out { false };
-    QString m_autocomplete_popup_query;
-    QString m_autocomplete_query_without_inline;
-    QString m_autocomplete_preview_query;
-    QString m_current_inline_autocomplete_suggestion;
-    QString m_pending_autocomplete_activation_query;
-    QString m_suppressed_inline_autocomplete_query;
 };
 
 }


### PR DESCRIPTION
Move location bar editing state into a chrome-agnostic `WebView::Omnibox` model, with Qt forwarding user events and rendering the model's display, selection, popup, and commit instructions.

This replaces the Qt location bar's flag-based inline completion and preview handling with one state machine whose commit behavior follows the text currently shown in the bar. In particular, Enter now activates the visible completion instead of sometimes submitting the typed prefix when top history suggestions change while the user is typing quickly.

The new LibWebView tests cover fast typing, stale and delayed suggestion delivery, completion suppression after edits and deletes, popup dismissal, preview restoration, arrow-key selection, clicked suggestions, suspended sessions, and re-entrant commits.