### PR TITLE
LibWeb: Clip and wrap broken img alt text

### DIFF
--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Utf16StringBuilder.h>
+#include <LibGfx/TextLayout.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
@@ -15,6 +17,48 @@
 #include <LibWeb/Platform/FontPlugin.h>
 
 namespace Web::Painting {
+
+static void paint_alt_text(DisplayListRecordingContext& context, Layout::Node const& layout_node, Gfx::IntRect const& content_rect, String const& alt_text, Color color)
+{
+    auto const& font = layout_node.font(context);
+    auto const metrics = font.pixel_metrics();
+    auto line_height = metrics.ascent + metrics.descent;
+    if (line_height <= 0)
+        return;
+
+    float baseline_y = content_rect.y() + metrics.ascent;
+    Utf16String line;
+    auto draw_line = [&] {
+        if (line.is_empty())
+            return;
+        auto glyph_run = Gfx::shape_text({}, 0, line.utf16_view(), font, Gfx::GlyphRun::TextType::Ltr);
+        context.display_list_recorder().draw_glyph_run({ static_cast<float>(content_rect.x()), baseline_y }, *glyph_run, color, content_rect, 1.0, Gfx::Orientation::Horizontal);
+        baseline_y += line_height;
+        line = {};
+    };
+
+    Utf16String::from_utf8(alt_text).for_each_split_view(' ', SplitBehavior::Nothing, [&](Utf16View const& word) {
+        Utf16StringBuilder builder;
+        builder.append(line);
+        if (!line.is_empty())
+            builder.append_ascii(' ');
+        builder.append(word);
+
+        auto candidate_line = builder.to_string();
+        if (line.is_empty() || font.width(candidate_line) <= content_rect.width()) {
+            line = move(candidate_line);
+            return IterationDecision::Continue;
+        }
+
+        draw_line();
+        builder.clear();
+        builder.append(word);
+        line = builder.to_string();
+        return IterationDecision::Continue;
+    });
+
+    draw_line();
+}
 
 NonnullRefPtr<ImagePaintable> ImagePaintable::create(Layout::SVGImageBox const& layout_box)
 {
@@ -65,7 +109,10 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
         if (renders_as_alt_text) {
             if (!m_alt_text.is_empty()) {
                 auto enclosing_rect = context.enclosing_device_rect(image_rect).to_type<int>();
-                context.display_list_recorder().draw_text(enclosing_rect, Utf16String::from_utf8(m_alt_text), layout_node().font(context), Gfx::TextAlignment::Center, computed_values().color());
+                context.display_list_recorder().save();
+                context.display_list_recorder().add_clip_rect(enclosing_rect);
+                paint_alt_text(context, layout_node(), enclosing_rect, m_alt_text, computed_values().color());
+                context.display_list_recorder().restore();
             }
         } else if (auto decoded_image_data = m_image_provider.decoded_image_data()) {
             ScopedCornerRadiusClip corner_clip { context, image_rect_device_pixels, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };

--- a/Tests/LibWeb/Text/expected/display_list/img-alt-text-clipped-to-content-rect.txt
+++ b/Tests/LibWeb/Text/expected/display_list/img-alt-text-clipped-to-content-rect.txt
@@ -1,0 +1,13 @@
+AccumulatedVisualContext Tree:
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (ImagePaintable(ImageBox<IMG>))
+
+DisplayList:
+SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x70]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,10 800x60]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,10 60x60]
+  FillPath@1 path_bounding_rect=[0,10 60x60]
+  DrawGlyphRun@1 rect=[5,15 50x50] translation=[-25,43] color=rgb(0, 0, 0)
+Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/img-alt-text-clipped-to-content-rect.txt
+++ b/Tests/LibWeb/Text/expected/display_list/img-alt-text-clipped-to-content-rect.txt
@@ -9,5 +9,10 @@ SaveLayer@0
   CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,10 800x60]
   CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,10 60x60]
   FillPath@1 path_bounding_rect=[0,10 60x60]
-  DrawGlyphRun@1 rect=[5,15 50x50] translation=[-25,43] color=rgb(0, 0, 0)
+  Save@1
+    AddClipRect@1 rect=[5,15 50x50]
+    DrawGlyphRun@1 rect=[5,15 50x50] translation=[5,23] color=rgb(0, 0, 0)
+    DrawGlyphRun@1 rect=[5,15 50x50] translation=[5,33] color=rgb(0, 0, 0)
+    DrawGlyphRun@1 rect=[5,15 50x50] translation=[5,43] color=rgb(0, 0, 0)
+  Restore@1
 Restore@0

--- a/Tests/LibWeb/Text/input/display_list/img-alt-text-clipped-to-content-rect.html
+++ b/Tests/LibWeb/Text/input/display_list/img-alt-text-clipped-to-content-rect.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../../../Ref/data/fonts/Ahem.ttf");
+    }
+
+    body {
+        margin: 0;
+        font: 10px Ahem;
+    }
+
+    img {
+        display: block;
+        width: 50px;
+        height: 50px;
+        border: 5px solid orange;
+    }
+</style>
+<script>
+    asyncTest(async (done) => {
+        await document.fonts.load("10px Ahem");
+
+        const image = document.createElement("img");
+        image.alt = "foo bar baz";
+        document.body.appendChild(image);
+
+        println(internals.dumpDisplayList());
+        done();
+    });
+</script>


### PR DESCRIPTION
This clips fallback alt text for broken img elements to the image content rect, so long alt text no longer bleeds through the border or outside the element.

It also paints the fallback text from the start edge and wraps it at word boundaries, matching other browsers more closely than the previous centered single-line rendering.

Added display-list coverage for a fixed-size broken image with a border and long alt text. Full test-web passes.

Before:

<img width="601" height="356" alt="Screenshot 2026-07-06 at 00 13 26" src="https://github.com/user-attachments/assets/e823f768-9456-434d-9e3f-e462961c1d08" />

After:

<img width="601" height="356" alt="Screenshot 2026-07-06 at 00 13 08" src="https://github.com/user-attachments/assets/cfbe4909-4d64-4d1a-9134-bc7119d22364" />
