### PR TITLE
LibWeb: Stop caching containing block used values

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -542,9 +542,9 @@ void BlockFormattingContext::rebuild_float_bands()
 
     for (auto& floating_box : m_floats) {
         floating_box->margin_box_rect_in_root_coordinate_space = margin_box_rect_in_ancestor_coordinate_space(floating_box->used_values, root());
-        auto const* containing_block = floating_box->used_values.containing_block_used_values();
+        auto const* containing_block = floating_box->used_values.node().containing_block();
         VERIFY(containing_block);
-        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
+        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(m_state.get(*containing_block), root());
         add_float_to_bands(*floating_box, containing_block_rect_in_root);
     }
 }
@@ -565,9 +565,9 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
     while (true) {
         auto border_box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_state, root());
         border_box_in_root_rect.translate_by(-box_state.border_box_left(), -box_state.border_box_top());
-        auto const* containing_block = box_state.containing_block_used_values();
+        auto const* containing_block = box.containing_block();
         VERIFY(containing_block);
-        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
+        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(m_state.get(*containing_block), root());
         containing_block_rect_in_root.set_y(border_box_in_root_rect.y());
         containing_block_rect_in_root.set_height(box_state.border_box_height());
         auto const& band = band_at(border_box_in_root_rect.y());
@@ -759,7 +759,9 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
         auto margins = box_state.margin_top + box_state.margin_bottom;
 
         // 2. Let size be the size of the initial containing block in the block flow direction minus margins.
-        auto size = box_state.containing_block_used_values()->content_height() - margins;
+        auto const* containing_block = box.containing_block();
+        VERIFY(containing_block);
+        auto size = m_state.get(*containing_block).content_height() - margins;
 
         // 3. Return the bigger value of size and the normal border box size the element would have
         //    according to the CSS specification.
@@ -790,7 +792,9 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
             auto margins = box_state.margin_top + box_state.margin_bottom;
 
             // 2. Let size be the size of element's parent element's content box in the block flow direction minus margins.
-            auto size = box_state.containing_block_used_values()->content_height() - margins;
+            auto const* containing_block = box.containing_block();
+            VERIFY(containing_block);
+            auto size = m_state.get(*containing_block).content_height() - margins;
 
             // 3. Return the bigger value of size and the normal border box size the element would have
             //    according to the CSS specification.
@@ -987,7 +991,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_state.has_subtree_root()
             && document_element && document_element->unsafe_layout_node()
             && box.is_inclusive_ancestor_of(*document_element->unsafe_layout_node())) {
-            return m_state.get_mutable(box);
+            if (auto* existing_state = m_state.try_get_mutable(box))
+                return *existing_state;
         }
         return m_state.create(box, layout_input.containing_block_constraints.percentage_basis_width, layout_input.containing_block_constraints.percentage_basis_height);
     }();

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1901,9 +1901,9 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
             return {};
 
         auto const& anchor_state = m_state.get(*anchor_box);
-        auto anchor_border_box_origin = anchor_state.cumulative_offset()
+        auto anchor_border_box_origin = m_state.cumulative_offset(anchor_state)
             - CSSPixelPoint { anchor_state.border_box_left(), anchor_state.border_box_top() };
-        auto containing_block_padding_box_origin = containing_block_state.cumulative_offset()
+        auto containing_block_padding_box_origin = m_state.cumulative_offset(containing_block_state)
             - CSSPixelPoint { containing_block_state.padding_left, containing_block_state.padding_top };
         return CSSPixelRect {
             anchor_border_box_origin - containing_block_padding_box_origin,
@@ -2237,7 +2237,8 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     auto const* static_position_cb = box.static_position_containing_block();
     auto actual_containing_block = box.containing_block();
     if (static_position_cb && static_position_cb != actual_containing_block) {
-        auto offset = m_state.get(*static_position_cb).cumulative_offset() - m_state.get(*actual_containing_block).cumulative_offset();
+        auto offset = m_state.cumulative_offset(m_state.get(*static_position_cb))
+            - m_state.cumulative_offset(m_state.get(*actual_containing_block));
         static_position += offset;
     }
 
@@ -3037,10 +3038,14 @@ CSSPixelRect FormattingContext::content_box_rect(LayoutState::UsedValues const& 
 CSSPixelRect FormattingContext::content_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const& used_values, Box const& ancestor_box) const
 {
     CSSPixelRect rect = { { 0, 0 }, used_values.content_size() };
-    for (auto const* current = &used_values; current; current = current->containing_block_used_values()) {
+    for (auto const* current = &used_values; current;) {
         if (&current->node() == &ancestor_box)
             return rect;
         rect.translate_by(current->offset);
+        auto const* containing_block = current->node().containing_block();
+        if (!containing_block)
+            break;
+        current = &m_state.get(*containing_block);
     }
     // If we get here, ancestor_box was not a containing block ancestor of `box`!
     VERIFY_NOT_REACHED();
@@ -3049,10 +3054,14 @@ CSSPixelRect FormattingContext::content_box_rect_in_ancestor_coordinate_space(La
 CSSPixelRect FormattingContext::margin_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const& used_values, Box const& ancestor_box) const
 {
     auto rect = margin_box_rect(used_values);
-    for (auto const* current = &used_values; current; current = current->containing_block_used_values()) {
+    for (auto const* current = &used_values; current;) {
         if (&current->node() == &ancestor_box)
             return rect;
         rect.translate_by(current->offset);
+        auto const* containing_block = current->node().containing_block();
+        if (!containing_block)
+            break;
+        current = &m_state.get(*containing_block);
     }
     // If we get here, ancestor_box was not a containing block ancestor of `box`!
     VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -95,22 +95,14 @@ LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node, Optional
 
     VERIFY(!m_subtree_root || m_subtree_root == &node || m_subtree_root->is_inclusive_ancestor_of(node));
 
-    UsedValues const* containing_block_used_values = nullptr;
-    if (m_subtree_root == &node) {
-        // For the subtree root, ancestor values are not available in the throwaway state.
-        containing_block_used_values = try_get(*node.containing_block());
-    } else if (!node.is_viewport()) {
-        containing_block_used_values = &ensure_used_values_for(*node.containing_block());
-    }
-
     auto& used_values = m_used_values_store.allocate(index);
-    used_values.set_node(node, containing_block_used_values, percentage_basis_width, percentage_basis_height);
+    used_values.set_node(node, percentage_basis_width, percentage_basis_height);
 
     if (auto const* list_item_box = as_if<ListItemBox>(node); list_item_box && list_item_box->marker()) {
         auto const& marker = *list_item_box->marker();
         if (!m_used_values_store.get(marker.layout_index())) {
             auto& marker_used_values = m_used_values_store.allocate(marker.layout_index());
-            marker_used_values.set_node(marker, &used_values,
+            marker_used_values.set_node(marker,
                 used_values.has_definite_width() ? Optional<CSSPixels> { used_values.content_width() } : Optional<CSSPixels> {},
                 used_values.has_definite_height() ? Optional<CSSPixels> { used_values.content_height() } : Optional<CSSPixels> {});
         }
@@ -124,7 +116,7 @@ LayoutState::UsedValues& LayoutState::populate_from_paintable(NodeWithStyle cons
     VERIFY(m_subtree_root);
     auto index = node.layout_index();
 
-    // NOTE: We skip set_node() here since it performs size resolution that requires a containing block,
+    // NOTE: We skip set_node() here since it performs size resolution that requires percentage bases,
     //       and materialize_from_paintable() overwrites all computed sizes immediately after.
     auto& used_values = m_used_values_store.allocate(index);
     used_values.m_node = &node;
@@ -140,31 +132,7 @@ LayoutState::UsedValues& LayoutState::populate_node_from(LayoutState const& sour
 
     auto& values = m_used_values_store.allocate(index);
     values = source.get(node);
-    values.m_containing_block_used_values = nullptr;
     return values;
-}
-
-LayoutState::UsedValues& LayoutState::ensure_used_values_for(NodeWithStyle const& node)
-{
-    auto index = node.layout_index();
-
-    if (auto* used_values = m_used_values_store.get(index))
-        return *used_values;
-
-    // During subtree layout, only the subtree root and nodes inside the subtree are allowed.
-    VERIFY(!m_subtree_root || m_subtree_root == &node || m_subtree_root->is_inclusive_ancestor_of(node));
-
-    UsedValues const* containing_block_used_values = nullptr;
-    if (m_subtree_root == &node) {
-        // For the subtree root, ancestor values are not available in the throwaway state.
-        containing_block_used_values = try_get(*node.containing_block());
-    } else if (!node.is_viewport()) {
-        containing_block_used_values = &ensure_used_values_for(*node.containing_block());
-    }
-
-    auto& used_values = m_used_values_store.allocate(index);
-    used_values.set_node(node, containing_block_used_values, {}, {});
-    return used_values;
 }
 
 LayoutState::UsedValues const* LayoutState::try_get(NodeWithStyle const& node) const
@@ -183,6 +151,15 @@ LayoutState::UsedValues const* LayoutState::try_get(Node const& node) const
     if (!node_with_style)
         return nullptr;
     return try_get(*node_with_style);
+}
+
+CSSPixelPoint LayoutState::cumulative_offset(UsedValues const& used_values) const
+{
+    if (used_values.m_cumulative_offset.has_value())
+        return *used_values.m_cumulative_offset;
+    if (auto const* containing_block = used_values.node().containing_block())
+        return cumulative_offset(get(*containing_block)) + used_values.offset;
+    return used_values.offset;
 }
 
 // https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region
@@ -893,7 +870,6 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
     containing_line_box_fragment = other.containing_line_box_fragment;
 
     m_node = other.m_node;
-    m_containing_block_used_values = other.m_containing_block_used_values;
     m_cumulative_offset = other.m_cumulative_offset;
     m_content_width = other.m_content_width;
     m_content_height = other.m_content_height;
@@ -908,10 +884,9 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
     return *this;
 }
 
-void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues const* containing_block_used_values, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height)
+void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height)
 {
     m_node = &node;
-    m_containing_block_used_values = containing_block_used_values;
 
     // NOTE: In the code below, we decide if `node` has definite width and/or height.
     //       This attempts to cover all the *general* cases where CSS considers sizes to be definite.

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -147,9 +147,7 @@ struct LayoutState {
 
         NodeWithStyle const& node() const { return *m_node; }
         NodeWithStyle& node() { return const_cast<NodeWithStyle&>(*m_node); }
-        void set_node(NodeWithStyle const&, UsedValues const* containing_block_used_values, Optional<CSSPixels> percentage_basis_width = {}, Optional<CSSPixels> percentage_basis_height = {});
-
-        UsedValues const* containing_block_used_values() const { return m_containing_block_used_values; }
+        void set_node(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_width = {}, Optional<CSSPixels> percentage_basis_height = {});
 
         CSSPixels content_width() const { return m_content_width; }
         CSSPixels content_height() const { return m_content_height; }
@@ -177,18 +175,6 @@ struct LayoutState {
         void set_content_offset(CSSPixelPoint new_offset) { offset = new_offset; }
         void set_content_x(CSSPixels x) { offset.set_x(x); }
         void set_content_y(CSSPixels y) { offset.set_y(y); }
-
-        // Offset from ICB (viewport) content edge to this box's content edge.
-        // Computed lazily by walking the containing block chain.
-        // For pre-populated nodes (partial relayout), returns the cached value from paintable absolute position.
-        CSSPixelPoint cumulative_offset() const
-        {
-            if (m_cumulative_offset.has_value())
-                return *m_cumulative_offset;
-            if (m_containing_block_used_values)
-                return m_containing_block_used_values->cumulative_offset() + offset;
-            return offset;
-        }
 
         // offset from top-left corner of content area of box's containing block to top-left corner of box's content area
         CSSPixelPoint offset;
@@ -382,7 +368,6 @@ struct LayoutState {
         }
 
         Layout::NodeWithStyle const* m_node { nullptr };
-        UsedValues const* m_containing_block_used_values { nullptr };
         Optional<CSSPixelPoint> m_cumulative_offset;
 
         CSSPixels m_content_width { 0 };
@@ -418,10 +403,13 @@ struct LayoutState {
     UsedValues* try_get_mutable(NodeWithStyle const&);
     UsedValues const* try_get(Node const&) const;
 
+    // Offset from ICB (viewport) content edge to this box's content edge.
+    // For pre-populated nodes (partial relayout), returns the cached value from paintable absolute position.
+    [[nodiscard]] CSSPixelPoint cumulative_offset(UsedValues const&) const;
+
     bool has_subtree_root() const { return m_subtree_root != nullptr; }
 
 private:
-    UsedValues& ensure_used_values_for(NodeWithStyle const&);
     void resolve_relative_positions();
 
     PagedStore<UsedValues> m_used_values_store;


### PR DESCRIPTION
UsedValues kept a cached pointer to its containing block's UsedValues from the old hash-map-backed LayoutState. The current paged store makes direct lookup cheap, and the cached pointer forces layout state creation to walk containing blocks early, blocking work to make that state usage more local.