### PR TITLE
LibJS+LibWasm: Cache primitive storage cage metadata in Wasm and JS

### DIFF
--- a/Libraries/LibGC/PrimitiveStorage.cpp
+++ b/Libraries/LibGC/PrimitiveStorage.cpp
@@ -52,6 +52,11 @@ PrimitiveStorage& PrimitiveStorage::the()
     return *storage;
 }
 
+ErrorOr<void> PrimitiveStorage::ensure_cage()
+{
+    return m_allocator.ensure_cage();
+}
+
 size_t PrimitiveStorage::Allocator::page_size()
 {
     return static_cast<size_t>(PAGE_SIZE);

--- a/Libraries/LibGC/PrimitiveStorage.h
+++ b/Libraries/LibGC/PrimitiveStorage.h
@@ -46,6 +46,7 @@ public:
 
     ErrorOr<PrimitiveStorageHandle> try_allocate(size_t size, ZeroFillNewBytes = ZeroFillNewBytes::Yes);
     ErrorOr<PrimitiveStorageHandle> try_reserve(size_t size, size_t capacity, ZeroFillNewBytes = ZeroFillNewBytes::Yes, size_t guard_size = 0);
+    ErrorOr<void> ensure_cage();
 
     bool is_valid(PrimitiveStorageHandle) const;
     bool contains(void const* address, size_t size = 1) const;
@@ -93,6 +94,7 @@ private:
         ErrorOr<void> resize(Allocation&, size_t old_size, size_t new_size, ZeroFillNewBytes);
         ErrorOr<Allocation> reallocate(Allocation const&, size_t old_size, size_t new_size, size_t new_capacity, ZeroFillNewBytes, bool force_large);
         void deallocate(Allocation&);
+        ErrorOr<void> ensure_cage();
 
         bool contains(void const* address, size_t size = 1) const;
         bool contains(Allocation const&, void const* address, size_t size = 1) const;
@@ -116,7 +118,6 @@ private:
             Vector<u32> free_slots;
         };
 
-        ErrorOr<void> ensure_cage();
         ErrorOr<Allocation> allocate_small_storage(size_t size, ZeroFillNewBytes);
         ErrorOr<Allocation> allocate_large_storage(size_t size, size_t capacity, ZeroFillNewBytes, size_t guard_size);
         ErrorOr<Allocation> allocate_from_new_slab(u16 size_class_index, size_t slot_size, ZeroFillNewBytes, size_t requested_size);

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -2292,31 +2292,6 @@ fn emit_instruction(
             }
         }
 
-        // load_c_symbol_address dst, symbol - Load the address of an external C symbol.
-        "load_c_symbol_address" => {
-            if insn.operands.len() == 2 {
-                let dst = resolve_op(&insn.operands[0], handler, program);
-                let symbol = match &insn.operands[1] {
-                    Operand::Register(symbol) | Operand::Constant(symbol) | Operand::Label(symbol) => symbol,
-                    _ => panic!("load_c_symbol_address expects a symbol operand"),
-                };
-                let symbol = format!("CSYM({symbol})");
-                match program.object_format {
-                    ObjectFormat::MachO => {
-                        w!(out, "    adrp {dst}, {symbol}@GOTPAGE");
-                        w!(out, "    ldr {dst}, [{dst}, {symbol}@GOTPAGEOFF]");
-                    }
-                    ObjectFormat::Elf => {
-                        w!(out, "    adrp {dst}, :got:{symbol}");
-                        w!(out, "    ldr {dst}, [{dst}, :got_lo12:{symbol}]");
-                    }
-                    ObjectFormat::Coff => {
-                        emit_symbol_addr(out, &dst, &symbol, program.object_format);
-                    }
-                }
-            }
-        }
-
         // Floating point instructions
         "fp_add" => {
             if insn.operands.len() == 2 {

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -1548,25 +1548,6 @@ fn emit_instruction(
             }
         }
 
-        // load_c_symbol_address dst, symbol - Load the address of an external C symbol.
-        "load_c_symbol_address" => {
-            if insn.operands.len() == 2 {
-                let dst = resolve_op(&insn.operands[0], handler, program);
-                let symbol = match &insn.operands[1] {
-                    Operand::Register(symbol) | Operand::Constant(symbol) | Operand::Label(symbol) => symbol,
-                    _ => panic!("load_c_symbol_address expects a symbol operand"),
-                };
-                match program.object_format {
-                    ObjectFormat::MachO | ObjectFormat::Elf => {
-                        w!(out, "    mov {dst}, QWORD PTR [rip + CSYM({symbol})@GOTPCREL]");
-                    }
-                    ObjectFormat::Coff => {
-                        w!(out, "    mov {dst}, QWORD PTR [rip + __imp_{symbol}]");
-                    }
-                }
-            }
-        }
-
         // Unconditional jump - resolve local labels
         "jmp" => {
             if let Some(Operand::Label(label)) = insn.operands.first() {

--- a/Libraries/LibJS/AsmIntGen/src/instructions.rs
+++ b/Libraries/LibJS/AsmIntGen/src/instructions.rs
@@ -552,8 +552,6 @@ pub const INSTRUCTIONS: &[InstructionInfo] = &[
         // Large offsets / non-power-of-two scales go through x9.
         ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
     ),
-    plain("load_c_symbol_address", &[GprOut, FuncSymbol]),
-
     // ------------------------------------------------------------------
     // Integer ALU
     // ------------------------------------------------------------------

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1847,9 +1847,8 @@ handler PutByValue
     load64 cached_offset, [obj, TYPED_ARRAY_CACHED_DATA_OFFSET]
     mov invalid_offset, TYPED_ARRAY_CACHED_DATA_OFFSET_INVALID
     branch_eq cached_offset, invalid_offset, .try_typed_array_slow
-    load_c_symbol_address elements, js_primitive_storage_cage_base
-    load64 elements, [elements, 0]
-    branch_zero elements, .try_typed_array_slow
+    load_vm elements
+    load64 elements, [elements, VM_PRIMITIVE_STORAGE_CAGE_BASE]
     assert_nonzero elements
     # Cached pointers only exist for fixed-length typed arrays, so array_length
     # is known to hold a concrete u32 value here.
@@ -2071,9 +2070,8 @@ handler GetByValue
     load64 cached_offset, [obj, TYPED_ARRAY_CACHED_DATA_OFFSET]
     mov invalid_offset, TYPED_ARRAY_CACHED_DATA_OFFSET_INVALID
     branch_eq cached_offset, invalid_offset, .try_typed_array_slow
-    load_c_symbol_address elements, js_primitive_storage_cage_base
-    load64 elements, [elements, 0]
-    branch_zero elements, .try_typed_array_slow
+    load_vm elements
+    load64 elements, [elements, VM_PRIMITIVE_STORAGE_CAGE_BASE]
     assert_nonzero elements
     # Cached pointers only exist for fixed-length typed arrays, so array_length
     # is known to hold a concrete u32 value here.

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -176,6 +176,7 @@ int main()
     EMIT_OFFSET(VM_INTERPRETER_STACK, VM, m_interpreter_stack);
     EMIT_OFFSET(VM_STACK_INFO, VM, m_stack_info);
     EMIT_OFFSET(VM_EXECUTION_GENERATION, VM, m_execution_generation);
+    EMIT_OFFSET(VM_PRIMITIVE_STORAGE_CAGE_BASE, VM, m_primitive_storage_cage_base);
     outln("const VM_INTERPRETER_STACK_TOP = {}", offsetof(VM, m_interpreter_stack) + offsetof(InterpreterStack, m_top));
 #if defined(HAS_ADDRESS_SANITIZER)
     outln("const VM_STACK_SPACE_LIMIT = {}", 96 * KiB);

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -17,6 +17,7 @@
 #include <LibCore/ImmutableBytes.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibGC/Heap.h>
+#include <LibGC/PrimitiveStorage.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
@@ -83,6 +84,9 @@ VM::VM(ErrorMessages error_messages)
     , m_error_messages(move(error_messages))
 {
     s_the = this;
+    MUST(GC::PrimitiveStorage::the().ensure_cage());
+    m_primitive_storage_cage_base = js_primitive_storage_cage_base;
+    VERIFY(m_primitive_storage_cage_base != 0);
 
     m_heap.register_sweep_callback([] {
         Bytecode::StaticPropertyLookupCache::sweep_all();

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -346,6 +346,7 @@ public:
 
     u32 execution_generation() const { return m_execution_generation; }
     void finish_execution_generation() { ++m_execution_generation; }
+    FlatPtr primitive_storage_cage_base() const { return m_primitive_storage_cage_base; }
 
     ThrowCompletionOr<Reference> resolve_binding(Utf16FlyString const&, Strict, Environment* = nullptr);
     ThrowCompletionOr<Reference> get_identifier_reference(Environment*, Utf16FlyString, Strict, size_t hops = 0);
@@ -562,6 +563,7 @@ private:
     WellKnownSymbols m_well_known_symbols;
 
     u32 m_execution_generation { 0 };
+    FlatPtr m_primitive_storage_cage_base { 0 };
     u32 m_run_executable_depth { 0 };
     u32 m_module_execution_depth { 0 };
     u64 m_module_async_evaluation_count { 0 }; // [[ModuleAsyncEvaluationCount]]

--- a/Libraries/LibWasm/Rust/src/compiler.rs
+++ b/Libraries/LibWasm/Rust/src/compiler.rs
@@ -272,6 +272,73 @@ impl CraneliftCompiler {
                 .ins()
                 .load(ptr_type, MemFlags::trusted(), configuration_val, locals_base_offset);
         builder.def_var(locals_base_var, initial_locals_base);
+        let default_memory_size_var = Variable::from_u32(11);
+        builder.declare_var(default_memory_size_var, types::I64);
+        let default_memory_storage_offset_var = Variable::from_u32(12);
+        builder.declare_var(default_memory_storage_offset_var, types::I64);
+        let primitive_storage_cage_base_var = Variable::from_u32(13);
+        builder.declare_var(primitive_storage_cage_base_var, ptr_type);
+
+        let uses_default_memory = insns.iter().any(|insn| {
+            let mem_idx = insn.imm3 & 0x7fff_ffff;
+            matches!(
+                insn.opcode,
+                op::I32_LOAD
+                    | op::I64_LOAD
+                    | op::F32_LOAD
+                    | op::F64_LOAD
+                    | op::I32_LOAD8_S
+                    | op::I32_LOAD8_U
+                    | op::I32_LOAD16_S
+                    | op::I32_LOAD16_U
+                    | op::I64_LOAD8_S
+                    | op::I64_LOAD8_U
+                    | op::I64_LOAD16_S
+                    | op::I64_LOAD16_U
+                    | op::I64_LOAD32_S
+                    | op::I64_LOAD32_U
+                    | op::I32_STORE
+                    | op::I64_STORE
+                    | op::F32_STORE
+                    | op::F64_STORE
+                    | op::I32_STORE8
+                    | op::I32_STORE16
+                    | op::I64_STORE8
+                    | op::I64_STORE16
+                    | op::I64_STORE32
+                    | op::SYNTHETIC_I32_STORELOCAL
+                    | op::SYNTHETIC_I64_STORELOCAL
+            ) && mem_idx == 0
+        });
+        if uses_default_memory {
+            let default_memory =
+                builder
+                    .ins()
+                    .load(ptr_type, MemFlags::trusted(), configuration_val, default_memory_offset);
+            let memory_buffer_offset = memory_instance_data_offset;
+            let memory_size = builder.ins().load(
+                types::I64,
+                MemFlags::trusted(),
+                default_memory,
+                memory_buffer_offset + memory_buffer_size_offset,
+            );
+            builder.def_var(default_memory_size_var, memory_size);
+            let storage_offset = builder.ins().load(
+                types::I64,
+                MemFlags::trusted(),
+                default_memory,
+                memory_buffer_offset + memory_buffer_storage_offset_offset,
+            );
+            builder.def_var(default_memory_storage_offset_var, storage_offset);
+            let cage_base_storage = builder.ins().func_addr(ptr_type, h_primitive_storage_cage_base);
+            let cage_base = builder.ins().load(ptr_type, MemFlags::trusted(), cage_base_storage, 0);
+            builder.def_var(primitive_storage_cage_base_var, cage_base);
+        } else {
+            let zero = builder.ins().iconst(types::I64, 0);
+            builder.def_var(default_memory_size_var, zero);
+            builder.def_var(default_memory_storage_offset_var, zero);
+            builder.def_var(primitive_storage_cage_base_var, zero);
+        }
 
         let mut control_stack: Vec<ControlFrame> = Vec::new();
 
@@ -287,7 +354,7 @@ impl CraneliftCompiler {
         let mut is_unreachable = false;
         let mut dirty_regs = [false; REG_COUNT];
         let mut stack_vars: Vec<Variable> = Vec::with_capacity(max_stack_depth);
-        const VSTACK_VAR_BASE: u32 = 11;
+        const VSTACK_VAR_BASE: u32 = 14;
 
         for i in 0..max_stack_depth {
             let var = Variable::from_u32(VSTACK_VAR_BASE + i as u32);
@@ -546,6 +613,31 @@ impl CraneliftCompiler {
             }};
         }
 
+        macro_rules! refresh_default_memory_cache {
+            ($builder:expr) => {{
+                if uses_default_memory {
+                    let cfg = $builder.use_var(config_var);
+                    let memory = $builder
+                        .ins()
+                        .load(ptr_type, MemFlags::trusted(), cfg, default_memory_offset);
+                    let memory_buffer_offset = memory_instance_data_offset;
+                    let memory_size = $builder.ins().load(
+                        types::I64,
+                        MemFlags::trusted(),
+                        memory,
+                        memory_buffer_offset + memory_buffer_size_offset,
+                    );
+                    $builder.def_var(default_memory_size_var, memory_size);
+                    let storage_offset = $builder.ins().load(
+                        types::I64,
+                        MemFlags::trusted(),
+                        memory,
+                        memory_buffer_offset + memory_buffer_storage_offset_offset,
+                    );
+                    $builder.def_var(default_memory_storage_offset_var, storage_offset);
+                }
+            }};
+        }
         // Call + trap-check macro for helper calls that do not consume caller register state.
         // The callee gets arguments explicitly (register immediates, stack, or call record), and the caller's virtual registers stay live in SSA across the call.
         macro_rules! do_call_and_check {
@@ -563,6 +655,7 @@ impl CraneliftCompiler {
                     .ins()
                     .load(ptr_type, MemFlags::trusted(), _cfg_for_lb, locals_base_offset);
                 $builder.def_var(locals_base_var, new_lb);
+                refresh_default_memory_cache!($builder);
             }};
         }
         macro_rules! set_trap {
@@ -588,17 +681,7 @@ impl CraneliftCompiler {
         }
         macro_rules! inline_default_memory_address {
             ($builder:expr, $addr:expr, $access_size:expr) => {{
-                let cfg = $builder.use_var(config_var);
-                let memory = $builder
-                    .ins()
-                    .load(ptr_type, MemFlags::trusted(), cfg, default_memory_offset);
-                let memory_buffer_offset = memory_instance_data_offset;
-                let memory_size = $builder.ins().load(
-                    types::I64,
-                    MemFlags::trusted(),
-                    memory,
-                    memory_buffer_offset + memory_buffer_size_offset,
-                );
+                let memory_size = $builder.use_var(default_memory_size_var);
 
                 let addr_too_large = $builder
                     .ins()
@@ -621,21 +704,13 @@ impl CraneliftCompiler {
                 $builder.switch_to_block(access_in_bounds);
                 $builder.seal_block(access_in_bounds);
 
-                let storage_offset = $builder.ins().load(
-                    types::I64,
-                    MemFlags::trusted(),
-                    memory,
-                    memory_buffer_offset + memory_buffer_storage_offset_offset,
-                );
+                let storage_offset = $builder.use_var(default_memory_storage_offset_var);
                 let unmasked_caged_offset = $builder.ins().iadd(storage_offset, $addr);
                 let cage_offset_mask = $builder
                     .ins()
                     .iconst(types::I64, primitive_storage_cage_offset_mask);
                 let caged_offset = $builder.ins().band(unmasked_caged_offset, cage_offset_mask);
-                let cage_base_storage = $builder.ins().func_addr(ptr_type, h_primitive_storage_cage_base);
-                let cage_base = $builder
-                    .ins()
-                    .load(ptr_type, MemFlags::trusted(), cage_base_storage, 0);
+                let cage_base = $builder.use_var(primitive_storage_cage_base_var);
                 let caged_offset = if ptr_type == types::I64 {
                     caged_offset
                 } else {
@@ -1663,6 +1738,9 @@ impl CraneliftCompiler {
                     let result = builder.inst_results(call)[0];
                     let result = builder.ins().sextend(types::I64, result);
                     write_dst!(builder, insn.destination, result);
+                    if insn.imm1 == 0 {
+                        refresh_default_memory_cache!(builder);
+                    }
                 }
 
                 op::MEMORY_COPY => {


### PR DESCRIPTION
This recovers part of the primitive storage cage performance cost without weakening the mitigation.

LibWasm now caches caged memory metadata in Cranelift-compiled functions and refreshes it after helper calls and memory.grow. LibJS now reserves the primitive storage cage during VM construction and caches the cage base in the VM, letting asm interpreter typed array fast paths avoid loading the exported C global through the GOT on every indexed access.

The fast paths still apply the primitive storage cage offset mask for every caged access, so the security mechanism remains active.