### PR TITLE
LibWeb: Implement WebGL framebuffer attachment queries

### DIFF
--- a/Libraries/LibWeb/WebGL/WebGLFramebuffer.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLFramebuffer.cpp
@@ -9,6 +9,8 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/WebGLFramebuffer.h>
 #include <LibWeb/WebGL/WebGLFramebuffer.h>
+#include <LibWeb/WebGL/WebGLRenderbuffer.h>
+#include <LibWeb/WebGL/WebGLTexture.h>
 
 namespace Web::WebGL {
 
@@ -30,6 +32,49 @@ void WebGLFramebuffer::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(WebGLFramebuffer);
     Base::initialize(realm);
+}
+
+void WebGLFramebuffer::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto& attachment : m_attachments) {
+        visitor.visit(attachment.value.texture);
+        visitor.visit(attachment.value.renderbuffer);
+    }
+}
+
+WebGLFramebuffer::Attachment const* WebGLFramebuffer::attachment(GLenum attachment) const
+{
+    auto it = m_attachments.find(attachment);
+    if (it == m_attachments.end())
+        return nullptr;
+    return &it->value;
+}
+
+void WebGLFramebuffer::set_renderbuffer_attachment(GLenum attachment, GC::Ptr<WebGLRenderbuffer> renderbuffer)
+{
+    if (!renderbuffer) {
+        m_attachments.remove(attachment);
+        return;
+    }
+
+    Attachment framebuffer_attachment;
+    framebuffer_attachment.renderbuffer = renderbuffer;
+    m_attachments.set(attachment, framebuffer_attachment);
+}
+
+void WebGLFramebuffer::set_texture_attachment(GLenum attachment, GC::Ptr<WebGLTexture> texture, GLenum texture_target, GLint level)
+{
+    if (!texture) {
+        m_attachments.remove(attachment);
+        return;
+    }
+
+    Attachment framebuffer_attachment;
+    framebuffer_attachment.texture = texture;
+    framebuffer_attachment.texture_target = texture_target;
+    framebuffer_attachment.texture_level = level;
+    m_attachments.set(attachment, framebuffer_attachment);
 }
 
 }

--- a/Libraries/LibWeb/WebGL/WebGLFramebuffer.h
+++ b/Libraries/LibWeb/WebGL/WebGLFramebuffer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <LibWeb/WebGL/WebGLObject.h>
 
 namespace Web::WebGL {
@@ -16,14 +17,29 @@ class WebGLFramebuffer final : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLFramebuffer);
 
 public:
+    struct Attachment {
+        GC::Ptr<WebGLTexture> texture;
+        GC::Ptr<WebGLRenderbuffer> renderbuffer;
+        GLenum texture_target { 0 };
+        GLint texture_level { 0 };
+    };
+
     static GC::Ref<WebGLFramebuffer> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual ~WebGLFramebuffer();
+
+    Attachment const* attachment(GLenum attachment) const;
+    void set_renderbuffer_attachment(GLenum attachment, GC::Ptr<WebGLRenderbuffer>);
+    void set_texture_attachment(GLenum attachment, GC::Ptr<WebGLTexture>, GLenum texture_target, GLint level);
 
 protected:
     explicit WebGLFramebuffer(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Visitor&) override;
+
+private:
+    HashMap<GLenum, Attachment> m_attachments;
 };
 
 }

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
@@ -105,7 +105,7 @@ interface mixin WebGLRenderingContextBase {
 
     GLenum getError();
 
-    [FIXME] any getFramebufferAttachmentParameter(GLenum target, GLenum attachment, GLenum pname);
+    any getFramebufferAttachmentParameter(GLenum target, GLenum attachment, GLenum pname);
     any getProgramParameter(WebGLProgram program, GLenum pname);
     DOMString? getProgramInfoLog(WebGLProgram program);
     any getRenderbufferParameter(GLenum target, GLenum pname);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
@@ -42,6 +42,53 @@ namespace Web::WebGL {
 static constexpr GLenum UNMASKED_VENDOR_WEBGL = 0x9245;
 static constexpr GLenum UNMASKED_RENDERER_WEBGL = 0x9246;
 
+static bool is_valid_framebuffer_binding_target(WebGLVersion version, GLenum target)
+{
+    if (target == GL_FRAMEBUFFER)
+        return true;
+    if (version == WebGLVersion::WebGL2 && (target == GL_READ_FRAMEBUFFER || target == GL_DRAW_FRAMEBUFFER))
+        return true;
+    return false;
+}
+
+static bool is_valid_framebuffer_attachment(WebGLVersion version, bool draw_buffers_extension_enabled, GLenum attachment)
+{
+    switch (attachment) {
+    case GL_COLOR_ATTACHMENT0:
+    case GL_DEPTH_ATTACHMENT:
+    case GL_STENCIL_ATTACHMENT:
+    case GL_DEPTH_STENCIL_ATTACHMENT:
+        return true;
+    default:
+        break;
+    }
+
+    if (version == WebGLVersion::WebGL2 || draw_buffers_extension_enabled)
+        return attachment > GL_COLOR_ATTACHMENT0 && attachment <= GL_COLOR_ATTACHMENT0 + 15;
+    return false;
+}
+
+static bool is_valid_framebuffer_texture_2d_target(GLenum target)
+{
+    switch (target) {
+    case GL_TEXTURE_2D:
+    case GL_TEXTURE_CUBE_MAP_POSITIVE_X:
+    case GL_TEXTURE_CUBE_MAP_NEGATIVE_X:
+    case GL_TEXTURE_CUBE_MAP_POSITIVE_Y:
+    case GL_TEXTURE_CUBE_MAP_NEGATIVE_Y:
+    case GL_TEXTURE_CUBE_MAP_POSITIVE_Z:
+    case GL_TEXTURE_CUBE_MAP_NEGATIVE_Z:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool is_cube_map_face(GLenum target)
+{
+    return target >= GL_TEXTURE_CUBE_MAP_POSITIVE_X && target <= GL_TEXTURE_CUBE_MAP_NEGATIVE_Z;
+}
+
 WebGLRenderingContextImpl::WebGLRenderingContextImpl(JS::Realm& realm, NonnullOwnPtr<WebGLContextProxy> context)
     : WebGLRenderingContextBase(realm)
     , m_context(move(context))
@@ -488,6 +535,9 @@ void WebGLRenderingContextImpl::delete_framebuffer(GC::Ptr<WebGLFramebuffer> fra
 
     auto handle = framebuffer_handle.value();
     m_context->delete_framebuffers(1, &handle);
+
+    if (m_framebuffer_binding == framebuffer)
+        m_framebuffer_binding = nullptr;
 }
 
 void WebGLRenderingContextImpl::delete_program(GC::Ptr<WebGLProgram> program)
@@ -684,6 +734,26 @@ void WebGLRenderingContextImpl::framebuffer_renderbuffer(WebIDL::UnsignedLong ta
 {
     m_context->make_current();
 
+    if (!is_valid_framebuffer_binding_target(m_context->webgl_version(), target)) {
+        set_error(GL_INVALID_ENUM);
+        return;
+    }
+
+    if (!is_valid_framebuffer_attachment(m_context->webgl_version(), extension_enabled("WEBGL_draw_buffers"sv), attachment)) {
+        set_error(GL_INVALID_ENUM);
+        return;
+    }
+
+    if (renderbuffertarget != GL_RENDERBUFFER) {
+        set_error(GL_INVALID_ENUM);
+        return;
+    }
+
+    if (!m_framebuffer_binding) {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+
     auto renderbuffer_handle = 0;
     if (renderbuffer) {
         auto handle_or_error = renderbuffer->handle(this);
@@ -694,11 +764,37 @@ void WebGLRenderingContextImpl::framebuffer_renderbuffer(WebIDL::UnsignedLong ta
         renderbuffer_handle = handle_or_error.release_value();
     }
     m_context->framebuffer_renderbuffer(target, attachment, renderbuffertarget, renderbuffer_handle);
+    m_framebuffer_binding->set_renderbuffer_attachment(attachment, renderbuffer);
 }
 
 void WebGLRenderingContextImpl::framebuffer_texture2d(WebIDL::UnsignedLong target, WebIDL::UnsignedLong attachment, WebIDL::UnsignedLong textarget, GC::Ptr<WebGLTexture> texture, WebIDL::Long level)
 {
     m_context->make_current();
+
+    if (!is_valid_framebuffer_binding_target(m_context->webgl_version(), target)) {
+        set_error(GL_INVALID_ENUM);
+        return;
+    }
+
+    if (!is_valid_framebuffer_attachment(m_context->webgl_version(), extension_enabled("WEBGL_draw_buffers"sv), attachment)) {
+        set_error(GL_INVALID_ENUM);
+        return;
+    }
+
+    if (!is_valid_framebuffer_texture_2d_target(textarget)) {
+        set_error(GL_INVALID_ENUM);
+        return;
+    }
+
+    if (level < 0 || (m_context->webgl_version() == WebGLVersion::WebGL1 && level != 0)) {
+        set_error(GL_INVALID_VALUE);
+        return;
+    }
+
+    if (!m_framebuffer_binding) {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
 
     auto texture_handle = 0;
     if (texture) {
@@ -710,6 +806,7 @@ void WebGLRenderingContextImpl::framebuffer_texture2d(WebIDL::UnsignedLong targe
         texture_handle = handle_or_error.release_value();
     }
     m_context->framebuffer_texture2d(target, attachment, textarget, texture_handle, level);
+    m_framebuffer_binding->set_texture_attachment(attachment, texture, textarget, level);
 }
 
 void WebGLRenderingContextImpl::front_face(WebIDL::UnsignedLong mode)
@@ -1618,6 +1715,58 @@ WebIDL::UnsignedLong WebGLRenderingContextImpl::get_error()
 {
     m_context->make_current();
     return get_error_value();
+}
+
+JS::Value WebGLRenderingContextImpl::get_framebuffer_attachment_parameter(WebIDL::UnsignedLong target, WebIDL::UnsignedLong attachment, WebIDL::UnsignedLong pname)
+{
+    m_context->make_current();
+
+    if (!is_valid_framebuffer_binding_target(m_context->webgl_version(), target)) {
+        set_error(GL_INVALID_ENUM);
+        return JS::js_null();
+    }
+
+    if (!m_framebuffer_binding) {
+        set_error(GL_INVALID_OPERATION);
+        return JS::js_null();
+    }
+
+    if (!is_valid_framebuffer_attachment(m_context->webgl_version(), extension_enabled("WEBGL_draw_buffers"sv), attachment)) {
+        set_error(GL_INVALID_ENUM);
+        return JS::js_null();
+    }
+
+    auto const* framebuffer_attachment = m_framebuffer_binding->attachment(attachment);
+    if (!framebuffer_attachment) {
+        if (pname == GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE)
+            return JS::Value(GL_NONE);
+        if (pname == GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME && m_context->webgl_version() == WebGLVersion::WebGL2)
+            return JS::js_null();
+        set_error(m_context->webgl_version() == WebGLVersion::WebGL2 ? GL_INVALID_OPERATION : GL_INVALID_ENUM);
+        return JS::js_null();
+    }
+
+    switch (pname) {
+    case GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE:
+        if (framebuffer_attachment->texture)
+            return JS::Value(GL_TEXTURE);
+        return JS::Value(GL_RENDERBUFFER);
+    case GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME:
+        if (framebuffer_attachment->texture)
+            return JS::Value(framebuffer_attachment->texture);
+        return JS::Value(framebuffer_attachment->renderbuffer);
+    case GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL:
+        if (framebuffer_attachment->texture)
+            return JS::Value(framebuffer_attachment->texture_level);
+        break;
+    case GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE:
+        if (framebuffer_attachment->texture)
+            return JS::Value(is_cube_map_face(framebuffer_attachment->texture_target) ? framebuffer_attachment->texture_target : 0);
+        break;
+    }
+
+    set_error(GL_INVALID_ENUM);
+    return JS::js_null();
 }
 
 JS::Value WebGLRenderingContextImpl::get_program_parameter(GC::Ref<WebGLProgram> program, WebIDL::UnsignedLong pname)

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.h
@@ -87,6 +87,7 @@ public:
     WebIDL::Long get_attrib_location(GC::Ref<WebGLProgram> program, String name);
     JS::Value get_buffer_parameter(WebIDL::UnsignedLong target, WebIDL::UnsignedLong pname);
     WebIDL::ExceptionOr<JS::Value> get_parameter(WebIDL::UnsignedLong pname);
+    JS::Value get_framebuffer_attachment_parameter(WebIDL::UnsignedLong target, WebIDL::UnsignedLong attachment, WebIDL::UnsignedLong pname);
     WebIDL::UnsignedLong get_error();
     JS::Value get_program_parameter(GC::Ref<WebGLProgram> program, WebIDL::UnsignedLong pname);
     Optional<String> get_program_info_log(GC::Ref<WebGLProgram> program);

--- a/Tests/LibWeb/Text/expected/canvas/webgl-framebuffer-attachment-parameter.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-framebuffer-attachment-parameter.txt
@@ -1,0 +1,31 @@
+default framebuffer query returns null: true
+default framebuffer query error: 1282
+user framebuffer BACK attachment query returns null: true
+user framebuffer BACK attachment query error: 1280
+empty color attachment type is NONE: true
+empty color attachment type error: 0
+empty color attachment name is null: true
+empty color attachment name error: 1280
+texture attachment type is TEXTURE: true
+texture attachment name is texture: true
+texture attachment level is 0: true
+texture attachment cube map face is 0: true
+texture attachment queries error: 0
+invalid texture attachment point error: 1280
+invalid texture attachment point preserves texture: true
+invalid texture attachment point preservation query error: 0
+invalid texture level error: 1281
+invalid texture level preserves texture: true
+invalid texture level preservation query error: 0
+default framebuffer texture attachment error: 1282
+default framebuffer texture attachment preserves texture: true
+default framebuffer texture attachment preservation query error: 0
+renderbuffer attachment type is RENDERBUFFER: true
+renderbuffer attachment name is renderbuffer: true
+renderbuffer attachment texture level is null: true
+renderbuffer texture level error: 1280
+invalid renderbuffer target error: 1280
+invalid renderbuffer target preserves renderbuffer: true
+invalid renderbuffer target preservation query error: 0
+detached color attachment type is NONE: true
+detached color attachment type error: 0

--- a/Tests/LibWeb/Text/input/canvas/webgl-framebuffer-attachment-parameter.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-framebuffer-attachment-parameter.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<canvas id="canvas" width="1" height="1"></canvas>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let gl = canvas.getContext("webgl");
+        if (!gl) {
+            println("WebGL unavailable");
+            return;
+        }
+
+        function printError(label) {
+            println(`${label}: ${gl.getError()}`);
+        }
+
+        let defaultFramebufferValue = gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+        println(`default framebuffer query returns null: ${defaultFramebufferValue === null}`);
+        printError("default framebuffer query error");
+
+        let framebuffer = gl.createFramebuffer();
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+
+        println(`user framebuffer BACK attachment query returns null: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) === null}`);
+        printError("user framebuffer BACK attachment query error");
+
+        println(`empty color attachment type is NONE: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) === gl.NONE}`);
+        printError("empty color attachment type error");
+        println(`empty color attachment name is null: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) === null}`);
+        printError("empty color attachment name error");
+
+        let texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+        println(`texture attachment type is TEXTURE: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) === gl.TEXTURE}`);
+        println(`texture attachment name is texture: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) === texture}`);
+        println(`texture attachment level is 0: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL) === 0}`);
+        println(`texture attachment cube map face is 0: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE) === 0}`);
+        printError("texture attachment queries error");
+
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.BACK, gl.TEXTURE_2D, texture, 0);
+        printError("invalid texture attachment point error");
+        println(`invalid texture attachment point preserves texture: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) === texture}`);
+        printError("invalid texture attachment point preservation query error");
+
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 1);
+        printError("invalid texture level error");
+        println(`invalid texture level preserves texture: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) === texture}`);
+        printError("invalid texture level preservation query error");
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+        printError("default framebuffer texture attachment error");
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        println(`default framebuffer texture attachment preserves texture: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) === texture}`);
+        printError("default framebuffer texture attachment preservation query error");
+
+        let renderbuffer = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 1, 1);
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, renderbuffer);
+
+        println(`renderbuffer attachment type is RENDERBUFFER: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) === gl.RENDERBUFFER}`);
+        println(`renderbuffer attachment name is renderbuffer: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) === renderbuffer}`);
+        println(`renderbuffer attachment texture level is null: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL) === null}`);
+        printError("renderbuffer texture level error");
+
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, renderbuffer);
+        printError("invalid renderbuffer target error");
+        println(`invalid renderbuffer target preserves renderbuffer: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) === renderbuffer}`);
+        printError("invalid renderbuffer target preservation query error");
+
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, null);
+        println(`detached color attachment type is NONE: ${gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) === gl.NONE}`);
+        printError("detached color attachment type error");
+    });
+</script>


### PR DESCRIPTION
Track WebGL framebuffer attachments so getFramebufferAttachmentParameter can report attachment object type, object name, texture level, and cube map face from the bound framebuffer.

Validate framebuffer target, attachment, texture target, level, and the presence of a bound framebuffer before updating the tracked attachment object. This keeps the client-side WebGL attachment state aligned with the command sent to ANGLE.

Add WebGL framebuffer attachment parameter coverage for texture, renderbuffer, detached, and invalid attachment states. The test only checks API validation and object identity, avoiding GPU-specific rendering output.

This makes Q1K3 at https://phoboslab.org/q1k3/ work in Ladybird :^)