### PR TITLE
UI/Qt: Allow window edge resizing over the native presentation window

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -617,10 +617,6 @@ void BrowserWindow::initialize_tab(Tab* tab)
             new_tab_from_url(ak_url_from_qurl(urls[i]), Web::HTML::ActivateTab::No);
     });
 
-    QObject::connect(&tab->view(), &WebContentView::native_window_pointer_event, this, [this] {
-        refresh_resize_cursor_at_current_position();
-    });
-
     tab->view().on_new_web_view = [this, tab](auto activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) {
         if (hints.popup) {
             WindowConfiguration configuration {
@@ -1205,6 +1201,12 @@ bool BrowserWindow::event(QEvent* event)
 
 bool BrowserWindow::eventFilter(QObject* object, QEvent* event)
 {
+    if (auto* native_window = as_if<QWindow>(object)) {
+        if (filter_native_window_event(*native_window, *event))
+            return true;
+        return QMainWindow::eventFilter(object, event);
+    }
+
     auto* widget = as_if<QWidget>(object);
     if (!widget || widget->window() != this)
         return QMainWindow::eventFilter(object, event);
@@ -1291,6 +1293,56 @@ bool BrowserWindow::eventFilter(QObject* object, QEvent* event)
         return true;
 
     return QMainWindow::eventFilter(object, event);
+}
+
+bool BrowserWindow::filter_native_window_event(QWindow& window, QEvent& event)
+{
+    if (!uses_client_side_decorations())
+        return false;
+
+    auto* window_handle = windowHandle();
+    if (!window_handle)
+        return false;
+
+    bool window_is_embedded_in_this_window = false;
+    for (auto const* ancestor = window.parent(); ancestor; ancestor = ancestor->parent()) {
+        if (ancestor == window_handle) {
+            window_is_embedded_in_this_window = true;
+            break;
+        }
+    }
+    if (!window_is_embedded_in_this_window)
+        return false;
+
+    switch (event.type()) {
+    case QEvent::Enter:
+        update_resize_cursor(mapFromGlobal(QCursor::pos()));
+        return false;
+    case QEvent::MouseMove:
+        update_resize_cursor(mapFromGlobal(static_cast<QMouseEvent const&>(event).globalPosition().toPoint()));
+        return false;
+    case QEvent::Leave: {
+        auto position = mapFromGlobal(QCursor::pos());
+        if (rect().contains(position))
+            update_resize_cursor(position);
+        else
+            clear_resize_cursor();
+        return false;
+    }
+    case QEvent::MouseButtonPress: {
+        auto const& mouse_event = static_cast<QMouseEvent const&>(event);
+        if (mouse_event.button() != Qt::LeftButton || isMaximized() || isFullScreen())
+            return false;
+
+        auto edges = resize_edges_for_position(mapFromGlobal(mouse_event.globalPosition().toPoint()));
+        if (edges == Qt::Edges {})
+            return false;
+
+        return window_handle->startSystemResize(edges);
+    }
+    default:
+        return false;
+    }
 }
 
 bool BrowserWindow::position_is_in_rounded_corner_cutout(QPoint const& position) const

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -171,6 +171,7 @@ private:
     bool position_is_in_rounded_corner_cutout(QPoint const&) const;
     Qt::Edges resize_edges_for_position(QPoint const&) const;
     Optional<Qt::CursorShape> resize_cursor_for_edges(Qt::Edges) const;
+    bool filter_native_window_event(QWindow&, QEvent&);
     bool start_window_resize(Qt::Edges, QPoint const& global_position);
     void update_window_resize(QPoint const& global_position);
     void finish_window_resize();

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -1088,7 +1088,6 @@ bool WebContentView::handle_vulkan_window_event(QEvent* event)
         return true;
     case QEvent::MouseMove:
         mouseMoveEvent(static_cast<QMouseEvent*>(event));
-        emit native_window_pointer_event();
         return true;
     case QEvent::MouseButtonPress:
         mousePressEvent(static_cast<QMouseEvent*>(event));
@@ -1104,7 +1103,6 @@ bool WebContentView::handle_vulkan_window_event(QEvent* event)
         return true;
     case QEvent::Leave:
         leaveEvent(event);
-        emit native_window_pointer_event();
         return true;
     case QEvent::FocusIn:
         focusInEvent(static_cast<QFocusEvent*>(event));

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -108,8 +108,6 @@ public slots:
 signals:
     void urls_dropped(QList<QUrl> const&);
 
-    void native_window_pointer_event();
-
 private:
     // ^WebView::ViewImplementation
     virtual void initialize_client(CreateNewClient) override;


### PR DESCRIPTION
Since we started presenting content with a native `QVulkanWindow` pointer events are delivered to the `QWindow` itself and bypass the normal `QWidget` event path. A press inside the window resize border was therefore forwarded to the web content, rather than beginning a window resize

Application-wide event filters run before the receiving window sees an event, so the browser window now handles pointer events from embedded native windows in its event filter, starting a system resize for presses inside the resize border and refreshing the resize cursor on pointer movement. This replaces the signal that previously forwarded pointer events solely to refresh the cursor.

This change essentially supersedes #10232, which was looking at the same issue but only fixed MouseMove/Leave events so that the resize cursor displayed correctly.

Fixes #10435