### PR TITLE
LibWebView+UI/Qt: Add private browsing support to LibWebView and the Qt UI

### DIFF
--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -229,12 +229,12 @@ void RequestClient::request_transferred(u64 request_id)
     (*request)->did_transfer({});
 }
 
-void RequestClient::retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url)
+void RequestClient::retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url, RequestServer::IsPrivate is_private)
 {
     String cookie;
 
     if (on_retrieve_http_cookie)
-        cookie = on_retrieve_http_cookie(url);
+        cookie = on_retrieve_http_cookie(url, is_private);
 
     async_retrieved_http_cookie(client_id, request_id, request_type, cookie);
 }

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -17,6 +17,7 @@
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibRequests/WebSocket.h>
 #include <LibWebSocket/WebSocket.h>
+#include <RequestServer/IsPrivate.h>
 #include <RequestServer/RequestClientEndpoint.h>
 #include <RequestServer/RequestServerEndpoint.h>
 
@@ -56,7 +57,7 @@ public:
     ErrorOr<Optional<Core::AnonymousBuffer>> retrieve_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData);
     ErrorOr<bool> create_synthetic_cache_entry(URL::URL const&, ByteString const& method);
 
-    Function<String(URL::URL const&)> on_retrieve_http_cookie;
+    Function<String(URL::URL const&, RequestServer::IsPrivate)> on_retrieve_http_cookie;
     Function<void()> on_request_server_died;
 
 private:
@@ -69,7 +70,7 @@ private:
     virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<IPC::File>, u64 javascript_bytecode_size, Optional<u64>) override;
     virtual void request_transferred(u64 request_id) override;
 
-    virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url) override;
+    virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url, RequestServer::IsPrivate) override;
 
     virtual void certificate_requested(u64 request_id) override;
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1032,11 +1032,12 @@ ErrorOr<void> Application::launch_request_server()
 {
     m_request_server_client = TRY(launch_request_server_process());
 
-    m_request_server_client->on_retrieve_http_cookie = [this](URL::URL const& url) -> String {
+    m_request_server_client->on_retrieve_http_cookie = [](URL::URL const& url, RequestServer::IsPrivate is_private) -> String {
+        auto& cookie_jar = Application::cookie_jar(is_private == RequestServer::IsPrivate::Yes ? IsPrivate::Yes : IsPrivate::No);
         if constexpr (!REQUESTSERVER_WIRE_DEBUG)
-            return m_cookie_jar->get_cookie(url, HTTP::Cookie::Source::Http);
+            return cookie_jar.get_cookie(url, HTTP::Cookie::Source::Http);
         auto started_at = MonotonicTime::now();
-        auto cookie = m_cookie_jar->get_cookie(url, HTTP::Cookie::Source::Http);
+        auto cookie = cookie_jar.get_cookie(url, HTTP::Cookie::Source::Http);
         auto elapsed_ms = (MonotonicTime::now() - started_at).to_milliseconds();
         if (elapsed_ms > 5) {
             dbgln("UI wire-cookie: get_cookie({}) took {} ms ({} bytes returned)",

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -538,12 +538,12 @@ void Application::open_url_in_new_window(URL::URL const& url)
     dbgln("open_url_in_new_window() is unsupported on this platform (url: {})", url);
 }
 
-ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, u64 initial_page_id)
+ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id)
 {
     auto request_server_handle = TRY(connect_new_request_server_client());
     auto image_decoder_handle = TRY(connect_new_image_decoder_client());
 
-    auto client = TRY(WebView::launch_web_content_process(initial_page_id));
+    auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id));
     client->async_initialize(initial_page_id);
     if (view.has_value())
         client->assign_view({}, *view);
@@ -705,6 +705,9 @@ void Application::crash_compositor_process()
 
 ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process(ViewImplementation& view)
 {
+    if (view.is_private() == IsPrivate::Yes)
+        return create_web_content_client(view, IsPrivate::Yes, allocate_page_id());
+
     if (m_spare_web_content_process) {
         auto web_content_client = m_spare_web_content_process.release_nonnull();
         launch_spare_web_content_process();
@@ -714,13 +717,13 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process
     }
 
     launch_spare_web_content_process();
-    return create_web_content_client(view, allocate_page_id());
+    return create_web_content_client(view, IsPrivate::No, allocate_page_id());
 }
 
-ErrorOr<Application::ChildFrameWebContentProcess> Application::launch_child_frame_web_content_process()
+ErrorOr<Application::ChildFrameWebContentProcess> Application::launch_child_frame_web_content_process(IsPrivate is_private)
 {
     auto page_id = allocate_page_id();
-    auto client = TRY(create_web_content_client({}, page_id));
+    auto client = TRY(create_web_content_client({}, is_private, page_id));
     return ChildFrameWebContentProcess {
         .client = move(client),
         .page_id = page_id,
@@ -748,7 +751,7 @@ void Application::launch_spare_web_content_process()
     Core::deferred_invoke([this]() {
         m_has_queued_task_to_launch_spare_web_content_process = false;
 
-        auto web_content_client = create_web_content_client({}, allocate_page_id());
+        auto web_content_client = create_web_content_client({}, IsPrivate::No, allocate_page_id());
         if (web_content_client.is_error()) {
             dbgln("Unable to create spare web content client: {}", web_content_client.error());
             return;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -134,6 +134,34 @@ Application::~Application()
     s_the = nullptr;
 }
 
+HistoryStore& Application::history_store(IsPrivate is_private)
+{
+    return is_private == IsPrivate::Yes
+        ? *the().ensure_private_browsing_session().history_store
+        : *the().m_history_store;
+}
+
+CookieJar& Application::cookie_jar(IsPrivate is_private)
+{
+    return is_private == IsPrivate::Yes
+        ? *the().ensure_private_browsing_session().cookie_jar
+        : *the().m_cookie_jar;
+}
+
+HSTSStore& Application::hsts_store(IsPrivate is_private)
+{
+    return is_private == IsPrivate::Yes
+        ? *the().ensure_private_browsing_session().hsts_store
+        : *the().m_hsts_store;
+}
+
+StorageJar& Application::storage_jar(IsPrivate is_private)
+{
+    return is_private == IsPrivate::Yes
+        ? *the().ensure_private_browsing_session().storage_jar
+        : *the().m_storage_jar;
+}
+
 ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 {
     TRY(handle_attached_debugger());
@@ -559,6 +587,50 @@ u64 Application::allocate_page_id()
 {
     VERIFY(m_next_page_or_compositor_context_id > 0);
     return m_next_page_or_compositor_context_id++;
+}
+
+PrivateBrowsingSession& Application::ensure_private_browsing_session()
+{
+    if (!m_private_browsing_session) {
+        m_private_browsing_session = adopt_own(*new PrivateBrowsingSession {
+            .cookie_jar = CookieJar::create(IsPrivate::Yes),
+            .storage_jar = StorageJar::create(),
+            .hsts_store = HSTSStore::create(),
+            .history_store = HistoryStore::create_disabled(),
+        });
+    }
+
+    return *m_private_browsing_session;
+}
+
+void Application::maybe_close_private_browsing_session()
+{
+    if (!m_private_browsing_session)
+        return;
+
+    auto has_private_view = false;
+    ViewImplementation::for_each_view([&](ViewImplementation& view) {
+        if (view.is_private() == IsPrivate::No)
+            return IterationDecision::Continue;
+
+        has_private_view = true;
+        return IterationDecision::Break;
+    });
+    if (has_private_view)
+        return;
+
+    auto has_private_client = false;
+    WebContentClient::for_each_client([&](WebContentClient& client) {
+        if (client.is_private() == IsPrivate::No)
+            return IterationDecision::Continue;
+
+        has_private_client = true;
+        return IterationDecision::Break;
+    });
+    if (has_private_client)
+        return;
+
+    m_private_browsing_session = nullptr;
 }
 
 Web::Compositor::CompositorContextId Application::allocate_compositor_context_id()
@@ -1405,6 +1477,12 @@ void Application::clear_browsing_data(ClearBrowsingDataOptions const& options)
         m_cookie_jar->expire_cookies_accessed_since(options.since);
         m_storage_jar->remove_items_accessed_since(options.since);
         m_hsts_store->remove_policies_observed_since(options.since);
+
+        if (m_private_browsing_session) {
+            m_private_browsing_session->cookie_jar->expire_cookies_accessed_since(options.since);
+            m_private_browsing_session->storage_jar->remove_items_accessed_since(options.since);
+            m_private_browsing_session->hsts_store->remove_policies_observed_since(options.since);
+        }
     }
 
     if (did_change_history)

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -22,6 +22,7 @@
 #include <LibDatabase/Database.h>
 #include <LibDevTools/DevToolsServer.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibIPC/TransportHandle.h>
 #include <LibImageDecoderClient/Client.h>
 #include <LibURL/InternalURLs.h>
 #include <LibURL/Parser.h>
@@ -568,7 +569,7 @@ void Application::open_url_in_new_window(URL::URL const& url)
 
 ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id)
 {
-    auto request_server_handle = TRY(connect_new_request_server_client());
+    auto request_server_handle = TRY(connect_new_request_server_client(is_private));
     auto image_decoder_handle = TRY(connect_new_image_decoder_client());
 
     auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id));
@@ -1055,14 +1056,31 @@ ErrorOr<void> Application::launch_request_server()
             VERIFY_NOT_REACHED();
         }
 
-        auto client_count = WebContentClient::client_count();
-        auto request_server_response = m_request_server_client->send_sync_but_allow_failure<Messages::RequestServer::ConnectNewClients>(client_count);
-        if (!request_server_response || request_server_response->handles().is_empty()) {
-            warnln("\033Failed to connect {} new clients to ImageDecoder\033[0m", client_count);
-            VERIFY_NOT_REACHED();
-        }
+        size_t normal_client_count = 0;
+        size_t private_client_count = 0;
+        WebContentClient::for_each_client([&](WebContentClient& client) {
+            client.is_private() == IsPrivate::No ? ++normal_client_count : ++private_client_count;
+            return IterationDecision::Continue;
+        });
 
-        WebContentClient::for_each_client([handles = request_server_response->take_handles()](WebContentClient& client) mutable {
+        auto create_handles = [&](auto is_private, auto client_count) -> Vector<IPC::TransportHandle> {
+            if (client_count == 0)
+                return {};
+
+            auto response = m_request_server_client->send_sync_but_allow_failure<Messages::RequestServer::ConnectNewClients>(client_count, is_private);
+            if (!response || response->handles().size() != client_count) {
+                warnln("Failed to connect {} new clients to RequestServer", client_count);
+                VERIFY_NOT_REACHED();
+            }
+
+            return response->take_handles();
+        };
+
+        auto normal_handles = create_handles(RequestServer::IsPrivate::No, normal_client_count);
+        auto private_handles = create_handles(RequestServer::IsPrivate::Yes, private_client_count);
+
+        WebContentClient::for_each_client([&](WebContentClient& client) {
+            auto& handles = client.is_private() == IsPrivate::No ? normal_handles : private_handles;
             client.async_connect_to_request_server(handles.take_last());
             return IterationDecision::Continue;
         });

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -2082,15 +2082,17 @@ void Application::traverse_the_history_by_delta(DevTools::TabDescription const& 
 
 Vector<HTTP::Cookie::Cookie> Application::cookies(DevTools::TabDescription const& description) const
 {
-    if (!ViewImplementation::find_view_by_id(description.id).has_value())
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
         return {};
 
-    return Application::cookie_jar().get_all_cookies();
+    return Application::cookie_jar(view->is_private()).get_all_cookies();
 }
 
 ErrorOr<void> Application::set_cookie(DevTools::TabDescription const& description, Optional<HTTP::Cookie::Cookie> old_cookie, HTTP::Cookie::Cookie cookie) const
 {
-    if (!ViewImplementation::find_view_by_id(description.id).has_value())
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
         return Error::from_string_literal("Unable to locate tab");
 
     auto url = URL::Parser::basic_parse(description.url);
@@ -2101,17 +2103,18 @@ ErrorOr<void> Application::set_cookie(DevTools::TabDescription const& descriptio
     if (old_cookie.has_value())
         old_key = CookieStorageKey { old_cookie->name, old_cookie->domain, old_cookie->path };
 
-    TRY(Application::cookie_jar().set_cookie_from_devtools(*url, move(old_key), move(cookie)));
+    TRY(Application::cookie_jar(view->is_private()).set_cookie_from_devtools(*url, move(old_key), move(cookie)));
     return {};
 }
 
 void Application::delete_cookies(DevTools::TabDescription const& description, Vector<HTTP::Cookie::Cookie> cookies) const
 {
-    if (!ViewImplementation::find_view_by_id(description.id).has_value())
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
         return;
 
     for (auto const& cookie : cookies)
-        Application::cookie_jar().delete_cookie({ cookie.name, cookie.domain, cookie.path });
+        Application::cookie_jar(view->is_private()).delete_cookie({ cookie.name, cookie.domain, cookie.path });
 }
 
 void Application::listen_for_host_cookie_changes(DevTools::TabDescription const& description, OnHostCookieChange on_host_cookie_change) const
@@ -2162,7 +2165,7 @@ ErrorOr<Optional<String>> Application::set_storage_item(DevTools::TabDescription
         return TRY(storage_set_result_to_error_or_old_value(result.release_value()));
     }
 
-    auto old_value = TRY(storage_set_result_to_error_or_old_value(Application::storage_jar().set_item(storage_endpoint, storage_key, key, value)));
+    auto old_value = TRY(storage_set_result_to_error_or_old_value(Application::storage_jar(view->is_private()).set_item(storage_endpoint, storage_key, key, value)));
     if (!old_value.has_value()) {
         view->notify_storage_changed({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Added, key });
     } else if (*old_value != value) {
@@ -2181,11 +2184,11 @@ ErrorOr<Optional<String>> Application::remove_storage_item(DevTools::TabDescript
     if (storage_endpoint == Web::StorageAPI::StorageEndpointType::SessionStorage)
         return view->remove_session_storage_item(key);
 
-    auto old_value = Application::storage_jar().get_item(storage_endpoint, storage_key, key);
+    auto old_value = Application::storage_jar(view->is_private()).get_item(storage_endpoint, storage_key, key);
     if (!old_value.has_value())
         return Optional<String> {};
 
-    Application::storage_jar().remove_item(storage_endpoint, storage_key, key);
+    Application::storage_jar(view->is_private()).remove_item(storage_endpoint, storage_key, key);
     view->notify_storage_changed({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Deleted, key });
     return old_value;
 }
@@ -2201,11 +2204,11 @@ ErrorOr<void> Application::clear_storage(DevTools::TabDescription const& descrip
         return {};
     }
 
-    auto keys = Application::storage_jar().get_all_keys(storage_endpoint, storage_key);
+    auto keys = Application::storage_jar(view->is_private()).get_all_keys(storage_endpoint, storage_key);
     if (keys.is_empty())
         return {};
 
-    Application::storage_jar().clear_storage_key(storage_endpoint, storage_key);
+    Application::storage_jar(view->is_private()).clear_storage_key(storage_endpoint, storage_key);
     view->notify_storage_changed({ storage_endpoint, storage_key, DevTools::DevToolsDelegate::StorageChange::Type::Cleared, {} });
     return {};
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -163,6 +163,27 @@ StorageJar& Application::storage_jar(IsPrivate is_private)
         : *the().m_storage_jar;
 }
 
+Requests::RequestClient& Application::request_server_client(IsPrivate is_private)
+{
+    if (is_private == IsPrivate::No)
+        return *the().m_request_server_client;
+
+    if (!the().m_private_request_server_client) {
+        auto handle = connect_new_request_server_client(IsPrivate::Yes).release_value_but_fixme_should_propagate_errors();
+        auto transport = handle.create_transport().release_value_but_fixme_should_propagate_errors();
+        auto request_server_client = make_ref_counted<Requests::RequestClient>(move(transport));
+
+#ifdef AK_OS_WINDOWS
+        auto response = request_server_client->send_sync<Messages::RequestServer::InitTransport>(Core::System::getpid());
+        request_server_client->transport().set_peer_pid(response->peer_pid());
+#endif
+
+        the().m_private_request_server_client = move(request_server_client);
+    }
+
+    return *the().m_private_request_server_client;
+}
+
 ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 {
     TRY(handle_attached_debugger());
@@ -1048,6 +1069,7 @@ ErrorOr<void> Application::launch_request_server()
 
     m_request_server_client->on_request_server_died = [this]() {
         m_request_server_client = nullptr;
+        m_private_request_server_client = nullptr;
 
         if (Core::EventLoop::current().was_exit_requested())
             return;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -84,10 +84,10 @@ public:
     void show_bookmarks_bar_changed(Badge<ApplicationSettingsObserver>);
     virtual void show_bookmark_context_menu(Gfx::IntPoint, Optional<BookmarkItem const&>, [[maybe_unused]] Optional<String const&> target_folder_id) { }
 
-    static HistoryStore& history_store() { return *the().m_history_store; }
-    static CookieJar& cookie_jar() { return *the().m_cookie_jar; }
-    static HSTSStore& hsts_store() { return *the().m_hsts_store; }
-    static StorageJar& storage_jar() { return *the().m_storage_jar; }
+    static HistoryStore& history_store(IsPrivate = IsPrivate::No);
+    static CookieJar& cookie_jar(IsPrivate = IsPrivate::No);
+    static HSTSStore& hsts_store(IsPrivate = IsPrivate::No);
+    static StorageJar& storage_jar(IsPrivate = IsPrivate::No);
 
     static ProcessManager& process_manager() { return *the().m_process_manager; }
 #if defined(AK_OS_MACOS)
@@ -102,6 +102,9 @@ public:
     };
     ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process(IsPrivate);
     u64 allocate_page_id();
+
+    void maybe_close_private_browsing_session();
+
     Web::Compositor::CompositorContextId allocate_compositor_context_id();
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);
     void register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id);
@@ -258,6 +261,7 @@ protected:
 
 private:
     ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, IsPrivate, u64 initial_page_id);
+    PrivateBrowsingSession& ensure_private_browsing_session();
     ErrorOr<void> launch_services();
     void launch_spare_web_content_process();
     ErrorOr<void> launch_compositor_process();
@@ -387,6 +391,7 @@ private:
     OwnPtr<CookieJar> m_cookie_jar;
     OwnPtr<HSTSStore> m_hsts_store;
     OwnPtr<StorageJar> m_storage_jar;
+    OwnPtr<PrivateBrowsingSession> m_private_browsing_session;
 
     OwnPtr<Core::TimeZoneWatcher> m_time_zone_watcher;
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -84,10 +84,10 @@ public:
     void show_bookmarks_bar_changed(Badge<ApplicationSettingsObserver>);
     virtual void show_bookmark_context_menu(Gfx::IntPoint, Optional<BookmarkItem const&>, [[maybe_unused]] Optional<String const&> target_folder_id) { }
 
-    static HistoryStore& history_store(IsPrivate = IsPrivate::No);
-    static CookieJar& cookie_jar(IsPrivate = IsPrivate::No);
-    static HSTSStore& hsts_store(IsPrivate = IsPrivate::No);
-    static StorageJar& storage_jar(IsPrivate = IsPrivate::No);
+    static HistoryStore& history_store(IsPrivate);
+    static CookieJar& cookie_jar(IsPrivate);
+    static HSTSStore& hsts_store(IsPrivate);
+    static StorageJar& storage_jar(IsPrivate);
 
     static ProcessManager& process_manager() { return *the().m_process_manager; }
 #if defined(AK_OS_MACOS)

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -33,6 +33,7 @@
 #include <LibWebView/FileDownloader.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Options.h>
+#include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/Process.h>
 #include <LibWebView/ProcessManager.h>
 #include <LibWebView/Settings.h>
@@ -99,7 +100,7 @@ public:
         NonnullRefPtr<WebContentClient> client;
         u64 page_id { 0 };
     };
-    ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process();
+    ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process(IsPrivate);
     u64 allocate_page_id();
     Web::Compositor::CompositorContextId allocate_compositor_context_id();
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);
@@ -256,7 +257,7 @@ protected:
     Main::Arguments& arguments() { return m_arguments; }
 
 private:
-    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, u64 initial_page_id);
+    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, IsPrivate, u64 initial_page_id);
     ErrorOr<void> launch_services();
     void launch_spare_web_content_process();
     ErrorOr<void> launch_compositor_process();

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -71,7 +71,7 @@ public:
     static RequestServerOptions const& request_server_options() { return the().m_request_server_options; }
     static WebContentOptions& web_content_options() { return the().m_web_content_options; }
 
-    static Requests::RequestClient& request_server_client() { return *the().m_request_server_client; }
+    static Requests::RequestClient& request_server_client(IsPrivate = IsPrivate::No);
     static ImageDecoderClient::Client& image_decoder_client() { return *the().m_image_decoder_client; }
 
     virtual bool supports_vertical_tabs() const { return false; }
@@ -372,6 +372,7 @@ private:
     Optional<Core::AnonymousBuffer> m_content_blocker_list_buffer;
 
     RefPtr<Requests::RequestClient> m_request_server_client;
+    RefPtr<Requests::RequestClient> m_private_request_server_client;
     RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
     RefPtr<CompositorClient> m_compositor_client;
     size_t m_compositor_restart_count { 0 };

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -42,7 +42,11 @@ Optional<AutocompleteEngine const&> find_autocomplete_engine_by_name(StringView 
     });
 }
 
-Autocomplete::Autocomplete() = default;
+Autocomplete::Autocomplete(IsPrivate is_private)
+    : m_is_private(is_private)
+{
+}
+
 Autocomplete::~Autocomplete() = default;
 
 void Autocomplete::cancel_pending_query()
@@ -301,7 +305,8 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Autocomplete query='{}' trimmed='{}'", m_query, trimmed_query);
 
-    m_history_suggestions = make_history_suggestions(trimmed_query, Application::history_store().autocomplete_entries(trimmed_query, m_max_suggestions));
+    // In private windows, we use a disabled history store for most things, but we allow querying non-private history for autocomplete.
+    m_history_suggestions = make_history_suggestions(trimmed_query, Application::history_store(IsPrivate::No).autocomplete_entries(trimmed_query, m_max_suggestions));
     auto literal_suggestion = preferred_literal_url_suggestion(trimmed_query, m_history_suggestions);
     auto search_suggestion = search_for_query_suggestion(trimmed_query);
 
@@ -351,7 +356,7 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
     if (!url.has_value())
         return;
 
-    m_request = Application::request_server_client().start_request("GET"sv, *url);
+    m_request = Application::request_server_client(m_is_private).start_request("GET"sv, *url);
 
     m_request->set_buffered_request_finished_callback(
         [this, engine = engine.release_value(), query = m_query, literal_suggestion, search_suggestion](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Core::ImmutableBytes payload) {

--- a/Libraries/LibWebView/Autocomplete.h
+++ b/Libraries/LibWebView/Autocomplete.h
@@ -16,6 +16,7 @@
 #include <AK/Vector.h>
 #include <LibRequests/Forward.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/PrivateBrowsing.h>
 
 namespace WebView {
 
@@ -61,7 +62,7 @@ WEBVIEW_API bool autocomplete_url_can_complete(StringView query, StringView sugg
 
 class WEBVIEW_API Autocomplete {
 public:
-    Autocomplete();
+    explicit Autocomplete(IsPrivate);
     ~Autocomplete();
 
     Function<void(Vector<AutocompleteSuggestion>, AutocompleteResultKind)> on_autocomplete_query_complete;
@@ -73,6 +74,7 @@ private:
     static ErrorOr<Vector<String>> received_autocomplete_respsonse(AutocompleteEngine const&, Optional<ByteString const&> content_type, StringView response);
     void invoke_autocomplete_query_complete(Vector<AutocompleteSuggestion> suggestions, AutocompleteResultKind) const;
 
+    IsPrivate m_is_private { IsPrivate::No };
     String m_query;
     size_t m_max_suggestions { default_autocomplete_suggestion_limit };
     Vector<AutocompleteSuggestion> m_history_suggestions;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -5,19 +5,21 @@ set(SOURCES
     BookmarkStore.cpp
     CanonicalTraversable.cpp
     BrowserProcess.cpp
+    CompositorClient.cpp
     ConsoleOutput.cpp
     CookieJar.cpp
     DOMNodeProperties.cpp
     FileDownloader.cpp
     HeadlessWebView.cpp
+    HelperProcess.cpp
     HistoryDebug.cpp
     HistoryStore.cpp
-    HelperProcess.cpp
     HSTSStore.cpp
     Menu.cpp
     Mutation.cpp
     Omnibox.cpp
     Plugins/ImageCodecPlugin.cpp
+    PrivateBrowsing.cpp
     Process.cpp
     ProcessHandle.cpp
     ProcessManager.cpp
@@ -34,8 +36,6 @@ set(SOURCES
     Utilities.cpp
     ViewImplementation.cpp
     WebContentClient.cpp
-    WebWorkerClient.cpp
-    WorkerProcessManager.cpp
     WebUI.cpp
     WebUI/BookmarksUI.cpp
     WebUI/DownloadsUI.cpp
@@ -43,7 +43,8 @@ set(SOURCES
     WebUI/ProcessesUI.cpp
     WebUI/SettingsUI.cpp
     WebUI/VersionUI.cpp
-    CompositorClient.cpp
+    WebWorkerClient.cpp
+    WorkerProcessManager.cpp
 )
 
 if (APPLE)

--- a/Libraries/LibWebView/CookieJar.cpp
+++ b/Libraries/LibWebView/CookieJar.cpp
@@ -70,16 +70,17 @@ ErrorOr<NonnullOwnPtr<CookieJar>> CookieJar::create(Database::Database& database
     statements.expire_cookie = TRY(database.prepare_statement("DELETE FROM Cookies WHERE (expiry_time < ?);"sv));
     statements.select_all_cookies = TRY(database.prepare_statement("SELECT name, value, same_site, creation_time, last_access_time, expiry_time, domain, path, secure, http_only, host_only, persistent FROM Cookies;"sv));
 
-    return adopt_own(*new CookieJar { PersistedStorage { database, statements } });
+    return adopt_own(*new CookieJar { PersistedStorage { database, statements }, IsPrivate::No });
 }
 
-NonnullOwnPtr<CookieJar> CookieJar::create()
+NonnullOwnPtr<CookieJar> CookieJar::create(IsPrivate is_private)
 {
-    return adopt_own(*new CookieJar { OptionalNone {} });
+    return adopt_own(*new CookieJar { OptionalNone {}, is_private });
 }
 
-CookieJar::CookieJar(Optional<PersistedStorage> persisted_storage)
+CookieJar::CookieJar(Optional<PersistedStorage> persisted_storage, IsPrivate is_private)
     : m_persisted_storage(move(persisted_storage))
+    , m_transient_storage(is_private)
 {
     if (!m_persisted_storage.has_value())
         return;
@@ -600,6 +601,11 @@ Vector<HTTP::Cookie::Cookie> CookieJar::get_matching_cookies(URL::URL const& url
     return cookie_list;
 }
 
+CookieJar::TransientStorage::TransientStorage(IsPrivate is_private)
+    : m_is_private(is_private)
+{
+}
+
 void CookieJar::TransientStorage::set_cookies(Cookies cookies)
 {
     m_cookies = move(cookies);
@@ -685,6 +691,9 @@ Requests::CacheSizes CookieJar::TransientStorage::estimate_storage_size_accessed
 void CookieJar::TransientStorage::send_cookie_changed_notifications(ReadonlySpan<CookieEntry> cookies, bool inform_web_view_about_changed_domains)
 {
     ViewImplementation::for_each_view([&](ViewImplementation& view) {
+        if (view.is_private() != m_is_private)
+            return IterationDecision::Continue;
+
         auto retrieval_host_canonical = HTTP::Cookie::canonicalize_domain(view.url());
         if (!retrieval_host_canonical.has_value())
             return IterationDecision::Continue;

--- a/Libraries/LibWebView/CookieJar.h
+++ b/Libraries/LibWebView/CookieJar.h
@@ -19,6 +19,7 @@
 #include <LibURL/Forward.h>
 #include <LibWeb/Forward.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/PrivateBrowsing.h>
 
 namespace WebView {
 
@@ -35,7 +36,7 @@ public:
     static ErrorOr<Database::MigrationOutcome> migrate_schema(Database::Database&, Database::MigrationMode = Database::MigrationMode::Apply);
 
     static ErrorOr<NonnullOwnPtr<CookieJar>> create(Database::Database&);
-    static NonnullOwnPtr<CookieJar> create();
+    static NonnullOwnPtr<CookieJar> create(IsPrivate = IsPrivate::No);
 
     ~CookieJar();
 
@@ -64,6 +65,8 @@ private:
     class WEBVIEW_API TransientStorage {
     public:
         using Cookies = HashMap<CookieStorageKey, HTTP::Cookie::Cookie>;
+
+        explicit TransientStorage(IsPrivate);
 
         void set_cookies(Cookies);
         void set_cookie(CookieStorageKey, HTTP::Cookie::Cookie);
@@ -96,8 +99,9 @@ private:
 
     private:
         using CookieEntry = decltype(declval<Cookies>().take_all_matching(nullptr))::ValueType;
-        static void send_cookie_changed_notifications(ReadonlySpan<CookieEntry>, bool inform_web_view_about_changed_domains = true);
+        void send_cookie_changed_notifications(ReadonlySpan<CookieEntry>, bool inform_web_view_about_changed_domains = true);
 
+        IsPrivate m_is_private { IsPrivate::No };
         Cookies m_cookies;
         Cookies m_dirty_cookies;
     };
@@ -111,7 +115,7 @@ private:
         RefPtr<Core::Timer> synchronization_timer {};
     };
 
-    explicit CookieJar(Optional<PersistedStorage>);
+    CookieJar(Optional<PersistedStorage>, IsPrivate);
 
     AK_MAKE_NONCOPYABLE(CookieJar);
     AK_MAKE_NONMOVABLE(CookieJar);

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -59,7 +59,7 @@ static String status_to_error_string(Optional<Requests::NetworkError> const& net
     return MUST(String::formatted("Received error response code {} while downloading file", *response_code));
 }
 
-u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
+u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination, IsPrivate is_private)
 {
     auto download_id = start_download(url, move(destination));
     auto* active = active_download(download_id);
@@ -71,7 +71,7 @@ u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
     auto request_headers = HTTP::HeaderList::create();
     request_headers->set({ "User-Agent"sv, Web::default_user_agent });
 
-    auto request = Application::request_server_client().start_request("GET"sv, url, *request_headers);
+    auto request = Application::request_server_client(is_private).start_request("GET"sv, url, *request_headers);
     if (!request) {
         fail_download(download_id, "Unable to start request to download file"_string);
         return download_id;

--- a/Libraries/LibWebView/FileDownloader.h
+++ b/Libraries/LibWebView/FileDownloader.h
@@ -18,6 +18,7 @@
 #include <LibRequests/Forward.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/PrivateBrowsing.h>
 
 namespace Core {
 
@@ -51,7 +52,7 @@ public:
     FileDownloader();
     ~FileDownloader();
 
-    u64 download_file(URL::URL const&, LexicalPath);
+    u64 download_file(URL::URL const&, LexicalPath, IsPrivate);
     u64 adopt_download(URL::URL const&, LexicalPath, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ReadonlyBytes initial_data = {});
     u64 start_download(URL::URL const&, LexicalPath, Optional<u64> total_size = {});
     bool has_active_downloads() const;

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -26,6 +26,7 @@ class OutOfProcessWebView;
 class ProcessManager;
 class Settings;
 class SiteIsolationManager;
+class StorageJar;
 class TraversableSessionHistory;
 class ViewImplementation;
 class WebContentClient;

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -277,9 +277,9 @@ ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process()
     return client;
 }
 
-ErrorOr<IPC::TransportHandle> connect_new_request_server_client()
+ErrorOr<IPC::TransportHandle> connect_new_request_server_client(IsPrivate is_private)
 {
-    auto response = Application::request_server_client().send_sync_but_allow_failure<Messages::RequestServer::ConnectNewClient>();
+    auto response = Application::request_server_client().send_sync_but_allow_failure<Messages::RequestServer::ConnectNewClient>(is_private == IsPrivate::Yes ? RequestServer::IsPrivate::Yes : RequestServer::IsPrivate::No);
     if (!response)
         return Error::from_string_literal("Failed to connect to RequestServer");
     return response->take_handle();

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -82,7 +82,7 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(u64 initial_page_id)
+ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate is_private, u64 initial_page_id)
 {
     auto const& browser_options = WebView::Application::browser_options();
     auto const& web_content_options = WebView::Application::web_content_options();
@@ -142,7 +142,7 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(u64
         arguments.append("--mach-server-name"sv);
         arguments.append(server.value());
     }
-    return launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), initial_page_id);
+    return launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), is_private, initial_page_id);
 }
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process()

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -182,7 +182,7 @@ ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process()
     return launch_server_process<WebView::CompositorClient>("Compositor"sv, move(arguments));
 }
 
-ErrorOr<NonnullRefPtr<WebWorkerClient>> launch_web_worker_process(Web::Bindings::AgentType type, Web::HTML::WorkerAgentId agent_id)
+ErrorOr<NonnullRefPtr<WebWorkerClient>> launch_web_worker_process(Web::Bindings::AgentType type, IsPrivate is_private, Web::HTML::WorkerAgentId agent_id)
 {
     auto const& browser_options = WebView::Application::browser_options();
     auto const& web_content_options = WebView::Application::web_content_options();
@@ -218,7 +218,7 @@ ErrorOr<NonnullRefPtr<WebWorkerClient>> launch_web_worker_process(Web::Bindings:
         arguments.append(server.value());
     }
 
-    return launch_server_process<WebWorkerClient>("WebWorker"sv, move(arguments), agent_id);
+    return launch_server_process<WebWorkerClient>("WebWorker"sv, move(arguments), is_private, agent_id);
 }
 
 ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process()

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -26,7 +26,7 @@ WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_
 WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebWorkerClient>> launch_web_worker_process(Web::Bindings::AgentType, IsPrivate, Web::HTML::WorkerAgentId);
 WEBVIEW_API ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process();
 
-WEBVIEW_API ErrorOr<IPC::TransportHandle> connect_new_request_server_client(IsPrivate = IsPrivate::No);
+WEBVIEW_API ErrorOr<IPC::TransportHandle> connect_new_request_server_client(IsPrivate);
 WEBVIEW_API ErrorOr<IPC::TransportHandle> connect_new_image_decoder_client();
 
 }

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -26,7 +26,7 @@ WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_
 WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebWorkerClient>> launch_web_worker_process(Web::Bindings::AgentType, Web::HTML::WorkerAgentId);
 WEBVIEW_API ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process();
 
-WEBVIEW_API ErrorOr<IPC::TransportHandle> connect_new_request_server_client();
+WEBVIEW_API ErrorOr<IPC::TransportHandle> connect_new_request_server_client(IsPrivate = IsPrivate::No);
 WEBVIEW_API ErrorOr<IPC::TransportHandle> connect_new_image_decoder_client();
 
 }

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -23,7 +23,7 @@ WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content
 
 WEBVIEW_API ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process();
 WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process();
-WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebWorkerClient>> launch_web_worker_process(Web::Bindings::AgentType, Web::HTML::WorkerAgentId);
+WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebWorkerClient>> launch_web_worker_process(Web::Bindings::AgentType, IsPrivate, Web::HTML::WorkerAgentId);
 WEBVIEW_API ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process();
 
 WEBVIEW_API ErrorOr<IPC::TransportHandle> connect_new_request_server_client(IsPrivate = IsPrivate::No);

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -13,12 +13,13 @@
 #include <LibRequests/RequestClient.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/WebContentClient.h>
 #include <LibWebView/WebWorkerClient.h>
 
 namespace WebView {
 
-WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(u64 initial_page_id);
+WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate, u64 initial_page_id);
 
 WEBVIEW_API ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process();
 WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process();

--- a/Libraries/LibWebView/Omnibox.cpp
+++ b/Libraries/LibWebView/Omnibox.cpp
@@ -12,7 +12,8 @@ namespace WebView {
 // Wraps the real autocomplete machinery (history store, search engine, remote suggestions).
 class AutocompleteSuggestionProvider final : public OmniboxSuggestionProvider {
 public:
-    AutocompleteSuggestionProvider()
+    AutocompleteSuggestionProvider(IsPrivate is_private)
+        : m_autocomplete(is_private)
     {
         m_autocomplete.on_autocomplete_query_complete = [this](auto suggestions, auto result_kind) {
             if (on_suggestions)
@@ -132,8 +133,8 @@ static Optional<size_t> index_of_exact_search_suggestion(String const& query, Ve
     });
 }
 
-Omnibox::Omnibox()
-    : Omnibox(make<AutocompleteSuggestionProvider>())
+Omnibox::Omnibox(IsPrivate is_private)
+    : Omnibox(make<AutocompleteSuggestionProvider>(is_private))
 {
 }
 

--- a/Libraries/LibWebView/Omnibox.h
+++ b/Libraries/LibWebView/Omnibox.h
@@ -14,6 +14,7 @@
 #include <AK/Vector.h>
 #include <LibWebView/Autocomplete.h>
 #include <LibWebView/Export.h>
+#include <LibWebView/PrivateBrowsing.h>
 
 namespace WebView {
 
@@ -56,7 +57,7 @@ class WEBVIEW_API Omnibox {
     AK_MAKE_NONMOVABLE(Omnibox);
 
 public:
-    Omnibox();
+    explicit Omnibox(IsPrivate);
     explicit Omnibox(NonnullOwnPtr<OmniboxSuggestionProvider>);
     ~Omnibox();
 

--- a/Libraries/LibWebView/PrivateBrowsing.cpp
+++ b/Libraries/LibWebView/PrivateBrowsing.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/CookieJar.h>
+#include <LibWebView/HSTSStore.h>
+#include <LibWebView/HistoryStore.h>
+#include <LibWebView/PrivateBrowsing.h>
+#include <LibWebView/StorageJar.h>
+
+namespace WebView {
+
+PrivateBrowsingSession::~PrivateBrowsingSession() = default;
+
+}

--- a/Libraries/LibWebView/PrivateBrowsing.h
+++ b/Libraries/LibWebView/PrivateBrowsing.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace WebView {
+
+enum class IsPrivate : u8 {
+    No,
+    Yes,
+};
+
+}

--- a/Libraries/LibWebView/PrivateBrowsing.h
+++ b/Libraries/LibWebView/PrivateBrowsing.h
@@ -6,13 +6,24 @@
 
 #pragma once
 
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Types.h>
+#include <LibWebView/Forward.h>
 
 namespace WebView {
 
 enum class IsPrivate : u8 {
     No,
     Yes,
+};
+
+struct PrivateBrowsingSession {
+    ~PrivateBrowsingSession();
+
+    NonnullOwnPtr<CookieJar> cookie_jar;
+    NonnullOwnPtr<StorageJar> storage_jar;
+    NonnullOwnPtr<HSTSStore> hsts_store;
+    NonnullOwnPtr<HistoryStore> history_store;
 };
 
 }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2126,7 +2126,7 @@ void ViewImplementation::initialize_context_menus()
         if (download_path.is_error())
             return;
 
-        Application::the().file_downloader().download_file(m_context_menu_url, download_path.release_value());
+        Application::the().file_downloader().download_file(m_context_menu_url, download_path.release_value(), is_private());
     });
     m_copy_image_action = Action::create("Copy Image"sv, ActionID::CopyImage, [this]() {
         if (!m_image_context_menu_bitmap.has_value())

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -88,6 +88,9 @@ ViewImplementation::~ViewImplementation()
 
     if (m_client_state.client)
         m_client_state.client->unregister_view(m_client_state.page_index);
+
+    if (m_is_private == IsPrivate::Yes)
+        Application::the().maybe_close_private_browsing_session();
 }
 
 WebContentClient& ViewImplementation::client()

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -134,9 +134,10 @@ void ViewImplementation::set_favicon(Badge<WebContentClient>, Gfx::Bitmap const&
     }
 
     if (m_favicon_base64_png.has_value()) {
-        Application::bookmark_store().update_favicon(m_url, *m_favicon_base64_png);
+        if (m_is_private == IsPrivate::No)
+            Application::bookmark_store().update_favicon(m_url, *m_favicon_base64_png);
         if (!m_should_suppress_history_for_current_load)
-            Application::history_store().update_favicon(m_url, *m_favicon_base64_png);
+            Application::history_store(m_is_private).update_favicon(m_url, *m_favicon_base64_png);
     }
 
     if (on_favicon_change)
@@ -339,7 +340,7 @@ Vector<ViewImplementation::SessionHistoryTraversalMenuItem> ViewImplementation::
 
     Vector<SessionHistoryTraversalMenuItem> items;
     auto append_item = [&](size_t target_step_index, TraversableSessionHistory::Entry const& target_entry) {
-        auto history_entry = Application::history_store().entry_for_url(target_entry.url);
+        auto history_entry = Application::history_store(m_is_private).entry_for_url(target_entry.url);
         auto url = target_entry.url.serialize();
         auto title = history_entry.has_value() && history_entry->title.has_value() && !history_entry->title->is_empty()
             ? move(*history_entry->title)
@@ -383,7 +384,9 @@ void ViewImplementation::zoom_in()
         return;
     m_zoom_level = round_to<int>((m_zoom_level + ZOOM_STEP) * 100) / 100.0;
     update_zoom();
-    Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
+
+    if (m_is_private == IsPrivate::No)
+        Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
 }
 
 void ViewImplementation::zoom_out()
@@ -392,7 +395,9 @@ void ViewImplementation::zoom_out()
         return;
     m_zoom_level = round_to<int>((m_zoom_level - ZOOM_STEP) * 100) / 100.0;
     update_zoom();
-    Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
+
+    if (m_is_private == IsPrivate::No)
+        Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
 }
 
 void ViewImplementation::set_zoom(double zoom_level)
@@ -406,7 +411,9 @@ void ViewImplementation::reset_zoom()
     m_zoom_level = 1.0;
     update_zoom();
     client().async_reset_zoom(m_client_state.page_index);
-    Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
+
+    if (m_is_private == IsPrivate::No)
+        Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
 }
 
 void ViewImplementation::enqueue_input_event(Web::InputEvent event)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -48,6 +48,7 @@
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/PageInfo.h>
+#include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/SessionHistory.h>
 #include <LibWebView/Settings.h>
 #include <LibWebView/StorageSetResult.h>
@@ -65,6 +66,8 @@ public:
 
     static void for_each_view(Function<IterationDecision(ViewImplementation&)>);
     static Optional<ViewImplementation&> find_view_by_id(u64);
+
+    IsPrivate is_private() const { return m_is_private; }
 
     u64 view_id() const { return m_view_id; }
 
@@ -463,6 +466,8 @@ protected:
         u64 page_index { 0 };
         bool has_usable_bitmap { false };
     } m_client_state;
+
+    IsPrivate m_is_private { IsPrivate::No };
 
     URL::URL m_url;
     Utf16String m_title;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1369,7 +1369,7 @@ void WebContentClient::did_post_broadcast_channel_message(u64, Web::HTML::Broadc
         client.async_broadcast_channel_message(message);
         return IterationDecision::Continue;
     });
-    WorkerProcessManager::the().broadcast_channel_message_from_web_content(message);
+    WorkerProcessManager::the().broadcast_channel_message_from_web_content(message, m_is_private);
 }
 
 Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -72,8 +72,9 @@ static bool is_download_in_progress(FileDownloader const& file_downloader, u64 d
     return download.has_value() && download->status == FileDownloader::DownloadStatus::InProgress;
 }
 
-WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, u64 initial_page_id)
+WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, IsPrivate is_private, u64 initial_page_id)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
+    , m_is_private(is_private)
     , m_initial_page_id(initial_page_id)
 {
     VERIFY(m_initial_page_id > 0);
@@ -156,6 +157,7 @@ void WebContentClient::remember_compositor_context(Web::Compositor::CompositorCo
 void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
 {
     VERIFY(m_views.is_empty());
+    VERIFY(view.is_private() == m_is_private);
     view.m_client_state.page_index = m_initial_page_id;
     m_views.set(m_initial_page_id, view);
 }
@@ -168,6 +170,7 @@ void WebContentClient::set_compositor_connection_id(Badge<Application>, i32 comp
 void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 {
     VERIFY(page_id > 0);
+    VERIFY(view.is_private() == m_is_private);
     if (m_detached_page_close_timer)
         m_detached_page_close_timer->stop();
     Application::process_manager().cancel_forced_exit(pid());
@@ -450,7 +453,7 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
     if (!site_isolation_manager.has_matching_pending_child_frame_navigation(page_id, frame_id, url, ChildFrameOwner::Remote))
         return;
 
-    auto remote_process_or_error = Application::the().launch_child_frame_web_content_process();
+    auto remote_process_or_error = Application::the().launch_child_frame_web_content_process(m_is_private);
     if (remote_process_or_error.is_error()) {
         warnln("Unable to create WebContent process for child frame navigation: {}", remote_process_or_error.error());
         site_isolation_manager.clear_pending_child_frame_navigation(page_id, frame_id);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -85,6 +85,9 @@ WebContentClient::~WebContentClient()
 {
     WorkerProcessManager::the().remove_web_content_owner(*this);
     clients().remove(this);
+
+    if (m_is_private == IsPrivate::Yes)
+        Application::the().maybe_close_private_browsing_session();
 }
 
 Optional<WebContentClient&> WebContentClient::client_for_compositor_context_id(Web::Compositor::CompositorContextId context_id)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -528,7 +528,7 @@ void WebContentClient::maybe_record_history_visit_for_current_load(u64 page_id, 
 
     // Title and favicon updates already give us a useful history entry, so
     // do not wait for did_finish_loading() on pages that never reach it.
-    Application::history_store().record_visit(url, move(title));
+    Application::history_store(m_is_private).record_visit(url, move(title));
     m_history_recorded_urls_for_current_load.set(page_id, normalized_url.release_value());
 }
 
@@ -668,9 +668,9 @@ void WebContentClient::did_finish_loading(u64 page_id, URL::URL url)
 
             maybe_record_history_visit_for_current_load(page_id, url, title, "load finish"sv);
             if (title.has_value())
-                Application::history_store().update_title(url, *title);
+                Application::history_store(m_is_private).update_title(url, *title);
             if (view->favicon_base64_png().has_value())
-                Application::history_store().update_favicon(url, *view->favicon_base64_png());
+                Application::history_store(m_is_private).update_favicon(url, *view->favicon_base64_png());
         }
 
         view->did_finish_navigation(client_url);
@@ -754,7 +754,7 @@ void WebContentClient::did_change_title(u64 page_id, Utf16String title)
                 view->url(),
                 title_utf8);
 
-            Application::history_store().update_title(view->url(), title_utf8);
+            Application::history_store(m_is_private).update_title(view->url(), title_utf8);
         }
 
         if (title.is_empty())
@@ -1240,23 +1240,23 @@ void WebContentClient::did_request_document_cookie_version_index(u64 page_id, i6
 
 Messages::WebContentClient::DidRequestAllCookiesWebdriverResponse WebContentClient::did_request_all_cookies_webdriver(URL::URL url)
 {
-    return Application::cookie_jar().get_all_cookies_webdriver(url);
+    return Application::cookie_jar(m_is_private).get_all_cookies_webdriver(url);
 }
 
 Messages::WebContentClient::DidRequestAllCookiesCookiestoreResponse WebContentClient::did_request_all_cookies_cookiestore(URL::URL url)
 {
-    return Application::cookie_jar().get_all_cookies_cookiestore(url);
+    return Application::cookie_jar(m_is_private).get_all_cookies_cookiestore(url);
 }
 
 Messages::WebContentClient::DidRequestNamedCookieResponse WebContentClient::did_request_named_cookie(URL::URL url, String name)
 {
-    return Application::cookie_jar().get_named_cookie(url, name);
+    return Application::cookie_jar(m_is_private).get_named_cookie(url, name);
 }
 
 Messages::WebContentClient::DidRequestCookieResponse WebContentClient::did_request_cookie(u64 page_id, URL::URL url, HTTP::Cookie::Source source)
 {
     HTTP::Cookie::VersionedCookie cookie;
-    cookie.cookie = Application::cookie_jar().get_cookie(url, source);
+    cookie.cookie = Application::cookie_jar(m_is_private).get_cookie(url, source);
 
     if (source == HTTP::Cookie::Source::NonHttp) {
         if (auto view = view_for_page_id(page_id); view.has_value())
@@ -1268,63 +1268,63 @@ Messages::WebContentClient::DidRequestCookieResponse WebContentClient::did_reque
 
 void WebContentClient::did_set_cookie(URL::URL url, HTTP::Cookie::ParsedCookie cookie, HTTP::Cookie::Source source)
 {
-    Application::cookie_jar().set_cookie(url, cookie, source);
+    Application::cookie_jar(m_is_private).set_cookie(url, cookie, source);
 }
 
 void WebContentClient::did_update_cookie(HTTP::Cookie::Cookie cookie)
 {
-    Application::cookie_jar().update_cookie(cookie);
+    Application::cookie_jar(m_is_private).update_cookie(cookie);
 }
 
 void WebContentClient::did_expire_cookies_with_time_offset(AK::Duration offset)
 {
-    Application::cookie_jar().expire_cookies_with_time_offset(offset);
+    Application::cookie_jar(m_is_private).expire_cookies_with_time_offset(offset);
 }
 
 void WebContentClient::did_request_delete_all_cookies(u64 page_id, u64 request_id, URL::URL url)
 {
-    Application::cookie_jar().delete_all_cookies(url);
+    Application::cookie_jar(m_is_private).delete_all_cookies(url);
     async_did_delete_all_cookies(page_id, request_id);
 }
 
 void WebContentClient::did_store_hsts_policy(String domain, HTTP::HSTS::ParsedHSTSPolicy policy)
 {
-    Application::hsts_store().store_policy(domain, policy);
+    Application::hsts_store(m_is_private).store_policy(domain, policy);
 }
 
 Messages::WebContentClient::DidIsKnownHstsHostResponse WebContentClient::did_is_known_hsts_host(String domain)
 {
-    return Application::hsts_store().is_known_hsts_host(domain);
+    return Application::hsts_store(m_is_private).is_known_hsts_host(domain);
 }
 
 Messages::WebContentClient::DidRequestStorageItemResponse WebContentClient::did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key)
 {
-    return Application::storage_jar().get_item(storage_endpoint, storage_key, bottle_key);
+    return Application::storage_jar(m_is_private).get_item(storage_endpoint, storage_key, bottle_key);
 }
 
 Messages::WebContentClient::DidSetStorageItemResponse WebContentClient::did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key, String value)
 {
-    return Application::storage_jar().set_item(storage_endpoint, storage_key, bottle_key, value);
+    return Application::storage_jar(m_is_private).set_item(storage_endpoint, storage_key, bottle_key, value);
 }
 
 void WebContentClient::did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key)
 {
-    Application::storage_jar().remove_item(storage_endpoint, storage_key, bottle_key);
+    Application::storage_jar(m_is_private).remove_item(storage_endpoint, storage_key, bottle_key);
 }
 
 Messages::WebContentClient::DidRequestStorageKeysResponse WebContentClient::did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key)
 {
-    return Application::storage_jar().get_all_keys(storage_endpoint, storage_key);
+    return Application::storage_jar(m_is_private).get_all_keys(storage_endpoint, storage_key);
 }
 
 void WebContentClient::did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key)
 {
-    Application::storage_jar().clear_storage_key(storage_endpoint, storage_key);
+    Application::storage_jar(m_is_private).clear_storage_key(storage_endpoint, storage_key);
 }
 
 Messages::WebContentClient::DidRequestStorageUsageResponse WebContentClient::did_request_storage_usage(String storage_key)
 {
-    return Application::storage_jar().usage(storage_key);
+    return Application::storage_jar(m_is_private).usage(storage_key);
 }
 
 void WebContentClient::did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<String> key, Optional<String> old_value, Optional<String> new_value)
@@ -1363,6 +1363,8 @@ void WebContentClient::did_post_broadcast_channel_message(u64, Web::HTML::Broadc
 {
     WebContentClient::for_each_client([&](auto& client) {
         if (client.pid() == message.source_process_id)
+            return IterationDecision::Continue;
+        if (client.is_private() != m_is_private)
             return IterationDecision::Continue;
         client.async_broadcast_channel_message(message);
         return IterationDecision::Continue;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -38,6 +38,7 @@
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/SiteIsolationManager.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentServerEndpoint.h>
@@ -62,14 +63,18 @@ public:
     static size_t client_count() { return clients().size(); }
     static Optional<WebContentClient&> client_for_compositor_context_id(Web::Compositor::CompositorContextId);
 
-    WebContentClient(NonnullOwnPtr<IPC::Transport>, u64 initial_page_id);
+    WebContentClient(NonnullOwnPtr<IPC::Transport>, IsPrivate, u64 initial_page_id);
     ~WebContentClient();
 
+    IsPrivate is_private() const { return m_is_private; }
+
     void assign_view(Badge<Application>, ViewImplementation&);
-    void set_compositor_connection_id(Badge<Application>, i32);
-    Optional<i32> compositor_connection_id(Badge<Application>) const { return m_compositor_connection_id; }
     void register_view(u64 page_id, ViewImplementation&);
     void unregister_view(u64 page_id);
+
+    void set_compositor_connection_id(Badge<Application>, i32);
+    Optional<i32> compositor_connection_id(Badge<Application>) const { return m_compositor_connection_id; }
+
     void prepare_for_detached_close(u64 page_id);
     void request_close(u64 page_id);
 
@@ -255,6 +260,8 @@ private:
     bool is_renderer_owned_download(u64 page_id, u64 download_id) const;
     void forget_renderer_owned_download(u64 download_id);
     void fail_renderer_owned_downloads();
+
+    IsPrivate m_is_private { IsPrivate::No };
 
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
     HashTable<u64> m_embedded_pages;

--- a/Libraries/LibWebView/WebUI.h
+++ b/Libraries/LibWebView/WebUI.h
@@ -33,6 +33,8 @@ public:
 protected:
     WebUI(WebContentClient&, NonnullOwnPtr<IPC::Transport>, String host);
 
+    WebContentClient& client() const { return m_client; }
+
     using Interface = Function<void(JsonValue)>;
 
     virtual void register_interfaces() { }

--- a/Libraries/LibWebView/WebUI/HistoryUI.cpp
+++ b/Libraries/LibWebView/WebUI/HistoryUI.cpp
@@ -9,6 +9,7 @@
 #include <LibURL/Parser.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/HistoryStore.h>
+#include <LibWebView/WebContentClient.h>
 #include <LibWebView/WebUI/HistoryUI.h>
 
 #include <algorithm>
@@ -75,7 +76,7 @@ void HistoryUI::load_history_entries(JsonValue const& data)
     else
         limit = DEFAULT_HISTORY_PAGE_SIZE;
 
-    auto entries = Application::history_store().list_entries(query, offset, *limit + 1);
+    auto entries = Application::history_store(client().is_private()).list_entries(query, offset, *limit + 1);
     auto has_more = entries.size() > *limit;
     if (has_more)
         entries.resize(*limit);
@@ -108,7 +109,7 @@ void HistoryUI::remove_history_entry(JsonValue const& data)
     if (!parsed_url.has_value())
         return;
 
-    Application::history_store().remove_entry_for_url(*parsed_url);
+    Application::history_store(client().is_private()).remove_entry_for_url(*parsed_url);
 }
 
 void HistoryUI::forget_history_site(JsonValue const& data)
@@ -124,7 +125,7 @@ void HistoryUI::forget_history_site(JsonValue const& data)
     if (!parsed_url.has_value())
         return;
 
-    Application::history_store().remove_entries_for_same_site(*parsed_url);
+    Application::history_store(client().is_private()).remove_entries_for_same_site(*parsed_url);
 }
 
 }

--- a/Libraries/LibWebView/WebWorkerClient.cpp
+++ b/Libraries/LibWebView/WebWorkerClient.cpp
@@ -12,6 +12,15 @@
 
 namespace WebView {
 
+WebWorkerClient::WebWorkerClient(NonnullOwnPtr<IPC::Transport> transport, IsPrivate is_private, Web::HTML::WorkerAgentId agent_id)
+    : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport))
+    , m_is_private(is_private)
+    , m_agent_id(agent_id)
+{
+}
+
+WebWorkerClient::~WebWorkerClient() = default;
+
 void WebWorkerClient::die()
 {
     WorkerProcessManager::the().worker_did_die(m_agent_id);
@@ -43,7 +52,7 @@ void WebWorkerClient::did_report_worker_exception(String message, String filenam
 Messages::WebWorkerClient::DidRequestCookieResponse WebWorkerClient::did_request_cookie(URL::URL url, HTTP::Cookie::Source source)
 {
     HTTP::Cookie::VersionedCookie cookie;
-    cookie.cookie = Application::cookie_jar().get_cookie(url, source);
+    cookie.cookie = Application::cookie_jar(m_is_private).get_cookie(url, source);
     return cookie;
 }
 
@@ -54,12 +63,12 @@ void WebWorkerClient::did_request_file(ByteString path, i32 request_id)
 
 void WebWorkerClient::did_store_hsts_policy(String domain, HTTP::HSTS::ParsedHSTSPolicy policy)
 {
-    Application::hsts_store().store_policy(domain, policy);
+    Application::hsts_store(m_is_private).store_policy(domain, policy);
 }
 
 Messages::WebWorkerClient::DidIsKnownHstsHostResponse WebWorkerClient::did_is_known_hsts_host(String domain)
 {
-    return Application::hsts_store().is_known_hsts_host(domain);
+    return Application::hsts_store(m_is_private).is_known_hsts_host(domain);
 }
 
 void WebWorkerClient::did_post_broadcast_channel_message(Web::HTML::BroadcastChannelMessage message)
@@ -76,13 +85,5 @@ void WebWorkerClient::close_worker_agent(Web::HTML::WorkerAgentId agent_id, Web:
 {
     WorkerProcessManager::the().close_worker_agent(*this, agent_id, owner_token);
 }
-
-WebWorkerClient::WebWorkerClient(NonnullOwnPtr<IPC::Transport> transport, Web::HTML::WorkerAgentId agent_id)
-    : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport))
-    , m_agent_id(agent_id)
-{
-}
-
-WebWorkerClient::~WebWorkerClient() = default;
 
 }

--- a/Libraries/LibWebView/WebWorkerClient.h
+++ b/Libraries/LibWebView/WebWorkerClient.h
@@ -17,6 +17,7 @@
 #include <LibWeb/Worker/WebWorkerClientEndpoint.h>
 #include <LibWeb/Worker/WebWorkerServerEndpoint.h>
 #include <LibWebView/Export.h>
+#include <LibWebView/PrivateBrowsing.h>
 
 namespace WebView {
 
@@ -28,8 +29,10 @@ class WEBVIEW_API WebWorkerClient final
 public:
     using InitTransport = Messages::WebWorkerServer::InitTransport;
 
-    explicit WebWorkerClient(NonnullOwnPtr<IPC::Transport>, Web::HTML::WorkerAgentId agent_id);
+    WebWorkerClient(NonnullOwnPtr<IPC::Transport>, IsPrivate, Web::HTML::WorkerAgentId agent_id);
     ~WebWorkerClient();
+
+    IsPrivate is_private() const { return m_is_private; }
 
     pid_t pid() const { return m_pid; }
     void set_pid(pid_t pid) { m_pid = pid; }
@@ -48,6 +51,8 @@ public:
 
 private:
     virtual void die() override;
+
+    IsPrivate m_is_private { IsPrivate::No };
 
     pid_t m_pid { -1 };
     Web::HTML::WorkerAgentId m_agent_id { 0 };

--- a/Libraries/LibWebView/WorkerProcessManager.cpp
+++ b/Libraries/LibWebView/WorkerProcessManager.cpp
@@ -29,7 +29,7 @@ Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(WebContentClie
         },
         .token = request.owner_token,
     };
-    return start_worker_agent(move(abstract_owner), move(request));
+    return start_worker_agent(move(abstract_owner), move(request), owner.is_private());
 }
 
 Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(WebWorkerClient& owner, Web::HTML::WorkerAgentStartRequest request)
@@ -40,15 +40,16 @@ Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(WebWorkerClien
         },
         .token = request.owner_token,
     };
-    return start_worker_agent(move(abstract_owner), move(request));
+    return start_worker_agent(move(abstract_owner), move(request), owner.is_private());
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworker
-Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(Owner owner, Web::HTML::WorkerAgentStartRequest request)
+Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(Owner owner, Web::HTML::WorkerAgentStartRequest request, IsPrivate is_private)
 {
     // 11.1. Let workerGlobalScope be null.
     if (request.agent_type == Web::Bindings::AgentType::SharedWorker) {
         SharedWorkerKey key {
+            .is_private = is_private,
             .storage_key = request.storage_key,
             .url = request.url,
             .name = request.name,
@@ -111,9 +112,9 @@ Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(Owner owner, W
     // AD-HOC: For DedicatedWorker there is no shared worker manager step; we always launch a fresh
     //         worker process here.
     auto agent_id = ++m_next_agent_id;
-    auto client = MUST(launch_web_worker_process(request.agent_type, agent_id));
+    auto client = MUST(launch_web_worker_process(request.agent_type, is_private, agent_id));
 
-    auto request_server_handle = MUST(connect_new_request_server_client());
+    auto request_server_handle = MUST(connect_new_request_server_client(is_private));
     auto image_decoder_handle = MUST(connect_new_image_decoder_client());
     client->async_connect_to_request_server(move(request_server_handle));
     client->async_connect_to_image_decoder(move(image_decoder_handle));
@@ -133,12 +134,14 @@ Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(Owner owner, W
         .credentials = request.credentials,
         .extended_lifetime = request.extended_lifetime,
         .worker_is_secure_context = request.caller_is_secure_context,
+        .is_private = is_private,
         .shared_worker_key = {},
         .owners = move(owners),
     };
 
     if (request.agent_type == Web::Bindings::AgentType::SharedWorker) {
         agent.shared_worker_key = SharedWorkerKey {
+            .is_private = is_private,
             .storage_key = request.storage_key,
             .url = request.url,
             .name = request.name,
@@ -204,11 +207,13 @@ void WorkerProcessManager::remove_web_worker_owner(WebWorkerClient& client)
         remove_agent(agent_id);
 }
 
-void WorkerProcessManager::broadcast_channel_message_from_web_content(Web::HTML::BroadcastChannelMessage const& message)
+void WorkerProcessManager::broadcast_channel_message_from_web_content(Web::HTML::BroadcastChannelMessage const& message, IsPrivate is_private)
 {
     for (auto& entry : m_agents) {
         auto& agent = entry.value;
         if (agent.client->pid() == message.source_process_id)
+            continue;
+        if (agent.is_private != is_private)
             continue;
         agent.client->async_broadcast_channel_message(message);
     }
@@ -345,8 +350,15 @@ void WorkerProcessManager::worker_did_request_file(Web::HTML::WorkerAgentId agen
 
 void WorkerProcessManager::worker_did_post_broadcast_channel_message(Web::HTML::WorkerAgentId agent_id, Web::HTML::BroadcastChannelMessage message)
 {
+    auto source_agent = m_agents.find(agent_id);
+    if (source_agent == m_agents.end())
+        return;
+    auto source_is_private = source_agent->value.is_private;
+
     WebContentClient::for_each_client([&](auto& client) {
         if (client.pid() == message.source_process_id)
+            return IterationDecision::Continue;
+        if (client.is_private() != source_is_private)
             return IterationDecision::Continue;
         client.async_broadcast_channel_message(message);
         return IterationDecision::Continue;
@@ -357,6 +369,8 @@ void WorkerProcessManager::worker_did_post_broadcast_channel_message(Web::HTML::
             continue;
         auto& agent = entry.value;
         if (agent.client->pid() == message.source_process_id)
+            continue;
+        if (agent.is_private != source_is_private)
             continue;
         agent.client->async_broadcast_channel_message(message);
     }

--- a/Libraries/LibWebView/WorkerProcessManager.h
+++ b/Libraries/LibWebView/WorkerProcessManager.h
@@ -15,6 +15,7 @@
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/PrivateBrowsing.h>
 
 namespace WebView {
 
@@ -23,6 +24,7 @@ public:
     static WorkerProcessManager& the();
 
     struct SharedWorkerKey {
+        IsPrivate is_private { IsPrivate::No };
         Web::StorageAPI::StorageKey storage_key;
         URL::URL url;
         String name;
@@ -38,7 +40,7 @@ public:
     void remove_web_content_owner(WebContentClient&);
     void remove_web_worker_owner(WebWorkerClient&);
 
-    void broadcast_channel_message_from_web_content(Web::HTML::BroadcastChannelMessage const&);
+    void broadcast_channel_message_from_web_content(Web::HTML::BroadcastChannelMessage const&, IsPrivate);
 
 private:
     friend class WebWorkerClient;
@@ -59,7 +61,7 @@ private:
         Web::HTML::WorkerAgentOwnerToken token { 0 };
     };
 
-    Web::HTML::WorkerAgentId start_worker_agent(Owner, Web::HTML::WorkerAgentStartRequest);
+    Web::HTML::WorkerAgentId start_worker_agent(Owner, Web::HTML::WorkerAgentStartRequest, IsPrivate);
 
     void notify_worker_script_load_success(Owner const&);
     void notify_worker_script_load_failure(Owner const&);
@@ -86,6 +88,7 @@ private:
         bool extended_lifetime { false };
         Optional<bool> worker_is_secure_context;
         bool closing { false };
+        IsPrivate is_private { IsPrivate::No };
         Optional<SharedWorkerKey> shared_worker_key;
         Vector<Owner> owners;
     };
@@ -103,7 +106,7 @@ template<>
 struct Traits<WebView::WorkerProcessManager::SharedWorkerKey> : public DefaultTraits<WebView::WorkerProcessManager::SharedWorkerKey> {
     static unsigned hash(WebView::WorkerProcessManager::SharedWorkerKey const& key)
     {
-        return pair_int_hash(pair_int_hash(Traits<Web::StorageAPI::StorageKey>::hash(key.storage_key), Traits<URL::URL>::hash(key.url)), key.name.hash());
+        return pair_int_hash(pair_int_hash(pair_int_hash(Traits<Web::StorageAPI::StorageKey>::hash(key.storage_key), Traits<URL::URL>::hash(key.url)), key.name.hash()), static_cast<unsigned>(key.is_private));
     }
 };
 

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -82,14 +82,17 @@ static auto time_curl_call(StringView label, F&& f)
 static constexpr i64 BURST_WINDOW_MS = 100;
 static constexpr u64 BURST_REPORT_THRESHOLD = 5;
 
-ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport, IsPrimaryConnection is_primary_connection, ConnectionMap& connections, Optional<HTTP::DiskCache&> disk_cache)
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport, IsPrimaryConnection is_primary_connection, IsPrivate is_private, ConnectionMap& connections, Optional<HTTP::DiskCache&> disk_cache)
     : IPC::ConnectionFromClient<RequestClientEndpoint, RequestServerEndpoint>(*this, move(transport), s_client_ids.allocate())
+    , m_is_private(is_private)
     , m_connections(connections)
     , m_disk_cache(disk_cache)
     , m_curl_multi(curl_multi_init())
     , m_resolver(Resolver::default_resolver())
-    , m_alt_svc_cache_path(ByteString::formatted("{}/Ladybird/alt-svc-cache.txt", Core::StandardPaths::cache_directory()))
 {
+    if (m_is_private == IsPrivate::No)
+        m_alt_svc_cache_path = ByteString::formatted("{}/Ladybird/alt-svc-cache.txt", Core::StandardPaths::cache_directory());
+
     if (is_primary_connection == IsPrimaryConnection::Yes) {
         VERIFY(g_primary_connection == nullptr);
         g_primary_connection = this;
@@ -172,9 +175,9 @@ Messages::RequestServer::InitTransportResponse ConnectionFromClient::init_transp
     VERIFY_NOT_REACHED();
 }
 
-Messages::RequestServer::ConnectNewClientResponse ConnectionFromClient::connect_new_client()
+Messages::RequestServer::ConnectNewClientResponse ConnectionFromClient::connect_new_client(IsPrivate is_private)
 {
-    auto client_socket = create_client_socket();
+    auto client_socket = create_client_socket(is_private);
     if (client_socket.is_error()) {
         dbgln("Failed to create client socket: {}", client_socket.error());
         return IPC::TransportHandle {};
@@ -183,13 +186,13 @@ Messages::RequestServer::ConnectNewClientResponse ConnectionFromClient::connect_
     return client_socket.release_value();
 }
 
-Messages::RequestServer::ConnectNewClientsResponse ConnectionFromClient::connect_new_clients(size_t count)
+Messages::RequestServer::ConnectNewClientsResponse ConnectionFromClient::connect_new_clients(size_t count, IsPrivate is_private)
 {
     Vector<IPC::TransportHandle> handles;
     handles.ensure_capacity(count);
 
     for (size_t i = 0; i < count; ++i) {
-        auto client_socket = create_client_socket();
+        auto client_socket = create_client_socket(is_private);
         if (client_socket.is_error()) {
             dbgln("Failed to create client socket: {}", client_socket.error());
             return Vector<IPC::TransportHandle> {};
@@ -201,13 +204,14 @@ Messages::RequestServer::ConnectNewClientsResponse ConnectionFromClient::connect
     return handles;
 }
 
-ErrorOr<IPC::TransportHandle> ConnectionFromClient::create_client_socket()
+ErrorOr<IPC::TransportHandle> ConnectionFromClient::create_client_socket(IsPrivate is_private)
 {
     auto paired = TRY(IPC::Transport::create_paired());
     auto handle = move(paired.remote_handle);
+    auto disk_cache = is_private == IsPrivate::Yes ? Optional<HTTP::DiskCache&> {} : m_disk_cache;
 
     // Note: A ref is stored in the m_connections map
-    auto client = adopt_ref(*new ConnectionFromClient(move(paired.local), IsPrimaryConnection::No, m_connections, m_disk_cache));
+    auto client = adopt_ref(*new ConnectionFromClient(move(paired.local), IsPrimaryConnection::No, is_private, m_connections, disk_cache));
 
     return handle;
 }

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -19,6 +19,7 @@
 #include <LibRequests/WebSocket.h>
 #include <LibWebSocket/WebSocket.h>
 #include <RequestServer/Forward.h>
+#include <RequestServer/IsPrivate.h>
 #include <RequestServer/RequestClientEndpoint.h>
 #include <RequestServer/RequestServerEndpoint.h>
 
@@ -42,15 +43,17 @@ public:
 
     static Optional<ConnectionFromClient&> primary_connection();
 
+    IsPrivate is_private() const { return m_is_private; }
+
     void start_revalidation_request(Badge<Request>, ByteString method, URL::URL, NonnullRefPtr<HTTP::HeaderList> request_headers, ByteBuffer request_body, HTTP::Cookie::IncludeCredentials, Core::ProxyData proxy_data);
     void request_complete(Badge<Request>, Request const&);
 
 private:
-    ConnectionFromClient(NonnullOwnPtr<IPC::Transport>, IsPrimaryConnection, ConnectionMap&, Optional<HTTP::DiskCache&>);
+    ConnectionFromClient(NonnullOwnPtr<IPC::Transport>, IsPrimaryConnection, IsPrivate, ConnectionMap&, Optional<HTTP::DiskCache&>);
 
     virtual Messages::RequestServer::InitTransportResponse init_transport(int peer_pid) override;
-    virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client() override;
-    virtual Messages::RequestServer::ConnectNewClientsResponse connect_new_clients(size_t count) override;
+    virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client(IsPrivate) override;
+    virtual Messages::RequestServer::ConnectNewClientsResponse connect_new_clients(size_t count, IsPrivate) override;
 
     virtual void set_disk_cache_settings(HTTP::DiskCacheSettings) override;
 
@@ -84,7 +87,9 @@ private:
     void check_active_requests();
     void fail_websocket(u64 websocket_id, Requests::WebSocket::Error);
 
-    ErrorOr<IPC::TransportHandle> create_client_socket();
+    ErrorOr<IPC::TransportHandle> create_client_socket(IsPrivate);
+
+    IsPrivate m_is_private { IsPrivate::No };
 
     ConnectionMap& m_connections;
     Optional<HTTP::DiskCache&> m_disk_cache;
@@ -101,7 +106,7 @@ private:
     HashMap<int, NonnullRefPtr<Core::Notifier>> m_write_notifiers;
 
     NonnullRefPtr<Resolver> m_resolver;
-    ByteString m_alt_svc_cache_path;
+    Optional<ByteString> m_alt_svc_cache_path;
 
     u64 m_next_revalidation_request_id { 0 };
 

--- a/Services/RequestServer/IsPrivate.h
+++ b/Services/RequestServer/IsPrivate.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace RequestServer {
+
+enum class IsPrivate : u8 {
+    No,
+    Yes,
+};
+
+}

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -854,7 +854,7 @@ void Request::handle_retrieve_cookie_state()
 
     if (auto connection = ConnectionFromClient::primary_connection(); connection.has_value()) {
         mark_lifecycle_event(this, &WireStats::cookie_started_at);
-        connection->async_retrieve_http_cookie(m_client->client_id(), m_request_id, m_type, m_url);
+        connection->async_retrieve_http_cookie(m_client->client_id(), m_request_id, m_type, m_url, m_client->is_private());
     } else {
         m_network_error = Requests::NetworkError::RequestServerDied;
         transition_to_state(State::Error);

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -375,7 +375,7 @@ NonnullOwnPtr<Request> Request::fetch(
     NonnullRefPtr<HTTP::HeaderList> request_headers,
     ByteBuffer request_body,
     HTTP::Cookie::IncludeCredentials include_credentials,
-    ByteString alt_svc_cache_path,
+    Optional<ByteString> alt_svc_cache_path,
     Core::ProxyData proxy_data,
     bool keep_alive_for_transfer)
 {
@@ -410,7 +410,7 @@ NonnullOwnPtr<Request> Request::revalidate(
     NonnullRefPtr<HTTP::HeaderList> request_headers,
     ByteBuffer request_body,
     HTTP::Cookie::IncludeCredentials include_credentials,
-    ByteString alt_svc_cache_path,
+    Optional<ByteString> alt_svc_cache_path,
     Core::ProxyData proxy_data)
 {
     auto request = adopt_own(*new Request { request_id, RequestType::BackgroundRevalidation, disk_cache, HTTP::CacheMode::Default, client, curl_multi, resolver, move(url), move(method), move(request_headers), move(request_body), include_credentials, move(alt_svc_cache_path), proxy_data });
@@ -432,7 +432,7 @@ Request::Request(
     NonnullRefPtr<HTTP::HeaderList> request_headers,
     ByteBuffer request_body,
     HTTP::Cookie::IncludeCredentials include_credentials,
-    ByteString alt_svc_cache_path,
+    Optional<ByteString> alt_svc_cache_path,
     Core::ProxyData proxy_data,
     bool keep_alive_for_transfer)
     : m_request_id(request_id)
@@ -934,7 +934,9 @@ void Request::handle_fetch_state()
     set_option(CURLOPT_PORT, m_url.port_or_default());
     set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
     set_option(CURLOPT_PIPEWAIT, 1L);
-    set_option(CURLOPT_ALTSVC, m_alt_svc_cache_path.characters());
+
+    if (m_alt_svc_cache_path.has_value())
+        set_option(CURLOPT_ALTSVC, m_alt_svc_cache_path->characters());
 
     set_option(CURLOPT_CUSTOMREQUEST, m_method.characters());
     set_option(CURLOPT_FOLLOWLOCATION, 0);

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -45,7 +45,7 @@ public:
         NonnullRefPtr<HTTP::HeaderList> request_headers,
         ByteBuffer request_body,
         HTTP::Cookie::IncludeCredentials include_credentials,
-        ByteString alt_svc_cache_path,
+        Optional<ByteString> alt_svc_cache_path,
         Core::ProxyData proxy_data,
         bool keep_alive_for_transfer);
 
@@ -68,7 +68,7 @@ public:
         NonnullRefPtr<HTTP::HeaderList> request_headers,
         ByteBuffer request_body,
         HTTP::Cookie::IncludeCredentials include_credentials,
-        ByteString alt_svc_cache_path,
+        Optional<ByteString> alt_svc_cache_path,
         Core::ProxyData proxy_data);
 
     virtual ~Request() override;
@@ -155,7 +155,7 @@ private:
         NonnullRefPtr<HTTP::HeaderList> request_headers,
         ByteBuffer request_body,
         HTTP::Cookie::IncludeCredentials include_credentials,
-        ByteString alt_svc_cache_path,
+        Optional<ByteString> alt_svc_cache_path,
         Core::ProxyData proxy_data,
         bool keep_alive_for_transfer = false);
 
@@ -226,7 +226,7 @@ private:
 
     HTTP::Cookie::IncludeCredentials m_include_credentials { HTTP::Cookie::IncludeCredentials::Yes };
 
-    ByteString m_alt_svc_cache_path;
+    Optional<ByteString> m_alt_svc_cache_path;
     Core::ProxyData m_proxy_data;
 
     Optional<u32> m_status_code;

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -3,6 +3,7 @@
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
+#include <RequestServer/IsPrivate.h>
 #include <RequestServer/RequestType.h>
 
 endpoint RequestClient
@@ -14,7 +15,7 @@ endpoint RequestClient
     headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key) =|
     request_transferred(u64 request_id) =|
 
-    retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, URL::URL url) =|
+    retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, URL::URL url, ::RequestServer::IsPrivate is_private) =|
 
     // Websocket API
     // FIXME: See if this can be merged with the regular APIs

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -8,13 +8,14 @@
 #include <LibIPC/TransportHandle.h>
 #include <LibURL/URL.h>
 #include <RequestServer/CacheLevel.h>
+#include <RequestServer/IsPrivate.h>
 #include <RequestServer/RequestType.h>
 
 endpoint RequestServer
 {
     init_transport(int peer_pid) => (int peer_pid)
-    connect_new_client() => (IPC::TransportHandle handle)
-    connect_new_clients(size_t count) => (Vector<IPC::TransportHandle> handles)
+    connect_new_client(::RequestServer::IsPrivate is_private) => (IPC::TransportHandle handle)
+    connect_new_clients(size_t count, ::RequestServer::IsPrivate is_private) => (Vector<IPC::TransportHandle> handles)
 
     set_disk_cache_settings(HTTP::DiskCacheSettings disk_cache_settings) =|
 

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -109,7 +109,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<RequestServer::ConnectionFromClient>(
         mach_server_name,
-        RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes, connections, disk_cache));
+        RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes,
+        RequestServer::IsPrivate::No,
+        connections,
+        disk_cache));
 
     return event_loop.exec();
 }

--- a/Tests/LibWebView/TestAutocomplete.cpp
+++ b/Tests/LibWebView/TestAutocomplete.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         .query_url = "http://127.0.0.1:47919/{}"sv,
     });
 
-    WebView::Autocomplete autocomplete;
+    WebView::Autocomplete autocomplete { WebView::IsPrivate::No };
 
     auto completed = false;
     autocomplete.on_autocomplete_query_complete = [&](auto const&, WebView::AutocompleteResultKind kind) {

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -386,7 +386,7 @@ static NSImage* location_field_globe_icon()
         m_fullscreen_should_restore_tab_bar = false;
 
         self.autocomplete = [[Autocomplete alloc] init:self withToolbarItem:self.location_toolbar_item];
-        m_autocomplete = make<WebView::Autocomplete>();
+        m_autocomplete = make<WebView::Autocomplete>(WebView::IsPrivate::No);
 
         m_autocomplete->on_autocomplete_query_complete = [weak_self](auto suggestions, WebView::AutocompleteResultKind result_kind) {
             TabController* self = weak_self;

--- a/UI/Gtk/Widgets/LadybirdLocationEntry.cpp
+++ b/UI/Gtk/Widgets/LadybirdLocationEntry.cpp
@@ -90,7 +90,7 @@ static void ladybird_location_entry_class_init(LadybirdLocationEntryClass* klass
 static void ladybird_location_entry_init(LadybirdLocationEntry* self)
 {
     self->state = adopt_own(*new LocationEntryState {
-        .autocomplete = make<WebView::Autocomplete>(),
+        .autocomplete = make<WebView::Autocomplete>(WebView::IsPrivate::No),
         .suggestions = {},
         .favicon = {},
         .selected_index = -1,

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -161,7 +161,7 @@ public:
 
         auto* file_menu = m_application_menu_bar->addMenu("&File");
 
-        auto* new_tab_action = add_application_menu_action(*file_menu, "New &Tab", QKeySequence::keyBindings(QKeySequence::StandardKey::AddTab));
+        auto* new_tab_action = add_application_menu_action(*file_menu, "New &Tab", { QKeySequence(Qt::CTRL | Qt::Key_T) });
         QObject::connect(new_tab_action, &QAction::triggered, this, [] {
             Application::the().open_new_tab();
         });

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -131,7 +131,7 @@ public:
 
 #if defined(AK_OS_MACOS)
         if (event_type == QEvent::ApplicationActivate && !has_visible_browser_window())
-            application.open_new_window();
+            application.open_new_window(WebView::IsPrivate::No);
 #endif
 
         return handled;
@@ -168,7 +168,12 @@ public:
 
         auto* new_window_action = add_application_menu_action(*file_menu, "New &Window", QKeySequence::keyBindings(QKeySequence::StandardKey::New));
         QObject::connect(new_window_action, &QAction::triggered, this, [] {
-            Application::the().open_new_window();
+            Application::the().open_new_window(WebView::IsPrivate::No);
+        });
+
+        auto* new_private_window_action = add_application_menu_action(*file_menu, "New Pri&vate Window", { QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_N) });
+        QObject::connect(new_private_window_action, &QAction::triggered, this, [] {
+            Application::the().open_new_window(WebView::IsPrivate::Yes);
         });
 
         m_reopen_recently_closed_tab_action = add_application_menu_action(*file_menu, {}, { QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_T) });
@@ -374,9 +379,10 @@ void Application::open_new_tab()
     tab.focus_location_editor();
 }
 
-void Application::open_new_window()
+void Application::open_new_window(WebView::IsPrivate is_private)
 {
-    new_window({ WebView::Application::settings().new_tab_page_url() }, configuration_for_new_window());
+    // FIXME: Create a new tab page specific to private windows.
+    new_window({ WebView::Application::settings().new_tab_page_url() }, configuration_for_new_window(), BrowserWindow::IsPopupWindow::No, is_private);
 }
 
 void Application::focus_location_editor()

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -143,7 +143,7 @@ public:
         if (!m_reopen_recently_closed_tab_action)
             return;
 
-        auto recently_closed_entry = Application::history_store().most_recently_closed_entry();
+        auto recently_closed_entry = Application::history_store(WebView::IsPrivate::No).most_recently_closed_entry();
         m_reopen_recently_closed_tab_action->setText("&Reopen Recently Closed Tab");
         m_reopen_recently_closed_tab_action->setEnabled(recently_closed_entry.has_value());
     }
@@ -392,7 +392,7 @@ void Application::focus_location_editor()
 
 void Application::reopen_recently_closed_tab()
 {
-    auto recently_closed_entry = Application::history_store().pop_most_recently_closed_entry();
+    auto recently_closed_entry = Application::history_store(WebView::IsPrivate::No).pop_most_recently_closed_entry();
     if (recently_closed_entry.has_value()) {
         if (recently_closed_entry->was_window) {
             auto& window = new_window(recently_closed_entry->urls);

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -404,7 +404,7 @@ void Application::reopen_recently_closed_tab()
             auto& window = new_window(recently_closed_entry->urls);
             window.activate_tab(static_cast<int>(recently_closed_entry->active_tab_index));
         } else if (!recently_closed_entry->urls.is_empty()) {
-            if (!m_active_window)
+            if (!m_active_window || m_active_window->is_private() == WebView::IsPrivate::Yes)
                 new_window({ recently_closed_entry->urls[0] });
             else
                 m_active_window->new_tab_from_url(recently_closed_entry->urls[0], Web::HTML::ActivateTab::Yes);

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -297,9 +297,9 @@ Core::EventLoop& Application::create_platform_event_loop()
     return event_loop;
 }
 
-BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& configuration, BrowserWindow::IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
+BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& configuration, BrowserWindow::IsPopupWindow is_popup_window, WebView::IsPrivate is_private, Tab* parent_tab, Optional<u64> page_index)
 {
-    auto* window = new BrowserWindow(initial_urls, is_popup_window, parent_tab, move(page_index));
+    auto* window = new BrowserWindow(initial_urls, is_popup_window, is_private, parent_tab, move(page_index));
     set_active_window(*window);
     QObject::connect(window, &QObject::destroyed, m_application.ptr(), [this, window] {
         if (m_active_window == window) {
@@ -521,7 +521,8 @@ bool Application::activate_tab_with_url(URL::URL const& url) const
 
 void Application::open_url_in_new_window(URL::URL const& url)
 {
-    this->new_window({ url });
+    auto is_private = m_active_window ? m_active_window->is_private() : WebView::IsPrivate::No;
+    this->new_window({ url }, {}, BrowserWindow::IsPopupWindow::No, is_private);
 }
 
 Optional<ByteString> Application::ask_user_for_download_path(ByteString const& file) const

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -38,7 +38,7 @@ public:
     BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& = {}, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, WebView::IsPrivate = WebView::IsPrivate::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
     WindowConfiguration configuration_for_new_window() const;
     void open_new_tab();
-    void open_new_window();
+    void open_new_window(WebView::IsPrivate);
     void focus_location_editor();
     void reopen_recently_closed_tab();
     void open_file();

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -9,6 +9,7 @@
 #include <AK/Function.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/PrivateBrowsing.h>
 #include <UI/Qt/BrowserWindow.h>
 
 #include <QApplication>
@@ -33,7 +34,8 @@ public:
     virtual ~Application() override;
 
     Function<void(URL::URL)> on_open_file;
-    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& = {}, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+
+    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& = {}, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, WebView::IsPrivate = WebView::IsPrivate::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
     WindowConfiguration configuration_for_new_window() const;
     void open_new_tab();
     void open_new_window();

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -446,7 +446,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     QObject::connect(m_tabs_container, &TabWidget::current_tab_changed, this, [this](int index) {
         auto* tab = m_tabs_container->tab(index);
         if (tab)
-            setWindowTitle(QString("%1 - Ladybird").arg(tab->title()));
+            update_window_title(tab->title());
 
         set_current_tab(tab);
         if (tab) {
@@ -892,6 +892,14 @@ void BrowserWindow::display_metadata_changed(Optional<u64> display_id, qreal ref
     });
 }
 
+void BrowserWindow::update_window_title(QString const& title)
+{
+    char const* format = is_private() == WebView::IsPrivate::Yes
+        ? "%1 - Ladybird (Private Browsing)"
+        : "%1 - Ladybird";
+    setWindowTitle(QString(format).arg(title));
+}
+
 void BrowserWindow::tab_title_changed(int index, QString const& title)
 {
     // NOTE: Qt uses ampersands for shortcut keys in tab titles, so we need to escape them.
@@ -902,7 +910,7 @@ void BrowserWindow::tab_title_changed(int index, QString const& title)
     m_tabs_container->set_tab_tooltip(index, title);
 
     if (m_tabs_container->current_index() == index)
-        setWindowTitle(QString("%1 - Ladybird").arg(title));
+        update_window_title(title);
 }
 
 void BrowserWindow::tab_favicon_changed(int index, QIcon const& icon)

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -678,6 +678,9 @@ void BrowserWindow::move_tab_to_window(int index, BrowserWindow& target_window, 
         return;
     }
 
+    if (is_private() != target_window.is_private())
+        return;
+
     auto* tab = m_tabs_container->tab(index);
     uninitialize_tab(tab);
     m_tabs_container->take_tab(index);

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -752,8 +752,12 @@ bool BrowserWindow::definitely_close_tab(int index)
     auto* tab = m_tabs_container->tab(index);
     auto url = tab->view().url();
     m_tabs_container->remove_tab(index);
-    Application::history_store(WebView::IsPrivate::No).record_closed_tab(url);
-    Application::the().update_reopen_recently_closed_actions();
+
+    if (m_is_private == WebView::IsPrivate::No) {
+        Application::history_store(WebView::IsPrivate::No).record_closed_tab(url);
+        Application::the().update_reopen_recently_closed_actions();
+    }
+
     tab->deleteLater();
 
     if (m_tabs_container->count() == 0) {
@@ -771,7 +775,7 @@ void BrowserWindow::update_reopen_recently_closed_action()
 
     auto recently_closed_entry = Application::history_store(WebView::IsPrivate::No).most_recently_closed_entry();
     m_reopen_recently_closed_tab_action->setText("&Reopen Recently Closed Tab");
-    m_reopen_recently_closed_tab_action->setEnabled(recently_closed_entry.has_value());
+    m_reopen_recently_closed_tab_action->setEnabled(m_is_private == WebView::IsPrivate::No && recently_closed_entry.has_value());
 }
 
 void BrowserWindow::move_tab(int old_index, int new_index)
@@ -1669,15 +1673,18 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
 
     Optional<Vector<URL::URL>> recently_closed_window_urls;
     size_t recently_closed_window_active_tab_index { 0 };
-    if (m_should_record_closed_window_on_close && m_tabs_container->count() > 0) {
-        recently_closed_window_urls = recently_closed_urls_for_window(*m_tabs_container);
-        recently_closed_window_active_tab_index = static_cast<size_t>(m_tabs_container->current_index());
-    }
 
-    if (m_is_popup_window == IsPopupWindow::No) {
-        Settings::the()->set_last_position(pos());
-        Settings::the()->set_last_size(size());
-        Settings::the()->set_is_maximized(isMaximized());
+    if (m_is_private == WebView::IsPrivate::No) {
+        if (m_should_record_closed_window_on_close && m_tabs_container->count() > 0) {
+            recently_closed_window_urls = recently_closed_urls_for_window(*m_tabs_container);
+            recently_closed_window_active_tab_index = static_cast<size_t>(m_tabs_container->current_index());
+        }
+
+        if (m_is_popup_window == IsPopupWindow::No) {
+            Settings::the()->set_last_position(pos());
+            Settings::the()->set_last_size(size());
+            Settings::the()->set_is_maximized(isMaximized());
+        }
     }
 
     QObject::deleteLater();

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -286,6 +286,11 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     m_hamburger_menu->addAction(m_new_window_action);
     file_menu->addAction(m_new_window_action);
 
+    m_new_private_window_action = new QAction("New Pri&vate Window", this);
+    m_new_private_window_action->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_N));
+    m_hamburger_menu->addAction(m_new_private_window_action);
+    file_menu->addAction(m_new_private_window_action);
+
     m_reopen_recently_closed_tab_action = new QAction("&Reopen Recently Closed Tab", this);
     m_reopen_recently_closed_tab_action->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_T));
     m_hamburger_menu->addAction(m_reopen_recently_closed_tab_action);
@@ -421,7 +426,10 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         Application::the().open_new_tab();
     });
     QObject::connect(m_new_window_action, &QAction::triggered, this, [] {
-        Application::the().open_new_window();
+        Application::the().open_new_window(WebView::IsPrivate::No);
+    });
+    QObject::connect(m_new_private_window_action, &QAction::triggered, this, [] {
+        Application::the().open_new_window(WebView::IsPrivate::Yes);
     });
     QObject::connect(m_reopen_recently_closed_tab_action, &QAction::triggered, this, [] {
         Application::the().reopen_recently_closed_tab();

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -277,7 +277,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     auto* file_menu = menuBar()->addMenu("&File");
 
     m_new_tab_action = new QAction("New &Tab", this);
-    m_new_tab_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::AddTab));
+    m_new_tab_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_T));
     m_hamburger_menu->addAction(m_new_tab_action);
     file_menu->addAction(m_new_tab_action);
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -235,8 +235,9 @@ static QIcon const& app_icon()
     return icon;
 }
 
-BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
-    : m_tabs_container(new TabWidget(this))
+BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window, WebView::IsPrivate is_private, Tab* parent_tab, Optional<u64> page_index)
+    : m_is_private(is_private)
+    , m_tabs_container(new TabWidget(this))
     , m_is_popup_window(is_popup_window)
 {
     auto& application = WebView::Application::the();
@@ -625,7 +626,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
                 .width = hints.width,
                 .height = hints.height,
             };
-            auto& window = Application::the().new_window({}, configuration, IsPopupWindow::Yes, tab, AK::move(page_index));
+            auto& window = Application::the().new_window({}, configuration, IsPopupWindow::Yes, m_is_private, tab, AK::move(page_index));
             return window.current_tab()->view().handle();
         }
         auto& new_tab = new_child_tab(activate_tab, *tab, page_index);
@@ -696,7 +697,7 @@ void BrowserWindow::detach_tab_to_new_window(int index, QPoint global_position)
         .maximized = isMaximized(),
     };
 
-    auto& window = Application::the().new_window({}, configuration);
+    auto& window = Application::the().new_window({}, configuration, IsPopupWindow::No, m_is_private);
     move_tab_to_window(index, window, 0);
 }
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -743,7 +743,7 @@ bool BrowserWindow::definitely_close_tab(int index)
     auto* tab = m_tabs_container->tab(index);
     auto url = tab->view().url();
     m_tabs_container->remove_tab(index);
-    Application::history_store().record_closed_tab(url);
+    Application::history_store(WebView::IsPrivate::No).record_closed_tab(url);
     Application::the().update_reopen_recently_closed_actions();
     tab->deleteLater();
 
@@ -760,7 +760,7 @@ void BrowserWindow::update_reopen_recently_closed_action()
     if (!m_reopen_recently_closed_tab_action)
         return;
 
-    auto recently_closed_entry = Application::history_store().most_recently_closed_entry();
+    auto recently_closed_entry = Application::history_store(WebView::IsPrivate::No).most_recently_closed_entry();
     m_reopen_recently_closed_tab_action->setText("&Reopen Recently Closed Tab");
     m_reopen_recently_closed_tab_action->setEnabled(recently_closed_entry.has_value());
 }
@@ -1676,7 +1676,7 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
     QMainWindow::closeEvent(event);
 
     if (event->isAccepted() && recently_closed_window_urls.has_value()) {
-        Application::history_store().record_closed_window(recently_closed_window_urls.release_value(), recently_closed_window_active_tab_index);
+        Application::history_store(WebView::IsPrivate::No).record_closed_window(recently_closed_window_urls.release_value(), recently_closed_window_active_tab_index);
         Application::the().update_reopen_recently_closed_actions();
     }
 }

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/Settings.h>
 #include <UI/Qt/Tab.h>
 #include <UI/Qt/TabBar.h>
@@ -94,10 +95,11 @@ public:
         Yes,
     };
 
-    BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window = IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window = IsPopupWindow::No, WebView::IsPrivate = WebView::IsPrivate::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
     virtual ~BrowserWindow() override;
 
     WebContentView& view() const { return m_current_tab->view(); }
+    WebView::IsPrivate is_private() const { return m_is_private; }
 
     int tab_count() { return m_tabs_container->count(); }
     int tab_index(Tab*);
@@ -214,6 +216,8 @@ private:
     Optional<u64> m_display_id;
     double m_device_pixel_ratio { 0 };
     double m_refresh_rate { 60.0 };
+
+    WebView::IsPrivate m_is_private { WebView::IsPrivate::No };
 
     TabWidget* m_tabs_container { nullptr };
     Tab* m_current_tab { nullptr };

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -168,6 +168,7 @@ private:
     Tab& create_new_tab(Web::HTML::ActivateTab, Tab& parent, Optional<u64> page_index);
     void initialize_tab(Tab*);
     void uninitialize_tab(Tab*);
+    void update_window_title(QString const&);
 
     void set_current_tab(Tab* tab);
     bool position_is_in_rounded_corner_cutout(QPoint const&) const;

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -233,6 +233,7 @@ private:
 
     QAction* m_new_tab_action { nullptr };
     QAction* m_new_window_action { nullptr };
+    QAction* m_new_private_window_action { nullptr };
     QAction* m_reopen_recently_closed_tab_action { nullptr };
     QAction* m_find_in_page_action { nullptr };
 

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -324,16 +324,20 @@ QMenu::separator {{
 
 QString toolbar_container_style_sheet(QPalette const& palette)
 {
+    auto dark = is_dark(palette);
+
     auto background = style_sheet_color(chrome_background(palette));
     auto surface_hover = style_sheet_color(chrome_control_surface_hover(palette));
     auto surface_pressed = style_sheet_color(chrome_control_surface_pressed(palette));
     auto control_border = style_sheet_color(chrome_control_border(palette));
     auto separator = style_sheet_color(chrome_border(palette));
-    auto window_controls_separator = style_sheet_color(mix(chrome_background(palette), chrome_border(palette), is_dark(palette) ? 0.36 : 0.46));
+    auto window_controls_separator = style_sheet_color(mix(chrome_background(palette), chrome_border(palette), dark ? 0.36 : 0.46));
     auto text = style_sheet_color(chrome_button_text(palette));
     auto disabled_text = style_sheet_color(chrome_muted_text(palette));
     auto close_hover = style_sheet_color(chrome_destructive_hover());
     auto close_text = style_sheet_color(chrome_destructive_text());
+    auto badge_surface = style_sheet_color(dark ? QColor(0x19, 0x0c, 0x4a) : QColor(0xe0, 0xd4, 0xff));
+    auto badge_border = style_sheet_color(dark ? QColor(0x9c, 0x90, 0xc8) : QColor(0x6c, 0x5f, 0x93));
 
     return qformatted(R"(
 QWidget#LadybirdToolbarContainer {{
@@ -378,6 +382,15 @@ QWidget#LadybirdNavigationToolbar QToolButton::menu-indicator {{
     image: none;
 }}
 
+QLabel#LadybirdPrivateBadge {{
+    color: {5};
+    background: {10};
+    border: 1px solid {11};
+    border-radius: 10px;
+    padding: 0 8px;
+    font-weight: 600;
+}}
+
 QWidget#LadybirdToolbarWindowControlsSeparator {{
     background: {9};
 }}
@@ -420,7 +433,7 @@ QWidget#LadybirdNavigationToolbar QToolButton#LadybirdCloseWindowButton[pressedO
     background: transparent;
 }}
 )",
-        background, surface_hover, surface_pressed, control_border, separator, text, disabled_text, close_hover, close_text, window_controls_separator);
+        background, surface_hover, surface_pressed, control_border, separator, text, disabled_text, close_hover, close_text, window_controls_separator, badge_surface, badge_border);
 }
 
 QString menu_bar_style_sheet(QPalette const& palette)

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -96,6 +96,7 @@ static constexpr int LOCATION_PILL_HORIZONTAL_PADDING = 18;
 
 LocationEdit::LocationEdit(QWidget* parent)
     : QLineEdit(parent)
+    , m_omnibox(WebView::IsPrivate::No)
     , m_autocomplete(new Autocomplete(this))
 {
     setObjectName("LadybirdLocationEdit");

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -94,9 +94,9 @@ static constexpr int LOCATION_TRAILING_ACTION_HEIGHT = 23;
 static constexpr int LOCATION_PILL_HEIGHT = 22;
 static constexpr int LOCATION_PILL_HORIZONTAL_PADDING = 18;
 
-LocationEdit::LocationEdit(QWidget* parent)
+LocationEdit::LocationEdit(QWidget* parent, WebView::IsPrivate is_private)
     : QLineEdit(parent)
-    , m_omnibox(WebView::IsPrivate::No)
+    , m_omnibox(is_private)
     , m_autocomplete(new Autocomplete(this))
 {
     setObjectName("LadybirdLocationEdit");

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibWebView/Omnibox.h>
+#include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/Settings.h>
 
 #include <QLineEdit>
@@ -31,7 +32,7 @@ class LocationEdit final
     Q_OBJECT
 
 public:
-    explicit LocationEdit(QWidget*);
+    LocationEdit(QWidget*, WebView::IsPrivate);
 
     void set_trailing_action(QAction*);
     QAction* trailing_action() const;

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -645,7 +645,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     toolbar_layout->setSpacing(6);
     toolbar_layout->setContentsMargins(TOOLBAR_HORIZONTAL_MARGIN, TOOLBAR_VERTICAL_MARGIN, TOOLBAR_HORIZONTAL_MARGIN, TOOLBAR_VERTICAL_MARGIN);
 
-    m_location_edit = new LocationEdit(this);
+    m_location_edit = new LocationEdit(this, m_window->is_private());
     m_bookmarks_bar = new BookmarksBar(this);
     m_loading_animation_timer = new QTimer(this);
     m_loading_animation_timer->setInterval(80);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -619,6 +619,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     tab_layout->setContentsMargins(0, 0, 0, 0);
 
     auto view_initial_state = WebContentViewInitialState {
+        .is_private = window->is_private(),
         .maximum_frames_per_second = window->refresh_rate(),
         .display_id = window->display_id(),
     };

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -672,6 +672,13 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     tab_layout->addWidget(m_view);
     tab_layout->addWidget(m_find_in_page);
 
+    m_private_badge = new QLabel("Private", m_toolbar);
+    m_private_badge->setObjectName("LadybirdPrivateBadge");
+    m_private_badge->setAlignment(Qt::AlignCenter);
+    m_private_badge->setFixedHeight(22);
+    m_private_badge->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_private_badge->setVisible(m_window->is_private() == WebView::IsPrivate::Yes);
+
     m_hamburger_button = new HamburgerButton(m_toolbar);
     m_hamburger_button->setText("Show &Menu");
     m_hamburger_button->setToolTip("Show Menu");
@@ -749,6 +756,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_location_edit->set_zoom_action(create_application_action(*m_location_edit, view().reset_zoom_action(), IncludeActionIcon::No));
     location_edit_layout->addWidget(m_location_edit);
     toolbar_layout->addWidget(location_edit_container, 1);
+    toolbar_layout->addWidget(m_private_badge, 0, Qt::AlignVCenter);
     m_right_toggle_vertical_tabs_expanded_button = create_toolbar_button(*m_toolbar, *m_toggle_vertical_tabs_expanded_action);
     toolbar_layout->addWidget(m_right_toggle_vertical_tabs_expanded_button, 0, Qt::AlignTop);
     m_downloads_button = new DownloadsButton(m_toolbar);

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -142,6 +142,7 @@ private:
     WindowControlButton* m_maximize_window_button { nullptr };
     WindowControlButton* m_close_window_button { nullptr };
     BookmarksBar* m_bookmarks_bar { nullptr };
+    QLabel* m_private_badge { nullptr };
     QToolButton* m_hamburger_button { nullptr };
     QToolButton* m_downloads_button { nullptr };
     QPointer<DownloadsPopover> m_downloads_popover;

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -117,6 +117,21 @@ static bool window_uses_client_side_decorations(QWidget& widget)
     return !top_level_window || top_level_window->uses_client_side_decorations();
 }
 
+static bool target_can_accept_tab_drop(QWidget& target, QDropEvent& event)
+{
+    if (!s_active_tab_drag_source)
+        return false;
+    if (!event.mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE))
+        return false;
+
+    auto* source_window = qobject_cast<BrowserWindow*>(s_active_tab_drag_source->window());
+    auto* target_window = qobject_cast<BrowserWindow*>(target.window());
+    if (!source_window || !target_window)
+        return false;
+
+    return source_window->is_private() == target_window->is_private();
+}
+
 static QPainterPath tab_shape_path(QRectF const& rect, qreal top_radius, qreal bottom_radius)
 {
     top_radius = min(top_radius, rect.height() / 2.0);
@@ -800,7 +815,7 @@ void TabBar::contextMenuEvent(QContextMenuEvent* event)
 
 void TabBar::dragEnterEvent(QDragEnterEvent* event)
 {
-    if (!m_tab_widget || !s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+    if (!m_tab_widget || !target_can_accept_tab_drop(*m_tab_widget, *event)) {
         event->ignore();
         return;
     }
@@ -819,7 +834,11 @@ void TabBar::dragLeaveEvent(QDragLeaveEvent* event)
 
 void TabBar::dragMoveEvent(QDragMoveEvent* event)
 {
-    if (!m_tab_widget || !s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+    if (!m_tab_widget || !target_can_accept_tab_drop(*m_tab_widget, *event)) {
+        if (m_drop_indicator_index != -1) {
+            m_drop_indicator_index = -1;
+            update();
+        }
         event->ignore();
         return;
     }
@@ -837,7 +856,11 @@ void TabBar::dragMoveEvent(QDragMoveEvent* event)
 void TabBar::dropEvent(QDropEvent* event)
 {
     hide_tab_preview();
-    if (!m_tab_widget || !s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+    if (!m_tab_widget || !target_can_accept_tab_drop(*m_tab_widget, *event)) {
+        if (m_drop_indicator_index != -1) {
+            m_drop_indicator_index = -1;
+            update();
+        }
         event->ignore();
         return;
     }
@@ -1857,7 +1880,7 @@ void TabWidget::resizeEvent(QResizeEvent* event)
 
 void TabWidget::accept_tab_drag(QDragMoveEvent* event)
 {
-    if (!s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+    if (!target_can_accept_tab_drop(*this, *event)) {
         event->ignore();
         return;
     }
@@ -1875,7 +1898,7 @@ void TabWidget::accept_tab_drag(QDragMoveEvent* event)
 
 void TabWidget::accept_tab_drop(QDropEvent* event, int index)
 {
-    if (!s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+    if (!target_can_accept_tab_drop(*this, *event)) {
         event->ignore();
         return;
     }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -445,6 +445,8 @@ static bool is_browser_reserved_shortcut(QKeyEvent const& event)
         return true;
     if (modifiers == (Qt::ControlModifier | Qt::ShiftModifier) && key == Qt::Key_T)
         return true;
+    if (modifiers == (Qt::ControlModifier | Qt::ShiftModifier) && key == Qt::Key_N)
+        return true;
 
     if (modifiers == Qt::ControlModifier && (key == Qt::Key_L || key == Qt::Key_Tab || key == Qt::Key_PageDown))
         return true;

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -433,8 +433,7 @@ static bool is_browser_reserved_shortcut(QKeyEvent const& event)
 {
     // Browser chrome shortcuts that manage tabs, windows, or focus should not wait for
     // WebContent to decide whether the page wants to suppress them.
-    if (event.matches(QKeySequence::StandardKey::AddTab)
-        || event.matches(QKeySequence::StandardKey::Close)
+    if (event.matches(QKeySequence::StandardKey::Close)
         || event.matches(QKeySequence::StandardKey::New)
         || event.matches(QKeySequence::StandardKey::Quit))
         return true;
@@ -442,6 +441,8 @@ static bool is_browser_reserved_shortcut(QKeyEvent const& event)
     auto const modifiers = event.modifiers() & (Qt::ControlModifier | Qt::ShiftModifier | Qt::AltModifier | Qt::MetaModifier);
     auto const key = event.key();
 
+    if (modifiers == Qt::ControlModifier && key == Qt::Key_T)
+        return true;
     if (modifiers == (Qt::ControlModifier | Qt::ShiftModifier) && key == Qt::Key_T)
         return true;
 

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -94,8 +94,10 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
 #endif
 
     m_device_pixel_ratio = devicePixelRatio();
+    m_is_private = initial_state.is_private;
     m_maximum_frames_per_second = initial_state.maximum_frames_per_second;
     m_display_id = initial_state.display_id;
+
     set_page_background_color_to_system_canvas(is_using_dark_system_theme(*this));
 
     QObject::connect(qGuiApp, &QGuiApplication::screenRemoved, [this](QScreen*) {

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -16,6 +16,7 @@
 #include <LibGfx/Rect.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
+#include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/ViewImplementation.h>
 
 #include <QMenu>
@@ -49,6 +50,7 @@ using WebContentViewBase = QWidget;
 #endif
 
 struct WebContentViewInitialState {
+    WebView::IsPrivate is_private { WebView::IsPrivate::No };
     double maximum_frames_per_second { 60.0 };
     Optional<u64> display_id;
 };


### PR DESCRIPTION
This PR adds initial support for private browsing windows. Isolation is enforced per-tab. A WebContent process is only ever wholly private or wholly normal, so a privacy flag lives on the connection objects and everything downstream routes off it. Private state is held in a lazily-created, in-memory session and destroyed when the last private window closes.

The following components are routed by privacy:

* Cookies, local/sessions storage, HSTS: stored in separate in-memory jars.
* History: private visits are never recorded (backed by a disabled history store).
* HTTP disk cache: private RequestServer connections are created with no disk cache.
* alt-svc cache file: not written for private connections.
* Per-host zoom and bookmark favicon updates: not persisted for private views.
* Downloads: routed through a dedicated private RequestServer client (private cookies, no cache).
* URL-bar search suggestions: autocomplete network queries go out on the private connection.
* Web/Shared/Dedicated workers: inherit their owner's privacy.
* BroadcastChannel and cookie-change notifications: filtered so messages/updates never cross the privacy boundary.
* DevTools cookie/storage access: routed by the inspected view's privacy.
* UI: private windows don't record recently-closed tabs/windows or persist window geometry; tabs can't be dragged between private and normal windows.

A couple things that are not totally separated by privacy:

* URL-bar history suggestions still read from normal history (read-only; private visits never leak into it).
* Explicit, user-initiated persistence still writes to disk: downloaded files, added bookmarks, and changes made via `about:settings`.

<img width="1234" height="1014" alt="Screenshot 2026-07-06 at 7 26 22 AM" src="https://github.com/user-attachments/assets/28c1a18b-dbf7-499b-8363-acc08d8de344" />

