### PR TITLE
Compositor: Allow reading libdrm data in Linux sandbox

### DIFF
--- a/Services/Compositor/SandboxLinux.cpp
+++ b/Services/Compositor/SandboxLinux.cpp
@@ -31,6 +31,7 @@ ErrorOr<void> apply_sandbox()
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/glvnd"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/usr/share/glvnd"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/usr/share/drirc.d"sv, Sandbox::LandlockPath::Access::ReadOnly));
+    TRY(Sandbox::add_landlock_path_if_exists(paths, "/usr/share/libdrm"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/usr/share/vulkan"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/dev/dri"sv, Sandbox::LandlockPath::Access::ReadWrite));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/dev/udmabuf"sv, Sandbox::LandlockPath::Access::ReadWrite));


### PR DESCRIPTION
Allow the Linux Compositor sandbox to read /usr/share/libdrm so GPU libraries can load driver metadata such as amdgpu.ids while probing WebGL support. The directory is read-only metadata alongside the other GL and Vulkan data directories already available to the process.