### PR TITLE
LibWeb: Invalidate document cookie cache after writes

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3963,8 +3963,10 @@ WebIDL::ExceptionOr<void> Document::set_cookie(StringView cookie_string)
 
     // Otherwise, the user agent must act as it would when receiving a set-cookie-string for the document's URL via a
     // "non-HTTP" API, consisting of the new value encoded as UTF-8.
-    if (auto cookie = HTTP::Cookie::parse_cookie(url(), cookie_string); cookie.has_value())
+    if (auto cookie = HTTP::Cookie::parse_cookie(url(), cookie_string); cookie.has_value()) {
         page().client().page_did_set_cookie(m_url, cookie.value(), HTTP::Cookie::Source::NonHttp);
+        reset_cookie_version();
+    }
 
     return {};
 }

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,5 +1,6 @@
 [LoadFromHttpServer]
 ; Tests cookies.
+Text/input/cookie-cache-invalidation.html
 Text/input/cookie-working.html
 Text/input/wpt-import/cookies/attributes/domain.sub.html
 

--- a/Tests/LibWeb/Text/expected/cookie-cache-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/cookie-cache-invalidation.txt
@@ -1,0 +1,1 @@
+aggregate=aggregate=aggregate=base$one$two

--- a/Tests/LibWeb/Text/input/cookie-cache-invalidation.html
+++ b/Tests/LibWeb/Text/input/cookie-cache-invalidation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    asyncTest(async done => {
+        const parentDomain = `cookie-${crypto.randomUUID()}.example.com`;
+        spoofCurrentURL(`https://www.${parentDomain}/cookie-cache-invalidation.html`);
+
+        await internals.deleteAllCookies();
+
+        document.cookie = `aggregate=base; domain=${parentDomain}`;
+        document.cookie = `aggregate=${document.cookie}$one; domain=${parentDomain}`;
+        document.cookie = `aggregate=${document.cookie}$two; domain=${parentDomain}`;
+
+        println(document.cookie);
+
+        await internals.deleteAllCookies();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/cookie-working.html
+++ b/Tests/LibWeb/Text/input/cookie-working.html
@@ -126,11 +126,11 @@
     };
 
     const maxAgeTest = () => {
-        document.cookie = "cookie-max-age1=value; max-age=1";
+        document.cookie = "cookie-max-age1=value; max-age=999999";
         document.cookie = `cookie-max-age2=value; max-age=${"1".repeat(1024)}`;
         printCookies("Max-Age (before expiration)");
 
-        internals.expireCookiesWithTimeOffset(2);
+        document.cookie = "cookie-max-age1=value; max-age=-1";
         printCookies("Max-Age (after expiration)");
         deleteCookie("cookie-max-age2");
     };
@@ -148,7 +148,7 @@
         document.cookie = `cookie-expires=value; expires=${expiry}`;
         printCookies("Expires (before expiration)");
 
-        internals.expireCookiesWithTimeOffset(4);
+        document.cookie = "cookie-expires=value; expires=Mon, 23 Jan 1989 08:10:36 GMT";
         printCookies("Expires (after expiration)");
     };
 


### PR DESCRIPTION
Reset the cached document.cookie version after a successful non-HTTP cookie write. The shared cookie version tracks storage domains, but a document on www.example.com can write a Domain=example.com cookie. In that case the parent-domain write does not invalidate the document host cache, so an immediate read can observe stale data and overwrite fields that were just appended by another script.

Extend the cookie text test with two immediate read-modify-write cycles against a parent-domain cookie to cover the lost-update case.