### PR TITLE
LibWeb: Transfer flex item's definite main size to its cross size

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -656,6 +656,23 @@ CSSPixels FlexFormattingContext::calculate_cross_size_from_main_size_and_aspect_
     return main_size * aspect_ratio;
 }
 
+// https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
+Optional<CSSPixels> FlexFormattingContext::cross_size_transferred_from_definite_main_size(FlexItem const& item) const
+{
+    // When a box has a preferred aspect ratio, its automatic sizes are calculated the same as for a
+    // replaced element with a natural aspect ratio and no natural size in that axis [...] The axis in
+    // which the preferred size calculation depends on this aspect ratio is called the ratio-dependent
+    // axis [...] The opposite axis (on which the ratio-dependent axis size depends) is the
+    // ratio-determining axis.
+    // NB: Only a transfer to an automatic inline cross size is performed here. When the cross axis is the
+    //     block axis, the block layout performed by the content cross size calculations already applies
+    //     the aspect ratio.
+    if (!cross_axis_is_horizontal() || !item.box.has_preferred_aspect_ratio() || !has_definite_main_size(item))
+        return {};
+    auto main_size = has_definite_main_size(m_flex_container_state) ? item.main_size.value_or(item.flex_base_size) : item.flex_base_size;
+    return calculate_cross_size_from_main_size_and_aspect_ratio(main_size, item.box.preferred_aspect_ratio().value());
+}
+
 // This function takes a size in the main axis and adjusts it according to the aspect ratio of the box
 // if the min/max constraints in the cross axis forces us to come up with a new main axis size.
 CSSPixels FlexFormattingContext::adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(Box const& box, CSSPixels main_size, CSS::Size const& min_cross_size, CSS::Size const& max_cross_size) const
@@ -2212,8 +2229,11 @@ CSSPixels FlexFormattingContext::calculate_cross_min_content_contribution(FlexIt
 {
     bool cross_size_auto = should_treat_cross_size_as_auto(item.box);
     auto size = [&] {
-        if (cross_size_auto)
+        if (cross_size_auto) {
+            if (auto transferred_cross_size = cross_size_transferred_from_definite_main_size(item); transferred_cross_size.has_value())
+                return *transferred_cross_size;
             return calculate_min_content_cross_size(item);
+        }
         return cross_axis_is_horizontal() ? get_pixel_width(item, computed_cross_size(item.box)) : get_pixel_height(item, computed_cross_size(item.box));
     }();
 
@@ -2235,8 +2255,11 @@ CSSPixels FlexFormattingContext::calculate_cross_max_content_contribution(FlexIt
 {
     bool cross_size_auto = should_treat_cross_size_as_auto(item.box);
     auto size = [&] {
-        if (cross_size_auto)
+        if (cross_size_auto) {
+            if (auto transferred_cross_size = cross_size_transferred_from_definite_main_size(item); transferred_cross_size.has_value())
+                return *transferred_cross_size;
             return calculate_max_content_cross_size(item);
+        }
         return cross_axis_is_horizontal() ? get_pixel_width(item, computed_cross_size(item.box)) : get_pixel_height(item, computed_cross_size(item.box));
     }();
 

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -231,6 +231,7 @@ private:
     [[nodiscard]] CSSPixels calculate_max_content_main_size(FlexItem const&) const;
     [[nodiscard]] CSSPixels calculate_min_content_cross_size(FlexItem const&) const;
     [[nodiscard]] CSSPixels calculate_max_content_cross_size(FlexItem const&) const;
+    [[nodiscard]] Optional<CSSPixels> cross_size_transferred_from_definite_main_size(FlexItem const&) const;
 
     [[nodiscard]] CSSPixels calculate_fit_content_main_size(FlexItem const&) const;
     [[nodiscard]] CSSPixels calculate_fit_content_cross_size(FlexItem const&) const;

--- a/Tests/LibWeb/Ref/expected/flex/column-shrink-to-fit-width-from-item-aspect-ratio-ref.html
+++ b/Tests/LibWeb/Ref/expected/flex/column-shrink-to-fit-width-from-item-aspect-ratio-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    div {
+        background-color: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/flex/column-shrink-to-fit-width-from-item-aspect-ratio.html
+++ b/Tests/LibWeb/Ref/input/flex/column-shrink-to-fit-width-from-item-aspect-ratio.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/flex/column-shrink-to-fit-width-from-item-aspect-ratio-ref.html" />
+<style>
+    .column {
+        display: inline-flex;
+        flex-direction: column;
+    }
+    .item {
+        background-color: green;
+        aspect-ratio: 1 / 1;
+        height: 100px;
+    }
+</style>
+<div class="column"><div class="item"></div></div>


### PR DESCRIPTION
Previously, only minimum and maximum main sizes were transferred through a flex item's preferred aspect ratio when calculating its cross size contribution. An item with a definite main size and an automatic inline cross size therefore collapsed to its content width instead of the width implied by the ratio.

Here's an example from https://x.com/awesomekling/status/2061376386623737905, where images with a definite height and aspect-ratio failed to appear because they were previously given zero width:

Before:

<img width="592" height="392" alt="image" src="https://github.com/user-attachments/assets/c000f6d4-5865-4b85-a1dc-cd2a17cb4ecd" />

After:

<img width="592" height="392" alt="image" src="https://github.com/user-attachments/assets/9a7c87b8-0459-4f66-ba53-370fa0d5264a" />
