### PR TITLE
LibWeb/HTML: Make input checked setter update radio groups

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1712,7 +1712,7 @@ void HTMLInputElement::signal_a_type_change()
     // - A type change is signalled for the element.
     if (type_state() == TypeAttributeState::RadioButton && checked()) {
         root().for_each_in_inclusive_subtree_of_type<HTMLInputElement>([&](auto& element) {
-            if (element.checked() && &element != this && is_in_same_radio_button_group(*this, element))
+            if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
                 element.set_checked(false);
             return TraversalDecision::Continue;
         });
@@ -2095,7 +2095,7 @@ void HTMLInputElement::form_associated_element_was_inserted()
         // - The element becomes connected.
         if (type_state() == TypeAttributeState::RadioButton && checked()) {
             root().for_each_in_inclusive_subtree_of_type<HTMLInputElement>([&](auto& element) {
-                if (element.checked() && &element != this && is_in_same_radio_button_group(*this, element))
+                if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
                     element.set_checked(false);
                 return TraversalDecision::Continue;
             });
@@ -2203,7 +2203,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::cloned(DOM::Node& copy, bool subtree
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#radio-button-group
-static bool is_in_same_radio_button_group(HTML::HTMLInputElement const& a, HTML::HTMLInputElement const& b)
+bool HTMLInputElement::is_in_same_radio_button_group_as(HTML::HTMLInputElement const& other) const
 {
     auto non_empty_equals = [](auto const& value_a, auto const& value_b) {
         return !value_a.is_empty() && value_a == value_b;
@@ -2212,17 +2212,17 @@ static bool is_in_same_radio_button_group(HTML::HTMLInputElement const& a, HTML:
     // other input elements b that fulfill all of the following conditions:
     return (
         // - Both a and b are in the same tree.
-        &a.root() == &b.root()
+        &root() == &other.root()
         // - The input element b's type attribute is in the Radio Button state.
-        && a.type_state() == b.type_state()
-        && b.type_state() == HTMLInputElement::TypeAttributeState::RadioButton
+        && type_state() == other.type_state()
+        && other.type_state() == HTMLInputElement::TypeAttributeState::RadioButton
         // - Either a and b have the same form owner, or they both have no form owner.
-        && a.form() == b.form()
+        && form() == other.form()
         // - They both have a name attribute, their name attributes are not empty, and the
         // value of a's name attribute equals the value of b's name attribute.
-        && a.name().has_value()
-        && b.name().has_value()
-        && non_empty_equals(a.name().value(), b.name().value()));
+        && name().has_value()
+        && other.name().has_value()
+        && non_empty_equals(name().value(), other.name().value()));
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)
@@ -2238,7 +2238,7 @@ void HTMLInputElement::set_checked_within_group()
         return;
 
     root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-        if (element.checked() && &element != this && is_in_same_radio_button_group(*this, element))
+        if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
             element.set_checked(false);
         return TraversalDecision::Continue;
     });
@@ -2263,7 +2263,7 @@ void HTMLInputElement::legacy_pre_activation_behavior()
     //    checkedness to true.
     if (type_state() == TypeAttributeState::RadioButton) {
         root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-            if (element.checked() && is_in_same_radio_button_group(*this, element)) {
+            if (element.checked() && is_in_same_radio_button_group_as(element)) {
                 m_legacy_pre_activation_behavior_checked_element_in_group = &element;
                 return TraversalDecision::Break;
             }
@@ -2293,7 +2293,7 @@ void HTMLInputElement::legacy_cancelled_activation_behavior()
         bool did_reselect_previous_element = false;
         if (m_legacy_pre_activation_behavior_checked_element_in_group) {
             auto& element_in_group = *m_legacy_pre_activation_behavior_checked_element_in_group;
-            if (is_in_same_radio_button_group(*this, element_in_group)) {
+            if (is_in_same_radio_button_group_as(element_in_group)) {
                 element_in_group.set_checked_within_group();
                 did_reselect_previous_element = true;
             }
@@ -3575,7 +3575,7 @@ bool HTMLInputElement::suffering_from_being_missing() const
         // If an element in the radio button group is required, and all of the input elements in the radio button group
         // have a checkedness that is false, then the element is suffering from being missing.
         root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-            if (is_in_same_radio_button_group(*this, element)) {
+            if (is_in_same_radio_button_group_as(element)) {
                 if (element.checked())
                     has_checkedness_false_for_all_elements_in_group = false;
                 if (element.has_attribute(HTML::AttributeNames::required))

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -216,17 +216,18 @@ void HTMLInputElement::set_checked(bool checked)
     CSS::Invalidation::invalidate_style_after_checked_state_change(*this, DOM::StyleInvalidationReason::HTMLInputElementSetChecked);
 
     set_needs_repaint();
-}
 
-void HTMLInputElement::set_checked_binding(bool checked)
-{
-    if (type_state() == TypeAttributeState::RadioButton) {
-        if (checked)
-            set_checked_within_group();
-        else
-            set_checked(false);
-    } else {
-        set_checked(checked);
+    // https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)
+    if (type_state() == TypeAttributeState::RadioButton && checked) {
+        // No point iterating the tree if we have an empty name.
+        if (!name().has_value() || name()->is_empty())
+            return;
+
+        root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
+            if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
+                element.set_checked(false);
+            return TraversalDecision::Continue;
+        });
     }
 }
 
@@ -2225,25 +2226,6 @@ bool HTMLInputElement::is_in_same_radio_button_group_as(HTML::HTMLInputElement c
         && non_empty_equals(name().value(), other.name().value()));
 }
 
-// https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)
-void HTMLInputElement::set_checked_within_group()
-{
-    if (checked())
-        return;
-
-    set_checked(true);
-
-    // No point iterating the tree if we have an empty name.
-    if (!name().has_value() || name()->is_empty())
-        return;
-
-    root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-        if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
-            element.set_checked(false);
-        return TraversalDecision::Continue;
-    });
-}
-
 // https://html.spec.whatwg.org/multipage/input.html#the-input-element:legacy-pre-activation-behavior
 void HTMLInputElement::legacy_pre_activation_behavior()
 {
@@ -2270,7 +2252,7 @@ void HTMLInputElement::legacy_pre_activation_behavior()
             return TraversalDecision::Continue;
         });
 
-        set_checked_within_group();
+        set_checked(true);
     }
 }
 
@@ -2294,7 +2276,7 @@ void HTMLInputElement::legacy_cancelled_activation_behavior()
         if (m_legacy_pre_activation_behavior_checked_element_in_group) {
             auto& element_in_group = *m_legacy_pre_activation_behavior_checked_element_in_group;
             if (is_in_same_radio_button_group_as(element_in_group)) {
-                element_in_group.set_checked_within_group();
+                element_in_group.set_checked(true);
                 did_reselect_previous_element = true;
             }
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -410,6 +410,7 @@ private:
     bool is_number_underflowing(double number) const;
     bool is_number_overflowing(double number) const;
     bool is_number_mismatching_step(double number) const;
+    bool is_in_same_radio_button_group_as(HTML::HTMLInputElement const&) const;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -104,9 +104,6 @@ public:
     bool checked() const { return m_checked; }
     void set_checked(bool);
 
-    bool checked_binding() const { return checked(); }
-    void set_checked_binding(bool);
-
     bool indeterminate() const;
     void set_indeterminate(bool);
 
@@ -322,7 +319,6 @@ private:
     void create_file_input_shadow_tree();
     void create_range_input_shadow_tree();
     WebIDL::ExceptionOr<void> run_input_activation_behavior(DOM::Event const&);
-    void set_checked_within_group();
 
     void handle_maxlength_attribute();
     WebIDL::ExceptionOr<void> handle_src_attribute(String const& value);

--- a/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -7,7 +7,7 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString alt;
     [CEReactions] attribute DOMString autocomplete;
     [CEReactions, Reflect=checked] attribute boolean defaultChecked;
-    [ImplementedAs=checked_binding] attribute boolean checked;
+    attribute boolean checked;
     [CEReactions, Reflect=dirname] attribute DOMString dirName;
     [CEReactions, Reflect] attribute boolean disabled;
     readonly attribute HTMLFormElement? form;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/common-dom-interfaces/collections/radionodelist.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/common-dom-interfaces/collections/radionodelist.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+3 Pass
+2 Fail
+Pass	The value attribute should be empty if no element is checked
+Pass	The RadioNodeList.value must be the first checked radio button's value
+Pass	Check the RadioNodeList.value on getting
+Fail	Check the RadioNodeList.value on setting
+Fail	Check the RadioNodeList.value on setting to 'on'

--- a/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/common-dom-interfaces/collections/radionodelist.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/common-dom-interfaces/collections/radionodelist.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-3 Pass
-2 Fail
+5 Pass
 Pass	The value attribute should be empty if no element is checked
 Pass	The RadioNodeList.value must be the first checked radio button's value
 Pass	Check the RadioNodeList.value on getting
-Fail	Check the RadioNodeList.value on setting
-Fail	Check the RadioNodeList.value on setting to 'on'
+Pass	Check the RadioNodeList.value on setting
+Pass	Check the RadioNodeList.value on setting to 'on'

--- a/Tests/LibWeb/Text/input/wpt-import/html/infrastructure/common-dom-interfaces/collections/radionodelist.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/infrastructure/common-dom-interfaces/collections/radionodelist.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: the RadioNodeList interface</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/multipage/common-dom-interfaces.html#radionodelist">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<form >
+  <input type="checkbox" name="rdo" value="0" id="r0" checked>
+  <input type="radio" name="rdo" id="r1">
+  <input type="radio" name="rdo" id="r2" value="2">
+</form>
+<script>
+
+var rdoList;
+
+setup(function () {
+  rdoList = document.forms[0].elements.namedItem("rdo");
+});
+
+//on getting
+test(function () {
+  assert_equals(rdoList.value, "", "The value attribute should be empty.");
+}, "The value attribute should be empty if no element is checked");
+
+test(function () {
+  document.getElementById("r2").checked = true;
+  assert_equals(rdoList.value, "2", "The value attribute should be 2.");
+}, "The RadioNodeList.value must be the first checked radio button's value");
+
+test(function () {
+  document.getElementById("r1").checked = true;
+  assert_equals(rdoList.value, "on", "The value attribute should be on.");
+
+  document.getElementById("r1").value = 1;
+  assert_equals(rdoList.value, "1", "The value attribute should be 1.");
+}, "Check the RadioNodeList.value on getting");
+
+//on setting
+test(function () {
+  assert_equals(rdoList.value, document.getElementById("r1").value,
+                "The value attribute should be equal to the first checked radio input element's value.");
+  assert_false(document.getElementById("r2").checked,
+               "The second radio input element should not be checked.");
+
+  rdoList.value = "2";
+  assert_equals(rdoList.value, document.getElementById("r2").value,
+                "The value attribute should be equal to the second radio input element's value.");
+  assert_true(document.getElementById("r2").checked,
+              "The second radio input element should be checked.");
+
+  //Do nothing if no element's value is equal to new value.
+  rdoList.value = "3";
+  assert_equals(rdoList.value, document.getElementById("r2").value,
+                "The value attribute should be the second radio input element's value.");
+  assert_true(document.getElementById("r2").checked,
+              "The second radio input element should be checked.");
+}, "Check the RadioNodeList.value on setting");
+
+//setting to on, specific case
+test(function () {
+  rdoList.value = "on";
+  assert_equals(rdoList.value, document.getElementById("r2").value,
+                "The value attribute should be the second radio input element's value.");
+  assert_true(document.getElementById("r2").checked,
+              "The second radio input element should be checked.");
+
+  document.getElementById("r1").removeAttribute("value");
+  rdoList.value = "on";
+  assert_equals(rdoList.value, document.getElementById("r1").value,
+                "The value attribute should be the first radio input element's value.");
+  assert_true(document.getElementById("r1").checked,
+              "The first radio input element should be checked.");
+}, "Check the RadioNodeList.value on setting to 'on'");
+
+
+</script>


### PR DESCRIPTION
Move the radio-group checkedness update into
HTMLInputElement::set_checked() itself, so all callers get the correct
behavior when checking a radio button.

This fixes RadioNodeList.value assignment, where selecting a later radio
could leave an earlier radio checked and cause the getter to keep
returning the earlier value.