### PR TITLE
LibWeb: Use display lists for SVG image painting

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -13,7 +13,6 @@
  */
 
 #include <AK/Debug.h>
-#include <LibGfx/DecodedImageFrame.h>
 #include <LibURL/Parser.h>
 #include <LibWeb/CSS/CSSFontFeatureValuesRule.h>
 #include <LibWeb/CSS/CSSFunctionDeclarations.h>

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2236,8 +2236,8 @@ NonnullRefPtr<StyleValue const> Parser::parse_as_sizes_attribute(DOM::Element co
 
         // 3. If size is auto, and img is not null, and img is being rendered, and img allows auto-sizes,
         //    then set size to the concrete object size width of img, in CSS pixels.
-        // FIXME: "img is being rendered" - we just see if it has a bitmap for now
-        if (size->has_auto() && img && img->current_image_frame().has_value() && img->allows_auto_sizes()) {
+        // FIXME: "img is being rendered" - we just see if it has image data for now
+        if (size->has_auto() && img && img->is_image_available() && img->allows_auto_sizes()) {
             // FIXME: The spec doesn't seem to tell us how to determine the concrete size of an <img>, so use the default sizing algorithm.
             //        Should this use some of the methods from FormattingContext?
             auto concrete_size = run_default_sizing_algorithm(

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -169,6 +169,15 @@ void ImageStyleValue::paint(DisplayListRecordingContext& context, DOM::Document 
     image_data->paint(context, dest_int_rect, image_rendering);
 }
 
+Optional<Painting::DisplayListResource> ImageStyleValue::record_display_list(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect) const
+{
+    auto image_data = this->image_data(document);
+    if (!image_data)
+        return {};
+
+    return image_data->record_display_list(dest_rect.size().to_type<int>(), context.display_list_recorder().resource_storage());
+}
+
 Optional<Gfx::DecodedImageFrame> ImageStyleValue::current_frame(DOM::Document const& document, DevicePixelRect const& dest_rect) const
 {
     if (auto image_data = this->image_data(document))

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -15,6 +15,8 @@
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOMURL/DOMURL.h>
+#include <LibWeb/HTML/AnimatedBitmapDecodedImageData.h>
+#include <LibWeb/HTML/BitmapDecodedImageData.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
@@ -202,11 +204,21 @@ GC::Ptr<HTML::DecodedImageData> ImageStyleValue::image_data(DOM::Document const&
 
 Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap(DOM::Document const& document) const
 {
-    if (auto decoded_frame = current_frame(document); decoded_frame.has_value()) {
-        auto const& bitmap = decoded_frame->bitmap();
-        if (bitmap.width() == 1 && bitmap.height() == 1)
-            return bitmap.get_pixel(0, 0);
-    }
+    auto image_data = this->image_data(document);
+    if (!image_data)
+        return {};
+
+    if (!is<HTML::BitmapDecodedImageData>(*image_data) && !is<HTML::AnimatedBitmapDecodedImageData>(*image_data))
+        return {};
+
+    auto decoded_frame = image_data->current_frame();
+    if (!decoded_frame.has_value())
+        return {};
+
+    auto const& bitmap = decoded_frame->bitmap();
+    if (bitmap.width() == 1 && bitmap.height() == 1)
+        return bitmap.get_pixel(0, 0);
+
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -90,6 +90,7 @@ public:
 
     virtual bool is_paintable(DOM::Document const&) const override;
     void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
+    Optional<Painting::DisplayListResource> record_display_list(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const&) const;
 
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
     Optional<Gfx::DecodedImageFrame> current_frame(DOM::Document const&, DevicePixelRect const& dest_rect = {}) const;

--- a/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.cpp
@@ -15,17 +15,25 @@ namespace Web::HTML {
 
 Gfx::IntSize canvas_image_source_dimensions(CanvasImageSource const& image)
 {
+    auto image_provider_intrinsic_size = [](Layout::ImageProvider const& image_provider) -> Optional<Gfx::IntSize> {
+        auto intrinsic_width = image_provider.intrinsic_width();
+        auto intrinsic_height = image_provider.intrinsic_height();
+        if (!intrinsic_width.has_value() || !intrinsic_height.has_value())
+            return {};
+        return Gfx::IntSize { intrinsic_width->to_int(), intrinsic_height->to_int() };
+    };
+
     return image.visit(
-        [](GC::Ref<HTMLImageElement> source) -> Gfx::IntSize {
-            if (auto frame = source->current_image_frame(); frame.has_value())
-                return frame->size();
+        [&](GC::Ref<HTMLImageElement> source) -> Gfx::IntSize {
+            if (auto intrinsic_size = image_provider_intrinsic_size(*source); intrinsic_size.has_value())
+                return *intrinsic_size;
 
             // FIXME: This is very janky and not correct.
             return { source->width(), source->height() };
         },
-        [](GC::Ref<SVG::SVGImageElement> source) -> Gfx::IntSize {
-            if (auto decoded_image_frame = source->current_image_frame(); decoded_image_frame.has_value())
-                return decoded_image_frame->size();
+        [&](GC::Ref<SVG::SVGImageElement> source) -> Gfx::IntSize {
+            if (auto intrinsic_size = image_provider_intrinsic_size(*source); intrinsic_size.has_value())
+                return *intrinsic_size;
 
             // FIXME: This is very janky and not correct.
             return { source->width()->anim_val()->value(), source->height()->anim_val()->value() };

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -1067,6 +1067,17 @@ static bool is_point_in_path_internal(Gfx::Path path, Gfx::AffineTransform const
     return path.contains(point, parse_fill_rule(fill_rule));
 }
 
+static bool image_provider_is_usable_for_canvas(Layout::ImageProvider const& image_provider)
+{
+    if (!image_provider.is_image_available())
+        return false;
+
+    auto intrinsic_width = image_provider.intrinsic_width();
+    auto intrinsic_height = image_provider.intrinsic_height();
+    return intrinsic_width.has_value() && intrinsic_height.has_value()
+        && *intrinsic_width > 0 && *intrinsic_height > 0;
+}
+
 bool CanvasRenderingContext2D::is_point_in_path(double x, double y, StringView fill_rule)
 {
     return is_point_in_path_internal(path(), drawing_state().transform, x, y, fill_rule);
@@ -1088,13 +1099,9 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
             if (image_element->current_request().state() == HTML::ImageRequest::State::Broken)
                 return WebIDL::InvalidStateError::create(image_element->realm(), "Image element state is broken"_utf16);
 
-            // If image is not fully decodable, then return bad.
-            auto current_image_frame = image_element->current_image_frame();
-            if (!current_image_frame.has_value())
-                return { CanvasImageSourceUsability::Bad };
-
-            // If image has an intrinsic width or intrinsic height (or both) equal to zero, then return bad.
-            if (current_image_frame->width() == 0 || current_image_frame->height() == 0)
+            // If image is not fully decodable, or has an intrinsic width or intrinsic height
+            // (or both) equal to zero, then return bad.
+            if (!image_provider_is_usable_for_canvas(*image_element))
                 return { CanvasImageSourceUsability::Bad };
             return Optional<CanvasImageSourceUsability> {};
         },
@@ -1102,13 +1109,9 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
         [](GC::Ref<SVG::SVGImageElement> image_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             // FIXME: If image's current request's state is broken, then throw an "InvalidStateError" DOMException.
 
-            // If image is not fully decodable, then return bad.
-            auto current_image_frame = image_element->current_image_frame();
-            if (!current_image_frame.has_value())
-                return { CanvasImageSourceUsability::Bad };
-
-            // If image has an intrinsic width or intrinsic height (or both) equal to zero, then return bad.
-            if (current_image_frame->width() == 0 || current_image_frame->height() == 0)
+            // If image is not fully decodable, or has an intrinsic width or intrinsic height
+            // (or both) equal to zero, then return bad.
+            if (!image_provider_is_usable_for_canvas(*image_element))
                 return { CanvasImageSourceUsability::Bad };
             return Optional<CanvasImageSourceUsability> {};
         },

--- a/Libraries/LibWeb/HTML/DecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/DecodedImageData.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/HTML/DecodedImageData.h>
+#include <LibWeb/Painting/DisplayList.h>
 
 namespace Web::HTML {
 
@@ -33,6 +34,11 @@ void DecodedImageData::Client::unregister_with_decoded_image_data_if_needed()
 DecodedImageData::DecodedImageData() = default;
 
 DecodedImageData::~DecodedImageData() = default;
+
+Optional<Painting::DisplayListResource> DecodedImageData::record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const
+{
+    return {};
+}
 
 void DecodedImageData::notify_clients_did_update()
 {

--- a/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -13,6 +13,7 @@
 #include <LibGfx/Size.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::HTML {
@@ -39,6 +40,7 @@ public:
     void set_is_cors_cross_origin(bool value) { m_is_cors_cross_origin = value; }
 
     virtual void paint([[maybe_unused]] DisplayListRecordingContext&, [[maybe_unused]] Gfx::IntRect dst_rect, CSS::ImageRendering) const = 0;
+    virtual Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
 
     virtual Optional<Gfx::DecodedImageFrame> default_frame(Gfx::IntSize = {}) const = 0;
     virtual Optional<Gfx::DecodedImageFrame> current_frame(Gfx::IntSize = {}) const = 0;

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -314,8 +314,8 @@ WebIDL::UnsignedLong HTMLImageElement::width() const
 
     // ...or else the density-corrected intrinsic width and height of the image, in CSS pixels,
     // if the image has intrinsic dimensions and is available but not being rendered.
-    if (auto bitmap = current_image_frame(); bitmap.has_value())
-        return bitmap->width();
+    if (auto width = intrinsic_width(); width.has_value() && *width > 0)
+        return width->to_int();
 
     // ...or else 0, if the image is not available or does not have intrinsic dimensions.
     return 0;
@@ -345,8 +345,8 @@ WebIDL::UnsignedLong HTMLImageElement::height() const
 
     // ...or else the density-corrected intrinsic height and height of the image, in CSS pixels,
     // if the image has intrinsic dimensions and is available but not being rendered.
-    if (auto bitmap = current_image_frame(); bitmap.has_value())
-        return bitmap->height();
+    if (auto height = intrinsic_height(); height.has_value() && *height > 0)
+        return height->to_int();
 
     // ...or else 0, if the image is not available or does not have intrinsic dimensions.
     return 0;
@@ -363,26 +363,22 @@ void HTMLImageElement::set_height(WebIDL::UnsignedLong height)
 unsigned HTMLImageElement::natural_width() const
 {
     // 1. If the image is not available, then return 0.
-    auto bitmap = current_image_frame();
-    if (!bitmap.has_value())
-        return 0;
-
     // 2. Return the respective component of the image's density-corrected natural width and height, in CSS pixels. [CSS]
     // FIXME: Implement density-corrected algorithm.
-    return bitmap->width();
+    if (auto width = intrinsic_width(); width.has_value() && *width > 0)
+        return width->to_int();
+    return 0;
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-naturalheight
 unsigned HTMLImageElement::natural_height() const
 {
     // 1. If the image is not available, then return 0.
-    auto bitmap = current_image_frame();
-    if (!bitmap.has_value())
-        return 0;
-
     // 2. Return the respective component of the image's density-corrected natural width and height, in CSS pixels. [CSS]
     // FIXME: Implement density-corrected algorithm.
-    return bitmap->height();
+    if (auto height = intrinsic_height(); height.has_value() && *height > 0)
+        return height->to_int();
+    return 0;
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-htmlimageelement-x

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -9,7 +9,6 @@
 #include <LibCore/Timer.h>
 #include <LibGC/Weak.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/Bindings/HTMLImageElement.h>
 #include <LibWeb/CSS/ComputedProperties.h>

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2404,8 +2404,8 @@ WebIDL::UnsignedLong HTMLInputElement::height() const
     }
 
     // ...or else the natural height and height of the image, in CSS pixels, if an image is available but not being rendered
-    if (auto bitmap = current_image_frame(); bitmap.has_value())
-        return bitmap->height();
+    if (auto height = intrinsic_height(); height.has_value() && *height > 0)
+        return height->to_int();
 
     // ...or else 0, if the image is not available or does not have intrinsic dimensions.
     return 0;
@@ -2439,8 +2439,8 @@ WebIDL::UnsignedLong HTMLInputElement::width() const
     }
 
     // ...or else the natural width and height of the image, in CSS pixels, if an image is available but not being rendered
-    if (auto bitmap = current_image_frame(); bitmap.has_value())
-        return bitmap->width();
+    if (auto width = intrinsic_width(); width.has_value() && *width > 0)
+        return width->to_int();
 
     // ...or else 0, if the image is not available or does not have intrinsic dimensions.
     return 0;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -15,7 +15,6 @@
 
 #include <AK/NeverDestroyed.h>
 #include <AK/Utf16StringBuilder.h>
-#include <LibGfx/DecodedImageFrame.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/RegExpObject.h>

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -327,7 +327,9 @@ void paint_background(DisplayListRecordingContext& context, PaintableBox const& 
 
             auto const& image_style_value = static_cast<CSS::ImageStyleValue const&>(image);
             if (auto display_list = image_style_value.record_display_list(context, document, dest_rect); display_list.has_value()) {
-                context.display_list_recorder().draw_repeated_display_list(dest_rect.to_type<int>(), clip_rect.to_type<int>(), *display_list, repeat_x, repeat_y);
+                auto dest_int_rect = dest_rect.to_type<int>();
+                auto scaling_mode = to_gfx_scaling_mode(image_rendering, dest_int_rect.size(), dest_int_rect.size());
+                context.display_list_recorder().draw_repeated_display_list(dest_int_rect, clip_rect.to_type<int>(), *display_list, scaling_mode, repeat_x, repeat_y);
             } else {
                 auto frame = image_style_value.current_frame(document, dest_rect);
                 if (!frame.has_value())

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -325,11 +325,16 @@ void paint_background(DisplayListRecordingContext& context, PaintableBox const& 
             if (dest_rect.height() == 0)
                 dest_rect.set_height(1);
 
-            auto frame = static_cast<CSS::ImageStyleValue const&>(image).current_frame(document, dest_rect);
-            if (!frame.has_value())
-                return;
-            auto scaling_mode = to_gfx_scaling_mode(image_rendering, frame->size(), dest_rect.size().to_type<int>());
-            context.display_list_recorder().draw_repeated_decoded_image_frame(dest_rect.to_type<int>(), clip_rect.to_type<int>(), *frame, scaling_mode, repeat_x, repeat_y);
+            auto const& image_style_value = static_cast<CSS::ImageStyleValue const&>(image);
+            if (auto display_list = image_style_value.record_display_list(context, document, dest_rect); display_list.has_value()) {
+                context.display_list_recorder().draw_repeated_display_list(dest_rect.to_type<int>(), clip_rect.to_type<int>(), *display_list, repeat_x, repeat_y);
+            } else {
+                auto frame = image_style_value.current_frame(document, dest_rect);
+                if (!frame.has_value())
+                    return;
+                auto scaling_mode = to_gfx_scaling_mode(image_rendering, frame->size(), dest_rect.size().to_type<int>());
+                context.display_list_recorder().draw_repeated_decoded_image_frame(dest_rect.to_type<int>(), clip_rect.to_type<int>(), *frame, scaling_mode, repeat_x, repeat_y);
+            }
         } else if ((repeat_x || repeat_y) && !repeat_x_has_gap && !repeat_y_has_gap && tile_count > max_tiles_before_pattern_fallback) {
             // A not-decoded-image repeating background otherwise records a separate painting command for every tile —
             // which for very-large tile counts can lead to enough commands that we crash. So, instead record a single

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -40,6 +40,11 @@ void DrawRepeatedDecodedImageFrame::dump(StringBuilder& builder) const
     builder.appendff(" dst_rect={} clip_rect={}", dst_rect, clip_rect);
 }
 
+void DrawRepeatedDisplayList::dump(StringBuilder& builder) const
+{
+    builder.appendff(" dst_rect={} clip_rect={}", dst_rect, clip_rect);
+}
+
 void DrawCompositedContext::dump(StringBuilder& builder) const
 {
     builder.appendff(" dst_rect={}", dst_rect);

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -8,6 +8,21 @@
 
 namespace Web::Painting {
 
+static StringView scaling_mode_name(Gfx::ScalingMode scaling_mode)
+{
+    switch (scaling_mode) {
+    case Gfx::ScalingMode::None:
+        return "None"sv;
+    case Gfx::ScalingMode::Bilinear:
+        return "Bilinear"sv;
+    case Gfx::ScalingMode::BilinearMipmap:
+        return "BilinearMipmap"sv;
+    case Gfx::ScalingMode::NearestNeighbor:
+        return "NearestNeighbor"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 Gfx::IntRect PaintOuterBoxShadow::bounding_rect() const
 {
     auto rect = shadow_rect;
@@ -42,7 +57,7 @@ void DrawRepeatedDecodedImageFrame::dump(StringBuilder& builder) const
 
 void DrawRepeatedDisplayList::dump(StringBuilder& builder) const
 {
-    builder.appendff(" dst_rect={} clip_rect={}", dst_rect, clip_rect);
+    builder.appendff(" dst_rect={} clip_rect={} scaling_mode={}", dst_rect, clip_rect, scaling_mode_name(scaling_mode));
 }
 
 void DrawCompositedContext::dump(StringBuilder& builder) const

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -39,6 +39,7 @@ class DisplayList;
     V(FillRect, fill_rect)                                                             \
     V(DrawScaledDecodedImageFrame, draw_scaled_decoded_image_frame)                    \
     V(DrawRepeatedDecodedImageFrame, draw_repeated_decoded_image_frame)                \
+    V(DrawRepeatedDisplayList, draw_repeated_display_list)                             \
     V(DrawCompositedContext, draw_composited_context)                                  \
     V(DrawCanvas, draw_canvas)                                                         \
     V(DrawVideoFrame, draw_video_frame)                                                \
@@ -183,6 +184,24 @@ struct DrawRepeatedDecodedImageFrame {
     Gfx::IntRect clip_rect;
     ImageFrameResourceId frame_id;
     Gfx::ScalingMode scaling_mode;
+    Repeat repeat;
+
+    [[nodiscard]] Gfx::IntRect bounding_rect() const { return clip_rect; }
+    void dump(StringBuilder&) const;
+};
+
+struct DrawRepeatedDisplayList {
+    static constexpr StringView command_name = "DrawRepeatedDisplayList"sv;
+    static constexpr DisplayListCommandType command_type = DisplayListCommandType::DrawRepeatedDisplayList;
+
+    struct Repeat {
+        bool x { false };
+        bool y { false };
+    };
+
+    Gfx::IntRect dst_rect;
+    Gfx::IntRect clip_rect;
+    DisplayListResourceId display_list_id;
     Repeat repeat;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return clip_rect; }

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -202,6 +202,7 @@ struct DrawRepeatedDisplayList {
     Gfx::IntRect dst_rect;
     Gfx::IntRect clip_rect;
     DisplayListResourceId display_list_id;
+    Gfx::ScalingMode scaling_mode;
     Repeat repeat;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return clip_rect; }

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -350,15 +350,15 @@ void DisplayListPlayerSkia::play_command(DrawRepeatedDecodedImageFrame const& co
     canvas.drawPaint(paint);
 }
 
-static void paint_repeated_image(SkCanvas& canvas, SkImage& image, Gfx::IntRect const& dst_rect, Gfx::IntRect const& clip_rect, bool repeat_x, bool repeat_y)
+static void paint_repeated_image(SkCanvas& canvas, SkImage& image, Gfx::IntRect const& dst_rect, Gfx::IntRect const& clip_rect, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y)
 {
     SkMatrix matrix;
     matrix.setTranslate(dst_rect.x(), dst_rect.y());
 
     auto tile_mode_x = repeat_x ? SkTileMode::kRepeat : SkTileMode::kDecal;
     auto tile_mode_y = repeat_y ? SkTileMode::kRepeat : SkTileMode::kDecal;
-    auto sampling = SkSamplingOptions(SkFilterMode::kLinear);
-    auto shader = image.makeShader(tile_mode_x, tile_mode_y, sampling, &matrix);
+    auto sampling_options = to_skia_sampling_options(scaling_mode);
+    auto shader = image.makeShader(tile_mode_x, tile_mode_y, sampling_options, &matrix);
 
     SkPaint paint;
     paint.setAntiAlias(true);
@@ -377,7 +377,7 @@ void DisplayListPlayerSkia::play_command(DrawRepeatedDisplayList const& command)
         return;
 
     if (auto image = resource_storage().cached_skia_image_for_display_list(command.display_list_id, tile_size, m_skia_backend_context)) {
-        paint_repeated_image(surface().canvas(), *image, command.dst_rect, command.clip_rect, command.repeat.x, command.repeat.y);
+        paint_repeated_image(surface().canvas(), *image, command.dst_rect, command.clip_rect, command.scaling_mode, command.repeat.x, command.repeat.y);
         return;
     }
 
@@ -392,7 +392,7 @@ void DisplayListPlayerSkia::play_command(DrawRepeatedDisplayList const& command)
 
     resource_storage().set_cached_skia_image_for_display_list(command.display_list_id, tile_size, m_skia_backend_context, image);
 
-    paint_repeated_image(surface().canvas(), *image, command.dst_rect, command.clip_rect, command.repeat.x, command.repeat.y);
+    paint_repeated_image(surface().canvas(), *image, command.dst_rect, command.clip_rect, command.scaling_mode, command.repeat.x, command.repeat.y);
 }
 
 void DisplayListPlayerSkia::play_command(AddClipRect const& command)

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -350,6 +350,51 @@ void DisplayListPlayerSkia::play_command(DrawRepeatedDecodedImageFrame const& co
     canvas.drawPaint(paint);
 }
 
+static void paint_repeated_image(SkCanvas& canvas, SkImage& image, Gfx::IntRect const& dst_rect, Gfx::IntRect const& clip_rect, bool repeat_x, bool repeat_y)
+{
+    SkMatrix matrix;
+    matrix.setTranslate(dst_rect.x(), dst_rect.y());
+
+    auto tile_mode_x = repeat_x ? SkTileMode::kRepeat : SkTileMode::kDecal;
+    auto tile_mode_y = repeat_y ? SkTileMode::kRepeat : SkTileMode::kDecal;
+    auto sampling = SkSamplingOptions(SkFilterMode::kLinear);
+    auto shader = image.makeShader(tile_mode_x, tile_mode_y, sampling, &matrix);
+
+    SkPaint paint;
+    paint.setAntiAlias(true);
+    paint.setShader(shader);
+
+    canvas.save();
+    canvas.clipRect(to_skia_rect(clip_rect), true);
+    canvas.drawPaint(paint);
+    canvas.restore();
+}
+
+void DisplayListPlayerSkia::play_command(DrawRepeatedDisplayList const& command)
+{
+    auto tile_size = command.dst_rect.size();
+    if (tile_size.is_empty())
+        return;
+
+    if (auto image = resource_storage().cached_skia_image_for_display_list(command.display_list_id, tile_size, m_skia_backend_context)) {
+        paint_repeated_image(surface().canvas(), *image, command.dst_rect, command.clip_rect, command.repeat.x, command.repeat.y);
+        return;
+    }
+
+    auto tile_surface = Gfx::PaintingSurface::create_with_size(tile_size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_skia_backend_context);
+    Gfx::PainterSkia painter { tile_surface };
+    painter.clear_rect(tile_surface->rect().to_type<float>(), Gfx::Color::Transparent);
+    auto const& tile_display_list = resource_storage().display_list_resource(command.display_list_id);
+    execute_display_list_into_surface(*tile_display_list.display_list, tile_display_list.visual_context_tree, *tile_surface);
+    auto image = tile_surface->sk_surface().makeImageSnapshot();
+    if (!image)
+        return;
+
+    resource_storage().set_cached_skia_image_for_display_list(command.display_list_id, tile_size, m_skia_backend_context, image);
+
+    paint_repeated_image(surface().canvas(), *image, command.dst_rect, command.clip_rect, command.repeat.x, command.repeat.y);
+}
+
 void DisplayListPlayerSkia::play_command(AddClipRect const& command)
 {
     auto& canvas = surface().canvas();

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -569,7 +569,7 @@ void DisplayListRecorder::draw_repeated_decoded_image_frame(Gfx::IntRect dst_rec
     });
 }
 
-void DisplayListRecorder::draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, DisplayListResource const& display_list, bool repeat_x, bool repeat_y)
+void DisplayListRecorder::draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, DisplayListResource const& display_list, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y)
 {
     if (dst_rect.is_empty() || clip_rect.is_empty())
         return;
@@ -577,6 +577,7 @@ void DisplayListRecorder::draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx:
         .dst_rect = dst_rect,
         .clip_rect = clip_rect,
         .display_list_id = resource_storage().add_display_list(display_list.display_list, display_list.visual_context_tree),
+        .scaling_mode = scaling_mode,
         .repeat = { repeat_x, repeat_y },
     });
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -558,11 +558,25 @@ void DisplayListRecorder::draw_scaled_decoded_image_frame(Gfx::IntRect const& ds
 
 void DisplayListRecorder::draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y)
 {
+    if (dst_rect.is_empty() || clip_rect.is_empty())
+        return;
     append_command(DrawRepeatedDecodedImageFrame {
         .dst_rect = dst_rect,
         .clip_rect = clip_rect,
         .frame_id = resource_storage().add_image_frame(frame),
         .scaling_mode = scaling_mode,
+        .repeat = { repeat_x, repeat_y },
+    });
+}
+
+void DisplayListRecorder::draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, DisplayListResource const& display_list, bool repeat_x, bool repeat_y)
+{
+    if (dst_rect.is_empty() || clip_rect.is_empty())
+        return;
+    append_command(DrawRepeatedDisplayList {
+        .dst_rect = dst_rect,
+        .clip_rect = clip_rect,
+        .display_list_id = resource_storage().add_display_list(display_list.display_list, display_list.visual_context_tree),
         .repeat = { repeat_x, repeat_y },
     });
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -78,7 +78,7 @@ public:
     void draw_video_frame(Gfx::IntRect const& dst_rect, VideoFrameResourceId, RefPtr<Media::VideoFrame const>, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
 
     void draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y);
-    void draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, DisplayListResource const&, bool repeat_x, bool repeat_y);
+    void draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, DisplayListResource const&, Gfx::ScalingMode, bool repeat_x, bool repeat_y);
 
     void draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness = 1, Gfx::LineStyle style = Gfx::LineStyle::Solid, Color alternate_color = Color::Transparent);
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -78,6 +78,7 @@ public:
     void draw_video_frame(Gfx::IntRect const& dst_rect, VideoFrameResourceId, RefPtr<Media::VideoFrame const>, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
 
     void draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y);
+    void draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, DisplayListResource const&, bool repeat_x, bool repeat_y);
 
     void draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness = 1, Gfx::LineStyle style = Gfx::LineStyle::Solid, Color alternate_color = Color::Transparent);
 

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -29,6 +29,19 @@ struct DisplayListStoredImageFrameResource {
     mutable RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
 };
 
+struct DisplayListCachedSkiaImageResource {
+    DisplayListCachedSkiaImageResource(Gfx::IntSize tile_size, RefPtr<Gfx::SkiaBackendContext> skia_backend_context, sk_sp<SkImage> image)
+        : tile_size(tile_size)
+        , skia_backend_context(move(skia_backend_context))
+        , image(move(image))
+    {
+    }
+
+    Gfx::IntSize tile_size;
+    RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
+    sk_sp<SkImage> image;
+};
+
 static sk_sp<SkImage> create_skia_image(Gfx::DecodedImageFrame const& frame, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
 {
     auto raster_image = Gfx::sk_image_from_bitmap(frame.bitmap(), frame.color_space());
@@ -149,6 +162,26 @@ Gfx::DecodedImageFrame const& DisplayListResourceStorage::image_frame(ImageFrame
 sk_sp<SkImage> DisplayListResourceStorage::skia_image_for_image_frame(ImageFrameResourceId id, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context) const
 {
     return skia_image_for_stored_image_frame(*m_image_frames.get(id.value()).value(), skia_backend_context);
+}
+
+sk_sp<SkImage> DisplayListResourceStorage::cached_skia_image_for_display_list(DisplayListResourceId id, Gfx::IntSize tile_size, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context) const
+{
+    auto cached_image = m_display_list_cached_skia_images.find(id.value());
+    if (cached_image == m_display_list_cached_skia_images.end())
+        return nullptr;
+
+    auto const& image = *cached_image->value;
+    if (image.tile_size != tile_size)
+        return nullptr;
+    if (image.skia_backend_context.ptr() != skia_backend_context.ptr())
+        return nullptr;
+
+    return image.image;
+}
+
+void DisplayListResourceStorage::set_cached_skia_image_for_display_list(DisplayListResourceId id, Gfx::IntSize tile_size, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context, sk_sp<SkImage> image) const
+{
+    m_display_list_cached_skia_images.set(id.value(), make<DisplayListCachedSkiaImageResource>(tile_size, skia_backend_context, move(image)));
 }
 
 static ReadonlyBytes inline_data(ReadonlyBytes payload, DisplayListDataSpan span)
@@ -329,6 +362,8 @@ void DisplayListResourceStorage::apply_transaction(DisplayListResourceTransactio
         m_video_frames.remove(id.value());
     for (auto id : transaction.display_list_ids_to_remove)
         m_display_lists.remove(id.value());
+    for (auto id : transaction.display_list_ids_to_remove)
+        m_display_list_cached_skia_images.remove(id.value());
 }
 
 void DisplayListResourceStorage::retain_only(DisplayListResourceSet const& resource_set)
@@ -347,6 +382,10 @@ void DisplayListResourceStorage::retain_only(DisplayListResourceSet const& resou
             && !m_video_frame_cache_reference_counts.contains(id);
     });
     m_display_lists.remove_all_matching([&](auto id, auto const&) {
+        return !resource_set.display_lists.contains(DisplayListResourceId { id })
+            && !m_display_list_cache_reference_counts.contains(id);
+    });
+    m_display_list_cached_skia_images.remove_all_matching([&](auto id, auto const&) {
         return !resource_set.display_lists.contains(DisplayListResourceId { id })
             && !m_display_list_cache_reference_counts.contains(id);
     });

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -57,6 +57,7 @@ struct DisplayListVideoFrameResource {
 };
 
 struct DisplayListStoredImageFrameResource;
+struct DisplayListCachedSkiaImageResource;
 
 struct DisplayListResource {
     DisplayListResource(NonnullRefPtr<DisplayList>, AccumulatedVisualContextTree);
@@ -109,6 +110,8 @@ public:
     Gfx::Font const& font(FontResourceId id) const { return *m_fonts.get(id.value()).value(); }
     Gfx::DecodedImageFrame const& image_frame(ImageFrameResourceId) const;
     sk_sp<SkImage> skia_image_for_image_frame(ImageFrameResourceId, RefPtr<Gfx::SkiaBackendContext> const&) const;
+    sk_sp<SkImage> cached_skia_image_for_display_list(DisplayListResourceId, Gfx::IntSize, RefPtr<Gfx::SkiaBackendContext> const&) const;
+    void set_cached_skia_image_for_display_list(DisplayListResourceId, Gfx::IntSize, RefPtr<Gfx::SkiaBackendContext> const&, sk_sp<SkImage>) const;
     RefPtr<Media::VideoFrame const> video_frame(VideoFrameResourceId id) const { return m_video_frames.get(id.value()).value(); }
     DisplayListResource const& display_list_resource(DisplayListResourceId id) const { return m_display_lists.get(id.value()).value(); }
     DisplayList const& display_list(DisplayListResourceId id) const { return *display_list_resource(id).display_list; }
@@ -121,6 +124,7 @@ private:
     HashMap<u64, NonnullOwnPtr<DisplayListStoredImageFrameResource>> m_image_frames;
     HashMap<u64, RefPtr<Media::VideoFrame const>> m_video_frames;
     HashMap<u64, DisplayListResource> m_display_lists;
+    mutable HashMap<u64, NonnullOwnPtr<DisplayListCachedSkiaImageResource>> m_display_list_cached_skia_images;
 
     HashMap<u64, size_t> m_font_cache_reference_counts;
     HashMap<u64, size_t> m_image_frame_cache_reference_counts;

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -32,6 +32,8 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
+    virtual Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const override;
+
     // FIXME: Support SVG animations. :^)
     DOM::Document const& svg_document() const { return *m_document; }
 
@@ -44,7 +46,6 @@ private:
     SVGDecodedImageData(GC::Ref<Page>, GC::Ref<SVGPageClient>, GC::Ref<DOM::Document>, GC::Ref<SVG::SVGSVGElement>);
 
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
-    Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
     void prune_cached_display_list_resources() const;
     void did_request_frame();
     void invalidate_cached_rendering();

--- a/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
+++ b/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
@@ -10,7 +10,6 @@ SaveLayer@0
   CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 120x80]
   Save@1
     AddClipRect@1 rect=[8,8 120x80]
-    DrawRepeatedDisplayList@1 dst_rect=[8,8 20x20] clip_rect=[8,8 120x80]
+    DrawRepeatedDisplayList@1 dst_rect=[8,8 20x20] clip_rect=[8,8 120x80] scaling_mode=NearestNeighbor
   Restore@1
 Restore@0
-

--- a/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
+++ b/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
@@ -1,0 +1,16 @@
+AccumulatedVisualContext Tree:
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x101]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x80]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 120x80]
+  Save@1
+    AddClipRect@1 rect=[8,8 120x80]
+    DrawRepeatedDisplayList@1 dst_rect=[8,8 20x20] clip_rect=[8,8 120x80]
+  Restore@1
+Restore@0
+

--- a/Tests/LibWeb/Text/input/display_list/repeated-svg-background-is-display-list.html
+++ b/Tests/LibWeb/Text/input/display_list/repeated-svg-background-is-display-list.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #target {
+        width: 120px;
+        height: 80px;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20'%3E%3Crect width='20' height='20' fill='green'/%3E%3Ccircle cx='10' cy='10' r='5' fill='white'/%3E%3C/svg%3E");
+        background-repeat: repeat;
+    }
+</style>
+<div id="target"></div>
+<script>
+    promiseTest(async () => {
+        while (true) {
+            await animationFrame();
+
+            const displayList = internals.dumpDisplayList();
+            if (displayList.includes("DrawRepeatedDisplayList")) {
+                println(displayList);
+                return;
+            }
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/display_list/repeated-svg-background-is-display-list.html
+++ b/Tests/LibWeb/Text/input/display_list/repeated-svg-background-is-display-list.html
@@ -6,6 +6,7 @@
         height: 80px;
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20'%3E%3Crect width='20' height='20' fill='green'/%3E%3Ccircle cx='10' cy='10' r='5' fill='white'/%3E%3C/svg%3E");
         background-repeat: repeat;
+        image-rendering: pixelated;
     }
 </style>
 <div id="target"></div>


### PR DESCRIPTION
This fixes a problem where scrolling on shopify.com could make WebContent churn at 100% CPU for roughly 20 seconds while rasterizing SVG image content on the CPU.

SVG image painting now routes through nested display lists instead of forcing SVG image data through decoded-frame rasterization. Repeated SVG CSS backgrounds use a `DrawRepeatedDisplayList` command, and SVG image painting can replay the recorded SVG display list in the compositor-backed Skia path.

The branch also removes avoidable decoded-frame probes from image metadata and sizing code, so `naturalWidth`, image input dimensions, `sizes=auto`, and canvas usability checks use image availability and intrinsic dimensions instead.

Repeated SVG display-list backgrounds carry the selected scaling mode, so `image-rendering: pixelated` and `crisp-edges` keep nearest-neighbor sampling.