### PR TITLE
UI/Qt: Forward native window container focus events to the host

### DIFF
--- a/Tests/UI/Qt/TestNativeWindowContainerFocus.cpp
+++ b/Tests/UI/Qt/TestNativeWindowContainerFocus.cpp
@@ -46,6 +46,19 @@ struct TestWindow {
     QWidget& sibling;
 };
 
+class FocusEventRecorder final : public QObject {
+public:
+    QEvent::Type last_focus_event { QEvent::None };
+
+private:
+    virtual bool eventFilter(QObject*, QEvent* event) override
+    {
+        if (event->type() == QEvent::FocusIn || event->type() == QEvent::FocusOut)
+            last_focus_event = event->type();
+        return false;
+    }
+};
+
 }
 
 TEST_CASE(focus_proxy_follows_container_visibility)
@@ -96,6 +109,33 @@ TEST_CASE(focus_is_not_stolen_from_other_widgets)
 
     Ladybird::set_native_window_container_visible(widgets.host, widgets.container, false);
     EXPECT_EQ(QApplication::focusWidget(), &widgets.sibling);
+}
+
+TEST_CASE(container_focus_events_are_forwarded_to_the_host)
+{
+    application();
+    TestWindow widgets;
+    Ladybird::install_native_window_container_focus_forwarding(widgets.host, widgets.container);
+
+    FocusEventRecorder recorder;
+    widgets.host.installEventFilter(&recorder);
+
+    widgets.host.setFocus();
+    QApplication::processEvents();
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, true);
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.container);
+    EXPECT_EQ(recorder.last_focus_event, QEvent::FocusIn);
+
+    widgets.sibling.setFocus();
+    EXPECT_EQ(recorder.last_focus_event, QEvent::FocusOut);
+
+    widgets.container.setFocus();
+    EXPECT_EQ(recorder.last_focus_event, QEvent::FocusIn);
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, false);
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.host);
+    EXPECT_EQ(recorder.last_focus_event, QEvent::FocusIn);
 }
 
 TEST_CASE(visibility_changes_are_idempotent)

--- a/UI/Qt/NativeWindowContainer.cpp
+++ b/UI/Qt/NativeWindowContainer.cpp
@@ -6,9 +6,36 @@
 
 #include <UI/Qt/NativeWindowContainer.h>
 
+#include <QCoreApplication>
+#include <QFocusEvent>
 #include <QWidget>
 
 namespace Ladybird {
+
+namespace {
+
+class FocusEventForwarder final : public QObject {
+public:
+    FocusEventForwarder(QWidget& host, QWidget& container)
+        : QObject(&container)
+        , m_host(host)
+    {
+    }
+
+private:
+    virtual bool eventFilter(QObject*, QEvent* event) override
+    {
+        if (event->type() == QEvent::FocusIn || event->type() == QEvent::FocusOut) {
+            QFocusEvent forwarded_event { event->type(), static_cast<QFocusEvent*>(event)->reason() };
+            QCoreApplication::sendEvent(&m_host, &forwarded_event);
+        }
+        return false;
+    }
+
+    QWidget& m_host;
+};
+
+}
 
 void set_native_window_container_visible(QWidget& host, QWidget& container, bool visible)
 {
@@ -29,6 +56,11 @@ void set_native_window_container_visible(QWidget& host, QWidget& container, bool
         if (container_had_focus)
             host.setFocus();
     }
+}
+
+void install_native_window_container_focus_forwarding(QWidget& host, QWidget& container)
+{
+    container.installEventFilter(new FocusEventForwarder(host, container));
 }
 
 }

--- a/UI/Qt/NativeWindowContainer.h
+++ b/UI/Qt/NativeWindowContainer.h
@@ -14,4 +14,6 @@ namespace Ladybird {
 // consistent: The container is the host's focus proxy only while it's visible.
 void set_native_window_container_visible(QWidget& host, QWidget& container, bool visible);
 
+void install_native_window_container_focus_forwarding(QWidget& host, QWidget& container);
+
 }

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -906,6 +906,7 @@ void WebContentView::create_vulkan_window()
     m_vulkan_window_container->setMouseTracking(true);
     m_vulkan_window_container->setGeometry(rect());
     m_vulkan_window_container->hide();
+    install_native_window_container_focus_forwarding(*this, *m_vulkan_window_container);
 }
 
 void WebContentView::set_vulkan_window_container_visible(bool visible)


### PR DESCRIPTION
The view's Vulkan window container becomes its focus proxy while visible. showing it moves keyboard focus onto the container and the view reports a focus loss to WebContent.

On Wayland, the embedded window never receives keyboard focus, meaning focus was never reported back, so the text caret stopped appearing in editable content.

Fixes a regression introduced in c242b066dbc.