### PR TITLE
LibWeb: Derive `<select>` baseline from its label text

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -703,8 +703,10 @@ void HTMLSelectElement::computed_properties_changed()
         auto appearance = computed_properties()->appearance();
         if (appearance == CSS::Appearance::None) {
             MUST(m_chevron_icon_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "none"_string));
+            MUST(m_inner_text_element->style_for_bindings()->set_property(CSS::PropertyID::MarginInlineEnd, "0"_string));
         } else {
             MUST(m_chevron_icon_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "block"_string));
+            MUST(m_inner_text_element->style_for_bindings()->set_property(CSS::PropertyID::MarginInlineEnd, "20px"_string));
         }
     }
 }
@@ -723,20 +725,26 @@ void HTMLSelectElement::create_shadow_tree_if_needed()
         display: flex;
         align-items: center;
         height: 100%;
+        position: relative;
     )~~~"_string);
     MUST(shadow_root->append_child(border));
 
     m_inner_text_element = DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     m_inner_text_element->set_attribute_value(HTML::AttributeNames::style, R"~~~(
         flex: 1;
+        margin-inline-end: 20px;
     )~~~"_string);
     MUST(border->append_child(*m_inner_text_element));
 
+    // NB: The chevron icon is positioned out of flow so that the label is the wrapper's only flex item, keeping the
+    //     baseline of the select derived from the label text. The label's margin-inline-end reserves its space.
     m_chevron_icon_element = DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     m_chevron_icon_element->set_attribute_value(HTML::AttributeNames::style, R"~~~(
+        position: absolute;
+        inset-inline-end: 0;
+        top: calc(50% - 8px);
         width: 16px;
         height: 16px;
-        margin-left: 4px;
     )~~~"_string);
 
     auto chevron_svg_element = DOM::create_element(document(), SVG::TagNames::svg, Namespace::SVG).release_value_but_fixme_should_propagate_errors();

--- a/Tests/LibWeb/Layout/expected/HTMLSelectElement-selected-index.txt
+++ b/Tests/LibWeb/Layout/expected/HTMLSelectElement-selected-index.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 38 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 22 0+0+8] children: inline
-      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 78.390625x18] baseline: 19
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 78.390625x18] baseline: 15.796875
       BlockContainer <select#select> at [13,10] inline-block [0+1+4 78.390625 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
-        Box <div> at [13,10] flex-container(row) [0+0+0 78.390625 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
-          BlockContainer <div> at [13,10] flex-item [0+0+0 58.390625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+        Box <div> at [13,10] positioned flex-container(row) [0+0+0 78.390625 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [13,10] flex-item [0+0+0 58.390625 0+0+20] [0+0+0 18 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 7, rect: [13,10 58.390625x18] baseline: 13.796875
                 "Value 1"
             TextNode <#text> (not painted)
-          BlockContainer <div> at [75.390625,11] flex-item [4+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+          BlockContainer <div> at [75.390625,11] positioned [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
             frag 0 from SVGSVGBox start: 0, length: 0, rect: [75.390625,11 16x16] baseline: 16
             SVGSVGBox <svg> at [75.390625,11] [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [SVG] children: not-inline
               SVGGeometryBox <path> at [79.390625,16.71875] [0+0+0 8 0+0+0] [0+0+0 4.953125 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/expected/pdf-viewer.txt
+++ b/Tests/LibWeb/Layout/expected/pdf-viewer.txt
@@ -171,7 +171,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       BlockContainer <select#scaleSelect> at [379.9375,3] flex-item [0+0+6 102.484375 38+0+0] [0+0+1 25 2+0+0] [BFC] children: not-inline
-                        Box <div> at [379.9375,3] flex-container(row) [0+0+0 102.484375 0+0+0] [0+0+0 25 0+0+0] [FFC] children: not-inline
+                        Box <div> at [379.9375,3] positioned flex-container(row) [0+0+0 102.484375 0+0+0] [0+0+0 25 0+0+0] [FFC] children: not-inline
                           BlockContainer <div> at [379.9375,8.5] flex-item [0+0+0 102.484375 0+0+0] [0+0+0 14 0+0+0] [BFC] children: inline
                             frag 0 from TextNode start: 0, length: 14, rect: [379.9375,8.5 102.484375x14] baseline: 10.59375
                                 "Automatic Zoom"

--- a/Tests/LibWeb/Layout/expected/select-baseline-from-label-text.txt
+++ b/Tests/LibWeb/Layout/expected/select-baseline-from-label-text.txt
@@ -1,0 +1,69 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 44 0+0+8] children: not-inline
+      BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [8,10 29.265625x18] baseline: 13.796875
+            "Xx "
+        frag 1 from BlockContainer start: 0, length: 0, rect: [42.265625,10 76.46875x18] baseline: 15.796875
+        frag 2 from TextNode start: 0, length: 1, rect: [123.734375,10 8x18] baseline: 13.796875
+            " "
+        frag 3 from BlockContainer start: 0, length: 0, rect: [136.734375,10 23.59375x18] baseline: 15.296875
+        TextNode <#text> (not painted)
+        BlockContainer <select> at [42.265625,10] inline-block [0+1+4 76.46875 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
+          Box <div> at [42.265625,10] positioned flex-container(row) [0+0+0 76.46875 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+            BlockContainer <div> at [42.265625,10] flex-item [0+0+0 56.46875 0+0+20] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 7, rect: [42.265625,10 56.46875x18] baseline: 13.796875
+                  "English"
+              TextNode <#text> (not painted)
+            BlockContainer <div> at [102.734375,11] positioned [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+              frag 0 from SVGSVGBox start: 0, length: 0, rect: [102.734375,11 16x16] baseline: 16
+              SVGSVGBox <svg> at [102.734375,11] [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [SVG] children: not-inline
+                SVGGeometryBox <path> at [106.734375,16.71875] [0+0+0 8 0+0+0] [0+0+0 4.953125 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        BlockContainer <input> at [136.734375,10] inline-block [0+1+4 23.59375 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> at [136.734375,10] flex-container(column) [0+0+0 23.59375 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> at [136.734375,10] flex-item [0+0+0 23.59375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from BlockContainer start: 0, length: 0, rect: [136.734375,10 23.59375x18] baseline: 13.796875
+              BlockContainer <span> at [136.734375,10] inline-block [0+0+0 23.59375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [136.734375,10 23.59375x18] baseline: 13.796875
+                    "Go"
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,30] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,30] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [8,32 29.265625x18] baseline: 13.796875
+            "Xx "
+        frag 1 from BlockContainer start: 0, length: 0, rect: [42.265625,32 56.46875x18] baseline: 15.796875
+        TextNode <#text> (not painted)
+        BlockContainer <select> at [42.265625,32] inline-block [0+1+4 56.46875 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
+          Box <div> at [42.265625,32] positioned flex-container(row) [0+0+0 56.46875 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+            BlockContainer <div> at [42.265625,32] flex-item [0+0+0 56.46875 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 7, rect: [42.265625,32 56.46875x18] baseline: 13.796875
+                  "English"
+              TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,52] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x22]
+        PaintableWithLines (BlockContainer<SELECT>) [37.265625,8 86.46875x22]
+          PaintableBox (Box<DIV>) [42.265625,10 76.46875x18]
+            PaintableWithLines (BlockContainer<DIV>) [42.265625,10 56.46875x18]
+            PaintableWithLines (BlockContainer<DIV>) [102.734375,11 16x16]
+              SVGSVGPaintable (SVGSVGBox<svg>) [102.734375,11 16x16]
+                SVGPathPaintable (SVGGeometryBox<path>) [106.734375,16.71875 8x4.953125]
+        PaintableWithLines (BlockContainer<INPUT>) [131.734375,8 33.59375x22]
+          PaintableWithLines (BlockContainer(anonymous)) [136.734375,10 23.59375x18]
+            PaintableWithLines (BlockContainer(anonymous)) [136.734375,10 23.59375x18]
+              PaintableWithLines (BlockContainer<SPAN>) [136.734375,10 23.59375x18]
+      PaintableWithLines (BlockContainer(anonymous)) [8,30 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,30 784x22]
+        PaintableWithLines (BlockContainer<SELECT>) [37.265625,30 66.46875x22]
+          PaintableBox (Box<DIV>) [42.265625,32 56.46875x18]
+            PaintableWithLines (BlockContainer<DIV>) [42.265625,32 56.46875x18]
+      PaintableWithLines (BlockContainer(anonymous)) [8,52 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x60] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/select-innerhtml-optgroup-selected-option.txt
+++ b/Tests/LibWeb/Layout/expected/select-innerhtml-optgroup-selected-option.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 38 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 22 0+0+8] children: inline
-      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 89.109375x18] baseline: 19
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 89.109375x18] baseline: 15.796875
       BlockContainer <select#s> at [13,10] inline-block [0+1+4 89.109375 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
-        Box <div> at [13,10] flex-container(row) [0+0+0 89.109375 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
-          BlockContainer <div> at [13,10] flex-item [0+0+0 69.109375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+        Box <div> at [13,10] positioned flex-container(row) [0+0+0 89.109375 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [13,10] flex-item [0+0+0 69.109375 0+0+20] [0+0+0 18 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 8, rect: [13,10 69.109375x18] baseline: 13.796875
                 "Option 2"
             TextNode <#text> (not painted)
-          BlockContainer <div> at [86.109375,11] flex-item [4+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+          BlockContainer <div> at [86.109375,11] positioned [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
             frag 0 from SVGSVGBox start: 0, length: 0, rect: [86.109375,11 16x16] baseline: 16
             SVGSVGBox <svg> at [86.109375,11] [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [SVG] children: not-inline
               SVGGeometryBox <path> at [90.109375,16.71875] [0+0+0 8 0+0+0] [0+0+0 4.953125 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/expected/select-with-option-selected.txt
+++ b/Tests/LibWeb/Layout/expected/select-with-option-selected.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 38 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 22 0+0+8] children: inline
-      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 89.109375x18] baseline: 19
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 89.109375x18] baseline: 15.796875
       BlockContainer <select> at [13,10] inline-block [0+1+4 89.109375 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
-        Box <div> at [13,10] flex-container(row) [0+0+0 89.109375 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
-          BlockContainer <div> at [13,10] flex-item [0+0+0 69.109375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+        Box <div> at [13,10] positioned flex-container(row) [0+0+0 89.109375 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [13,10] flex-item [0+0+0 69.109375 0+0+20] [0+0+0 18 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 8, rect: [13,10 69.109375x18] baseline: 13.796875
                 "Option 2"
             TextNode <#text> (not painted)
-          BlockContainer <div> at [86.109375,11] flex-item [4+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+          BlockContainer <div> at [86.109375,11] positioned [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
             frag 0 from SVGSVGBox start: 0, length: 0, rect: [86.109375,11 16x16] baseline: 16
             SVGSVGBox <svg> at [86.109375,11] [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [SVG] children: not-inline
               SVGGeometryBox <path> at [90.109375,16.71875] [0+0+0 8 0+0+0] [0+0+0 4.953125 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/input/select-baseline-from-label-text.html
+++ b/Tests/LibWeb/Layout/input/select-baseline-from-label-text.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+input {
+    vertical-align: middle;
+}
+</style>
+<div>Xx <select><option>English</option></select> <input type="submit" value="Go"></div>
+<div>Xx <select style="appearance: none"><option>English</option></select></div>

--- a/Tests/LibWeb/Ref/expected/select-chevron-color-ref.html
+++ b/Tests/LibWeb/Ref/expected/select-chevron-color-ref.html
@@ -2,9 +2,9 @@
 The arrow in this select should be green:<br>
 <!-- using a button here since it should have the same default styles as a select -->
 <button style="color: green;">
-  <div style="display: flex; align-items: center; height: 100%;">
-    <div style="flex: 1;"></div>
-    <div style="width: 16px; height: 16px; margin-left: 4px; display: block;">
+  <div style="display: flex; align-items: center; height: 100%; position: relative;">
+    <div style="flex: 1; margin-inline-end: 20px;"></div>
+    <div style="position: absolute; inset-inline-end: 0; top: calc(50% - 8px); width: 16px; height: 16px; display: block;">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
         <path fill="currentcolor" d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"></path>
       </svg>


### PR DESCRIPTION
Previously, the select element's chevron icon was the endmost flex item in its internal shadow tree, so last-baseline derivation generated the select's baseline from the bottom edge of the icon instead of the displayed label. This misaligned select elements against surrounding inline content.

We now position the icon out of flow and reserve its space with a margin on the label element instead. The label is then the only flex item, so the baseline derives from the label text through the standard baseline rules.

Fixes the alignment of a language dropdown on https://aur.archlinux.org:

Before:

<img width="749" height="133" alt="image" src="https://github.com/user-attachments/assets/4b661424-9315-4582-8d95-981666c9a61a" />


After:

<img width="749" height="133" alt="image" src="https://github.com/user-attachments/assets/205cb7ce-b356-4e57-9337-e777f2dc92b5" />

