### PR TITLE
UI/Qt: Handle Cocoa IME replacement ranges

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -279,6 +279,7 @@ void EventLoop::process_input_events() const
 
             for (size_t i = 0; i < event.coalesced_event_count; ++i)
                 page_client.report_finished_handling_input_event(event.page_id, EventResult::Dropped);
+            page_client.did_handle_input_event(event.page_id, event.event);
             page_client.report_finished_handling_input_event(event.page_id, result);
         }
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -302,8 +302,8 @@ template<>
 inline bool Node::fast_is<HTML::FormAssociatedTextControlElement>() const { return is_html_input_element() || is_html_textarea_element(); }
 
 template<>
-HTML::FormAssociatedTextControlElement* Node::fast_as<HTML::FormAssociatedTextControlElement>();
+WEB_API HTML::FormAssociatedTextControlElement* Node::fast_as<HTML::FormAssociatedTextControlElement>();
 template<>
-HTML::FormAssociatedTextControlElement const* Node::fast_as<HTML::FormAssociatedTextControlElement>() const;
+WEB_API HTML::FormAssociatedTextControlElement const* Node::fast_as<HTML::FormAssociatedTextControlElement>() const;
 
 }

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4054,8 +4054,13 @@ void LocalNavigable::set_marked_text_from_input_method(Utf16String const& text)
     replace_input_method_marked_text(text);
 }
 
-void LocalNavigable::commit_text_from_input_method(Utf16String const& text)
+void LocalNavigable::commit_text_from_input_method(Utf16String const& text, i32 replacement_start, i32 replacement_length)
 {
+    if ((replacement_start != 0 || replacement_length != 0) && apply_input_method_commit_replacement(text, replacement_start, replacement_length)) {
+        m_input_method_composition_node = nullptr;
+        return;
+    }
+
     // The input method has committed text and finished the composition. Replace the marked text with the committed
     // text, then end the composition — so the text becomes ordinary editable content.
     replace_input_method_marked_text(text);
@@ -4084,15 +4089,19 @@ void LocalNavigable::replace_input_method_marked_text(Utf16String const& text)
         return;
     }
 
-    // Drop a stale composition start (for example, if the editable content was replaced out from under us).
-    if (m_input_method_composition_node && !m_input_method_composition_node->is_connected())
+    // Drop a stale composition start (for example, if the editable content was replaced out from under us, or focus moved
+    // to a different editable).
+    if (m_input_method_composition_node && (!m_input_method_composition_node->is_connected() || document->active_input_events_target(m_input_method_composition_node) != target))
         m_input_method_composition_node = nullptr;
 
     // The caret is the end of the marked text. Read it while the selection is still collapsed. Forming the marked-text
     // selection below would otherwise make cursor_position() return null for form controls.
     auto caret = document->cursor_position();
-    if (!caret)
+    if (!caret) {
+        if (!m_input_method_composition_node)
+            target->handle_insert(UIEvents::InputTypes::insertText, text);
         return;
+    }
 
     if (m_input_method_composition_node) {
         // A composition is already in progress. Select the existing marked text [composition start, caret] — so that
@@ -4106,6 +4115,62 @@ void LocalNavigable::replace_input_method_marked_text(Utf16String const& text)
     }
 
     target->handle_insert(UIEvents::InputTypes::insertText, text);
+}
+
+bool LocalNavigable::apply_input_method_commit_replacement(Utf16String const& text, i32 replacement_start, i32 replacement_length)
+{
+    if (replacement_length < 0)
+        return false;
+
+    auto document = active_document();
+    if (!document || !document->is_fully_active()) {
+        m_input_method_composition_node = nullptr;
+        return true;
+    }
+    auto* target = document->active_input_events_target();
+    if (!target) {
+        m_input_method_composition_node = nullptr;
+        return true;
+    }
+
+    if (m_input_method_composition_node && (!m_input_method_composition_node->is_connected() || document->active_input_events_target(m_input_method_composition_node) != target))
+        m_input_method_composition_node = nullptr;
+
+    auto caret = document->cursor_position();
+    if (!caret) {
+        if (!m_input_method_composition_node) {
+            target->handle_insert(UIEvents::InputTypes::insertText, text);
+            return true;
+        }
+        return false;
+    }
+
+    auto preedit_start_node = m_input_method_composition_node ? m_input_method_composition_node : caret->node();
+    auto preedit_start_offset = m_input_method_composition_node ? m_input_method_composition_offset : caret->offset();
+    if (!preedit_start_node || preedit_start_node != caret->node())
+        return false;
+
+    size_t replacement_start_offset = preedit_start_offset;
+    if (replacement_start < 0) {
+        auto offset_delta = static_cast<size_t>(-static_cast<i64>(replacement_start));
+        if (offset_delta > preedit_start_offset)
+            return false;
+        replacement_start_offset -= offset_delta;
+    } else {
+        auto offset_delta = static_cast<size_t>(replacement_start);
+        if (offset_delta > NumericLimits<size_t>::max() - replacement_start_offset)
+            return false;
+        replacement_start_offset += offset_delta;
+    }
+
+    auto replacement_length_as_size = static_cast<size_t>(replacement_length);
+    if (replacement_start_offset > preedit_start_node->length() || replacement_length_as_size > preedit_start_node->length() - replacement_start_offset)
+        return false;
+
+    target->set_selection_anchor(*preedit_start_node, replacement_start_offset);
+    target->set_selection_focus(*preedit_start_node, replacement_start_offset + replacement_length_as_size);
+    target->handle_insert(UIEvents::InputTypes::insertText, text);
+    return true;
 }
 
 // https://drafts.csswg.org/css-view-transitions-1/#snapshot-containing-block

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -232,7 +232,7 @@ public:
     void select_all();
     void paste(Utf16String const&);
     void set_marked_text_from_input_method(Utf16String const& text);
-    void commit_text_from_input_method(Utf16String const& text);
+    void commit_text_from_input_method(Utf16String const& text, i32 replacement_start = 0, i32 replacement_length = 0);
     void unmark_text_from_input_method();
 
     Web::EventHandler& event_handler() { return m_event_handler; }
@@ -343,6 +343,7 @@ private:
     //         m_input_method_composition_offset record the start of the marked (preedit) text; the marked text spans
     //         from there to the caret. A null node means no composition is in progress.
     void replace_input_method_marked_text(Utf16String const& text);
+    bool apply_input_method_commit_replacement(Utf16String const& text, i32 replacement_start, i32 replacement_length);
     GC::Ptr<DOM::Node> m_input_method_composition_node;
     size_t m_input_method_composition_offset { 0 };
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -421,9 +421,9 @@ void Internals::set_marked_text_from_input_method(Utf16String const& text)
     page().focused_navigable().set_marked_text_from_input_method(text);
 }
 
-void Internals::commit_text_from_input_method(Utf16String const& text)
+void Internals::commit_text_from_input_method(Utf16String const& text, WebIDL::Long replacement_start, WebIDL::Long replacement_length)
 {
-    page().focused_navigable().commit_text_from_input_method(text);
+    page().focused_navigable().commit_text_from_input_method(text, replacement_start, replacement_length);
 }
 
 void Internals::unmark_text_from_input_method()

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -68,7 +68,7 @@ public:
     String selected_text_for_clipboard();
 
     void set_marked_text_from_input_method(Utf16String const& text);
-    void commit_text_from_input_method(Utf16String const& text);
+    void commit_text_from_input_method(Utf16String const& text, WebIDL::Long replacement_start, WebIDL::Long replacement_length);
     void unmark_text_from_input_method();
     GC::Ptr<Geometry::DOMRect> current_caret_rect();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -54,7 +54,7 @@ interface Internals {
     // text. unmarkText finalizes the composition — leaving the current preedit in place. Each fires an InputEvent with
     // inputType = "insertText" on the focused editable. All are no-ops if nothing editable is focused.
     undefined setMarkedTextFromInputMethod(Utf16DOMString text);
-    undefined commitTextFromInputMethod(Utf16DOMString text);
+    undefined commitTextFromInputMethod(Utf16DOMString text, optional long replacementStart = 0, optional long replacementLength = 0);
     undefined unmarkTextFromInputMethod();
 
     // Returns the bounds of the current text caret in viewport-relative CSS pixels — or null if no editable element is

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -462,6 +462,7 @@ public:
     virtual CSS::PreferredMotion preferred_motion() const = 0;
     virtual size_t screen_count() const = 0;
     virtual Queue<QueuedInputEvent>& input_event_queue() = 0;
+    virtual void did_handle_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] InputEvent const&) { }
     virtual void report_finished_handling_input_event(u64 page_id, EventResult event_was_handled) = 0;
     virtual Compositor::CompositorContextId allocate_compositor_context_id(Compositor::PagePresentationRegistration page_presentation_registration)
     {

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1220,9 +1220,9 @@ void ViewImplementation::set_marked_text_from_input_method(Utf16String const& te
     client().async_set_marked_text_from_input_method(page_id(), text);
 }
 
-void ViewImplementation::commit_text_from_input_method(Utf16String const& text)
+void ViewImplementation::commit_text_from_input_method(Utf16String const& text, i32 replacement_start, i32 replacement_length)
 {
-    client().async_commit_text_from_input_method(page_id(), text);
+    client().async_commit_text_from_input_method(page_id(), text, replacement_start, replacement_length);
 }
 
 void ViewImplementation::unmark_text_from_input_method()
@@ -1232,15 +1232,15 @@ void ViewImplementation::unmark_text_from_input_method()
 
 Optional<Web::DevicePixelRect> ViewImplementation::get_input_caret_rect()
 {
-    // Returns the most-recent caret position pushed by WebContent (see set_input_caret_rect). Deliberately makes no
-    // synchronous IPC request: This is read from inside AppKit text-input callbacks — where blocking can re-enter the
+    // Returns the most-recent caret position pushed by WebContent (see set_input_method_state). Deliberately makes no
+    // synchronous IPC request: This is read from inside AppKit text-input callbacks, where blocking can re-enter the
     // run loop and deadlock the input method.
-    return m_input_caret_rect;
+    return m_input_method_state.caret_rect;
 }
 
-void ViewImplementation::set_input_caret_rect(Badge<WebContentClient>, Optional<Web::DevicePixelRect> rect)
+void ViewImplementation::set_input_method_state(Badge<WebContentClient>, InputMethodState state)
 {
-    m_input_caret_rect = rect;
+    m_input_method_state = move(state);
 }
 
 void ViewImplementation::retrieved_clipboard_entries(u64 request_id, ReadonlySpan<Web::Clipboard::SystemClipboardItem> items)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -240,11 +240,21 @@ public:
 
     // Used by platform input methods to drive marked/preedit-text composition, and to query the on-screen caret
     // position for placing IME overlays.
+    struct InputMethodState {
+        bool is_enabled { false };
+        i32 cursor_position { 0 };
+        i32 anchor_position { 0 };
+        Utf16String text_before_cursor;
+        Utf16String text_after_cursor;
+        Optional<Web::DevicePixelRect> caret_rect;
+    };
+
     void set_marked_text_from_input_method(Utf16String const& text);
-    void commit_text_from_input_method(Utf16String const& text);
+    void commit_text_from_input_method(Utf16String const& text, i32 replacement_start = 0, i32 replacement_length = 0);
     void unmark_text_from_input_method();
     Optional<Web::DevicePixelRect> get_input_caret_rect();
-    void set_input_caret_rect(Badge<WebContentClient>, Optional<Web::DevicePixelRect>);
+    InputMethodState const& input_method_state() const { return m_input_method_state; }
+    void set_input_method_state(Badge<WebContentClient>, InputMethodState);
 
     Web::HTML::MuteState page_mute_state() const { return m_mute_state; }
     void toggle_page_mute_state();
@@ -608,8 +618,8 @@ protected:
     u64 m_next_webdriver_navigation_completion_request_id { 0 };
     HashMap<u64, OwnPtr<WebDriverNavigationCompletionRequest>> m_pending_webdriver_navigation_completion_requests;
 
-    // Most recent caret position pushed by WebContent, Used for placing platform IME overlays without a sync IPC.
-    Optional<Web::DevicePixelRect> m_input_caret_rect;
+    // Most recent input-method state pushed by WebContent. Used for platform IME callbacks without a sync IPC.
+    InputMethodState m_input_method_state;
 
     Web::ViewportIsFullscreen m_is_fullscreen { Web::ViewportIsFullscreen::No };
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1665,10 +1665,10 @@ void WebContentClient::did_finish_handling_input_event(u64 page_id, Web::EventRe
     SiteIsolationManager::the().remote_child_frame_did_finish_handling_input_event(*this, page_id, event_result);
 }
 
-void WebContentClient::did_update_input_caret_rect(u64 page_id, Optional<Web::DevicePixelRect> rect)
+void WebContentClient::did_update_input_method_state(u64 page_id, Optional<Web::DevicePixelRect> caret_rect, bool is_enabled, i32 cursor_position, i32 anchor_position, Utf16String text_before_cursor, Utf16String text_after_cursor)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
-        view->set_input_caret_rect({}, rect);
+        view->set_input_method_state({}, { is_enabled, cursor_position, anchor_position, move(text_before_cursor), move(text_after_cursor), caret_rect });
 }
 
 void WebContentClient::did_change_theme_color(u64 page_id, Gfx::Color color)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -224,7 +224,7 @@ private:
     virtual void did_request_file_picker(u64 page_id, Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles) override;
     virtual void did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) override;
     virtual void did_finish_handling_input_event(u64 page_id, Web::EventResult event_result) override;
-    virtual void did_update_input_caret_rect(u64 page_id, Optional<Web::DevicePixelRect> rect) override;
+    virtual void did_update_input_method_state(u64 page_id, Optional<Web::DevicePixelRect> caret_rect, bool is_enabled, i32 cursor_position, i32 anchor_position, Utf16String text_before_cursor, Utf16String text_after_cursor) override;
     virtual void did_finish_test(u64 page_id, String text) override;
     virtual void did_set_test_timeout(u64 page_id, double milliseconds) override;
     virtual void did_receive_reference_test_metadata(u64 page_id, JsonValue) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -12,6 +12,7 @@
 #include <AK/Debug.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
+#include <AK/Math.h>
 #include <AK/OwnPtr.h>
 #include <AK/QuickSort.h>
 #include <LibCore/Process.h>
@@ -51,6 +52,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/HTMLTextAreaElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
 #include <LibWeb/HTML/NavigableContainer.h>
@@ -2077,43 +2079,78 @@ void ConnectionFromClient::paste(u64 page_id, Utf16String text)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->page().focused_navigable().paste(text);
+    update_input_method_state(page_id);
 }
 
 void ConnectionFromClient::set_marked_text_from_input_method(u64 page_id, Utf16String text)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->page().focused_navigable().set_marked_text_from_input_method(text);
-    update_input_method_caret_rect(page_id);
+    update_input_method_state(page_id);
 }
 
-void ConnectionFromClient::commit_text_from_input_method(u64 page_id, Utf16String text)
+void ConnectionFromClient::commit_text_from_input_method(u64 page_id, Utf16String text, i32 replacement_start, i32 replacement_length)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->page().focused_navigable().commit_text_from_input_method(text);
-    update_input_method_caret_rect(page_id);
+        page->page().focused_navigable().commit_text_from_input_method(text, replacement_start, replacement_length);
+    update_input_method_state(page_id);
 }
 
 void ConnectionFromClient::unmark_text_from_input_method(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->page().focused_navigable().unmark_text_from_input_method();
+    update_input_method_state(page_id);
 }
 
-void ConnectionFromClient::update_input_method_caret_rect(u64 page_id)
+static constexpr size_t maximum_input_method_surrounding_text_length = 1024;
+
+void ConnectionFromClient::update_input_method_state(u64 page_id)
 {
     auto page = this->page(page_id);
     if (!page.has_value())
         return;
 
-    // Push the updated caret position to the UI — so platform input methods can place their overlays. We deliberately
-    // push this asynchronously — rather than answering a synchronous request from inside an AppKit text-input callback.
-    // Blocking there re-enters the run loop — and can deadlock input-method server <-> UI <-> WebContent message flow.
+    // Push the updated input state to the UI, so platform input methods can place their overlays. We deliberately
+    // push this asynchronously instead of answering a synchronous request from inside an AppKit text-input callback.
+    // Blocking there re-enters the run loop and can deadlock input-method server <-> UI <-> WebContent message flow.
     Optional<Web::DevicePixelRect> caret_rect;
+    bool is_enabled = false;
+    i32 cursor_position = 0;
+    i32 anchor_position = 0;
+    Utf16String text_before_cursor;
+    Utf16String text_after_cursor;
+
     if (auto document = page->page().focused_navigable().active_document()) {
         if (auto rect = document->current_caret_rect(); rect.has_value())
             caret_rect = page->page().enclosing_device_rect(*rect);
+
+        if (auto const* text_control = as_if<Web::HTML::FormAssociatedTextControlElement>(document->focused_area().ptr())) {
+            if (text_control->selection_start_binding().has_value()) {
+                auto value = text_control->relevant_value();
+                auto selection_start = text_control->selection_start();
+                auto selection_end = text_control->selection_end();
+                auto cursor = text_control->selection_direction_state() == Web::HTML::SelectionDirection::Backward ? selection_start : selection_end;
+                auto anchor = cursor == selection_start ? selection_end : selection_start;
+                auto value_length = value.length_in_code_units();
+                auto text_before_start = cursor > maximum_input_method_surrounding_text_length ? cursor - maximum_input_method_surrounding_text_length : 0;
+                auto text_after_length = min(value_length - cursor, maximum_input_method_surrounding_text_length);
+
+                auto const& html_element = text_control->text_control_to_html_element();
+                if (auto const* input_element = as_if<Web::HTML::HTMLInputElement>(html_element))
+                    is_enabled = input_element->is_mutable();
+                else if (auto const* text_area_element = as_if<Web::HTML::HTMLTextAreaElement>(html_element))
+                    is_enabled = text_area_element->is_mutable();
+
+                cursor_position = AK::clamp_to<i32>(cursor);
+                anchor_position = AK::clamp_to<i32>(anchor);
+                text_before_cursor = Utf16String::from_utf16(value.substring_view(text_before_start, cursor - text_before_start));
+                text_after_cursor = Utf16String::from_utf16(value.substring_view(cursor, text_after_length));
+            }
+        }
     }
-    async_did_update_input_caret_rect(page_id, caret_rect);
+
+    async_did_update_input_method_state(page_id, caret_rect, is_enabled, cursor_position, anchor_position, move(text_before_cursor), move(text_after_cursor));
 }
 
 void ConnectionFromClient::set_content_blockers(u64 page_id, Core::AnonymousBuffer patterns_buffer)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -62,6 +62,7 @@ public:
     Function<void(IPC::TransportHandle const&)> on_image_decoder_connection;
 
     Queue<Web::QueuedInputEvent>& input_event_queue() { return m_input_event_queue; }
+    void update_input_method_state(u64 page_id);
 
 private:
     explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
@@ -209,9 +210,8 @@ private:
 
     virtual void paste(u64 page_id, Utf16String text) override;
     virtual void set_marked_text_from_input_method(u64 page_id, Utf16String text) override;
-    virtual void commit_text_from_input_method(u64 page_id, Utf16String text) override;
+    virtual void commit_text_from_input_method(u64 page_id, Utf16String text, i32 replacement_start, i32 replacement_length) override;
     virtual void unmark_text_from_input_method(u64 page_id) override;
-    void update_input_method_caret_rect(u64 page_id);
 
     virtual void system_time_zone_changed() override;
 

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -341,6 +341,33 @@ Queue<Web::QueuedInputEvent>& PageClient::input_event_queue()
     return client().input_event_queue();
 }
 
+void PageClient::did_handle_input_event(u64 page_id, Web::InputEvent const& event)
+{
+    auto should_update_input_method_state = event.visit(
+        [](Web::KeyEvent const&) {
+            return true;
+        },
+        [](Web::MouseEvent const& mouse_event) {
+            switch (mouse_event.type) {
+            case Web::MouseEvent::Type::MouseDown:
+            case Web::MouseEvent::Type::MouseUp:
+                return true;
+            case Web::MouseEvent::Type::MouseMove:
+                return mouse_event.buttons != Web::UIEvents::MouseButton::None;
+            case Web::MouseEvent::Type::MouseLeave:
+            case Web::MouseEvent::Type::MouseWheel:
+                return false;
+            }
+            VERIFY_NOT_REACHED();
+        },
+        [](auto const&) {
+            return false;
+        });
+
+    if (should_update_input_method_state)
+        client().update_input_method_state(page_id);
+}
+
 void PageClient::report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled)
 {
     client().async_did_finish_handling_input_event(page_id, event_was_handled);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -53,6 +53,7 @@ public:
     ErrorOr<void> connect_to_web_ui(IPC::TransportHandle);
 
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override;
+    virtual void did_handle_input_event(u64 page_id, Web::InputEvent const&) override;
     virtual void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled) override;
     virtual Web::Compositor::CompositorContextId allocate_compositor_context_id(Web::Compositor::PagePresentationRegistration) override;
 

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -158,7 +158,7 @@ endpoint WebContentClient
     did_request_file_picker(u64 page_id, Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles allow_multiple_files) =|
     did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) =|
     did_finish_handling_input_event(u64 page_id, Web::EventResult event_result) =|
-    did_update_input_caret_rect(u64 page_id, Optional<Web::DevicePixelRect> rect) =|
+    did_update_input_method_state(u64 page_id, Optional<Web::DevicePixelRect> caret_rect, bool is_enabled, i32 cursor_position, i32 anchor_position, Utf16String text_before_cursor, Utf16String text_after_cursor) =|
     did_change_theme_color(u64 page_id, Gfx::Color color) =|
     did_change_background_color(u64 page_id, Gfx::Color color) =|
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -137,7 +137,7 @@ endpoint WebContentServer
     select_all(u64 page_id) =|
     paste(u64 page_id, Utf16String text) =|
     set_marked_text_from_input_method(u64 page_id, Utf16String text) =|
-    commit_text_from_input_method(u64 page_id, Utf16String text) =|
+    commit_text_from_input_method(u64 page_id, Utf16String text, i32 replacement_start, i32 replacement_length) =|
     unmark_text_from_input_method(u64 page_id) =|
 
     find_in_page(u64 page_id, String query, AK::CaseSensitivity case_sensitivity) =|

--- a/Tests/LibWeb/Text/expected/input-method-insert-text.txt
+++ b/Tests/LibWeb/Text/expected/input-method-insert-text.txt
@@ -19,4 +19,6 @@ after second composition commit: "你好"
 after unmark keeps preedit: "你好?"
 after abort clears preedit: "你好?"
 after abort, fresh preedit at moved caret: "你z好?"
+replacement-range commit value: "å"
+replacement-range input event: {"inputType":"insertText","data":"å"}
 caret rect is viewport-relative (moves with scroll): true

--- a/Tests/LibWeb/Text/input/input-method-insert-text.html
+++ b/Tests/LibWeb/Text/input/input-method-insert-text.html
@@ -118,6 +118,18 @@
         internals.setMarkedTextFromInputMethod("z");
         println(`after abort, fresh preedit at moved caret: ${JSON.stringify(preedit.value)}`);
 
+        // Some input methods commit text by replacing text around the caret instead of first setting preedit text.
+        const replacement = document.createElement("input");
+        replacement.value = "a";
+        document.body.appendChild(replacement);
+        replacement.focus();
+        replacement.setSelectionRange(1, 1);
+        event_promise = waitForEvent(replacement, "input");
+        internals.commitTextFromInputMethod("å", -1, 1);
+        event = await event_promise;
+        println(`replacement-range commit value: ${JSON.stringify(replacement.value)}`);
+        println(`replacement-range input event: ${JSON.stringify(event)}`);
+
         // #5: currentCaretRect is viewport-relative, so scrolling the page moves the caret rect by the scroll delta.
         const tall = document.createElement("div");
         tall.style.height = "3000px";

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -495,16 +495,54 @@ void WebContentView::inputMethodEvent(QInputMethodEvent* event)
         return;
     }
 
-    if (!event->commitString().isEmpty()) {
-        QKeyEvent keyEvent(QEvent::KeyPress, 0, Qt::NoModifier, event->commitString());
-        keyPressEvent(&keyEvent);
-    }
+    if (!event->commitString().isEmpty() || event->replacementLength() != 0)
+        commit_text_from_input_method(utf16_string_from_qstring(event->commitString()), event->replacementStart(), event->replacementLength());
+
+    set_marked_text_from_input_method(utf16_string_from_qstring(event->preeditString()));
     event->accept();
 }
 
-QVariant WebContentView::inputMethodQuery(Qt::InputMethodQuery) const
+static Optional<QRectF> input_method_rect_for_caret(Optional<Web::DevicePixelRect> const& caret_rect, double device_pixel_ratio)
 {
-    return QVariant();
+    if (!caret_rect.has_value())
+        return {};
+
+    return QRectF {
+        caret_rect->x().value() / device_pixel_ratio,
+        caret_rect->y().value() / device_pixel_ratio,
+        max(caret_rect->width().value() / device_pixel_ratio, 1.0),
+        max(caret_rect->height().value() / device_pixel_ratio, 1.0),
+    };
+}
+
+QVariant WebContentView::inputMethodQuery(Qt::InputMethodQuery query) const
+{
+    auto const& state = input_method_state();
+
+    switch (query) {
+    case Qt::ImEnabled:
+        return state.is_enabled;
+    case Qt::ImCursorRectangle:
+    case Qt::ImAnchorRectangle:
+        if (auto rect = input_method_rect_for_caret(state.caret_rect, device_pixel_ratio()); rect.has_value())
+            return *rect;
+        return WebContentViewBase::inputMethodQuery(query);
+    case Qt::ImAbsolutePosition:
+    case Qt::ImCursorPosition:
+        return state.cursor_position;
+    case Qt::ImAnchorPosition:
+        return state.anchor_position;
+    case Qt::ImTextBeforeCursor:
+        return qstring_from_utf16_string(state.text_before_cursor);
+    case Qt::ImTextAfterCursor:
+        return qstring_from_utf16_string(state.text_after_cursor);
+    case Qt::ImSurroundingText:
+        return qstring_from_utf16_string(state.text_before_cursor) + qstring_from_utf16_string(state.text_after_cursor);
+    case Qt::ImReadOnly:
+        return !state.is_enabled;
+    default:
+        return WebContentViewBase::inputMethodQuery(query);
+    }
 }
 
 void WebContentView::leaveEvent(QEvent* event)


### PR DESCRIPTION
macOS accent popup commits selected accents with an AppKit replacement range that covers the base character inserted by the long press. Qt's Cocoa input code only converts that range when the focus object answers input-method cursor queries. LibWeb also ignored replacement metadata when a commit arrived.

Cache focused text-control input method state in WebView so Qt can answer Cocoa's cursor, surrounding-text, and caret-rectangle queries without sync IPC. Pass Qt commit replacement metadata through WebContent and apply it when committing IME text, so the accent popup replaces the base character instead of appending and anchors near the caret.

Add internals coverage for replacement commits.