### PR TITLE
UI/Qt: Fix macOS tab focus and fallback menus

### DIFF
--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -196,7 +196,14 @@ public:
         auto* help_menu = m_application_menu_bar->addMenu("&Help");
         help_menu->addAction(create_application_action(*help_menu, application.open_about_page_action(), IncludeActionIcon::No));
 
+        m_inspect_menu = create_application_menu(*m_application_menu_bar, application.inspect_menu());
+        m_application_menu_bar->insertMenu(help_menu->menuAction(), m_inspect_menu);
+
+        m_debug_menu = create_application_menu(*m_application_menu_bar, application.debug_menu());
+        m_application_menu_bar->insertMenu(help_menu->menuAction(), m_debug_menu);
+
         update_reopen_recently_closed_action();
+        update_application_menu_bar_tab_menus();
     }
 #endif
 
@@ -212,6 +219,15 @@ public:
     {
         if (m_bookmarks_menu)
             repopulate_application_menu(*m_bookmarks_menu, *m_application_menu_bar, Application::the().bookmarks_menu());
+    }
+
+    void update_application_menu_bar_tab_menus()
+    {
+        auto has_active_tab = Application::the().active_tab() != nullptr;
+        if (m_inspect_menu)
+            m_inspect_menu->menuAction()->setVisible(has_active_tab);
+        if (m_debug_menu)
+            m_debug_menu->menuAction()->setVisible(has_active_tab && Application::the().debug_menu().visible());
     }
 #endif
 
@@ -234,6 +250,8 @@ private:
 #if defined(AK_OS_MACOS)
     QMenuBar* m_application_menu_bar { nullptr };
     QMenu* m_bookmarks_menu { nullptr };
+    QMenu* m_inspect_menu { nullptr };
+    QMenu* m_debug_menu { nullptr };
     QAction* m_reopen_recently_closed_tab_action { nullptr };
 #endif
 };
@@ -266,8 +284,10 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Win
     auto* window = new BrowserWindow(initial_urls, is_popup_window, parent_tab, move(page_index));
     set_active_window(*window);
     QObject::connect(window, &QObject::destroyed, m_application.ptr(), [this, window] {
-        if (m_active_window == window)
+        if (m_active_window == window) {
             m_active_window = nullptr;
+            update_macos_application_menu();
+        }
     });
 
     auto should_focus_location_editor = initial_urls.size() == 1 && initial_urls.first() == WebView::Application::settings().new_tab_page_url();
@@ -291,6 +311,12 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Win
         });
     }
     return *window;
+}
+
+void Application::set_active_window(BrowserWindow& window)
+{
+    m_active_window = &window;
+    update_macos_application_menu();
 }
 
 void Application::open_new_tab()
@@ -399,6 +425,14 @@ void Application::initialize_macos_application_menu()
 #if defined(AK_OS_MACOS)
     if (m_application)
         static_cast<LadybirdQApplication*>(m_application.ptr())->create_application_menu_bar();
+#endif
+}
+
+void Application::update_macos_application_menu() const
+{
+#if defined(AK_OS_MACOS)
+    if (m_application)
+        static_cast<LadybirdQApplication*>(m_application.ptr())->update_application_menu_bar_tab_menus();
 #endif
 }
 

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -45,11 +45,12 @@ public:
     QMenu* qt_bookmarks_menu() const;
 
     BrowserWindow& active_window() const { return *m_active_window; }
-    void set_active_window(BrowserWindow& w) { m_active_window = &w; }
+    void set_active_window(BrowserWindow&);
     BrowserWindow* active_window_if_any() const { return m_active_window; }
 
     Tab* active_tab() const { return m_active_window ? m_active_window->current_tab() : nullptr; }
     void update_reopen_recently_closed_actions() const;
+    void update_macos_application_menu() const;
 
 private:
     explicit Application();

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -441,10 +441,13 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
 
         set_current_tab(tab);
         if (tab) {
-            if (auto* focus_widget = tab->focusWidget(); focus_widget && tab->isAncestorOf(focus_widget))
-                focus_widget->setFocus();
-            else
-                tab->view().setFocus();
+            QWidget* focus_widget = &tab->view();
+            if (auto* tab_focus_widget = tab->focusWidget(); tab_focus_widget && tab->isAncestorOf(tab_focus_widget))
+                focus_widget = tab_focus_widget;
+#if defined(AK_OS_MACOS)
+            make_appkit_window_first_responder(*focus_widget);
+#endif
+            focus_widget->setFocus();
         }
         fullscreen_mode().exit(FullscreenMode::ExitInitiatedBy::UI);
     });


### PR DESCRIPTION
Fix two macOS-specific Qt/AppKit integration issues.

When switching tabs, synchronize AppKit’s first responder with the widget receiving Qt focus. This keeps native key dispatch pointed at the visible tab, so normal Qt shortcut handling continues to work after web content had focus.

Also add the Inspect and Debug menus to the parentless macOS fallback menubar, hiding them when there is no active tab. This keeps the windowless app menu behavior while avoiding missing tab menus when Qt falls back to that menubar.