### PR TITLE
Use static position y to seed abspos replaced element top

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2291,7 +2291,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     // If 'margin-top' or 'margin-bottom' is specified as 'auto' its used value is determined by the rules below.
     // 2. If both 'top' and 'bottom' have the value 'auto', replace 'top' with the element's static position.
     if (top.is_auto() && bottom.is_auto()) {
-        top = CSS::Length::make_px(static_position.x());
+        top = CSS::Length::make_px(static_position.y());
     }
 
     // 3. If 'bottom' is 'auto', replace any 'auto' on 'margin-top' or 'margin-bottom' with '0'.

--- a/Tests/LibWeb/Text/expected/abspos-replaced-auto-insets-static-position.txt
+++ b/Tests/LibWeb/Text/expected/abspos-replaced-auto-insets-static-position.txt
@@ -1,0 +1,5 @@
+top: 70px
+right: 170px
+bottom: 90px
+left: 70px
+offset within containing block: 70,50

--- a/Tests/LibWeb/Text/expected/abspos-replaced-auto-insets-static-position.txt
+++ b/Tests/LibWeb/Text/expected/abspos-replaced-auto-insets-static-position.txt
@@ -1,5 +1,5 @@
-top: 70px
+top: 50px
 right: 170px
-bottom: 90px
+bottom: 110px
 left: 70px
 offset within containing block: 70,50

--- a/Tests/LibWeb/Text/input/abspos-replaced-auto-insets-static-position.html
+++ b/Tests/LibWeb/Text/input/abspos-replaced-auto-insets-static-position.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    #cb {
+        position: relative;
+        width: 300px;
+        height: 200px;
+        font-size: 0;
+    }
+    #first-line-spacer {
+        display: inline-block;
+        width: 10px;
+        height: 50px;
+    }
+    #inline-spacer {
+        display: inline-block;
+        width: 70px;
+        height: 20px;
+    }
+    #target {
+        position: absolute;
+    }
+</style>
+<div id="cb">
+    <span id="first-line-spacer"></span><br>
+    <span id="inline-spacer"></span><canvas id="target" width="60" height="40"></canvas>
+</div>
+<script>
+    // An absolutely positioned replaced element with all insets auto is placed
+    // at its static position, which here has distinct x and y coordinates:
+    // x = 70 (after the inline spacer), y = 50 (on the second line). The
+    // resolved values of the inset properties must reflect that position, so
+    // top/bottom must be derived from the static y, not the static x. The
+    // resolved top must always match the box's actual offset within the
+    // containing block printed below.
+    test(() => {
+        const target = document.getElementById("target");
+        const style = getComputedStyle(target);
+        for (const property of ["top", "right", "bottom", "left"])
+            println(`${property}: ${style[property]}`);
+        const rect = target.getBoundingClientRect();
+        const cbRect = document.getElementById("cb").getBoundingClientRect();
+        println(`offset within containing block: ${rect.x - cbRect.x},${rect.y - cbRect.y}`);
+    });
+</script>


### PR DESCRIPTION
When an absolutely positioned replaced element has auto top and bottom,
the height solver replaces top with the element's static position, but
it read the static position's x coordinate instead of its y. The final
offset was unaffected because the auto/auto axis takes its position
directly from the static position rect, but the wrong value was stored
in the used inset_top/inset_bottom, and getComputedStyle reported
top/bottom values mirroring the horizontal axis.