### PR TITLE
LibWeb: Make RequiredInvalidationAfterStyleChange hierarchical

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -859,7 +859,7 @@ AnimationUpdateContext::~AnimationUpdateContext()
         bool invalidated_assigned_slottables_for_descendant_slots = false;
         if (!element.pseudo_element().has_value()) {
             CSS::Invalidation::invalidate_assigned_slottables_after_slot_style_change(target);
-            if (invalidation.inherited_style_changed || invalidation.rebuild_layout_tree) {
+            if (invalidation.inherited_style_changed || invalidation.needs_layout_tree_rebuild()) {
                 CSS::Invalidation::invalidate_assigned_slottables_for_descendant_slots_after_inherited_style_change(target);
                 invalidated_assigned_slottables_for_descendant_slots = true;
             }
@@ -876,13 +876,13 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 return TraversalDecision::SkipChildrenAndContinue;
             CSS::Invalidation::invalidate_assigned_slottables_after_slot_style_change(element);
             if (!invalidated_assigned_slottables_for_descendant_slots
-                && (element_invalidation.inherited_style_changed || element_invalidation.rebuild_layout_tree)) {
+                && (element_invalidation.inherited_style_changed || element_invalidation.needs_layout_tree_rebuild())) {
                 CSS::Invalidation::invalidate_assigned_slottables_for_descendant_slots_after_inherited_style_change(target);
                 invalidated_assigned_slottables_for_descendant_slots = true;
             }
             // NB: Descendant invalidations are merged into one, so value-only visual context updates must be
             //     scheduled here, for each affected descendant.
-            if (element_invalidation.update_accumulated_visual_context_values && !element_invalidation.rebuild_accumulated_visual_contexts)
+            if (element_invalidation.accumulated_visual_contexts() == CSS::AccumulatedVisualContextInvalidation::UpdateValues)
                 element.document().schedule_accumulated_visual_context_value_update(element);
             invalidation |= element_invalidation;
             return TraversalDecision::Continue;
@@ -897,9 +897,9 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 pseudo_element_node->apply_style(*style);
         }
 
-        if (invalidation.relayout)
+        if (invalidation.needs_relayout())
             target->set_needs_layout_update(DOM::SetNeedsLayoutReason::KeyframeEffect);
-        if (invalidation.rebuild_layout_tree) {
+        if (invalidation.needs_layout_tree_rebuild()) {
             // We mark layout tree for rebuild starting from parent element to correctly invalidate
             // "display" property change to/from "contents" value.
             if (auto parent_element = target->parent_element()) {
@@ -908,9 +908,9 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 target->set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::KeyframeEffect);
             }
         }
-        if (invalidation.rebuild_accumulated_visual_contexts) {
+        if (invalidation.accumulated_visual_contexts() == CSS::AccumulatedVisualContextInvalidation::Rebuild) {
             element.document().set_needs_accumulated_visual_contexts_update(true);
-        } else if (invalidation.update_accumulated_visual_context_values) {
+        } else if (invalidation.accumulated_visual_contexts() == CSS::AccumulatedVisualContextInvalidation::UpdateValues) {
             // NB: Element-reference pseudo elements (e.g. ::placeholder) are not synthetic, so schedule their
             //     layout node directly instead of going through the owning element.
             if (element.pseudo_element().has_value()) {
@@ -921,10 +921,10 @@ AnimationUpdateContext::~AnimationUpdateContext()
             }
         }
 
-        if (invalidation.repaint) {
+        if (invalidation.needs_repaint()) {
             target->set_needs_repaint();
         }
-        if (invalidation.rebuild_stacking_context_tree)
+        if (invalidation.needs_stacking_context_tree_rebuild())
             element.document().invalidate_stacking_context_tree();
     }
 }

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -180,9 +180,7 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     // NOTE: If the text-transform property changes, it may affect layout. Furthermore, since the
     //       Layout::TextNode caches the post-transform text, we have to update the layout tree.
     if (property_id == CSS::PropertyID::TextTransform) {
-        invalidation.rebuild_layout_tree = true;
-        invalidation.relayout = true;
-        invalidation.repaint = true;
+        invalidation.ensure_at_least(InvalidationLevel::RebuildLayoutTree);
         return invalidation;
     }
 
@@ -194,7 +192,7 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     }
 
     if (AK::first_is_one_of(property_id, CSS::PropertyID::CounterReset, CSS::PropertyID::CounterSet, CSS::PropertyID::CounterIncrement)) {
-        invalidation.rebuild_layout_tree = true;
+        invalidation.ensure_at_least(InvalidationLevel::RebuildLayoutTree);
         return invalidation;
     }
 
@@ -205,11 +203,11 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     if (property_id == CSS::PropertyID::Visibility) {
         // We don't need to relayout if the visibility changes from visible to hidden or vice versa. Only collapse requires relayout.
         if ((old_value && old_value->to_keyword() == CSS::Keyword::Collapse) != (new_value && new_value->to_keyword() == CSS::Keyword::Collapse))
-            invalidation.relayout = true;
+            invalidation.ensure_at_least(InvalidationLevel::Relayout);
         // Of course, we still have to repaint on any visibility change.
-        invalidation.repaint = true;
+        invalidation.ensure_at_least(InvalidationLevel::Repaint);
     } else if (CSS::property_affects_layout(property_id)) {
-        invalidation.relayout = true;
+        invalidation.ensure_at_least(InvalidationLevel::Relayout);
     }
 
     if (CSS::property_affects_stacking_context(property_id)) {
@@ -225,32 +223,31 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
         // causing it to be painted from both step 8 (m_positioned_descendants) and
         // step 9 (m_children with z >= 1), resulting in double painting.
         if (property_id == CSS::PropertyID::ZIndex) {
-            invalidation.rebuild_stacking_context_tree = true;
+            invalidation.set_needs_stacking_context_tree_rebuild();
         } else {
             // OPTIMIZATION: Only rebuild stacking context tree when property crosses from a neutral value (doesn't create
             //               stacking context) to a creating value or vice versa.
             bool old_creates = is_stacking_context_creating_value(property_id, old_value);
             bool new_creates = is_stacking_context_creating_value(property_id, new_value);
             if (old_creates != new_creates) {
-                invalidation.rebuild_stacking_context_tree = true;
+                invalidation.set_needs_stacking_context_tree_rebuild();
             }
         }
     }
-    invalidation.repaint = true;
 
+    bool needs_repaint = true;
     if (CSS::property_affects_accumulated_visual_contexts(property_id)) {
         if (accumulated_visual_context_change_is_value_only(property_id, old_value, new_value))
-            invalidation.update_accumulated_visual_context_values = true;
+            invalidation.ensure_at_least(AccumulatedVisualContextInvalidation::UpdateValues);
         else
-            invalidation.rebuild_accumulated_visual_contexts = true;
+            invalidation.ensure_at_least(AccumulatedVisualContextInvalidation::Rebuild);
         if (!accumulated_visual_context_change_requires_repaint(property_id, old_value, new_value)
-            && !invalidation.rebuild_stacking_context_tree
-            && !invalidation.relayout
-            && !invalidation.rebuild_layout_tree
-            && !invalidation.recompute_descendant_styles
-            && !invalidation.inherited_style_changed)
-            invalidation.repaint = false;
+            && !invalidation.needs_repaint()
+            && !invalidation.recompute_descendant_styles)
+            needs_repaint = false;
     }
+    if (needs_repaint)
+        invalidation.ensure_at_least(InvalidationLevel::Repaint);
 
     return invalidation;
 }

--- a/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -6,18 +6,42 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 
+// Ordered by increasing severity. A higher level always implies all lower levels.
+enum class InvalidationLevel : u8 {
+    None,
+    Repaint,
+    Relayout,
+    RebuildLayoutTree,
+};
+
+// Ordered by increasing severity: Rebuild subsumes UpdateValues.
+enum class AccumulatedVisualContextInvalidation : u8 {
+    None,
+    UpdateValues,
+    Rebuild,
+};
+
 struct RequiredInvalidationAfterStyleChange {
-    bool repaint : 1 { false };
-    bool rebuild_stacking_context_tree : 1 { false };
-    bool relayout : 1 { false };
-    bool rebuild_layout_tree : 1 { false };
-    bool rebuild_accumulated_visual_contexts : 1 { false };
-    // Only node values changed (e.g. an animated transform matrix); patch them in place instead of rebuilding.
-    bool update_accumulated_visual_context_values : 1 { false };
+    void ensure_at_least(InvalidationLevel level) { m_level = max(m_level, level); }
+    void ensure_at_least(AccumulatedVisualContextInvalidation invalidation) { m_accumulated_visual_contexts = max(m_accumulated_visual_contexts, invalidation); }
+
+    void set_needs_stacking_context_tree_rebuild()
+    {
+        m_rebuild_stacking_context_tree = true;
+        ensure_at_least(InvalidationLevel::Repaint);
+    }
+
+    [[nodiscard]] bool needs_repaint() const { return m_level >= InvalidationLevel::Repaint; }
+    [[nodiscard]] bool needs_relayout() const { return m_level >= InvalidationLevel::Relayout; }
+    [[nodiscard]] bool needs_layout_tree_rebuild() const { return m_level >= InvalidationLevel::RebuildLayoutTree; }
+    [[nodiscard]] bool needs_stacking_context_tree_rebuild() const { return m_rebuild_stacking_context_tree; }
+    [[nodiscard]] AccumulatedVisualContextInvalidation accumulated_visual_contexts() const { return m_accumulated_visual_contexts; }
+
     // The element's change affects rule matching for descendants, without necessarily changing inherited style.
     bool recompute_descendant_styles : 1 { false };
     // At least one inherited longhand changed, so shadow-tree descendants may need inherited style recomputation.
@@ -25,19 +49,33 @@ struct RequiredInvalidationAfterStyleChange {
 
     void operator|=(RequiredInvalidationAfterStyleChange const& other)
     {
-        repaint |= other.repaint;
-        rebuild_stacking_context_tree |= other.rebuild_stacking_context_tree;
-        relayout |= other.relayout;
-        rebuild_layout_tree |= other.rebuild_layout_tree;
-        rebuild_accumulated_visual_contexts |= other.rebuild_accumulated_visual_contexts;
-        update_accumulated_visual_context_values |= other.update_accumulated_visual_context_values;
+        m_level = max(m_level, other.m_level);
+        m_accumulated_visual_contexts = max(m_accumulated_visual_contexts, other.m_accumulated_visual_contexts);
+        m_rebuild_stacking_context_tree |= other.m_rebuild_stacking_context_tree;
         recompute_descendant_styles |= other.recompute_descendant_styles;
         inherited_style_changed |= other.inherited_style_changed;
     }
 
-    [[nodiscard]] bool is_none() const { return !repaint && !rebuild_stacking_context_tree && !relayout && !rebuild_layout_tree && !rebuild_accumulated_visual_contexts && !update_accumulated_visual_context_values && !recompute_descendant_styles && !inherited_style_changed; }
-    [[nodiscard]] bool is_full() const { return repaint && rebuild_stacking_context_tree && relayout && rebuild_layout_tree; }
-    static RequiredInvalidationAfterStyleChange full() { return { true, true, true, true, false }; }
+    [[nodiscard]] bool is_none() const
+    {
+        return m_level == InvalidationLevel::None
+            && m_accumulated_visual_contexts == AccumulatedVisualContextInvalidation::None
+            && !recompute_descendant_styles
+            && !inherited_style_changed;
+    }
+
+    static RequiredInvalidationAfterStyleChange full()
+    {
+        RequiredInvalidationAfterStyleChange invalidation;
+        invalidation.ensure_at_least(InvalidationLevel::RebuildLayoutTree);
+        invalidation.set_needs_stacking_context_tree_rebuild();
+        return invalidation;
+    }
+
+private:
+    InvalidationLevel m_level { InvalidationLevel::None };
+    AccumulatedVisualContextInvalidation m_accumulated_visual_contexts { AccumulatedVisualContextInvalidation::None };
+    bool m_rebuild_stacking_context_tree : 1 { false };
 };
 
 RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::PropertyID property_id, StyleValue const* old_value, StyleValue const* new_value);

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -28,15 +28,15 @@ static void apply_element_style_invalidation_after_style_change(DOM::Element& el
 {
     if (invalidate_assigned_slottables)
         Invalidation::invalidate_assigned_slottables_after_slot_style_change(element);
-    if (invalidate_descendant_slots && (invalidation.inherited_style_changed || invalidation.rebuild_layout_tree))
+    if (invalidate_descendant_slots && (invalidation.inherited_style_changed || invalidation.needs_layout_tree_rebuild()))
         Invalidation::invalidate_assigned_slottables_for_descendant_slots_after_inherited_style_change(element);
 
-    if (invalidation.update_accumulated_visual_context_values && !invalidation.rebuild_accumulated_visual_contexts)
+    if (invalidation.accumulated_visual_contexts() == AccumulatedVisualContextInvalidation::UpdateValues)
         element.document().schedule_accumulated_visual_context_value_update(element);
 
-    if (invalidation.relayout)
+    if (invalidation.needs_relayout())
         element.set_needs_layout_update(DOM::SetNeedsLayoutReason::StyleChange);
-    if (invalidation.rebuild_layout_tree) {
+    if (invalidation.needs_layout_tree_rebuild()) {
         // Mark the parent to handle display changes to/from contents correctly.
         if (auto parent_element = element.parent_element())
             parent_element->set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::StyleChange);
@@ -49,14 +49,11 @@ static void apply_element_style_invalidation_after_style_change(DOM::Element& el
 
 static void apply_document_style_invalidation_after_style_change(DOM::Document& document, RequiredInvalidationAfterStyleChange const& invalidation)
 {
-    if (invalidation.repaint
-        || invalidation.rebuild_stacking_context_tree
-        || invalidation.relayout
-        || invalidation.rebuild_layout_tree)
+    if (invalidation.needs_repaint())
         document.set_needs_to_record_display_list();
-    if (invalidation.rebuild_accumulated_visual_contexts)
+    if (invalidation.accumulated_visual_contexts() == AccumulatedVisualContextInvalidation::Rebuild)
         document.set_needs_accumulated_visual_contexts_update(true);
-    if (invalidation.rebuild_stacking_context_tree)
+    if (invalidation.needs_stacking_context_tree_rebuild())
         document.invalidate_stacking_context_tree();
 }
 
@@ -189,7 +186,7 @@ static void enter_style_update_frame(StyleUpdateFrame& frame, StyleComputer& sty
         frame.children_need_inherited_style_update |= frame.needs_inherited_style_update;
     // NB: When display changes to/from flex/grid/contents, children may need to be blockified or un-blockified.
     //     This requires a full style recompute, not just inherited style update.
-    frame.children_need_full_style_recompute = frame.node_invalidation.rebuild_layout_tree;
+    frame.children_need_full_style_recompute = frame.node_invalidation.needs_layout_tree_rebuild();
     frame.descendant_style_recompute_needed = frame.ancestor_needs_descendant_style_recompute || frame.node_invalidation.recompute_descendant_styles;
 
     // OPTIMIZATION: Descendants of a display:none element are not rendered and their computed style is not observable
@@ -539,7 +536,7 @@ ComputedProperties const* update_style_for_element(DOM::Document& document, DOM:
             descendant_style_recompute_needed = false;
         }
 
-        if (did_change_custom_properties || invalidation.rebuild_layout_tree)
+        if (did_change_custom_properties || invalidation.needs_layout_tree_rebuild())
             descendant_style_recompute_needed = true;
 
         if (i > 1) {

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -934,7 +934,7 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation(C
     CSS::RequiredInvalidationAfterStyleChange invalidation;
 
     if (old_style.computed_font_list(font_computer) != new_style.computed_font_list(font_computer))
-        invalidation.relayout = true;
+        invalidation.ensure_at_least(CSS::InvalidationLevel::Relayout);
 
     for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
         auto property_id = static_cast<CSS::PropertyID>(i);
@@ -956,11 +956,8 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation(C
 
         // NB: We only propagate content to computed values for relevant elements so if the old layout node doesn't
         //     have a value for content we know it isn't a relevant element and invalidation isn't required.
-        if (old_content.has_value() && old_content->counter_style_dependencies != new_style.content(abstract_element, 0).content_data.counter_style_dependencies) {
-            invalidation.rebuild_layout_tree = true;
-            invalidation.relayout = true;
-            invalidation.repaint = true;
-        }
+        if (old_content.has_value() && old_content->counter_style_dependencies != new_style.content(abstract_element, 0).content_data.counter_style_dependencies)
+            invalidation.ensure_at_least(CSS::InvalidationLevel::RebuildLayoutTree);
 
         auto const& old_list_style_type = old_computed_values.list_style_type();
 
@@ -971,11 +968,8 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation(C
                 ValueComparingRefPtr<CSS::CounterStyle const> old_counter_style = old_list_style_type.get<RefPtr<CSS::CounterStyle const>>();
                 ValueComparingRefPtr<CSS::CounterStyle const> new_counter_style = new_list_style_type.get<RefPtr<CSS::CounterStyle const>>();
 
-                if (old_counter_style != new_counter_style) {
-                    invalidation.rebuild_layout_tree = true;
-                    invalidation.relayout = true;
-                    invalidation.repaint = true;
-                }
+                if (old_counter_style != new_counter_style)
+                    invalidation.ensure_at_least(CSS::InvalidationLevel::RebuildLayoutTree);
             }
         }
     }
@@ -1042,12 +1036,12 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
 
 void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
 {
-    if (invalidation.rebuild_layout_tree || !unsafe_layout_node())
+    if (invalidation.needs_layout_tree_rebuild() || !unsafe_layout_node())
         return;
 
     // If we're keeping the layout tree, we can just apply the new style to the existing layout tree.
     unsafe_layout_node()->apply_style(*m_computed_properties);
-    if (invalidation.repaint)
+    if (invalidation.needs_repaint())
         set_needs_repaint();
 
     // Do the same for pseudo-elements.
@@ -1058,7 +1052,7 @@ void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalid
 
         if (auto node_with_style = pseudo_element.unsafe_layout_node()) {
             node_with_style->apply_style(*pseudo_element_style);
-            if (invalidation.repaint && node_with_style->first_paintable())
+            if (invalidation.needs_repaint() && node_with_style->first_paintable())
                 node_with_style->first_paintable()->set_needs_repaint();
         }
     });


### PR DESCRIPTION
RequiredInvalidationAfterStyleChange was eight independent bools, so nothing stopped a producer from requesting a higher invalidation degree without the lower degrees it implies, e.g. setting relayout while leaving repaint unset. Two sites actually did that and relied on downstream machinery to paper over it: font list changes set relayout alone, and counter properties set rebuild_layout_tree alone.

Replace the repaint/relayout/rebuild-layout-tree bools with an ordered InvalidationLevel enum merged via max(), so a higher degree always implies the lower ones and the inconsistent states become unrepresentable. The two accumulated-visual-context bools get the same treatment as a small ordered enum, which also replaces the hand-written "update && !rebuild" guards in consumers. The stacking context tree flag stays separate because relayout must not imply it, but its setter now enforces the one implication it does have: rebuilding the stacking context tree changes painting order and therefore requires a repaint.

The two under-invalidating sites now produce the implied lower degrees as well. This is redundant but harmless: layout tree rebuilds already schedule layout and repaint via Node::set_needs_layout_tree_update, and relayout repaints the affected areas once it runs. Also removes the unused is_full() predicate.