### PR TITLE
LibWeb: Resolve box-model percentages from LayoutInput constraints

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -759,9 +759,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
         auto margins = box_state.margin_top + box_state.margin_bottom;
 
         // 2. Let size be the size of the initial containing block in the block flow direction minus margins.
-        auto const* containing_block = box.containing_block();
-        VERIFY(containing_block);
-        auto size = m_state.get(*containing_block).content_height() - margins;
+        auto size = containing_block_constraints.percentage_basis_height.value_or(0) - margins;
 
         // 3. Return the bigger value of size and the normal border box size the element would have
         //    according to the CSS specification.
@@ -792,9 +790,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
             auto margins = box_state.margin_top + box_state.margin_bottom;
 
             // 2. Let size be the size of element's parent element's content box in the block flow direction minus margins.
-            auto const* containing_block = box.containing_block();
-            VERIFY(containing_block);
-            auto size = m_state.get(*containing_block).content_height() - margins;
+            auto size = containing_block_constraints.percentage_basis_height.value_or(0) - margins;
 
             // 3. Return the bigger value of size and the normal border box size the element would have
             //    according to the CSS specification.

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -320,7 +320,8 @@ bool FlexFormattingContext::is_direction_reverse() const
 
 void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::FlexDirection) const
 {
-    auto width_of_containing_block = m_flex_container_state.content_width();
+    // Percentages on flex item box-model metrics resolve against the flex container's inline size.
+    auto width_of_containing_block = m_item_percentage_bases.percentage_basis_width.value_or(0);
 
     item.used_values.padding_left = item.box.computed_values().padding().left().to_px_or_zero(width_of_containing_block);
     item.used_values.padding_right = item.box.computed_values().padding().right().to_px_or_zero(width_of_containing_block);

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -351,7 +351,8 @@ void InlineFormattingContext::generate_line_boxes()
     auto writing_mode = m_context_box.computed_values().writing_mode();
 
     InlineLevelIterator iterator(*this, m_state, containing_block(), m_containing_block_used_values, *m_layout_input, m_layout_mode);
-    LineBuilder line_builder(*this, m_state, m_containing_block_used_values, direction, writing_mode);
+    auto containing_block_width = m_layout_input->containing_block_constraints.percentage_basis_width.value_or(0);
+    LineBuilder line_builder(*this, m_state, m_containing_block_used_values, containing_block_width, direction, writing_mode);
 
     // NOTE: When we ignore collapsible whitespace chunks at the start of a line,
     //       we have to remember how much start margin, border and padding that chunk had
@@ -518,7 +519,8 @@ void InlineFormattingContext::generate_line_boxes()
 
                     if (box->display_before_box_type_transformation().is_block_outside()) {
                         auto block_position = marker.preceded_by_in_flow_content ? line_box.bottom() : marker.offset().y();
-                        static_position_rect.rect = { { 0, block_position }, { m_containing_block_used_values.content_width(), 0 } };
+                        auto containing_block_width = m_layout_input->containing_block_constraints.percentage_basis_width.value_or(0);
+                        static_position_rect.rect = { { 0, block_position }, { containing_block_width, 0 } };
                     } else {
                         static_position_rect.rect = { marker.offset(), { 0, 0 } };
                     }

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -61,21 +61,23 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
 
     auto const& computed_values = node.computed_values();
 
-    used_values.margin_top = computed_values.margin().top().to_px_or_zero(m_containing_block_used_values.content_width());
-    used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(m_containing_block_used_values.content_width());
+    auto containing_block_width = m_layout_input.containing_block_constraints.percentage_basis_width.value_or(0);
 
-    used_values.margin_left = computed_values.margin().left().to_px_or_zero(m_containing_block_used_values.content_width());
+    used_values.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_width);
+    used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_width);
+
+    used_values.margin_left = computed_values.margin().left().to_px_or_zero(containing_block_width);
     used_values.border_left = computed_values.border_left().width;
-    used_values.padding_left = computed_values.padding().left().to_px_or_zero(m_containing_block_used_values.content_width());
+    used_values.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
 
-    used_values.margin_right = computed_values.margin().right().to_px_or_zero(m_containing_block_used_values.content_width());
+    used_values.margin_right = computed_values.margin().right().to_px_or_zero(containing_block_width);
     used_values.border_right = computed_values.border_right().width;
-    used_values.padding_right = computed_values.padding().right().to_px_or_zero(m_containing_block_used_values.content_width());
+    used_values.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
 
     used_values.border_top = computed_values.border_top().width;
     used_values.border_bottom = computed_values.border_bottom().width;
-    used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(m_containing_block_used_values.content_width());
-    used_values.padding_top = computed_values.padding().top().to_px_or_zero(m_containing_block_used_values.content_width());
+    used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
+    used_values.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
 
     m_extra_leading_metrics->margin += used_values.margin_left;
     m_extra_leading_metrics->border += used_values.border_left;

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -10,7 +10,7 @@
 
 namespace Web::Layout {
 
-LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_state, LayoutState::UsedValues& containing_block_used_values, CSS::Direction direction, CSS::WritingMode writing_mode)
+LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_state, LayoutState::UsedValues& containing_block_used_values, CSSPixels containing_block_width, CSS::Direction direction, CSS::WritingMode writing_mode)
     : m_context(context)
     , m_layout_state(layout_state)
     , m_containing_block_used_values(containing_block_used_values)
@@ -18,7 +18,7 @@ LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_s
     , m_writing_mode(writing_mode)
 {
     auto text_indent = m_context.containing_block().computed_values().text_indent();
-    m_text_indent = text_indent.length_percentage.to_px(m_containing_block_used_values.content_width());
+    m_text_indent = text_indent.length_percentage.to_px(containing_block_width);
     m_text_indent_each_line = text_indent.each_line;
     m_text_indent_hanging = text_indent.hanging;
     begin_new_line(false);

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -15,7 +15,7 @@ class LineBuilder {
     AK_MAKE_NONMOVABLE(LineBuilder);
 
 public:
-    LineBuilder(InlineFormattingContext&, LayoutState&, LayoutState::UsedValues& containing_block_used_values, CSS::Direction, CSS::WritingMode);
+    LineBuilder(InlineFormattingContext&, LayoutState&, LayoutState::UsedValues& containing_block_used_values, CSSPixels containing_block_width, CSS::Direction, CSS::WritingMode);
 
     enum class ForcedBreak {
         No,


### PR DESCRIPTION
Several sites still borrowed the percentage basis by reading an ancestor UsedValues (content_width()/content_height()) directly, which only works because layout state is globally readable. Convert them to read the basis that already travels down through LayoutInput's containing_block_constraints, matching the pattern introduced when constraints were threaded through LayoutInput.