### PR TITLE
LibWeb: Re-record the display list when the visual-context version bumps

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4186,6 +4186,7 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
     if (should_record_display_list) {
+        m_compositor_display_list_visual_context_tree_version = display_list->compatible_visual_context_tree_version();
         compositor_context().update_display_list(*display_list, visual_context_tree.release_value(), move(resource_transaction), move(scroll_state_snapshot));
         document_paintable->did_update_visual_context_tree_in_compositor();
         m_display_list_resource_storage.retain_only(display_list_resources);
@@ -4194,6 +4195,7 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
         m_compositor_display_list_paint_config = paint_config;
     } else {
         if (visual_context_tree_needs_compositor_update) {
+            VERIFY(document_paintable->visual_context_tree().version() == m_compositor_display_list_visual_context_tree_version);
             compositor_context().update_visual_context_tree(document_paintable->visual_context_tree());
             document_paintable->did_update_visual_context_tree_in_compositor();
         }

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -380,6 +380,7 @@ private:
     bool m_should_show_line_box_borders { false };
     bool m_should_show_caret_hit_test_debug_overlay { false };
     Optional<PaintConfig> m_compositor_display_list_paint_config;
+    u64 m_compositor_display_list_visual_context_tree_version { 0 };
     Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Painting::DisplayListResourceSet m_compositor_display_list_resources;
     OwnPtr<Compositor::CompositorContextHandle> m_compositor_context;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -97,6 +97,16 @@ void Internals::set_test_timeout(double milliseconds)
     page().client().page_did_set_test_timeout(milliseconds);
 }
 
+void Internals::force_incompatible_visual_context_tree_rebuild()
+{
+    auto& document = window().associated_document();
+    auto paintable = document.paintable();
+    if (!paintable)
+        return;
+    paintable->set_force_incompatible_visual_context_tree_rebuild_for_testing();
+    document.set_needs_accumulated_visual_contexts_update(true);
+}
+
 // https://web-platform-tests.org/writing-tests/reftests.html#components-of-a-reftest
 WebIDL::ExceptionOr<void> Internals::load_reference_test_metadata()
 {

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -36,6 +36,7 @@ public:
 
     void signal_test_is_done(String const& text);
     void set_test_timeout(double milliseconds);
+    void force_incompatible_visual_context_tree_rebuild();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
 
     WebIDL::ExceptionOr<String> set_time_zone(StringView time_zone);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -3,6 +3,7 @@ interface Internals {
 
     undefined signalTestIsDone(DOMString text);
     undefined setTestTimeout(double milliseconds);
+    undefined forceIncompatibleVisualContextTreeRebuild();
     undefined loadReferenceTestMetadata();
 
     DOMString setTimeZone(DOMString timeZone);

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -219,7 +219,12 @@ void ViewportPaintable::assign_scroll_frames()
 void ViewportPaintable::assign_accumulated_visual_contexts()
 {
     auto visual_context_tree = build_accumulated_visual_context_tree(*this);
-    if (m_visual_context_tree.has_value() && visual_context_tree.is_compatible_with(*m_visual_context_tree)) {
+    auto is_compatible = m_visual_context_tree.has_value() && visual_context_tree.is_compatible_with(*m_visual_context_tree);
+    if (m_force_incompatible_visual_context_tree_rebuild_for_testing) {
+        m_force_incompatible_visual_context_tree_rebuild_for_testing = false;
+        is_compatible = false;
+    }
+    if (is_compatible) {
         visual_context_tree.reuse_version_from(*m_visual_context_tree);
     } else {
         document().set_needs_to_record_display_list();

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -219,8 +219,11 @@ void ViewportPaintable::assign_scroll_frames()
 void ViewportPaintable::assign_accumulated_visual_contexts()
 {
     auto visual_context_tree = build_accumulated_visual_context_tree(*this);
-    if (m_visual_context_tree.has_value() && visual_context_tree.is_compatible_with(*m_visual_context_tree))
+    if (m_visual_context_tree.has_value() && visual_context_tree.is_compatible_with(*m_visual_context_tree)) {
         visual_context_tree.reuse_version_from(*m_visual_context_tree);
+    } else {
+        document().set_needs_to_record_display_list();
+    }
     m_visual_context_tree = move(visual_context_tree);
     m_visual_context_tree_needs_compositor_update = true;
 }

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -34,6 +34,7 @@ public:
     void update_visual_viewport_accumulated_visual_context();
     bool visual_context_tree_needs_compositor_update() const { return m_visual_context_tree_needs_compositor_update; }
     void did_update_visual_context_tree_in_compositor() { m_visual_context_tree_needs_compositor_update = false; }
+    void set_force_incompatible_visual_context_tree_rebuild_for_testing() { m_force_incompatible_visual_context_tree_rebuild_for_testing = true; }
     bool has_visual_context_tree() const { return m_visual_context_tree.has_value(); }
 
     GC::Ptr<Selection::Selection> selection() const;
@@ -76,6 +77,7 @@ private:
 
     Optional<AccumulatedVisualContextTree> m_visual_context_tree;
     bool m_visual_context_tree_needs_compositor_update { false };
+    bool m_force_incompatible_visual_context_tree_rebuild_for_testing { false };
 };
 
 template<>

--- a/Tests/LibWeb/Crash/HTML/compositor-visual-context-tree-version-mismatch.html
+++ b/Tests/LibWeb/Crash/HTML/compositor-visual-context-tree-version-mismatch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!-- An incompatible visual-context-tree rebuild mints a new tree version. On a composited (no-repaint) frame, the
+     producer must send a full display-list re-record — not a bare update_visual_context_tree carrying the new version
+     that the compositor's current display list doesn't match. See issue #10418. -->
+<html class="test-wait">
+<body>
+<div style="will-change: transform">content</div>
+<script>
+    let n = 0;
+    function frame() {
+        n++;
+        // Arm across a range — so it lands on a composited (no-repaint) frame after the page settles.
+        if (n >= 15 && n <= 30) internals.forceIncompatibleVisualContextTreeRebuild();
+        if (n >= 40) { document.documentElement.classList.remove("test-wait"); return; }
+        requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+</script>
+</body>
+</html>


### PR DESCRIPTION
**Problem:** Crash in compositor due to visual-context-tree version mismatch

**Cause:** When the accumulated visual context tree is rebuilt into an incompatible shape, it’s assigned a new version. If that happens on a composited frame that doesn’t repaint, the producer sends a bare `update_visual_context_tree` carrying the new version. But we recorded the compositor's current display list against the old version — so the compositor rejects it, and crashes.

**Fix:** When `assign_accumulated_visual_contexts` produces an incompatible tree, force a display-list re-record — so a fresh display list carrying the new version is sent, rather than a bare update. And also enforce it at the source: WebContent now verifies that a bare visual-context-tree update matches the version of its last-recorded display list — failing fast in the producer, rather than only in the compositor process. Fixes: https://github.com/LadybirdBrowser/ladybird/issues/10418.
