### PR TITLE
LibWebView+UI/Qt: Refine omnibox and new window behavior

### DIFF
--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -87,12 +87,50 @@ StringView autocomplete_section_title(AutocompleteSuggestionSection section)
     return ByteString::formatted("[{}]", ByteString::join(", "sv, values));
 }
 
-static Vector<AutocompleteSuggestion> make_history_suggestions(Vector<HistoryEntry> history_entries)
+static Optional<StringView> url_without_scheme(StringView url)
+{
+    auto scheme_separator = url.find("://"sv);
+    if (!scheme_separator.has_value())
+        return {};
+
+    return url.substring_view(*scheme_separator + 3);
+}
+
+static StringView autocomplete_searchable_url(StringView url)
+{
+    auto stripped_url = url_without_scheme(url).value_or(url);
+    if (stripped_url.starts_with("www."sv, CaseSensitivity::CaseInsensitive))
+        stripped_url = stripped_url.substring_view(4);
+
+    return stripped_url;
+}
+
+static StringView autocomplete_url_query(StringView query)
+{
+    auto stripped_query = url_without_scheme(query).value_or(query);
+    if (stripped_query.starts_with("www."sv, CaseSensitivity::CaseInsensitive))
+        stripped_query = stripped_query.substring_view(4);
+
+    return stripped_query;
+}
+
+static bool history_entry_url_matches_query(StringView query, StringView url)
+{
+    auto url_query = autocomplete_url_query(query);
+    if (url_query.is_empty())
+        return false;
+
+    auto searchable_url = autocomplete_searchable_url(url);
+    return searchable_url.starts_with(url_query, CaseSensitivity::CaseInsensitive);
+}
+
+static Vector<AutocompleteSuggestion> make_history_suggestions(StringView query, Vector<HistoryEntry> history_entries)
 {
     Vector<AutocompleteSuggestion> suggestions;
     suggestions.ensure_capacity(history_entries.size());
 
     for (auto& entry : history_entries) {
+        auto can_be_automatically_selected = history_entry_url_matches_query(query, entry.url.bytes_as_string_view());
         suggestions.unchecked_append({
             .source = AutocompleteSuggestionSource::History,
             .section = AutocompleteSuggestionSection::History,
@@ -100,6 +138,7 @@ static Vector<AutocompleteSuggestion> make_history_suggestions(Vector<HistoryEnt
             .title = move(entry.title),
             .subtitle = {},
             .favicon_base64_png = move(entry.favicon_base64_png),
+            .can_be_automatically_selected = can_be_automatically_selected,
         });
     }
 
@@ -262,7 +301,7 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Autocomplete query='{}' trimmed='{}'", m_query, trimmed_query);
 
-    m_history_suggestions = make_history_suggestions(Application::history_store().autocomplete_entries(trimmed_query, m_max_suggestions));
+    m_history_suggestions = make_history_suggestions(trimmed_query, Application::history_store().autocomplete_entries(trimmed_query, m_max_suggestions));
     auto literal_suggestion = preferred_literal_url_suggestion(trimmed_query, m_history_suggestions);
     auto search_suggestion = search_for_query_suggestion(trimmed_query);
 

--- a/Libraries/LibWebView/Autocomplete.h
+++ b/Libraries/LibWebView/Autocomplete.h
@@ -50,6 +50,7 @@ struct WEBVIEW_API AutocompleteSuggestion {
     Optional<String> title;
     Optional<String> subtitle;
     Optional<String> favicon_base64_png;
+    bool can_be_automatically_selected { true };
 };
 
 WEBVIEW_API ReadonlySpan<AutocompleteEngine> autocomplete_engines();

--- a/Libraries/LibWebView/Omnibox.cpp
+++ b/Libraries/LibWebView/Omnibox.cpp
@@ -348,6 +348,11 @@ Optional<size_t> Omnibox::update_completion_for_suggestions(Vector<AutocompleteS
     if (suggestions.is_empty())
         return {};
 
+    if (!suggestions.first().can_be_automatically_selected) {
+        restore_query_display();
+        return {};
+    }
+
     // A literal URL always wins: no completion, restore the typed text.
     if (suggestions.first().source == AutocompleteSuggestionSource::LiteralURL) {
         restore_query_display();

--- a/Libraries/LibWebView/Omnibox.cpp
+++ b/Libraries/LibWebView/Omnibox.cpp
@@ -124,6 +124,14 @@ static Optional<size_t> index_of_suggestion(String const& suggestion_text, Vecto
     });
 }
 
+static Optional<size_t> index_of_exact_search_suggestion(String const& query, Vector<AutocompleteSuggestion> const& suggestions)
+{
+    return suggestions.find_first_index_if([&](auto const& suggestion) {
+        return suggestion.source == AutocompleteSuggestionSource::Search
+            && suggestion_matches_query_exactly(query, suggestion.text);
+    });
+}
+
 Omnibox::Omnibox()
     : Omnibox(make<AutocompleteSuggestionProvider>())
 {
@@ -350,7 +358,7 @@ Optional<size_t> Omnibox::update_completion_for_suggestions(Vector<AutocompleteS
 
     if (!suggestions.first().can_be_automatically_selected) {
         restore_query_display();
-        return {};
+        return index_of_exact_search_suggestion(m_query, suggestions);
     }
 
     // A literal URL always wins: no completion, restore the typed text.

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -17,12 +17,25 @@ using WebView::Omnibox;
 
 AutocompleteSuggestion row(AutocompleteSuggestionSource source, AutocompleteSuggestionSection section, StringView text)
 {
-    return { .source = source, .section = section, .text = MUST(String::from_utf8(text)), .title = {}, .subtitle = {}, .favicon_base64_png = {} };
+    return { .source = source, .section = section, .text = MUST(String::from_utf8(text)), .title = {}, .subtitle = {}, .favicon_base64_png = {}, .can_be_automatically_selected = true };
 }
 
 AutocompleteSuggestion history_row(StringView url)
 {
     return row(AutocompleteSuggestionSource::History, AutocompleteSuggestionSection::History, url);
+}
+
+AutocompleteSuggestion non_automatic_history_row(StringView url, StringView title)
+{
+    return {
+        .source = AutocompleteSuggestionSource::History,
+        .section = AutocompleteSuggestionSection::History,
+        .text = MUST(String::from_utf8(url)),
+        .title = MUST(String::from_utf8(title)),
+        .subtitle = {},
+        .favicon_base64_png = {},
+        .can_be_automatically_selected = false,
+    };
 }
 
 AutocompleteSuggestion search_row(StringView query)
@@ -396,22 +409,58 @@ TEST_CASE(a_literal_url_suggestion_never_completes)
     EXPECT_EQ(harness.commits.last(), "t.example/path"sv);
 }
 
-TEST_CASE(a_top_row_that_does_not_match_the_prefix_is_only_highlighted)
+TEST_CASE(a_top_row_that_does_not_match_the_prefix_is_not_automatically_selected)
 {
     Harness harness;
     harness.begin_editing();
 
     harness.press_key('t');
-    harness.provider->deliver({ history_row("https://odd.example/t"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
+    harness.provider->deliver({ non_automatic_history_row("https://odd.example/t"sv, "Odd"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
     EXPECT_EQ(harness.display_text, "t"sv);
-    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+    EXPECT(!harness.omnibox.selected_suggestion().has_value());
 
-    // The top row is the default action even without a completion.
     harness.omnibox.return_pressed();
-    EXPECT_EQ(harness.commits.last(), "https://odd.example/t"sv);
+    EXPECT_EQ(harness.commits.last(), "t"sv);
 }
 
-TEST_CASE(a_fresh_non_prefix_top_row_wins_after_editing_a_completion)
+TEST_CASE(a_title_only_history_row_is_not_automatically_selected)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    for (auto code_point : "eau de"sv)
+        harness.press_key(code_point);
+
+    harness.provider->deliver({ non_automatic_history_row("https://example.com/fragrance"sv, "Eau de Parfum"sv), search_row("eau de"sv) }, AutocompleteResultKind::Final);
+    EXPECT_EQ(harness.display_text, "eau de"sv);
+    EXPECT(!harness.omnibox.selected_suggestion().has_value());
+    EXPECT(harness.omnibox.is_popup_visible());
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "eau de"sv);
+}
+
+TEST_CASE(a_user_chosen_title_only_history_row_is_activated)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    for (auto code_point : "eau de"sv)
+        harness.press_key(code_point);
+
+    harness.provider->deliver({ non_automatic_history_row("https://example.com/fragrance"sv, "Eau de Parfum"sv), search_row("eau de"sv) }, AutocompleteResultKind::Final);
+
+    EXPECT(harness.omnibox.select_next_suggestion());
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+    EXPECT_EQ(harness.display_text, "https://example.com/fragrance"sv);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.size(), 1u);
+    EXPECT_EQ(harness.commits.last(), "https://example.com/fragrance"sv);
+}
+
+TEST_CASE(a_fresh_non_prefix_url_top_row_does_not_win_after_editing_a_completion)
 {
     Harness harness;
     harness.begin_editing();
@@ -420,17 +469,17 @@ TEST_CASE(a_fresh_non_prefix_top_row_wins_after_editing_a_completion)
     harness.provider->deliver({ history_row("https://www.thev.example/"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
     EXPECT_EQ(harness.display_text, "thev.example"sv);
 
-    // The user types over the completion, and the fresh top hit is selected because it matched by title,
-    // not because its URL can inline-complete the typed query.
+    // The user types over the completion, and the fresh top hit is not
+    // selected merely because the query appears somewhere in its URL.
     for (auto code_point : "itle match"sv)
         harness.press_key(code_point);
-    harness.provider->deliver({ history_row("https://news.ycombinator.com/"sv), search_row("title match"sv) }, AutocompleteResultKind::Final);
+    harness.provider->deliver({ non_automatic_history_row("https://news.ycombinator.com/title-match"sv, "Title Match"sv), search_row("title match"sv) }, AutocompleteResultKind::Final);
     EXPECT_EQ(harness.display_text, "title match"sv);
-    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+    EXPECT(!harness.omnibox.selected_suggestion().has_value());
 
     harness.omnibox.return_pressed();
     EXPECT_EQ(harness.commits.size(), 1u);
-    EXPECT_EQ(harness.commits.last(), "https://news.ycombinator.com/"sv);
+    EXPECT_EQ(harness.commits.last(), "title match"sv);
 }
 
 TEST_CASE(clicking_a_suggestion_commits_it)

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -417,7 +417,7 @@ TEST_CASE(a_top_row_that_does_not_match_the_prefix_is_not_automatically_selected
     harness.press_key('t');
     harness.provider->deliver({ non_automatic_history_row("https://odd.example/t"sv, "Odd"sv), search_row("t"sv) }, AutocompleteResultKind::Final);
     EXPECT_EQ(harness.display_text, "t"sv);
-    EXPECT(!harness.omnibox.selected_suggestion().has_value());
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 1u);
 
     harness.omnibox.return_pressed();
     EXPECT_EQ(harness.commits.last(), "t"sv);
@@ -433,7 +433,7 @@ TEST_CASE(a_title_only_history_row_is_not_automatically_selected)
 
     harness.provider->deliver({ non_automatic_history_row("https://example.com/fragrance"sv, "Eau de Parfum"sv), search_row("eau de"sv) }, AutocompleteResultKind::Final);
     EXPECT_EQ(harness.display_text, "eau de"sv);
-    EXPECT(!harness.omnibox.selected_suggestion().has_value());
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 1u);
     EXPECT(harness.omnibox.is_popup_visible());
 
     harness.omnibox.return_pressed();
@@ -475,7 +475,7 @@ TEST_CASE(a_fresh_non_prefix_url_top_row_does_not_win_after_editing_a_completion
         harness.press_key(code_point);
     harness.provider->deliver({ non_automatic_history_row("https://news.ycombinator.com/title-match"sv, "Title Match"sv), search_row("title match"sv) }, AutocompleteResultKind::Final);
     EXPECT_EQ(harness.display_text, "title match"sv);
-    EXPECT(!harness.omnibox.selected_suggestion().has_value());
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 1u);
 
     harness.omnibox.return_pressed();
     EXPECT_EQ(harness.commits.size(), 1u);

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -70,6 +70,8 @@ private:
 
 #endif
 
+static constexpr int new_window_cascade_offset = 32;
+
 #if defined(AK_OS_MACOS)
 static bool has_visible_browser_window()
 {
@@ -335,6 +337,31 @@ void Application::set_active_window(BrowserWindow& window)
     update_macos_application_menu();
 }
 
+WindowConfiguration Application::configuration_for_new_window() const
+{
+    if (auto* previous_active_window = active_window_if_any(); previous_active_window && previous_active_window->isVisible()) {
+        return {
+            .x = previous_active_window->pos().x() + new_window_cascade_offset,
+            .y = previous_active_window->pos().y() + new_window_cascade_offset,
+            .width = previous_active_window->width(),
+            .height = previous_active_window->height(),
+            .maximized = previous_active_window->isMaximized(),
+        };
+    }
+
+    auto last_size = Settings::the()->last_size();
+    WindowConfiguration configuration {
+        .width = last_size.width(),
+        .height = last_size.height(),
+        .maximized = Settings::the()->is_maximized(),
+    };
+    if (auto last_position = Settings::the()->last_position(); last_position.has_value()) {
+        configuration.x = last_position->x();
+        configuration.y = last_position->y();
+    }
+    return configuration;
+}
+
 void Application::open_new_tab()
 {
     if (!m_active_window) {
@@ -349,13 +376,7 @@ void Application::open_new_tab()
 
 void Application::open_new_window()
 {
-    WindowConfiguration configuration {};
-    if (auto* previous_active_window = active_window_if_any()) {
-        configuration.width = previous_active_window->width();
-        configuration.height = previous_active_window->height();
-        configuration.maximized = previous_active_window->isMaximized();
-    }
-    new_window({ WebView::Application::settings().new_tab_page_url() }, configuration);
+    new_window({ WebView::Application::settings().new_tab_page_url() }, configuration_for_new_window());
 }
 
 void Application::focus_location_editor()

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -70,6 +70,17 @@ private:
 
 #endif
 
+#if defined(AK_OS_MACOS)
+static bool has_visible_browser_window()
+{
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (as_if<BrowserWindow>(widget) && widget->isVisible())
+            return true;
+    }
+    return false;
+}
+#endif
+
 class LadybirdQApplication : public QApplication {
 public:
     explicit LadybirdQApplication(Main::Arguments& arguments)
@@ -115,6 +126,11 @@ public:
         auto handled = QApplication::event(event);
         if (event_type == QEvent::ApplicationPaletteChange || event_type == QEvent::ThemeChange)
             update_chrome_style();
+
+#if defined(AK_OS_MACOS)
+        if (event_type == QEvent::ApplicationActivate && !has_visible_browser_window())
+            application.open_new_window();
+#endif
 
         return handled;
     }

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -34,6 +34,7 @@ public:
 
     Function<void(URL::URL)> on_open_file;
     BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& = {}, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    WindowConfiguration configuration_for_new_window() const;
     void open_new_tab();
     void open_new_window();
     void focus_location_editor();

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -158,7 +158,9 @@ LocationEdit::LocationEdit(QWidget* parent)
 
         if (display.selection_start.has_value()) {
             auto selection_start = qstring_offset_for_byte_offset(display.text, *display.selection_start);
-            setSelection(selection_start, static_cast<int>(display_text.length()) - selection_start);
+            auto selection_length = static_cast<int>(display_text.length()) - selection_start;
+            setCursorPosition(static_cast<int>(display_text.length()));
+            cursorBackward(true, selection_length);
         } else {
             deselect();
             setCursorPosition(static_cast<int>(display_text.length()));
@@ -222,7 +224,7 @@ LocationEdit::LocationEdit(QWidget* parent)
         // A selection reaching the end of the text (an inline completion, select-all on focus) still
         // counts as "at the end": replacing it appends, and completions may be applied over it.
         bool at_end = new_position == text().length()
-            && (!hasSelectedText() || selectionEnd() == text().length());
+            || (hasSelectedText() && selectionEnd() == text().length());
         m_omnibox.cursor_moved(at_end);
     });
 

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -90,13 +90,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         };
 
         browser_process.on_new_window = [&](auto const& urls) {
-            Ladybird::WindowConfiguration configuration {};
-            if (auto* previous_active_window = app->active_window_if_any()) {
-                configuration.width = previous_active_window->width();
-                configuration.height = previous_active_window->height();
-                configuration.maximized = previous_active_window->isMaximized();
-            }
-            app->new_window(urls, configuration);
+            app->new_window(urls, app->configuration_for_new_window());
         };
 
         auto last_size = Ladybird::Settings::the()->last_size();


### PR DESCRIPTION
This improves a few browser-chrome behaviors in the Qt UI.

Autocomplete no longer automatically selects weak history matches when the query only matches a page title or a non-prefix part of the URL. Those suggestions remain visible and manually activatable, but Enter keeps searching for the typed query by default. When that happens, the exact search suggestion is selected so the popup highlight matches the default action.

The Qt location edit now keeps the typed part of an inline-completed URL visible, even when the completed URL is wider than the omnibox.

On macOS, activating the app with no visible browser windows opens a new window. New browser windows are also cascaded from the active window by a small offset, falling back to the last saved window geometry when no browser window is visible.