### PR TITLE
LibWeb: Cache querySelector/querySelectorAll results

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -377,6 +377,7 @@ set(SOURCES
     DOM/PseudoElement.cpp
     DOM/QualifiedName.cpp
     DOM/Range.cpp
+    DOM/SelectorQuery.cpp
     DOM/ShadowRoot.cpp
     DOM/Slot.cpp
     DOM/SlotRegistry.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -105,6 +105,7 @@
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/DOM/Range.h>
+#include <LibWeb/DOM/SelectorQuery.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOM/TreeWalker.h>
@@ -9523,7 +9524,7 @@ static bool contains_named_namespace(CSS::SelectorList const& selectors)
     return false;
 }
 
-Optional<CSS::SelectorList> const& Document::parse_or_cache_selector_list(StringView selector_text) const
+RefPtr<SelectorQuery const> Document::selector_query_for(StringView selector_text) const
 {
     static constexpr size_t MAX_SELECTOR_QUERY_CACHE_SIZE = 512;
 
@@ -9538,13 +9539,15 @@ Optional<CSS::SelectorList> const& Document::parse_or_cache_selector_list(String
     if (maybe_selectors.has_value() && contains_named_namespace(maybe_selectors.value()))
         maybe_selectors.clear();
 
+    RefPtr<SelectorQuery const> query;
+    if (maybe_selectors.has_value())
+        query = SelectorQuery::create(maybe_selectors.release_value());
+
     if (m_selector_query_cache.size() >= MAX_SELECTOR_QUERY_CACHE_SIZE)
         m_selector_query_cache.remove(m_selector_query_cache.begin());
 
-    m_selector_query_cache.set(selector_text_string, move(maybe_selectors));
-    auto it = m_selector_query_cache.find(selector_text_string);
-    VERIFY(it != m_selector_query_cache.end());
-    return it->value;
+    m_selector_query_cache.set(selector_text_string, query);
+    return query;
 }
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -763,6 +763,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
 
     visitor.visit(m_potentially_named_elements);
     m_anchor_name_map.visit_edges(visitor);
+    if (m_query_selector_result_cache)
+        m_query_selector_result_cache->visit_edges(visitor);
 
     for (auto& event : m_pending_animation_event_queue) {
         visitor.visit(event.event);
@@ -3547,6 +3549,11 @@ void Document::adopt_node(Node& node)
             old_document.m_node_iterators.remove(&node_iterator);
             m_node_iterators.set(&node_iterator);
         }
+
+        // AD-HOC: A parentless node leaves oldDocument without any mutation observable through oldDocument's
+        //         dom_tree_version. Bump it so that caches keyed on that version can't serve stale results for this
+        //         node if it is later adopted back after being mutated under another document.
+        old_document.bump_dom_tree_version();
     }
 }
 
@@ -9548,6 +9555,13 @@ RefPtr<SelectorQuery const> Document::selector_query_for(StringView selector_tex
 
     m_selector_query_cache.set(selector_text_string, query);
     return query;
+}
+
+QuerySelectorResultCache& Document::query_selector_result_cache()
+{
+    if (!m_query_selector_result_cache)
+        m_query_selector_result_cache = make<QuerySelectorResultCache>();
+    return *m_query_selector_result_cache;
 }
 
 }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1143,7 +1143,7 @@ public:
 
     void exit_pointer_lock();
 
-    Optional<CSS::SelectorList> const& parse_or_cache_selector_list(StringView) const;
+    RefPtr<SelectorQuery const> selector_query_for(StringView) const;
 
     GC::Ptr<HTML::CustomElementRegistry> custom_element_registry() const;
     void set_custom_element_registry(GC::Ptr<HTML::CustomElementRegistry> custom_element_registry) { m_custom_element_registry = custom_element_registry; }
@@ -1638,8 +1638,9 @@ private:
     // https://drafts.csswg.org/css-values-5/#random-caching
     HashMap<CSS::RandomCachingKey, double> m_element_shared_css_random_base_value_cache;
 
-    // Cache of parsed selector lists for querySelectorAll/querySelector/matches/closest.
-    mutable HashMap<String, Optional<CSS::SelectorList>> m_selector_query_cache;
+    // Cache of parsed selector queries for querySelectorAll/querySelector/matches/closest.
+    // A null value means the selector string failed to parse.
+    mutable HashMap<String, RefPtr<SelectorQuery const>> m_selector_query_cache;
 
     // https://fullscreen.spec.whatwg.org/#list-of-pending-fullscreen-events
     Vector<PendingFullscreenEvent> m_pending_fullscreen_events;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -487,7 +487,14 @@ public:
     QuirksMode mode() const { return m_quirks_mode; }
     bool in_quirks_mode() const { return m_quirks_mode == QuirksMode::Yes; }
     bool in_limited_quirks_mode() const { return m_quirks_mode == QuirksMode::Limited; }
-    void set_quirks_mode(QuirksMode mode) { m_quirks_mode = mode; }
+    void set_quirks_mode(QuirksMode mode)
+    {
+        if (m_quirks_mode == mode)
+            return;
+        m_quirks_mode = mode;
+        // Quirks mode changes how id and class selectors match, so cached query results must not survive it.
+        bump_dom_tree_version();
+    }
 
     bool parser_cannot_change_the_mode() const { return m_parser_cannot_change_the_mode; }
     void set_parser_cannot_change_the_mode(bool parser_cannot_change_the_mode) { m_parser_cannot_change_the_mode = parser_cannot_change_the_mode; }
@@ -1144,6 +1151,7 @@ public:
     void exit_pointer_lock();
 
     RefPtr<SelectorQuery const> selector_query_for(StringView) const;
+    QuerySelectorResultCache& query_selector_result_cache();
 
     GC::Ptr<HTML::CustomElementRegistry> custom_element_registry() const;
     void set_custom_element_registry(GC::Ptr<HTML::CustomElementRegistry> custom_element_registry) { m_custom_element_registry = custom_element_registry; }
@@ -1641,6 +1649,9 @@ private:
     // Cache of parsed selector queries for querySelectorAll/querySelector/matches/closest.
     // A null value means the selector string failed to parse.
     mutable HashMap<String, RefPtr<SelectorQuery const>> m_selector_query_cache;
+
+    // Cache of querySelectorAll results, validated lazily against dom_tree_version/character_data_version.
+    OwnPtr<QuerySelectorResultCache> m_query_selector_result_cache;
 
     // https://fullscreen.spec.whatwg.org/#list-of-pending-fullscreen-events
     Vector<PendingFullscreenEvent> m_pending_fullscreen_events;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -59,6 +59,7 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
+#include <LibWeb/DOM/SelectorQuery.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Geometry/DOMRect.h>
@@ -1383,14 +1384,14 @@ GC::Ptr<ShadowRoot> Element::shadow_root_for_bindings() const
 WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
 {
     // 1. Let s be the result of parse a selector from selectors.
-    auto const& maybe_selectors = document().parse_or_cache_selector_list(selectors);
+    auto query = document().selector_query_for(selectors);
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
-    if (!maybe_selectors.has_value())
+    if (!query)
         return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_utf16);
 
     // 3. If the result of match a selector against an element, using s, this, and scoping root this, returns success, then return true; otherwise, return false.
-    for (auto const& s : maybe_selectors.value()) {
+    for (auto const& s : query->selectors()) {
         SelectorEngine::MatchContext context;
         if (SelectorEngine::matches(s, *this, nullptr, context, static_cast<ParentNode const*>(this)))
             return true;
@@ -1402,10 +1403,10 @@ WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
 WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) const
 {
     // 1. Let s be the result of parse a selector from selectors.
-    auto const& maybe_selectors = document().parse_or_cache_selector_list(selectors);
+    auto query = document().selector_query_for(selectors);
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
-    if (!maybe_selectors.has_value())
+    if (!query)
         return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_utf16);
 
     auto matches_selectors = [this](CSS::SelectorList const& selector_list, Element const* element) {
@@ -1418,7 +1419,7 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
         return false;
     };
 
-    auto const& selector_list = maybe_selectors.value();
+    auto const& selector_list = query->selectors();
 
     // 3. Let elements be this’s inclusive ancestors that are elements, in reverse tree order.
     for (auto* element = this; element; element = element->parent_element()) {

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -7,13 +7,13 @@
  */
 
 #include <LibWeb/CSS/Parser/Parser.h>
-#include <LibWeb/CSS/SelectorEngine.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/HTMLCollection.h>
+#include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/DOM/NodeOperations.h>
 #include <LibWeb/DOM/ParentNode.h>
+#include <LibWeb/DOM/SelectorQuery.h>
 #include <LibWeb/DOM/ShadowRoot.h>
-#include <LibWeb/DOM/StaticNodeList.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Infra/Strings.h>
@@ -23,63 +23,37 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(ParentNode);
 
-enum class ReturnMatches {
-    First,
-    All,
-};
-// https://dom.spec.whatwg.org/#scope-match-a-selectors-string
-static WebIDL::ExceptionOr<Variant<GC::Ptr<Element>, GC::Ref<NodeList>>> scope_match_a_selectors_string(ParentNode& node, StringView selector_text, ReturnMatches return_matches)
-{
-    // To scope-match a selectors string selectors against a node, run these steps:
-    auto& document = node.document();
-
-    // 1. Let s be the result of parse a selector selectors.
-    auto const& maybe_selectors = document.parse_or_cache_selector_list(selector_text);
-
-    // 2. If s is failure, then throw a "SyntaxError" DOMException.
-    if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(node.realm(), "Failed to parse selector"_utf16);
-
-    auto const& selectors = maybe_selectors.value();
-
-    // 3. Return the result of match a selector against a tree with s and node’s root using scoping root node.
-    GC::Ptr<Element> single_result;
-    Vector<GC::Root<Node>> results;
-    // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
-    node.for_each_in_subtree_of_type<Element>([&](auto& element) {
-        for (auto const& selector : selectors) {
-            SelectorEngine::MatchContext context;
-            if (SelectorEngine::matches(selector, element, nullptr, context, node)) {
-                if (return_matches == ReturnMatches::First) {
-                    single_result = &element;
-                    return TraversalDecision::Break;
-                }
-                results.append(element);
-                break;
-            }
-        }
-        return TraversalDecision::Continue;
-    });
-
-    if (return_matches == ReturnMatches::First)
-        return { single_result };
-
-    return { StaticNodeList::create(node.realm(), move(results)) };
-}
-
 // https://dom.spec.whatwg.org/#dom-parentnode-queryselector
 WebIDL::ExceptionOr<GC::Ptr<Element>> ParentNode::query_selector(StringView selector_text)
 {
     // The querySelector(selectors) method steps are to return the first result of running scope-match a selectors string selectors against this,
     // if the result is not an empty list; otherwise null.
-    return TRY(scope_match_a_selectors_string(*this, selector_text, ReturnMatches::First)).get<GC::Ptr<Element>>();
+
+    // Scope-match step 1. Let s be the result of parse a selector selectors.
+    auto query = document().selector_query_for(selector_text);
+
+    // Scope-match step 2. If s is failure, then throw a "SyntaxError" DOMException.
+    if (!query)
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_utf16);
+
+    // Scope-match step 3. Return the result of match a selector against a tree with s and node’s root using scoping root node.
+    return query->query_first(*this);
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
 WebIDL::ExceptionOr<GC::Ref<NodeList>> ParentNode::query_selector_all(StringView selector_text)
 {
     // The querySelectorAll(selectors) method steps are to return the static result of running scope-match a selectors string selectors against this.
-    return TRY(scope_match_a_selectors_string(*this, selector_text, ReturnMatches::All)).get<GC::Ref<NodeList>>();
+
+    // Scope-match step 1. Let s be the result of parse a selector selectors.
+    auto query = document().selector_query_for(selector_text);
+
+    // Scope-match step 2. If s is failure, then throw a "SyntaxError" DOMException.
+    if (!query)
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_utf16);
+
+    // Scope-match step 3. Return the result of match a selector against a tree with s and node’s root using scoping root node.
+    return query->query_all(*this);
 }
 
 GC::Ptr<Element> ParentNode::first_element_child()

--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/SelectorEngine.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/ParentNode.h>
+#include <LibWeb/DOM/SelectorQuery.h>
+#include <LibWeb/DOM/StaticNodeList.h>
+
+namespace Web::DOM {
+
+SelectorQuery::SelectorQuery(CSS::SelectorList&& selectors)
+    : m_selectors(move(selectors))
+{
+}
+
+// https://dom.spec.whatwg.org/#scope-match-a-selectors-string
+// This implements step 3, "match a selector against a tree" with the parsed selectors,
+// stopping at the first match.
+GC::Ptr<Element> SelectorQuery::query_first(ParentNode& root) const
+{
+    GC::Ptr<Element> result;
+    // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
+    root.for_each_in_subtree_of_type<Element>([&](auto& element) {
+        for (auto const& selector : m_selectors) {
+            SelectorEngine::MatchContext context;
+            if (SelectorEngine::matches(selector, element, nullptr, context, root)) {
+                result = &element;
+                return TraversalDecision::Break;
+            }
+        }
+        return TraversalDecision::Continue;
+    });
+    return result;
+}
+
+// https://dom.spec.whatwg.org/#scope-match-a-selectors-string
+// This implements step 3, "match a selector against a tree" with the parsed selectors.
+GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
+{
+    Vector<GC::Root<Node>> results;
+    // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
+    root.for_each_in_subtree_of_type<Element>([&](auto& element) {
+        for (auto const& selector : m_selectors) {
+            SelectorEngine::MatchContext context;
+            if (SelectorEngine::matches(selector, element, nullptr, context, root)) {
+                results.append(element);
+                break;
+            }
+        }
+        return TraversalDecision::Continue;
+    });
+    return StaticNodeList::create(root.realm(), move(results));
+}
+
+}

--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/WeakInlines.h>
 #include <LibWeb/CSS/SelectorEngine.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ParentNode.h>
 #include <LibWeb/DOM/SelectorQuery.h>
@@ -12,9 +14,66 @@
 
 namespace Web::DOM {
 
+// Whether matching this pseudo-class can only change when Document::dom_tree_version() or
+// Document::character_data_version() change, i.e. it depends only on tree structure, attributes and character
+// data. Pseudo-classes that also depend on other state (user interaction, element states like checkedness or
+// validity, navigation, history, custom element upgrades, ...) must not be on this list.
+static bool pseudo_class_matching_is_covered_by_version_counters(CSS::PseudoClass pseudo_class)
+{
+    switch (pseudo_class) {
+    case CSS::PseudoClass::AnyLink: // Presence of an href attribute.
+    case CSS::PseudoClass::Empty:   // Child nodes and their character data.
+    case CSS::PseudoClass::FirstChild:
+    case CSS::PseudoClass::FirstOfType:
+    case CSS::PseudoClass::Has: // Container; argument selectors are checked via the recursive pseudo-class bitmap.
+    case CSS::PseudoClass::Heading:
+    case CSS::PseudoClass::Is:
+    case CSS::PseudoClass::LastChild:
+    case CSS::PseudoClass::LastOfType:
+    case CSS::PseudoClass::Link: // Matches like :any-link; we treat all links as unvisited.
+    case CSS::PseudoClass::Not:
+    case CSS::PseudoClass::NthChild:
+    case CSS::PseudoClass::NthLastChild:
+    case CSS::PseudoClass::NthLastOfType:
+    case CSS::PseudoClass::NthOfType:
+    case CSS::PseudoClass::OnlyChild:
+    case CSS::PseudoClass::OnlyOfType:
+    case CSS::PseudoClass::Optional:
+    case CSS::PseudoClass::Required:
+    case CSS::PseudoClass::Root:
+    case CSS::PseudoClass::Scope: // The scoping root is part of the result cache key.
+    case CSS::PseudoClass::Where:
+        return true;
+    default:
+        return false;
+    }
+}
+
 SelectorQuery::SelectorQuery(CSS::SelectorList&& selectors)
     : m_selectors(move(selectors))
 {
+    m_is_result_cacheable = true;
+    for (auto const& selector : m_selectors) {
+        // NB: The contained-pseudo-class bitmap may be under-collected for selectors containing the nesting
+        //     selector, so we cannot rely on it (and `&` has no useful meaning in a query anyway).
+        if (selector->contains_the_nesting_selector()) {
+            m_is_result_cacheable = false;
+            break;
+        }
+        for (size_t i = 0; i < to_underlying(CSS::PseudoClass::__Count); ++i) {
+            auto pseudo_class = static_cast<CSS::PseudoClass>(i);
+            if (!selector->contains_pseudo_class(pseudo_class))
+                continue;
+            if (!pseudo_class_matching_is_covered_by_version_counters(pseudo_class)) {
+                m_is_result_cacheable = false;
+                break;
+            }
+            if (pseudo_class == CSS::PseudoClass::Empty)
+                m_depends_on_character_data = true;
+        }
+        if (!m_is_result_cacheable)
+            break;
+    }
 }
 
 // https://dom.spec.whatwg.org/#scope-match-a-selectors-string
@@ -22,6 +81,12 @@ SelectorQuery::SelectorQuery(CSS::SelectorList&& selectors)
 // stopping at the first match.
 GC::Ptr<Element> SelectorQuery::query_first(ParentNode& root) const
 {
+    if (m_is_result_cacheable) {
+        auto& document = root.document();
+        if (auto const* cached_elements = document.query_selector_result_cache().get(document, root, *this))
+            return cached_elements->is_empty() ? nullptr : cached_elements->first().ptr();
+    }
+
     GC::Ptr<Element> result;
     // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
     root.for_each_in_subtree_of_type<Element>([&](auto& element) {
@@ -37,23 +102,88 @@ GC::Ptr<Element> SelectorQuery::query_first(ParentNode& root) const
     return result;
 }
 
+static GC::Ref<NodeList> create_node_list(JS::Realm& realm, Vector<GC::RawPtr<Element>> const& elements)
+{
+    Vector<GC::Root<Node>> nodes;
+    nodes.ensure_capacity(elements.size());
+    for (auto const& element : elements)
+        nodes.unchecked_append(GC::make_root(static_cast<Node&>(*element)));
+    return StaticNodeList::create(realm, move(nodes));
+}
+
 // https://dom.spec.whatwg.org/#scope-match-a-selectors-string
 // This implements step 3, "match a selector against a tree" with the parsed selectors.
 GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
 {
-    Vector<GC::Root<Node>> results;
+    auto& document = root.document();
+
+    if (m_is_result_cacheable) {
+        if (auto const* cached_elements = document.query_selector_result_cache().get(document, root, *this))
+            return create_node_list(root.realm(), *cached_elements);
+    }
+
+    Vector<GC::RawPtr<Element>> elements;
     // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
     root.for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto const& selector : m_selectors) {
             SelectorEngine::MatchContext context;
             if (SelectorEngine::matches(selector, element, nullptr, context, root)) {
-                results.append(element);
+                elements.append(element);
                 break;
             }
         }
         return TraversalDecision::Continue;
     });
-    return StaticNodeList::create(root.realm(), move(results));
+
+    auto node_list = create_node_list(root.realm(), elements);
+    if (m_is_result_cacheable)
+        document.query_selector_result_cache().set(document, root, *this, move(elements));
+    return node_list;
+}
+
+void QuerySelectorResultCache::clear_if_dom_tree_changed(Document const& document)
+{
+    if (m_dom_tree_version == document.dom_tree_version())
+        return;
+    m_entries.clear();
+    m_dom_tree_version = document.dom_tree_version();
+}
+
+Vector<GC::RawPtr<Element>> const* QuerySelectorResultCache::get(Document const& document, ParentNode const& root, SelectorQuery const& query)
+{
+    clear_if_dom_tree_changed(document);
+
+    auto it = m_entries.find(Key { &root, &query });
+    if (it == m_entries.end())
+        return nullptr;
+
+    auto const& entry = it->value;
+    if (entry.root.ptr() != &root
+        || (query.depends_on_character_data() && entry.character_data_version != document.character_data_version())) {
+        m_entries.remove(it);
+        return nullptr;
+    }
+
+    return &entry.elements;
+}
+
+void QuerySelectorResultCache::set(Document const& document, ParentNode const& root, SelectorQuery const& query, Vector<GC::RawPtr<Element>> elements)
+{
+    static constexpr size_t MAX_QUERY_SELECTOR_RESULT_CACHE_SIZE = 64;
+
+    clear_if_dom_tree_changed(document);
+
+    if (m_entries.size() >= MAX_QUERY_SELECTOR_RESULT_CACHE_SIZE)
+        m_entries.remove(m_entries.begin());
+
+    m_entries.set(Key { &root, &query }, Entry { root, query, document.character_data_version(), move(elements) });
+}
+
+void QuerySelectorResultCache::visit_edges(GC::Cell::Visitor&)
+{
+    // Entries intentionally contain only weak or raw GC pointers, so the cache does not keep query roots or matched
+    // elements alive.
+    (void)m_entries;
 }
 
 }

--- a/Libraries/LibWeb/DOM/SelectorQuery.h
+++ b/Libraries/LibWeb/DOM/SelectorQuery.h
@@ -6,8 +6,11 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/RefCounted.h>
+#include <LibGC/Cell.h>
 #include <LibGC/Ptr.h>
+#include <LibGC/Weak.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/Forward.h>
 
@@ -24,6 +27,9 @@ public:
 
     CSS::SelectorList const& selectors() const { return m_selectors; }
 
+    bool is_result_cacheable() const { return m_is_result_cacheable; }
+    bool depends_on_character_data() const { return m_depends_on_character_data; }
+
     GC::Ptr<Element> query_first(ParentNode&) const;
     GC::Ref<NodeList> query_all(ParentNode&) const;
 
@@ -31,6 +37,62 @@ private:
     explicit SelectorQuery(CSS::SelectorList&&);
 
     CSS::SelectorList m_selectors;
+
+    // Whether matching can only change when the document's dom_tree_version (plus character_data_version, see below)
+    // changes. Queries with selectors that depend on other state (:hover, :checked, :target, etc) are not cacheable.
+    bool m_is_result_cacheable { false };
+
+    // Whether matching also depends on character data (only :empty), so cached results must additionally be
+    // validated against the document's character_data_version.
+    bool m_depends_on_character_data { false };
+};
+
+// Caches querySelectorAll element lists per (query root, selector query) so that repeated queries against an
+// unchanged document can skip the subtree walk. Entries are validated lazily against the document's mutation
+// version counters, so no notification on DOM mutation is needed: the whole cache is emptied on first use after
+// dom_tree_version has changed.
+class QuerySelectorResultCache {
+    AK_MAKE_NONCOPYABLE(QuerySelectorResultCache);
+    AK_MAKE_NONMOVABLE(QuerySelectorResultCache);
+
+public:
+    QuerySelectorResultCache() = default;
+
+    Vector<GC::RawPtr<Element>> const* get(Document const&, ParentNode const& root, SelectorQuery const&);
+    void set(Document const&, ParentNode const& root, SelectorQuery const&, Vector<GC::RawPtr<Element>>);
+    void visit_edges(GC::Cell::Visitor&);
+
+private:
+    void clear_if_dom_tree_changed(Document const&);
+
+    struct Key {
+        GC::RawPtr<ParentNode const> root;
+        SelectorQuery const* query { nullptr };
+        bool operator==(Key const&) const = default;
+    };
+
+    struct KeyTraits : public DefaultTraits<Key> {
+        static unsigned hash(Key const& key) { return pair_int_hash(ptr_hash(key.root.ptr()), ptr_hash(key.query)); }
+    };
+
+    struct Entry {
+        // Weak so the cache never keeps a disconnected query root alive, and so that a dead root can never be
+        // confused with a new node allocated at the same address.
+        GC::Weak<ParentNode> root;
+
+        // Keeps the query alive (and its address unique) even if the document's selector query cache evicts it.
+        NonnullRefPtr<SelectorQuery const> query;
+
+        u64 character_data_version { 0 };
+
+        // Raw pointers are safe here: the elements were descendants of root when cached, and with dom_tree_version
+        // unchanged no node in this document has been inserted or removed since, so they are still descendants of
+        // root and kept alive by it. Entries are only used after validating the version and that root is alive.
+        Vector<GC::RawPtr<Element>> elements;
+    };
+
+    u64 m_dom_tree_version { 0 };
+    HashMap<Key, Entry, KeyTraits> m_entries;
 };
 
 }

--- a/Libraries/LibWeb/DOM/SelectorQuery.h
+++ b/Libraries/LibWeb/DOM/SelectorQuery.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <LibGC/Ptr.h>
+#include <LibWeb/CSS/Selector.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::DOM {
+
+// A selectors string parsed for use by querySelector(All), matches() and closest().
+// Documents cache these per selector string, so one SelectorQuery may be reused by many queries.
+class SelectorQuery : public RefCounted<SelectorQuery> {
+public:
+    static NonnullRefPtr<SelectorQuery> create(CSS::SelectorList&& selectors)
+    {
+        return adopt_ref(*new SelectorQuery(move(selectors)));
+    }
+
+    CSS::SelectorList const& selectors() const { return m_selectors; }
+
+    GC::Ptr<Element> query_first(ParentNode&) const;
+    GC::Ref<NodeList> query_all(ParentNode&) const;
+
+private:
+    explicit SelectorQuery(CSS::SelectorList&&);
+
+    CSS::SelectorList m_selectors;
+};
+
+}

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -575,6 +575,7 @@ class ProcessingInstruction;
 class PseudoElement;
 class Range;
 class RegisteredObserver;
+class SelectorQuery;
 class ShadowRoot;
 class SlotRegistry;
 class StaticNodeList;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -573,6 +573,7 @@ class ParentNode;
 class Position;
 class ProcessingInstruction;
 class PseudoElement;
+class QuerySelectorResultCache;
 class Range;
 class RegisteredObserver;
 class SelectorQuery;

--- a/Tests/LibWeb/Text/expected/DOM/querySelectorAll-results-stay-fresh-across-mutations.txt
+++ b/Tests/LibWeb/Text/expected/DOM/querySelectorAll-results-stay-fresh-across-mutations.txt
@@ -12,6 +12,10 @@ same selector returns distinct NodeList objects: true
 [data-k] count after removeAttribute: 0
 :disabled count before: 0
 :disabled count after: 1
+FACE :enabled count before define: 0
+FACE :enabled count after define: 1
+FACE :disabled count before define: 0
+FACE :disabled count after define: 1
 :checked count before: 0
 :checked count after: 1
 :has(:checked) count after: 1
@@ -31,3 +35,7 @@ traveler .y count: 1
 traveler .y count after adopt roundtrip: 2
 querySelector agrees with querySelectorAll[0]: true
 querySelector after remove: true
+repeated query returns distinct objects: true
+repeated query returns identical non-empty results: true
+querySelector agrees with repeated querySelectorAll[0]: true
+repeated empty query stays empty: true

--- a/Tests/LibWeb/Text/expected/DOM/querySelectorAll-results-stay-fresh-across-mutations.txt
+++ b/Tests/LibWeb/Text/expected/DOM/querySelectorAll-results-stay-fresh-across-mutations.txt
@@ -1,0 +1,33 @@
+same selector returns distinct NodeList objects: true
+.item count after append: 1
+.item count after second append: 2
+.item count after remove: 1
+.item count from document: 1
+.item count after classList.remove: 0
+.item count after classList.add: 1
+#needle count after id set: 1
+#needle count after id removed: 0
+[data-k=v] count after setAttribute: 1
+[data-k=v] count after attribute value change: 0
+[data-k] count after removeAttribute: 0
+:disabled count before: 0
+:disabled count after: 1
+:checked count before: 0
+:checked count after: 1
+:has(:checked) count after: 1
+div:empty count before: 0
+div:empty count after text.data = "": 1
+div:empty count after text.data restored: 0
+div:empty count after textContent = "": 1
+i:nth-child(2) before reorder: two
+i:nth-child(2) after reorder: one
+:scope > .item count: 1
+:scope > .item count after append: 2
+disconnected .x count: 1
+disconnected .x count after append: 2
+shadow .s count: 1
+shadow .s count after append: 2
+traveler .y count: 1
+traveler .y count after adopt roundtrip: 2
+querySelector agrees with querySelectorAll[0]: true
+querySelector after remove: true

--- a/Tests/LibWeb/Text/input/DOM/querySelectorAll-results-stay-fresh-across-mutations.html
+++ b/Tests/LibWeb/Text/input/DOM/querySelectorAll-results-stay-fresh-across-mutations.html
@@ -52,6 +52,24 @@
         button.disabled = true;
         println(`:disabled count after: ${host.querySelectorAll(":disabled").length}`);
 
+        // Form-associated custom element upgrades change :enabled/:disabled matching.
+        const enabledCustomElement = document.createElement("cache-enabled-control");
+        host.appendChild(enabledCustomElement);
+        println(`FACE :enabled count before define: ${host.querySelectorAll("cache-enabled-control:enabled").length}`);
+        customElements.define("cache-enabled-control", class extends HTMLElement {
+            static get formAssociated() { return true; }
+        });
+        println(`FACE :enabled count after define: ${host.querySelectorAll("cache-enabled-control:enabled").length}`);
+
+        const disabledCustomElement = document.createElement("cache-disabled-control");
+        disabledCustomElement.setAttribute("disabled", "");
+        host.appendChild(disabledCustomElement);
+        println(`FACE :disabled count before define: ${host.querySelectorAll("cache-disabled-control:disabled").length}`);
+        customElements.define("cache-disabled-control", class extends HTMLElement {
+            static get formAssociated() { return true; }
+        });
+        println(`FACE :disabled count after define: ${host.querySelectorAll("cache-disabled-control:disabled").length}`);
+
         // :checked tracks checkedness, which changes without any attribute mutation.
         const checkbox = document.createElement("input");
         checkbox.type = "checkbox";
@@ -124,5 +142,21 @@
         println(`querySelector agrees with querySelectorAll[0]: ${firstItem === host.querySelectorAll(".item")[0]}`);
         host.removeChild(firstItem);
         println(`querySelector after remove: ${host.querySelector(".item") === host.querySelectorAll(".item")[0]}`);
+
+        // Repeated identical queries with no intervening mutation return the same elements
+        // in fresh NodeList objects.
+        const repeatA = document.querySelectorAll("span.item");
+        const repeatB = document.querySelectorAll("span.item");
+        println(`repeated query returns distinct objects: ${repeatA !== repeatB}`);
+        let identical = repeatA.length > 0 && repeatA.length === repeatB.length;
+        for (let i = 0; i < repeatA.length; ++i)
+            identical = identical && repeatA[i] === repeatB[i];
+        println(`repeated query returns identical non-empty results: ${identical}`);
+        println(`querySelector agrees with repeated querySelectorAll[0]: ${document.querySelector("span.item") === repeatA[0]}`);
+
+        // Repeated queries with empty results stay empty.
+        const emptyA = document.querySelectorAll(".no-such-class");
+        const emptyB = document.querySelectorAll(".no-such-class");
+        println(`repeated empty query stays empty: ${emptyA.length === 0 && emptyB.length === 0}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/DOM/querySelectorAll-results-stay-fresh-across-mutations.html
+++ b/Tests/LibWeb/Text/input/DOM/querySelectorAll-results-stay-fresh-across-mutations.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="host"></div>
+<div id="list"></div>
+<div id="shadow-host"></div>
+<script>
+    test(() => {
+        const host = document.getElementById("host");
+
+        // Each call must return a fresh static NodeList object.
+        println(`same selector returns distinct NodeList objects: ${document.querySelectorAll("div") !== document.querySelectorAll("div")}`);
+
+        // Structural mutations are reflected in subsequent queries.
+        const first = document.createElement("span");
+        first.className = "item";
+        host.appendChild(first);
+        println(`.item count after append: ${host.querySelectorAll(".item").length}`);
+        const second = document.createElement("span");
+        second.className = "item";
+        host.appendChild(second);
+        println(`.item count after second append: ${host.querySelectorAll(".item").length}`);
+        host.removeChild(first);
+        println(`.item count after remove: ${host.querySelectorAll(".item").length}`);
+
+        // The same selector queried from different roots gives per-root results.
+        println(`.item count from document: ${document.querySelectorAll(".item").length}`);
+
+        // Class attribute changes are reflected.
+        second.classList.remove("item");
+        println(`.item count after classList.remove: ${host.querySelectorAll(".item").length}`);
+        second.classList.add("item");
+        println(`.item count after classList.add: ${host.querySelectorAll(".item").length}`);
+
+        // Id changes are reflected.
+        second.id = "needle";
+        println(`#needle count after id set: ${host.querySelectorAll("#needle").length}`);
+        second.removeAttribute("id");
+        println(`#needle count after id removed: ${host.querySelectorAll("#needle").length}`);
+
+        // Attribute changes are reflected.
+        second.setAttribute("data-k", "v");
+        println(`[data-k=v] count after setAttribute: ${host.querySelectorAll("[data-k=v]").length}`);
+        second.setAttribute("data-k", "w");
+        println(`[data-k=v] count after attribute value change: ${host.querySelectorAll("[data-k=v]").length}`);
+        second.removeAttribute("data-k");
+        println(`[data-k] count after removeAttribute: ${host.querySelectorAll("[data-k]").length}`);
+
+        // :disabled tracks the disabled attribute.
+        const button = document.createElement("button");
+        host.appendChild(button);
+        println(`:disabled count before: ${host.querySelectorAll(":disabled").length}`);
+        button.disabled = true;
+        println(`:disabled count after: ${host.querySelectorAll(":disabled").length}`);
+
+        // :checked tracks checkedness, which changes without any attribute mutation.
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        host.appendChild(checkbox);
+        println(`:checked count before: ${host.querySelectorAll(":checked").length}`);
+        checkbox.checked = true;
+        println(`:checked count after: ${host.querySelectorAll(":checked").length}`);
+        println(`:has(:checked) count after: ${document.querySelectorAll("div:has(:checked)").length}`);
+
+        // :empty tracks character data mutations that don't change the tree structure.
+        const emptyProbe = document.createElement("div");
+        const text = document.createTextNode("hello");
+        emptyProbe.appendChild(text);
+        host.appendChild(emptyProbe);
+        println(`div:empty count before: ${host.querySelectorAll("div:empty").length}`);
+        text.data = "";
+        println(`div:empty count after text.data = "": ${host.querySelectorAll("div:empty").length}`);
+        text.data = "hello again";
+        println(`div:empty count after text.data restored: ${host.querySelectorAll("div:empty").length}`);
+        emptyProbe.textContent = "";
+        println(`div:empty count after textContent = "": ${host.querySelectorAll("div:empty").length}`);
+
+        // Structural pseudo-classes see sibling reordering.
+        const list = document.getElementById("list");
+        list.innerHTML = "<i>one</i><i>two</i><i>three</i>";
+        println(`i:nth-child(2) before reorder: ${list.querySelectorAll("i:nth-child(2)")[0].textContent}`);
+        list.insertBefore(list.children[2], list.children[0]);
+        println(`i:nth-child(2) after reorder: ${list.querySelectorAll("i:nth-child(2)")[0].textContent}`);
+
+        // :scope queries see mutations too.
+        println(`:scope > .item count: ${host.querySelectorAll(":scope > .item").length}`);
+        const third = document.createElement("span");
+        third.className = "item";
+        host.appendChild(third);
+        println(`:scope > .item count after append: ${host.querySelectorAll(":scope > .item").length}`);
+
+        // Queries rooted at a disconnected node see mutations.
+        const disconnected = document.createElement("div");
+        disconnected.innerHTML = `<p class="x"></p>`;
+        println(`disconnected .x count: ${disconnected.querySelectorAll(".x").length}`);
+        const extra = document.createElement("p");
+        extra.className = "x";
+        disconnected.appendChild(extra);
+        println(`disconnected .x count after append: ${disconnected.querySelectorAll(".x").length}`);
+
+        // Queries rooted in a shadow tree see mutations inside it.
+        const shadowRoot = document.getElementById("shadow-host").attachShadow({ mode: "open" });
+        shadowRoot.innerHTML = `<p class="s"></p>`;
+        println(`shadow .s count: ${shadowRoot.querySelectorAll(".s").length}`);
+        const shadowExtra = document.createElement("p");
+        shadowExtra.className = "s";
+        shadowRoot.appendChild(shadowExtra);
+        println(`shadow .s count after append: ${shadowRoot.querySelectorAll(".s").length}`);
+
+        // A node adopted into another document, mutated there, and adopted back
+        // must not report stale results in its original document.
+        const otherDocument = document.implementation.createHTMLDocument("");
+        const traveler = document.createElement("div");
+        traveler.innerHTML = `<p class="y"></p>`;
+        println(`traveler .y count: ${traveler.querySelectorAll(".y").length}`);
+        otherDocument.adoptNode(traveler);
+        const foreignChild = otherDocument.createElement("p");
+        foreignChild.className = "y";
+        traveler.appendChild(foreignChild);
+        document.adoptNode(traveler);
+        println(`traveler .y count after adopt roundtrip: ${traveler.querySelectorAll(".y").length}`);
+
+        // querySelector agrees with querySelectorAll before and after mutations.
+        const firstItem = host.querySelector(".item");
+        println(`querySelector agrees with querySelectorAll[0]: ${firstItem === host.querySelectorAll(".item")[0]}`);
+        host.removeChild(firstItem);
+        println(`querySelector after remove: ${host.querySelector(".item") === host.querySelectorAll(".item")[0]}`);
+    });
+</script>


### PR DESCRIPTION
Add a per-document cache for `querySelectorAll` and `querySelector` results when a selector is known to depend only on DOM tree state, attributes, character data, and the query root. Entries are validated lazily against `dom_tree_version`, and against `character_data_version` for selectors involving `:empty`.

Selectors with stateful or externally driven pseudo-classes keep using the live path. The pseudo-class allowlist is intentionally narrow, so selectors such as `:hover`, `:checked`, `:target`, `:enabled`, and `:disabled` are not cached.

This also moves selector query execution into a `SelectorQuery` object and adds freshness coverage for structural mutations, attribute mutations, character data, quirks mode changes, adoption, `querySelector` reuse, and form-associated custom element upgrades.

This dramatically improves performance when viewing GitHub actions logs, among other things. :^)