### PR TITLE
LibWeb: Protect the unload-check callback against a destroyed navigable

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -2574,6 +2574,12 @@ void LocalNavigable::begin_navigation(NavigateParams params)
         // 1. Let unloadPromptCanceled be the result of checking if unloading is user-canceled for navigable's active document's inclusive descendant navigables.
         traversable_navigable()->check_if_unloading_is_canceled(this->active_document()->inclusive_descendant_navigables(),
             GC::create_function(heap(), [this, source_snapshot_params, target_snapshot_params, csp_navigation_type, document_resource, url, navigation_id, referrer_policy, initiator_origin_snapshot, response, history_handling, initiator_base_url_snapshot, user_involvement, params = move(params)](LocalTraversableNavigable::CheckIfUnloadingIsCanceledResult unload_prompt_canceled) mutable {
+                // AD-HOC: Not in the spec but we should not navigate a navigable that has been destroyed.
+                if (has_been_destroyed()) {
+                    set_delaying_load_events(false);
+                    return;
+                }
+
                 // 2. If unloadPromptCanceled is not "continue", or navigable's ongoing navigation is no longer navigationId:
                 if (unload_prompt_canceled != LocalTraversableNavigable::CheckIfUnloadingIsCanceledResult::Continue) {
                     // FIXME: 1. Invoke WebDriver BiDi navigation failed with navigable and a new WebDriver BiDi navigation status whose id is navigationId, status is "canceled", and url is url.

--- a/Tests/LibWeb/Crash/HTML/navigate-then-remove-iframe-during-unload-check.html
+++ b/Tests/LibWeb/Crash/HTML/navigate-then-remove-iframe-during-unload-check.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!-- Navigating an iframe runs the async "checking if unloading is user-canceled" step of its navigation. Removing the
+     iframe before that step's callback runs destroys the iframe's navigable — clearing its active document, window, and
+     browsing context. The callback must not dereference that destroyed navigable. -->
+<html class="test-wait">
+<body>
+<script>
+    const iframe = document.createElement("iframe");
+    iframe.src = "../../Assets/blank.html";
+    let navigated = false;
+    iframe.onload = () => {
+        if (navigated)
+            return;
+        navigated = true;
+
+        // Start a navigation (begin_navigation -> check if unloading is canceled, asynchronous)...
+        iframe.src = "../../Assets/blank.html?2";
+        // ...then destroy the navigable before the callback fires.
+        iframe.remove();
+
+        setTimeout(() => document.documentElement.classList.remove("test-wait"), 500);
+    };
+    document.body.appendChild(iframe);
+</script>
+</body>
+</html>


### PR DESCRIPTION
**Problem:** Crash when loading the w3schools site.

**Cause:** Our callback for “checking if unloading is user-canceled” was navigating a navigable that had already been destroyed.

**Fix:** Check `has_been_destroyed()` in our “checking if unloading is user-canceled” callback — as we already do in other parts of the same code. Fixes: https://github.com/LadybirdBrowser/ladybird/issues/10384.
