### PR TITLE
LibWeb: Fix atomic inline abspos containing blocks

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1649,8 +1649,69 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
         return {};
 
     Optional<CSSPixelRect> bounding_rect;
-    auto union_rect = [&](CSSPixelRect const& rect) {
-        bounding_rect = bounding_rect.has_value() ? bounding_rect->united(rect) : rect;
+    Optional<CSSPixelRect> empty_bounding_rect;
+    auto union_rect = [](Optional<CSSPixelRect>& destination, CSSPixelRect const& rect) {
+        if (!destination.has_value()) {
+            destination = rect;
+            return;
+        }
+        auto left = min(destination->left(), rect.left());
+        auto top = min(destination->top(), rect.top());
+        auto right = max(destination->right(), rect.right());
+        auto bottom = max(destination->bottom(), rect.bottom());
+        destination = CSSPixelRect { left, top, right - left, bottom - top };
+    };
+    auto add_fragment_rect = [&](CSSPixelRect const& rect) {
+        if (rect.is_empty()) {
+            union_rect(empty_bounding_rect, rect);
+            return;
+        }
+        union_rect(bounding_rect, rect);
+    };
+    auto make_physical_rect = [](CSS::WritingMode writing_mode, CSSPixels inline_start, CSSPixels block_start, CSSPixels inline_size, CSSPixels block_size) {
+        if (writing_mode == CSS::WritingMode::HorizontalTb)
+            return CSSPixelRect { { inline_start, block_start }, { inline_size, block_size } };
+        return CSSPixelRect { { block_start, inline_start }, { block_size, inline_size } };
+    };
+    auto add_atomic_inline_fragment_rect = [&](Box const& box_child, LayoutState::UsedValues const& child_used_values) {
+        if (!child_used_values.containing_line_box_fragment.has_value())
+            return;
+
+        auto const* containing_block = box_child.containing_block();
+        auto const* containing_block_used_values = containing_block ? state.try_get(*containing_block) : nullptr;
+        auto const* abspos_containing_block_used_values = state.try_get(abspos_containing_block);
+        if (!containing_block_used_values || !abspos_containing_block_used_values)
+            return;
+
+        auto const& containing_line_box_fragment = child_used_values.containing_line_box_fragment.value();
+        if (containing_line_box_fragment.line_box_index >= containing_block_used_values->line_boxes.size())
+            return;
+
+        auto const& line_box = containing_block_used_values->line_boxes[containing_line_box_fragment.line_box_index];
+        if (containing_line_box_fragment.fragment_index >= line_box.fragments().size())
+            return;
+
+        auto const& fragment = line_box.fragments()[containing_line_box_fragment.fragment_index];
+        auto const containing_block_offset = state.cumulative_offset(*containing_block_used_values)
+            - state.cumulative_offset(*abspos_containing_block_used_values);
+        auto const writing_mode = fragment.writing_mode();
+        auto const is_horizontal = writing_mode == CSS::WritingMode::HorizontalTb;
+        auto const inline_axis_border_box_start = fragment.inline_offset() - (is_horizontal ? child_used_values.border_box_left() : child_used_values.border_box_top());
+        auto const inline_axis_border_box_extent = is_horizontal
+            ? child_used_values.border_box_width()
+            : child_used_values.border_box_height();
+        auto const block_axis_line_height = inline_node.computed_values().line_height();
+        auto const block_axis_start = [&] {
+            if (box_child.computed_values().block_axis_is_reverse())
+                return fragment.block_offset() + child_used_values.border_box_right() - block_axis_line_height;
+            return fragment.block_offset() - (is_horizontal ? child_used_values.border_box_top() : child_used_values.border_box_left());
+        }();
+        add_fragment_rect(make_physical_rect(writing_mode,
+            inline_axis_border_box_start,
+            block_axis_start,
+            inline_axis_border_box_extent,
+            block_axis_line_height)
+                .translated(containing_block_offset));
     };
 
     // Walk outer_block's subtree in pre-order, threading the running offset from
@@ -1663,8 +1724,11 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
         if (used_values && !used_values->line_boxes.is_empty()) {
             for (auto const& line_box : used_values->line_boxes) {
                 for (auto const& fragment : line_box.fragments()) {
-                    if (auto const* dom = fragment.layout_node().dom_node(); dom && inline_dom_node->is_inclusive_ancestor_of(*dom))
-                        union_rect({ fragment.offset() + offset, fragment.size() });
+                    if (fragment.is_atomic_inline())
+                        continue;
+                    if (auto const* dom = fragment.layout_node().dom_node(); dom && inline_dom_node->is_inclusive_ancestor_of(*dom)) {
+                        add_fragment_rect({ fragment.offset() + offset, fragment.size() });
+                    }
                 }
             }
         }
@@ -1679,6 +1743,11 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
                 auto const* dom = box_child->dom_node();
                 if (!dom || !inline_dom_node->is_inclusive_ancestor_of(*dom))
                     continue;
+                if (box_child->is_atomic_inline()) {
+                    if (child_used_values)
+                        add_atomic_inline_fragment_rect(*box_child, *child_used_values);
+                    continue;
+                }
                 // child_offset addresses the box's content area; the border-box origin sits
                 // (border-left + padding-left, border-top + padding-top) before that.
                 if (child_used_values) {
@@ -1686,7 +1755,7 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
                         child_used_values->border_left + child_used_values->padding_left,
                         child_used_values->border_top + child_used_values->padding_top,
                     };
-                    union_rect({ border_box_origin, { child_used_values->border_box_width(), child_used_values->border_box_height() } });
+                    add_fragment_rect({ border_box_origin, { child_used_values->border_box_width(), child_used_values->border_box_height() } });
                 }
             }
             self(*child, child_offset);
@@ -1700,6 +1769,8 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
     }
     walk(*outer_block, outer_offset);
 
+    if (!bounding_rect.has_value())
+        bounding_rect = empty_bounding_rect;
     if (!bounding_rect.has_value())
         return {};
 

--- a/Tests/LibWeb/Layout/expected/abspos-inline-containing-block-atomic-inline-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-inline-containing-block-atomic-inline-border-box.txt
@@ -1,0 +1,246 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] positioned [0+0+0 400 0+0+0] [0+0+0 400 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,0] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,20] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
+        InlineNode <span.host> at [34,30] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [34,30 0x0] baseline: 10
+          BlockContainer <span.atomic.empty-padded> at [34,30] inline-block [0+4+10 0 10+4+0] [0+4+6 0 6+4+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [20,20] positioned [0+0+0 28 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,60] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,60] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
+        InlineNode <span.host> at [25,65] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [25,65 0x0] baseline: 5
+          BlockContainer <span.atomic.border-only> at [25,65] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [20,60] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,100] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,100] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
+        InlineNode <span.host> at [29,105] [0+0+0 12 0+0+0] [0+0+0 8 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [29,105 12x8] baseline: 5
+          BlockContainer <span.atomic.sized-padded> at [29,105] inline-block [0+2+7 12 7+2+0] [0+2+3 8 3+2+0] [BFC] children: not-inline
+        BlockContainer <span.percentage> at [50,100] positioned [0+0+0 30 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,140] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,140] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
+        InlineNode <span.host> at [20,140] [0+0+0 18.125 0+0+0] [0+0+0 20 0+0+0]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,140 12.125x20] baseline: 16
+              "x"
+          frag 1 from BlockContainer start: 0, length: 0, rect: [39.125,145 6x10] baseline: 5
+          TextNode <#text> (not painted)
+          BlockContainer <span.atomic.mixed> at [39.125,145] inline-block [0+3+4 6 4+3+0] [0+3+2 10 2+3+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [20,140] positioned [0+0+0 32.125 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,180] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,180] [20+0+0 360 0+0+20] [20+0+0 44 0+0+20] children: inline
+        InlineNode <span.host> at [22,182] [0+0+0 8 0+0+0] [0+0+0 40 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [22,182 8x40] baseline: 2
+          BlockContainer <span.atomic.tall> at [22,182] inline-block [0+2+0 8 0+2+0] [0+2+0 40 0+2+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [20,180] positioned [0+0+0 12 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,244] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,244] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
+        InlineNode <span.host.large-line-height> at [25,249] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [25,249 0x0] baseline: 5
+          BlockContainer <span.atomic.border-only> at [25,249] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [20,244] positioned [0+0+0 10 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,284] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,284] [20+0+0 360 0+0+20] [20+0+0 60 0+0+20] children: inline
+        InlineNode <span.large-sibling> at [20,284] [0+0+0 30.75 0+0+0] [0+0+0 60 0+0+0]
+          frag 0 from TextNode start: 0, length: 1, rect: [20,284 30.75x60] baseline: 42
+              "T"
+          TextNode <#text> (not painted)
+        InlineNode <span.host> at [55.75,321] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [55.75,321 0x0] baseline: 10
+          BlockContainer <span.atomic.baseline.border-only> at [55.75,321] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [50.75,316] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,364] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.vertical> at [20,364] [20+0+0 360 0+0+20] [20+0+0 10 0+0+20] children: inline
+        InlineNode <span.host> at [375,369] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [375,369 0x0] baseline: 5
+          BlockContainer <span.atomic.border-only> at [375,369] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [360,364] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,394] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.vertical> at [20,394] [20+0+0 360 0+0+20] [20+0+0 30 0+0+20] children: inline
+        InlineNode <span.host> at [367,403] [0+0+0 8 0+0+0] [0+0+0 12 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [367,403 8x12] baseline: 5
+          BlockContainer <span.atomic.sized-padded> at [367,403] inline-block [0+2+7 12 7+2+0] [0+2+3 8 3+2+0] [BFC] children: not-inline
+        BlockContainer <span.percentage> at [362,424] positioned [0+0+0 20 0+0+0] [0+0+0 18 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,444] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.vertical> at [20,444] [20+0+0 360 0+0+20] [20+0+0 10 0+0+20] children: inline
+        InlineNode <span.host.large-line-height> at [375,449] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [375,449 0x0] baseline: 5
+          BlockContainer <span.atomic.border-only> at [375,449] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [350,444] positioned [0+0+0 30 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,474] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.vertical-lr> at [20,474] [20+0+0 360 0+0+20] [20+0+0 30 0+0+20] children: inline
+        InlineNode <span.host> at [367,483] [0+0+0 8 0+0+0] [0+0+0 12 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [367,483 8x12] baseline: 5
+          BlockContainer <span.atomic.sized-padded> at [367,483] inline-block [0+2+7 12 7+2+0] [0+2+3 8 3+2+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [358,478] positioned [0+0+0 20 0+0+0] [0+0+0 18 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,524] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.vertical> at [20,524] [20+0+0 360 0+0+20] [20+0+0 10 0+0+20] children: inline
+        InlineNode <span.host> at [381,529] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [381,529 0x0] baseline: 10
+          BlockContainer <span.atomic.baseline.border-only> at [381,529] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [366,524] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,554] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.vertical> at [20,554] [20+0+0 360 0+0+20] [20+0+0 10 0+0+20] children: inline
+        InlineNode <span.host> at [380,559] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [380,559 0x0] baseline: 10.375
+          BlockContainer <span.atomic.middle.border-only> at [380,559] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [365,554] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,584] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,584] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
+        InlineNode <span.host> at [25,594] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [25,594 0x0] baseline: 10.375
+          BlockContainer <span.atomic.middle.border-only> at [25,594] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [20,589] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,624] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case> at [20,624] [20+0+0 360 0+0+20] [20+0+0 40 0+0+20] children: inline
+        InlineNode <span.zero-host> at [20,634] [0+0+0 45.046875 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from TextNode start: 0, length: 5, rect: [20,634 45.046875x0] baseline: 6
+              "first"
+          frag 0 from TextNode start: 0, length: 6, rect: [20,654 68.5x0] baseline: 6
+              "second"
+          TextNode <#text> (not painted)
+          BreakNode <br> (not painted)
+          TextNode <#text> (not painted)
+        BlockContainer <span.overlay> at [20,634] positioned [0+0+0 68.5 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,684] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.sideways> at [20,684] [20+0+0 360 0+0+20] [20+0+0 24 0+0+20] children: inline
+        InlineNode <span.host> at [361,701] [0+0+0 8 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [361,701 8x0] baseline: 5
+          BlockContainer <span.atomic.asymmetric> at [361,701] inline-block [0+8+9 0 1+6+0] [0+2+3 8 7+4+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [348,696] positioned [0+0+0 20 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,728] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.sideways-lr> at [20,728] [20+0+0 360 0+0+20] [20+0+0 24 0+0+20] children: inline
+        InlineNode <span.host> at [361,745] [0+0+0 8 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [361,745 8x0] baseline: 5
+          BlockContainer <span.atomic.asymmetric> at [361,745] inline-block [0+8+9 0 1+6+0] [0+2+3 8 7+4+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [344,740] positioned [0+0+0 20 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,772] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.case.sideways> at [20,772] [20+0+0 360 0+0+20] [20+0+0 24 0+0+20] children: inline
+        InlineNode <span.host.large-line-height> at [361,789] [0+0+0 8 0+0+0] [0+0+0 0 0+0+0]
+          frag 0 from BlockContainer start: 0, length: 0, rect: [361,789 8x0] baseline: 5
+          BlockContainer <span.atomic.asymmetric> at [361,789] inline-block [0+8+9 0 1+6+0] [0+2+3 8 7+4+0] [BFC] children: not-inline
+        BlockContainer <span.overlay> at [338,784] positioned [0+0+0 30 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,816] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x808]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 400x400]
+      PaintableWithLines (BlockContainer(anonymous)) [0,0 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,20 360x20]
+        PaintableWithLines (InlineNode<SPAN>.host) [34,30 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.empty-padded) [20,20 28x20]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,20 28x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,60 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,60 360x20]
+        PaintableWithLines (InlineNode<SPAN>.host) [25,65 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.border-only) [20,60 10x10]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,60 10x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,100 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,100 360x20]
+        PaintableWithLines (InlineNode<SPAN>.host) [29,105 12x8]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.sized-padded) [20,100 30x18]
+        PaintableWithLines (BlockContainer<SPAN>.percentage) [50,100 30x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,140 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,140 360x20]
+        PaintableWithLines (InlineNode<SPAN>.host) [20,140 18.125x20]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.mixed) [32.125,140 20x20]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,140 32.125x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,180 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,180 360x44]
+        PaintableWithLines (InlineNode<SPAN>.host) [22,182 8x40]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.tall) [20,180 12x44]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,180 12x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,244 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,244 360x20]
+        PaintableWithLines (InlineNode<SPAN>.host.large-line-height) [25,249 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.border-only) [20,244 10x10]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,244 10x30]
+      PaintableWithLines (BlockContainer(anonymous)) [0,284 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,284 360x60]
+        PaintableWithLines (InlineNode<SPAN>.large-sibling) [20,284 30.75x60]
+        PaintableWithLines (InlineNode<SPAN>.host) [55.75,321 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.baseline.border-only) [50.75,316 10x10]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [50.75,316 10x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,364 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,364 360x10]
+        PaintableWithLines (InlineNode<SPAN>.host) [375,369 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.border-only) [370,364 10x10]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [360,364 20x10]
+      PaintableWithLines (BlockContainer(anonymous)) [0,394 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,394 360x30]
+        PaintableWithLines (InlineNode<SPAN>.host) [367,403 8x12]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.sized-padded) [358,398 30x18]
+        PaintableWithLines (BlockContainer<SPAN>.percentage) [362,424 20x18]
+      PaintableWithLines (BlockContainer(anonymous)) [0,444 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,444 360x10]
+        PaintableWithLines (InlineNode<SPAN>.host.large-line-height) [375,449 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.border-only) [370,444 10x10]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [350,444 30x10]
+      PaintableWithLines (BlockContainer(anonymous)) [0,474 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.vertical-lr) [20,474 360x30]
+        PaintableWithLines (InlineNode<SPAN>.host) [367,483 8x12]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.sized-padded) [358,478 30x18]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [358,478 20x18]
+      PaintableWithLines (BlockContainer(anonymous)) [0,524 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,524 360x10]
+        PaintableWithLines (InlineNode<SPAN>.host) [381,529 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.baseline.border-only) [376,524 10x10]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [366,524 20x10]
+      PaintableWithLines (BlockContainer(anonymous)) [0,554 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,554 360x10]
+        PaintableWithLines (InlineNode<SPAN>.host) [380,559 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.middle.border-only) [375,554 10x10]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [365,554 20x10]
+      PaintableWithLines (BlockContainer(anonymous)) [0,584 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,584 360x20]
+        PaintableWithLines (InlineNode<SPAN>.host) [25,594 0x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.middle.border-only) [20,589 10x10]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,589 10x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,624 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case) [20,624 360x40]
+        PaintableWithLines (InlineNode<SPAN>.zero-host) [20,634 45.046875x0]
+
+        PaintableWithLines (InlineNode<SPAN>.zero-host) [20,654 68.5x0]
+        PaintableWithLines (InlineNode<SPAN>.zero-host) [20,634 45.046875x0]
+
+        PaintableWithLines (InlineNode<SPAN>.zero-host) [20,654 68.5x0]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,634 68.5x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,684 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.sideways) [20,684 360x24]
+        PaintableWithLines (InlineNode<SPAN>.host) [361,701 8x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.asymmetric) [344,696 24x24]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [348,696 20x24]
+      PaintableWithLines (BlockContainer(anonymous)) [0,728 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.sideways-lr) [20,728 360x24]
+        PaintableWithLines (InlineNode<SPAN>.host) [361,745 8x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.asymmetric) [344,740 24x24]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [344,740 20x24]
+      PaintableWithLines (BlockContainer(anonymous)) [0,772 400x0]
+      PaintableWithLines (BlockContainer<DIV>.case.sideways) [20,772 360x24]
+        PaintableWithLines (InlineNode<SPAN>.host.large-line-height) [361,789 8x0]
+          PaintableWithLines (BlockContainer<SPAN>.atomic.asymmetric) [344,784 24x24]
+        PaintableWithLines (BlockContainer<SPAN>.overlay) [338,784 30x24]
+      PaintableWithLines (BlockContainer(anonymous)) [0,816 400x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/abspos-inline-containing-block-atomic-inline-border-box.html
+++ b/Tests/LibWeb/Layout/input/abspos-inline-containing-block-atomic-inline-border-box.html
@@ -1,0 +1,118 @@
+<!doctype html><style>
+    * {
+        box-sizing: content-box;
+    }
+    body {
+        margin: 0;
+        position: absolute;
+        width: 400px;
+        height: 400px;
+        font: 20px SerenitySans;
+        line-height: 20px;
+    }
+    .case {
+        margin: 20px;
+        line-height: 20px;
+    }
+    .host {
+        position: relative;
+    }
+    .large-line-height {
+        line-height: 30px;
+    }
+    .vertical {
+        writing-mode: vertical-rl;
+    }
+    .vertical-lr {
+        writing-mode: vertical-lr;
+    }
+    .sideways {
+        writing-mode: sideways-rl;
+    }
+    .sideways-lr {
+        writing-mode: sideways-lr;
+    }
+    .large-sibling {
+        font-size: 40px;
+        line-height: 60px;
+    }
+    .atomic {
+        display: inline-block;
+        vertical-align: top;
+    }
+    .baseline {
+        vertical-align: baseline;
+    }
+    .middle {
+        vertical-align: middle;
+    }
+    .zero-host {
+        position: relative;
+        line-height: 0;
+    }
+    .empty-padded {
+        width: 0;
+        height: 0;
+        padding: 6px 10px;
+        border: 4px solid black;
+    }
+    .border-only {
+        width: 0;
+        height: 0;
+        border: 5px solid black;
+    }
+    .sized-padded {
+        width: 12px;
+        height: 8px;
+        padding: 3px 7px;
+        border: 2px solid black;
+    }
+    .mixed {
+        width: 6px;
+        height: 10px;
+        padding: 2px 4px;
+        border: 3px solid black;
+    }
+    .tall {
+        width: 8px;
+        height: 40px;
+        border: 2px solid black;
+    }
+    .asymmetric {
+        width: 0;
+        height: 8px;
+        padding: 3px 1px 7px 9px;
+        border-width: 2px 6px 4px 8px;
+        border-style: solid;
+        border-color: black;
+    }
+    .overlay {
+        position: absolute;
+        inset: 0;
+        background: orange;
+    }
+    .percentage {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background: orange;
+    }
+</style><body>
+    <div class="case"><span class="host"><span class="atomic empty-padded"></span><span class="overlay"></span></span></div>
+    <div class="case"><span class="host"><span class="atomic border-only"></span><span class="overlay"></span></span></div>
+    <div class="case"><span class="host"><span class="atomic sized-padded"></span><span class="percentage"></span></span></div>
+    <div class="case"><span class="host">x<span class="atomic mixed"></span><span class="overlay"></span></span></div>
+    <div class="case"><span class="host"><span class="atomic tall"></span><span class="overlay"></span></span></div>
+    <div class="case"><span class="host large-line-height"><span class="atomic border-only"></span><span class="overlay"></span></span></div>
+    <div class="case"><span class="large-sibling">T</span><span class="host"><span class="atomic baseline border-only"></span><span class="overlay"></span></span></div>
+    <div class="case vertical"><span class="host"><span class="atomic border-only"></span><span class="overlay"></span></span></div>
+    <div class="case vertical"><span class="host"><span class="atomic sized-padded"></span><span class="percentage"></span></span></div>
+    <div class="case vertical"><span class="host large-line-height"><span class="atomic border-only"></span><span class="overlay"></span></span></div>
+    <div class="case vertical-lr"><span class="host"><span class="atomic sized-padded"></span><span class="overlay"></span></span></div>
+    <div class="case vertical"><span class="host"><span class="atomic baseline border-only"></span><span class="overlay"></span></span></div>
+    <div class="case vertical"><span class="host"><span class="atomic middle border-only"></span><span class="overlay"></span></span></div>
+    <div class="case"><span class="host"><span class="atomic middle border-only"></span><span class="overlay"></span></span></div>
+    <div class="case"><span class="zero-host">first<br>second<span class="overlay"></span></span></div>
+    <div class="case sideways"><span class="host"><span class="atomic asymmetric"></span><span class="overlay"></span></span></div>
+    <div class="case sideways-lr"><span class="host"><span class="atomic asymmetric"></span><span class="overlay"></span></span></div>
+    <div class="case sideways"><span class="host large-line-height"><span class="atomic asymmetric"></span><span class="overlay"></span></span></div>

--- a/Tests/LibWeb/Text/expected/hit_testing/absolute-positioned-child-of-wrapped-inline.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/absolute-positioned-child-of-wrapped-inline.txt
@@ -1,0 +1,3 @@
+Overlay starts near button: true
+Overlay height does not span previous lines: true
+Point above button does not hit overlay: true

--- a/Tests/LibWeb/Text/input/hit_testing/absolute-positioned-child-of-wrapped-inline.html
+++ b/Tests/LibWeb/Text/input/hit_testing/absolute-positioned-child-of-wrapped-inline.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        font: 16px/24px Arial;
+        margin: 0;
+    }
+
+    .container {
+        border: 1px solid black;
+        margin: 20px;
+        width: 320px;
+    }
+
+    .nowrap {
+        white-space: nowrap;
+    }
+
+    .relative {
+        position: relative;
+    }
+
+    .overlay {
+        block-size: 100%;
+        inline-size: 100%;
+        inset-block-start: 0;
+        inset-inline-start: 0;
+        position: absolute;
+        z-index: 1;
+    }
+
+    button {
+        display: inline-block;
+        height: 20px;
+        padding: 0;
+        vertical-align: text-top;
+        width: 115px;
+    }
+</style>
+<div class="container">
+    This is a long inline text run which should wrap before the overlay pill and
+    put the pill onto a later line after enough words.<span class="nowrap"><span
+        class="relative"><span>&nbsp;</span><a class="overlay" href="#"></a><button>Oxford +1</button></span></span>
+</div>
+<script>
+    test(() => {
+        const overlay = document.querySelector(".overlay");
+        const button = document.querySelector("button");
+        const overlayRect = overlay.getBoundingClientRect();
+        const buttonRect = button.getBoundingClientRect();
+
+        println(`Overlay starts near button: ${overlayRect.top >= buttonRect.top - 2}`);
+        println(`Overlay height does not span previous lines: ${overlayRect.height < 40}`);
+
+        const hitAboveButton = document.elementFromPoint(
+            buttonRect.left + buttonRect.width / 2,
+            buttonRect.top - 40
+        );
+        println(`Point above button does not hit overlay: ${hitAboveButton !== overlay}`);
+    });
+</script>


### PR DESCRIPTION
Compute containing blocks for absolutely positioned descendants of positioned inline boxes from their inline fragments, including atomic inline descendants. Preserve atomic border boxes, empty fragment extents, line-height-sized block-axis extents, vertical writing modes, and reverse block-axis writing modes.

Add layout dump coverage for wrapped inline hit testing, atomic inline border and padding contributions, empty split fragments, line-height mismatches, vertical writing modes, and sideways writing modes.

This fixes an issue where source annotations in Google Search's "AI overview" had hitboxes that extended vertically far above the visible annotation pill.