### PR TITLE
LibWeb: Populate ancestor state in min-height layout

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1095,13 +1095,14 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         // min-height. If so, we run layout with min-height as the available height.
         if (should_treat_height_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
             LayoutState throwaway_state(box);
-            // Populate the entire containing block chain: the throwaway BFC may encounter abspos
-            // elements whose containing block is an ancestor above `box`. We stop when the source
-            // state lacks an entry, which happens when it is itself a nested throwaway state.
-            for (auto cb = box.containing_block(); cb; cb = cb->containing_block()) {
-                if (!m_state.try_get(*cb))
-                    break;
-                throwaway_state.populate_node_from(m_state, *cb);
+            // Populate ancestor state: the throwaway BFC may encounter abspos
+            // elements whose containing block is an ancestor above `box`, even if
+            // it is not in `box`'s containing block chain.
+            for (auto* ancestor = box.parent(); ancestor; ancestor = ancestor->parent()) {
+                auto* ancestor_box = as_if<Box>(*ancestor);
+                if (!ancestor_box || !m_state.try_get(*ancestor_box))
+                    continue;
+                throwaway_state.populate_node_from(m_state, *ancestor_box);
             }
 
             throwaway_state.create(box, layout_input.containing_block_constraints.percentage_basis_width, layout_input.containing_block_constraints.percentage_basis_height);

--- a/Tests/LibWeb/Crash/Layout/abspos-in-min-height-throwaway-layout.html
+++ b/Tests/LibWeb/Crash/Layout/abspos-in-min-height-throwaway-layout.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!-- This exercises the min-height measurement throwaway layout path. The abspos
+     containing block is the positioned table row, which is outside the measured
+     flex subtree and not in that flex container's containing block chain. -->
+<style>
+    #table {
+        display: table;
+    }
+
+    #positioned-row {
+        display: table-row;
+        position: relative;
+    }
+
+    #cell {
+        display: table-cell;
+    }
+
+    #measured-flex {
+        display: flex;
+        min-height: 1px;
+    }
+
+    #grid {
+        display: grid;
+    }
+
+    #flex {
+        display: flex;
+    }
+
+    #abspos {
+        position: absolute;
+    }
+</style>
+<div id="table">
+    <div id="positioned-row">
+        <div id="cell">
+            <div id="measured-flex">
+                <div id="grid">
+                    <div id="flex">
+                        <div id="abspos"></div>
+                        <div>content</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    document.body.offsetHeight;
+</script>


### PR DESCRIPTION
Min-height measurement uses a throwaway layout state for independent formatting contexts. That state copied the measured box's containing block chain, but an absolutely positioned descendant can be contained by an ancestor that is not in that chain, such as a positioned table row.

Copy available ancestor box state into the throwaway state so flex and grid static-position layout can create used values for those descendants without leaving the subtree. Add a crash test for a positioned table row outside the measured flex subtree.