### PR TITLE
LibWasm: Fix off-by-two overflow in the macOS Cranelift shm name

### DIFF
--- a/Libraries/LibWasm/CraneliftBridge.cpp
+++ b/Libraries/LibWasm/CraneliftBridge.cpp
@@ -1184,8 +1184,9 @@ static void try_cranelift_compile_batch(Vector<BatchInput>& batch)
 #elif defined(AK_OS_MACOS)
     // macOS lacks memfd_create; use shm_open + shm_unlink for an anonymous fd.
     char shm_name[] = "/libwasm-cranelift-XXXXXX";
-    arc4random_buf(shm_name + 21, 6);
-    for (int i = 21; i < 27; ++i)
+    constexpr size_t shm_suffix_offset = sizeof("/libwasm-cranelift-") - 1;
+    arc4random_buf(shm_name + shm_suffix_offset, 6);
+    for (size_t i = shm_suffix_offset; i < shm_suffix_offset + 6; ++i)
         shm_name[i] = 'A' + (static_cast<unsigned char>(shm_name[i]) % 26);
     int fd = shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, 0600);
     if (fd < 0)


### PR DESCRIPTION
**Problem:** macOS WebAssembly modules instantiated through the JS API are never JIT-compiled; every function silently falls back to the bytecode interpreter — so WebAssembly runs roughly an order of magnitude slower.

**Cause:** `try_cranelift_compile_batch` names its shared-memory IPC segment by randomizing a placeholder suffix. The prefix `/libwasm-cranelift-` is 19 characters — so the six-character placeholder starts at offset 19. But the code randomizes six bytes starting at offset 21, and loops thru index 26. That overwrites the terminating null, and writes one byte past the end of the buffer — leaving the name unterminated. `shm_open` then reads past the buffer and fails with `ENAMETOOLONG` — so the batch returns before spawning the compiler: No function is compiled to native code.

**Fix:** Derive the suffix offset from the prefix length — so the six random bytes land on the placeholder, and the terminator is preserved.

Discovered while working on https://github.com/LadybirdBrowser/ladybird/issues/10442.
