### PR TITLE
Replace inline continuations with flat block-in-inline layout

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -122,6 +122,7 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/PixelUnits.h>
@@ -1653,6 +1654,12 @@ GC::Ref<Geometry::DOMRectList> Element::get_client_rects_for_bindings() const
     return Geometry::DOMRectList::create(realm(), move(rects));
 }
 
+static void append_transformed_border_box_rect(Vector<CSSPixelRect>& rects, Painting::PaintableBox const& paintable_box)
+{
+    auto absolute_rect = paintable_box.absolute_border_box_rect();
+    rects.append(paintable_box.transform_rect_to_viewport(absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
+}
+
 static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element const& element)
 {
     // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList
@@ -1673,9 +1680,27 @@ static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element c
     //          are left in the final list.
 
     Vector<CSSPixelRect> rects;
+    if (auto const* inline_node = as_if<Layout::InlineNode>(element.layout_node())) {
+        Painting::PaintableWithLines const* paintable_with_only_block_level_fragments = nullptr;
+        for (auto const& paintable : inline_node->paintables()) {
+            auto const* paintable_with_lines = as_if<Painting::PaintableWithLines>(paintable.ptr());
+            if (!paintable_with_lines)
+                continue;
+            if (paintable_with_lines->has_only_block_level_fragments()) {
+                paintable_with_only_block_level_fragments = paintable_with_lines;
+                continue;
+            }
+            append_transformed_border_box_rect(rects, *paintable_with_lines);
+        }
+        // An inline element whose content is only interrupting blocks generates no line fragments, but per CSSOM
+        // we still report its (zero-sized) border area instead of an empty list.
+        if (rects.is_empty() && paintable_with_only_block_level_fragments)
+            append_transformed_border_box_rect(rects, *paintable_with_only_block_level_fragments);
+        return rects;
+    }
+
     if (auto paintable_box = element.paintable_box()) {
-        auto absolute_rect = paintable_box->absolute_border_box_rect();
-        rects.append(paintable_box->transform_rect_to_viewport(absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
+        append_transformed_border_box_rect(rects, *paintable_box);
     } else if (element.paintable()) {
         dbgln("FIXME: Failed to get client rects for element ({})", element.debug_description());
     }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1806,15 +1806,6 @@ void Node::clear_layout_node_paintables()
         return;
 
     m_layout_node->clear_paintables();
-
-    // NB: Block-in-inline splitting can create multiple layout nodes for a single DOM node. Only the last one is stored
-    //     in m_layout_node so we need to clear the paintables for the continued nodes as well
-    auto* node_with_metrics = as_if<Layout::NodeWithStyleAndBoxModelMetrics>(*m_layout_node);
-    if (!node_with_metrics)
-        return;
-
-    for (auto* continuation = node_with_metrics->continuation_of_node(); continuation; continuation = continuation->continuation_of_node())
-        continuation->clear_paintables();
 }
 
 void Node::removed_from(IsSubtreeRoot, Node*, Node&)

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -344,10 +344,6 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
         }
     }
 
-    if (auto const* potential_continuation_node = as_if<Layout::NodeWithStyleAndBoxModelMetrics>(layout_node);
-        potential_continuation_node && potential_continuation_node->continuation_of_node())
-        builder.append(" continuation"sv);
-
     builder.append("\n"sv);
 
     if (layout_node.dom_node() && is<HTML::HTMLImageElement>(*layout_node.dom_node())) {

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -880,8 +880,18 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
     // The element's height is the distance from its top content edge to the first applicable of the following:
 
     // 1. the bottom edge of the last line box, if the box establishes a inline formatting context with one or more lines
-    if (box.children_are_inline() && !box_state.line_boxes.is_empty())
-        return box_state.line_boxes.last().bottom();
+    if (box.children_are_inline() && !box_state.line_boxes.is_empty()) {
+        auto height = box_state.line_boxes.last().bottom();
+        if (box_state.line_boxes.last().has_block_level_box()) {
+            auto margin_bottom = m_margin_state.current_collapsed_margin();
+            if (box_state.padding_bottom == 0 && box_state.border_bottom == 0) {
+                m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(true);
+                margin_bottom = 0;
+            }
+            height = max(CSSPixels(0), height + margin_bottom);
+        }
+        return height;
+    }
 
     // 2. the bottom edge of the bottom (possibly collapsed) margin of its last in-flow child, if the child's bottom margin does not collapse with the element's bottom margin
     // 3. the bottom border edge of the last in-flow child whose top margin doesn't collapse with the element's bottom margin
@@ -926,6 +936,29 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
 
     // 4. zero, otherwise
     return 0;
+}
+
+void BlockFormattingContext::layout_interrupting_block_inside_inline_context(Box const& box, BlockContainer const& containing_block, LayoutInput const& layout_input, LineBuilder& line_builder)
+{
+    CSSPixels dummy_bottom_of_lowest_margin_box = 0;
+    CSSPixels block_bottom;
+    {
+        TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, line_builder.current_block_offset() };
+        layout_block_level_box(box, containing_block, dummy_bottom_of_lowest_margin_box, layout_input);
+        block_bottom = m_y_offset_of_current_block_container.value_or(line_builder.current_block_offset());
+    }
+    line_builder.append_block_level_box(box, block_bottom, m_margin_state.current_collapsed_margin());
+}
+
+CSSPixels BlockFormattingContext::commit_pending_margin_before_inline_content()
+{
+    auto margin_collapses_with_block_container = m_margin_state.has_block_container_waiting_for_final_y_position();
+    auto collapsed_margin = m_margin_state.current_collapsed_margin();
+
+    m_margin_state.update_block_waiting_for_final_y_position();
+    m_margin_state.reset();
+
+    return margin_collapses_with_block_container ? CSSPixels(0) : collapsed_margin;
 }
 
 void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContainer const& block_container, CSSPixels& bottom_of_lowest_margin_box, LayoutInput const& layout_input)
@@ -1114,28 +1147,27 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
-        if (box.children_are_inline()) {
-            layout_inline_children(as<BlockContainer>(box), layout_input, space_available_for_children);
-        } else {
-            auto registered_block_container_y_position_update_callback = false;
-            if (box_state.border_top > 0 || box_state.padding_top > 0) {
-                // margin-top of block container can't collapse with it's children if it has non zero border or padding
-                m_margin_state.reset();
-            } else if (!m_margin_state.has_block_container_waiting_for_final_y_position()) {
-                // margin-top of block container can be updated during children layout hence it's final y position yet to be determined
-                m_margin_state.register_block_container_y_position_update_callback([this, &box, y, introduce_clearance](CSSPixels margin_top) {
-                    if (introduce_clearance == DidIntroduceClearance::No) {
-                        place_block_level_element_in_normal_flow_vertically(box, margin_top + y);
-                    }
-                });
-                registered_block_container_y_position_update_callback = true;
-            }
+        auto registered_block_container_y_position_update_callback = false;
+        if (box_state.border_top > 0 || box_state.padding_top > 0) {
+            // margin-top of block container can't collapse with its children if it has non-zero border or padding.
+            m_margin_state.reset();
+        } else if (!m_margin_state.has_block_container_waiting_for_final_y_position()) {
+            // margin-top of block container can be updated during children layout hence its final y position is yet to be determined.
+            m_margin_state.register_block_container_y_position_update_callback([this, &box, y, introduce_clearance](CSSPixels margin_top) {
+                if (introduce_clearance == DidIntroduceClearance::No) {
+                    place_block_level_element_in_normal_flow_vertically(box, margin_top + y);
+                }
+            });
+            registered_block_container_y_position_update_callback = true;
+        }
 
+        if (box.children_are_inline())
+            layout_inline_children(as<BlockContainer>(box), layout_input, space_available_for_children);
+        else
             layout_block_level_children(as<BlockContainer>(box), layout_input, space_available_for_children);
 
-            if (registered_block_container_y_position_update_callback) {
-                m_margin_state.unregister_block_container_y_position_update_callback();
-            }
+        if (registered_block_container_y_position_update_callback) {
+            m_margin_state.unregister_block_container_y_position_update_callback();
         }
     }
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -57,6 +57,9 @@ public:
 
     void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutInput const&, CSSPixels y, LineBuilder* = nullptr);
 
+    void layout_interrupting_block_inside_inline_context(Box const&, BlockContainer const& containing_block, LayoutInput const&, LineBuilder&);
+    CSSPixels commit_pending_margin_before_inline_content();
+
     void layout_block_level_box(Box const&, BlockContainer const&, CSSPixels& bottom_of_lowest_margin_box, LayoutInput const&);
 
     void resolve_vertical_box_model_metrics(Box const&, CSSPixels width_of_containing_block);

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -501,6 +501,9 @@ CSSPixels FormattingContext::greatest_child_width(Box const& box) const
 
 CSSPixels FormattingContext::line_box_physical_width(Box const& box, LineBox const& line_box)
 {
+    if (line_box.has_block_level_box())
+        return line_box.inline_length();
+
     if (box.computed_values().writing_mode() == CSS::WritingMode::HorizontalTb)
         return line_box.width();
 
@@ -601,8 +604,13 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
         // the top content edge and the bottom of the bottommost line box.
         auto const& line_boxes = m_state.get(root).line_boxes;
         top = 0;
-        if (!line_boxes.is_empty())
+        if (!line_boxes.is_empty()) {
             bottom = line_boxes.last().bottom();
+            // A trailing interrupting block's bottom margin cannot collapse out of a BFC root,
+            // so it contributes to the root's auto height. The line box bottom excludes it.
+            if (line_boxes.last().has_block_level_box())
+                bottom = max(CSSPixels(0), bottom.value() + line_boxes.last().block_level_box_bottom_margin());
+        }
     } else {
         // If it has block-level children, the height is the distance between
         // the top margin-edge of the topmost block-level child box
@@ -2981,9 +2989,26 @@ CSSPixels FormattingContext::box_baseline(Box const& box, BaselineSet baseline_s
     bool derive_baseline_from_content = baseline_set == BaselineSet::First || is_flex_or_grid_container || has_visible_overflow;
 
     if (derive_baseline_from_content && !box_state.line_boxes.is_empty()) {
-        auto const& line_box = baseline_set == BaselineSet::First ? box_state.line_boxes.first() : box_state.line_boxes.last();
-        auto line_box_top = line_box.bottom() - line_box.block_length();
-        return box_state.margin_box_top() + line_box_top + line_box.baseline();
+        auto baseline_for_line_box = [&](LineBox const& line_box) {
+            if (!line_box.has_block_level_box()) {
+                auto line_box_top = line_box.bottom() - line_box.block_length();
+                return box_state.margin_box_top() + line_box_top + line_box.baseline();
+            }
+
+            VERIFY(line_box.fragments().size() == 1);
+            auto const& block_child = as<Box>(line_box.fragments().first().layout_node());
+            auto const& block_child_state = m_state.get(block_child);
+            auto child_offset_from_margin_edge = block_child_state.offset.y() - block_child_state.margin_box_top();
+            return box_state.margin_box_top() + child_offset_from_margin_edge + box_baseline(block_child, baseline_set);
+        };
+
+        if (baseline_set == BaselineSet::First) {
+            auto line_box = box_state.line_boxes.first_matching([](auto& line_box) { return !line_box.is_empty(); });
+            return baseline_for_line_box(line_box.value_or(box_state.line_boxes.first()));
+        }
+
+        auto line_box = box_state.line_boxes.last_matching([](auto& line_box) { return !line_box.is_empty(); });
+        return baseline_for_line_box(line_box.value_or(box_state.line_boxes.last()));
     }
 
     // Derive baseline from block children if this box derives its baseline from its content.

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/Dump.h>
@@ -74,10 +75,14 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
     m_layout_input.emplace(layout_input);
     generate_line_boxes();
 
+    auto const& line_boxes = m_containing_block_used_values.line_boxes;
     CSSPixels content_height = 0;
-
-    for (auto& line_box : m_containing_block_used_values.line_boxes)
-        content_height += line_box.height();
+    if (any_of(line_boxes, [](auto& line_box) { return line_box.has_block_level_box(); })) {
+        content_height = line_boxes.last().bottom();
+    } else {
+        for (auto& line_box : line_boxes)
+            content_height += line_box.height();
+    }
 
     // NOTE: We ask the parent BFC to calculate the automatic content width of this IFC.
     //       This ensures that any floated boxes are taken into account.
@@ -370,11 +375,13 @@ void InlineFormattingContext::generate_line_boxes()
         auto& item = item_opt.value();
 
         // Ignore collapsible whitespace chunks at the start of line, and if the last fragment already ends in whitespace.
-        if (item.is_collapsible_whitespace && (line_boxes.is_empty() || line_boxes.last().is_empty_or_ends_in_whitespace())) {
+        if (item.is_collapsible_whitespace && (line_boxes.is_empty() || line_boxes.last().is_empty_or_ends_in_whitespace() || line_boxes.last().has_block_level_box())) {
             if (item.node->computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
                 auto next_width = iterator.next_non_whitespace_sequence_width();
-                if (next_width > 0)
+                if (next_width > 0) {
+                    line_builder.prepare_to_append_inline_content();
                     line_builder.break_if_needed(next_width);
+                }
             }
             leading_margin_from_collapsible_whitespace += item.margin_start;
             leading_border_from_collapsible_whitespace += item.border_start;
@@ -403,6 +410,7 @@ void InlineFormattingContext::generate_line_boxes()
         }
         case InlineLevelIterator::Item::Type::Element: {
             auto& box = as<Layout::Box>(*item.node);
+            line_builder.prepare_to_append_inline_content();
             compute_inset(box, content_box_rect(m_containing_block_used_values).size());
             if (containing_block().computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
                 auto minimum_space_needed_on_line = item.border_box_width();
@@ -415,8 +423,19 @@ void InlineFormattingContext::generate_line_boxes()
             line_builder.append_box(box, item.border_start + item.padding_start, item.padding_end + item.border_end, item.margin_start, item.margin_end);
             break;
         }
-        case InlineLevelIterator::Item::Type::BlockLevelBox:
-            VERIFY_NOT_REACHED();
+        case InlineLevelIterator::Item::Type::BlockLevelBox: {
+            auto& box = as<Layout::Box>(*item.node);
+            // The interrupting block cannot carry inline start-edge PBM; stash it back so it attaches to the next
+            // inline item instead of being dropped.
+            // FIXME: InlineLevelIterator's pending leading inline PBM still attaches to content after an interrupting
+            // block, even though the inline start edge should render on the line before the block.
+            leading_margin_from_collapsible_whitespace += item.margin_start;
+            leading_border_from_collapsible_whitespace += item.border_start;
+            leading_padding_from_collapsible_whitespace += item.padding_start;
+            line_builder.finish_current_line_before_block_level_box();
+            parent().layout_interrupting_block_inside_inline_context(box, containing_block(), *m_layout_input, line_builder);
+            break;
+        }
         case InlineLevelIterator::Item::Type::AbsolutelyPositionedElement:
             if (auto const* box = as_if<Box>(*item.node)) {
                 line_builder.append_static_position_marker(*box);
@@ -426,6 +445,7 @@ void InlineFormattingContext::generate_line_boxes()
 
         case InlineLevelIterator::Item::Type::FloatingElement:
             if (auto* box = as_if<Box>(*item.node)) {
+                line_builder.commit_pending_margin_before_float();
                 if (!is<ListItemMarkerBox>(*box))
                     m_state.create(*box, m_layout_input->containing_block_constraints.percentage_basis_width, m_layout_input->containing_block_constraints.percentage_basis_height);
                 (void)parent().clear_floating_boxes(*item.node, *this);
@@ -437,6 +457,7 @@ void InlineFormattingContext::generate_line_boxes()
 
         case InlineLevelIterator::Item::Type::Text: {
             auto& text_node = as<Layout::TextNode>(*item.node);
+            line_builder.prepare_to_append_inline_content();
 
             if (text_node.computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
                 bool is_whitespace = false;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -415,6 +415,8 @@ void InlineFormattingContext::generate_line_boxes()
             line_builder.append_box(box, item.border_start + item.padding_start, item.padding_end + item.border_end, item.margin_start, item.margin_end);
             break;
         }
+        case InlineLevelIterator::Item::Type::BlockLevelBox:
+            VERIFY_NOT_REACHED();
         case InlineLevelIterator::Item::Type::AbsolutelyPositionedElement:
             if (auto const* box = as_if<Box>(*item.node)) {
                 line_builder.append_static_position_marker(*box);

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -32,7 +32,7 @@ InlineLevelIterator::InlineLevelIterator(Layout::InlineFormattingContext& inline
 static bool is_inline_flow_interrupting_block(Layout::Node const& node)
 {
     auto const* node_with_metrics = as_if<Layout::NodeWithStyleAndBoxModelMetrics>(node);
-    return node_with_metrics && node_with_metrics->should_create_inline_continuation();
+    return node_with_metrics && node_with_metrics->is_inline_flow_interrupting_block();
 }
 
 void InlineLevelIterator::generate_all_items()

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -29,6 +29,12 @@ InlineLevelIterator::InlineLevelIterator(Layout::InlineFormattingContext& inline
     generate_all_items();
 }
 
+static bool is_inline_flow_interrupting_block(Layout::Node const& node)
+{
+    auto const* node_with_metrics = as_if<Layout::NodeWithStyleAndBoxModelMetrics>(node);
+    return node_with_metrics && node_with_metrics->should_create_inline_continuation();
+}
+
 void InlineLevelIterator::generate_all_items()
 {
     for (;;) {
@@ -38,7 +44,7 @@ void InlineLevelIterator::generate_all_items()
 
         // Track accumulated width for tab calculations.
         // Reset on forced breaks since tabs measure from line start.
-        if (item->type == Item::Type::ForcedBreak) {
+        if (item->type == Item::Type::ForcedBreak || item->type == Item::Type::BlockLevelBox) {
             m_accumulated_width_for_tabs = 0;
         } else {
             m_accumulated_width_for_tabs += item->border_box_width();
@@ -104,12 +110,13 @@ void InlineLevelIterator::exit_node_with_box_model_metrics()
     m_box_model_node_stack.take_last();
 }
 
-// This is similar to Layout::Node::next_in_pre_order() but will not descend into inline-block nodes.
+// This is similar to Layout::Node::next_in_pre_order() but will not descend into inline-block or interrupting block-level nodes.
 Layout::Node const* InlineLevelIterator::next_inline_node_in_pre_order(Layout::Node const& current, Layout::Node const* stay_within)
 {
     if (current.first_child()
-        && current.first_child()->display().is_inline_outside()
+        && (current.first_child()->display().is_inline_outside() || is_inline_flow_interrupting_block(*current.first_child()))
         && current.display().is_flow_inside()
+        && !is_inline_flow_interrupting_block(current)
         && !current.is_replaced_box()) {
         if (!current.is_box() || !static_cast<Box const&>(current).is_out_of_flow(m_inline_formatting_context))
             return current.first_child();
@@ -149,13 +156,14 @@ void InlineLevelIterator::compute_next()
             //       We should skip and let SVGFormattingContext take care of them.
             m_next_node = m_next_node->next_sibling();
         }
-    } while (m_next_node && (!m_next_node->is_inline() && !m_next_node->is_out_of_flow(m_inline_formatting_context)));
+    } while (m_next_node && (!m_next_node->is_inline() && !m_next_node->is_out_of_flow(m_inline_formatting_context) && !is_inline_flow_interrupting_block(*m_next_node)));
 }
 
 void InlineLevelIterator::skip_to_next()
 {
     if (m_next_node
         && is<Layout::NodeWithStyleAndBoxModelMetrics>(*m_next_node)
+        && m_next_node->is_inline()
         && m_next_node->display().is_flow_inside()
         && !m_next_node->is_out_of_flow(m_inline_formatting_context)
         && !m_next_node->is_replaced_box())
@@ -177,7 +185,7 @@ CSSPixels InlineLevelIterator::next_non_whitespace_sequence_width()
     CSSPixels next_width = 0;
     for (size_t i = m_next_item_index; i < m_items.size(); ++i) {
         auto const& next_item = m_items[i];
-        if (next_item.type == InlineLevelIterator::Item::Type::ForcedBreak)
+        if (next_item.type == InlineLevelIterator::Item::Type::ForcedBreak || next_item.type == InlineLevelIterator::Item::Type::BlockLevelBox)
             break;
         if (next_item.node->computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
             if (next_item.type != InlineLevelIterator::Item::Type::Text)
@@ -404,6 +412,14 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
     }
 
     auto const& box = as<Layout::Box>(*m_current_node);
+    if (is_inline_flow_interrupting_block(box)) {
+        skip_to_next();
+        return Item {
+            .type = Item::Type::BlockLevelBox,
+            .node = &box,
+        };
+    }
+
     auto const& box_state = [&]() -> LayoutState::UsedValues const& {
         if (!m_box_model_node_stack.is_empty() && m_box_model_node_stack.last() == &box)
             return m_layout_state.get_mutable(box);

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -26,6 +26,7 @@ public:
         enum class Type {
             Text,
             Element,
+            BlockLevelBox,
             ForcedBreak,
             AbsolutelyPositionedElement,
             FloatingElement,

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -419,12 +419,50 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
     return scrollable_overflow_rect;
 }
 
+struct InlineAncestorChainRelativeOffset {
+    CSSPixelPoint offset;
+    bool found_inline_node { false };
+};
+
+// Accumulates relative position insets from a chain of inline-flow ancestors, starting at first_ancestor
+// and walking up until stop_at or the first ancestor that is not inline-flow.
+static InlineAncestorChainRelativeOffset accumulated_relative_insets_from_inline_ancestor_chain(Node const* first_ancestor, Node const* stop_at)
+{
+    InlineAncestorChainRelativeOffset result;
+    for (auto const* ancestor = first_ancestor; ancestor && ancestor != stop_at; ancestor = ancestor->parent()) {
+        if (!is<Layout::NodeWithStyleAndBoxModelMetrics>(*ancestor))
+            break;
+        if (!ancestor->display().is_inline_outside() || !ancestor->display().is_flow_inside())
+            break;
+        result.found_inline_node |= is<Layout::InlineNode>(*ancestor);
+        if (ancestor->computed_values().position() == CSS::Positioning::Relative) {
+            VERIFY(ancestor->first_paintable());
+            auto const& ancestor_paintable_box = as<Painting::PaintableBox>(*ancestor->first_paintable());
+            auto const& inset = ancestor_paintable_box.box_model().inset;
+            result.offset.translate_by(inset.left, inset.top);
+        }
+    }
+    return result;
+}
+
 void LayoutState::resolve_relative_positions()
 {
-    // This function resolves relative position offsets of fragments that belong to inline paintables.
-    // It runs *after* the paint tree has been constructed, so it modifies paintable node & fragment offsets directly.
+    // This function resolves relative position offsets contributed by inline-flow ancestor chains, which
+    // apply both to fragments that belong to inline paintables and to block-level boxes interrupting an
+    // inline (block-in-inline). It runs *after* the paint tree has been constructed, so it modifies
+    // paintable node & fragment offsets directly.
     m_used_values_store.for_each([&](UsedValues& used_values) {
         auto& node = const_cast<NodeWithStyle&>(used_values.node());
+
+        if (auto const* box = as_if<Box>(node); box && box->is_in_flow() && box->display().is_block_outside()) {
+            auto accumulated = accumulated_relative_insets_from_inline_ancestor_chain(box->parent(), box->containing_block());
+            if (accumulated.found_inline_node) {
+                for (auto& paintable : node.paintables()) {
+                    auto& paintable_box = as<Painting::PaintableBox>(*paintable);
+                    paintable_box.set_offset(paintable_box.offset().translated(accumulated.offset));
+                }
+            }
+        }
 
         for (auto& paintable : node.paintables()) {
             auto* inline_paintable = as_if<Painting::PaintableWithLines>(paintable.ptr());
@@ -432,25 +470,9 @@ void LayoutState::resolve_relative_positions()
                 continue;
 
             for (auto& fragment : inline_paintable->fragments()) {
-                auto const& fragment_node = fragment.layout_node();
-                if (!is<Layout::NodeWithStyleAndBoxModelMetrics>(*fragment_node.parent()))
-                    continue;
-                // Collect effective relative position offset from inline-flow parent chain.
-                CSSPixelPoint offset;
-                for (auto* ancestor = fragment_node.parent(); ancestor; ancestor = ancestor->parent()) {
-                    if (!is<Layout::NodeWithStyleAndBoxModelMetrics>(*ancestor))
-                        break;
-                    if (!ancestor->display().is_inline_outside() || !ancestor->display().is_flow_inside())
-                        break;
-                    if (ancestor->computed_values().position() == CSS::Positioning::Relative) {
-                        VERIFY(ancestor->first_paintable());
-                        auto ancestor_paintable = ancestor->first_paintable();
-                        auto const& ancestor_node = as<Painting::PaintableBox>(*ancestor_paintable);
-                        auto const& inset = ancestor_node.box_model().inset;
-                        offset.translate_by(inset.left, inset.top);
-                    }
-                }
-                const_cast<Painting::PaintableFragment&>(fragment).set_offset(fragment.offset().translated(offset));
+                auto accumulated = accumulated_relative_insets_from_inline_ancestor_chain(fragment.layout_node().parent(), nullptr);
+                if (!accumulated.offset.is_zero())
+                    const_cast<Painting::PaintableFragment&>(fragment).set_offset(fragment.offset().translated(accumulated.offset));
             }
         }
     });
@@ -533,7 +555,7 @@ void LayoutState::commit(Box& root)
 
     auto try_to_relocate_fragment_in_inline_node = [&](auto& fragment, Painting::LineBoxData line_box_data, Painting::PaintableBox::FragmentationState fragmentation_state) -> bool {
         for (auto const* parent = fragment.layout_node().parent(); parent; parent = parent->parent()) {
-            if (parent->is_atomic_inline())
+            if (!parent->display().is_inline_outside() || !parent->display().is_flow_inside())
                 break;
             if (is<InlineNode>(*parent)) {
                 auto& inline_node = const_cast<InlineNode&>(static_cast<InlineNode const&>(*parent));
@@ -735,6 +757,12 @@ void LayoutState::commit(Box& root)
             continue;
         if (!is<InlineNode>(paintable_with_lines->layout_node()))
             continue;
+
+        if (paintable_with_lines->has_only_block_level_fragments()) {
+            paintable_with_lines->set_offset(paintable_with_lines->fragments().first().offset());
+            paintable_with_lines->set_content_size({});
+            continue;
+        }
 
         Optional<CSSPixelPoint> offset;
         CSSPixelSize size;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -478,9 +478,31 @@ void LayoutState::resolve_relative_positions()
     });
 }
 
-static void build_paint_tree(Node& node, RefPtr<Painting::Paintable> parent_paintable = nullptr)
+static Optional<size_t> line_index_for_paint_parent_matching(Painting::Paintable const& paintable)
+{
+    if (auto const* paintable_with_lines = as_if<Painting::PaintableWithLines>(paintable); paintable_with_lines && is<InlineNode>(paintable.layout_node()))
+        return paintable_with_lines->line_index();
+
+    if (auto const* paintable_box = as_if<Painting::PaintableBox>(paintable)) {
+        if (paintable_box->containing_line_box_data().has_value())
+            return paintable_box->containing_line_box_data()->index;
+    }
+
+    return {};
+}
+
+// An InlineNode has one paintable per line it spans; a child paintable must be attached to the parent
+// paintable for the line it belongs to, keyed by line index.
+static void build_paint_tree(Node& node, Painting::Paintable* fallback_parent_paintable = nullptr, HashMap<size_t, Painting::Paintable*> const* parent_paintable_by_line_index = nullptr)
 {
     for (auto& paintable : node.paintables()) {
+        auto* parent_paintable = fallback_parent_paintable;
+        if (parent_paintable_by_line_index) {
+            if (auto line_index = line_index_for_paint_parent_matching(*paintable); line_index.has_value()) {
+                if (auto matching_parent = parent_paintable_by_line_index->get(line_index.value()); matching_parent.has_value())
+                    parent_paintable = matching_parent.value();
+            }
+        }
         if (parent_paintable && !paintable->forms_unconnected_subtree()) {
             VERIFY(!paintable->parent());
             parent_paintable->append_child(paintable);
@@ -489,8 +511,19 @@ static void build_paint_tree(Node& node, RefPtr<Painting::Paintable> parent_pain
         if (node.dom_node())
             node.dom_node()->set_paintable(paintable);
     }
+
+    if (!node.first_child())
+        return;
+
+    HashMap<size_t, Painting::Paintable*> paintable_by_line_index;
+    if (is<InlineNode>(node)) {
+        for (auto& paintable : node.paintables()) {
+            if (auto* paintable_with_lines = as_if<Painting::PaintableWithLines>(paintable.ptr()))
+                paintable_by_line_index.set(paintable_with_lines->line_index(), paintable_with_lines);
+        }
+    }
     for (auto child = node.first_child(); child; child = child->next_sibling()) {
-        build_paint_tree(*child, node.first_paintable());
+        build_paint_tree(*child, node.first_paintable().ptr(), is<InlineNode>(node) ? &paintable_by_line_index : nullptr);
     }
 }
 
@@ -746,7 +779,7 @@ void LayoutState::commit(Box& root)
         paintable.set_offset(offset);
     });
 
-    build_paint_tree(root, parent_paintable);
+    build_paint_tree(root, parent_paintable.ptr());
 
     resolve_relative_positions();
 

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -566,14 +566,8 @@ void LayoutState::commit(Box& root)
     root.for_each_in_inclusive_subtree([&](Node& node) {
         if (auto* dom_node = node.dom_node())
             dom_node->clear_paintable();
-        if (is<InlineNode>(node) && node.dom_node()) {
-            // Inline nodes might have a continuation chain; add all inline nodes that are part of it.
-            for (GC::Ptr inline_node = static_cast<NodeWithStyleAndBoxModelMetrics*>(&node);
-                inline_node; inline_node = inline_node->continuation_of_node()) {
-                if (is<InlineNode>(*inline_node))
-                    inline_nodes.set(static_cast<InlineNode*>(inline_node.ptr()));
-            }
-        }
+        if (is<InlineNode>(node) && node.dom_node())
+            inline_nodes.set(static_cast<InlineNode*>(&node));
         return TraversalDecision::Continue;
     });
 

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -59,6 +59,8 @@ public:
     bool is_empty_or_ends_in_whitespace() const;
     bool is_empty() const { return m_fragments.is_empty() && !m_has_break; }
     bool has_forced_break() const { return m_has_forced_break; }
+    bool has_block_level_box() const { return m_has_block_level_box; }
+    CSSPixels block_level_box_bottom_margin() const { return m_block_level_box_bottom_margin; }
 
     AvailableSize original_available_width() const { return m_original_available_width; }
 
@@ -80,6 +82,9 @@ private:
     CSSPixels m_block_length { 0 };
     CSSPixels m_bottom { 0 };
     CSSPixels m_baseline { 0 };
+    // For a line box holding an interrupting block-level box: the block's pending (collapsed) bottom margin,
+    // which is not included in m_bottom. Needed to size BFC roots whose last line is such a line.
+    CSSPixels m_block_level_box_bottom_margin { 0 };
     CSS::Direction m_direction { CSS::Direction::Ltr };
     CSS::WritingMode m_writing_mode { CSS::WritingMode::HorizontalTb };
 
@@ -88,6 +93,7 @@ private:
 
     bool m_has_break { false };
     bool m_has_forced_break { false };
+    bool m_has_block_level_box { false };
 };
 
 }

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -81,6 +81,7 @@ void LineBuilder::begin_new_line(bool increment_y, bool is_first_break_in_sequen
 
     if (should_indent)
         line_box.m_inline_length += m_text_indent;
+    m_current_line_committed_pending_margin = false;
 }
 
 LineBox& LineBuilder::ensure_last_line_box()
@@ -93,6 +94,8 @@ LineBox& LineBuilder::ensure_last_line_box()
 
 void LineBuilder::append_box(Box const& box, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin)
 {
+    prepare_to_append_inline_content();
+
     auto& box_state = m_layout_state.get_mutable(box);
     auto& line_box = ensure_last_line_box();
     line_box.add_fragment(box, 0, 0, leading_size, trailing_size, leading_margin, trailing_margin,
@@ -114,6 +117,8 @@ void LineBuilder::append_box(Box const& box, CSSPixels leading_size, CSSPixels t
 
 void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun> glyph_run)
 {
+    prepare_to_append_inline_content();
+
     auto& line_box = ensure_last_line_box();
     line_box.add_fragment(text_node, offset_in_node, length_in_node, leading_size, trailing_size, leading_margin,
         trailing_margin, content_width, content_height, 0, 0, move(glyph_run));
@@ -124,6 +129,97 @@ void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_
 void LineBuilder::append_static_position_marker(Box const& box)
 {
     ensure_last_line_box().add_static_position_marker(box);
+}
+
+void LineBuilder::prepare_to_append_inline_content()
+{
+    if (m_current_line_committed_pending_margin)
+        return;
+
+    auto& line_box = ensure_last_line_box();
+    if (line_box.has_block_level_box())
+        return;
+
+    auto margin_before_line = m_context.parent().commit_pending_margin_before_inline_content();
+    if (margin_before_line != 0) {
+        m_current_block_offset += margin_before_line;
+        recalculate_available_space();
+    }
+    m_current_line_committed_pending_margin = true;
+    m_pending_margin_follows_block_level_box = false;
+}
+
+void LineBuilder::commit_pending_margin_before_float()
+{
+    // Floats are placed at the current block offset without committing pending margins (which may still collapse
+    // with following block-level siblings). But a margin left pending by an interrupting block must be committed,
+    // or the float would sit higher than the inline content that will share its line.
+    if (m_pending_margin_follows_block_level_box)
+        prepare_to_append_inline_content();
+}
+
+void LineBuilder::finish_current_line_before_block_level_box()
+{
+    auto& line_boxes = m_containing_block_used_values.line_boxes;
+    if (line_boxes.is_empty() || line_boxes.last().is_empty())
+        return;
+
+    auto& last_line_box = ensure_last_line_box();
+    last_line_box.m_has_break = true;
+    // The interrupting block ends the inline flow here, so this line is "the last line before a forced break"
+    // for text-align purposes and must not be stretched by justification.
+    last_line_box.m_has_forced_break = true;
+
+    m_last_line_needs_update = true;
+    update_last_line();
+
+    line_boxes.append(LineBox(m_direction, m_writing_mode));
+    begin_new_line(true);
+}
+
+void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom, CSSPixels block_bottom_margin)
+{
+    auto& box_state = m_layout_state.get_mutable(box);
+    auto& line_box = ensure_last_line_box();
+    VERIFY(line_box.fragments().is_empty());
+
+    // The fragment stores logical (inline/block) coordinates, while the box state carries physical ones.
+    auto is_horizontal = m_writing_mode == CSS::WritingMode::HorizontalTb;
+    auto inline_offset = is_horizontal ? box_state.offset.x() : box_state.offset.y();
+    auto block_offset = is_horizontal ? box_state.offset.y() : box_state.offset.x();
+    auto inline_length = is_horizontal ? box_state.content_width() : box_state.content_height();
+    auto block_length = is_horizontal ? box_state.content_height() : box_state.content_width();
+
+    line_box.m_fragments.append(LineBoxFragment { box, 0, 0, inline_offset, block_offset,
+        inline_length, block_length, box_state.border_box_top(), m_direction, m_writing_mode, {} });
+    line_box.m_inline_length = is_horizontal ? box_state.margin_box_width() : box_state.margin_box_height();
+    line_box.m_block_length = 0;
+    line_box.m_bottom = block_bottom;
+    line_box.m_baseline = 0;
+    line_box.m_has_block_level_box = true;
+    line_box.m_block_level_box_bottom_margin = block_bottom_margin;
+    line_box.m_has_break = true;
+    // The interrupting block also ends the inline flow after itself; any content that follows starts on a fresh line.
+    line_box.m_has_forced_break = true;
+
+    box_state.containing_line_box_fragment = LineBoxFragmentCoordinate {
+        .line_box_index = m_containing_block_used_values.line_boxes.size() - 1,
+        .fragment_index = 0,
+    };
+
+    // Static position markers recorded on this line will never go through update_last_line(), so anchor them
+    // at the flow position the interrupting block starts at.
+    for (auto& marker : line_box.static_position_markers())
+        marker.block_offset += m_current_block_offset;
+
+    m_pending_margin_follows_block_level_box = true;
+    m_current_block_offset = block_bottom;
+    m_max_height_on_current_line = 0;
+    m_last_line_needs_update = false;
+    m_should_advance_to_last_line_box_bottom = false;
+
+    m_containing_block_used_values.line_boxes.append(LineBox(m_direction, m_writing_mode));
+    begin_new_line(false);
 }
 
 CSSPixels LineBuilder::ceiling_for_float_to_be_inserted_here(Box const& box)
@@ -174,6 +270,14 @@ void LineBuilder::update_last_line()
         return;
 
     auto& line_box = line_boxes.last();
+
+    if (line_box.has_block_level_box()) {
+        m_should_advance_to_last_line_box_bottom = false;
+        return;
+    }
+
+    if (!line_box.fragments().is_empty())
+        prepare_to_append_inline_content();
 
     auto text_align = m_context.containing_block().computed_values().text_align();
     auto direction = m_context.containing_block().computed_values().direction();

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -26,6 +26,10 @@ public:
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
     void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun>);
     void append_static_position_marker(Box const&);
+    void prepare_to_append_inline_content();
+    void commit_pending_margin_before_float();
+    void finish_current_line_before_block_level_box();
+    void append_block_level_box(Box const&, CSSPixels block_bottom, CSSPixels block_bottom_margin);
 
     // Returns whether a line break occurred.
     bool break_if_needed(CSSPixels next_item_width)
@@ -71,6 +75,8 @@ private:
 
     bool m_last_line_needs_update { false };
     bool m_should_advance_to_last_line_box_bottom { false };
+    bool m_current_line_committed_pending_margin { false };
+    bool m_pending_margin_follows_block_level_box { false };
 };
 
 }

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1105,9 +1105,6 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
 
     propagate_style_to_anonymous_wrappers();
 
-    if (auto* box_node = as_if<NodeWithStyleAndBoxModelMetrics>(*this))
-        box_node->propagate_style_along_continuation(computed_style);
-
     rebuild_image_observers();
 }
 
@@ -1669,15 +1666,6 @@ bool NodeWithStyleAndBoxModelMetrics::is_inline_flow_interrupting_block() const
         return false;
 
     return true;
-}
-
-void NodeWithStyleAndBoxModelMetrics::propagate_style_along_continuation(CSS::ComputedProperties const& computed_style) const
-{
-    auto continuation = continuation_of_node();
-    while (continuation && continuation->is_anonymous())
-        continuation = continuation->continuation_of_node();
-    if (continuation)
-        continuation->apply_style(computed_style);
 }
 
 void Node::set_needs_layout_update(DOM::SetNeedsLayoutReason reason)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1629,9 +1629,10 @@ bool Node::has_paint_containment() const
     return false;
 }
 
-bool NodeWithStyleAndBoxModelMetrics::should_create_inline_continuation() const
+bool NodeWithStyleAndBoxModelMetrics::is_inline_flow_interrupting_block() const
 {
-    // This node must have an inline parent.
+    // This node remains a layout child of its inline-flow parent. InlineLevelIterator emits it as a BlockLevelBox item
+    // so the inline formatting context can lay it out as an interrupting block.
     if (!parent())
         return false;
     auto const& parent_display = parent()->display();
@@ -1642,7 +1643,7 @@ bool NodeWithStyleAndBoxModelMetrics::should_create_inline_continuation() const
     if (display().is_inline_outside() || is_out_of_flow())
         return false;
 
-    // This node must not have `display: contents`; inline continuation gets handled by its children.
+    // This node must not have `display: contents`; interrupting block handling gets delegated to its children.
     if (display().is_contents())
         return false;
 
@@ -1654,16 +1655,16 @@ bool NodeWithStyleAndBoxModelMetrics::should_create_inline_continuation() const
     if (is<SVG::SVGForeignObjectElement>(parent()->dom_node()))
         return false;
 
-    // Non-root SVG elements and foreign object boxes should never be split.
+    // Non-root SVG elements and foreign object boxes should not interrupt inline flow.
     if (is_svg_box() || is_svg_foreign_object_box())
         return false;
 
-    // Nested SVG roots should never be split, but a top-level SVG root inside an HTML inline element should be.
+    // Nested SVG roots should not interrupt inline flow, but a top-level SVG root inside an HTML inline element should.
     if (is_svg_svg_box() && (parent()->is_svg_box() || parent()->is_svg_svg_box()))
         return false;
 
     // Replaced boxes with children (e.g. media elements with shadow DOM controls)
-    // have their own formatting context; don't split them.
+    // have their own formatting context; don't let their children interrupt inline flow.
     if (parent()->is_replaced_box_with_children())
         return false;
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -381,7 +381,7 @@ public:
     NodeWithStyleAndBoxModelMetrics* continuation_of_node() const { return m_continuation_of_node.ptr(); }
     void set_continuation_of_node(Badge<TreeBuilder>, NodeWithStyleAndBoxModelMetrics* node) { m_continuation_of_node = node; }
 
-    bool should_create_inline_continuation() const;
+    bool is_inline_flow_interrupting_block() const;
 
     void propagate_style_along_continuation(CSS::ComputedProperties const&) const;
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -378,12 +378,7 @@ class NodeWithStyleAndBoxModelMetrics : public NodeWithStyle {
     LAYOUT_NODE(NodeWithStyleAndBoxModelMetrics, NodeWithStyle);
 
 public:
-    NodeWithStyleAndBoxModelMetrics* continuation_of_node() const { return m_continuation_of_node.ptr(); }
-    void set_continuation_of_node(Badge<TreeBuilder>, NodeWithStyleAndBoxModelMetrics* node) { m_continuation_of_node = node; }
-
     bool is_inline_flow_interrupting_block() const;
-
-    void propagate_style_along_continuation(CSS::ComputedProperties const&) const;
 
 protected:
     NodeWithStyleAndBoxModelMetrics(DOM::Document&, DOM::Node*, CSS::ComputedProperties const&);
@@ -395,8 +390,6 @@ protected:
 
 private:
     virtual bool is_node_with_style_and_box_model_metrics() const final { return true; }
-
-    WeakPtr<NodeWithStyleAndBoxModelMetrics> m_continuation_of_node;
 };
 
 template<>

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -109,7 +109,7 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
 
 static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layout_parent, Layout::Node& layout_node)
 {
-    // Inline is fine for in-flow block children; we'll maintain the (non-)inline invariant after insertion.
+    // Inline is fine for in-flow block children; the inline formatting context can contain interrupting blocks.
     if (!layout_node.is_anonymous() && layout_parent.is_inline() && layout_parent.display().is_flow_inside() && !layout_node.is_out_of_flow())
         return layout_parent;
 
@@ -162,7 +162,10 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
 void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
 {
     // Find the nearest ancestor that can host the node.
+    NodeWithStyle* topmost_skipped_inline_flow_ancestor = nullptr;
+    bool skipped_inline_flow_ancestor_had_children = false;
     auto& nearest_insertion_ancestor = [&]() -> NodeWithStyle& {
+        NodeWithStyle* previously_skipped_inline_flow_ancestor = nullptr;
         for (auto& ancestor : m_ancestor_stack.in_reverse()) {
             if (ancestor->is_svg_foreign_object_box())
                 return *ancestor;
@@ -170,8 +173,19 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
             auto const& ancestor_display = ancestor->display();
 
             // Out-of-flow nodes cannot be hosted in inline flow nodes.
-            if (node.is_out_of_flow() && ancestor_display.is_inline_outside() && ancestor_display.is_flow_inside())
+            if (node.is_out_of_flow() && ancestor_display.is_inline_outside() && ancestor_display.is_flow_inside()) {
+                topmost_skipped_inline_flow_ancestor = ancestor;
+                // Content precedes the out-of-flow node only if some skipped inline has a child other than
+                // the previously skipped inline itself (which is always its child in the skip chain).
+                for (auto child = ancestor->first_child(); child; child = child->next_sibling()) {
+                    if (child.ptr() != previously_skipped_inline_flow_ancestor) {
+                        skipped_inline_flow_ancestor_had_children = true;
+                        break;
+                    }
+                }
+                previously_skipped_inline_flow_ancestor = ancestor;
                 continue;
+            }
 
             return *ancestor;
         }
@@ -181,8 +195,16 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
     auto& insertion_point = display.is_inline_outside() ? insertion_parent_for_inline_node(nearest_insertion_ancestor)
                                                         : insertion_parent_for_block_node(nearest_insertion_ancestor, node);
 
+    auto should_insert_before_topmost_skipped_inline_ancestor = node.is_out_of_flow()
+        && mode == AppendOrPrepend::Append
+        && topmost_skipped_inline_flow_ancestor
+        && !skipped_inline_flow_ancestor_had_children
+        && topmost_skipped_inline_flow_ancestor->parent() == &insertion_point;
+
     if (mode == AppendOrPrepend::Prepend)
         insertion_point.prepend_child(node);
+    else if (should_insert_before_topmost_skipped_inline_ancestor)
+        insertion_point.insert_before(node, *topmost_skipped_inline_flow_ancestor);
     else
         insertion_point.append_child(node);
 
@@ -190,8 +212,9 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
         // After inserting an inline-level box into a parent, mark the parent as having inline children.
         insertion_point.set_children_are_inline(true);
     } else if (node.is_in_flow()) {
-        // After inserting an in-flow block-level box into a parent, mark the parent as having non-inline children.
-        insertion_point.set_children_are_inline(false);
+        // Inline-flow parents keep their inline children flag; their IFC may contain interrupting blocks.
+        if (!insertion_point.display().is_inline_outside() || !insertion_point.display().is_flow_inside())
+            insertion_point.set_children_are_inline(false);
     }
 }
 
@@ -615,161 +638,6 @@ RefPtr<NodeWithStyle> TreeBuilder::create_content_replacement_if_needed(DOM::Ele
     return create_content_image_box(element.document(), element, style, image);
 }
 
-// Block nodes inside inline nodes are allowed, but to maintain the invariant that either all layout children are
-// inline or non-inline, we need to rearrange the tree a bit. All inline ancestors up to the node we've inserted are
-// wrapped in an anonymous block, which is inserted into the nearest non-inline ancestor. We then recreate the inline
-// ancestors in another anonymous block inserted after the node so we can continue adding children.
-//
-// Effectively, we try to turn this:
-//
-//     InlineNode 1
-//       TextNode 1
-//       InlineNode N
-//         TextNode N
-//         BlockContainer (node)
-//
-// Into this:
-//
-//     BlockContainer (anonymous "before")
-//       InlineNode 1
-//         TextNode 1
-//         InlineNode N
-//           TextNode N
-//     BlockContainer (anonymous "middle") continuation
-//       BlockContainer (node)
-//     BlockContainer (anonymous "after")
-//       InlineNode 1 continuation
-//         InlineNode N
-//
-// To be able to reconstruct their relation after restructuring, layout nodes keep track of their continuation. The
-// top-most inline node of the "after" wrapper points to the "middle" wrapper, which points to the top-most inline node
-// of the "before" wrapper. All other inline nodes in the "after" wrapper point to their counterparts in the "before"
-// wrapper, to make it easier to create the right paintables since a DOM::Node only has a single Layout::Node.
-//
-// Appending then continues in the "after" tree. If a new block node is then inserted, we can reuse the "middle" wrapper
-// if no inline siblings exist for node or its ancestors, and leave the existing "after" wrapper alone. Otherwise, we
-// create new wrappers and extend the continuation chain.
-//
-// Inspired by: https://webkit.org/blog/115/webcore-rendering-ii-blocks-and-inlines/
-void TreeBuilder::restructure_block_node_in_inline_parent(NodeWithStyleAndBoxModelMetrics& node)
-{
-    // Mark parent as inline again
-    auto& parent = *node.parent();
-    VERIFY(!parent.children_are_inline());
-    parent.set_children_are_inline(true);
-
-    // Find nearest ancestor that establishes a BFC (block container) and is not display: contents or anonymous.
-    auto& nearest_block_ancestor = [&] -> NodeWithStyle& {
-        for (auto* ancestor = parent.parent(); ancestor; ancestor = ancestor->parent()) {
-            if (is<BlockContainer>(*ancestor) && !ancestor->display().is_contents() && !ancestor->is_anonymous())
-                return *ancestor;
-        }
-        VERIFY_NOT_REACHED();
-    }();
-    nearest_block_ancestor.set_children_are_inline(false);
-
-    // Find the topmost inline ancestor.
-    RefPtr<NodeWithStyleAndBoxModelMetrics> topmost_inline_ancestor;
-    for (auto* ancestor = &parent; ancestor; ancestor = ancestor->parent()) {
-        if (ancestor == &nearest_block_ancestor)
-            break;
-        if (ancestor->is_inline())
-            topmost_inline_ancestor = static_cast<NodeWithStyleAndBoxModelMetrics*>(ancestor);
-    }
-    VERIFY(topmost_inline_ancestor);
-
-    // We need to host the topmost inline ancestor and its previous siblings in an anonymous "before" wrapper. If an
-    // inline wrapper does not already exist, we create a new one and add it to the nearest block ancestor.
-    RefPtr<Node> before_wrapper;
-    if (auto last_child = nearest_block_ancestor.last_child(); last_child && last_child->is_anonymous() && last_child->children_are_inline()) {
-        before_wrapper = last_child;
-    } else {
-        before_wrapper = nearest_block_ancestor.create_anonymous_wrapper();
-
-        before_wrapper->set_children_are_inline(true);
-        nearest_block_ancestor.append_child(*before_wrapper);
-    }
-    if (topmost_inline_ancestor->parent() != before_wrapper.ptr()) {
-        RefPtr<Node> inline_to_move = topmost_inline_ancestor;
-        while (inline_to_move) {
-            auto next = inline_to_move->previous_sibling();
-            inline_to_move->remove();
-            before_wrapper->insert_before(*inline_to_move, before_wrapper->first_child());
-            inline_to_move = next;
-        }
-    }
-
-    // If we are part of an existing continuation and all inclusive ancestors have no previous siblings, we can reuse
-    // the existing middle wrapper. Otherwiser, we create a new middle wrapper to contain the block node and add it to
-    // the nearest block ancestor.
-    bool needs_new_continuation = true;
-    RefPtr<NodeWithStyleAndBoxModelMetrics> middle_wrapper;
-    if (topmost_inline_ancestor->continuation_of_node()) {
-        needs_new_continuation = false;
-        for (RefPtr<Node> ancestor = node; ancestor != topmost_inline_ancestor; ancestor = ancestor->parent()) {
-            if (ancestor->previous_sibling()) {
-                needs_new_continuation = true;
-                break;
-            }
-        }
-        if (!needs_new_continuation)
-            middle_wrapper = topmost_inline_ancestor->continuation_of_node();
-    }
-    if (!middle_wrapper) {
-        middle_wrapper = static_cast<NodeWithStyleAndBoxModelMetrics&>(*nearest_block_ancestor.create_anonymous_wrapper());
-        nearest_block_ancestor.append_child(*middle_wrapper);
-        middle_wrapper->set_continuation_of_node({}, topmost_inline_ancestor);
-    }
-
-    // Move the block node to the middle wrapper.
-    node.remove();
-    middle_wrapper->append_child(node);
-
-    // If we need a new continuation, recreate inline ancestors in another anonymous block so we can continue adding new
-    // nodes. We don't need to do this if we are within an existing continuation and there were no previous siblings in
-    // any inclusive ancestor of node in the after wrapper.
-    if (needs_new_continuation) {
-        auto after_wrapper = nearest_block_ancestor.create_anonymous_wrapper();
-        RefPtr<Node> current_parent = after_wrapper;
-        for (RefPtr<Node> inline_node = topmost_inline_ancestor;
-            inline_node && is<DOM::Element>(inline_node->dom_node()); inline_node = inline_node->last_child()) {
-            auto& element = static_cast<DOM::Element&>(*inline_node->dom_node());
-
-            auto style = element.computed_properties();
-            auto new_layout_node = element.create_layout_node(*style);
-            if (!new_layout_node)
-                break;
-            auto* new_inline_node = as_if<NodeWithStyleAndBoxModelMetrics>(*new_layout_node);
-            if (!new_inline_node)
-                break;
-            if (inline_node == topmost_inline_ancestor) {
-                // The topmost inline ancestor points to the middle wrapper, which in turns points to the original node.
-                new_inline_node->set_continuation_of_node({}, middle_wrapper);
-                topmost_inline_ancestor = *new_inline_node;
-            } else {
-                // We need all other inline nodes to point to their original node so we can walk the continuation chain
-                // in LayoutState and create the right paintables.
-                new_inline_node->set_continuation_of_node({}, &static_cast<NodeWithStyleAndBoxModelMetrics&>(*inline_node));
-            }
-
-            current_parent->append_child(*new_inline_node);
-            current_parent = *new_inline_node;
-
-            // Replace the node in the ancestor stack with the new node.
-            auto& node_with_style = static_cast<NodeWithStyle&>(*inline_node);
-            if (auto stack_index = m_ancestor_stack.find_first_index(&node_with_style); stack_index.has_value())
-                m_ancestor_stack[stack_index.release_value()] = new_inline_node;
-
-            // Stop recreating nodes when we've reached node's parent.
-            if (inline_node == &parent)
-                break;
-        }
-
-        after_wrapper->set_children_are_inline(true);
-        nearest_block_ancestor.append_child(after_wrapper);
-    }
-}
-
 static bool is_ignorable_whitespace(Layout::Node const& node)
 {
     if (auto* text_node = as_if<TextNode>(node); text_node && text_node->text_for_rendering().is_ascii_whitespace())
@@ -1129,13 +997,6 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
     if (should_create_layout_node) {
         update_layout_tree_after_children(dom_node, *layout_node, context, element_has_content_visibility_hidden);
         wrap_in_button_layout_tree_if_needed(dom_node, *layout_node);
-
-        // If we completely finished inserting a block level element into an inline parent, we need to fix up the tree so
-        // that we can maintain the invariant that all children are either inline or non-inline. We can't do this earlier,
-        // because the restructuring adds new children after this node that become part of the ancestor stack.
-        if (auto node_with_metrics = as_if<NodeWithStyleAndBoxModelMetrics>(*layout_node);
-            node_with_metrics && node_with_metrics->should_create_inline_continuation())
-            restructure_block_node_in_inline_parent(*node_with_metrics);
     }
 
     // https://www.w3.org/TR/css-contain-2/#containment-style

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -63,7 +63,6 @@ private:
     RefPtr<NodeWithStyle> create_pseudo_element_if_needed(DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
     RefPtr<NodeWithStyle> create_content_replacement_if_needed(DOM::Element&, CSS::ComputedProperties const&) const;
     static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);
-    void restructure_block_node_in_inline_parent(NodeWithStyleAndBoxModelMetrics&);
 
     RefPtr<Layout::Node> m_layout_root;
     Vector<Layout::NodeWithStyle*> m_ancestor_stack;

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -871,46 +871,41 @@ CSSPixelRect PaintableBox::overflow_clip_edge_rect() const
 }
 
 template<typename Callable>
-static CSSPixelRect united_rect_for_continuation_chain(PaintableBox const& start, Callable get_rect)
+static CSSPixelRect united_rect_for_all_paintables(PaintableBox const& start, Callable get_rect)
 {
-    // Combine the absolute rects of all paintable boxes of all nodes in the continuation chain. Without this, we
-    // calculate the wrong rect for inline nodes that were split because of block elements.
+    // Inline nodes can have one paintable per line, so combine all paintables for this layout node.
     Optional<CSSPixelRect> result;
 
-    // FIXME: instead of walking the continuation chain in the layout tree, also keep track of this chain in the
-    //        painting tree so we can skip visiting the layout nodes altogether.
-    for (auto const* node = &start.layout_node_with_style_and_box_metrics(); node; node = node->continuation_of_node()) {
-        for (auto const& paintable : node->paintables()) {
-            if (!is<PaintableBox>(paintable))
-                continue;
-            auto const& paintable_box = static_cast<PaintableBox const&>(*paintable);
-            auto paintable_border_box_rect = get_rect(paintable_box);
-            if (!result.has_value())
-                result = paintable_border_box_rect;
-            else if (!paintable_border_box_rect.is_empty())
-                result->unite(paintable_border_box_rect);
-        }
+    for (auto const& paintable : start.layout_node().paintables()) {
+        if (!is<PaintableBox>(paintable))
+            continue;
+        auto const& paintable_box = static_cast<PaintableBox const&>(*paintable);
+        auto paintable_border_box_rect = get_rect(paintable_box);
+        if (!result.has_value())
+            result = paintable_border_box_rect;
+        else if (!paintable_border_box_rect.is_empty())
+            result->unite(paintable_border_box_rect);
     }
     return result.value_or({});
 }
 
 CSSPixelRect PaintableBox::absolute_united_border_box_rect() const
 {
-    return united_rect_for_continuation_chain(*this, [](auto const& paintable_box) {
+    return united_rect_for_all_paintables(*this, [](auto const& paintable_box) {
         return paintable_box.absolute_border_box_rect();
     });
 }
 
 CSSPixelRect PaintableBox::absolute_united_content_rect() const
 {
-    return united_rect_for_continuation_chain(*this, [](auto const& paintable_box) {
+    return united_rect_for_all_paintables(*this, [](auto const& paintable_box) {
         return paintable_box.absolute_rect();
     });
 }
 
 CSSPixelRect PaintableBox::absolute_united_padding_box_rect() const
 {
-    return united_rect_for_continuation_chain(*this, [](auto const& paintable_box) {
+    return united_rect_for_all_paintables(*this, [](auto const& paintable_box) {
         return paintable_box.absolute_padding_box_rect();
     });
 }
@@ -1201,15 +1196,7 @@ void PaintableBox::record_hit_test_items(DisplayListRecordingContext& context, P
         if (layout_node().is_anonymous()
             && !layout_node().is_generated_for_pseudo_element()
             && !layout_node().is_list_item_marker_box()) {
-            auto continuation_node = layout_node_with_style_and_box_metrics().continuation_of_node();
-            if (!continuation_node)
-                return;
-            while (continuation_node->continuation_of_node())
-                continuation_node = continuation_node->continuation_of_node();
-            auto& continuation_paintable = *continuation_node->first_paintable();
-            if (!continuation_paintable.visible_for_hit_testing())
-                return;
-            target = &continuation_paintable;
+            return;
         }
 
         hit_test_display_list->append_box(*this, *target, absolute_border_box_rect(), accumulated_visual_context_index(), border_radii_data());
@@ -1381,7 +1368,7 @@ void PaintableBox::paint_middle_button_scroll_indicator(DisplayListRecordingCont
 void PaintableBox::paint_inspector_overlay_internal(DisplayListRecordingContext& context) const
 {
     auto content_rect = absolute_united_content_rect();
-    auto margin_rect = united_rect_for_continuation_chain(*this, [](PaintableBox const& box) {
+    auto margin_rect = united_rect_for_all_paintables(*this, [](PaintableBox const& box) {
         auto margin_box = box.box_model().margin_box();
         return CSSPixelRect {
             box.absolute_x() - margin_box.left,

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -115,7 +115,7 @@ public:
     CSSPixelRect absolute_border_box_rect() const;
     CSSPixelRect overflow_clip_edge_rect() const;
 
-    // These united versions of the above rects take continuation into account.
+    // These united versions of the above rects include all paintables for this layout node.
     CSSPixelRect absolute_united_border_box_rect() const;
     CSSPixelRect absolute_united_content_rect() const;
     CSSPixelRect absolute_united_padding_box_rect() const;

--- a/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -39,6 +39,10 @@ public:
     }
     RefPtr<PaintableBox> containing_block_paintable() const;
 
+    // Interrupting block-level boxes (block-in-inline) are recorded as phantom fragments; most
+    // fragment consumers (hit testing, render spans, client rects) must skip them.
+    bool is_block_level_box() const { return layout_node().display().is_block_outside(); }
+
     size_t start_offset() const { return m_start_offset; }
     size_t length_in_code_units() const { return m_length_in_code_units; }
 

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -99,8 +99,11 @@ void PaintableWithLines::record_hit_test_items(DisplayListRecordingContext& cont
         return;
     }
 
-    for (auto const& fragment : m_fragments)
+    for (auto const& fragment : m_fragments) {
+        if (fragment.is_block_level_box())
+            continue;
         hit_test_display_list->append_text_fragment(fragment, accumulated_visual_context_for_descendants_index());
+    }
 
     if (stacking_context()
         && is_inline()
@@ -158,6 +161,11 @@ void PaintableWithLines::paint(DisplayListRecordingContext& context, PaintPhase 
     if (!is_visible())
         return;
 
+    // An inline's per-line paintable that only hosts an interrupting block's phantom fragment generates no box
+    // of its own; painting its background/border would draw a degenerate box at the block's corner.
+    if (is<Layout::InlineNode>(layout_node()) && has_only_block_level_fragments())
+        return;
+
     PaintableBox::paint(context, phase);
 
     if (phase == PaintPhase::Foreground) {
@@ -187,6 +195,9 @@ void PaintableWithLines::paint(DisplayListRecordingContext& context, PaintPhase 
 
 void compute_render_spans(PaintableFragment const& fragment, Vector<PaintableFragment::FragmentSpan, 4>& spans)
 {
+    if (fragment.is_block_level_box())
+        return;
+
     auto const* text_node = as_if<Layout::TextNode>(fragment.layout_node());
     if (!text_node) {
         // Non-text fragments still need shadow painting.

--- a/Libraries/LibWeb/Painting/PaintableWithLines.h
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/AllOf.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/PaintableFragment.h>
@@ -24,6 +25,11 @@ public:
 
     Vector<PaintableFragment> const& fragments() const { return m_fragments; }
     Vector<PaintableFragment>& fragments() { return m_fragments; }
+
+    bool has_only_block_level_fragments() const
+    {
+        return !m_fragments.is_empty() && all_of(m_fragments, [](auto& fragment) { return fragment.is_block_level_box(); });
+    }
 
     void add_fragment(Layout::LineBoxFragment const& fragment, LineBoxData line_box_data)
     {

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -11,6 +11,7 @@
 #include <AK/TemporaryChange.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
@@ -128,12 +129,27 @@ static bool establishes_inline_level_painting_context(Paintable const& paintable
     return layout_node.is_inline_block() || layout_node.is_inline_table();
 }
 
+static bool is_pure_inline_box(Paintable const& paintable)
+{
+    // NOTE: An InlineNode is never a replaced box and never establishes an inline-level painting
+    //       context (inline-block/inline-table produce a BlockContainer), so only the float and
+    //       positioned checks can vary here.
+    return is<Layout::InlineNode>(paintable.layout_node())
+        && !paintable.is_floating()
+        && !paintable.is_positioned();
+}
+
 static void paint_inline_level_non_positioned_descendant(DisplayListRecordingContext& context, Paintable const& paintable)
 {
     paint_node(paintable, context, PaintPhase::Background);
     paint_node(paintable, context, PaintPhase::Border);
     paint_node(paintable, context, PaintPhase::TableCollapsedBorder);
-    StackingContext::paint_descendants(context, paintable, StackingContext::StackingContextPaintPhase::BackgroundAndBorders);
+    // A pure InlineNode paintable paints its own background/border in the inline-level phase. Its block descendants, if
+    // any, are painted by the earlier BackgroundAndBorders descent through pure inline boxes. In today's layout trees,
+    // this subtree sweep is a no-op for InlineNodes: it can only find inline children, floats, or positioned boxes,
+    // all of which are skipped by the BackgroundAndBorders phase.
+    if (!is<Layout::InlineNode>(paintable.layout_node()))
+        StackingContext::paint_descendants(context, paintable, StackingContext::StackingContextPaintPhase::BackgroundAndBorders);
 
     // https://drafts.csswg.org/css2/#elaborate-stacking-contexts
     // "For inline-block and inline-table elements: [...] treat the element as if it created a new stacking context,
@@ -223,6 +239,8 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
                 paint_node(child, context, PaintPhase::Border);
                 paint_descendants(context, child, phase);
                 paint_node(child, context, PaintPhase::TableCollapsedBorder);
+            } else if (is_pure_inline_box(child)) {
+                paint_descendants(context, child, phase);
             }
             break;
         case StackingContextPaintPhase::Floats:

--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -29,31 +29,27 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 14, rect: [235,55 74.296875x10] baseline: 8
                     "the world ends"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> at [235,65] [0+0+0 139.96875 0+0+0] [0+0+0 0 0+0+0] children: inline
+              BlockContainer <(anonymous)> at [235,65] [0+0+0 139.96875 0+0+0] [0+0+0 38 0+0+0] children: inline
                 TextNode <#text> (not painted)
-                InlineNode <form> at [235,65] [0+0+0 0 0+0+0] [0+0+0 10 0+0+0]
+                InlineNode <form> at [235,65] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+                  frag 0 from BlockContainer start: 0, length: 0, rect: [235,65 139.96875x19] baseline: 0
+                  frag 0 from BlockContainer start: 0, length: 0, rect: [235,84 139.96875x19] baseline: 0
                   TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> at [235,65] [0+0+0 139.96875 0+0+0] [0+0+0 19 0+0+0] children: not-inline continuation
-                BlockContainer <p> at [235,65] [0+0+0 139.96875 0+0+0] [0+0+0 19 0+0+0] children: inline
-                  frag 0 from TextNode start: 33, length: 5, rect: [235,65 27.5x19] baseline: 12.5
-                      "bang "
-                  frag 1 from RadioButton start: 0, length: 0, rect: [262.5,65 12x12] baseline: 12
+                  BlockContainer <p> at [235,65] [0+0+0 139.96875 0+0+0] [0+0+0 19 0+0+0] children: inline
+                    frag 0 from TextNode start: 33, length: 5, rect: [235,65 27.5x19] baseline: 12.5
+                        "bang "
+                    frag 1 from RadioButton start: 0, length: 0, rect: [262.5,65 12x12] baseline: 12
+                    TextNode <#text> (not painted)
+                    RadioButton <input> at [262.5,65] inline-block [0+0+0 12 0+0+0] [0+0+0 12 0+0+0] children: not-inline
+                    TextNode <#text> (not painted)
                   TextNode <#text> (not painted)
-                  RadioButton <input> at [262.5,65] inline-block [0+0+0 12 0+0+0] [0+0+0 12 0+0+0] children: not-inline
-                  TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> at [235,84] [0+0+0 139.96875 0+0+0] [0+0+0 0 0+0+0] children: inline
-                InlineNode <form> at [235,84] [0+0+0 0 0+0+0] [0+0+0 10 0+0+0] continuation
-                  TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> at [235,84] [0+0+0 139.96875 0+0+0] [0+0+0 19 0+0+0] children: not-inline continuation
-                BlockContainer <p> at [235,84] [0+0+0 139.96875 0+0+0] [0+0+0 19 0+0+0] children: inline
-                  frag 0 from TextNode start: 33, length: 8, rect: [235,84 45.171875x19] baseline: 12.5
-                      "whimper "
-                  frag 1 from RadioButton start: 0, length: 0, rect: [280.171875,84 12x12] baseline: 12
-                  TextNode <#text> (not painted)
-                  RadioButton <input> at [280.171875,84] inline-block [0+0+0 12 0+0+0] [0+0+0 12 0+0+0] children: not-inline
-                  TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> at [235,103] [0+0+0 139.96875 0+0+0] [0+0+0 0 0+0+0] children: inline
-                InlineNode <form> at [235,103] [0+0+0 0 0+0+0] [0+0+0 10 0+0+0] continuation
+                  BlockContainer <p> at [235,84] [0+0+0 139.96875 0+0+0] [0+0+0 19 0+0+0] children: inline
+                    frag 0 from TextNode start: 33, length: 8, rect: [235,84 45.171875x19] baseline: 12.5
+                        "whimper "
+                    frag 1 from RadioButton start: 0, length: 0, rect: [280.171875,84 12x12] baseline: 12
+                    TextNode <#text> (not painted)
+                    RadioButton <input> at [280.171875,84] inline-block [0+0+0 12 0+0+0] [0+0+0 12 0+0+0] children: not-inline
+                    TextNode <#text> (not painted)
                   TextNode <#text> (not painted)
                 TextNode <#text> (not painted)
             TextNode <#text> (not painted)
@@ -144,18 +140,21 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableWithLines (BlockContainer<LI>#bar) [225,45 159.96875x110]
               PaintableWithLines (BlockContainer(anonymous)) [235,55 139.96875x0]
               PaintableWithLines (BlockContainer<P>) [235,55 139.96875x10]
-              PaintableWithLines (BlockContainer(anonymous)) [235,65 139.96875x0]
-                PaintableWithLines (InlineNode<FORM>) [235,65 0x10]
-              PaintableWithLines (BlockContainer(anonymous)) [235,65 139.96875x19]
-                PaintableWithLines (BlockContainer<P>) [235,65 139.96875x19]
-                  RadioButtonPaintable (RadioButton<INPUT>) [262.5,65 12x12]
-              PaintableWithLines (BlockContainer(anonymous)) [235,84 139.96875x0]
-                PaintableWithLines (InlineNode<FORM>) [235,84 0x10]
-              PaintableWithLines (BlockContainer(anonymous)) [235,84 139.96875x19]
-                PaintableWithLines (BlockContainer<P>) [235,84 139.96875x19]
-                  RadioButtonPaintable (RadioButton<INPUT>) [280.171875,84 12x12]
-              PaintableWithLines (BlockContainer(anonymous)) [235,103 139.96875x0]
-                PaintableWithLines (InlineNode<FORM>) [235,103 0x10]
+              PaintableWithLines (BlockContainer(anonymous)) [235,65 139.96875x38]
+                PaintableWithLines (InlineNode<FORM>) [235,65 0x0]
+                  PaintableWithLines (BlockContainer<P>) [235,65 139.96875x19]
+                    RadioButtonPaintable (RadioButton<INPUT>) [262.5,65 12x12]
+
+                PaintableWithLines (InlineNode<FORM>) [235,84 0x0]
+                  PaintableWithLines (BlockContainer<P>) [235,84 139.96875x19]
+                    RadioButtonPaintable (RadioButton<INPUT>) [280.171875,84 12x12]
+                PaintableWithLines (InlineNode<FORM>) [235,65 0x0]
+                  PaintableWithLines (BlockContainer<P>) [235,65 139.96875x19]
+                    RadioButtonPaintable (RadioButton<INPUT>) [262.5,65 12x12]
+
+                PaintableWithLines (InlineNode<FORM>) [235,84 0x0]
+                  PaintableWithLines (BlockContainer<P>) [235,84 139.96875x19]
+                    RadioButtonPaintable (RadioButton<INPUT>) [280.171875,84 12x12]
             PaintableWithLines (BlockContainer<LI>) [394.96875,45 80x120]
             PaintableWithLines (BlockContainer<LI>#baz) [135,175 120x120]
           PaintableWithLines (BlockContainer(anonymous)) [135,45 340x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-first-in-nested-inline-flow-ancestors.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-first-in-nested-inline-flow-ancestors.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
+        BlockContainer <b> at [0,0] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [0,0 10x20] baseline: 13
+              "X"
+          TextNode <#text> (not painted)
+        InlineNode <span> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
+          InlineNode <i> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
+            frag 0 from TextNode start: 0, length: 4, rect: [0,0 40x20] baseline: 13
+                "text"
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,20] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x20]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x20]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 800x20]
+        PaintableWithLines (BlockContainer<B>) [0,0 10x20]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 40x20]
+          PaintableWithLines (InlineNode<I>) [0,0 40x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,20 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x20] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-pseudo-after-trailing-interrupting-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-pseudo-after-trailing-interrupting-block.txt
@@ -1,0 +1,39 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+      BlockContainer <div.rel> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: inline
+          InlineNode <span> at [0,0] [0+0+0 10 0+0+0] [0+0+0 20 0+0+0]
+            frag 0 from TextNode start: 0, length: 1, rect: [0,0 10x20] baseline: 13
+                "a"
+            frag 0 from BlockContainer start: 0, length: 0, rect: [0,20 800x10] baseline: 0
+            TextNode <#text> (not painted)
+            BlockContainer <div> at [0,20] [0+0+0 800 0+0+0] [0+0+0 10 0+0+0] children: inline
+              frag 0 from TextNode start: 0, length: 5, rect: [0,20 50x20] baseline: 13
+                  "block"
+              TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,30] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+          frag 0 from GeneratedTextNode start: 0, length: 1, rect: [0,30 10x20] baseline: 13
+              "X"
+          GeneratedTextNode <(anonymous)> (not painted)
+      BlockContainer <(anonymous)> at [0,30] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x30]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x30]
+      PaintableWithLines (BlockContainer<DIV>.rel) [0,0 800x30]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x30]
+          PaintableWithLines (InlineNode<SPAN>) [0,0 10x20]
+
+          PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+            PaintableWithLines (BlockContainer<DIV>) [0,20 800x10]
+          PaintableWithLines (InlineNode<SPAN>) [0,0 10x20]
+
+          PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+            PaintableWithLines (BlockContainer<DIV>) [0,20 800x10]
+        PaintableWithLines (BlockContainer(anonymous)) [0,30 10x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,30 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x30] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-static-position-after-interrupting-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-static-position-after-interrupting-block.txt
@@ -1,0 +1,41 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 10, rect: [0,0 100x20] baseline: 13
+            "first line"
+        TextNode <#text> (not painted)
+        BreakNode <br> (not painted)
+        BlockContainer <b> at [0,20] positioned [0+0+0 30 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [0,20 30x20] baseline: 13
+              "abs"
+          TextNode <#text> (not painted)
+        InlineNode <span> at [0,20] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [0,20 800x20] baseline: 0
+          frag 0 from TextNode start: 0, length: 4, rect: [0,40 40x20] baseline: 13
+              "rest"
+          BlockContainer <div> at [0,20] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
+            frag 0 from TextNode start: 0, length: 5, rect: [0,20 50x20] baseline: 13
+                "block"
+            TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,60] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x60]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 800x60]
+        PaintableWithLines (BlockContainer<B>) [0,20 30x20]
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 800x20]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,40 40x20]
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 800x20]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,40 40x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,60 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x60] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-root-height-includes-trailing-interrupting-block-margin.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-root-height-includes-trailing-interrupting-block-margin.txt
@@ -1,0 +1,32 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 90 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 90 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] [0+0+0 800 0+0+0] [0+0+0 90 0+0+0] [BFC] children: inline
+        InlineNode <span> at [0,0] [0+0+0 10 0+0+0] [0+0+0 20 0+0+0]
+          frag 0 from TextNode start: 0, length: 1, rect: [0,0 10x20] baseline: 13
+              "a"
+          frag 0 from BlockContainer start: 0, length: 0, rect: [0,20 800x20] baseline: 0
+          TextNode <#text> (not painted)
+          BlockContainer <div> at [0,20] [0+0+0 800 0+0+0] [0+0+0 20 0+0+50] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [0,20 10x20] baseline: 13
+                "b"
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,90] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x90]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x90]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 800x90]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 10x20]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 800x20]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 10x20]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 800x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,90 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x90] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-in-inline-vertical-writing-mode.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-in-inline-vertical-writing-mode.txt
@@ -1,0 +1,45 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 200 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 200 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] [0+0+0 300 0+0+500] [0+0+0 200 0+0+0] children: inline
+        InlineNode <span> at [280,0] [0+0+0 20 0+0+0] [0+0+0 10 0+0+0]
+          frag 0 from TextNode start: 0, length: 1, rect: [280,0 20x10] baseline: 13
+              "a"
+          frag 0 from BlockContainer start: 0, length: 0, rect: [0,20 50x20] baseline: 0
+          frag 0 from TextNode start: 0, length: 1, rect: [320,0 20x10] baseline: 13
+              "c"
+          TextNode <#text> (not painted)
+          BlockContainer <div> at [0,20] [0+0+0 50 0+0+250] [0+0+0 20 0+0+0] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [30,20 20x10] baseline: 13
+                "b"
+            TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,200] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x200]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x200]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 300x200]
+        PaintableWithLines (InlineNode<SPAN>) [280,0 20x10]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 50x20]
+
+        PaintableWithLines (InlineNode<SPAN>) [320,0 20x10]
+        PaintableWithLines (InlineNode<SPAN>) [280,0 20x10]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 50x20]
+
+        PaintableWithLines (InlineNode<SPAN>) [320,0 20x10]
+        PaintableWithLines (InlineNode<SPAN>) [280,0 20x10]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 50x20]
+
+        PaintableWithLines (InlineNode<SPAN>) [320,0 20x10]
+      PaintableWithLines (BlockContainer(anonymous)) [0,200 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x200] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-inside-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-inside-inline.txt
@@ -7,32 +7,25 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       frag 2 from TextNode start: 0, length: 4, rect: [70.796875,8 35.203125x18] baseline: 13.796875
           " baz"
       TextNode <#text> (not painted)
-      BlockContainer <div> at [43.15625,8] inline-block [0+0+0 27.640625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: not-inline
-        BlockContainer <(anonymous)> at [43.15625,8] [0+0+0 27.640625 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <div> at [43.15625,8] inline-block [0+0+0 27.640625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <span> at [43.15625,8] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [43.15625,8 27.640625x18] baseline: 0
           TextNode <#text> (not painted)
-          InlineNode <span> at [43.15625,8] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
-            TextNode <#text> (not painted)
-        BlockContainer <(anonymous)> at [43.15625,8] [0+0+0 27.640625 0+0+0] [0+0+0 18 0+0+0] children: not-inline continuation
           BlockContainer <div> at [43.15625,8] [0+0+0 27.640625 0+0+0] [0+0+0 18 0+0+0] children: inline
             frag 0 from TextNode start: 0, length: 3, rect: [43.15625,8 27.640625x18] baseline: 13.796875
                 "bar"
             TextNode <#text> (not painted)
-        BlockContainer <(anonymous)> at [43.15625,26] [0+0+0 27.640625 0+0+0] [0+0+0 0 0+0+0] children: inline
-          InlineNode <span> at [43.15625,26] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] continuation
-            TextNode <#text> (not painted)
           TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
       TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableWithLines (BlockContainer<DIV>) [43.15625,8 27.640625x18]
-        PaintableWithLines (BlockContainer(anonymous)) [43.15625,8 27.640625x0]
-          PaintableWithLines (InlineNode<SPAN>) [43.15625,8 0x18]
-        PaintableWithLines (BlockContainer(anonymous)) [43.15625,8 27.640625x18]
+        PaintableWithLines (InlineNode<SPAN>) [43.15625,8 0x0]
           PaintableWithLines (BlockContainer<DIV>) [43.15625,8 27.640625x18]
-        PaintableWithLines (BlockContainer(anonymous)) [43.15625,26 27.640625x0]
-          PaintableWithLines (InlineNode<SPAN>) [43.15625,26 0x18]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x34] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/box-with-percentage-height-wrapped-in-anonymous.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/box-with-percentage-height-wrapped-in-anonymous.txt
@@ -1,30 +1,39 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: not-inline
-      BlockContainer <div.outer> at [8,8] [0+0+0 100 0+0+684] [0+0+0 100 0+0+0] children: not-inline
-        BlockContainer <(anonymous)> at [8,8] [0+0+0 100 0+0+0] [0+0+0 18 0+0+0] children: inline
-          InlineNode <div.inline> at [8,8] [0+0+0 9.34375 0+0+0] [0+0+0 18 0+0+0]
-            frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x18] baseline: 13.796875
-                "a"
-            TextNode <#text> (not painted)
-        BlockContainer <(anonymous)> at [8,26] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline continuation
+      BlockContainer <div.outer> at [8,8] [0+0+0 100 0+0+684] [0+0+0 100 0+0+0] children: inline
+        InlineNode <div.inline> at [8,8] [0+0+0 9.34375 0+0+0] [0+0+0 18 0+0+0]
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x18] baseline: 13.796875
+              "a"
+          frag 0 from BlockContainer start: 0, length: 0, rect: [8,26 100x100] baseline: 0
+          frag 0 from TextNode start: 0, length: 1, rect: [8,126 9.46875x18] baseline: 13.796875
+              "b"
+          TextNode <#text> (not painted)
           BlockContainer <div.inner> at [8,26] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
-        BlockContainer <(anonymous)> at [8,126] [0+0+0 100 0+0+0] [0+0+0 18 0+0+0] children: inline
-          InlineNode <div.inline> at [8,126] [0+0+0 9.46875 0+0+0] [0+0+0 18 0+0+0] continuation
-            frag 0 from TextNode start: 0, length: 1, rect: [8,126 9.46875x18] baseline: 13.796875
-                "b"
-            TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (BlockContainer<DIV>.outer) [8,8 100x100]
-        PaintableWithLines (BlockContainer(anonymous)) [8,8 100x18]
-          PaintableWithLines (InlineNode<DIV>.inline) [8,8 9.34375x18]
-        PaintableWithLines (BlockContainer(anonymous)) [8,26 100x100]
+        PaintableWithLines (InlineNode<DIV>.inline) [8,8 9.34375x18]
+
+        PaintableWithLines (InlineNode<DIV>.inline) [8,26 0x0]
           PaintableWithLines (BlockContainer<DIV>.inner) [8,26 100x100]
-        PaintableWithLines (BlockContainer(anonymous)) [8,126 100x18]
-          PaintableWithLines (InlineNode<DIV>.inline) [8,126 9.46875x18]
+
+        PaintableWithLines (InlineNode<DIV>.inline) [8,126 9.46875x18]
+        PaintableWithLines (InlineNode<DIV>.inline) [8,8 9.34375x18]
+
+        PaintableWithLines (InlineNode<DIV>.inline) [8,26 0x0]
+          PaintableWithLines (BlockContainer<DIV>.inner) [8,26 100x100]
+
+        PaintableWithLines (InlineNode<DIV>.inline) [8,126 9.46875x18]
+        PaintableWithLines (InlineNode<DIV>.inline) [8,8 9.34375x18]
+
+        PaintableWithLines (InlineNode<DIV>.inline) [8,26 0x0]
+          PaintableWithLines (BlockContainer<DIV>.inner) [8,26 100x100]
+
+        PaintableWithLines (InlineNode<DIV>.inline) [8,126 9.46875x18]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x116] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-after-interrupting-block-with-bottom-margin.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-after-interrupting-block-with-bottom-margin.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 70 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 70 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] [0+0+0 800 0+0+0] [0+0+0 70 0+0+0] children: inline
+        InlineNode <span> at [0,0] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [0,0 800x10] baseline: 0
+          frag 0 from TextNode start: 0, length: 4, rect: [20,50 40x20] baseline: 13
+              "text"
+          BlockContainer <div> at [0,0] [0+0+0 800 0+0+0] [0+0+0 10 0+0+40] children: inline
+            frag 0 from TextNode start: 0, length: 5, rect: [0,0 50x20] baseline: 13
+                "block"
+            TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+        ImageBox <img> at [0,50] floating [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [0,70] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x70]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x70]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 800x70]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,0 800x10]
+
+        PaintableWithLines (InlineNode<SPAN>) [20,50 40x20]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,0 800x10]
+
+        PaintableWithLines (InlineNode<SPAN>) [20,50 40x20]
+        ImagePaintable (ImageBox<IMG>) [0,50 20x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,70 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x70] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-start-padding-attaches-after-interrupting-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-start-padding-attaches-after-interrupting-block.txt
@@ -1,0 +1,33 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: inline
+        InlineNode <span> at [0,0] [0+0+50 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [0,0 800x10] baseline: 0
+          frag 0 from TextNode start: 0, length: 4, rect: [50,10 40x20] baseline: 13
+              "text"
+          TextNode <#text> (not painted)
+          BlockContainer <div> at [0,0] [0+0+0 800 0+0+0] [0+0+0 10 0+0+0] children: inline
+            frag 0 from TextNode start: 0, length: 5, rect: [0,0 50x20] baseline: 13
+                "block"
+            TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,30] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x30]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x30]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 800x30]
+        PaintableWithLines (InlineNode<SPAN>) [-50,0 50x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,0 800x10]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,10 90x20]
+        PaintableWithLines (InlineNode<SPAN>) [-50,0 50x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,0 800x10]
+
+        PaintableWithLines (InlineNode<SPAN>) [0,10 90x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,30 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x30] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/justify-line-before-interrupting-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/justify-line-before-interrupting-block.txt
@@ -1,0 +1,84 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 70 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 70 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] [0+0+0 200 0+0+600] [0+0+0 70 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 2, rect: [0,0 20x20] baseline: 13
+            "aa"
+        frag 1 from TextNode start: 2, length: 1, rect: [20,0 10x20] baseline: 13
+            " "
+        frag 2 from TextNode start: 3, length: 2, rect: [30,0 20x20] baseline: 13
+            "bb"
+        frag 3 from TextNode start: 5, length: 1, rect: [50,0 10x20] baseline: 13
+            " "
+        frag 4 from TextNode start: 6, length: 2, rect: [60,0 20x20] baseline: 13
+            "cc"
+        frag 5 from TextNode start: 0, length: 2, rect: [0,30 20x20] baseline: 13
+            "dd"
+        frag 6 from TextNode start: 2, length: 1, rect: [20,30 10x20] baseline: 13
+            " "
+        frag 7 from TextNode start: 3, length: 2, rect: [30,30 20x20] baseline: 13
+            "ee"
+        frag 8 from TextNode start: 5, length: 1, rect: [50,30 10x20] baseline: 13
+            " "
+        frag 9 from TextNode start: 6, length: 2, rect: [60,30 20x20] baseline: 13
+            "ff"
+        frag 10 from TextNode start: 8, length: 1, rect: [80,30 10x20] baseline: 13
+            " "
+        frag 11 from TextNode start: 9, length: 2, rect: [90,30 20x20] baseline: 13
+            "gg"
+        frag 12 from TextNode start: 11, length: 1, rect: [110,30 10x20] baseline: 13
+            " "
+        frag 13 from TextNode start: 12, length: 2, rect: [120,30 20x20] baseline: 13
+            "hh"
+        frag 14 from TextNode start: 14, length: 1, rect: [140,30 10x20] baseline: 13
+            " "
+        frag 15 from TextNode start: 15, length: 2, rect: [150,30 20x20] baseline: 13
+            "ii"
+        frag 16 from TextNode start: 17, length: 1, rect: [170,30 10x20] baseline: 13
+            " "
+        frag 17 from TextNode start: 18, length: 2, rect: [180,30 20x20] baseline: 13
+            "jj"
+        frag 18 from TextNode start: 21, length: 2, rect: [0,50 20x20] baseline: 13
+            "kk"
+        frag 19 from TextNode start: 23, length: 1, rect: [20,50 10x20] baseline: 13
+            " "
+        frag 20 from TextNode start: 24, length: 2, rect: [30,50 20x20] baseline: 13
+            "ll"
+        frag 21 from TextNode start: 26, length: 1, rect: [50,50 10x20] baseline: 13
+            " "
+        frag 22 from TextNode start: 27, length: 2, rect: [60,50 20x20] baseline: 13
+            "mm"
+        frag 23 from TextNode start: 29, length: 1, rect: [80,50 10x20] baseline: 13
+            " "
+        frag 24 from TextNode start: 30, length: 2, rect: [90,50 20x20] baseline: 13
+            "nn"
+        frag 25 from TextNode start: 32, length: 1, rect: [110,50 10x20] baseline: 13
+            " "
+        frag 26 from TextNode start: 33, length: 2, rect: [120,50 20x20] baseline: 13
+            "oo"
+        frag 27 from TextNode start: 35, length: 1, rect: [140,50 10x20] baseline: 13
+            " "
+        frag 28 from TextNode start: 36, length: 2, rect: [150,50 20x20] baseline: 13
+            "pp"
+        frag 29 from TextNode start: 38, length: 1, rect: [170,50 10x20] baseline: 13
+            " "
+        frag 30 from TextNode start: 39, length: 2, rect: [180,50 20x20] baseline: 13
+            "qq"
+        TextNode <#text> (not painted)
+        InlineNode <span> at [0,20] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [0,20 200x10] baseline: 0
+          BlockContainer <div> at [0,20] [0+0+0 200 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,70] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x70]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x70]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 200x70]
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 200x10]
+      PaintableWithLines (BlockContainer(anonymous)) [0,70 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x70] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/content-image-simple.txt
+++ b/Tests/LibWeb/Layout/expected/content-image-simple.txt
@@ -26,14 +26,14 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1216]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x1200]
         PaintableWithLines (InlineNode(anonymous)) [8,394 454.796875x400]
           ImagePaintable (ImageBox(anonymous)) [35.15625,8 400x400]
-          ImagePaintable (ImageBox(anonymous)) [8,408 400x400]
 
         PaintableWithLines (InlineNode(anonymous)) [8,408 427.203125x400]
+          ImagePaintable (ImageBox(anonymous)) [8,408 400x400]
         PaintableWithLines (InlineNode(anonymous)) [8,394 454.796875x400]
           ImagePaintable (ImageBox(anonymous)) [35.15625,8 400x400]
-          ImagePaintable (ImageBox(anonymous)) [8,408 400x400]
 
         PaintableWithLines (InlineNode(anonymous)) [8,408 427.203125x400]
+          ImagePaintable (ImageBox(anonymous)) [8,408 400x400]
         ImagePaintable (ImageBox<IMG>) [8,808 400x400]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/inline-element-position-change.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/inline-element-position-change.txt
@@ -1,28 +1,21 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 79.875 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,21.4375] [8+0+0 784 0+0+8] [8+0+0 37 0+0+21.4375] children: not-inline
-      BlockContainer <(anonymous)> at [8,21.4375] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
-        InlineNode <a> at [8,21.4375] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
-          InlineNode <span#foo> at [8,21.4375] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
-      BlockContainer <(anonymous)> at [8,21.4375] [0+0+0 784 0+0+0] [0+0+0 37 0+0+0] children: not-inline continuation
+    BlockContainer <body> at [8,21.4375] [8+0+0 784 0+0+8] [8+0+0 37 0+0+21.4375] children: inline
+      InlineNode <a> at [8,21.4375] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,21.4375 784x37] baseline: 0
+        InlineNode <span#foo> at [8,21.4375] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
         BlockContainer <h1> at [8,21.4375] [0+0+0 784 0+0+0] [21.4375+0+0 37 0+0+21.4375] children: inline
           frag 0 from TextNode start: 0, length: 4, rect: [8,21.4375 63.5625x37] baseline: 28.09375
               "test"
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,79.875] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
-        InlineNode <a> at [8,79.875] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] continuation
-          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x79.875]
     PaintableWithLines (BlockContainer<BODY>) [8,21.4375 784x37]
-      PaintableWithLines (BlockContainer(anonymous)) [8,21.4375 784x0]
-        PaintableWithLines (InlineNode<A>) [8,21.4375 0x18]
-          PaintableWithLines (InlineNode<SPAN>#foo) [8,21.4375 0x18]
-      PaintableWithLines (BlockContainer(anonymous)) [8,21.4375 784x37]
+      PaintableWithLines (InlineNode<A>) [8,21.4375 0x0]
+        PaintableWithLines (InlineNode<SPAN>#foo) [8,21.4375 0x18]
         PaintableWithLines (BlockContainer<H1>) [8,21.4375 784x37]
-      PaintableWithLines (BlockContainer(anonymous)) [8,79.875 784x0]
-        PaintableWithLines (InlineNode<A>) [8,79.875 0x18]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x79.875] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-first-in-nested-inline-flow-ancestors.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-first-in-nested-inline-flow-ancestors.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div style="position: relative"><span><i><b style="position: absolute">X</b>text</i></span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-pseudo-after-trailing-interrupting-block.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-pseudo-after-trailing-interrupting-block.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<style>
+.rel { position: relative; }
+.rel::after { content: "X"; position: absolute; }
+</style>
+<div class="rel"><span>a<div style="height: 10px; background: blue">block</div></span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-static-position-after-interrupting-block.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-static-position-after-interrupting-block.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div>first line<br><span><b style="position: absolute">abs</b><div>block</div>rest</span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/bfc-root-height-includes-trailing-interrupting-block-margin.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/bfc-root-height-includes-trailing-interrupting-block-margin.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div style="display: flow-root; background: red"><span>a<div style="margin-bottom: 50px">b</div></span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-in-inline-vertical-writing-mode.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-in-inline-vertical-writing-mode.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div style="writing-mode: vertical-rl; width: 300px; height: 200px"><span>a<div style="width: 50px; height: 20px; background: blue">b</div>c</span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-after-interrupting-block-with-bottom-margin.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-after-interrupting-block-with-bottom-margin.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div><span><div style="margin-bottom: 40px; height: 10px; background: blue">block</div><img style="float: left; width: 20px; height: 20px">text</span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/inline-start-padding-attaches-after-interrupting-block.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/inline-start-padding-attaches-after-interrupting-block.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div><span style="padding-left: 50px; background: yellow"> <div style="height: 10px; background: blue">block</div>text</span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/justify-line-before-interrupting-block.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/justify-line-before-interrupting-block.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div style="text-align: justify; width: 200px">aa bb cc<span><div style="height: 10px; background: blue"></div></span>dd ee ff gg hh ii jj kk ll mm nn oo pp qq</div>

--- a/Tests/LibWeb/Text/expected/HTML/HTMLElement-offsetFoo-for-split-inline-element.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLElement-offsetFoo-for-split-inline-element.txt
@@ -1,4 +1,4 @@
 b.offsetTop: 8
 b.offsetLeft: 8
-b.offsetWidth: 784
+b.offsetWidth: 27
 b.offsetHeight: 54

--- a/Tests/LibWeb/Text/expected/display_list/block-in-inline-no-border-for-phantom-inline-box.txt
+++ b/Tests/LibWeb/Text/expected/display_list/block-in-inline-no-border-for-phantom-inline-box.txt
@@ -1,0 +1,21 @@
+AccumulatedVisualContext Tree:
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x90]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x80]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x80]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[100,50 50x10]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,-2 9.84375x24]
+  FillPath@1 path_bounding_rect=[0,-2 10x24]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[98,48 4x4]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[-2,58 9.921875x24]
+  FillPath@1 path_bounding_rect=[-2,58 10x24]
+  DrawGlyphRun@1 rect=[2,0 6x20] translation=[2,13] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[100,50 7x20] translation=[100,63] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[0,60 6x20] translation=[0,73] color=rgb(0, 0, 0)
+Restore@0
+

--- a/Tests/LibWeb/Text/expected/geometry/getClientRects-inline-basics.txt
+++ b/Tests/LibWeb/Text/expected/geometry/getClientRects-inline-basics.txt
@@ -1,0 +1,14 @@
+wrap: 3
+wrap[0]: 10,10 40x20
+wrap[1]: 10,30 40x20
+wrap[2]: 10,50 40x20
+interrupted: 2
+interrupted[0]: 10,80 30x20
+interrupted[1]: 10,130 40x20
+interrupted bounding: 10,80 40x70
+only-block: 1
+only-block[0]: 10,160 0x0
+only-block bounding: 10,160 0x0
+empty: 1
+empty[0]: 10,200 0x20
+none: 0

--- a/Tests/LibWeb/Text/expected/hit_testing/pointer-events.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/pointer-events.txt
@@ -4,8 +4,8 @@
 <DIV id="b3">
 <DIV id="b2">
 ---
-<A id="c1">
 <BODY>
+<HTML>
 ---
 <I id="d2">
 <B id="d1">

--- a/Tests/LibWeb/Text/input/display_list/block-in-inline-no-border-for-phantom-inline-box.html
+++ b/Tests/LibWeb/Text/input/display_list/block-in-inline-no-border-for-phantom-inline-box.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../../../Ref/data/fonts/Ahem.ttf");
+    }
+
+    body {
+        margin: 0;
+        font: 10px/20px Ahem;
+    }
+
+    span {
+        border: 2px solid red;
+    }
+</style>
+<body>
+    <!-- The span's per-line box that only hosts the interrupting block must not paint a degenerate border. -->
+    <div><span>a<div style="margin: 30px 0 0 100px; width: 50px; height: 10px">x</div>b</span></div>
+    <script>
+        test(() => {
+            println(internals.dumpDisplayList());
+        });
+    </script>
+</body>

--- a/Tests/LibWeb/Text/input/geometry/getClientRects-inline-basics.html
+++ b/Tests/LibWeb/Text/input/geometry/getClientRects-inline-basics.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../../../Ref/data/fonts/Ahem.ttf");
+    }
+
+    body {
+        margin: 0;
+        font: 10px/20px Ahem;
+    }
+
+    .case {
+        margin: 10px 0 0 10px;
+        width: 45px;
+    }
+
+    #interrupted-block,
+    #only-block-block {
+        display: block;
+        width: 80px;
+        height: 30px;
+    }
+</style>
+<body>
+    <div class="case"><span id="wrap">aaaa aaaa aaaa</span></div>
+    <div class="case"><span id="interrupted">ana<div id="interrupted-block">block</div>tomy</span></div>
+    <div class="case"><span id="only-block"><div id="only-block-block">block</div></span></div>
+    <div class="case"><span id="empty"></span></div>
+    <span id="none" style="display: none;">none</span>
+
+    <script>
+        promiseTest(async () => {
+            await document.fonts.ready;
+            await animationFrame();
+
+            function formatNumber(value) {
+                if (Object.is(value, -0))
+                    return "0";
+                if (Number.isInteger(value))
+                    return `${value}`;
+                return value.toFixed(2);
+            }
+
+            function formatRect(rect) {
+                return `${formatNumber(rect.x)},${formatNumber(rect.y)} ${formatNumber(rect.width)}x${formatNumber(rect.height)}`;
+            }
+
+            function printClientRects(id) {
+                const rects = document.getElementById(id).getClientRects();
+                println(`${id}: ${rects.length}`);
+                for (let i = 0; i < rects.length; ++i)
+                    println(`${id}[${i}]: ${formatRect(rects[i])}`);
+            }
+
+            printClientRects("wrap");
+            printClientRects("interrupted");
+            println(`interrupted bounding: ${formatRect(document.getElementById("interrupted").getBoundingClientRect())}`);
+            printClientRects("only-block");
+            println(`only-block bounding: ${formatRect(document.getElementById("only-block").getBoundingClientRect())}`);
+            printClientRects("empty");
+            printClientRects("none");
+        });
+    </script>
+</body>


### PR DESCRIPTION
A block inside an inline currently triggers continuation surgery: the
inline is split into anonymous wrappers, its inline ancestors are
recreated as fresh layout nodes, and the pieces are linked with weak
pointers. One element ends up with several layout nodes, which every
DOM↔layout consumer (style propagation, paintable lifecycle, offset
geometry, hit testing) has to special-case, and which still gets
`getClientRects()` and border painting wrong. It is also the one place
where tree construction rewrites ancestors outside the inserted node —
a standing hazard for incremental layout.

This series deletes that model: the block stays where the DOM puts it,
and the IFC force-breaks lines around it, laying it out as an
"interrupting block" through the parent BFC. One element, one layout
node; the split exists only at the fragment level.

Commits 1–3 land the machinery inert (iterator item, BFC/IFC
interleaving, paint parenting), commit 4 flips construction, commit 5
deletes the continuation links and consumers, commit 6 fixes
`getClientRects()` on inlines to return per-fragment rects.

Rebaselines: 4 continuation dump tests, geometry unchanged (incl.
acid1). Behavior fixes: `offsetWidth` of split inlines, hit testing
through `pointer-events: none`. New tests cover margins, floats,
abspos static positions, justify, and vertical writing modes around
interrupting blocks.