### PR TITLE
Stop hoisting out-of-flow boxes out of inline ancestors

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -979,24 +979,11 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             auto& box_state = is<ListItemMarkerBox>(box) || box_is_document_element
                 ? m_state.get_mutable(box)
                 : m_state.create(box, {}, {});
+            // NB: An originally-inline absolutely positioned box never reaches this path; the tree
+            //     builder keeps out-of-flow boxes in inline context, where static position markers
+            //     pin them at their exact flow position.
             StaticPositionRect static_position;
-            auto static_position_x = CSSPixels(0);
-            auto static_position_y = m_y_offset_of_current_block_container.value();
-            if (box.display_before_box_type_transformation().is_inline_outside()) {
-                auto sibling_ref = box.previous_sibling();
-                auto const* sibling = as_if<Box>(sibling_ref.ptr());
-                if (sibling && sibling->is_anonymous() && sibling->children_are_inline()) {
-                    // The sibling may have been skipped by layout entirely (e.g. a whitespace-only
-                    // anonymous container), in which case it has no state to derive a position from.
-                    if (auto const* sibling_state = m_state.try_get(*sibling)) {
-                        if (auto const& inline_end_static_position_rect = sibling_state->inline_end_static_position_rect(); inline_end_static_position_rect.has_value()) {
-                            static_position_x = sibling_state->offset.x() + inline_end_static_position_rect->rect.x();
-                            static_position_y = sibling_state->offset.y() + inline_end_static_position_rect->rect.y();
-                        }
-                    }
-                }
-            }
-            static_position.rect = { { static_position_x, static_position_y }, { 0, 0 } };
+            static_position.rect = { { 0, m_y_offset_of_current_block_container.value() }, { 0, 0 } };
             box_state.set_static_position_rect(static_position);
         }
         return;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -438,7 +438,11 @@ void InlineFormattingContext::generate_line_boxes()
         }
         case InlineLevelIterator::Item::Type::AbsolutelyPositionedElement:
             if (auto const* box = as_if<Box>(*item.node)) {
-                line_builder.append_static_position_marker(*box);
+                // Enclosing inline boxes' start edges arrive either still unattached in the iterator
+                // or restashed onto this item from a skipped collapsible whitespace chunk.
+                auto preceded_by_inline_box_start_edges = item.preceded_by_unattached_inline_start_edges
+                    || item.margin_start != 0 || item.border_start != 0 || item.padding_start != 0;
+                line_builder.append_static_position_marker(*box, preceded_by_inline_box_start_edges);
                 absolute_boxes.append(box);
             }
             break;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -451,6 +451,7 @@ void InlineFormattingContext::generate_line_boxes()
                 (void)parent().clear_floating_boxes(*item.node, *this);
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
+                line_builder.set_unbreakable_run_width_interrupted_by_float(iterator.next_non_whitespace_sequence_width());
                 parent().layout_floating_box(*box, containing_block(), *m_layout_input, 0, &line_builder);
             }
             break;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -568,7 +568,6 @@ void InlineFormattingContext::generate_line_boxes()
     }
 
     line_builder.remove_last_line_if_empty();
-    m_containing_block_used_values.set_inline_end_static_position_rect(calculate_inline_end_static_position_rect());
 }
 
 bool InlineFormattingContext::any_floats_intrude_in_block_range(CSSPixels block_start, CSSPixels block_end) const
@@ -604,52 +603,6 @@ CSSPixels InlineFormattingContext::vertical_float_clearance() const
 void InlineFormattingContext::set_vertical_float_clearance(CSSPixels vertical_float_clearance)
 {
     m_vertical_float_clearance = vertical_float_clearance;
-}
-
-StaticPositionRect InlineFormattingContext::calculate_inline_end_static_position_rect() const
-{
-    CSSPixels logical_inline_position = 0;
-    CSSPixels logical_block_position = 0;
-
-    auto to_physical_position = [](CSS::WritingMode writing_mode, CSSPixels logical_inline_position, CSSPixels logical_block_position) {
-        if (writing_mode != CSS::WritingMode::HorizontalTb)
-            return CSSPixelPoint { logical_block_position, logical_inline_position };
-        return CSSPixelPoint { logical_inline_position, logical_block_position };
-    };
-    auto writing_mode = containing_block().computed_values().writing_mode();
-
-    if (m_containing_block_used_values.line_boxes.is_empty())
-        return { .rect = { to_physical_position(writing_mode, logical_inline_position, logical_block_position), { 0, 0 } } };
-
-    CSSPixels line_boxes_bottom = 0;
-    for (auto const& line_box : m_containing_block_used_values.line_boxes)
-        line_boxes_bottom = max(line_boxes_bottom, line_box.bottom());
-
-    auto const& last_line_box = m_containing_block_used_values.line_boxes.last();
-    if (last_line_box.has_forced_break()) {
-        logical_block_position = line_boxes_bottom;
-        return { .rect = { to_physical_position(writing_mode, logical_inline_position, logical_block_position), { 0, 0 } } };
-    }
-
-    if (last_line_box.fragments().is_empty()) {
-        logical_block_position = line_boxes_bottom;
-        return { .rect = { to_physical_position(writing_mode, logical_inline_position, logical_block_position), { 0, 0 } } };
-    }
-
-    auto const& last_fragment = last_line_box.fragments().last();
-    auto direction = containing_block().computed_values().direction();
-    if (containing_block().is_anonymous() && containing_block().parent())
-        direction = containing_block().parent()->computed_values().direction();
-
-    if (direction == CSS::Direction::Rtl) {
-        logical_inline_position = last_fragment.inline_offset();
-    } else {
-        auto last_fragment_visual_inline_end = last_fragment.inline_offset() + last_fragment.inline_length();
-        logical_inline_position = max(last_fragment_visual_inline_end, last_line_box.inline_length());
-    }
-    logical_block_position = last_fragment.block_offset();
-
-    return { .rect = { to_physical_position(last_fragment.writing_mode(), logical_inline_position, logical_block_position), { 0, 0 } } };
 }
 
 }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -43,7 +43,6 @@ private:
     void generate_line_boxes();
     void apply_text_overflow_ellipsis(Vector<LineBox>&);
     void apply_justification_to_fragments(CSS::TextJustify, LineBox&, bool is_last_line);
-    StaticPositionRect calculate_inline_end_static_position_rect() const;
 
     LayoutState::UsedValues& m_containing_block_used_values;
 

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -114,7 +114,9 @@ void InlineLevelIterator::exit_node_with_box_model_metrics()
 Layout::Node const* InlineLevelIterator::next_inline_node_in_pre_order(Layout::Node const& current, Layout::Node const* stay_within)
 {
     if (current.first_child()
-        && (current.first_child()->display().is_inline_outside() || is_inline_flow_interrupting_block(*current.first_child()))
+        && (current.first_child()->display().is_inline_outside()
+            || is_inline_flow_interrupting_block(*current.first_child())
+            || current.first_child()->is_out_of_flow(m_inline_formatting_context))
         && current.display().is_flow_inside()
         && !is_inline_flow_interrupting_block(current)
         && !current.is_replaced_box()) {

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -378,10 +378,13 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
 
     if (m_current_node->is_absolutely_positioned()) {
         auto const& node = *m_current_node;
+        auto has_unattached_inline_start_edges = m_extra_leading_metrics.has_value()
+            && (m_extra_leading_metrics->margin != 0 || m_extra_leading_metrics->border != 0 || m_extra_leading_metrics->padding != 0);
         skip_to_next();
         return Item {
             .type = Item::Type::AbsolutelyPositionedElement,
             .node = &node,
+            .preceded_by_unattached_inline_start_edges = has_unattached_inline_start_edges,
         };
     }
 

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -45,6 +45,9 @@ public:
         CSSPixels margin_end { 0.0f };
         bool is_collapsible_whitespace { false };
         bool can_break_before { false };
+        // An enclosing inline box was entered with non-zero start-edge margin/border/padding that
+        // hasn't attached to any fragment yet. Only set for AbsolutelyPositionedElement items.
+        bool preceded_by_unattached_inline_start_edges { false };
 
         CSSPixels border_box_width() const
         {

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -521,7 +521,12 @@ static void build_paint_tree(Node& node, Painting::Paintable* fallback_parent_pa
         }
     }
     for (auto child = node.first_child(); child; child = child->next_sibling()) {
-        build_paint_tree(*child, node.first_paintable().ptr(), is<InlineNode>(node) ? &paintable_by_line_index : nullptr);
+        // An InlineNode without paintables of its own (an anonymous inline whose only children are
+        // out-of-flow boxes generates no line fragments) must not orphan its descendants' paintables;
+        // pass the nearest ancestor paintable through. Other paintable-less nodes (e.g. non-rendered
+        // SVG subtrees) keep their descendants disconnected on purpose.
+        auto* fallback_for_children = node.first_paintable() ? node.first_paintable().ptr() : (is<InlineNode>(node) ? fallback_parent_paintable : nullptr);
+        build_paint_tree(*child, fallback_for_children, is<InlineNode>(node) ? &paintable_by_line_index : nullptr);
     }
 }
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -225,13 +225,6 @@ struct LayoutState {
 
         Optional<LineBoxFragmentCoordinate> containing_line_box_fragment;
 
-        void set_inline_end_static_position_rect(StaticPositionRect const& static_position_rect) { ensure_rare_data().inline_end_static_position_rect = static_position_rect; }
-        Optional<StaticPositionRect> const& inline_end_static_position_rect() const
-        {
-            static Optional<StaticPositionRect> const empty;
-            return m_rare ? m_rare->inline_end_static_position_rect : empty;
-        }
-
         void add_floating_descendant(Box const& box) { ensure_rare_data().floating_descendants.set(&box); }
         HashTable<Box const*> const& floating_descendants() const
         {
@@ -357,7 +350,6 @@ struct LayoutState {
             Optional<Painting::Paintable::BordersDataWithElementKind> override_borders_data;
             Optional<Painting::SVGGraphicsPaintable::ComputedTransforms> computed_svg_transforms;
             Optional<StaticPositionRect> static_position_rect;
-            Optional<StaticPositionRect> inline_end_static_position_rect;
         };
 
         RareData& ensure_rare_data()

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -60,14 +60,17 @@ void LineBox::add_fragment(Node const& layout_node, size_t start, size_t length,
     m_block_length = max(m_block_length, content_height + border_box_top + border_box_bottom);
 }
 
-void LineBox::add_static_position_marker(Box const& box)
+void LineBox::add_static_position_marker(Box const& box, bool preceded_by_inline_box_start_edges)
 {
+    // Inline box start edges count like content here: a line box holding an inline element with
+    // non-zero margin, border or padding is not a zero-height line box (CSS 2 § 9.4.2), so a
+    // block-level abspos after such an edge belongs below this line, not at its top.
     m_static_position_markers.append(StaticPositionMarker {
         .box = &box,
         .inline_offset = m_inline_length,
         .block_offset = 0,
         .writing_mode = m_writing_mode,
-        .preceded_by_in_flow_content = !m_fragments.is_empty(),
+        .preceded_by_in_flow_content = !m_fragments.is_empty() || preceded_by_inline_box_start_edges,
     });
 }
 

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -45,7 +45,7 @@ public:
     CSSPixels baseline() const { return m_baseline; }
 
     void add_fragment(Node const& layout_node, size_t start, size_t length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run = {});
-    void add_static_position_marker(Box const&);
+    void add_static_position_marker(Box const&, bool preceded_by_inline_box_start_edges);
 
     Vector<LineBoxFragment> const& fragments() const { return m_fragments; }
     Vector<LineBoxFragment>& fragments() { return m_fragments; }

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -126,9 +126,9 @@ void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_
     m_max_height_on_current_line = max(m_max_height_on_current_line, line_box.block_length());
 }
 
-void LineBuilder::append_static_position_marker(Box const& box)
+void LineBuilder::append_static_position_marker(Box const& box, bool preceded_by_inline_box_start_edges)
 {
-    ensure_last_line_box().add_static_position_marker(box);
+    ensure_last_line_box().add_static_position_marker(box, preceded_by_inline_box_start_edges);
 }
 
 void LineBuilder::prepare_to_append_inline_content()

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -234,9 +234,16 @@ CSSPixels LineBuilder::ceiling_for_float_to_be_inserted_here(Box const& box)
     auto const& current_line = ensure_last_line_box();
     auto current_line_width = current_line.width() - current_line.get_trailing_whitespace_width();
 
+    // A float interrupting an unbreakable run cannot let the remainder of the run overflow across it;
+    // the remainder must also fit beside the float for the float to stay on this line.
+    auto width_needed_beside_float = current_line_width;
+    if (!current_line.is_empty_or_ends_in_whitespace())
+        width_needed_beside_float += m_unbreakable_run_width_interrupted_by_float;
+    m_unbreakable_run_width_interrupted_by_float = 0;
+
     // If there's already inline content on the current line, check if the new float can fit
     // alongside the content. If not, place it on the next line.
-    if (current_line_width > 0 && (current_line_width + width) > m_available_width_for_current_line)
+    if (current_line_width > 0 && (width_needed_beside_float + width) > m_available_width_for_current_line)
         candidate_block_offset += current_line.height();
 
     return max(candidate_block_offset, m_context.vertical_float_clearance());

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -51,6 +51,7 @@ public:
 
     void recalculate_available_space();
     CSSPixels ceiling_for_float_to_be_inserted_here(Box const&);
+    void set_unbreakable_run_width_interrupted_by_float(CSSPixels width) { m_unbreakable_run_width_interrupted_by_float = width; }
 
     void did_introduce_clearance(CSSPixels);
 
@@ -67,6 +68,7 @@ private:
     AvailableSize m_available_width_for_current_line { AvailableSize::make_indefinite() };
     CSSPixels m_current_block_offset { 0 };
     CSSPixels m_max_height_on_current_line { 0 };
+    CSSPixels m_unbreakable_run_width_interrupted_by_float { 0 };
     CSSPixels m_text_indent { 0 };
     bool m_text_indent_hanging : 1 { false };
     bool m_text_indent_each_line : 1 { false };

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -25,7 +25,7 @@ public:
     void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
     void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun>);
-    void append_static_position_marker(Box const&);
+    void append_static_position_marker(Box const&, bool preceded_by_inline_box_start_edges);
     void prepare_to_append_inline_content();
     void commit_pending_margin_before_float();
     void finish_current_line_before_block_level_box();

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1562,7 +1562,9 @@ bool Node::has_layout_containment() const
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
-    // FIXME: Implement this.
+    // FIXME: Also check for internal ruby boxes.
+    if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
+        return false;
 
     if (computed_values().contain().layout_containment)
         return true;
@@ -1610,7 +1612,9 @@ bool Node::has_paint_containment() const
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
-    // FIXME: Implement this
+    // FIXME: Also check for internal ruby boxes.
+    if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
+        return false;
 
     if (computed_values().contain().paint_containment)
         return true;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -107,7 +107,7 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
     return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
 }
 
-static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layout_parent, Layout::Node& layout_node)
+static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layout_parent, Layout::Node& layout_node, TreeBuilder::AppendOrPrepend mode)
 {
     // Inline is fine for in-flow block children (interrupting blocks) and for out-of-flow children;
     // the inline formatting context emits items for both.
@@ -123,10 +123,13 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
     if (!has_inline_or_in_flow_block_children(*new_parent))
         return *new_parent;
 
-    // If the block is out-of-flow and is not a pseudo element,
-    if (layout_node.is_out_of_flow() && !layout_node.is_generated_for_pseudo_element()) {
-        // And the parent's last child is an anonymous block, join that anonymous block.
-        if (!new_parent->display().is_flex_inside()
+    // If the block is out-of-flow,
+    if (layout_node.is_out_of_flow()) {
+        // And we're appending while the parent's last child is an anonymous block, join that
+        // anonymous block. Prepended boxes (e.g. an absolutely positioned ::before) belong at the
+        // very start of the parent, not at the start of its trailing inline run.
+        if (mode == TreeBuilder::AppendOrPrepend::Append
+            && !new_parent->display().is_flex_inside()
             && !new_parent->display().is_grid_inside()
             && !new_parent->last_child()->is_generated_for_pseudo_element()
             && new_parent->last_child()->is_anonymous()
@@ -165,7 +168,7 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
     auto& nearest_insertion_ancestor = *m_ancestor_stack.last();
 
     auto& insertion_point = display.is_inline_outside() ? insertion_parent_for_inline_node(nearest_insertion_ancestor)
-                                                        : insertion_parent_for_block_node(nearest_insertion_ancestor, node);
+                                                        : insertion_parent_for_block_node(nearest_insertion_ancestor, node, mode);
 
     if (mode == AppendOrPrepend::Prepend)
         insertion_point.prepend_child(node);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -109,8 +109,9 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
 
 static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layout_parent, Layout::Node& layout_node)
 {
-    // Inline is fine for in-flow block children; the inline formatting context can contain interrupting blocks.
-    if (!layout_node.is_anonymous() && layout_parent.is_inline() && layout_parent.display().is_flow_inside() && !layout_node.is_out_of_flow())
+    // Inline is fine for in-flow block children (interrupting blocks) and for out-of-flow children;
+    // the inline formatting context emits items for both.
+    if (!layout_node.is_anonymous() && layout_parent.is_inline() && layout_parent.display().is_flow_inside())
         return layout_parent;
 
     // Make sure we're not inserting into an inline node, since those do not support block nodes.
@@ -161,50 +162,13 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
 
 void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
 {
-    // Find the nearest ancestor that can host the node.
-    NodeWithStyle* topmost_skipped_inline_flow_ancestor = nullptr;
-    bool skipped_inline_flow_ancestor_had_children = false;
-    auto& nearest_insertion_ancestor = [&]() -> NodeWithStyle& {
-        NodeWithStyle* previously_skipped_inline_flow_ancestor = nullptr;
-        for (auto& ancestor : m_ancestor_stack.in_reverse()) {
-            if (ancestor->is_svg_foreign_object_box())
-                return *ancestor;
-
-            auto const& ancestor_display = ancestor->display();
-
-            // Out-of-flow nodes cannot be hosted in inline flow nodes.
-            if (node.is_out_of_flow() && ancestor_display.is_inline_outside() && ancestor_display.is_flow_inside()) {
-                topmost_skipped_inline_flow_ancestor = ancestor;
-                // Content precedes the out-of-flow node only if some skipped inline has a child other than
-                // the previously skipped inline itself (which is always its child in the skip chain).
-                for (auto child = ancestor->first_child(); child; child = child->next_sibling()) {
-                    if (child.ptr() != previously_skipped_inline_flow_ancestor) {
-                        skipped_inline_flow_ancestor_had_children = true;
-                        break;
-                    }
-                }
-                previously_skipped_inline_flow_ancestor = ancestor;
-                continue;
-            }
-
-            return *ancestor;
-        }
-        VERIFY_NOT_REACHED();
-    }();
+    auto& nearest_insertion_ancestor = *m_ancestor_stack.last();
 
     auto& insertion_point = display.is_inline_outside() ? insertion_parent_for_inline_node(nearest_insertion_ancestor)
                                                         : insertion_parent_for_block_node(nearest_insertion_ancestor, node);
 
-    auto should_insert_before_topmost_skipped_inline_ancestor = node.is_out_of_flow()
-        && mode == AppendOrPrepend::Append
-        && topmost_skipped_inline_flow_ancestor
-        && !skipped_inline_flow_ancestor_had_children
-        && topmost_skipped_inline_flow_ancestor->parent() == &insertion_point;
-
     if (mode == AppendOrPrepend::Prepend)
         insertion_point.prepend_child(node);
-    else if (should_insert_before_topmost_skipped_inline_ancestor)
-        insertion_point.insert_before(node, *topmost_skipped_inline_flow_ancestor);
     else
         insertion_point.append_child(node);
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -18,6 +18,11 @@ public:
 
     RefPtr<Layout::Node> build(DOM::Node&);
 
+    enum class AppendOrPrepend {
+        Append,
+        Prepend,
+    };
+
 private:
     struct Context {
         bool has_svg_root = false;
@@ -55,10 +60,6 @@ private:
     Vector<NonnullRefPtr<Box>> generate_missing_parents(NodeWithStyle& root);
     void missing_cells_fixup(Vector<NonnullRefPtr<Box>> const&);
 
-    enum class AppendOrPrepend {
-        Append,
-        Prepend,
-    };
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
     RefPtr<NodeWithStyle> create_pseudo_element_if_needed(DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
     RefPtr<NodeWithStyle> create_content_replacement_if_needed(DOM::Element&, CSS::ComputedProperties const&) const;

--- a/Tests/LibWeb/Layout/expected/abspos-after-consecutive-forced-breaks-static-position.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-after-consecutive-forced-breaks-static-position.txt
@@ -4,13 +4,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <ul> at [0,0] [0+0+0 800 0+0+0] [0+0+0 40 0+0+0] children: not-inline
         BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)
-        ListItemBox <li> at [0,0] positioned [0+0+0 100 0+0+700] [0+0+0 40 0+0+0] children: not-inline
-          BlockContainer <(anonymous)> at [0,0] [0+0+0 100 0+0+0] [0+0+0 40 0+0+0] children: inline
-            frag 0 from TextNode start: 0, length: 3, rect: [0,0 30x20] baseline: 13
-                "XXX"
-            TextNode <#text> (not painted)
-            BreakNode <br> (not painted)
-            BreakNode <br> (not painted)
+        ListItemBox <li> at [0,0] positioned [0+0+0 100 0+0+700] [0+0+0 40 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [0,0 30x20] baseline: 13
+              "XXX"
+          TextNode <#text> (not painted)
+          BreakNode <br> (not painted)
+          BreakNode <br> (not painted)
           BlockContainer <(anonymous)> at [0,40] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
             frag 0 from GeneratedTextNode start: 0, length: 1, rect: [0,40 10x20] baseline: 13
                 "X"
@@ -26,7 +25,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<UL>) [0,0 800x40]
         PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
         PaintableWithLines (ListItemBox<LI>) [0,0 100x40]
-          PaintableWithLines (BlockContainer(anonymous)) [0,0 100x40]
           PaintableWithLines (BlockContainer(anonymous)) [0,40 10x20]
         PaintableWithLines (BlockContainer(anonymous)) [0,40 800x0]
       PaintableWithLines (BlockContainer(anonymous)) [0,40 800x0]

--- a/Tests/LibWeb/Layout/expected/abspos-element-with-inline-as-abspos-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-element-with-inline-as-abspos-containing-block.txt
@@ -5,14 +5,14 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         frag 0 from TextNode start: 0, length: 8, rect: [8,8 74.125x18] baseline: 13.796875
             "Features"
         TextNode <#text> (not painted)
-      BlockContainer <span.span2> at [85.625,16.09375] positioned [0+0+0 8 0+0+0] [0+0+0 8 0+0+0] [BFC] children: not-inline
+        BlockContainer <span.span2> at [85.625,16.09375] positioned [0+0+0 8 0+0+0] [0+0+0 8 0+0+0] [BFC] children: not-inline
       TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 300x300]
       PaintableWithLines (InlineNode<SPAN>.span1) [8,8 90.125x18]
-      PaintableWithLines (BlockContainer<SPAN>.span2) [85.625,16.09375 8x8]
+        PaintableWithLines (BlockContainer<SPAN>.span2) [85.625,16.09375 8x8]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/abspos-inline-containing-block-atomic-inline-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-inline-containing-block-atomic-inline-border-box.txt
@@ -7,21 +7,21 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         InlineNode <span.host> at [34,30] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [34,30 0x0] baseline: 10
           BlockContainer <span.atomic.empty-padded> at [34,30] inline-block [0+4+10 0 10+4+0] [0+4+6 0 6+4+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [20,20] positioned [0+0+0 28 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [20,20] positioned [0+0+0 28 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,60] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case> at [20,60] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
         InlineNode <span.host> at [25,65] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [25,65 0x0] baseline: 5
           BlockContainer <span.atomic.border-only> at [25,65] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [20,60] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [20,60] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,100] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case> at [20,100] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
         InlineNode <span.host> at [29,105] [0+0+0 12 0+0+0] [0+0+0 8 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [29,105 12x8] baseline: 5
           BlockContainer <span.atomic.sized-padded> at [29,105] inline-block [0+2+7 12 7+2+0] [0+2+3 8 3+2+0] [BFC] children: not-inline
-        BlockContainer <span.percentage> at [50,100] positioned [0+0+0 30 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.percentage> at [50,100] positioned [0+0+0 30 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,140] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case> at [20,140] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
@@ -31,21 +31,21 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           frag 1 from BlockContainer start: 0, length: 0, rect: [39.125,145 6x10] baseline: 5
           TextNode <#text> (not painted)
           BlockContainer <span.atomic.mixed> at [39.125,145] inline-block [0+3+4 6 4+3+0] [0+3+2 10 2+3+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [20,140] positioned [0+0+0 32.125 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [20,140] positioned [0+0+0 32.125 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,180] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case> at [20,180] [20+0+0 360 0+0+20] [20+0+0 44 0+0+20] children: inline
         InlineNode <span.host> at [22,182] [0+0+0 8 0+0+0] [0+0+0 40 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [22,182 8x40] baseline: 2
           BlockContainer <span.atomic.tall> at [22,182] inline-block [0+2+0 8 0+2+0] [0+2+0 40 0+2+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [20,180] positioned [0+0+0 12 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [20,180] positioned [0+0+0 12 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,244] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case> at [20,244] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
         InlineNode <span.host.large-line-height> at [25,249] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [25,249 0x0] baseline: 5
           BlockContainer <span.atomic.border-only> at [25,249] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [20,244] positioned [0+0+0 10 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [20,244] positioned [0+0+0 10 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,284] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case> at [20,284] [20+0+0 360 0+0+20] [20+0+0 60 0+0+20] children: inline
@@ -56,56 +56,56 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         InlineNode <span.host> at [55.75,321] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [55.75,321 0x0] baseline: 10
           BlockContainer <span.atomic.baseline.border-only> at [55.75,321] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [50.75,316] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [50.75,316] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,364] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.vertical> at [20,364] [20+0+0 360 0+0+20] [20+0+0 10 0+0+20] children: inline
         InlineNode <span.host> at [375,369] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [375,369 0x0] baseline: 5
           BlockContainer <span.atomic.border-only> at [375,369] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [360,364] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [360,364] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,394] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.vertical> at [20,394] [20+0+0 360 0+0+20] [20+0+0 30 0+0+20] children: inline
         InlineNode <span.host> at [367,403] [0+0+0 8 0+0+0] [0+0+0 12 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [367,403 8x12] baseline: 5
           BlockContainer <span.atomic.sized-padded> at [367,403] inline-block [0+2+7 12 7+2+0] [0+2+3 8 3+2+0] [BFC] children: not-inline
-        BlockContainer <span.percentage> at [362,424] positioned [0+0+0 20 0+0+0] [0+0+0 18 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.percentage> at [362,424] positioned [0+0+0 20 0+0+0] [0+0+0 18 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,444] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.vertical> at [20,444] [20+0+0 360 0+0+20] [20+0+0 10 0+0+20] children: inline
         InlineNode <span.host.large-line-height> at [375,449] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [375,449 0x0] baseline: 5
           BlockContainer <span.atomic.border-only> at [375,449] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [350,444] positioned [0+0+0 30 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [350,444] positioned [0+0+0 30 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,474] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.vertical-lr> at [20,474] [20+0+0 360 0+0+20] [20+0+0 30 0+0+20] children: inline
         InlineNode <span.host> at [367,483] [0+0+0 8 0+0+0] [0+0+0 12 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [367,483 8x12] baseline: 5
           BlockContainer <span.atomic.sized-padded> at [367,483] inline-block [0+2+7 12 7+2+0] [0+2+3 8 3+2+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [358,478] positioned [0+0+0 20 0+0+0] [0+0+0 18 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [358,478] positioned [0+0+0 20 0+0+0] [0+0+0 18 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,524] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.vertical> at [20,524] [20+0+0 360 0+0+20] [20+0+0 10 0+0+20] children: inline
         InlineNode <span.host> at [381,529] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [381,529 0x0] baseline: 10
           BlockContainer <span.atomic.baseline.border-only> at [381,529] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [366,524] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [366,524] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,554] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.vertical> at [20,554] [20+0+0 360 0+0+20] [20+0+0 10 0+0+20] children: inline
         InlineNode <span.host> at [380,559] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [380,559 0x0] baseline: 10.375
           BlockContainer <span.atomic.middle.border-only> at [380,559] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [365,554] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [365,554] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,584] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case> at [20,584] [20+0+0 360 0+0+20] [20+0+0 20 0+0+20] children: inline
         InlineNode <span.host> at [25,594] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [25,594 0x0] baseline: 10.375
           BlockContainer <span.atomic.middle.border-only> at [25,594] inline-block [0+5+0 0 0+5+0] [0+5+0 0 0+5+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [20,589] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [20,589] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,624] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case> at [20,624] [20+0+0 360 0+0+20] [20+0+0 40 0+0+20] children: inline
@@ -117,28 +117,28 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           TextNode <#text> (not painted)
           BreakNode <br> (not painted)
           TextNode <#text> (not painted)
-        BlockContainer <span.overlay> at [20,634] positioned [0+0+0 68.5 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [20,634] positioned [0+0+0 68.5 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,684] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.sideways> at [20,684] [20+0+0 360 0+0+20] [20+0+0 24 0+0+20] children: inline
         InlineNode <span.host> at [361,701] [0+0+0 8 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [361,701 8x0] baseline: 5
           BlockContainer <span.atomic.asymmetric> at [361,701] inline-block [0+8+9 0 1+6+0] [0+2+3 8 7+4+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [348,696] positioned [0+0+0 20 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [348,696] positioned [0+0+0 20 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,728] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.sideways-lr> at [20,728] [20+0+0 360 0+0+20] [20+0+0 24 0+0+20] children: inline
         InlineNode <span.host> at [361,745] [0+0+0 8 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [361,745 8x0] baseline: 5
           BlockContainer <span.atomic.asymmetric> at [361,745] inline-block [0+8+9 0 1+6+0] [0+2+3 8 7+4+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [344,740] positioned [0+0+0 20 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [344,740] positioned [0+0+0 20 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,772] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.case.sideways> at [20,772] [20+0+0 360 0+0+20] [20+0+0 24 0+0+20] children: inline
         InlineNode <span.host.large-line-height> at [361,789] [0+0+0 8 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [361,789 8x0] baseline: 5
           BlockContainer <span.atomic.asymmetric> at [361,789] inline-block [0+8+9 0 1+6+0] [0+2+3 8 7+4+0] [BFC] children: not-inline
-        BlockContainer <span.overlay> at [338,784] positioned [0+0+0 30 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+          BlockContainer <span.overlay> at [338,784] positioned [0+0+0 30 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [0,816] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
@@ -149,97 +149,98 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x808]
       PaintableWithLines (BlockContainer<DIV>.case) [20,20 360x20]
         PaintableWithLines (InlineNode<SPAN>.host) [34,30 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.empty-padded) [20,20 28x20]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,20 28x20]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [20,20 28x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,60 400x0]
       PaintableWithLines (BlockContainer<DIV>.case) [20,60 360x20]
         PaintableWithLines (InlineNode<SPAN>.host) [25,65 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.border-only) [20,60 10x10]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,60 10x20]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [20,60 10x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,100 400x0]
       PaintableWithLines (BlockContainer<DIV>.case) [20,100 360x20]
         PaintableWithLines (InlineNode<SPAN>.host) [29,105 12x8]
           PaintableWithLines (BlockContainer<SPAN>.atomic.sized-padded) [20,100 30x18]
-        PaintableWithLines (BlockContainer<SPAN>.percentage) [50,100 30x20]
+          PaintableWithLines (BlockContainer<SPAN>.percentage) [50,100 30x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,140 400x0]
       PaintableWithLines (BlockContainer<DIV>.case) [20,140 360x20]
         PaintableWithLines (InlineNode<SPAN>.host) [20,140 18.125x20]
           PaintableWithLines (BlockContainer<SPAN>.atomic.mixed) [32.125,140 20x20]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,140 32.125x20]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [20,140 32.125x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,180 400x0]
       PaintableWithLines (BlockContainer<DIV>.case) [20,180 360x44]
         PaintableWithLines (InlineNode<SPAN>.host) [22,182 8x40]
           PaintableWithLines (BlockContainer<SPAN>.atomic.tall) [20,180 12x44]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,180 12x20]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [20,180 12x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,244 400x0]
       PaintableWithLines (BlockContainer<DIV>.case) [20,244 360x20]
         PaintableWithLines (InlineNode<SPAN>.host.large-line-height) [25,249 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.border-only) [20,244 10x10]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,244 10x30]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [20,244 10x30]
       PaintableWithLines (BlockContainer(anonymous)) [0,284 400x0]
       PaintableWithLines (BlockContainer<DIV>.case) [20,284 360x60]
         PaintableWithLines (InlineNode<SPAN>.large-sibling) [20,284 30.75x60]
         PaintableWithLines (InlineNode<SPAN>.host) [55.75,321 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.baseline.border-only) [50.75,316 10x10]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [50.75,316 10x20]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [50.75,316 10x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,364 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,364 360x10]
         PaintableWithLines (InlineNode<SPAN>.host) [375,369 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.border-only) [370,364 10x10]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [360,364 20x10]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [360,364 20x10]
       PaintableWithLines (BlockContainer(anonymous)) [0,394 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,394 360x30]
         PaintableWithLines (InlineNode<SPAN>.host) [367,403 8x12]
           PaintableWithLines (BlockContainer<SPAN>.atomic.sized-padded) [358,398 30x18]
-        PaintableWithLines (BlockContainer<SPAN>.percentage) [362,424 20x18]
+          PaintableWithLines (BlockContainer<SPAN>.percentage) [362,424 20x18]
       PaintableWithLines (BlockContainer(anonymous)) [0,444 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,444 360x10]
         PaintableWithLines (InlineNode<SPAN>.host.large-line-height) [375,449 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.border-only) [370,444 10x10]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [350,444 30x10]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [350,444 30x10]
       PaintableWithLines (BlockContainer(anonymous)) [0,474 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.vertical-lr) [20,474 360x30]
         PaintableWithLines (InlineNode<SPAN>.host) [367,483 8x12]
           PaintableWithLines (BlockContainer<SPAN>.atomic.sized-padded) [358,478 30x18]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [358,478 20x18]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [358,478 20x18]
       PaintableWithLines (BlockContainer(anonymous)) [0,524 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,524 360x10]
         PaintableWithLines (InlineNode<SPAN>.host) [381,529 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.baseline.border-only) [376,524 10x10]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [366,524 20x10]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [366,524 20x10]
       PaintableWithLines (BlockContainer(anonymous)) [0,554 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.vertical) [20,554 360x10]
         PaintableWithLines (InlineNode<SPAN>.host) [380,559 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.middle.border-only) [375,554 10x10]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [365,554 20x10]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [365,554 20x10]
       PaintableWithLines (BlockContainer(anonymous)) [0,584 400x0]
       PaintableWithLines (BlockContainer<DIV>.case) [20,584 360x20]
         PaintableWithLines (InlineNode<SPAN>.host) [25,594 0x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.middle.border-only) [20,589 10x10]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,589 10x20]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [20,589 10x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,624 400x0]
       PaintableWithLines (BlockContainer<DIV>.case) [20,624 360x40]
         PaintableWithLines (InlineNode<SPAN>.zero-host) [20,634 45.046875x0]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [20,634 68.5x20]
 
         PaintableWithLines (InlineNode<SPAN>.zero-host) [20,654 68.5x0]
         PaintableWithLines (InlineNode<SPAN>.zero-host) [20,634 45.046875x0]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [20,634 68.5x20]
 
         PaintableWithLines (InlineNode<SPAN>.zero-host) [20,654 68.5x0]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [20,634 68.5x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,684 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.sideways) [20,684 360x24]
         PaintableWithLines (InlineNode<SPAN>.host) [361,701 8x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.asymmetric) [344,696 24x24]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [348,696 20x24]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [348,696 20x24]
       PaintableWithLines (BlockContainer(anonymous)) [0,728 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.sideways-lr) [20,728 360x24]
         PaintableWithLines (InlineNode<SPAN>.host) [361,745 8x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.asymmetric) [344,740 24x24]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [344,740 20x24]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [344,740 20x24]
       PaintableWithLines (BlockContainer(anonymous)) [0,772 400x0]
       PaintableWithLines (BlockContainer<DIV>.case.sideways) [20,772 360x24]
         PaintableWithLines (InlineNode<SPAN>.host.large-line-height) [361,789 8x0]
           PaintableWithLines (BlockContainer<SPAN>.atomic.asymmetric) [344,784 24x24]
-        PaintableWithLines (BlockContainer<SPAN>.overlay) [338,784 30x24]
+          PaintableWithLines (BlockContainer<SPAN>.overlay) [338,784 30x24]
       PaintableWithLines (BlockContainer(anonymous)) [0,816 400x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/abspos-pseudo-element-with-inline-as-abspos-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-pseudo-element-with-inline-as-abspos-containing-block.txt
@@ -1,23 +1,19 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: not-inline
-      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
-        InlineNode <span> at [8,8] [0+0+0 74.125 16+0+0] [0+0+0 18 0+0+0]
-          frag 0 from TextNode start: 0, length: 8, rect: [8,8 74.125x18] baseline: 13.796875
-              "Features"
-          TextNode <#text> (not painted)
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: inline
+      InlineNode <span> at [8,8] [0+0+0 74.125 16+0+0] [0+0+0 18 0+0+0]
+        frag 0 from TextNode start: 0, length: 8, rect: [8,8 74.125x18] baseline: 13.796875
+            "Features"
+        TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [85.625,16.09375] positioned [0+0+0 8 0+0+0] [0+0+0 5 0+0+0] [BFC] children: inline
         GeneratedTextNode <(anonymous)> (not painted)
-      BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
-        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
-      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]
-        PaintableWithLines (InlineNode<SPAN>) [8,8 90.125x18]
+      PaintableWithLines (InlineNode<SPAN>) [8,8 90.125x18]
       PaintableWithLines (BlockContainer(anonymous)) [85.625,16.09375 8x5]
-      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x34] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-in-nested-inlines-on-later-line.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-in-nested-inlines-on-later-line.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 40 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] [0+0+0 800 0+0+0] [0+0+0 40 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [0,0 50x20] baseline: 13
+            "line1"
+        TextNode <#text> (not painted)
+        BreakNode <br> (not painted)
+        InlineNode <span> at [0,0] [0+0+0 0 0+0+0] [0+0+0 20 0+0+0]
+          InlineNode <i> at [0,20] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
+            frag 0 from TextNode start: 0, length: 2, rect: [0,20 20x20] baseline: 13
+                "ab"
+            frag 1 from TextNode start: 0, length: 2, rect: [20,20 20x20] baseline: 13
+                "cd"
+            TextNode <#text> (not painted)
+            BlockContainer <b> at [20,20] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [20,20 10x20] baseline: 13
+                  "X"
+              TextNode <#text> (not painted)
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,40] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x40]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 800x40]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 0x20]
+          PaintableWithLines (InlineNode<I>) [0,20 40x20]
+            PaintableWithLines (BlockContainer<B>) [20,20 10x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,40 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x40] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-only-child-of-span.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-only-child-of-span.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      BlockContainer <div> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        InlineNode <span> at [0,0] [0+0+5 0 5+0+0] [0+0+5 20 5+0+0]
+          BlockContainer <b> at [0,0] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [0,0 10x20] baseline: 13
+                "X"
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 800x0]
+        PaintableWithLines (InlineNode<SPAN>) [-5,-5 10x30]
+          PaintableWithLines (BlockContainer<B>) [0,0 10x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-pseudo-after-trailing-interrupting-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-pseudo-after-trailing-interrupting-block.txt
@@ -1,17 +1,16 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: not-inline
-      BlockContainer <div.rel> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: not-inline
-        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: inline
-          InlineNode <span> at [0,0] [0+0+0 10 0+0+0] [0+0+0 20 0+0+0]
-            frag 0 from TextNode start: 0, length: 1, rect: [0,0 10x20] baseline: 13
-                "a"
-            frag 0 from BlockContainer start: 0, length: 0, rect: [0,20 800x10] baseline: 0
+      BlockContainer <div.rel> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: inline
+        InlineNode <span> at [0,0] [0+0+0 10 0+0+0] [0+0+0 20 0+0+0]
+          frag 0 from TextNode start: 0, length: 1, rect: [0,0 10x20] baseline: 13
+              "a"
+          frag 0 from BlockContainer start: 0, length: 0, rect: [0,20 800x10] baseline: 0
+          TextNode <#text> (not painted)
+          BlockContainer <div> at [0,20] [0+0+0 800 0+0+0] [0+0+0 10 0+0+0] children: inline
+            frag 0 from TextNode start: 0, length: 5, rect: [0,20 50x20] baseline: 13
+                "block"
             TextNode <#text> (not painted)
-            BlockContainer <div> at [0,20] [0+0+0 800 0+0+0] [0+0+0 10 0+0+0] children: inline
-              frag 0 from TextNode start: 0, length: 5, rect: [0,20 50x20] baseline: 13
-                  "block"
-              TextNode <#text> (not painted)
         BlockContainer <(anonymous)> at [0,30] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
           frag 0 from GeneratedTextNode start: 0, length: 1, rect: [0,30 10x20] baseline: 13
               "X"
@@ -23,15 +22,14 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x30]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x30]
       PaintableWithLines (BlockContainer<DIV>.rel) [0,0 800x30]
-        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x30]
-          PaintableWithLines (InlineNode<SPAN>) [0,0 10x20]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 10x20]
 
-          PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
-            PaintableWithLines (BlockContainer<DIV>) [0,20 800x10]
-          PaintableWithLines (InlineNode<SPAN>) [0,0 10x20]
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 800x10]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 10x20]
 
-          PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
-            PaintableWithLines (BlockContainer<DIV>) [0,20 800x10]
+        PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<DIV>) [0,20 800x10]
         PaintableWithLines (BlockContainer(anonymous)) [0,30 10x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,30 800x0]
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-static-position-after-interrupting-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-static-position-after-interrupting-block.txt
@@ -6,14 +6,14 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             "first line"
         TextNode <#text> (not painted)
         BreakNode <br> (not painted)
-        BlockContainer <b> at [0,20] positioned [0+0+0 30 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 3, rect: [0,20 30x20] baseline: 13
-              "abs"
-          TextNode <#text> (not painted)
         InlineNode <span> at [0,20] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
           frag 0 from BlockContainer start: 0, length: 0, rect: [0,20 800x20] baseline: 0
           frag 0 from TextNode start: 0, length: 4, rect: [0,40 40x20] baseline: 13
               "rest"
+          BlockContainer <b> at [0,20] positioned [0+0+0 30 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 3, rect: [0,20 30x20] baseline: 13
+                "abs"
+            TextNode <#text> (not painted)
           BlockContainer <div> at [0,20] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
             frag 0 from TextNode start: 0, length: 5, rect: [0,20 50x20] baseline: 13
                 "block"
@@ -26,12 +26,13 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x60]
       PaintableWithLines (BlockContainer<DIV>) [0,0 800x60]
-        PaintableWithLines (BlockContainer<B>) [0,20 30x20]
         PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<B>) [0,20 30x20]
           PaintableWithLines (BlockContainer<DIV>) [0,20 800x20]
 
         PaintableWithLines (InlineNode<SPAN>) [0,40 40x20]
         PaintableWithLines (InlineNode<SPAN>) [0,20 0x0]
+          PaintableWithLines (BlockContainer<B>) [0,20 30x20]
           PaintableWithLines (BlockContainer<DIV>) [0,20 800x20]
 
         PaintableWithLines (InlineNode<SPAN>) [0,40 40x20]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
@@ -4,11 +4,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 414.703125x57] baseline: 45.484375
       BlockContainer <button.button_button___eDCW> at [13,10] positioned inline-block [0+1+4 414.703125 4+1+0] [0+1+1 57 1+1+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> at [13,10] flex-container(column) [0+0+0 414.703125 0+0+0] [0+0+0 57 0+0+0] [FFC] children: not-inline
-          BlockContainer <(anonymous)> at [13,10] flex-item [0+0+0 414.703125 0+0+0] [0+0+0 57 0+0+0] [BFC] children: not-inline
-            BlockContainer <(anonymous)> at [13,10] [0+0+0 414.703125 0+0+0] [0+0+0 57 0+0+0] children: inline
-              frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.703125x57] baseline: 43.484375
-                  "See more games"
-              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> at [13,10] flex-item [0+0+0 414.703125 0+0+0] [0+0+0 57 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.703125x57] baseline: 43.484375
+                "See more games"
+            TextNode <#text> (not painted)
             BlockContainer <(anonymous)> at [9,9] positioned [0+0+0 422.703125 0+0+0] [0+0+0 59 0+0+0] [BFC] children: inline
               GeneratedTextNode <(anonymous)> (not painted)
 
@@ -18,7 +17,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<BUTTON>.button_button___eDCW) [8,8 424.703125x61]
         PaintableWithLines (BlockContainer(anonymous)) [13,10 414.703125x57]
           PaintableWithLines (BlockContainer(anonymous)) [13,10 414.703125x57]
-            PaintableWithLines (BlockContainer(anonymous)) [13,10 414.703125x57]
             PaintableWithLines (BlockContainer(anonymous)) [9,9 422.703125x59]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-after-interrupting-block-with-bottom-margin.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-after-interrupting-block-with-bottom-margin.txt
@@ -10,8 +10,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             frag 0 from TextNode start: 0, length: 5, rect: [0,0 50x20] baseline: 13
                 "block"
             TextNode <#text> (not painted)
+          ImageBox <img> at [0,50] floating [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] children: not-inline
           TextNode <#text> (not painted)
-        ImageBox <img> at [0,50] floating [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] children: not-inline
       BlockContainer <(anonymous)> at [0,70] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
@@ -21,13 +21,14 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<DIV>) [0,0 800x70]
         PaintableWithLines (InlineNode<SPAN>) [0,0 0x0]
           PaintableWithLines (BlockContainer<DIV>) [0,0 800x10]
+          ImagePaintable (ImageBox<IMG>) [0,50 20x20]
 
         PaintableWithLines (InlineNode<SPAN>) [20,50 40x20]
         PaintableWithLines (InlineNode<SPAN>) [0,0 0x0]
           PaintableWithLines (BlockContainer<DIV>) [0,0 800x10]
+          ImagePaintable (ImageBox<IMG>) [0,50 20x20]
 
         PaintableWithLines (InlineNode<SPAN>) [20,50 40x20]
-        ImagePaintable (ImageBox<IMG>) [0,50 20x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,70 800x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-first-in-span.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-first-in-span.txt
@@ -1,16 +1,12 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-      BlockContainer <div> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
-        InlineNode <span> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
-          InlineNode <i> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
-            frag 0 from TextNode start: 0, length: 4, rect: [0,0 40x20] baseline: 13
-                "text"
-            BlockContainer <b> at [0,0] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 1, rect: [0,0 10x20] baseline: 13
-                  "X"
-              TextNode <#text> (not painted)
-            TextNode <#text> (not painted)
+      BlockContainer <div> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
+        InlineNode <span> at [20,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
+          frag 0 from TextNode start: 0, length: 4, rect: [20,0 40x20] baseline: 13
+              "text"
+          ImageBox <img> at [0,0] floating [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+          TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [0,20] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
@@ -18,9 +14,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x20]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x20]
       PaintableWithLines (BlockContainer<DIV>) [0,0 800x20]
-        PaintableWithLines (InlineNode<SPAN>) [0,0 40x20]
-          PaintableWithLines (InlineNode<I>) [0,0 40x20]
-            PaintableWithLines (BlockContainer<B>) [0,0 10x20]
+        PaintableWithLines (InlineNode<SPAN>) [20,0 40x20]
+          ImagePaintable (ImageBox<IMG>) [0,0 20x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,20 800x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/span-pseudo-abspos-after.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/span-pseudo-abspos-after.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-      BlockContainer <div> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
-        InlineNode <span> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
-          InlineNode <i> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
+      BlockContainer <div> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
+          InlineNode <span> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
             frag 0 from TextNode start: 0, length: 4, rect: [0,0 40x20] baseline: 13
                 "text"
-            BlockContainer <b> at [0,0] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 1, rect: [0,0 10x20] baseline: 13
-                  "X"
-              TextNode <#text> (not painted)
             TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [40,0] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+          frag 0 from GeneratedTextNode start: 0, length: 1, rect: [40,0 10x20] baseline: 13
+              "X"
+          GeneratedTextNode <(anonymous)> (not painted)
       BlockContainer <(anonymous)> at [0,20] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
@@ -18,9 +18,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x20]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x20]
       PaintableWithLines (BlockContainer<DIV>) [0,0 800x20]
-        PaintableWithLines (InlineNode<SPAN>) [0,0 40x20]
-          PaintableWithLines (InlineNode<I>) [0,0 40x20]
-            PaintableWithLines (BlockContainer<B>) [0,0 10x20]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x20]
+          PaintableWithLines (InlineNode<SPAN>) [0,0 40x20]
+        PaintableWithLines (BlockContainer(anonymous)) [40,0 10x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,20 800x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/span-pseudo-abspos-after.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/span-pseudo-abspos-after.txt
@@ -1,12 +1,11 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-      BlockContainer <div> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
-          InlineNode <span> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
-            frag 0 from TextNode start: 0, length: 4, rect: [0,0 40x20] baseline: 13
-                "text"
-            TextNode <#text> (not painted)
+      BlockContainer <div> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
+        InlineNode <span> at [0,0] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0]
+          frag 0 from TextNode start: 0, length: 4, rect: [0,0 40x20] baseline: 13
+              "text"
+          TextNode <#text> (not painted)
         BlockContainer <(anonymous)> at [40,0] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
           frag 0 from GeneratedTextNode start: 0, length: 1, rect: [40,0 10x20] baseline: 13
               "X"
@@ -18,8 +17,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x20]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x20]
       PaintableWithLines (BlockContainer<DIV>) [0,0 800x20]
-        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x20]
-          PaintableWithLines (InlineNode<SPAN>) [0,0 40x20]
+        PaintableWithLines (InlineNode<SPAN>) [0,0 40x20]
         PaintableWithLines (BlockContainer(anonymous)) [40,0 10x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,20 800x0]
 

--- a/Tests/LibWeb/Layout/expected/pseudo-element-position-absolute.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-position-absolute.txt
@@ -6,28 +6,25 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           frag 0 from TextNode start: 0, length: 6, rect: [8,8 54.796875x18] baseline: 13.796875
               "foobar"
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,26] positioned [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
-        frag 0 from GeneratedTextNode start: 0, length: 3, rect: [8,26 27.203125x18] baseline: 13.796875
-            "baz"
-        GeneratedTextNode <(anonymous)> (not painted)
-      BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        BlockContainer <(anonymous)> at [8,26] positioned [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from GeneratedTextNode start: 0, length: 3, rect: [8,26 27.203125x18] baseline: 13.796875
+              "baz"
+          GeneratedTextNode <(anonymous)> (not painted)
         TextNode <#text> (not painted)
       BlockContainer <div> at [8,26] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
         frag 0 from TextNode start: 0, length: 11, rect: [8,26 97.640625x18] baseline: 13.796875
             "lorem ipsum"
         TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-        BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <span> at [8,44] [0+0+0 54.796875 0+0+0] [0+0+0 18 0+0+0]
+          frag 0 from TextNode start: 0, length: 6, rect: [8,44 54.796875x18] baseline: 13.796875
+              "foobar"
           TextNode <#text> (not painted)
-          InlineNode <span> at [8,44] [0+0+0 54.796875 0+0+0] [0+0+0 18 0+0+0]
-            frag 0 from TextNode start: 0, length: 6, rect: [8,44 54.796875x18] baseline: 13.796875
-                "foobar"
-            TextNode <#text> (not painted)
         BlockContainer <(anonymous)> at [8,62] positioned [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
           frag 0 from GeneratedTextNode start: 0, length: 3, rect: [8,62 27.203125x18] baseline: 13.796875
               "baz"
           GeneratedTextNode <(anonymous)> (not painted)
-      BlockContainer <(anonymous)> at [8,62] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
@@ -35,14 +32,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x54]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]
         PaintableWithLines (InlineNode<SPAN>) [8,8 54.796875x18]
-      PaintableWithLines (BlockContainer(anonymous)) [8,26 50x50]
-      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,26 50x50]
       PaintableWithLines (BlockContainer<DIV>) [8,26 784x18]
       PaintableWithLines (BlockContainer(anonymous)) [8,44 784x18]
-        PaintableWithLines (BlockContainer(anonymous)) [8,44 784x18]
-          PaintableWithLines (InlineNode<SPAN>) [8,44 54.796875x18]
+        PaintableWithLines (InlineNode<SPAN>) [8,44 54.796875x18]
         PaintableWithLines (BlockContainer(anonymous)) [8,62 50x50]
-      PaintableWithLines (BlockContainer(anonymous)) [8,62 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x70] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-position-absolute.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-position-absolute.txt
@@ -16,16 +16,17 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         frag 0 from TextNode start: 0, length: 11, rect: [8,26 97.640625x18] baseline: 13.796875
             "lorem ipsum"
         TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
-        TextNode <#text> (not painted)
-        InlineNode <span> at [8,44] [0+0+0 54.796875 0+0+0] [0+0+0 18 0+0+0]
-          frag 0 from TextNode start: 0, length: 6, rect: [8,44 54.796875x18] baseline: 13.796875
-              "foobar"
+      BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,62] positioned [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
-        frag 0 from GeneratedTextNode start: 0, length: 3, rect: [8,62 27.203125x18] baseline: 13.796875
-            "baz"
-        GeneratedTextNode <(anonymous)> (not painted)
+          InlineNode <span> at [8,44] [0+0+0 54.796875 0+0+0] [0+0+0 18 0+0+0]
+            frag 0 from TextNode start: 0, length: 6, rect: [8,44 54.796875x18] baseline: 13.796875
+                "foobar"
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,62] positioned [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from GeneratedTextNode start: 0, length: 3, rect: [8,62 27.203125x18] baseline: 13.796875
+              "baz"
+          GeneratedTextNode <(anonymous)> (not painted)
       BlockContainer <(anonymous)> at [8,62] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
@@ -38,8 +39,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,26 784x18]
       PaintableWithLines (BlockContainer(anonymous)) [8,44 784x18]
-        PaintableWithLines (InlineNode<SPAN>) [8,44 54.796875x18]
-      PaintableWithLines (BlockContainer(anonymous)) [8,62 50x50]
+        PaintableWithLines (BlockContainer(anonymous)) [8,44 784x18]
+          PaintableWithLines (InlineNode<SPAN>) [8,44 54.796875x18]
+        PaintableWithLines (BlockContainer(anonymous)) [8,62 50x50]
       PaintableWithLines (BlockContainer(anonymous)) [8,62 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-in-nested-inlines-on-later-line.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-in-nested-inlines-on-later-line.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div>line1<br><span><i>ab<b style="position: absolute">X</b>cd</i></span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-only-child-of-span.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-only-child-of-span.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div style="position: relative"><span style="padding: 5px"><b style="position: absolute">X</b></span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-first-in-span.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-first-in-span.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+</style>
+<div><span><img style="float: left; width: 20px; height: 20px">text</span></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/span-pseudo-abspos-after.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/span-pseudo-abspos-after.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+span::after { content: "X"; position: absolute; }
+</style>
+<div style="position: relative"><span>text</span></div>

--- a/Tests/LibWeb/Ref/expected/float-mid-inline-wraps-following-text-ref.html
+++ b/Tests/LibWeb/Ref/expected/float-mid-inline-wraps-following-text-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+div.container { width: 60px; }
+b { float: left; width: 20px; height: 20px; background: blue; display: block; }
+</style>
+<div class="container">AAA <b></b> BBB CCC</div>

--- a/Tests/LibWeb/Ref/input/float-mid-inline-wraps-following-text.html
+++ b/Tests/LibWeb/Ref/input/float-mid-inline-wraps-following-text.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/float-mid-inline-wraps-following-text-ref.html">
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+* { margin: 0; }
+body { font: 10px/20px Ahem; }
+div.container { width: 60px; }
+b { float: left; width: 20px; height: 20px; background: blue; display: block; }
+</style>
+<div class="container"><span>AAA <b></b> BBB CCC</span></div>

--- a/Tests/LibWeb/Text/expected/css/abspos-only-child-of-span-geometry.txt
+++ b/Tests/LibWeb/Text/expected/css/abspos-only-child-of-span-geometry.txt
@@ -1,0 +1,3 @@
+target rect: 0,10 10x10
+elementFromPoint hits target: true
+host rect count: 1

--- a/Tests/LibWeb/Text/expected/css/abspos-static-position-after-inline-start-edges.txt
+++ b/Tests/LibWeb/Text/expected/css/abspos-static-position-after-inline-start-edges.txt
@@ -1,0 +1,3 @@
+direct: abspos block offset in wrapper: 20
+restashed: abspos block offset in wrapper: 20
+control: abspos block offset in wrapper: 0

--- a/Tests/LibWeb/Text/expected/css/abspos-toggle-on-inline-child-relayout.txt
+++ b/Tests/LibWeb/Text/expected/css/abspos-toggle-on-inline-child-relayout.txt
@@ -1,0 +1,3 @@
+in flow: 20,0 20x20
+absolute: 20,0 20x20
+back in flow: 20,0 20x20

--- a/Tests/LibWeb/Text/input/css/abspos-only-child-of-span-geometry.html
+++ b/Tests/LibWeb/Text/input/css/abspos-only-child-of-span-geometry.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+body { margin: 0; font: 10px/20px Ahem; }
+#rel { position: relative; }
+#target { position: absolute; width: 10px; height: 10px; background: blue; }
+</style>
+<div id="rel"><span id="host" style="padding: 5px"><b id="target"></b></span></div>
+<script>
+promiseTest(async () => {
+    await document.fonts.ready;
+    await animationFrame();
+
+    const target = document.getElementById("target");
+    const rect = target.getBoundingClientRect();
+    println(`target rect: ${Math.round(rect.x)},${Math.round(rect.y)} ${Math.round(rect.width)}x${Math.round(rect.height)}`);
+
+    const hit = document.elementFromPoint(rect.x + 5, rect.y + 5);
+    println(`elementFromPoint hits target: ${hit === target}`);
+
+    const hostRects = document.getElementById("host").getClientRects();
+    println(`host rect count: ${hostRects.length}`);
+});
+</script>

--- a/Tests/LibWeb/Text/input/css/abspos-static-position-after-inline-start-edges.html
+++ b/Tests/LibWeb/Text/input/css/abspos-static-position-after-inline-start-edges.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+body { margin: 0; font: 10px/20px Ahem; }
+.wrapper { position: relative; }
+.edge { border-left: 40px solid transparent; }
+.abs { position: absolute; width: 10px; height: 10px; }
+</style>
+<!-- The span's start edge opens the line, so the block-level abspos anchors below it (CSS 2 § 9.4.2:
+     a line box containing an inline element with non-zero border is not a zero-height line box). -->
+<div class="wrapper" id="direct"><span class="edge"><div class="abs"></div>X</span></div>
+<!-- Same, but the span's start edge reaches the abspos via the collapsible whitespace chunk that
+     gets skipped at the start of the line. -->
+<div class="wrapper" id="restashed"><span class="edge"> <div class="abs"></div>X</span></div>
+<!-- No inline start edges precede the abspos: it anchors at the line top. -->
+<div class="wrapper" id="control"><div class="abs"></div>X</div>
+<script>
+promiseTest(async () => {
+    await document.fonts.ready;
+    await animationFrame();
+
+    for (const id of ["direct", "restashed", "control"]) {
+        const wrapper = document.getElementById(id);
+        const target = wrapper.querySelector(".abs");
+        const offset = Math.round(target.getBoundingClientRect().y - wrapper.getBoundingClientRect().y);
+        println(`${id}: abspos block offset in wrapper: ${offset}`);
+    }
+});
+</script>

--- a/Tests/LibWeb/Text/input/css/abspos-toggle-on-inline-child-relayout.html
+++ b/Tests/LibWeb/Text/input/css/abspos-toggle-on-inline-child-relayout.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+body { margin: 0; font: 10px/20px Ahem; }
+</style>
+<div><span id="host">ab<b id="target">cd</b>ef</span></div>
+<script>
+promiseTest(async () => {
+    await document.fonts.ready;
+    await animationFrame();
+
+    const target = document.getElementById("target");
+    const positionOf = (element) => {
+        const rect = element.getBoundingClientRect();
+        return `${Math.round(rect.x)},${Math.round(rect.y)} ${Math.round(rect.width)}x${Math.round(rect.height)}`;
+    };
+
+    println(`in flow: ${positionOf(target)}`);
+
+    target.style.position = "absolute";
+    println(`absolute: ${positionOf(target)}`);
+
+    target.style.position = "";
+    println(`back in flow: ${positionOf(target)}`);
+});
+</script>


### PR DESCRIPTION
This removes the last tree surgery left in inline layout after the flat inline model: abspos and floating boxes are no longer reparented out of their inline ancestors, so the layout tree now simply mirrors the DOM for all inline content.

Besides deleting the hoisting special cases, this makes static positions exact instead of approximated: out-of-flow boxes become inline formatting context items at their true document position, so their static position falls out of the line-box markers — mid-content, on later lines, with float intrusion — rather than being reconstructed in the BFC from an anonymous sibling's "end of inline run". That reconstruction machinery loses its last client and is deleted at the end of the series. A DOM mutation of an out-of-flow child also no longer restructures the layout tree far from the mutated node, which is groundwork for incremental layout.

Five of the eight commits are standalone fixes for real bugs the hoisting had been masking (float clear handling, contain on non-atomic inlines, floats interrupting unbreakable runs, and two static-position rules).