### PR TITLE
LibWeb: Handle cyclic percentage intrinsic sizing for replaced boxes

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -506,16 +506,15 @@ CSSPixels FlexFormattingContext::specified_main_max_size_for_intrinsic_contribut
     if (should_treat_main_max_size_as_none(item.box))
         return CSSPixels::max();
 
-    if (computed_max_size.contains_percentage()) {
-        // If the box is replaced, a cyclic percentage in the value of any max size property is resolved against
-        // zero when calculating the min-content contribution in the corresponding axis.
-        if (item.box.is_replaced_box() && available_size.is_min_content())
-            return 0;
-
+    switch (cyclic_percentage_intrinsic_contribution(item.box, computed_max_size, available_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+    case CyclicPercentageIntrinsicContribution::ResolveAsZero:
+        return 0;
+    case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
         return CSSPixels::max();
+    case CyclicPercentageIntrinsicContribution::NotCyclic:
+        return specified_main_max_size(item);
     }
-
-    return specified_main_max_size(item);
+    VERIFY_NOT_REACHED();
 }
 
 void FlexFormattingContext::set_has_definite_main_size(FlexItem& item)

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -819,7 +819,17 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     // depend on the replaced element's width, then the used value of 'width' is calculated from the constraint equation used for block-level,
     // non-replaced elements in normal flow.
     if (computed_height.is_auto() && computed_width.is_auto() && !intrinsic.has_width() && !intrinsic.has_height() && box.has_preferred_aspect_ratio()) {
-        return calculate_stretch_fit_width(box, available_space.width);
+        if (!available_space.width.is_intrinsic_sizing_constraint())
+            return calculate_stretch_fit_width(box, available_space.width);
+
+        switch (cyclic_percentage_intrinsic_contribution(box, box.computed_values().width(), available_space.width, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+        case CyclicPercentageIntrinsicContribution::ResolveAsZero:
+            return 0;
+        case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
+            break;
+        case CyclicPercentageIntrinsicContribution::NotCyclic:
+            return calculate_stretch_fit_width(box, available_space.width);
+        }
     }
 
     // Otherwise, if 'width' has a computed value of 'auto', and the element has an intrinsic width, then that intrinsic width is the used value of 'width'.

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2624,10 +2624,14 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
 
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
     if (computed_width.contains_percentage()) {
-        if (!box.is_replaced_box() && available_space.width.is_min_content())
+        switch (cyclic_percentage_intrinsic_contribution(box, computed_width, available_space.width, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+        case CyclicPercentageIntrinsicContribution::ResolveAsZero:
+            return false;
+        case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
             return true;
-        if (available_space.width.is_max_content())
-            return true;
+        case CyclicPercentageIntrinsicContribution::NotCyclic:
+            break;
+        }
         if (available_space.width.is_indefinite())
             return true;
     }
@@ -2655,10 +2659,14 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
 
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
     if (computed_height.contains_percentage()) {
-        if (!box.is_replaced_box() && available_space.height.is_min_content())
+        switch (cyclic_percentage_intrinsic_contribution(box, computed_height, available_space.height, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+        case CyclicPercentageIntrinsicContribution::ResolveAsZero:
+            return false;
+        case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
             return true;
-        if (available_space.height.is_max_content())
-            return true;
+        case CyclicPercentageIntrinsicContribution::NotCyclic:
+            break;
+        }
         // https://www.w3.org/TR/CSS22/visudet.html#the-height-property
         // If the height of the containing block is not specified explicitly (i.e., it depends on
         // content height), and this element is not absolutely positioned, the percentage value
@@ -2920,12 +2928,13 @@ bool FormattingContext::should_treat_max_width_as_none(Box const& box, Available
         return true;
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
     if (max_width.contains_percentage()) {
-        if (available_width.is_max_content())
-            return true;
-        if (available_width.is_min_content()) {
-            if (!box.is_replaced_box())
-                return true;
+        switch (cyclic_percentage_intrinsic_contribution(box, max_width, available_width, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+        case CyclicPercentageIntrinsicContribution::ResolveAsZero:
             return false;
+        case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
+            return true;
+        case CyclicPercentageIntrinsicContribution::NotCyclic:
+            break;
         }
         if (!containing_block_constraints.percentage_basis_width.has_value())
             return true;
@@ -2961,6 +2970,24 @@ bool FormattingContext::should_treat_max_height_as_none(Box const& box, Availabl
     if (max_height.is_min_content() && available_height.is_min_content())
         return true;
     return false;
+}
+
+FormattingContext::CyclicPercentageIntrinsicContribution FormattingContext::cyclic_percentage_intrinsic_contribution(Box const& box, CSS::Size const& size, AvailableSize const& available_size, CyclicPercentageSizeProperty size_property) const
+{
+    if (!size.contains_percentage())
+        return CyclicPercentageIntrinsicContribution::NotCyclic;
+
+    // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
+    if (available_size.is_min_content()) {
+        if (size_property == CyclicPercentageSizeProperty::PreferredOrMaxSize && box.is_replaced_box())
+            return CyclicPercentageIntrinsicContribution::ResolveAsZero;
+        return CyclicPercentageIntrinsicContribution::TreatAsInitialValue;
+    }
+
+    if (available_size.is_max_content())
+        return CyclicPercentageIntrinsicContribution::TreatAsInitialValue;
+
+    return CyclicPercentageIntrinsicContribution::NotCyclic;
 }
 
 CSSPixels FormattingContext::gap_to_px(Variant<CSS::LengthPercentage, CSS::NormalGap> const& gap, CSSPixels reference_value) const

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -195,6 +195,20 @@ protected:
 
     [[nodiscard]] bool box_is_sized_as_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
+    enum class CyclicPercentageIntrinsicContribution {
+        NotCyclic,
+        ResolveAsZero,
+        TreatAsInitialValue,
+    };
+    // CSS Sizing resolves cyclic percentages differently for minimum sizes than for preferred/max sizes.
+    // In particular, replaced boxes resolve cyclic preferred/max sizes against zero for min-content
+    // contributions, while cyclic min sizes are treated as their initial value.
+    enum class CyclicPercentageSizeProperty {
+        PreferredOrMaxSize,
+        MinSize,
+    };
+    [[nodiscard]] CyclicPercentageIntrinsicContribution cyclic_percentage_intrinsic_contribution(Box const&, CSS::Size const&, AvailableSize const&, CyclicPercentageSizeProperty) const;
+
     OwnPtr<FormattingContext> layout_inside(Box const&, LayoutMode, LayoutInput const&);
 
     struct SpaceUsedByFloats {

--- a/Tests/LibWeb/Layout/expected/grid/inline-svg-cyclic-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/inline-svg-cyclic-percentage-width.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 332 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 332 0+0+0] children: not-inline
+      Box <div.grid> at [0,0] [0+0+0 800 0+0+0] [0+0+0 332 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <p> at [0,16] [0+0+0 300 0+0+0] [16+0+0 300 0+0+16] [BFC] children: inline
+          frag 0 from SVGSVGBox start: 0, length: 0, rect: [0,16 300x300] baseline: 300
+          SVGSVGBox <svg> at [0,16] [0+0+0 300 0+0+0] [0+0+0 300 0+0+0] [SVG] children: not-inline
+            SVGGeometryBox <circle> at [0,16] [0+0+0 303.03125 0+0+0] [0+0+0 303.03125 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,332] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x332]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x332]
+      PaintableBox (Box<DIV>.grid) [0,0 800x332]
+        PaintableWithLines (BlockContainer<P>) [0,16 300x300]
+          SVGSVGPaintable (SVGSVGBox<svg>) [0,16 300x300] overflow: [0,16 303.03125x303.03125]
+            SVGPathPaintable (SVGGeometryBox<circle>) [0,16 303.03125x303.03125]
+      PaintableWithLines (BlockContainer(anonymous)) [0,332 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x332] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/inline-svg-cyclic-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/grid/inline-svg-cyclic-percentage-width.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<style>
+body {
+    margin: 0;
+}
+
+.grid {
+    display: grid;
+    justify-content: space-between;
+}
+
+p {
+    margin: 16px 0;
+}
+</style>
+<div class="grid">
+    <p><svg width="100%" viewBox="0 0 99 99"><circle cx="50" cy="50" r="50" fill="red"></circle></svg></p>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-flexbox/svg-no-natural-size-grandchild.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-flexbox/svg-no-natural-size-grandchild.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1217941">
+<link rel="match" href="../../../../expected/wpt-import/css/css-flexbox/../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="The flex-item shouldn't have a zero max content size.">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: flex; align-items: center; width: 100px; height: 100px; background: red;">
+  <div style="line-height: 0;">
+    <svg height="100%" width="100%" viewBox="0 0 1 1">
+      <rect height="100%" width="100%" fill="green"></rect>
+    </svg>
+  </div>
+</div>
+


### PR DESCRIPTION
Share the CSS Sizing cyclic-percentage contribution logic between replaced width/max-width handling and flex intrinsic max-size clamping.

This lets cyclic percentage inline SVG widths fall through to the replaced 300px fallback during max-content sizing, without changing non-cyclic auto sizing such as width: max-content replaced content.

Fixes a missing logo on kickstarter.com

Before:

<img width="1380" height="822" alt="image" src="https://github.com/user-attachments/assets/496e5c49-2b30-439d-a756-9a9dec18e4e1" />

After:

<img width="1380" height="822" alt="image" src="https://github.com/user-attachments/assets/836fc030-047d-4d2e-b026-fbfb01815584" />

NB: The site is crashing for me quite reliably with:

```
VERIFICATION FAILED: m_playback_manager != nullptr at /Users/shannonbooth/Developer/ladybird/Libraries/LibWeb/HTML/HTMLMediaElement.cpp:2734
Stack trace (most recent call first):
#0  0x000000010b01ad47 in Web::HTML::HTMLMediaElement::play_element() (.cold.1) at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.1.0.dylib
#1  0x0000000109fe09ff in Web::HTML::HTMLMediaElement::play_element() at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.1.0.dylib
#2  0x0000000109fe04b3 in Web::HTML::HTMLMediaElement::play() at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.1.0.dylib
#3  0x000000010a872f93 in Web::Bindings::HTMLMediaElementPrototype::play(JS::VM&) at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.1.0.dylib
```

Fixes: #10377
