### PR TITLE
LibWeb: Derive button content-box height from the button's used height

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1094,21 +1094,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         // For boxes with auto height but non-auto min-height, we need to determine if the content height is less than
         // min-height. If so, we run layout with min-height as the available height.
         if (should_treat_height_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
-            LayoutState throwaway_state(box);
-            // Populate ancestor state: the throwaway BFC may encounter abspos
-            // elements whose containing block is an ancestor above `box`, even if
-            // it is not in `box`'s containing block chain.
-            for (auto* ancestor = box.parent(); ancestor; ancestor = ancestor->parent()) {
-                auto* ancestor_box = as_if<Box>(*ancestor);
-                if (!ancestor_box || !m_state.try_get(*ancestor_box))
-                    continue;
-                throwaway_state.populate_node_from(m_state, *ancestor_box);
-            }
-
-            throwaway_state.create(box, layout_input.containing_block_constraints.percentage_basis_width, layout_input.containing_block_constraints.percentage_basis_height);
-            auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
-            measuring_context->run(layout_input.with_available_space(inner_available_space));
-            auto content_height = measuring_context->automatic_content_height();
+            auto content_height = measure_automatic_content_height(box, inner_available_space, layout_input.containing_block_constraints);
             auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
             if (content_height < min_height) {
                 inner_available_space.height = AvailableSize::make_definite(min_height);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1093,13 +1093,17 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
         // For boxes with auto height but non-auto min-height, we need to determine if the content height is less than
         // min-height. If so, we run layout with min-height as the available height.
+        Optional<CSSPixels> measured_content_height;
         if (should_treat_height_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
             auto content_height = measure_automatic_content_height(box, inner_available_space, layout_input.containing_block_constraints);
+            measured_content_height = content_height;
             auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
             if (content_height < min_height) {
                 inner_available_space.height = AvailableSize::make_definite(min_height);
             }
         }
+
+        make_button_content_box_definite(box, available_space, layout_input.containing_block_constraints, measured_content_height);
 
         independent_formatting_context->run(layout_input.with_available_space(inner_available_space));
         if (is<TableWrapper>(block_container) && box.display().is_table_inside()) {

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -612,6 +612,23 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
     return max(CSSPixels(0.0f), bottom.value_or(0) - top.value_or(0));
 }
 
+CSSPixels FormattingContext::measure_automatic_content_height(Box const& box, AvailableSpace const& inner_available_space, ContainingBlockConstraints const& containing_block_constraints)
+{
+    LayoutState throwaway_state(box);
+    // Populate ancestor state: the throwaway formatting context may encounter abspos elements whose
+    // containing block is an ancestor above `box`, even if it is not in `box`'s containing block chain.
+    for (auto* ancestor = box.parent(); ancestor; ancestor = ancestor->parent()) {
+        auto* ancestor_box = as_if<Box>(*ancestor);
+        if (!ancestor_box || !m_state.try_get(*ancestor_box))
+            continue;
+        throwaway_state.populate_node_from(m_state, *ancestor_box);
+    }
+    throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
+    auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
+    measuring_context->run(LayoutInput { inner_available_space, containing_block_constraints });
+    return measuring_context->automatic_content_height();
+}
+
 // 17.5.2 Table width algorithms: the 'table-layout' property
 // https://www.w3.org/TR/CSS22/tables.html#width-layout
 CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
@@ -627,6 +628,51 @@ CSSPixels FormattingContext::measure_automatic_content_height(Box const& box, Av
     auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
     measuring_context->run(LayoutInput { inner_available_space, containing_block_constraints });
     return measuring_context->automatic_content_height();
+}
+
+void FormattingContext::make_button_content_box_definite(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, Optional<CSSPixels> measured_content_height)
+{
+    auto const* html_element = as_if<HTML::HTMLElement>(box.dom_node());
+    if (!html_element || !html_element->uses_button_layout())
+        return;
+
+    // Flex/grid-inside buttons are their own flex/grid container and get no anonymous content wrapper,
+    // so there is nothing to make definite for centering.
+    auto display = box.display();
+    if (display.is_flex_inside() || display.is_grid_inside())
+        return;
+
+    auto const& computed_values = box.computed_values();
+
+    // With auto height and no min-height the content box already exactly wraps the content, so there is
+    // no extra space to center within and no need to force a definite content box.
+    if (computed_values.height().is_auto() && computed_values.min_height().is_auto())
+        return;
+
+    auto& box_state = m_state.get_mutable(box);
+    if (box_state.has_definite_height())
+        return;
+
+    auto natural_content_height = measured_content_height.value_or_lazy_evaluated([&] {
+        return measure_automatic_content_height(box, box_state.available_inner_space_or_constraints_from(available_space), containing_block_constraints);
+    });
+
+    auto used_height = should_treat_height_as_auto(box, available_space, containing_block_constraints)
+        ? natural_content_height
+        : calculate_inner_height(box, available_space, computed_values.height(), containing_block_constraints);
+    if (!should_treat_max_height_as_none(box, available_space.height, containing_block_constraints) && !computed_values.max_height().is_auto())
+        used_height = min(used_height, calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints));
+    if (!computed_values.min_height().is_auto())
+        used_height = max(used_height, calculate_inner_height(box, available_space, computed_values.min_height(), containing_block_constraints));
+
+    // Only force a definite content box when the button is taller than its content, so a min-height or a larger height
+    // has room to center within. A content-sized box stays indefinite, so an intrinsic keyword height does not resolve
+    // percentage-height descendants.
+    if (used_height <= natural_content_height)
+        return;
+
+    box_state.set_content_height(used_height);
+    box_state.set_has_definite_height(true);
 }
 
 // 17.5.2 Table width algorithms: the 'table-layout' property
@@ -2018,6 +2064,8 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
         if ((!computed_values.height().is_auto() && computed_height_establishes_definite_containing_block_height(computed_values.height())) || height_resolved_from_aspect_ratio)
             box_state.set_has_definite_height(true);
     }
+
+    make_button_content_box_definite(box, available_space, absolutely_positioned_constraints);
 
     auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, LayoutInput { box_state.available_inner_space_or_constraints_from(available_space), absolutely_positioned_constraints });
 

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -212,6 +212,8 @@ protected:
     CSSPixels compute_auto_height_for_block_formatting_context_root(Box const&) const;
     static CSSPixels line_box_physical_width(Box const&, LineBox const&);
 
+    CSSPixels measure_automatic_content_height(Box const&, AvailableSpace const& inner_available_space, ContainingBlockConstraints const&);
+
     [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
     ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&, ContainingBlockConstraints const&);

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -213,6 +213,7 @@ protected:
     static CSSPixels line_box_physical_width(Box const&, LineBox const&);
 
     CSSPixels measure_automatic_content_height(Box const&, AvailableSpace const& inner_available_space, ContainingBlockConstraints const&);
+    void make_button_content_box_definite(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, Optional<CSSPixels> measured_content_height = {});
 
     [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -178,6 +178,8 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     if (box.display().is_flex_inside())
         parent().resolve_used_height_if_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
 
+    make_button_content_box_definite(box, *m_available_space, box_constraints);
+
     auto child_layout_input = m_layout_input->with_available_space(box_state.available_inner_space_or_constraints_from(*m_available_space));
     auto independent_formatting_context = layout_inside(box, layout_mode, child_layout_input);
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1263,7 +1263,6 @@ void TreeBuilder::wrap_in_button_layout_tree_if_needed(DOM::Node& dom_node, Layo
         flex_computed_values.set_justify_content(CSS::JustifyContent::Center);
         flex_computed_values.set_flex_direction(CSS::FlexDirection::Column);
         flex_computed_values.set_height(CSS::Size::make_percentage(CSS::Percentage(100)));
-        flex_computed_values.set_min_height(parent.computed_values().min_height());
 
         auto content_box_wrapper = parent.create_anonymous_wrapper();
         auto& content_computed_values = content_box_wrapper->mutable_computed_values();

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-min-height-box-sizing.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-min-height-box-sizing.txt
@@ -1,0 +1,88 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 246 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 230 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 50 0+0+0] children: inline
+        InlineNode <span.inline> at [18,18] [0+0+0 6.0625 0+0+0] [0+0+0 30 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [18,18 6.0625x30] baseline: 28
+          BlockContainer <button> at [18,18] inline-block [0+5+5 6.0625 5+5+0] [0+5+5 30 5+5+0] [BFC] children: not-inline
+            BlockContainer <(anonymous)> at [18,18] flex-container(column) [0+0+0 6.0625 0+0+0] [0+0+0 30 0+0+0] [FFC] children: not-inline
+              BlockContainer <(anonymous)> at [18,28] flex-item [0+0+0 6.0625 0+0+0] [0+0+0 10 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [18,28 6.0625x10] baseline: 8
+                    "x"
+                TextNode <#text> (not painted)
+      BlockContainer <div.block> at [8,58] [0+0+0 784 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+        BlockContainer <button> at [18,68] [0+5+5 6.0625 5+5+757.9375] [0+5+5 30 5+5+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> at [18,68] flex-container(column) [0+0+0 6.0625 0+0+0] [0+0+0 30 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> at [18,78] flex-item [0+0+0 6.0625 0+0+0] [0+0+0 10 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [18,78 6.0625x10] baseline: 8
+                  "x"
+              TextNode <#text> (not painted)
+      Box <div.flex> at [8,108] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 50 0+0+0] [FFC] children: not-inline
+        BlockContainer <button> at [18,118] flex-item [0+5+5 6.0625 5+5+0] [0+5+5 30 5+5+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> at [18,118] flex-container(column) [0+0+0 6.0625 0+0+0] [0+0+0 30 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> at [18,128] flex-item [0+0+0 6.0625 0+0+0] [0+0+0 10 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [18,128 6.0625x10] baseline: 8
+                  "x"
+              TextNode <#text> (not painted)
+      BlockContainer <div.intrinsic> at [8,158] [0+0+0 784 0+0+0] [0+0+0 50 0+0+0] children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [18,168 6.0625x30] baseline: 28
+        BlockContainer <button> at [18,168] inline-block [0+5+5 6.0625 5+5+0] [0+5+5 30 5+5+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> at [18,168] flex-container(column) [0+0+0 6.0625 0+0+0] [0+0+0 30 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> at [18,178] flex-item [0+0+0 6.0625 0+0+0] [0+0+0 10 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [18,178 6.0625x10] baseline: 8
+                  "x"
+              TextNode <#text> (not painted)
+      BlockContainer <div.abs> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+        BlockContainer <button> at [18,260] positioned [0+5+5 6.0625 5+5+0] [0+5+5 30 5+5+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> at [18,260] flex-container(column) [0+0+0 6.0625 0+0+0] [0+0+0 30 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> at [18,270] flex-item [0+0+0 6.0625 0+0+0] [0+0+0 10 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [18,270 6.0625x10] baseline: 8
+                  "x"
+              TextNode <#text> (not painted)
+      BlockContainer <div.indefinite> at [8,208] [0+0+0 784 0+0+0] [0+0+0 30 0+0+0] children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [18,218 6.0625x10] baseline: 18
+        BlockContainer <button> at [18,218] inline-block [0+5+5 6.0625 5+5+0] [0+5+5 10 5+5+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> at [18,218] flex-container(column) [0+0+0 6.0625 0+0+0] [0+0+0 10 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> at [18,218] flex-item [0+0+0 6.0625 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+              BlockContainer <div.pct> at [18,218] [0+0+0 6.0625 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+              BlockContainer <div> at [18,218] [0+0+0 6.0625 0+0+0] [0+0+0 10 0+0+0] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [18,218 6.0625x10] baseline: 8
+                    "x"
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,238] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x246]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x230]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x50]
+        PaintableWithLines (InlineNode<SPAN>.inline) [18,18 6.0625x30]
+          PaintableWithLines (BlockContainer<BUTTON>) [8,8 26.0625x50]
+            PaintableWithLines (BlockContainer(anonymous)) [18,18 6.0625x30]
+              PaintableWithLines (BlockContainer(anonymous)) [18,28 6.0625x10]
+      PaintableWithLines (BlockContainer<DIV>.block) [8,58 784x50]
+        PaintableWithLines (BlockContainer<BUTTON>) [8,58 26.0625x50]
+          PaintableWithLines (BlockContainer(anonymous)) [18,68 6.0625x30]
+            PaintableWithLines (BlockContainer(anonymous)) [18,78 6.0625x10]
+      PaintableBox (Box<DIV>.flex) [8,108 784x50]
+        PaintableWithLines (BlockContainer<BUTTON>) [8,108 26.0625x50]
+          PaintableWithLines (BlockContainer(anonymous)) [18,118 6.0625x30]
+            PaintableWithLines (BlockContainer(anonymous)) [18,128 6.0625x10]
+      PaintableWithLines (BlockContainer<DIV>.intrinsic) [8,158 784x50]
+        PaintableWithLines (BlockContainer<BUTTON>) [8,158 26.0625x50]
+          PaintableWithLines (BlockContainer(anonymous)) [18,168 6.0625x30]
+            PaintableWithLines (BlockContainer(anonymous)) [18,178 6.0625x10]
+      PaintableWithLines (BlockContainer<DIV>.abs) [8,208 784x0]
+        PaintableWithLines (BlockContainer<BUTTON>) [8,250 26.0625x50]
+          PaintableWithLines (BlockContainer(anonymous)) [18,260 6.0625x30]
+            PaintableWithLines (BlockContainer(anonymous)) [18,270 6.0625x10]
+      PaintableWithLines (BlockContainer<DIV>.indefinite) [8,208 784x30]
+        PaintableWithLines (BlockContainer<BUTTON>) [8,208 26.0625x30]
+          PaintableWithLines (BlockContainer(anonymous)) [18,218 6.0625x10]
+            PaintableWithLines (BlockContainer(anonymous)) [18,218 6.0625x10]
+              PaintableWithLines (BlockContainer<DIV>.pct) [18,218 6.0625x0]
+              PaintableWithLines (BlockContainer<DIV>) [18,218 6.0625x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,238 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x246] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-min-height.txt
@@ -1,21 +1,21 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 120 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 104 0+0+8] children: inline
-      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 143.515625x100] baseline: 56.796875
-      BlockContainer <button> at [13,10] inline-block [0+1+4 143.515625 4+1+0] [0+1+1 100 1+1+0] [BFC] children: not-inline
-        BlockContainer <(anonymous)> at [13,10] flex-container(column) [0+0+0 143.515625 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
-          BlockContainer <(anonymous)> at [13,51] flex-item [0+0+0 143.515625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 19, rect: [13,51 143.515625x18] baseline: 13.796875
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 143.515625x96] baseline: 54.796875
+      BlockContainer <button> at [13,10] inline-block [0+1+4 143.515625 4+1+0] [0+1+1 96 1+1+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [13,10] flex-container(column) [0+0+0 143.515625 0+0+0] [0+0+0 96 0+0+0] [FFC] children: not-inline
+          BlockContainer <(anonymous)> at [13,49] flex-item [0+0+0 143.515625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 19, rect: [13,49 143.515625x18] baseline: 13.796875
                 "Middle-aligned text"
             TextNode <#text> (not painted)
       TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x120]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
-      PaintableWithLines (BlockContainer<BUTTON>) [8,8 153.515625x104]
-        PaintableWithLines (BlockContainer(anonymous)) [13,10 143.515625x100]
-          PaintableWithLines (BlockContainer(anonymous)) [13,51 143.515625x18]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<BUTTON>) [8,8 153.515625x100]
+        PaintableWithLines (BlockContainer(anonymous)) [13,10 143.515625x96]
+          PaintableWithLines (BlockContainer(anonymous)) [13,49 143.515625x18]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x120] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/button-min-height-box-sizing.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/button-min-height-box-sizing.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html><style>
+    button {
+        box-sizing: border-box;
+        min-height: 50px;
+        padding: 5px;
+        border: 5px solid black;
+        font: 10px / 10px SerenitySans;
+    }
+    .flex { display: flex; align-items: flex-start; }
+    .block button { display: block; }
+    .intrinsic button { height: fit-content; }
+    .abs button { position: absolute; top: 250px; }
+    .indefinite button { min-height: auto; height: fit-content; }
+    .indefinite .pct { height: 100%; }
+</style>
+<body
+    ><span class="inline"><button>x</button></span
+    ><div class="block"><button>x</button></div
+    ><div class="flex"><button>x</button></div
+    ><div class="intrinsic"><button>x</button></div
+    ><div class="abs"><button>x</button></div
+    ><div class="indefinite"><button><div class="pct"></div><div>x</div></button></div
+></body>


### PR DESCRIPTION
Previously, the flex box that fills and centers a button's contents copied the button's min-height, but has no padding or border of its own. A border-box button therefore counted its padding and border twice and rendered too tall, and buttons with an intrinsic height did not center their contents.

We now size the content box from the button's used height instead, so the wrapper can resolve its percentage height and center the contents.

Fixes the height of buttons on https://pintrest.com:

Before:

<img width="1143" height="623" alt="image" src="https://github.com/user-attachments/assets/f0fb6b41-e28d-429e-ba07-d2a20264e252" />


After:

<img width="1143" height="623" alt="image" src="https://github.com/user-attachments/assets/c83b335e-0ef0-47f0-b594-081aa5be772c" />

