### PR TITLE
LibWeb: Skip IntersectionObserver targets with stale layout

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6245,7 +6245,9 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
             // 3. If the intersection root is an Element, and target is not a descendant of the intersection root in the containing block chain, skip to step 11.
             // FIXME: Actually use the containing block chain.
             // NOTE: Check if target has a layout node is not in the spec but required to match other browsers.
-            if (target->layout_node() && (is_implicit_root || &target->document() == &intersection_root_node->document()) && !(root_is_element && !target->is_descendant_of(*intersection_root_node))) {
+            // AD-HOC: A target whose document was excluded from this rendering update has stale layout; treat it as
+            //         not intersecting like other engines instead of reading its geometry.
+            if (target->document().layout_is_up_to_date() && target->layout_node() && (is_implicit_root || &target->document() == &intersection_root_node->document()) && !(root_is_element && !target->is_descendant_of(*intersection_root_node))) {
                 // 4. Set targetRect to the DOMRectReadOnly obtained by getting the bounding box for target.
                 target_rect = target->bounding_client_rect_assuming_layout_clean();
 

--- a/Tests/LibWeb/Crash/HTML/intersection-observer-implicit-root-target-in-render-blocked-iframe.html
+++ b/Tests/LibWeb/Crash/HTML/intersection-observer-implicit-root-target-in-render-blocked-iframe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<iframe></iframe>
+<script>
+    const iframe = document.querySelector("iframe");
+
+    iframe.onload = () => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                document.documentElement.classList.remove("test-wait");
+            });
+        });
+    };
+
+    iframe.srcdoc = `<body>x<script>
+        const target = document.documentElement;
+        new IntersectionObserver(() => {}).observe(target);
+        target.getBoundingClientRect();
+        document.body.remove();
+    <\/script>`;
+</script>
+</html>


### PR DESCRIPTION
An implicit-root IntersectionObserver is registered on the top-level document, but its targets may live in a descendant document. Documents excluded from the rendering update are not laid out, so a target's layout can be stale when the top-level document updates its intersection observations. We now skip such stale targets, avoiding a crash.

The stack trace generated by the included crash test (before this fix is applied) matches a crash I saw on https://sudoku.com but wasn't able to reproduce reliably.