### PR TITLE
LibWeb: Patch visual context values in place instead of rebuilding

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -880,6 +880,10 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 CSS::Invalidation::invalidate_assigned_slottables_for_descendant_slots_after_inherited_style_change(target);
                 invalidated_assigned_slottables_for_descendant_slots = true;
             }
+            // NB: Descendant invalidations are merged into one, so value-only visual context updates must be
+            //     scheduled here, for each affected descendant.
+            if (element_invalidation.update_accumulated_visual_context_values && !element_invalidation.rebuild_accumulated_visual_contexts)
+                element.document().schedule_accumulated_visual_context_value_update(element);
             invalidation |= element_invalidation;
             return TraversalDecision::Continue;
         });
@@ -904,8 +908,18 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 target->set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::KeyframeEffect);
             }
         }
-        if (invalidation.rebuild_accumulated_visual_contexts)
+        if (invalidation.rebuild_accumulated_visual_contexts) {
             element.document().set_needs_accumulated_visual_contexts_update(true);
+        } else if (invalidation.update_accumulated_visual_context_values) {
+            // NB: Element-reference pseudo elements (e.g. ::placeholder) are not synthetic, so schedule their
+            //     layout node directly instead of going through the owning element.
+            if (element.pseudo_element().has_value()) {
+                if (auto pseudo_element_node = target->pseudo_element_unsafe_layout_node(element.pseudo_element().value()))
+                    element.document().schedule_accumulated_visual_context_value_update(*pseudo_element_node);
+            } else {
+                element.document().schedule_accumulated_visual_context_value_update(target);
+            }
+        }
 
         if (invalidation.repaint) {
             target->set_needs_repaint();

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -135,6 +135,33 @@ static bool accumulated_visual_context_change_requires_repaint(CSS::PropertyID p
     return false;
 }
 
+// Whether this change only affects values carried by existing accumulated visual context nodes, so they can be
+// patched in place. Presence flips (e.g. transform none <-> non-none) change the tree structure and which boxes
+// establish abs/fixed positioning containing blocks, and must rebuild instead.
+// NB: Must only include properties whose data update_accumulated_visual_context_values() recomputes.
+static bool accumulated_visual_context_change_is_value_only(CSS::PropertyID property_id, StyleValue const* old_value, StyleValue const* new_value)
+{
+    switch (property_id) {
+    case CSS::PropertyID::TransformOrigin:
+    case CSS::PropertyID::PerspectiveOrigin:
+        // Origins never affect node presence.
+        return true;
+    case CSS::PropertyID::Transform:
+    case CSS::PropertyID::Translate:
+    case CSS::PropertyID::Rotate:
+    case CSS::PropertyID::Scale:
+    case CSS::PropertyID::Opacity:
+    case CSS::PropertyID::Filter:
+    case CSS::PropertyID::MixBlendMode:
+    case CSS::PropertyID::Perspective:
+        // Value-only when the property contributes a node both before and after the change.
+        return is_stacking_context_creating_value(property_id, old_value)
+            && is_stacking_context_creating_value(property_id, new_value);
+    default:
+        return false;
+    }
+}
+
 RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::PropertyID property_id, StyleValue const* old_value, StyleValue const* new_value)
 {
     RequiredInvalidationAfterStyleChange invalidation;
@@ -212,7 +239,10 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     invalidation.repaint = true;
 
     if (CSS::property_affects_accumulated_visual_contexts(property_id)) {
-        invalidation.rebuild_accumulated_visual_contexts = true;
+        if (accumulated_visual_context_change_is_value_only(property_id, old_value, new_value))
+            invalidation.update_accumulated_visual_context_values = true;
+        else
+            invalidation.rebuild_accumulated_visual_contexts = true;
         if (!accumulated_visual_context_change_requires_repaint(property_id, old_value, new_value)
             && !invalidation.rebuild_stacking_context_tree
             && !invalidation.relayout

--- a/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -16,6 +16,8 @@ struct RequiredInvalidationAfterStyleChange {
     bool relayout : 1 { false };
     bool rebuild_layout_tree : 1 { false };
     bool rebuild_accumulated_visual_contexts : 1 { false };
+    // Only node values changed (e.g. an animated transform matrix); patch them in place instead of rebuilding.
+    bool update_accumulated_visual_context_values : 1 { false };
     // The element's change affects rule matching for descendants, without necessarily changing inherited style.
     bool recompute_descendant_styles : 1 { false };
     // At least one inherited longhand changed, so shadow-tree descendants may need inherited style recomputation.
@@ -28,11 +30,12 @@ struct RequiredInvalidationAfterStyleChange {
         relayout |= other.relayout;
         rebuild_layout_tree |= other.rebuild_layout_tree;
         rebuild_accumulated_visual_contexts |= other.rebuild_accumulated_visual_contexts;
+        update_accumulated_visual_context_values |= other.update_accumulated_visual_context_values;
         recompute_descendant_styles |= other.recompute_descendant_styles;
         inherited_style_changed |= other.inherited_style_changed;
     }
 
-    [[nodiscard]] bool is_none() const { return !repaint && !rebuild_stacking_context_tree && !relayout && !rebuild_layout_tree && !rebuild_accumulated_visual_contexts && !recompute_descendant_styles && !inherited_style_changed; }
+    [[nodiscard]] bool is_none() const { return !repaint && !rebuild_stacking_context_tree && !relayout && !rebuild_layout_tree && !rebuild_accumulated_visual_contexts && !update_accumulated_visual_context_values && !recompute_descendant_styles && !inherited_style_changed; }
     [[nodiscard]] bool is_full() const { return repaint && rebuild_stacking_context_tree && relayout && rebuild_layout_tree; }
     static RequiredInvalidationAfterStyleChange full() { return { true, true, true, true, false }; }
 };

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -31,6 +31,9 @@ static void apply_element_style_invalidation_after_style_change(DOM::Element& el
     if (invalidate_descendant_slots && (invalidation.inherited_style_changed || invalidation.rebuild_layout_tree))
         Invalidation::invalidate_assigned_slottables_for_descendant_slots_after_inherited_style_change(element);
 
+    if (invalidation.update_accumulated_visual_context_values && !invalidation.rebuild_accumulated_visual_contexts)
+        element.document().schedule_accumulated_visual_context_value_update(element);
+
     if (invalidation.relayout)
         element.set_needs_layout_update(DOM::SetNeedsLayoutReason::StyleChange);
     if (invalidation.rebuild_layout_tree) {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2110,8 +2110,21 @@ void Document::update_paint_and_hit_testing_properties_if_needed()
 
     if (m_needs_accumulated_visual_contexts_update) {
         m_needs_accumulated_visual_contexts_update = false;
+        m_paintable_boxes_needing_visual_context_value_update.clear_with_capacity();
         if (auto paintable = this->unsafe_paintable()) {
             paintable->assign_accumulated_visual_contexts();
+        }
+    } else if (!m_paintable_boxes_needing_visual_context_value_update.is_empty()) {
+        auto paintable_boxes = move(m_paintable_boxes_needing_visual_context_value_update);
+        if (auto paintable = this->unsafe_paintable()) {
+            for (auto const& weak_paintable_box : paintable_boxes) {
+                auto paintable_box = weak_paintable_box.strong_ref();
+                if (!paintable_box || !paintable->update_accumulated_visual_context_values(*paintable_box)) {
+                    // Structure changed after all; rebuild the whole tree.
+                    paintable->assign_accumulated_visual_contexts();
+                    break;
+                }
+            }
         }
     }
 }
@@ -8141,6 +8154,41 @@ void Document::set_needs_accumulated_visual_contexts_update(bool value)
     m_needs_accumulated_visual_contexts_update = value;
     if (value)
         set_needs_repaint(InvalidateDisplayList::No);
+}
+
+void Document::schedule_accumulated_visual_context_value_update(Layout::Node const& layout_node)
+{
+    // NB: A full rebuild is already pending and will refresh all node values anyway.
+    if (m_needs_accumulated_visual_contexts_update)
+        return;
+
+    // NB: Cap the queue in case it's never consumed (e.g. forced style updates in a document that never paints).
+    static constexpr size_t max_pending_visual_context_value_updates = 1024;
+    if (m_paintable_boxes_needing_visual_context_value_update.size() >= max_pending_visual_context_value_updates) {
+        m_paintable_boxes_needing_visual_context_value_update.clear();
+        set_needs_accumulated_visual_contexts_update(true);
+        return;
+    }
+
+    bool scheduled_any = false;
+    for (auto const& layout_node_paintable : layout_node.paintables()) {
+        if (auto* paintable_box = as_if<Painting::PaintableBox>(*layout_node_paintable)) {
+            m_paintable_boxes_needing_visual_context_value_update.append(*paintable_box);
+            scheduled_any = true;
+        }
+    }
+    if (scheduled_any)
+        set_needs_repaint(InvalidateDisplayList::No);
+}
+
+void Document::schedule_accumulated_visual_context_value_update(Element& element)
+{
+    if (auto* layout_node = element.unsafe_layout_node())
+        schedule_accumulated_visual_context_value_update(*layout_node);
+    element.for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement const& pseudo_element) {
+        if (auto* pseudo_element_layout_node = pseudo_element.unsafe_layout_node())
+            schedule_accumulated_visual_context_value_update(*pseudo_element_layout_node);
+    });
 }
 
 void Document::set_needs_to_record_display_list()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -939,6 +939,8 @@ public:
 
     void set_needs_accumulated_visual_contexts_update(bool);
     bool needs_accumulated_visual_contexts_update() const { return m_needs_accumulated_visual_contexts_update; }
+    void schedule_accumulated_visual_context_value_update(Element&);
+    void schedule_accumulated_visual_context_value_update(Layout::Node const&);
 
     virtual JS::Value named_item_value(FlyString const& name) const override;
     virtual Vector<FlyString> supported_property_names() const override;
@@ -1547,6 +1549,7 @@ private:
     bool m_design_mode_enabled { false };
 
     bool m_needs_accumulated_visual_contexts_update { false };
+    Vector<WeakPtr<Painting::PaintableBox>> m_paintable_boxes_needing_visual_context_value_update;
     bool m_needs_invalidation_of_elements_affected_by_has { false };
     RefPtr<Painting::HitTestDisplayList> m_hit_test_display_list;
     Optional<CSSPixelRect> m_caret_hit_test_debug_rect;

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -29,6 +29,7 @@
 namespace Web::Painting {
 
 AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable&);
+bool update_accumulated_visual_context_values(ViewportPaintable&, PaintableBox&);
 void update_visual_viewport_accumulated_visual_context(ViewportPaintable&);
 
 bool ClipData::contains(DevicePixelPoint point) const
@@ -275,6 +276,34 @@ static Optional<ClipPathData> compute_basic_shape_clip_path_data(PaintableBox co
     return ClipPathData { move(device_path), device_bounding_rect, fill_rule };
 }
 
+static Optional<PerspectiveData> compute_perspective_data(PaintableBox const& paintable_box, CSS::ComputedValues const& computed_values, float scale)
+{
+    auto perspective_matrix = compute_perspective_matrix(paintable_box, computed_values);
+    if (!perspective_matrix.has_value())
+        return {};
+    return PerspectiveData { scale_matrix_for_device_pixels(*perspective_matrix, scale) };
+}
+
+// NB: Resolves the box's filter as a side effect, since the effects data embeds the resolved gfx filter.
+static Optional<EffectsData> compute_effects_data(PaintableBox& box, double pixel_ratio)
+{
+    auto const& computed_values = box.computed_values();
+    if (computed_values.filter().has_filters())
+        box.set_filter(resolve_css_filter(computed_values.filter(), box));
+    else
+        box.set_filter({});
+
+    auto gfx_filter = to_gfx_filter(box.filter(), pixel_ratio);
+    EffectsData effects {
+        computed_values.opacity(),
+        mix_blend_mode_to_compositing_and_blending_operator(computed_values.mix_blend_mode()),
+        move(gfx_filter)
+    };
+    if (!effects.needs_layer())
+        return {};
+    return effects;
+}
+
 AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable& viewport_paintable)
 {
     auto& document = viewport_paintable.document();
@@ -285,19 +314,6 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
     auto append_node = [&](VisualContextIndex parent_index, VisualContextData data) -> VisualContextIndex {
         return visual_context_tree.append(move(data), parent_index);
-    };
-
-    auto make_effects_data = [&](PaintableBox const& box) -> Optional<EffectsData> {
-        auto const& computed_values = box.computed_values();
-        auto gfx_filter = to_gfx_filter(box.filter(), pixel_ratio);
-        EffectsData effects {
-            computed_values.opacity(),
-            mix_blend_mode_to_compositing_and_blending_operator(computed_values.mix_blend_mode()),
-            move(gfx_filter)
-        };
-        if (!effects.needs_layer())
-            return {};
-        return effects;
     };
 
     auto visual_viewport_context_index = VISUAL_VIEWPORT_NODE_INDEX;
@@ -315,12 +331,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
     };
 
     auto build_paintable_box = [&](auto& self, PaintableBox& paintable_box, DescendantVisualContexts inherited_contexts) -> void {
-        // Resolve filters before make_effects_data reads them.
-        auto const& paintable_box_computed_values = paintable_box.computed_values();
-        if (paintable_box_computed_values.filter().has_filters())
-            paintable_box.set_filter(resolve_css_filter(paintable_box_computed_values.filter(), paintable_box));
-        else
-            paintable_box.set_filter({});
+        auto first_visual_context_node_index = visual_context_tree.nodes().size();
 
         VisualContextIndex inherited_state;
 
@@ -392,7 +403,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
         auto const& computed_values = paintable_box.computed_values();
 
-        if (auto effects = make_effects_data(paintable_box); effects.has_value())
+        if (auto effects = compute_effects_data(paintable_box, pixel_ratio); effects.has_value())
             append_to_own_and_positioned_descendant_contexts(effects.value());
 
         if (auto transform_data = compute_transform(paintable_box, computed_values, pixel_ratio); transform_data.has_value()) {
@@ -460,10 +471,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         // Build state for descendants: own state + perspective + clip + scroll.
         VisualContextIndex state_for_descendants = own_state;
 
-        if (auto perspective_matrix = compute_perspective_matrix(paintable_box, computed_values); perspective_matrix.has_value()) {
-            auto scaled_matrix = scale_matrix_for_device_pixels(*perspective_matrix, scale);
-            state_for_descendants = append_node(state_for_descendants, PerspectiveData { scaled_matrix });
-        }
+        if (auto perspective_data = compute_perspective_data(paintable_box, computed_values, scale); perspective_data.has_value())
+            state_for_descendants = append_node(state_for_descendants, *perspective_data);
 
         if (auto clip_data = compute_clip_data(paintable_box, computed_values, converter); clip_data.has_value())
             state_for_descendants = append_node(state_for_descendants, clip_data.value());
@@ -475,6 +484,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         }
 
         paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
+        paintable_box.set_visual_context_node_range(first_visual_context_node_index, visual_context_tree.nodes().size());
         if (paintable_box.layout_node().establishes_an_absolute_positioning_containing_block())
             state_for_absolute_position_descendants = state_for_descendants;
         if (paintable_box.layout_node().establishes_a_fixed_positioning_containing_block())
@@ -502,6 +512,57 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
     });
 
     return visual_context_tree;
+}
+
+// Patches the transform/effects/perspective values of the box's existing visual context nodes in place.
+// Returns false if the box's node structure no longer matches; the caller must then do a full rebuild.
+bool update_accumulated_visual_context_values(ViewportPaintable& viewport_paintable, PaintableBox& paintable_box)
+{
+    auto& visual_context_tree = viewport_paintable.visual_context_tree();
+    auto begin = paintable_box.visual_context_nodes_begin();
+    auto end = paintable_box.visual_context_nodes_end();
+    if (end > visual_context_tree.nodes().size())
+        return false;
+
+    auto pixel_ratio = viewport_paintable.document().page().client().device_pixels_per_css_pixel();
+    auto const& computed_values = paintable_box.computed_values();
+
+    auto effects = compute_effects_data(paintable_box, pixel_ratio);
+    auto transform = compute_transform(paintable_box, computed_values, pixel_ratio);
+    auto perspective = compute_perspective_data(paintable_box, computed_values, static_cast<float>(pixel_ratio));
+
+    paintable_box.set_has_non_invertible_css_transform(transform.has_value() && !transform->matrix.is_invertible());
+
+    bool found_transform = false;
+    bool found_effects = false;
+    bool found_perspective = false;
+    for (size_t i = begin; i < end; ++i) {
+        auto& node = visual_context_tree.node_at(VisualContextIndex { i });
+        if (auto* transform_data = node.data.get_pointer<TransformData>()) {
+            if (!transform.has_value())
+                return false;
+            *transform_data = *transform;
+            found_transform = true;
+        } else if (auto* effects_data = node.data.get_pointer<EffectsData>()) {
+            if (!effects.has_value())
+                return false;
+            *effects_data = *effects;
+            found_effects = true;
+        } else if (auto* perspective_data = node.data.get_pointer<PerspectiveData>()) {
+            if (!perspective.has_value())
+                return false;
+            *perspective_data = *perspective;
+            found_perspective = true;
+        }
+    }
+
+    if (transform.has_value() != found_transform)
+        return false;
+    if (effects.has_value() != found_effects)
+        return false;
+    if (perspective.has_value() != found_perspective)
+        return false;
+    return true;
 }
 
 void update_visual_viewport_accumulated_visual_context(ViewportPaintable& viewport_paintable)

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -135,6 +135,7 @@ public:
     WEB_API void reuse_version_from(AccumulatedVisualContextTree const&);
 
     AccumulatedVisualContextNode const& node_at(VisualContextIndex index) const { return m_nodes[index.value()]; }
+    AccumulatedVisualContextNode& node_at(VisualContextIndex index) { return m_nodes[index.value()]; }
     ReadonlySpan<AccumulatedVisualContextNode> nodes() const { return m_nodes.span(); }
 
     VisualContextIndex find_common_ancestor(VisualContextIndex a, VisualContextIndex b) const;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -314,6 +314,15 @@ public:
     void set_fixed_background_visual_context(VisualContextIndex index) { m_fixed_background_visual_context = index; }
     [[nodiscard]] Optional<VisualContextIndex> fixed_background_visual_context() const { return m_fixed_background_visual_context; }
 
+    // Range of visual context nodes this box appended during the last tree build, used for in-place value patching.
+    void set_visual_context_node_range(size_t begin, size_t end)
+    {
+        m_visual_context_nodes_begin = begin;
+        m_visual_context_nodes_end = end;
+    }
+    [[nodiscard]] size_t visual_context_nodes_begin() const { return m_visual_context_nodes_begin; }
+    [[nodiscard]] size_t visual_context_nodes_end() const { return m_visual_context_nodes_end; }
+
     [[nodiscard]] ScrollFrameIndex enclosing_scroll_frame_index() const { return m_enclosing_scroll_frame_index; }
 
     [[nodiscard]] ScrollFrameIndex own_scroll_frame_index() const { return m_own_scroll_frame_index; }
@@ -364,6 +373,8 @@ private:
     VisualContextIndex m_accumulated_visual_context_index { VISUAL_VIEWPORT_NODE_INDEX };
     VisualContextIndex m_accumulated_visual_context_for_descendants_index { VISUAL_VIEWPORT_NODE_INDEX };
     Optional<VisualContextIndex> m_fixed_background_visual_context;
+    size_t m_visual_context_nodes_begin { 0 };
+    size_t m_visual_context_nodes_end { 0 };
 
     Optional<BordersDataWithElementKind> m_override_borders_data;
     Optional<TableCellCoordinates> m_table_cell_coordinates;

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -27,6 +27,7 @@
 namespace Web::Painting {
 
 AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaintable&);
+bool update_accumulated_visual_context_values(ViewportPaintable&, PaintableBox&);
 void update_visual_viewport_accumulated_visual_context(ViewportPaintable&);
 
 NonnullRefPtr<ViewportPaintable> ViewportPaintable::create(Layout::Viewport const& layout_viewport)
@@ -231,6 +232,18 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
     }
     m_visual_context_tree = move(visual_context_tree);
     m_visual_context_tree_needs_compositor_update = true;
+}
+
+bool ViewportPaintable::update_accumulated_visual_context_values(PaintableBox& paintable_box)
+{
+    if (!m_visual_context_tree.has_value())
+        return false;
+    if (m_force_incompatible_visual_context_tree_rebuild_for_testing)
+        return false;
+    if (!Painting::update_accumulated_visual_context_values(*this, paintable_box))
+        return false;
+    m_visual_context_tree_needs_compositor_update = true;
+    return true;
 }
 
 void ViewportPaintable::update_visual_viewport_accumulated_visual_context()

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -31,6 +31,7 @@ public:
     void refresh_scroll_state();
 
     void assign_accumulated_visual_contexts();
+    bool update_accumulated_visual_context_values(PaintableBox&);
     void update_visual_viewport_accumulated_visual_context();
     bool visual_context_tree_needs_compositor_update() const { return m_visual_context_tree_needs_compositor_update; }
     void did_update_visual_context_tree_in_compositor() { m_visual_context_tree_needs_compositor_update = false; }

--- a/Tests/LibWeb/Text/expected/visual-context-value-only-updates.txt
+++ b/Tests/LibWeb/Text/expected/visual-context-value-only-updates.txt
@@ -1,0 +1,18 @@
+initial transform: x=108, y=80, width=100, height=100
+patched transform: x=258, y=60, width=100, height=100
+added translate: x=263, y=65, width=100, height=100
+patched translate: x=288, y=70, width=100, height=100
+added rotate and scale: x=412.609375, y=83.3125, width=231.6875, height=231.6875
+patched rotate and scale: x=213, y=90, width=50, height=50
+patched transform-origin: x=-12, y=60, width=100, height=100
+transform removed: x=58, y=50, width=100, height=100
+opacity 0.5: x=58, y=50, width=100, height=100
+opacity 0.25: x=58, y=50, width=100, height=100
+opacity 1: x=58, y=50, width=100, height=100
+added filter: x=58, y=50, width=100, height=100
+patched filter, added blend mode: x=58, y=50, width=100, height=100
+patched blend mode: x=58, y=50, width=100, height=100
+animation at 50%: x=108, y=50, width=100, height=100
+animation at 100%: x=158, y=50, width=100, height=100
+inherited transform at 50%: x=268, y=50
+inherited transform at 100%: x=458, y=50

--- a/Tests/LibWeb/Text/input/visual-context-value-only-updates.html
+++ b/Tests/LibWeb/Text/input/visual-context-value-only-updates.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<!-- Value-only transform/opacity changes patch the accumulated visual context tree in place instead of
+     rebuilding it. Verify geometry queries across a sequence of value-only and structural changes. -->
+<style>
+    #box {
+        width: 100px;
+        height: 100px;
+        background-color: skyblue;
+        margin: 50px;
+    }
+</style>
+<script src="include.js"></script>
+<div id="box"><div id="child" style="width: 50px; height: 50px; transform: inherit"></div></div>
+<script>
+    test(() => {
+        const box = document.getElementById('box');
+        // NB: Print at the end: printing mutates the DOM, dirtying layout, which would force full tree
+        //     rebuilds instead of exercising the in-place value updates.
+        const lines = [];
+        const print_rect = label => {
+            const rect = box.getBoundingClientRect();
+            lines.push(`${label}: x=${rect.x}, y=${rect.y}, width=${rect.width}, height=${rect.height}`);
+        };
+
+        // Build the initial tree with a transform node present.
+        box.style.transform = 'translate(50px, 30px)';
+        print_rect('initial transform');
+
+        // Value-only change: patches the transform node in place.
+        box.style.transform = 'translate(200px, 10px)';
+        print_rect('patched transform');
+
+        // Structural change: adding a translate where there was none.
+        box.style.translate = '5px 5px';
+        print_rect('added translate');
+
+        // Value-only changes via the individual transform properties.
+        box.style.translate = '30px 10px';
+        print_rect('patched translate');
+        box.style.rotate = '10deg';
+        box.style.scale = '2';
+        print_rect('added rotate and scale');
+        box.style.rotate = '0deg';
+        box.style.scale = '0.5';
+        print_rect('patched rotate and scale');
+        box.style.rotate = '';
+        box.style.scale = '';
+
+        // Value-only change to transform-origin combined with a rotation.
+        box.style.transform = 'rotate(90deg)';
+        box.style.transformOrigin = '0 0';
+        print_rect('patched transform-origin');
+
+        // Structural change: removing all transforms drops the transform node and rebuilds the tree.
+        box.style.transform = 'none';
+        box.style.translate = 'none';
+        box.style.transformOrigin = '';
+        print_rect('transform removed');
+
+        // Structural change: opacity < 1 adds an effects node.
+        box.style.opacity = '0.5';
+        print_rect('opacity 0.5');
+
+        // Value-only change: patches the effects node in place.
+        box.style.opacity = '0.25';
+        print_rect('opacity 0.25');
+
+        // Structural change: opacity back to 1 removes the effects node.
+        box.style.opacity = '1';
+        print_rect('opacity 1');
+
+        // Filter and mix-blend-mode changes exercise the effects node without affecting geometry.
+        box.style.filter = 'blur(2px)';
+        print_rect('added filter');
+        box.style.filter = 'blur(4px)';
+        box.style.mixBlendMode = 'multiply';
+        print_rect('patched filter, added blend mode');
+        box.style.mixBlendMode = 'screen';
+        print_rect('patched blend mode');
+        box.style.filter = '';
+        box.style.mixBlendMode = '';
+
+        // Value-only transform patches driven by a paused animation.
+        const animation = box.animate(
+            [{ transform: 'translateX(0px)' }, { transform: 'translateX(100px)' }],
+            { duration: 1000, fill: 'forwards' });
+        animation.pause();
+        animation.currentTime = 500;
+        print_rect('animation at 50%');
+        animation.currentTime = 1000;
+        print_rect('animation at 100%');
+        animation.cancel();
+
+        // A parent animation must also patch descendants whose values change through inheritance.
+        const child = document.getElementById('child');
+        const parent_animation = box.animate(
+            [{ transform: 'translateX(10px)' }, { transform: 'translateX(200px)' }],
+            { duration: 1000, fill: 'forwards' });
+        parent_animation.pause();
+        parent_animation.currentTime = 500;
+        let rect = child.getBoundingClientRect();
+        lines.push(`inherited transform at 50%: x=${rect.x}, y=${rect.y}`);
+        parent_animation.currentTime = 1000;
+        rect = child.getBoundingClientRect();
+        lines.push(`inherited transform at 100%: x=${rect.x}, y=${rect.y}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>


### PR DESCRIPTION
Any change to a property feeding the accumulated visual context tree (transform, opacity, etc.) set a document-level flag that rebuilt the entire tree on the next frame. On pages with continuously animated transforms this rebuild dominated profiles, at ~80% of WebContent main-thread time.

Style invalidation now distinguishes structural changes (node presence flips, e.g. transform none <-> non-none) from value-only ones. The latter recompute just the affected box's transform, effects and perspective data and patch its existing nodes in place, via the node range recorded during the last full build, falling back to a full rebuild whenever the node structure no longer matches. Animation updates schedule these patches per affected element, including descendants whose values change through inheritance and element-backed pseudo elements. Covered by a new test exercising geometry queries across value-only and structural changes, including animation-driven and inherited ones.