### PR TITLE
LibWeb: Don't skip positioned ancestors when computing `offsetParent()`

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -542,6 +542,11 @@ GC::Ptr<DOM::Element> HTMLElement::offset_parent() const
     if (layout_node()->is_fixed_position() && no_ancestor_establishes_a_fixed_position_containing_block)
         return nullptr;
 
+    // NB: The spec does not define "the element is in a fixed position containing block".  Other engines treat it as
+    //     holding only when the element itself is fixed-positioned. We also set it to true for the remainder of the
+    //     walk once a fixed-positioned ancestor is crossed.
+    auto element_is_in_a_fixed_position_containing_block = layout_node()->is_fixed_position();
+
     // 2. Let ancestor be the parent of the element in the flat tree and repeat these substeps:
     auto ancestor = first_flat_tree_ancestor_of_type<DOM::Element>();
     while (true) {
@@ -549,8 +554,10 @@ GC::Ptr<DOM::Element> HTMLElement::offset_parent() const
         //    fixed, and no ancestor establishes a fixed position containing block, terminate this algorithm and return
         //    null.
         bool ancestor_is_closed_shadow_hidden = ancestor->is_closed_shadow_hidden_from(*this);
+        bool ancestor_is_fixed_position = ancestor->computed_properties()->position() == CSS::Positioning::Fixed;
+        auto const* ancestor_layout_node = ancestor->layout_node();
         if (ancestor_is_closed_shadow_hidden
-            && ancestor->computed_properties()->position() == CSS::Positioning::Fixed
+            && ancestor_is_fixed_position
             && no_ancestor_establishes_a_fixed_position_containing_block)
             return nullptr;
 
@@ -561,15 +568,18 @@ GC::Ptr<DOM::Element> HTMLElement::offset_parent() const
             //     Such ancestors can't be positioned or establish containing blocks, so we skip those checks.
             // - The element is in a fixed position containing block, and ancestor is a containing block for
             //   fixed-positioned descendants.
-            // FIXME: This is ambiguous but I believe it means any ancestor establishes a fixed position containing block.
-            //        https://github.com/w3c/csswg-drafts/pull/12531/commits/48e905bb3859f80ce822299f7e6b76515d867fc3#r2623785087
-            if (!no_ancestor_establishes_a_fixed_position_containing_block && ancestor->layout_node() && ancestor->layout_node()->establishes_a_fixed_positioning_containing_block())
-                return const_cast<Element*>(ancestor);
+            if (element_is_in_a_fixed_position_containing_block) {
+                if (ancestor_layout_node && ancestor_layout_node->establishes_a_fixed_positioning_containing_block())
+                    return const_cast<Element*>(ancestor);
+            }
             // - The element is not in a fixed position containing block, and:
-            if (no_ancestor_establishes_a_fixed_position_containing_block) {
+            else {
                 // - ancestor is a containing block of absolutely-positioned descendants (regardless of whether there
                 //   are any absolutely-positioned descendants).
-                if (ancestor->layout_node() && ancestor->layout_node()->is_positioned())
+                // NB: is_positioned() covers positioned inline ancestors, which
+                //     establishes_an_absolute_positioning_containing_block() excludes because they do not generate a
+                //     box.
+                if (ancestor_layout_node && (ancestor_layout_node->is_positioned() || ancestor_layout_node->establishes_an_absolute_positioning_containing_block()))
                     return const_cast<Element*>(ancestor);
                 // - It is the body element.
                 if (ancestor->is_html_body_element())
@@ -581,6 +591,9 @@ GC::Ptr<DOM::Element> HTMLElement::offset_parent() const
             }
             // - FIXME: The element has a different effective zoom than ancestor.
         }
+
+        if (ancestor_layout_node && ancestor_layout_node->is_fixed_position())
+            element_is_in_a_fixed_position_containing_block = true;
 
         // 3. If there is no more parent of ancestor in the flat tree, terminate this algorithm and return null.
         auto parent_of_ancestor = ancestor->first_flat_tree_ancestor_of_type<DOM::Element>();

--- a/Tests/LibWeb/Text/expected/HTML/HTMLElement-offsetParent-inside-fixed-position-containing-block.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLElement-offsetParent-inside-fixed-position-containing-block.txt
@@ -1,0 +1,28 @@
+child-of-relative-parent:
+  offsetParent: relative-parent-in-backdrop-filter
+  offsetLeft: 10
+  offsetTop: 0
+static-child-in-transform:
+  offsetParent: relative-parent-in-transform
+  offsetLeft: 0
+  offsetTop: 0
+fixed-child-in-transform:
+  offsetParent: transform-ancestor
+  offsetLeft: 30
+  offsetTop: 20
+static-child-of-transform:
+  offsetParent: transform-ancestor
+  offsetLeft: 0
+  offsetTop: 50
+fixed-without-fixed-position-containing-block:
+  offsetParent: null
+  offsetLeft: 5
+  offsetTop: 40
+child-of-boxless-fixed-ancestor:
+  offsetParent: BODY
+  offsetLeft: 0
+  offsetTop: 150
+child-of-boxless-fixed-in-relative-parent:
+  offsetParent: relative-parent-of-boxless-fixed
+  offsetLeft: 0
+  offsetTop: 0

--- a/Tests/LibWeb/Text/input/HTML/HTMLElement-offsetParent-inside-fixed-position-containing-block.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLElement-offsetParent-inside-fixed-position-containing-block.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<style>
+* {
+    margin: 0;
+    padding: 0;
+}
+div {
+    width: 50px;
+    height: 50px;
+}
+</style>
+<div id="backdrop-filter-ancestor" style="backdrop-filter: blur(2px); padding: 25px">
+    <div id="relative-parent-in-backdrop-filter" style="position: relative; margin-left: 75px">
+        <div id="child-of-relative-parent" style="margin-left: 10px"></div>
+    </div>
+</div>
+<div id="transform-ancestor" style="transform: translateX(10px)">
+    <div id="relative-parent-in-transform" style="position: relative">
+        <div id="static-child-in-transform"></div>
+        <div id="fixed-child-in-transform" style="position: fixed; top: 20px; left: 30px"></div>
+    </div>
+    <div id="static-child-of-transform"></div>
+</div>
+<div id="fixed-without-fixed-position-containing-block" style="position: fixed; top: 40px; left: 5px"></div>
+<div style="display: contents; position: fixed">
+    <div id="child-of-boxless-fixed-ancestor"></div>
+</div>
+<div id="relative-parent-of-boxless-fixed" style="position: relative">
+    <div style="display: contents; position: fixed">
+        <div id="child-of-boxless-fixed-in-relative-parent"></div>
+    </div>
+</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        for (const id of [
+            "child-of-relative-parent",
+            "static-child-in-transform",
+            "fixed-child-in-transform",
+            "static-child-of-transform",
+            "fixed-without-fixed-position-containing-block",
+            "child-of-boxless-fixed-ancestor",
+            "child-of-boxless-fixed-in-relative-parent",
+        ]) {
+            const element = document.getElementById(id);
+            const offsetParent = element.offsetParent;
+            println(`${id}:`);
+            println(`  offsetParent: ${offsetParent ? offsetParent.id || offsetParent.nodeName : "null"}`);
+            println(`  offsetLeft: ${element.offsetLeft}`);
+            println(`  offsetTop: ${element.offsetTop}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Previously, if any ancestor established a fixed positioning containing block, offsetParent returned the nearest such ancestor for every element, skipping nearer positioned ancestors.

We now interpret "the element is in a fixed position containing block" as other engines do: only fixed-positioned elements search for a fixed positioning containing block, while all other elements stop at the nearest ancestor that is a containing block for absolutely positioned descendants.

Fixes the "Classic" vs "AI Search" selector background on https://rightmove.co.uk:

Before:

<img width="764" height="198" alt="image" src="https://github.com/user-attachments/assets/375a66fe-7e8c-4987-8609-60b7089233d6" />

After:

<img width="764" height="198" alt="image" src="https://github.com/user-attachments/assets/0374f30e-faa1-44eb-91dd-a4302cc58dc3" />