### PR TITLE
LibWebView: Introduce CanonicalNavigable and start building UI process navigation tree

### DIFF
--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     Attribute.cpp
     Autocomplete.cpp
     BookmarkStore.cpp
+    CanonicalNavigable.cpp
     CanonicalTraversable.cpp
     BrowserProcess.cpp
     CompositorClient.cpp

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -7,17 +7,105 @@
 #include <LibWebView/CanonicalNavigable.h>
 
 #include <LibWeb/Page/ViewportIsFullscreen.h>
+#include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace WebView {
 
-CanonicalNavigable::CanonicalNavigable(String id, String parent_id)
+CanonicalNavigable::CanonicalNavigable(String id, String parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id)
     : m_id(move(id))
     , m_parent_id(move(parent_id))
+    , m_reporting_client(move(reporting_client))
+    , m_reporting_page_id(reporting_page_id)
 {
 }
 
 CanonicalNavigable::~CanonicalNavigable() = default;
+
+WebContentClient& CanonicalNavigable::reporting_client() const
+{
+    VERIFY(m_reporting_client);
+    return *m_reporting_client;
+}
+
+// https://html.spec.whatwg.org/multipage/document-sequences.html#nav-top
+CanonicalTraversable& CanonicalNavigable::top_level_traversable()
+{
+    // 1. Let navigable be inputNavigable.
+    auto* navigable = this;
+
+    // 2. While navigable's parent is not null, set navigable to navigable's parent.
+    while (navigable->parent())
+        navigable = navigable->parent();
+
+    // 3. Return navigable.
+    VERIFY(navigable->is_top_level_traversable());
+    return static_cast<CanonicalTraversable&>(*navigable);
+}
+
+CanonicalTraversable const& CanonicalNavigable::top_level_traversable() const
+{
+    return const_cast<CanonicalNavigable&>(*this).top_level_traversable();
+}
+
+CanonicalNavigable& CanonicalNavigable::append_child(NonnullOwnPtr<CanonicalNavigable> child)
+{
+    VERIFY(!child->m_parent);
+    child->m_parent = this;
+    m_children.append(move(child));
+    return *m_children.last();
+}
+
+NonnullOwnPtr<CanonicalNavigable> CanonicalNavigable::remove_child(CanonicalNavigable& child)
+{
+    for (size_t i = 0; i < m_children.size(); ++i) {
+        if (m_children[i].ptr() != &child)
+            continue;
+
+        auto removed_child = m_children.take(i);
+        VERIFY(removed_child->m_parent == this);
+        removed_child->m_parent = nullptr;
+        return removed_child;
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+IterationDecision CanonicalNavigable::for_each_in_inclusive_subtree(Function<IterationDecision(CanonicalNavigable&)> const& callback)
+{
+    if (callback(*this) == IterationDecision::Break)
+        return IterationDecision::Break;
+
+    return for_each_in_subtree(callback);
+}
+
+IterationDecision CanonicalNavigable::for_each_in_subtree(Function<IterationDecision(CanonicalNavigable&)> const& callback)
+{
+    for (auto const& child : m_children) {
+        if (child->for_each_in_inclusive_subtree(callback) == IterationDecision::Break)
+            return IterationDecision::Break;
+    }
+
+    return IterationDecision::Continue;
+}
+
+IterationDecision CanonicalNavigable::for_each_in_inclusive_subtree(Function<IterationDecision(CanonicalNavigable const&)> const& callback) const
+{
+    if (callback(*this) == IterationDecision::Break)
+        return IterationDecision::Break;
+
+    return for_each_in_subtree(callback);
+}
+
+IterationDecision CanonicalNavigable::for_each_in_subtree(Function<IterationDecision(CanonicalNavigable const&)> const& callback) const
+{
+    for (auto const& child : m_children) {
+        if (child->for_each_in_inclusive_subtree(callback) == IterationDecision::Break)
+            return IterationDecision::Break;
+    }
+
+    return IterationDecision::Continue;
+}
 
 WebContentClient& CanonicalNavigable::remote_host_client() const
 {

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/CanonicalNavigable.h>
+
+#include <LibWeb/Page/ViewportIsFullscreen.h>
+#include <LibWebView/WebContentClient.h>
+
+namespace WebView {
+
+CanonicalNavigable::CanonicalNavigable(String id, String parent_id)
+    : m_id(move(id))
+    , m_parent_id(move(parent_id))
+{
+}
+
+CanonicalNavigable::~CanonicalNavigable() = default;
+
+WebContentClient& CanonicalNavigable::remote_host_client() const
+{
+    VERIFY(m_remote_client);
+    return *m_remote_client;
+}
+
+void CanonicalNavigable::set_remote_host(NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)
+{
+    detach_remote_host();
+
+    m_host_locality = HostLocality::Remote;
+    m_remote_client = move(remote_client);
+    m_remote_page_id = remote_page_id;
+}
+
+void CanonicalNavigable::detach_remote_host()
+{
+    if (has_remote_host()) {
+        m_remote_client->async_set_page_parent_context(m_remote_page_id, {});
+        m_remote_client->request_close(m_remote_page_id);
+    }
+
+    m_host_locality = HostLocality::Local;
+    m_remote_client = nullptr;
+    m_remote_page_id = 0;
+}
+
+void CanonicalNavigable::set_viewport(Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
+{
+    m_viewport_rect = viewport_rect;
+    m_device_pixel_ratio = device_pixel_ratio;
+
+    if (has_remote_host()) {
+        m_remote_client->async_set_viewport(
+            m_remote_page_id,
+            viewport_rect.size(),
+            device_pixel_ratio,
+            Web::ViewportIsFullscreen::No);
+    }
+}
+
+void CanonicalNavigable::did_commit_navigation(URL::URL url)
+{
+    m_last_committed_url = move(url);
+    m_pending_navigation.clear();
+}
+
+Optional<URL::URL> CanonicalNavigable::document_url() const
+{
+    if (m_last_committed_url.has_value())
+        return m_last_committed_url;
+
+    if (m_pending_navigation.has_value())
+        return m_pending_navigation->target_url;
+
+    return {};
+}
+
+void CanonicalNavigable::record_pending_navigation(URL::URL const& url, HostLocality target_locality, Optional<u64> remote_page_id)
+{
+    m_pending_navigation = PendingNavigation {
+        .target_url = url,
+        .target_locality = target_locality,
+        .remote_page_id = remote_page_id,
+    };
+}
+
+bool CanonicalNavigable::has_matching_pending_navigation(URL::URL const& url, HostLocality target_locality) const
+{
+    return m_pending_navigation.has_value()
+        && m_pending_navigation->target_locality == target_locality
+        && m_pending_navigation->target_url == url;
+}
+
+}

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -6,11 +6,16 @@
 
 #pragma once
 
+#include <AK/Function.h>
+#include <AK/IterationDecision.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
+#include <AK/Weakable.h>
 #include <LibURL/URL.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/Export.h>
@@ -18,7 +23,8 @@
 
 namespace WebView {
 
-class WEBVIEW_API CanonicalNavigable final {
+class WEBVIEW_API CanonicalNavigable
+    : public Weakable<CanonicalNavigable> {
 public:
     enum class HostLocality : u8 {
         Local,
@@ -31,11 +37,32 @@ public:
         Optional<u64> remote_page_id;
     };
 
-    CanonicalNavigable(String id, String parent_id);
-    ~CanonicalNavigable();
+    CanonicalNavigable(String id, String parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id);
+    virtual ~CanonicalNavigable();
+
+    virtual bool is_top_level_traversable() const { return false; }
 
     String const& id() const { return m_id; }
     String const& parent_id() const { return m_parent_id; }
+
+    // The WebContent process and page whose document tree contains this frame. When the
+    // frame is local, this process also hosts the frame's active document.
+    WebContentClient& reporting_client() const;
+    u64 reporting_page_id() const { return m_reporting_page_id; }
+
+    CanonicalNavigable* parent() { return m_parent; }
+    CanonicalNavigable const* parent() const { return m_parent; }
+    Vector<NonnullOwnPtr<CanonicalNavigable>> const& children() const { return m_children; }
+
+    CanonicalTraversable& top_level_traversable();
+    CanonicalTraversable const& top_level_traversable() const;
+
+    CanonicalNavigable& append_child(NonnullOwnPtr<CanonicalNavigable>);
+    NonnullOwnPtr<CanonicalNavigable> remove_child(CanonicalNavigable&);
+    IterationDecision for_each_in_inclusive_subtree(Function<IterationDecision(CanonicalNavigable&)> const&);
+    IterationDecision for_each_in_subtree(Function<IterationDecision(CanonicalNavigable&)> const&);
+    IterationDecision for_each_in_inclusive_subtree(Function<IterationDecision(CanonicalNavigable const&)> const&) const;
+    IterationDecision for_each_in_subtree(Function<IterationDecision(CanonicalNavigable const&)> const&) const;
 
     bool has_remote_host() const { return m_host_locality == HostLocality::Remote && m_remote_client && m_remote_page_id != 0; }
     WebContentClient& remote_host_client() const;
@@ -58,6 +85,10 @@ public:
 private:
     String m_id;
     String m_parent_id;
+    RefPtr<WebContentClient> m_reporting_client;
+    u64 m_reporting_page_id { 0 };
+    CanonicalNavigable* m_parent { nullptr };
+    Vector<NonnullOwnPtr<CanonicalNavigable>> m_children;
 
     Optional<URL::URL> m_last_committed_url;
     Optional<PendingNavigation> m_pending_navigation;

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
+#include <AK/RefPtr.h>
+#include <AK/String.h>
+#include <AK/Types.h>
+#include <LibURL/URL.h>
+#include <LibWeb/PixelUnits.h>
+#include <LibWebView/Export.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+class WEBVIEW_API CanonicalNavigable final {
+public:
+    enum class HostLocality : u8 {
+        Local,
+        Remote,
+    };
+
+    struct PendingNavigation {
+        URL::URL target_url;
+        HostLocality target_locality { HostLocality::Local };
+        Optional<u64> remote_page_id;
+    };
+
+    CanonicalNavigable(String id, String parent_id);
+    ~CanonicalNavigable();
+
+    String const& id() const { return m_id; }
+    String const& parent_id() const { return m_parent_id; }
+
+    bool has_remote_host() const { return m_host_locality == HostLocality::Remote && m_remote_client && m_remote_page_id != 0; }
+    WebContentClient& remote_host_client() const;
+    u64 remote_host_page_id() const { return m_remote_page_id; }
+
+    void set_remote_host(NonnullRefPtr<WebContentClient>, u64 remote_page_id);
+    void detach_remote_host();
+
+    Optional<Web::DevicePixelRect> const& viewport_rect() const { return m_viewport_rect; }
+    double device_pixel_ratio() const { return m_device_pixel_ratio; }
+    void set_viewport(Web::DevicePixelRect, double device_pixel_ratio);
+
+    void did_commit_navigation(URL::URL);
+    Optional<URL::URL> document_url() const;
+
+    void record_pending_navigation(URL::URL const&, HostLocality, Optional<u64> remote_page_id = {});
+    void clear_pending_navigation() { m_pending_navigation.clear(); }
+    bool has_matching_pending_navigation(URL::URL const&, HostLocality) const;
+
+private:
+    String m_id;
+    String m_parent_id;
+
+    Optional<URL::URL> m_last_committed_url;
+    Optional<PendingNavigation> m_pending_navigation;
+    Optional<Web::DevicePixelRect> m_viewport_rect;
+    double m_device_pixel_ratio { 1 };
+
+    HostLocality m_host_locality { HostLocality::Local };
+    RefPtr<WebContentClient> m_remote_client;
+    u64 m_remote_page_id { 0 };
+};
+
+}

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -6,8 +6,69 @@
 
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/SiteIsolation.h>
+#include <LibWebView/WebContentClient.h>
 
 namespace WebView {
+
+CanonicalTraversable::CanonicalTraversable()
+    : CanonicalNavigable(String {}, String {}, nullptr, 0)
+{
+}
+
+CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, String parent_frame_id, String frame_id, CanonicalNavigable& fallback_parent)
+{
+    if (auto existing_navigable = find(page_id, frame_id); existing_navigable.has_value())
+        remove(*existing_navigable);
+
+    auto navigable = make<CanonicalNavigable>(move(frame_id), move(parent_frame_id), &reporting_client, page_id);
+
+    // A frame's parent frame is always created (and thus reported) before the frame
+    // itself, so if the parent is not in the index, the parent is the top-level document
+    // of the reporting page: the fallback parent.
+    auto* parent = &fallback_parent;
+    if (auto indexed_parent = find(page_id, navigable->parent_id()); indexed_parent.has_value())
+        parent = &*indexed_parent;
+
+    auto& navigable_ref = parent->append_child(move(navigable));
+    m_navigable_index.set(NavigableKey { page_id, navigable_ref.id() }, navigable_ref.make_weak_ptr());
+    return navigable_ref;
+}
+
+Optional<CanonicalNavigable&> CanonicalTraversable::find(u64 page_id, StringView frame_id)
+{
+    auto navigable = m_navigable_index.get(NavigableKey { page_id, MUST(String::from_utf8(frame_id)) });
+    if (!navigable.has_value() || !navigable.value())
+        return {};
+
+    return *navigable.value();
+}
+
+Optional<CanonicalNavigable const&> CanonicalTraversable::find(u64 page_id, StringView frame_id) const
+{
+    auto navigable = m_navigable_index.get(NavigableKey { page_id, MUST(String::from_utf8(frame_id)) });
+    if (!navigable.has_value() || !navigable.value())
+        return {};
+
+    return *navigable.value();
+}
+
+void CanonicalTraversable::remove(CanonicalNavigable& navigable)
+{
+    VERIFY(&navigable != this);
+    remove_from_index(navigable);
+
+    auto* parent = navigable.parent();
+    VERIFY(parent);
+    (void)parent->remove_child(navigable);
+}
+
+void CanonicalTraversable::remove_from_index(CanonicalNavigable& navigable)
+{
+    navigable.for_each_in_inclusive_subtree([&](CanonicalNavigable& child) {
+        m_navigable_index.remove(NavigableKey { child.reporting_page_id(), child.id() });
+        return IterationDecision::Continue;
+    });
+}
 
 static Optional<size_t> current_top_level_history_entry_index_for_step(Vector<Web::HTML::SessionHistoryEntryDescriptor> const& entries, Optional<i32> current_step)
 {

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -7,15 +7,19 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/HashFunctions.h>
+#include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <AK/WeakPtr.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/VisibilityState.h>
+#include <LibWebView/CanonicalNavigable.h>
 #include <LibWebView/Export.h>
 #include <LibWebView/SessionHistory.h>
 
@@ -198,8 +202,25 @@ struct PageLoadPreparation {
     bool should_update_navigation_action_state { false };
 };
 
-class WEBVIEW_API CanonicalTraversable final {
+class WEBVIEW_API CanonicalTraversable final
+    : public CanonicalNavigable {
 public:
+    struct NavigableKey {
+        u64 page_id { 0 };
+        String frame_id;
+
+        bool operator==(NavigableKey const&) const = default;
+    };
+
+    CanonicalTraversable();
+
+    virtual bool is_top_level_traversable() const override { return true; }
+
+    CanonicalNavigable& insert(WebContentClient& reporting_client, u64 page_id, String parent_frame_id, String frame_id, CanonicalNavigable& fallback_parent);
+    Optional<CanonicalNavigable&> find(u64 page_id, StringView frame_id);
+    Optional<CanonicalNavigable const&> find(u64 page_id, StringView frame_id) const;
+    void remove(CanonicalNavigable&);
+
     TraversableSessionHistory const& session_history() const { return m_session_history; }
 
     Web::HTML::VisibilityState system_visibility_state() const { return m_system_visibility_state; }
@@ -242,9 +263,11 @@ public:
 
 private:
     void abandon_pending_web_content_session_history_seed();
+    void remove_from_index(CanonicalNavigable&);
     WebContentSessionHistoryUpdateResult update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot, URL::URL const& current_url);
     WebContentSessionHistoryUpdateResult adopt_web_content_session_history_after_rejected_seed(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
 
+    HashMap<NavigableKey, WeakPtr<CanonicalNavigable>> m_navigable_index;
     TraversableSessionHistory m_session_history;
     Web::HTML::VisibilityState m_system_visibility_state { Web::HTML::VisibilityState::Hidden };
     bool m_current_web_content_session_history_matches_mirror { false };
@@ -253,6 +276,18 @@ private:
     u64 m_next_traverse_history_step_cancelation_check_request_id { 0 };
     Optional<URL::URL> m_session_history_entry_url_loading_from_ui_process;
     PendingWebContentSessionHistorySeed m_pending_web_content_session_history_seed;
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<WebView::CanonicalTraversable::NavigableKey> : public DefaultTraits<WebView::CanonicalTraversable::NavigableKey> {
+    static unsigned hash(WebView::CanonicalTraversable::NavigableKey const& key)
+    {
+        return pair_int_hash(Traits<u64>::hash(key.page_id), key.frame_id.hash());
+    }
 };
 
 }

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -16,6 +16,7 @@ class Action;
 class Application;
 class Autocomplete;
 class BookmarkStore;
+class CanonicalNavigable;
 class CanonicalTraversable;
 class CompositorClient;
 class CookieJar;

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -6,8 +6,8 @@
 
 #include <LibWebView/SiteIsolationManager.h>
 
-#include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
+#include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/SiteIsolation.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
@@ -20,145 +20,93 @@ SiteIsolationManager& SiteIsolationManager::the()
     return manager;
 }
 
-void SiteIsolationManager::did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id)
+static URL::URL embedding_page_url_for_child_frame_navigation(CanonicalNavigable const& child_frame, URL::URL const& fallback_url)
 {
-    auto& child_frames = m_child_frames.ensure(page_id, [] {
-        return HashMap<String, NonnullOwnPtr<CanonicalNavigable>> {};
-    });
-    auto child_frame = make<CanonicalNavigable>(frame_id, move(parent_frame_id));
-    child_frames.set(move(frame_id), move(child_frame));
+    if (auto const* parent = child_frame.parent()) {
+        if (auto url = parent->document_url(); url.has_value())
+            return *url;
+    }
+
+    return fallback_url;
 }
 
 Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(WebContentClient& parent_client, u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
 {
-    if (target == Web::NavigationTarget::IFrame && frame_id.has_value()) {
-        if (auto child_frame = this->child_frame(page_id, *frame_id); child_frame.has_value())
-            current_url = embedding_page_url_for_child_frame_navigation(parent_client, page_id, *child_frame, current_url);
-    }
+    Optional<CanonicalNavigable&> child_frame;
+    if (target == Web::NavigationTarget::IFrame && frame_id.has_value())
+        child_frame = parent_client.child_frame(page_id, *frame_id);
+
+    if (child_frame.has_value())
+        current_url = embedding_page_url_for_child_frame_navigation(*child_frame, current_url);
 
     auto decision = WebView::is_url_suitable_for_same_process_navigation(current_url, target_url, target)
         ? Web::NavigationProcessDecision::Local
         : Web::NavigationProcessDecision::Remote;
 
-    if (target == Web::NavigationTarget::IFrame && frame_id.has_value()) {
+    if (child_frame.has_value()) {
         auto target_locality = decision == Web::NavigationProcessDecision::Local
             ? CanonicalNavigable::HostLocality::Local
             : CanonicalNavigable::HostLocality::Remote;
-        record_pending_child_frame_navigation(page_id, *frame_id, target_url, target_locality);
+        child_frame->record_pending_navigation(target_url, target_locality);
 
         if (target_locality == CanonicalNavigable::HostLocality::Local)
-            transition_child_frame_to_local(parent_client, page_id, *frame_id);
+            transition_child_frame_to_local(*child_frame);
     }
 
     return decision;
 }
 
-void SiteIsolationManager::did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
+Optional<SiteIsolationManager::RemoteChildFrameInputTarget> SiteIsolationManager::remote_child_frame_input_target_at(WebContentClient& client, u64 page_id, Web::DevicePixelPoint position) const
 {
-    auto child_frame = this->child_frame(page_id, frame_id);
-    if (!child_frame.has_value())
-        return;
-
-    child_frame->set_viewport(viewport_rect, device_pixel_ratio);
-}
-
-bool SiteIsolationManager::did_commit_child_frame_navigation(WebContentClient& parent_client, u64 page_id, StringView frame_id, URL::URL const& url)
-{
-    auto child_frame = this->child_frame(page_id, frame_id);
-    if (!child_frame.has_value())
-        return false;
-
-    if (child_frame->has_remote_host())
-        transition_child_frame_to_local(parent_client, page_id, frame_id);
-
-    child_frame->did_commit_navigation(url);
-    return true;
-}
-
-void SiteIsolationManager::did_destroy_child_frame(WebContentClient& parent_client, u64 page_id, StringView frame_id)
-{
-    auto child_frames = m_child_frames.get(page_id);
-    if (!child_frames.has_value())
-        return;
-
-    transition_child_frame_to_local(parent_client, page_id, frame_id);
-
-    child_frames->remove(frame_id);
-    if (child_frames->is_empty())
-        m_child_frames.remove(page_id);
-}
-
-Optional<SiteIsolationManager::RemoteChildFrameInputTarget> SiteIsolationManager::remote_child_frame_input_target_at(u64 page_id, Web::DevicePixelPoint position) const
-{
-    auto child_frames = m_child_frames.get(page_id);
-    if (!child_frames.has_value())
+    auto* host = client.navigable_for_page(page_id);
+    if (!host)
         return {};
 
-    for (auto const& child_frame_entry : *child_frames) {
-        auto const& child_frame = *child_frame_entry.value;
+    Optional<RemoteChildFrameInputTarget> target;
+    host->for_each_in_subtree([&](CanonicalNavigable const& child_frame) {
+        if (child_frame.reporting_page_id() != page_id)
+            return IterationDecision::Continue;
+
         auto const& viewport_rect = child_frame.viewport_rect();
         if (!child_frame.has_remote_host() || !viewport_rect.has_value())
-            continue;
+            return IterationDecision::Continue;
         if (!viewport_rect->contains(position))
-            continue;
+            return IterationDecision::Continue;
 
-        return RemoteChildFrameInputTarget {
+        target = RemoteChildFrameInputTarget {
             .remote_client = &child_frame.remote_host_client(),
             .remote_page_id = child_frame.remote_host_page_id(),
             .viewport_rect = *viewport_rect,
         };
-    }
+        return IterationDecision::Break;
+    });
 
-    return {};
+    return target;
 }
 
-bool SiteIsolationManager::remote_child_frame_did_finish_loading(WebContentClient& remote_client, u64 remote_page_id, URL::URL const& url)
+void SiteIsolationManager::remove_page(WebContentClient& client, u64 page_id)
 {
-    auto parent_frame = parent_frame_for_remote_page(remote_client, remote_page_id);
-    if (!parent_frame.has_value())
-        return false;
+    auto* host = client.navigable_for_page(page_id);
+    if (!host)
+        return;
 
-    parent_frame->child_frame->did_commit_navigation(url);
-    parent_frame->parent_client->async_run_iframe_load_event_steps(parent_frame->page_id, parent_frame->frame_id);
-    return true;
-}
-
-bool SiteIsolationManager::remote_child_frame_did_commit_navigation(WebContentClient& remote_client, u64 remote_page_id, URL::URL const& url)
-{
-    auto parent_frame = parent_frame_for_remote_page(remote_client, remote_page_id);
-    if (!parent_frame.has_value())
-        return false;
-
-    parent_frame->child_frame->did_commit_navigation(url);
-    return true;
-}
-
-bool SiteIsolationManager::remote_child_frame_did_finish_handling_input_event(WebContentClient& remote_client, u64 remote_page_id, Web::EventResult event_result)
-{
-    auto parent_frame = parent_frame_for_remote_page(remote_client, remote_page_id);
-    if (!parent_frame.has_value())
-        return false;
-
-    parent_frame->parent_client->did_finish_handling_input_event(parent_frame->page_id, event_result);
-    return true;
-}
-
-void SiteIsolationManager::remove_page(u64 page_id)
-{
-    m_child_frames.remove(page_id);
+    // All children of the hosting navigable are the frames the page reported; any deeper
+    // frames belong to their subtrees and follow them out.
+    while (!host->children().is_empty())
+        remove_child_frame_subtree(*host->children().last());
 }
 
 void SiteIsolationManager::remove_all_pages_for_client(WebContentClient& client)
 {
     Vector<u64> page_ids;
-    for (auto const& page_child_frames : m_child_frames) {
-        auto page_id = page_child_frames.key;
-        if (client_owns_page(client, page_id))
-            page_ids.append(page_id);
-    }
+    page_ids.ensure_capacity(client.m_views.size() + client.m_embedded_pages.size());
+    for (auto const& view_entry : client.m_views)
+        page_ids.append(view_entry.key);
+    for (auto const& embedded_page_entry : client.m_embedded_pages)
+        page_ids.append(embedded_page_entry.key);
 
     for (auto page_id : page_ids)
-        remove_page(page_id);
+        remove_page(client, page_id);
 }
 
 String SiteIsolationManager::dump_process_tree(WebContentClient& client, u64 page_id) const
@@ -175,51 +123,24 @@ String SiteIsolationManager::dump_process_tree(WebContentClient& client, u64 pag
         return processes.size() - 1;
     };
 
-    auto sorted_child_frame_ids = [&](u64 page_id, Optional<StringView> parent_frame_id) {
-        Vector<String> child_frame_ids;
-        auto child_frames = m_child_frames.get(page_id);
-        if (!child_frames.has_value())
-            return child_frame_ids;
-
-        for (auto const& child_frame_entry : *child_frames) {
-            auto const& child_frame = *child_frame_entry.value;
-            auto is_child_of_parent_frame = parent_frame_id.has_value()
-                ? child_frame.parent_id() == *parent_frame_id
-                : !child_frames->contains(child_frame.parent_id());
-            if (is_child_of_parent_frame)
-                child_frame_ids.append(child_frame_entry.key);
-        }
-
-        quick_sort(child_frame_ids);
-        return child_frame_ids;
-    };
-
-    Function<void(WebContentClient&, u64, Optional<StringView>, size_t)> dump_frame_tree;
-    dump_frame_tree = [&](WebContentClient& current_client, u64 current_page_id, Optional<StringView> parent_frame_id, size_t depth) {
-        auto child_frames = m_child_frames.get(current_page_id);
-        if (!child_frames.has_value())
-            return;
-
-        auto child_frame_ids = sorted_child_frame_ids(current_page_id, parent_frame_id);
-        for (size_t i = 0; i < child_frame_ids.size(); ++i) {
-            auto child_frame = this->child_frame(current_page_id, child_frame_ids[i]);
-            VERIFY(child_frame.has_value());
+    Function<void(CanonicalNavigable const&, size_t)> dump_frame_tree;
+    dump_frame_tree = [&](CanonicalNavigable const& parent, size_t depth) {
+        for (size_t i = 0; i < parent.children().size(); ++i) {
+            auto const& child_frame = *parent.children()[i];
 
             builder.append_repeated(' ', depth * 2);
-            builder.appendff("iframe#{}: {}", i, child_frame->has_remote_host() ? "remote"sv : "local"sv);
-            if (child_frame->has_remote_host())
-                builder.appendff(" WebContent#{}", process_index(child_frame->remote_host_client()));
+            builder.appendff("iframe#{}: {}", i, child_frame.has_remote_host() ? "remote"sv : "local"sv);
+            if (child_frame.has_remote_host())
+                builder.appendff(" WebContent#{}", process_index(child_frame.remote_host_client()));
             builder.append('\n');
 
-            if (child_frame->has_remote_host())
-                dump_frame_tree(child_frame->remote_host_client(), child_frame->remote_host_page_id(), {}, depth + 1);
-            else
-                dump_frame_tree(current_client, current_page_id, child_frame_ids[i].bytes_as_string_view(), depth + 1);
+            dump_frame_tree(child_frame, depth + 1);
         }
     };
 
     builder.appendff("WebContent#{}\n", process_index(client));
-    dump_frame_tree(client, page_id, {}, 1);
+    if (auto* host = client.navigable_for_page(page_id))
+        dump_frame_tree(*host, 1);
     return builder.to_string_without_validation();
 }
 
@@ -227,189 +148,59 @@ HashMap<pid_t, pid_t> SiteIsolationManager::remote_frame_process_embedders() con
 {
     HashMap<pid_t, pid_t> embedders;
 
-    for (auto const& page_child_frames : m_child_frames) {
-        WebContentClient* embedder_client = nullptr;
-        WebContentClient::for_each_client([&](auto& client) {
-            if (!client_owns_page(client, page_child_frames.key))
-                return IterationDecision::Continue;
-
-            embedder_client = &client;
-            return IterationDecision::Break;
-        });
-        if (!embedder_client)
-            continue;
-
-        for (auto const& child_frame_entry : page_child_frames.value) {
-            auto const& child_frame = *child_frame_entry.value;
-            if (!child_frame.has_remote_host())
+    WebContentClient::for_each_client([&](WebContentClient& client) {
+        for (auto const& embedded_page_entry : client.m_embedded_pages) {
+            auto* child_frame = client.embedded_page_host(embedded_page_entry.key);
+            if (!child_frame)
                 continue;
 
-            embedders.set(child_frame.remote_host_client().pid(), embedder_client->pid());
-        }
-    }
-
-    return embedders;
-}
-
-bool SiteIsolationManager::has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, CanonicalNavigable::HostLocality target_locality) const
-{
-    auto child_frame = this->child_frame(page_id, frame_id);
-    if (!child_frame.has_value())
-        return false;
-
-    return child_frame->has_matching_pending_navigation(url, target_locality);
-}
-
-void SiteIsolationManager::record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, CanonicalNavigable::HostLocality target_locality, Optional<u64> remote_page_id)
-{
-    auto child_frame = this->child_frame(page_id, frame_id);
-    if (!child_frame.has_value())
-        return;
-
-    child_frame->record_pending_navigation(url, target_locality, remote_page_id);
-}
-
-void SiteIsolationManager::clear_pending_child_frame_navigation(u64 page_id, StringView frame_id)
-{
-    auto child_frame = this->child_frame(page_id, frame_id);
-    if (!child_frame.has_value())
-        return;
-
-    child_frame->clear_pending_navigation();
-}
-
-void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)
-{
-    auto child_frame = this->child_frame(page_id, frame_id);
-    if (!child_frame.has_value())
-        return;
-
-    transition_child_frame_to_local(parent_client, page_id, frame_id);
-
-    child_frame->set_remote_host(move(remote_client), remote_page_id);
-    parent_client.async_set_remote_child_frame_compositor_context(
-        page_id,
-        MUST(String::from_utf8(frame_id)),
-        Web::Compositor::compositor_context_id_for_page(remote_page_id));
-}
-
-void SiteIsolationManager::transition_child_frame_to_local(WebContentClient& parent_client, u64 page_id, StringView frame_id)
-{
-    auto child_frame = this->child_frame(page_id, frame_id);
-    if (!child_frame.has_value())
-        return;
-
-    parent_client.async_set_remote_child_frame_compositor_context(page_id, MUST(String::from_utf8(frame_id)), {});
-
-    child_frame->detach_remote_host();
-}
-
-void SiteIsolationManager::close_remote_child_frames_for_page(WebContentClient& parent_client, u64 page_id)
-{
-    auto child_frames = m_child_frames.get(page_id);
-    if (!child_frames.has_value())
-        return;
-
-    Vector<String> remote_child_frame_ids;
-    for (auto const& child_frame_entry : *child_frames) {
-        if (child_frame_entry.value->has_remote_host())
-            remote_child_frame_ids.append(child_frame_entry.key);
-    }
-
-    for (auto const& frame_id : remote_child_frame_ids)
-        transition_child_frame_to_local(parent_client, page_id, frame_id);
-}
-
-Optional<CanonicalNavigable&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id)
-{
-    auto child_frames = m_child_frames.get(page_id);
-    if (!child_frames.has_value())
-        return {};
-
-    auto child_frame = child_frames->get(frame_id);
-    if (!child_frame.has_value())
-        return {};
-
-    return *child_frame.value();
-}
-
-Optional<CanonicalNavigable const&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id) const
-{
-    auto child_frames = m_child_frames.get(page_id);
-    if (!child_frames.has_value())
-        return {};
-
-    auto child_frame = child_frames->get(frame_id);
-    if (!child_frame.has_value())
-        return {};
-
-    return *child_frame.value();
-}
-
-bool SiteIsolationManager::client_owns_page(WebContentClient const& client, u64 page_id)
-{
-    return client.m_views.contains(page_id) || client.m_embedded_pages.contains(page_id);
-}
-
-Optional<SiteIsolationManager::ParentFrame> SiteIsolationManager::parent_frame_for_remote_page(WebContentClient& remote_client, u64 remote_page_id)
-{
-    Optional<ParentFrame> result;
-
-    WebContentClient::for_each_client([&](auto& parent_client) {
-        for (auto& page_child_frames : m_child_frames) {
-            auto parent_page_id = page_child_frames.key;
-            if (!client_owns_page(parent_client, parent_page_id))
-                continue;
-
-            for (auto& child_frame_entry : page_child_frames.value) {
-                auto& child_frame = *child_frame_entry.value;
-                if (!child_frame.has_remote_host() || &child_frame.remote_host_client() != &remote_client || child_frame.remote_host_page_id() != remote_page_id)
-                    continue;
-
-                result = ParentFrame {
-                    .parent_client = &parent_client,
-                    .page_id = parent_page_id,
-                    .frame_id = child_frame_entry.key,
-                    .child_frame = &child_frame,
-                };
-                return IterationDecision::Break;
-            }
+            embedders.set(client.pid(), child_frame->reporting_client().pid());
         }
 
         return IterationDecision::Continue;
     });
 
-    return result;
+    return embedders;
 }
 
-Optional<URL::URL> SiteIsolationManager::document_url_for_child_frame(CanonicalNavigable const& child_frame)
+void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)
 {
-    return child_frame.document_url();
+    auto child_frame = parent_client.child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+
+    transition_child_frame_to_local(*child_frame);
+
+    child_frame->set_remote_host(move(remote_client), remote_page_id);
+    parent_client.async_set_remote_child_frame_compositor_context(
+        page_id,
+        child_frame->id(),
+        Web::Compositor::compositor_context_id_for_page(remote_page_id));
 }
 
-URL::URL SiteIsolationManager::document_url_for_page(WebContentClient& client, u64 page_id, URL::URL const& fallback_url)
+void SiteIsolationManager::transition_child_frame_to_local(CanonicalNavigable& child_frame)
 {
-    if (auto view = client.view_for_page_id(page_id); view.has_value())
-        return view->url();
+    child_frame.reporting_client().async_set_remote_child_frame_compositor_context(child_frame.reporting_page_id(), child_frame.id(), {});
 
-    if (client.m_embedded_pages.contains(page_id)) {
-        if (auto parent_frame = parent_frame_for_remote_page(client, page_id); parent_frame.has_value()) {
-            if (auto url = document_url_for_child_frame(*parent_frame->child_frame); url.has_value())
-                return *url;
-        }
+    // The frames of the closed remote page (this frame's children) die with it; that
+    // page's process is going away and will not report their destruction.
+    if (child_frame.has_remote_host()) {
+        while (!child_frame.children().is_empty())
+            remove_child_frame_subtree(*child_frame.children().last());
     }
 
-    return fallback_url;
+    child_frame.detach_remote_host();
 }
 
-URL::URL SiteIsolationManager::embedding_page_url_for_child_frame_navigation(WebContentClient& parent_client, u64 page_id, CanonicalNavigable const& child_frame, URL::URL const& fallback_url)
+void SiteIsolationManager::remove_child_frame_subtree(CanonicalNavigable& child_frame)
 {
-    if (auto parent_frame = this->child_frame(page_id, child_frame.parent_id()); parent_frame.has_value()) {
-        if (auto url = document_url_for_child_frame(*parent_frame); url.has_value())
-            return *url;
-    }
+    while (!child_frame.children().is_empty())
+        remove_child_frame_subtree(*child_frame.children().last());
 
-    return document_url_for_page(parent_client, page_id, fallback_url);
+    if (child_frame.has_remote_host())
+        transition_child_frame_to_local(child_frame);
+
+    child_frame.top_level_traversable().remove(child_frame);
 }
 
 }

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -8,7 +8,6 @@
 
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
-#include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWebView/SiteIsolation.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
@@ -24,10 +23,9 @@ SiteIsolationManager& SiteIsolationManager::the()
 void SiteIsolationManager::did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id)
 {
     auto& child_frames = m_child_frames.ensure(page_id, [] {
-        return HashMap<String, ChildFrameHost> {};
+        return HashMap<String, NonnullOwnPtr<CanonicalNavigable>> {};
     });
-    ChildFrameHost child_frame;
-    child_frame.parent_frame_id = move(parent_frame_id);
+    auto child_frame = make<CanonicalNavigable>(frame_id, move(parent_frame_id));
     child_frames.set(move(frame_id), move(child_frame));
 }
 
@@ -43,12 +41,12 @@ Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(W
         : Web::NavigationProcessDecision::Remote;
 
     if (target == Web::NavigationTarget::IFrame && frame_id.has_value()) {
-        auto target_owner = decision == Web::NavigationProcessDecision::Local
-            ? ChildFrameOwner::Local
-            : ChildFrameOwner::Remote;
-        record_pending_child_frame_navigation(page_id, *frame_id, target_url, target_owner);
+        auto target_locality = decision == Web::NavigationProcessDecision::Local
+            ? CanonicalNavigable::HostLocality::Local
+            : CanonicalNavigable::HostLocality::Remote;
+        record_pending_child_frame_navigation(page_id, *frame_id, target_url, target_locality);
 
-        if (target_owner == ChildFrameOwner::Local)
+        if (target_locality == CanonicalNavigable::HostLocality::Local)
             transition_child_frame_to_local(parent_client, page_id, *frame_id);
     }
 
@@ -61,15 +59,7 @@ void SiteIsolationManager::did_update_child_frame_viewport(u64 page_id, String f
     if (!child_frame.has_value())
         return;
 
-    child_frame->viewport_rect = viewport_rect;
-    child_frame->device_pixel_ratio = device_pixel_ratio;
-    if (child_frame->is_remote()) {
-        child_frame->remote_client->async_set_viewport(
-            child_frame->remote_page_id,
-            viewport_rect.size(),
-            device_pixel_ratio,
-            Web::ViewportIsFullscreen::No);
-    }
+    child_frame->set_viewport(viewport_rect, device_pixel_ratio);
 }
 
 bool SiteIsolationManager::did_commit_child_frame_navigation(WebContentClient& parent_client, u64 page_id, StringView frame_id, URL::URL const& url)
@@ -78,11 +68,10 @@ bool SiteIsolationManager::did_commit_child_frame_navigation(WebContentClient& p
     if (!child_frame.has_value())
         return false;
 
-    if (child_frame->is_remote())
+    if (child_frame->has_remote_host())
         transition_child_frame_to_local(parent_client, page_id, frame_id);
 
-    child_frame->last_committed_url = url;
-    child_frame->pending_navigation.clear();
+    child_frame->did_commit_navigation(url);
     return true;
 }
 
@@ -106,16 +95,17 @@ Optional<SiteIsolationManager::RemoteChildFrameInputTarget> SiteIsolationManager
         return {};
 
     for (auto const& child_frame_entry : *child_frames) {
-        auto const& child_frame = child_frame_entry.value;
-        if (!child_frame.is_remote() || !child_frame.viewport_rect.has_value())
+        auto const& child_frame = *child_frame_entry.value;
+        auto const& viewport_rect = child_frame.viewport_rect();
+        if (!child_frame.has_remote_host() || !viewport_rect.has_value())
             continue;
-        if (!child_frame.viewport_rect->contains(position))
+        if (!viewport_rect->contains(position))
             continue;
 
         return RemoteChildFrameInputTarget {
-            .remote_client = child_frame.remote_client,
-            .remote_page_id = child_frame.remote_page_id,
-            .viewport_rect = *child_frame.viewport_rect,
+            .remote_client = &child_frame.remote_host_client(),
+            .remote_page_id = child_frame.remote_host_page_id(),
+            .viewport_rect = *viewport_rect,
         };
     }
 
@@ -128,8 +118,7 @@ bool SiteIsolationManager::remote_child_frame_did_finish_loading(WebContentClien
     if (!parent_frame.has_value())
         return false;
 
-    parent_frame->child_frame->last_committed_url = url;
-    parent_frame->child_frame->pending_navigation.clear();
+    parent_frame->child_frame->did_commit_navigation(url);
     parent_frame->parent_client->async_run_iframe_load_event_steps(parent_frame->page_id, parent_frame->frame_id);
     return true;
 }
@@ -140,8 +129,7 @@ bool SiteIsolationManager::remote_child_frame_did_commit_navigation(WebContentCl
     if (!parent_frame.has_value())
         return false;
 
-    parent_frame->child_frame->last_committed_url = url;
-    parent_frame->child_frame->pending_navigation.clear();
+    parent_frame->child_frame->did_commit_navigation(url);
     return true;
 }
 
@@ -194,10 +182,10 @@ String SiteIsolationManager::dump_process_tree(WebContentClient& client, u64 pag
             return child_frame_ids;
 
         for (auto const& child_frame_entry : *child_frames) {
-            auto const& child_frame = child_frame_entry.value;
+            auto const& child_frame = *child_frame_entry.value;
             auto is_child_of_parent_frame = parent_frame_id.has_value()
-                ? child_frame.parent_frame_id == *parent_frame_id
-                : !child_frames->contains(child_frame.parent_frame_id);
+                ? child_frame.parent_id() == *parent_frame_id
+                : !child_frames->contains(child_frame.parent_id());
             if (is_child_of_parent_frame)
                 child_frame_ids.append(child_frame_entry.key);
         }
@@ -214,17 +202,17 @@ String SiteIsolationManager::dump_process_tree(WebContentClient& client, u64 pag
 
         auto child_frame_ids = sorted_child_frame_ids(current_page_id, parent_frame_id);
         for (size_t i = 0; i < child_frame_ids.size(); ++i) {
-            auto child_frame = child_frames->get(child_frame_ids[i]);
+            auto child_frame = this->child_frame(current_page_id, child_frame_ids[i]);
             VERIFY(child_frame.has_value());
 
             builder.append_repeated(' ', depth * 2);
-            builder.appendff("iframe#{}: {}", i, child_frame->is_remote() ? "remote"sv : "local"sv);
-            if (child_frame->is_remote())
-                builder.appendff(" WebContent#{}", process_index(*child_frame->remote_client));
+            builder.appendff("iframe#{}: {}", i, child_frame->has_remote_host() ? "remote"sv : "local"sv);
+            if (child_frame->has_remote_host())
+                builder.appendff(" WebContent#{}", process_index(child_frame->remote_host_client()));
             builder.append('\n');
 
-            if (child_frame->is_remote())
-                dump_frame_tree(*child_frame->remote_client, child_frame->remote_page_id, {}, depth + 1);
+            if (child_frame->has_remote_host())
+                dump_frame_tree(child_frame->remote_host_client(), child_frame->remote_host_page_id(), {}, depth + 1);
             else
                 dump_frame_tree(current_client, current_page_id, child_frame_ids[i].bytes_as_string_view(), depth + 1);
         }
@@ -252,38 +240,33 @@ HashMap<pid_t, pid_t> SiteIsolationManager::remote_frame_process_embedders() con
             continue;
 
         for (auto const& child_frame_entry : page_child_frames.value) {
-            auto const& child_frame = child_frame_entry.value;
-            if (!child_frame.is_remote())
+            auto const& child_frame = *child_frame_entry.value;
+            if (!child_frame.has_remote_host())
                 continue;
 
-            embedders.set(child_frame.remote_client->pid(), embedder_client->pid());
+            embedders.set(child_frame.remote_host_client().pid(), embedder_client->pid());
         }
     }
 
     return embedders;
 }
 
-bool SiteIsolationManager::has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, ChildFrameOwner target_owner) const
+bool SiteIsolationManager::has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, CanonicalNavigable::HostLocality target_locality) const
 {
     auto child_frame = this->child_frame(page_id, frame_id);
-    if (!child_frame.has_value() || !child_frame->pending_navigation.has_value())
+    if (!child_frame.has_value())
         return false;
 
-    return child_frame->pending_navigation->target_owner == target_owner
-        && child_frame->pending_navigation->target_url == url;
+    return child_frame->has_matching_pending_navigation(url, target_locality);
 }
 
-void SiteIsolationManager::record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, ChildFrameOwner target_owner, Optional<u64> remote_page_id)
+void SiteIsolationManager::record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const& url, CanonicalNavigable::HostLocality target_locality, Optional<u64> remote_page_id)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
         return;
 
-    child_frame->pending_navigation = PendingChildFrameNavigation {
-        .target_url = url,
-        .target_owner = target_owner,
-        .remote_page_id = remote_page_id,
-    };
+    child_frame->record_pending_navigation(url, target_locality, remote_page_id);
 }
 
 void SiteIsolationManager::clear_pending_child_frame_navigation(u64 page_id, StringView frame_id)
@@ -292,10 +275,10 @@ void SiteIsolationManager::clear_pending_child_frame_navigation(u64 page_id, Str
     if (!child_frame.has_value())
         return;
 
-    child_frame->pending_navigation.clear();
+    child_frame->clear_pending_navigation();
 }
 
-void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, RefPtr<WebContentClient> remote_client, u64 remote_page_id)
+void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
@@ -303,9 +286,7 @@ void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& pa
 
     transition_child_frame_to_local(parent_client, page_id, frame_id);
 
-    child_frame->owner = ChildFrameOwner::Remote;
-    child_frame->remote_client = move(remote_client);
-    child_frame->remote_page_id = remote_page_id;
+    child_frame->set_remote_host(move(remote_client), remote_page_id);
     parent_client.async_set_remote_child_frame_compositor_context(
         page_id,
         MUST(String::from_utf8(frame_id)),
@@ -320,14 +301,7 @@ void SiteIsolationManager::transition_child_frame_to_local(WebContentClient& par
 
     parent_client.async_set_remote_child_frame_compositor_context(page_id, MUST(String::from_utf8(frame_id)), {});
 
-    if (child_frame->is_remote()) {
-        child_frame->remote_client->async_set_page_parent_context(child_frame->remote_page_id, {});
-        child_frame->remote_client->request_close(child_frame->remote_page_id);
-    }
-
-    child_frame->owner = ChildFrameOwner::Local;
-    child_frame->remote_client = nullptr;
-    child_frame->remote_page_id = 0;
+    child_frame->detach_remote_host();
 }
 
 void SiteIsolationManager::close_remote_child_frames_for_page(WebContentClient& parent_client, u64 page_id)
@@ -338,7 +312,7 @@ void SiteIsolationManager::close_remote_child_frames_for_page(WebContentClient& 
 
     Vector<String> remote_child_frame_ids;
     for (auto const& child_frame_entry : *child_frames) {
-        if (child_frame_entry.value.is_remote())
+        if (child_frame_entry.value->has_remote_host())
             remote_child_frame_ids.append(child_frame_entry.key);
     }
 
@@ -346,22 +320,30 @@ void SiteIsolationManager::close_remote_child_frames_for_page(WebContentClient& 
         transition_child_frame_to_local(parent_client, page_id, frame_id);
 }
 
-Optional<SiteIsolationManager::ChildFrameHost&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id)
+Optional<CanonicalNavigable&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id)
 {
     auto child_frames = m_child_frames.get(page_id);
     if (!child_frames.has_value())
         return {};
 
-    return child_frames->get(frame_id);
+    auto child_frame = child_frames->get(frame_id);
+    if (!child_frame.has_value())
+        return {};
+
+    return *child_frame.value();
 }
 
-Optional<SiteIsolationManager::ChildFrameHost const&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id) const
+Optional<CanonicalNavigable const&> SiteIsolationManager::child_frame(u64 page_id, StringView frame_id) const
 {
     auto child_frames = m_child_frames.get(page_id);
     if (!child_frames.has_value())
         return {};
 
-    return child_frames->get(frame_id);
+    auto child_frame = child_frames->get(frame_id);
+    if (!child_frame.has_value())
+        return {};
+
+    return *child_frame.value();
 }
 
 bool SiteIsolationManager::client_owns_page(WebContentClient const& client, u64 page_id)
@@ -380,8 +362,8 @@ Optional<SiteIsolationManager::ParentFrame> SiteIsolationManager::parent_frame_f
                 continue;
 
             for (auto& child_frame_entry : page_child_frames.value) {
-                auto& child_frame = child_frame_entry.value;
-                if (!child_frame.is_remote() || child_frame.remote_client.ptr() != &remote_client || child_frame.remote_page_id != remote_page_id)
+                auto& child_frame = *child_frame_entry.value;
+                if (!child_frame.has_remote_host() || &child_frame.remote_host_client() != &remote_client || child_frame.remote_host_page_id() != remote_page_id)
                     continue;
 
                 result = ParentFrame {
@@ -400,15 +382,9 @@ Optional<SiteIsolationManager::ParentFrame> SiteIsolationManager::parent_frame_f
     return result;
 }
 
-Optional<URL::URL> SiteIsolationManager::document_url_for_child_frame(ChildFrameHost const& child_frame)
+Optional<URL::URL> SiteIsolationManager::document_url_for_child_frame(CanonicalNavigable const& child_frame)
 {
-    if (child_frame.last_committed_url.has_value())
-        return child_frame.last_committed_url;
-
-    if (child_frame.pending_navigation.has_value())
-        return child_frame.pending_navigation->target_url;
-
-    return {};
+    return child_frame.document_url();
 }
 
 URL::URL SiteIsolationManager::document_url_for_page(WebContentClient& client, u64 page_id, URL::URL const& fallback_url)
@@ -426,9 +402,9 @@ URL::URL SiteIsolationManager::document_url_for_page(WebContentClient& client, u
     return fallback_url;
 }
 
-URL::URL SiteIsolationManager::embedding_page_url_for_child_frame_navigation(WebContentClient& parent_client, u64 page_id, ChildFrameHost const& child_frame, URL::URL const& fallback_url)
+URL::URL SiteIsolationManager::embedding_page_url_for_child_frame_navigation(WebContentClient& parent_client, u64 page_id, CanonicalNavigable const& child_frame, URL::URL const& fallback_url)
 {
-    if (auto parent_frame = this->child_frame(page_id, child_frame.parent_frame_id); parent_frame.has_value()) {
+    if (auto parent_frame = this->child_frame(page_id, child_frame.parent_id()); parent_frame.has_value()) {
         if (auto url = document_url_for_child_frame(*parent_frame); url.has_value())
             return *url;
     }

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
@@ -16,6 +17,7 @@
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWebView/CanonicalNavigable.h>
 #include <LibWebView/Forward.h>
 
 namespace WebView {
@@ -23,33 +25,6 @@ namespace WebView {
 class WEBVIEW_API SiteIsolationManager {
 public:
     static SiteIsolationManager& the();
-
-    enum class ChildFrameOwner : u8 {
-        Local,
-        Remote,
-    };
-
-    struct PendingChildFrameNavigation {
-        URL::URL target_url;
-        ChildFrameOwner target_owner { ChildFrameOwner::Local };
-        Optional<u64> remote_page_id;
-    };
-
-    struct ChildFrameHost {
-        String parent_frame_id;
-        Optional<URL::URL> last_committed_url;
-        Optional<PendingChildFrameNavigation> pending_navigation;
-        Optional<Web::DevicePixelRect> viewport_rect;
-        double device_pixel_ratio { 1 };
-        ChildFrameOwner owner { ChildFrameOwner::Local };
-        RefPtr<WebContentClient> remote_client;
-        u64 remote_page_id { 0 };
-
-        bool is_remote() const
-        {
-            return owner == ChildFrameOwner::Remote && remote_client && remote_page_id != 0;
-        }
-    };
 
     struct RemoteChildFrameInputTarget {
         RefPtr<WebContentClient> remote_client;
@@ -72,17 +47,17 @@ public:
     String dump_process_tree(WebContentClient&, u64 page_id) const;
     HashMap<pid_t, pid_t> remote_frame_process_embedders() const;
 
-    bool has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, ChildFrameOwner) const;
-    void record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, ChildFrameOwner, Optional<u64> remote_page_id = {});
+    bool has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, CanonicalNavigable::HostLocality) const;
+    void record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, CanonicalNavigable::HostLocality, Optional<u64> remote_page_id = {});
     void clear_pending_child_frame_navigation(u64 page_id, StringView frame_id);
-    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, RefPtr<WebContentClient>, u64 remote_page_id);
+    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
     void transition_child_frame_to_local(WebContentClient& parent_client, u64 page_id, StringView frame_id);
     void close_remote_child_frames_for_page(WebContentClient&, u64 page_id);
 
-    Optional<ChildFrameHost&> child_frame(u64 page_id, StringView frame_id);
-    Optional<ChildFrameHost const&> child_frame(u64 page_id, StringView frame_id) const;
+    Optional<CanonicalNavigable&> child_frame(u64 page_id, StringView frame_id);
+    Optional<CanonicalNavigable const&> child_frame(u64 page_id, StringView frame_id) const;
 
-    template<CallableAs<IterationDecision, String const&, ChildFrameHost const&> Callback>
+    template<CallableAs<IterationDecision, String const&, CanonicalNavigable const&> Callback>
     void for_each_child_frame(u64 page_id, Callback callback) const;
 
 private:
@@ -92,19 +67,19 @@ private:
         WebContentClient* parent_client { nullptr };
         u64 page_id { 0 };
         String frame_id;
-        ChildFrameHost* child_frame { nullptr };
+        CanonicalNavigable* child_frame { nullptr };
     };
 
     static bool client_owns_page(WebContentClient const&, u64 page_id);
     Optional<ParentFrame> parent_frame_for_remote_page(WebContentClient&, u64 page_id);
     URL::URL document_url_for_page(WebContentClient&, u64 page_id, URL::URL const& fallback_url);
-    Optional<URL::URL> document_url_for_child_frame(ChildFrameHost const&);
-    URL::URL embedding_page_url_for_child_frame_navigation(WebContentClient&, u64 page_id, ChildFrameHost const&, URL::URL const&);
+    Optional<URL::URL> document_url_for_child_frame(CanonicalNavigable const&);
+    URL::URL embedding_page_url_for_child_frame_navigation(WebContentClient&, u64 page_id, CanonicalNavigable const&, URL::URL const&);
 
-    HashMap<u64, HashMap<String, ChildFrameHost>> m_child_frames;
+    HashMap<u64, HashMap<String, NonnullOwnPtr<CanonicalNavigable>>> m_child_frames;
 };
 
-template<CallableAs<IterationDecision, String const&, SiteIsolationManager::ChildFrameHost const&> Callback>
+template<CallableAs<IterationDecision, String const&, CanonicalNavigable const&> Callback>
 void SiteIsolationManager::for_each_child_frame(u64 page_id, Callback callback) const
 {
     auto child_frames = m_child_frames.get(page_id);
@@ -112,7 +87,7 @@ void SiteIsolationManager::for_each_child_frame(u64 page_id, Callback callback) 
         return;
 
     for (auto const& entry : *child_frames) {
-        if (callback(entry.key, entry.value) == IterationDecision::Break)
+        if (callback(entry.key, *entry.value) == IterationDecision::Break)
             return;
     }
 }

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -7,14 +7,11 @@
 #pragma once
 
 #include <AK/HashMap.h>
-#include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibURL/URL.h>
-#include <LibWeb/Page/EventResult.h>
-#include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/CanonicalNavigable.h>
@@ -34,62 +31,20 @@ public:
 
     Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
 
-    void did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id);
-    void did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio);
-    bool did_commit_child_frame_navigation(WebContentClient&, u64 page_id, StringView frame_id, URL::URL const& url);
-    void did_destroy_child_frame(WebContentClient&, u64 page_id, StringView frame_id);
-    Optional<RemoteChildFrameInputTarget> remote_child_frame_input_target_at(u64 page_id, Web::DevicePixelPoint) const;
-    bool remote_child_frame_did_commit_navigation(WebContentClient& remote_client, u64 remote_page_id, URL::URL const&);
-    bool remote_child_frame_did_finish_loading(WebContentClient& remote_client, u64 remote_page_id, URL::URL const&);
-    bool remote_child_frame_did_finish_handling_input_event(WebContentClient& remote_client, u64 remote_page_id, Web::EventResult);
-    void remove_page(u64 page_id);
+    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
+    void transition_child_frame_to_local(CanonicalNavigable&);
+
+    void remove_child_frame_subtree(CanonicalNavigable&);
+
+    void remove_page(WebContentClient&, u64 page_id);
     void remove_all_pages_for_client(WebContentClient&);
+
+    Optional<RemoteChildFrameInputTarget> remote_child_frame_input_target_at(WebContentClient&, u64 page_id, Web::DevicePixelPoint) const;
     String dump_process_tree(WebContentClient&, u64 page_id) const;
     HashMap<pid_t, pid_t> remote_frame_process_embedders() const;
 
-    bool has_matching_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, CanonicalNavigable::HostLocality) const;
-    void record_pending_child_frame_navigation(u64 page_id, StringView frame_id, URL::URL const&, CanonicalNavigable::HostLocality, Optional<u64> remote_page_id = {});
-    void clear_pending_child_frame_navigation(u64 page_id, StringView frame_id);
-    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
-    void transition_child_frame_to_local(WebContentClient& parent_client, u64 page_id, StringView frame_id);
-    void close_remote_child_frames_for_page(WebContentClient&, u64 page_id);
-
-    Optional<CanonicalNavigable&> child_frame(u64 page_id, StringView frame_id);
-    Optional<CanonicalNavigable const&> child_frame(u64 page_id, StringView frame_id) const;
-
-    template<CallableAs<IterationDecision, String const&, CanonicalNavigable const&> Callback>
-    void for_each_child_frame(u64 page_id, Callback callback) const;
-
 private:
     SiteIsolationManager() = default;
-
-    struct ParentFrame {
-        WebContentClient* parent_client { nullptr };
-        u64 page_id { 0 };
-        String frame_id;
-        CanonicalNavigable* child_frame { nullptr };
-    };
-
-    static bool client_owns_page(WebContentClient const&, u64 page_id);
-    Optional<ParentFrame> parent_frame_for_remote_page(WebContentClient&, u64 page_id);
-    URL::URL document_url_for_page(WebContentClient&, u64 page_id, URL::URL const& fallback_url);
-    Optional<URL::URL> document_url_for_child_frame(CanonicalNavigable const&);
-    URL::URL embedding_page_url_for_child_frame_navigation(WebContentClient&, u64 page_id, CanonicalNavigable const&, URL::URL const&);
-
-    HashMap<u64, HashMap<String, NonnullOwnPtr<CanonicalNavigable>>> m_child_frames;
 };
-
-template<CallableAs<IterationDecision, String const&, CanonicalNavigable const&> Callback>
-void SiteIsolationManager::for_each_child_frame(u64 page_id, Callback callback) const
-{
-    auto child_frames = m_child_frames.get(page_id);
-    if (!child_frames.has_value())
-        return;
-
-    for (auto const& entry : *child_frames) {
-        if (callback(entry.key, *entry.value) == IterationDecision::Break)
-            return;
-    }
-}
 
 }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -118,6 +118,7 @@ void ViewImplementation::set_url(URL::URL url)
 
     auto previous_host = current_host();
     m_url = move(url);
+    m_top_level_traversable.did_commit_navigation(m_url);
     update_bookmark_action();
 
     if (current_host() != previous_host)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -71,6 +71,9 @@ public:
 
     u64 view_id() const { return m_view_id; }
 
+    CanonicalTraversable& traversable() { return m_top_level_traversable; }
+    CanonicalTraversable const& traversable() const { return m_top_level_traversable; }
+
     void set_url(Badge<WebContentClient>, URL::URL url) { set_url(move(url)); }
     URL::URL const& url() const { return m_url; }
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/WebDriver/Error.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/HSTSStore.h>
 #include <LibWebView/HelperProcess.h>
@@ -185,8 +186,7 @@ void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 void WebContentClient::unregister_view(u64 page_id)
 {
     forget_compositor_context(Web::Compositor::compositor_context_id_for_page(page_id));
-    SiteIsolationManager::the().close_remote_child_frames_for_page(*this, page_id);
-    SiteIsolationManager::the().remove_page(page_id);
+    SiteIsolationManager::the().remove_page(*this, page_id);
 
     // A page that still needs a beforeunload check is not a detached
     // background close. It is being closed without waiting for WebContent,
@@ -238,9 +238,9 @@ void WebContentClient::request_close(u64 page_id)
     async_request_close(page_id);
 }
 
-void WebContentClient::register_embedded_page(u64 page_id)
+void WebContentClient::register_embedded_page(u64 page_id, CanonicalNavigable& child_frame)
 {
-    m_embedded_pages.set(page_id);
+    m_embedded_pages.set(page_id, child_frame.make_weak_ptr());
     Application::process_manager().cancel_forced_exit(pid());
 }
 
@@ -248,6 +248,39 @@ void WebContentClient::unregister_embedded_page(u64 page_id)
 {
     m_embedded_pages.remove(page_id);
     close_server_if_unused();
+}
+
+CanonicalNavigable* WebContentClient::embedded_page_host(u64 page_id)
+{
+    auto host = m_embedded_pages.find(page_id);
+    if (host == m_embedded_pages.end())
+        return nullptr;
+
+    auto* child_frame = host->value.ptr();
+    if (!child_frame || !child_frame->has_remote_host() || &child_frame->remote_host_client() != this)
+        return nullptr;
+
+    return child_frame;
+}
+
+CanonicalNavigable* WebContentClient::navigable_for_page(u64 page_id)
+{
+    if (auto* child_frame = embedded_page_host(page_id))
+        return child_frame;
+
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        return &view->traversable();
+
+    return nullptr;
+}
+
+Optional<CanonicalNavigable&> WebContentClient::child_frame(u64 page_id, StringView frame_id)
+{
+    auto* host = navigable_for_page(page_id);
+    if (!host)
+        return {};
+
+    return host->top_level_traversable().find(page_id, frame_id);
 }
 
 void WebContentClient::close_server_if_unused()
@@ -370,7 +403,7 @@ bool WebContentClient::send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPo
 
 bool WebContentClient::handle_mouse_event_in_compositor(u64 page_id, Web::MouseEvent const& event)
 {
-    if (auto target = SiteIsolationManager::the().remote_child_frame_input_target_at(page_id, event.position); target.has_value()) {
+    if (auto target = SiteIsolationManager::the().remote_child_frame_input_target_at(*this, page_id, event.position); target.has_value()) {
         auto translated_event = event.clone_without_browser_data();
         translated_event.position.set_x(event.position.x() - target->viewport_rect.x());
         translated_event.position.set_y(event.position.y() - target->viewport_rect.y());
@@ -399,7 +432,7 @@ bool WebContentClient::handle_pinch_event_in_compositor(u64 page_id, Web::PinchE
 
 void WebContentClient::dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const& event)
 {
-    if (auto target = SiteIsolationManager::the().remote_child_frame_input_target_at(page_id, event.position); target.has_value()) {
+    if (auto target = SiteIsolationManager::the().remote_child_frame_input_target_at(*this, page_id, event.position); target.has_value()) {
         auto translated_event = event.clone_without_browser_data();
         translated_event.position.set_x(event.position.x() - target->viewport_rect.x());
         translated_event.position.set_y(event.position.y() - target->viewport_rect.y());
@@ -449,25 +482,24 @@ Messages::WebContentClient::DecideNavigationProcessResponse WebContentClient::de
 
 void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 page_id, String frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
-    auto& site_isolation_manager = SiteIsolationManager::the();
-    auto child_frame = site_isolation_manager.child_frame(page_id, frame_id);
+    auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
         return;
-    if (!site_isolation_manager.has_matching_pending_child_frame_navigation(page_id, frame_id, url, CanonicalNavigable::HostLocality::Remote))
+    if (!child_frame->has_matching_pending_navigation(url, CanonicalNavigable::HostLocality::Remote))
         return;
 
     auto remote_process_or_error = Application::the().launch_child_frame_web_content_process(m_is_private);
     if (remote_process_or_error.is_error()) {
         warnln("Unable to create WebContent process for child frame navigation: {}", remote_process_or_error.error());
-        site_isolation_manager.clear_pending_child_frame_navigation(page_id, frame_id);
+        child_frame->clear_pending_navigation();
         return;
     }
 
     auto remote_process = remote_process_or_error.release_value();
     auto remote_page_id = remote_process.page_id;
     auto remote_client = move(remote_process.client);
-    site_isolation_manager.record_pending_child_frame_navigation(page_id, frame_id, url, CanonicalNavigable::HostLocality::Remote, remote_page_id);
-    remote_client->register_embedded_page(remote_page_id);
+    child_frame->record_pending_navigation(url, CanonicalNavigable::HostLocality::Remote, remote_page_id);
+    remote_client->register_embedded_page(remote_page_id, *child_frame);
     remote_client->async_set_page_parent_context(remote_page_id, Web::Compositor::compositor_context_id_for_page(page_id));
     if (child_frame->viewport_rect().has_value()) {
         remote_client->async_set_viewport(
@@ -479,27 +511,40 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
     remote_client->async_set_system_visibility_state(remote_page_id, Web::HTML::VisibilityState::Visible);
     remote_client->async_load_url_with_document_resource(remote_page_id, url, move(document_resource), history_handling);
 
-    site_isolation_manager.transition_child_frame_to_remote(*this, page_id, frame_id, move(remote_client), remote_page_id);
+    SiteIsolationManager::the().transition_child_frame_to_remote(*this, page_id, frame_id, move(remote_client), remote_page_id);
 }
 
 void WebContentClient::did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id)
 {
-    SiteIsolationManager::the().did_create_child_frame(page_id, move(parent_frame_id), move(frame_id));
+    auto* host = navigable_for_page(page_id);
+    if (!host)
+        return;
+
+    host->top_level_traversable().insert(*this, page_id, move(parent_frame_id), move(frame_id), *host);
 }
 
 void WebContentClient::did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
 {
-    SiteIsolationManager::the().did_update_child_frame_viewport(page_id, move(frame_id), viewport_rect, device_pixel_ratio);
+    if (auto child_frame = this->child_frame(page_id, frame_id); child_frame.has_value())
+        child_frame->set_viewport(viewport_rect, device_pixel_ratio);
 }
 
 void WebContentClient::did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url)
 {
-    SiteIsolationManager::the().did_commit_child_frame_navigation(*this, page_id, frame_id, url);
+    auto child_frame = this->child_frame(page_id, frame_id);
+    if (!child_frame.has_value())
+        return;
+
+    if (child_frame->has_remote_host())
+        SiteIsolationManager::the().transition_child_frame_to_local(*child_frame);
+
+    child_frame->did_commit_navigation(move(url));
 }
 
 void WebContentClient::did_destroy_child_frame(u64 page_id, String frame_id)
 {
-    SiteIsolationManager::the().did_destroy_child_frame(*this, page_id, frame_id);
+    if (auto child_frame = this->child_frame(page_id, frame_id); child_frame.has_value())
+        SiteIsolationManager::the().remove_child_frame_subtree(*child_frame);
 }
 
 void WebContentClient::did_start_webdriver_navigation(u64 page_id, URL::URL url)
@@ -677,8 +722,8 @@ void WebContentClient::did_finish_loading(u64 page_id, URL::URL url)
             if (listener.on_load_finish)
                 listener.on_load_finish(client_url);
         }
-    } else {
-        SiteIsolationManager::the().remote_child_frame_did_commit_navigation(*this, page_id, url);
+    } else if (auto* child_frame = embedded_page_host(page_id)) {
+        child_frame->did_commit_navigation(url);
     }
 }
 
@@ -775,8 +820,9 @@ void WebContentClient::did_change_url(u64 page_id, URL::URL url)
 
         if (view->on_url_change)
             view->on_url_change(url);
-    } else {
-        SiteIsolationManager::the().remote_child_frame_did_finish_loading(*this, page_id, url);
+    } else if (auto* child_frame = embedded_page_host(page_id)) {
+        child_frame->did_commit_navigation(url);
+        child_frame->reporting_client().async_run_iframe_load_event_steps(child_frame->reporting_page_id(), child_frame->id());
     }
 }
 
@@ -1389,10 +1435,9 @@ void WebContentClient::did_request_activate_tab(u64 page_id)
 
 void WebContentClient::did_close_browsing_context(u64 page_id)
 {
+    SiteIsolationManager::the().remove_page(*this, page_id);
     unregister_embedded_page(page_id);
     m_detached_pages_pending_close.remove(page_id);
-    SiteIsolationManager::the().close_remote_child_frames_for_page(*this, page_id);
-    SiteIsolationManager::the().remove_page(page_id);
 
     if (auto view = m_views.get(page_id); view.has_value()) {
         if ((*view)->on_close)
@@ -1665,7 +1710,8 @@ void WebContentClient::did_finish_handling_input_event(u64 page_id, Web::EventRe
         return;
     }
 
-    SiteIsolationManager::the().remote_child_frame_did_finish_handling_input_event(*this, page_id, event_result);
+    if (auto* child_frame = embedded_page_host(page_id))
+        child_frame->reporting_client().did_finish_handling_input_event(child_frame->reporting_page_id(), event_result);
 }
 
 void WebContentClient::did_update_input_method_state(u64 page_id, Optional<Web::DevicePixelRect> caret_rect, bool is_enabled, i32 cursor_position, i32 anchor_position, Utf16String text_before_cursor, Utf16String text_after_cursor)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -453,7 +453,7 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
     auto child_frame = site_isolation_manager.child_frame(page_id, frame_id);
     if (!child_frame.has_value())
         return;
-    if (!site_isolation_manager.has_matching_pending_child_frame_navigation(page_id, frame_id, url, ChildFrameOwner::Remote))
+    if (!site_isolation_manager.has_matching_pending_child_frame_navigation(page_id, frame_id, url, CanonicalNavigable::HostLocality::Remote))
         return;
 
     auto remote_process_or_error = Application::the().launch_child_frame_web_content_process(m_is_private);
@@ -466,14 +466,14 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
     auto remote_process = remote_process_or_error.release_value();
     auto remote_page_id = remote_process.page_id;
     auto remote_client = move(remote_process.client);
-    site_isolation_manager.record_pending_child_frame_navigation(page_id, frame_id, url, ChildFrameOwner::Remote, remote_page_id);
+    site_isolation_manager.record_pending_child_frame_navigation(page_id, frame_id, url, CanonicalNavigable::HostLocality::Remote, remote_page_id);
     remote_client->register_embedded_page(remote_page_id);
     remote_client->async_set_page_parent_context(remote_page_id, Web::Compositor::compositor_context_id_for_page(page_id));
-    if (child_frame->viewport_rect.has_value()) {
+    if (child_frame->viewport_rect().has_value()) {
         remote_client->async_set_viewport(
             remote_page_id,
-            child_frame->viewport_rect->size(),
-            child_frame->device_pixel_ratio,
+            child_frame->viewport_rect()->size(),
+            child_frame->device_pixel_ratio(),
             Web::ViewportIsFullscreen::No);
     }
     remote_client->async_set_system_visibility_state(remote_page_id, Web::HTML::VisibilityState::Visible);
@@ -500,11 +500,6 @@ void WebContentClient::did_commit_child_frame_navigation(u64 page_id, String fra
 void WebContentClient::did_destroy_child_frame(u64 page_id, String frame_id)
 {
     SiteIsolationManager::the().did_destroy_child_frame(*this, page_id, frame_id);
-}
-
-Optional<WebContentClient::ChildFrameHost const&> WebContentClient::child_frame(u64 page_id, StringView frame_id) const
-{
-    return SiteIsolationManager::the().child_frame(page_id, frame_id);
 }
 
 void WebContentClient::did_start_webdriver_navigation(u64 page_id, URL::URL url)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -13,6 +13,7 @@
 #include <AK/SourceLocation.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/WeakPtr.h>
 #include <LibCore/Forward.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/SharedImage.h>
@@ -76,8 +77,13 @@ public:
     void request_close(u64 page_id);
 
     void web_ui_disconnected(Badge<WebUI>);
-    void register_embedded_page(u64 page_id);
+    void register_embedded_page(u64 page_id, CanonicalNavigable&);
     void unregister_embedded_page(u64 page_id);
+
+    CanonicalNavigable* embedded_page_host(u64 page_id);
+    CanonicalNavigable* navigable_for_page(u64 page_id);
+
+    Optional<CanonicalNavigable&> child_frame(u64 page_id, StringView frame_id);
 
     bool has_views() const { return !m_views.is_empty(); }
 
@@ -257,7 +263,7 @@ private:
     IsPrivate m_is_private { IsPrivate::No };
 
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
-    HashTable<u64> m_embedded_pages;
+    HashMap<u64, WeakPtr<CanonicalNavigable>> m_embedded_pages;
     HashTable<u64> m_detached_pages_pending_close;
     HashMap<Web::Compositor::CompositorContextId, Optional<u64>> m_compositor_contexts;
     HashMap<u64, u64> m_renderer_owned_downloads;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -39,7 +39,6 @@
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/PrivateBrowsing.h>
-#include <LibWebView/SiteIsolationManager.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentServerEndpoint.h>
 
@@ -54,8 +53,6 @@ class WEBVIEW_API WebContentClient final
 
 public:
     using InitTransport = Messages::WebContentServer::InitTransport;
-    using ChildFrameOwner = SiteIsolationManager::ChildFrameOwner;
-    using ChildFrameHost = SiteIsolationManager::ChildFrameHost;
 
     template<CallableAs<IterationDecision, WebContentClient&> Callback>
     static void for_each_client(Callback callback);
@@ -98,10 +95,6 @@ public:
     void notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
     void did_present_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store);
     void did_present_bitmap(u64 page_id, Gfx::IntRect, i32 bitmap_id);
-    Optional<ChildFrameHost const&> child_frame(u64 page_id, StringView frame_id) const;
-
-    template<CallableAs<IterationDecision, String const&, ChildFrameHost const&> Callback>
-    void for_each_child_frame(u64 page_id, Callback callback) const;
 
     pid_t pid() const { return m_process_handle.pid; }
     void set_pid(pid_t pid) { m_process_handle.pid = pid; }
@@ -287,12 +280,6 @@ void WebContentClient::for_each_client(Callback callback)
         if (callback(*it) == IterationDecision::Break)
             return;
     }
-}
-
-template<CallableAs<IterationDecision, String const&, WebContentClient::ChildFrameHost const&> Callback>
-void WebContentClient::for_each_child_frame(u64 page_id, Callback callback) const
-{
-    SiteIsolationManager::the().for_each_child_frame(page_id, move(callback));
 }
 
 }


### PR DESCRIPTION
And use it to start building a UI process side navigation tree. This is a step for site isolation as this UI process navigation tree needs to be replicated into each WebContent process so the WebContent process can represent "remote" navigation objects.