### PR TITLE
LibWeb: Fix input button wrapping and anchor activation

### DIFF
--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -658,6 +658,13 @@ input:is([type=reset i], [type=button i], [type=submit i]), button {
     text-align: center;
 }
 
+/* https://www.w3.org/TR/css-ui-3/#default-style-sheet
+ * CSS UI 3's informative default style sheet gives input buttons no wrapping.
+ */
+input:is([type=reset i], [type=button i], [type=submit i]) {
+    white-space: pre;
+}
+
 input, button {
     display: inline-block;
 }

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -3219,6 +3219,21 @@ bool HTMLInputElement::is_single_line() const
 
 bool HTMLInputElement::has_activation_behavior() const
 {
+    // https://html.spec.whatwg.org/multipage/input.html#the-input-element:activation-behaviour
+    // Input activation runs this element's input activation behavior, if any,
+    // and then popover target activation.
+    // https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
+    // Button-state inputs have no input activation behavior.
+    //
+    // NB: Per spec, input elements have activation behavior even when those
+    //     steps are a no-op. However, making a no-op input button the
+    //     activation target prevents activation behavior on ancestor anchors.
+    //     For compatibility with other browsers, let plain input buttons yield
+    //     to ancestors.
+    if (type_state() == TypeAttributeState::Button
+        && !PopoverTargetAttributes::get_the_popover_target_element(const_cast<HTMLInputElement&>(*this)))
+        return false;
+
     return true;
 }
 

--- a/Tests/LibWeb/Layout/expected/inline-button-line-height.txt
+++ b/Tests/LibWeb/Layout/expected/inline-button-line-height.txt
@@ -1,0 +1,181 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 359 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 343 0+0+8] children: not-inline
+      BlockContainer <form> at [8,8] [0+0+0 300 0+0+484] [0+0+0 343 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,8] [0+0+0 300 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        Box <div.radios--container> at [8,8] flex-container(row) [0+0+0 300 0+0+0] [0+0+0 189 0+0+0] [FFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          Box <div.radios--main> at [8,8] flex-container(row) flex-item [0+0+0 170 6+0+0] [0+0+0 47 16+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            RadioButton <input.radios--input> at [15,10] flex-item [0+2+5 0 5+2+0] [0+2+0 0 0+2+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            BlockContainer <label.radios--value-button> at [40,10] flex-item [0+2+16 120 16+2+0] [0+2+0 43 0+2+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 6, rect: [40,10 120x43] baseline: 27.5
+                  "100 ML"
+              TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          Box <div.radios--main> at [8,71] flex-container(row) flex-item [0+0+0 150 6+0+0] [0+0+0 47 16+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            RadioButton <input.radios--input> at [15,73] flex-item [0+2+5 0 5+2+0] [0+2+0 0 0+2+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            BlockContainer <label.radios--value-button> at [40,73] flex-item [0+2+16 100 16+2+0] [0+2+0 43 0+2+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 5, rect: [40,73 100x43] baseline: 27.5
+                  "50 ML"
+              TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          Box <div.radios--main> at [8,134] flex-container(row) flex-item [0+0+0 150 6+0+0] [0+0+0 47 16+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            RadioButton <input.radios--input> at [15,136] flex-item [0+2+5 0 5+2+0] [0+2+0 0 0+2+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            BlockContainer <label.radios--value-button> at [40,136] flex-item [0+2+16 100 16+2+0] [0+2+0 43 0+2+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 5, rect: [40,136 100x43] baseline: 27.5
+                  "30 ML"
+              TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          Box <div.radios--main> at [164,134] flex-container(row) flex-item [0+0+0 130 0+0+0] [0+0+0 47 16+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            RadioButton <input.radios--input> at [171,136] flex-item [0+2+5 0 5+2+0] [0+2+0 0 0+2+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            BlockContainer <label.radios--value-button> at [196,136] flex-item [0+2+16 80 16+2+0] [0+2+0 43 0+2+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 4, rect: [196,136 80x43] baseline: 27.5
+                  "15ML"
+              TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,197] [0+0+0 300 0+0+0] [0+0+0 154 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [119,257 20x23] baseline: 17.5
+              " "
+          frag 1 from TextNode start: 0, length: 1, rect: [128,315 20x23] baseline: 17.5
+              " "
+          TextNode <#text> (not painted)
+          InlineNode <a> at [15,199] [0+0+0 157 0+0+0] [0+0+0 44 0+0+0]
+            frag 0 from BlockContainer start: 0, length: 0, rect: [15,199 157x44] baseline: 30
+            BlockContainer <input.radios--input> at [15,199] inline-block [0+2+5 157 5+2+0] [0+2+0 44 0+2+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [15,199] flex-container(column) [0+0+0 157 0+0+0] [0+0+0 44 0+0+0] [FFC] children: not-inline
+                BlockContainer <(anonymous)> at [15,209.5] flex-item [0+0+0 157 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                  frag 0 from BlockContainer start: 0, length: 0, rect: [15,209.5 420x23] baseline: 17.5
+                  BlockContainer <span> at [15,209.5] inline-block [0+0+0 420 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 21, rect: [15,209.5 420x23] baseline: 17.5
+                        "100ml Limited Edition"
+                    TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          InlineNode <a> at [15,247] [0+0+0 97 0+0+0] [0+0+0 44 0+0+0]
+            frag 0 from BlockContainer start: 0, length: 0, rect: [15,247 97x44] baseline: 30
+            BlockContainer <input.radios--input> at [15,247] inline-block [0+2+5 97 5+2+0] [0+2+0 44 0+2+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [15,247] flex-container(column) [0+0+0 97 0+0+0] [0+0+0 44 0+0+0] [FFC] children: not-inline
+                BlockContainer <(anonymous)> at [15,257.5] flex-item [0+0+0 97 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                  frag 0 from BlockContainer start: 0, length: 0, rect: [15,257.5 240x23] baseline: 17.5
+                  BlockContainer <span> at [15,257.5] inline-block [0+0+0 240 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 12, rect: [15,257.5 240x23] baseline: 17.5
+                        "Coffret 30ml"
+                    TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          InlineNode <a> at [146,247] [0+0+0 97 0+0+0] [0+0+0 44 0+0+0]
+            frag 0 from BlockContainer start: 0, length: 0, rect: [146,247 97x44] baseline: 30
+            BlockContainer <input.radios--input> at [146,247] inline-block [0+2+5 97 5+2+0] [0+2+0 44 0+2+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [146,247] flex-container(column) [0+0+0 97 0+0+0] [0+0+0 44 0+0+0] [FFC] children: not-inline
+                BlockContainer <(anonymous)> at [146,257.5] flex-item [0+0+0 97 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                  frag 0 from BlockContainer start: 0, length: 0, rect: [146,257.5 240x23] baseline: 17.5
+                  BlockContainer <span> at [146,257.5] inline-block [0+0+0 240 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 12, rect: [146,257.5 240x23] baseline: 17.5
+                        "Coffret 50ml"
+                    TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          InlineNode <a> at [15,305] [0+0+0 106 0+0+0] [0+0+0 44 0+0+0]
+            frag 0 from BlockContainer start: 0, length: 0, rect: [15,305 106x44] baseline: 40
+            BlockContainer <input.radios--input> at [15,305] inline-block [0+2+5 106 5+2+0] [10+2+0 44 0+2+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [15,305] flex-container(column) [0+0+0 106 0+0+0] [0+0+0 44 0+0+0] [FFC] children: not-inline
+                BlockContainer <(anonymous)> at [15,315.5] flex-item [0+0+0 106 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                  frag 0 from BlockContainer start: 0, length: 0, rect: [15,315.5 260x23] baseline: 17.5
+                  BlockContainer <span> at [15,315.5] inline-block [0+0+0 260 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 13, rect: [15,315.5 260x23] baseline: 17.5
+                        "Coffret 100ml"
+                    TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          InlineNode <a> at [155,305] [0+0+0 135 0+0+0] [0+0+0 44 0+0+0]
+            frag 0 from BlockContainer start: 0, length: 0, rect: [155,305 135x44] baseline: 40
+            BlockContainer <input.radios--input> at [155,305] inline-block [0+2+5 135 5+2+0] [10+2+0 44 0+2+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [155,305] flex-container(column) [0+0+0 135 0+0+0] [0+0+0 44 0+0+0] [FFC] children: not-inline
+                BlockContainer <(anonymous)> at [155,315.5] flex-item [0+0+0 135 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                  frag 0 from BlockContainer start: 0, length: 0, rect: [155,315.5 320x23] baseline: 17.5
+                  BlockContainer <span> at [155,315.5] inline-block [0+0+0 320 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 16, rect: [155,315.5 320x23] baseline: 17.5
+                        "Lait corps 200ml"
+                    TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,351] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x359]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x343]
+      PaintableWithLines (BlockContainer<FORM>) [8,8 300x343]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 300x0]
+        PaintableBox (Box<DIV>.radios--container) [8,8 300x189]
+          PaintableBox (Box<DIV>.radios--main) [8,8 176x63]
+            RadioButtonPaintable (RadioButton<INPUT>.radios--input) [8,8 14x4]
+            PaintableWithLines (BlockContainer<LABEL>.radios--value-button) [22,8 156x47]
+          PaintableBox (Box<DIV>.radios--main) [8,71 156x63]
+            RadioButtonPaintable (RadioButton<INPUT>.radios--input) [8,71 14x4]
+            PaintableWithLines (BlockContainer<LABEL>.radios--value-button) [22,71 136x47]
+          PaintableBox (Box<DIV>.radios--main) [8,134 156x63]
+            RadioButtonPaintable (RadioButton<INPUT>.radios--input) [8,134 14x4]
+            PaintableWithLines (BlockContainer<LABEL>.radios--value-button) [22,134 136x47]
+          PaintableBox (Box<DIV>.radios--main) [164,134 130x63]
+            RadioButtonPaintable (RadioButton<INPUT>.radios--input) [164,134 14x4]
+            PaintableWithLines (BlockContainer<LABEL>.radios--value-button) [178,134 116x47]
+        PaintableWithLines (BlockContainer(anonymous)) [8,197 300x154]
+          PaintableWithLines (InlineNode<A>) [15,199 157x44]
+            PaintableWithLines (BlockContainer<INPUT>.radios--input) [8,197 171x48]
+              PaintableWithLines (BlockContainer(anonymous)) [15,199 157x44]
+                PaintableWithLines (BlockContainer(anonymous)) [15,209.5 157x23]
+                  PaintableWithLines (BlockContainer<SPAN>) [15,209.5 420x23]
+          PaintableWithLines (InlineNode<A>) [15,247 97x44]
+            PaintableWithLines (BlockContainer<INPUT>.radios--input) [8,245 111x48]
+              PaintableWithLines (BlockContainer(anonymous)) [15,247 97x44]
+                PaintableWithLines (BlockContainer(anonymous)) [15,257.5 97x23]
+                  PaintableWithLines (BlockContainer<SPAN>) [15,257.5 240x23]
+          PaintableWithLines (InlineNode<A>) [146,247 97x44]
+            PaintableWithLines (BlockContainer<INPUT>.radios--input) [139,245 111x48]
+              PaintableWithLines (BlockContainer(anonymous)) [146,247 97x44]
+                PaintableWithLines (BlockContainer(anonymous)) [146,257.5 97x23]
+                  PaintableWithLines (BlockContainer<SPAN>) [146,257.5 240x23]
+          PaintableWithLines (InlineNode<A>) [15,305 106x44]
+            PaintableWithLines (BlockContainer<INPUT>.radios--input) [8,303 120x48]
+              PaintableWithLines (BlockContainer(anonymous)) [15,305 106x44]
+                PaintableWithLines (BlockContainer(anonymous)) [15,315.5 106x23]
+                  PaintableWithLines (BlockContainer<SPAN>) [15,315.5 260x23]
+          PaintableWithLines (InlineNode<A>) [155,305 135x44]
+            PaintableWithLines (BlockContainer<INPUT>.radios--input) [148,303 149x48]
+              PaintableWithLines (BlockContainer(anonymous)) [155,305 135x44]
+                PaintableWithLines (BlockContainer(anonymous)) [155,315.5 135x23]
+                  PaintableWithLines (BlockContainer<SPAN>) [155,315.5 320x23]
+      PaintableWithLines (BlockContainer(anonymous)) [8,351 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x359] (z-index: auto)
+  SC for RadioButton<INPUT>.radios--input [15,10 0x0] (z-index: auto)
+  SC for RadioButton<INPUT>.radios--input [15,73 0x0] (z-index: auto)
+  SC for RadioButton<INPUT>.radios--input [15,136 0x0] (z-index: auto)
+  SC for RadioButton<INPUT>.radios--input [171,136 0x0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/inline-button-line-height.html
+++ b/Tests/LibWeb/Layout/input/inline-button-line-height.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../../Ref/data/fonts/Ahem.ttf");
+    }
+
+    body {
+        font: 20px Ahem;
+    }
+
+    form {
+        width: 300px;
+    }
+
+    .radios--container {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    .radios--container > *:not(:last-child) {
+        padding-right: 6px;
+    }
+
+    .radios--main {
+        display: flex;
+        padding-bottom: 16px;
+    }
+
+    .radios--value-button {
+        border: 2px solid gray;
+        line-height: 43px;
+        padding: 0 16px;
+    }
+
+    .radios--input[type="radio"] {
+        height: 1px;
+        margin: 0;
+        opacity: 0;
+        width: 1px;
+    }
+
+    input {
+        border: 2px solid black;
+        height: 48px;
+        padding: 0 5px;
+    }
+</style>
+<form>
+    <div class="radios--container">
+        <div class="radios--main">
+            <input class="radios--input" type="radio" checked>
+            <label class="radios--value-button">100 ML</label>
+        </div>
+        <div class="radios--main">
+            <input class="radios--input" type="radio">
+            <label class="radios--value-button">50 ML</label>
+        </div>
+        <div class="radios--main">
+            <input class="radios--input" type="radio">
+            <label class="radios--value-button">30 ML</label>
+        </div>
+        <div class="radios--main">
+            <input class="radios--input" type="radio">
+            <label class="radios--value-button">15ML</label>
+        </div>
+    </div>
+    <a><input class="radios--input" style="width: 171px" type="button" value="100ml Limited Edition"></a>
+    <a><input class="radios--input" style="width: 111px" type="button" value="Coffret 30ml"></a>
+    <a><input class="radios--input" style="width: 111px" type="button" value="Coffret 50ml"></a>
+    <a><input class="radios--input" style="margin-top: 10px; width: 120px" type="button" value="Coffret 100ml"></a>
+    <a><input class="radios--input" style="margin-top: 10px; width: 149px" type="button" value="Lait corps 200ml"></a>
+</form>

--- a/Tests/LibWeb/Text/expected/input-button-inside-anchor.txt
+++ b/Tests/LibWeb/Text/expected/input-button-inside-anchor.txt
@@ -1,0 +1,1 @@
+link activated

--- a/Tests/LibWeb/Text/expected/input-button-popover-target.txt
+++ b/Tests/LibWeb/Text/expected/input-button-popover-target.txt
@@ -1,0 +1,1 @@
+popover open: true

--- a/Tests/LibWeb/Text/input/input-button-inside-anchor.html
+++ b/Tests/LibWeb/Text/input/input-button-inside-anchor.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    function linkActivated() {
+        println("link activated");
+        window.done();
+    }
+</script>
+<a href="javascript:linkActivated()"><input id="button" type="button" value="Click me"></a>
+<script>
+    asyncTest((done) => {
+        window.done = done;
+        document.getElementById("button").dispatchEvent(new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+        }));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/input-button-popover-target.html
+++ b/Tests/LibWeb/Text/input/input-button-popover-target.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div id="popover" popover>Popover</div>
+<input id="button" type="button" popovertarget="popover" value="Open popover">
+<script>
+    test(() => {
+        document.getElementById("button").dispatchEvent(new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+        }));
+        println(`popover open: ${document.getElementById("popover").matches(":popover-open")}`);
+    });
+</script>


### PR DESCRIPTION
This fixes two issues found on a [Lolita Lempicka product page](https://www.lolitalempicka.com/en/products/mon-premier-parfum):

- Keep submit, reset, and button-state input labels on one line in the user-agent stylesheet, matching browser behavior while preserving normal `<button>` wrapping.

- Let plain `<input type=button>` elements inside anchors yield activation to the ancestor link, while preserving popover activation for input buttons with `popovertarget`.

The branch adds layout coverage for the input button wrapping case and text tests for both anchor navigation and popover activation.

Before (see bottom left corner):

<img width="1105" height="897" alt="Screenshot 2026-07-06 at 00 21 17" src="https://github.com/user-attachments/assets/05e6becf-043c-4851-af24-b1421ea1b7bf" />

After:

<img width="1105" height="897" alt="Screenshot 2026-07-06 at 01 13 37" src="https://github.com/user-attachments/assets/02e079be-63d7-43d2-af3a-b765bb89e921" />
