### PR TITLE
LibWeb: Fix scoped layout state crashes

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2316,9 +2316,20 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     auto const* static_position_cb = box.static_position_containing_block();
     auto actual_containing_block = box.containing_block();
     if (static_position_cb && static_position_cb != actual_containing_block) {
-        auto offset = m_state.cumulative_offset(m_state.get(*static_position_cb))
-            - m_state.cumulative_offset(m_state.get(*actual_containing_block));
-        static_position += offset;
+        // The offset between the static position containing block and the actual containing block only depends on
+        // boxes at or below the point where their containing block chains merge. Accumulate offsets up to that
+        // point instead of comparing ICB-relative offsets: containing blocks above the merge point may be outside
+        // the scope of the current layout (e.g. during intrinsic sizing) and have no used values at all.
+        auto const* merge_point = static_position_cb;
+        while (merge_point != actual_containing_block && !merge_point->is_ancestor_of(*actual_containing_block))
+            merge_point = merge_point->containing_block();
+        auto offset_relative_to_merge_point = [&](Box const& descendant) {
+            CSSPixelPoint offset;
+            for (auto const* node = &descendant; node != merge_point; node = node->containing_block())
+                offset += m_state.get(*node).offset;
+            return offset;
+        };
+        static_position += offset_relative_to_merge_point(*static_position_cb) - offset_relative_to_merge_point(*actual_containing_block);
     }
 
     // Horizontal axis

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -111,6 +111,15 @@ LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node, Optional
     return used_values;
 }
 
+void LayoutState::discard_used_values_for_descendants(Box const& root)
+{
+    root.for_each_in_subtree([&](auto const& descendant) {
+        if (auto const* node_with_style = as_if<NodeWithStyle>(descendant))
+            m_used_values_store.remove(node_with_style->layout_index());
+        return TraversalDecision::Continue;
+    });
+}
+
 LayoutState::UsedValues& LayoutState::populate_from_paintable(NodeWithStyle const& node, Painting::Paintable const& paintable)
 {
     VERIFY(m_subtree_root);

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -98,6 +98,18 @@ public:
         return page->entries[index & PageMask];
     }
 
+    void remove(u32 index)
+    {
+        auto page_index = index >> PageBits;
+        if (page_index >= m_pages.size())
+            return;
+        auto& page = m_pages[page_index];
+        if (!page)
+            return;
+        // NB: The entry is only unlinked here; its destructor runs when the allocator is destroyed.
+        page->entries[index & PageMask] = nullptr;
+    }
+
     T& allocate(u32 index)
     {
         auto page_index = index >> PageBits;
@@ -395,6 +407,10 @@ struct LayoutState {
     UsedValues const& get(NodeWithStyle const&) const;
 
     UsedValues& create(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height);
+
+    // Discards used values created for the descendants of `root` by an earlier layout pass, so an
+    // intentional second layout of the subtree can create them anew.
+    void discard_used_values_for_descendants(Box const& root);
 
     UsedValues& populate_from_paintable(NodeWithStyle const&, Painting::Paintable const&);
     UsedValues& populate_node_from(LayoutState const& source, NodeWithStyle const& node);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1119,6 +1119,9 @@ void TableFormattingContext::compute_table_height()
         }
 
         cell_state.set_content_width(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
+        // This is the second inside layout of this cell in the same layout state: its descendants
+        // already have used values from the first pass, so discard them before creating them anew.
+        m_state.discard_used_values_for_descendants(cell.box);
         if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         }

--- a/Tests/LibWeb/Crash/Layout/abspos-static-position-offset-in-throwaway-layout.html
+++ b/Tests/LibWeb/Crash/Layout/abspos-static-position-offset-in-throwaway-layout.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!-- The float triggers intrinsic width measurement with a throwaway layout state.
+     Inside it, the inline-level flex container gets definite used sizes before its
+     inside is laid out, so its flex item insides are laid out in Normal mode,
+     including the abspos box whose static position containing block (the wrapper)
+     differs from its actual containing block (the positioned flex item). Computing
+     the offset between the two must not walk containing blocks above the measured
+     float, since they have no used values in the throwaway state. -->
+<style>
+    #float {
+        float: left;
+    }
+
+    #inline-flex {
+        display: inline-flex;
+    }
+
+    #positioned-item {
+        display: flex;
+        position: relative;
+    }
+
+    #abspos {
+        position: absolute;
+    }
+</style>
+<div id="float">
+    <div id="inline-flex">
+        <div id="positioned-item">
+            <div id="wrapper">
+                <div id="abspos"></div>
+                <div>content</div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    document.body.offsetHeight;
+</script>

--- a/Tests/LibWeb/Crash/Layout/table-percentage-height-cell-second-pass-relayout.html
+++ b/Tests/LibWeb/Crash/Layout/table-percentage-height-cell-second-pass-relayout.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!-- Percentage-height table cells get a second inside layout once the final table
+     height is known. That relayout runs in the same layout state as the first pass,
+     so it must not trip the create-once used values invariant for the cells'
+     descendants, whether in-flow or absolutely positioned. -->
+<table style="height: 100px">
+    <tr>
+        <td style="height: 100%">
+            <div>in-flow block child</div>
+            <div style="position: relative">
+                <img style="position: absolute">
+            </div>
+        </td>
+    </tr>
+</table>
+<script>
+    document.body.offsetHeight;
+</script>


### PR DESCRIPTION
Fix two cases where layout reused or queried used values outside the valid scope of the current layout state.

Abspos static-position offset adjustment now accumulates offsets only up to the merge point of the static-position and actual containing block chains. This avoids walking out of intrinsic sizing throwaway layout state while preserving the same relative offset.

Percentage-height table cells now explicitly discard descendant used values before their second inside layout pass. This lets descendants create fresh used values instead of tripping the create-once invariant.

This adds crash tests for the YouTube intrinsic sizing case and the percentage-height table cell relayout case.

Fixes #10452
Also fixes https://youtube.com/ crashing with the new invariant enforcements.