### PR TITLE
Compute box baselines eagerly during layout

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -150,6 +150,10 @@ void BlockFormattingContext::run(LayoutInput const& layout_input)
             m_state.get_mutable(*child_box).margin_bottom = m_margin_state.current_collapsed_margin();
             break;
         }
+
+        // The margin reassignment above changed a child's margin box, which the root's baselines may
+        // have been derived from (a scroll container child exports its bottom margin edge), so re-derive them.
+        compute_and_store_baselines(m_state.get_mutable(root()));
     }
 }
 
@@ -1239,6 +1243,8 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
             block_container_state.set_content_height(bottom_of_lowest_margin_box);
         }
     }
+
+    compute_and_store_baselines(m_state.get_mutable(block_container));
 }
 
 // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
@@ -1311,6 +1317,8 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     auto fieldset_border_box_top_in_content = -(fieldset_state.border_top + fieldset_state.padding_top);
     auto legend_content_y = fieldset_border_box_top_in_content + legend_border_box_centering_offset + legend_state.border_box_top();
     legend_state.set_content_y(legend_content_y);
+
+    compute_and_store_baselines(fieldset_state);
 }
 
 void BlockFormattingContext::resolve_vertical_box_model_metrics(Box const& box, CSSPixels width_of_containing_block)

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -259,6 +259,8 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
         }
 
         resolve_baseline_aligned_items();
+
+        compute_and_store_baselines(m_flex_container_state);
     }
 
     if (m_state.should_collect_devtools_layout_data())

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2996,27 +2996,6 @@ bool FormattingContext::can_skip_is_anonymous_text_run(Box& box)
     return false;
 }
 
-Box const* FormattingContext::box_child_to_derive_baseline_from(Box const& box, BaselineSet baseline_set) const
-{
-    if (!box.has_children() || box.children_are_inline())
-        return nullptr;
-    // Find the first/last in-flow child that has a baseline (either directly via line boxes, or via its descendants).
-    auto deriving_first_baseline = baseline_set == BaselineSet::First;
-    for (auto child = deriving_first_baseline ? box.first_child() : box.last_child(); child;
-        child = deriving_first_baseline ? child->next_sibling() : child->previous_sibling()) {
-        auto const* child_box = as_if<Box>(*child);
-        if (!child_box)
-            continue;
-        if (child_box->is_out_of_flow(*this))
-            continue;
-        if (auto const* child_state = m_state.try_get(*child_box); child_state && !child_state->line_boxes.is_empty())
-            return child_box;
-        if (box_child_to_derive_baseline_from(*child_box, baseline_set))
-            return child_box;
-    }
-    return nullptr;
-}
-
 void FormattingContext::compute_and_store_baselines(LayoutState::UsedValues& used_values) const
 {
     // NOTE: This may run more than once for the same UsedValues (e.g. table cells are laid out twice),
@@ -3051,6 +3030,14 @@ void FormattingContext::compute_and_store_baselines(LayoutState::UsedValues& use
         return;
 
     // Derive baselines from the first/last in-flow child that has a baseline set of its own.
+    // https://drafts.csswg.org/css-flexbox-1/#flex-baselines
+    // Otherwise, if the flex container has at least one flex item, the flex container's first/last main-axis baseline
+    // set is generated from the alignment baseline of the startmost/endmost flex item.
+    // https://drafts.csswg.org/css-grid-1/#grid-baselines
+    // Otherwise, the grid container's first (last) baseline set is generated from the alignment baseline of the first
+    // (last) grid item in row-major grid order.
+    // FIXME: This does not yet select the spec-defined startmost/endmost flex item, or the first/last grid item in
+    //        row-major grid order.
     auto baseline_from_children = [&](BaselineSet baseline_set) -> Optional<CSSPixels> {
         auto deriving_first_baseline = baseline_set == BaselineSet::First;
         for (auto child = deriving_first_baseline ? box.first_child() : box.last_child(); child;
@@ -3128,51 +3115,17 @@ CSSPixels FormattingContext::box_baseline(Box const& box, BaselineSet baseline_s
     bool has_visible_overflow = overflow_x == CSS::Overflow::Visible && overflow_y == CSS::Overflow::Visible;
     bool derive_baseline_from_content = baseline_set == BaselineSet::First || is_flex_or_grid_container || has_visible_overflow;
 
-    if (derive_baseline_from_content && !box_state.line_boxes.is_empty()) {
-        auto baseline_for_line_box = [&](LineBox const& line_box) {
-            if (!line_box.has_block_level_box()) {
-                auto line_box_top = line_box.bottom() - line_box.block_length();
-                return box_state.margin_box_top() + line_box_top + line_box.baseline();
-            }
-
-            VERIFY(line_box.fragments().size() == 1);
-            auto const& block_child = as<Box>(line_box.fragments().first().layout_node());
-            auto const& block_child_state = m_state.get(block_child);
-            auto child_offset_from_margin_edge = block_child_state.offset.y() - block_child_state.margin_box_top();
-            return box_state.margin_box_top() + child_offset_from_margin_edge + box_baseline(block_child, baseline_set);
-        };
-
-        if (baseline_set == BaselineSet::First) {
-            auto line_box = box_state.line_boxes.first_matching([](auto& line_box) { return !line_box.is_empty(); });
-            return baseline_for_line_box(line_box.value_or(box_state.line_boxes.first()));
-        }
-
-        auto line_box = box_state.line_boxes.last_matching([](auto& line_box) { return !line_box.is_empty(); });
-        return baseline_for_line_box(line_box.value_or(box_state.line_boxes.last()));
-    }
-
-    // Derive baseline from block children if this box derives its baseline from its content.
-    // https://drafts.csswg.org/css-flexbox-1/#flex-baselines
-    // Otherwise, if the flex container has at least one flex item, the flex container's first/last main-axis baseline
-    // set is generated from the alignment baseline of the startmost/endmost flex item.
-    // https://drafts.csswg.org/css-grid-1/#grid-baselines
-    // Otherwise, the grid container's first (last) baseline set is generated from the alignment baseline of the first
-    // (last) grid item in row-major grid order.
-    // FIXME: This does not yet select the spec-defined startmost/endmost flex item, or the first/last grid item in
-    //        row-major grid order.
-    // AD-HOC: We also derive baseline from children for <input> elements. Per the HTML spec, inputs have
-    //         `overflow: clip !important`, so CSS2 says to use bottom margin edge. However, the internal shadow tree
-    //         baseline should determine the control's baseline for proper alignment with adjacent text.
+    // AD-HOC: We also use the content-derived baseline for <input> elements with block children. Per the HTML spec,
+    //         inputs have `overflow: clip !important`, so CSS2 says to use bottom margin edge. However, the internal
+    //         shadow tree baseline should determine the control's baseline for proper alignment with adjacent text.
     //         https://html.spec.whatwg.org/multipage/rendering.html#form-controls
-    if (auto const* child_box = box_child_to_derive_baseline_from(box, baseline_set)) {
-        if (derive_baseline_from_content || is<HTML::HTMLInputElement>(box.dom_node())) {
-            auto const& child_box_state = m_state.get(*child_box);
-            auto child_offset_from_margin_edge = child_box_state.offset.y() - child_box_state.margin_box_top();
-            return box_state.margin_box_top() + child_offset_from_margin_edge + box_baseline(*child_box, baseline_set);
-        }
-    }
+    bool input_derives_from_children = is<HTML::HTMLInputElement>(box.dom_node()) && !box.children_are_inline();
 
-    // If none of the children have a baseline set, the bottom margin edge of the box is used.
+    auto const& content_baseline = baseline_set == BaselineSet::First ? box_state.first_baseline : box_state.last_baseline;
+    if (content_baseline.has_value() && (derive_baseline_from_content || input_derives_from_children))
+        return box_state.margin_box_top() + *content_baseline;
+
+    // If the box has no baseline set, the bottom margin edge of the box is used.
     return box_state.margin_box_height();
 }
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -3017,6 +3017,64 @@ Box const* FormattingContext::box_child_to_derive_baseline_from(Box const& box, 
     return nullptr;
 }
 
+void FormattingContext::compute_and_store_baselines(LayoutState::UsedValues& used_values) const
+{
+    // NOTE: This may run more than once for the same UsedValues (e.g. table cells are laid out twice),
+    //       so reset both baselines before deriving them anew.
+    used_values.first_baseline = {};
+    used_values.last_baseline = {};
+
+    auto const& box = as<Box>(used_values.node());
+
+    if (!used_values.line_boxes.is_empty()) {
+        auto baseline_for_line_box = [&](LineBox const& line_box, BaselineSet baseline_set) -> CSSPixels {
+            if (!line_box.has_block_level_box()) {
+                auto line_box_top = line_box.bottom() - line_box.block_length();
+                return line_box_top + line_box.baseline();
+            }
+
+            VERIFY(line_box.fragments().size() == 1);
+            auto const& block_child = as<Box>(line_box.fragments().first().layout_node());
+            auto const& block_child_state = m_state.get(block_child);
+            auto child_offset_from_margin_edge = block_child_state.offset.y() - block_child_state.margin_box_top();
+            return child_offset_from_margin_edge + box_baseline(block_child, baseline_set);
+        };
+
+        auto first_line_box = used_values.line_boxes.first_matching([](auto& line_box) { return !line_box.is_empty(); });
+        used_values.first_baseline = baseline_for_line_box(first_line_box.value_or(used_values.line_boxes.first()), BaselineSet::First);
+        auto last_line_box = used_values.line_boxes.last_matching([](auto& line_box) { return !line_box.is_empty(); });
+        used_values.last_baseline = baseline_for_line_box(last_line_box.value_or(used_values.line_boxes.last()), BaselineSet::Last);
+        return;
+    }
+
+    if (!box.has_children() || box.children_are_inline())
+        return;
+
+    // Derive baselines from the first/last in-flow child that has a baseline set of its own.
+    auto baseline_from_children = [&](BaselineSet baseline_set) -> Optional<CSSPixels> {
+        auto deriving_first_baseline = baseline_set == BaselineSet::First;
+        for (auto child = deriving_first_baseline ? box.first_child() : box.last_child(); child;
+            child = deriving_first_baseline ? child->next_sibling() : child->previous_sibling()) {
+            auto const* child_box = as_if<Box>(*child);
+            if (!child_box)
+                continue;
+            if (child_box->is_out_of_flow(*this))
+                continue;
+            auto const* child_state = m_state.try_get(*child_box);
+            if (!child_state)
+                continue;
+            auto const& child_baseline = deriving_first_baseline ? child_state->first_baseline : child_state->last_baseline;
+            if (!child_baseline.has_value())
+                continue;
+            auto child_offset_from_margin_edge = child_state->offset.y() - child_state->margin_box_top();
+            return child_offset_from_margin_edge + box_baseline(*child_box, baseline_set);
+        }
+        return {};
+    };
+    used_values.first_baseline = baseline_from_children(BaselineSet::First);
+    used_values.last_baseline = baseline_from_children(BaselineSet::Last);
+}
+
 CSSPixels FormattingContext::box_baseline(Box const& box, BaselineSet baseline_set) const
 {
     auto const& box_state = m_state.get(box);

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -173,6 +173,7 @@ public:
     [[nodiscard]] CSSPixelRect content_box_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixels box_baseline(Box const&, BaselineSet) const;
+    void compute_and_store_baselines(LayoutState::UsedValues&) const;
 
     [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;
     [[nodiscard]] CSSPixels calculate_stretch_fit_height(Box const&, AvailableSize const&) const;

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -256,8 +256,6 @@ protected:
 
     [[nodiscard]] Optional<CSSPixels> compute_auto_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout) const;
 
-    [[nodiscard]] Box const* box_child_to_derive_baseline_from(Box const&, BaselineSet) const;
-
     Type m_type {};
     LayoutMode m_layout_mode;
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2910,6 +2910,8 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
             independent_formatting_context->parent_context_did_dimension_child_root_box();
     }
 
+    compute_and_store_baselines(m_state.get_mutable(grid_container()));
+
     auto serialize_standalone_axis = [](auto const& tracks, auto const& lines) {
         CSS::GridTrackSizeList result;
         for (size_t i = 0; i < lines.size(); ++i) {

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -88,6 +88,8 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
     //       This ensures that any floated boxes are taken into account.
     m_automatic_content_width = parent().greatest_child_width(containing_block());
     m_automatic_content_height = content_height;
+
+    compute_and_store_baselines(m_containing_block_used_values);
 }
 
 void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode layout_mode)

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -934,6 +934,8 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
     inset_top = other.inset_top;
     inset_bottom = other.inset_bottom;
     line_boxes = other.line_boxes;
+    first_baseline = other.first_baseline;
+    last_baseline = other.last_baseline;
     containing_line_box_fragment = other.containing_line_box_fragment;
 
     m_node = other.m_node;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -216,6 +216,13 @@ struct LayoutState {
 
         Vector<LineBox> line_boxes;
 
+        // Baselines of this box's in-flow content, relative to the box's content-box top edge.
+        // Populated eagerly by the formatting context that lays out this box's children.
+        // An empty Optional means the box has no baseline set (https://drafts.csswg.org/css-align-3/#baseline-export);
+        // consumers synthesize a baseline from the margin box instead.
+        Optional<CSSPixels> first_baseline;
+        Optional<CSSPixels> last_baseline;
+
         CSSPixels margin_box_left() const { return margin_left + border_left_collapsed() + padding_left; }
         CSSPixels margin_box_right() const { return margin_right + border_right_collapsed() + padding_right; }
         CSSPixels margin_box_top() const { return margin_top + border_top_collapsed() + padding_top; }

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1899,6 +1899,19 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     // A visual representation of this model can be found at https://www.w3.org/TR/css-tables-3/images/table_container.png
     m_state.get_mutable(table_box()).margin_bottom += total_captions_height;
 
+    // Derive baselines for the table internals bottom-up (rows, then row groups, then the table box)
+    // now that all offsets are final, so the table exports its baseline to outside consumers
+    // (e.g. an inline-table participating in a line box).
+    for (auto& row : m_rows)
+        compute_and_store_baselines(m_state.get_mutable(row.box));
+    table_box().for_each_child_of_type<Box>([&](Box const& child) {
+        auto const& display = child.display();
+        if (display.is_table_row_group() || display.is_table_header_group() || display.is_table_footer_group())
+            compute_and_store_baselines(m_state.get_mutable(child));
+        return IterationDecision::Continue;
+    });
+    compute_and_store_baselines(m_state.get_mutable(table_box()));
+
     m_automatic_content_height = m_table_height;
 }
 


### PR DESCRIPTION
Box baselines are now computed once, by the formatting context that lays out each box's children, and stored on the box's UsedValues; box_baseline() shrinks from a recursive tree walk into an O(1) lookup that just applies the consumer-side rules. Previously every query re-derived the answer backwards by descending into the box's already-laid-out line boxes and block children — repeated O(depth) rewalks (twice per baseline-aligned flex item, once per box fragment on every line update), an implicit "only call after layout_inside()" protocol, and inconsistent float classification depending on which context asked.