### PR TITLE
LibWeb: Use targeted style invalidation for :active and :open state changes

### DIFF
--- a/Libraries/LibWeb/CSS/Invalidation/ElementStateInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/ElementStateInvalidator.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibWeb/CSS/Invalidation/ElementStateInvalidator.h>
-#include <LibWeb/CSS/Invalidation/HasMutationFeatureCollector.h>
 #include <LibWeb/CSS/InvalidationSet.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/StyleInvalidationReason.h>
@@ -15,16 +14,9 @@ namespace Web::CSS::Invalidation {
 static void invalidate_style_after_pseudo_class_state_change(DOM::Element& element, DOM::StyleInvalidationReason reason,
     PseudoClass pseudo_class)
 {
-    bool may_affect_has_selectors = false;
-    element.for_each_style_scope_which_may_observe_the_node([&](StyleScope& scope) {
-        if (element_has_feature_used_in_has_selector(element, pseudo_class, scope))
-            may_affect_has_selectors = true;
-    });
-    if (may_affect_has_selectors) {
-        element.invalidate_style(reason);
-        return;
-    }
-
+    // NB: Rules observing this pseudo-class through :has() are handled by the property-based invalidation path, which
+    //     consults the :has() metadata recorded for feature pseudo-classes. Both :active and :open are feature
+    //     pseudo-classes, so no coarse fallback is needed here.
     Vector<InvalidationSet::Property, 1> pseudo_class_properties {
         { .type = InvalidationSet::Property::Type::PseudoClass, .value = pseudo_class },
     };

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationFeatureCollector.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationFeatureCollector.cpp
@@ -87,25 +87,6 @@ bool HasMutationFeatureCollector::subtree_has_feature_used_in_has_selector(DOM::
     return found;
 }
 
-bool element_has_feature_used_in_has_selector(DOM::Element const& element, PseudoClass changed_pseudo_class,
-    StyleScope const& style_scope)
-{
-    if (!style_scope.may_have_has_selectors())
-        return false;
-
-    auto const& data = style_scope.style_invalidation_data();
-
-    HasMutationFeatureCollector collector { data };
-    if (!collector.has_any_metadata())
-        return true;
-    if (data.has_selectors_sensitive_to_featureless_subtree_changes)
-        return true;
-    if (data.pseudo_classes_used_in_has_selectors.contains(changed_pseudo_class))
-        return true;
-
-    return collector.element_has_feature_used_in_has_selector(element);
-}
-
 bool subtree_has_feature_used_in_has_selector(DOM::Node& node, StyleScope const& style_scope)
 {
     auto const& data = style_scope.style_invalidation_data();

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationFeatureCollector.h
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationFeatureCollector.h
@@ -15,7 +15,6 @@ class Node;
 
 namespace Web::CSS {
 
-enum class PseudoClass;
 struct StyleInvalidationData;
 class StyleScope;
 
@@ -33,7 +32,6 @@ private:
     StyleInvalidationData const& m_data;
 };
 
-[[nodiscard]] bool element_has_feature_used_in_has_selector(DOM::Element const&, PseudoClass, StyleScope const&);
 [[nodiscard]] bool subtree_has_feature_used_in_has_selector(DOM::Node&, StyleScope const&);
 
 }

--- a/Libraries/LibWeb/CSS/Invalidation/InvalidationSetMatcher.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/InvalidationSetMatcher.cpp
@@ -12,6 +12,8 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/HTML/HTMLDetailsElement.h>
+#include <LibWeb/HTML/HTMLDialogElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
@@ -186,6 +188,9 @@ bool element_matches_any_invalidation_set_property(DOM::Element const& element, 
                 return element.matches_focus_within_pseudo_class();
             case PseudoClass::Active:
                 return element.is_being_activated();
+            case PseudoClass::Open:
+                return is<HTML::HTMLDetailsElement>(element) || is<HTML::HTMLDialogElement>(element)
+                    || is<HTML::HTMLSelectElement>(element) || is<HTML::HTMLInputElement>(element);
             case PseudoClass::Target:
                 return element.document().target_element() == &element;
             case PseudoClass::FirstChild:

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
@@ -422,10 +422,12 @@ static bool pseudo_class_can_be_used_as_has_invalidation_feature(PseudoClass pse
         PseudoClass::AnyLink,
         PseudoClass::LocalLink,
         PseudoClass::Hover,
+        PseudoClass::Active,
         PseudoClass::Focus,
         PseudoClass::FocusVisible,
         PseudoClass::FocusWithin,
-        PseudoClass::Target);
+        PseudoClass::Target,
+        PseudoClass::Open);
 }
 
 static void collect_properties_used_in_has(Selector::SimpleSelector const& selector, StyleInvalidationData& style_invalidation_data, Optional<HasInvalidationMetadata> metadata)

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/active-state-featureless-has-targeted-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/active-state-featureless-has-targeted-invalidation.txt
@@ -1,0 +1,2 @@
+active color: rgb(1, 2, 3)
+FAIL: :active state change recomputed 509 elements

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/active-state-featureless-has-targeted-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/active-state-featureless-has-targeted-invalidation.txt
@@ -1,2 +1,2 @@
 active color: rgb(1, 2, 3)
-FAIL: :active state change recomputed 509 elements
+PASS: :active state change stayed targeted

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/has-active-and-open-pseudo-class-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/has-active-and-open-pseudo-class-invalidation.txt
@@ -1,0 +1,6 @@
+before mousedown: rgb(0, 0, 0)
+during mousedown: rgb(1, 2, 3)
+after mouseup: rgb(0, 0, 0)
+before open: rgb(0, 0, 0)
+open: rgb(4, 5, 6)
+closed: rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/input/css/style-invalidation/active-state-featureless-has-targeted-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/active-state-featureless-has-targeted-invalidation.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    /* A :has() selector with a featureless argument that cannot be affected by
+       pseudo-class state changes. It must not cause :active state changes to
+       fall back to whole-subtree style invalidation. */
+    .featureless-has-hook:has(:not(.missing)) {
+        color: rgb(9, 9, 9);
+    }
+
+    #active-target {
+        display: block;
+        width: 80px;
+        height: 40px;
+        color: black;
+    }
+
+    #active-target:active {
+        color: rgb(1, 2, 3);
+    }
+</style>
+<div class="featureless-has-hook">hook</div>
+<div id="big"></div>
+<button id="active-target">target</button>
+<script>
+    test(() => {
+        const big = document.getElementById("big");
+        for (let i = 0; i < 500; ++i) {
+            const leaf = document.createElement("span");
+            leaf.textContent = `leaf ${i}`;
+            big.appendChild(leaf);
+        }
+
+        const activeTarget = document.getElementById("active-target");
+        const rect = activeTarget.getBoundingClientRect();
+        const x = Math.floor(rect.left + rect.width / 2);
+        const y = Math.floor(rect.top + rect.height / 2);
+
+        internals.mouseMove(x, y);
+        internals.updateStyle();
+        internals.resetStyleInvalidationCounters();
+
+        internals.clickAndHold(x, y);
+        internals.updateStyle();
+
+        println(`active color: ${getComputedStyle(activeTarget).color}`);
+
+        const counters = internals.getStyleInvalidationCounters();
+        if (counters.elementStyleRecomputations < 50)
+            println("PASS: :active state change stayed targeted");
+        else
+            println(`FAIL: :active state change recomputed ${counters.elementStyleRecomputations} elements`);
+
+        internals.mouseUp(x, y);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/has-active-and-open-pseudo-class-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/has-active-and-open-pseudo-class-invalidation.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #active-container {
+        color: rgb(0, 0, 0);
+    }
+
+    #active-container:has(:active) {
+        color: rgb(1, 2, 3);
+    }
+
+    #active-target {
+        display: block;
+        width: 80px;
+        height: 40px;
+    }
+
+    #open-container {
+        color: rgb(0, 0, 0);
+    }
+
+    #open-container:has(:open) {
+        color: rgb(4, 5, 6);
+    }
+</style>
+<div id="active-container">
+    <button id="active-target">target</button>
+</div>
+<div id="open-container">
+    <details id="toggle"><summary>summary</summary>content</details>
+</div>
+<script>
+    test(() => {
+        const activeContainer = document.getElementById("active-container");
+        const activeTarget = document.getElementById("active-target");
+        const rect = activeTarget.getBoundingClientRect();
+        const x = Math.floor(rect.left + rect.width / 2);
+        const y = Math.floor(rect.top + rect.height / 2);
+
+        println(`before mousedown: ${getComputedStyle(activeContainer).color}`);
+
+        internals.clickAndHold(x, y);
+        internals.updateStyle();
+        println(`during mousedown: ${getComputedStyle(activeContainer).color}`);
+
+        internals.mouseUp(x, y);
+        internals.updateStyle();
+        println(`after mouseup: ${getComputedStyle(activeContainer).color}`);
+
+        const openContainer = document.getElementById("open-container");
+        const toggle = document.getElementById("toggle");
+
+        println(`before open: ${getComputedStyle(openContainer).color}`);
+
+        toggle.setAttribute("open", "");
+        internals.updateStyle();
+        println(`open: ${getComputedStyle(openContainer).color}`);
+
+        toggle.removeAttribute("open");
+        internals.updateStyle();
+        println(`closed: ${getComputedStyle(openContainer).color}`);
+    });
+</script>


### PR DESCRIPTION
`:active` and `:open` state changes fell back to whole-subtree style invalidation whenever the stylesheet had a `:has()` selector the element might affect. Since Active and Open were not usable as `:has()` invalidation features, selectors like `:has(:not(.foo))` tripped this fallback for every element on the page.

Mousedown flips `:active` on the whole ancestor chain including html, so each mousedown and mouseup restyled the entire document. On https://fragrantica.com this made double-clicking a word in a comment take several seconds.

Make Active and Open feature pseudo-classes for :has() metadata, teach the invalidation set matcher about `:open`, and drop the fallback, matching how `:hover` is handled. Includes tests for invalidation scope and for `:has(:active)` and `:has(:open)` correctness.