### PR TITLE
LibWebView: Guard async callbacks after teardown

### DIFF
--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1438,19 +1438,30 @@ void WebContentClient::did_request_webdriver_history_traversal(u64 page_id, u64 
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         auto view_id = view->view_id();
+        auto weak_this = static_cast<Core::EventReceiver&>(*this).make_weak_ptr();
         // This request originates from WebDriver in WebContent. Defer the UI
         // traversal so it can safely call back into WebContent for the
         // cancelation checks from the traverse history step algorithm.
-        Core::deferred_invoke([this, page_id, request_id, view_id, delta] {
+        Core::deferred_invoke([weak_this, page_id, request_id, view_id, delta] {
+            auto self = weak_this.strong_ref();
+            if (!self)
+                return;
+            auto& client = static_cast<WebContentClient&>(*self);
+
             auto view = ViewImplementation::find_view_by_id(view_id);
             if (!view.has_value()) {
-                async_complete_webdriver_history_traversal(page_id, request_id, false, false, false);
+                client.async_complete_webdriver_history_traversal(page_id, request_id, false, false, false);
                 return;
             }
 
-            auto complete = [this, page_id, request_id](ViewImplementation::HistoryTraversalOutcome outcome) {
+            auto complete = [weak_this, page_id, request_id](ViewImplementation::HistoryTraversalOutcome outcome) {
+                auto self = weak_this.strong_ref();
+                if (!self)
+                    return;
+                auto& client = static_cast<WebContentClient&>(*self);
+
                 auto traversal_started = outcome.status == ViewImplementation::HistoryTraversalStatus::Started;
-                async_complete_webdriver_history_traversal(
+                client.async_complete_webdriver_history_traversal(
                     page_id,
                     request_id,
                     true,
@@ -1459,9 +1470,14 @@ void WebContentClient::did_request_webdriver_history_traversal(u64 page_id, u64 
             };
 
             auto outcome = view->traverse_the_history_by_delta(delta, ViewImplementation::CheckForCancelation::Yes,
-                [this, page_id, request_id](ViewImplementation::HistoryTraversalOutcome outcome) {
+                [weak_this, page_id, request_id](ViewImplementation::HistoryTraversalOutcome outcome) {
+                    auto self = weak_this.strong_ref();
+                    if (!self)
+                        return;
+                    auto& client = static_cast<WebContentClient&>(*self);
+
                     auto traversal_started = outcome.status == ViewImplementation::HistoryTraversalStatus::Started;
-                    async_complete_webdriver_history_traversal(
+                    client.async_complete_webdriver_history_traversal(
                         page_id,
                         request_id,
                         true,

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -396,6 +396,7 @@ void SettingsUI::estimate_browsing_data_sizes(JsonValue const& options)
         return;
 
     auto& application = Application::the();
+    auto weak_this = static_cast<Core::EventReceiver&>(*this).make_weak_ptr();
 
     auto since = [&]() {
         if (auto since = options.as_object().get_integer<i64>("since"sv); since.has_value())
@@ -404,7 +405,14 @@ void SettingsUI::estimate_browsing_data_sizes(JsonValue const& options)
     }();
 
     application.estimate_browsing_data_size_accessed_since(since)
-        ->when_resolved([this](Application::BrowsingDataSizes sizes) {
+        ->when_resolved([weak_this](Application::BrowsingDataSizes const& sizes) {
+            if (!weak_this)
+                return;
+
+            auto& settings_ui = static_cast<SettingsUI&>(*weak_this.ptr());
+            if (!settings_ui.is_open())
+                return;
+
             JsonObject result;
 
             result.set("cacheSizeSinceRequestedTime"sv, sizes.cache_size_since_requested_time);
@@ -413,7 +421,7 @@ void SettingsUI::estimate_browsing_data_sizes(JsonValue const& options)
             result.set("siteDataSizeSinceRequestedTime"sv, sizes.site_data_size_since_requested_time);
             result.set("totalSiteDataSize"sv, sizes.total_site_data_size);
 
-            async_send_message("estimatedBrowsingDataSizes"sv, move(result));
+            settings_ui.async_send_message("estimatedBrowsingDataSizes"sv, move(result));
         })
         .when_rejected([](Error const& error) {
             dbgln("Failed to estimate browsing data sizes: {}", error);


### PR DESCRIPTION
Two LibWebView paths kept raw pointers across async work that could outlive the object owning the IPC connection.

I saw a crash coming from `about:settings` requesting browsing-data sizes, then the settings WebUI being torn down before RequestServer replied. The resolved promise could send IPC through a destroyed transport.

A related WebDriver history traversal path had the same lifetime shape through deferred completion callbacks. Both paths now capture weak EventReceiver pointers and drop stale completions if the client has already been destroyed