### PR TITLE
LibWeb: Run microtask checkpoints while spinning the event loop

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/ScopeGuard.h>
 #include <AK/TemporaryChange.h>
 #include <LibCore/EventLoop.h>
 #include <LibJS/Runtime/VM.h>
@@ -90,6 +91,16 @@ void EventLoop::spin_until(GC::Ref<GC::Function<bool()>> goal_condition)
     auto& vm = this->vm();
     vm.save_execution_context_stack();
     vm.clear_execution_context_stack();
+
+    // AD-HOC: spin_until may be invoked synchronously in a microtask checkpoint (e.g., sync XHR from an async function
+    //         resumed after 'await'; its continuation runs as a microtask). Because performing a microtask checkpoint
+    //         is non-reentrant, the microtasks the spun operation depends on (e.g., reading to completion the fetch
+    //         response body's stream) would never run, deadlocking the spin. spin_until establishes a nested event-loop
+    //         context (it saves and clears the JavaScript execution context stack above, and pumps tasks and microtask
+    //         checkpoints below). So, let microtask checkpoints run during the spin, restoring the flag on the way out.
+    auto was_performing_a_microtask_checkpoint = m_performing_a_microtask_checkpoint;
+    m_performing_a_microtask_checkpoint = false;
+    ScopeGuard restore_microtask_checkpoint_state = [&] { m_performing_a_microtask_checkpoint = was_performing_a_microtask_checkpoint; };
 
     // 5. Perform a microtask checkpoint.
     perform_a_microtask_checkpoint();

--- a/Tests/LibWeb/Text/expected/XHR/XMLHttpRequest-synchronous-send-from-microtask.txt
+++ b/Tests/LibWeb/Text/expected/XHR/XMLHttpRequest-synchronous-send-from-microtask.txt
@@ -1,0 +1,1 @@
+status=200 response=hello

--- a/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-synchronous-send-from-microtask.html
+++ b/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-synchronous-send-from-microtask.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // A sync XHR performed from within a microtask (here, an async function resumed after await) must not deadlock.
+    // Reading the response body to completion needs microtasks to run — and performing a microtask checkpoint is
+    // non-reentrant. So, spinning the event loop for the synchronous send must still let microtask checkpoints run.
+    asyncTest(async (done) => {
+        await Promise.resolve();
+
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", "data:text/plain,hello", false);
+        xhr.send();
+
+        println("status=" + xhr.status + " response=" + xhr.responseText);
+        done();
+    });
+</script>


### PR DESCRIPTION
**Problem:** Deadlock/hang from sync XHR performed from within a microtask.

**Cause:** A synchronous send spins the event loop until the response body’s been fully read. Reading the body to completion resolves via microtasks, but performing a microtask checkpoint is non-reentrant. When `spin_until` is entered from within a checkpoint — the async function’s continuation runs as a microtask — every nested checkpoint is a no-op. So, the body-read promises never settle — and the spin never returns.

**Fix:** `spin_until` already establishes a nested event-loop context: It saves and clears the JavaScript execution context stack, and pumps tasks and microtask checkpoints. Let those microtask checkpoints run during the spin by clearing the performing-a-microtask-checkpoint flag for its duration, restoring it on the way out.

Discovered this while working on https://github.com/LadybirdBrowser/ladybird/issues/10442.
