### PR TITLE
LibWeb: Accept font-relative lengths in SVG natural size negotiation

### DIFF
--- a/Libraries/LibWeb/Layout/NavigableContainerViewport.cpp
+++ b/Libraries/LibWeb/Layout/NavigableContainerViewport.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLObjectElement.h>
@@ -32,7 +33,11 @@ CSS::SizeWithAspectRatio NavigableContainerViewport::natural_size() const
         if (auto const* root = content_document->document_element();
             root && root->is_svg_svg_element()) {
 
-            auto metrics = SVG::SVGSVGElement::negotiate_natural_metrics(static_cast<SVG::SVGSVGElement const&>(*root));
+            auto const& svg_root = as<SVG::SVGSVGElement>(*root);
+            auto resolution_context = svg_root.layout_node()
+                ? CSS::Length::ResolutionContext::for_layout_node(*svg_root.layout_node())
+                : CSS::Length::ResolutionContext::for_document(*content_document);
+            auto metrics = SVG::SVGSVGElement::negotiate_natural_metrics(svg_root, resolution_context);
             return { metrics.width, metrics.height, metrics.aspect_ratio };
         }
     }

--- a/Libraries/LibWeb/Layout/SVGSVGBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGSVGBox.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/Layout/ReplacedBox.h>
@@ -25,7 +26,7 @@ RefPtr<Painting::Paintable> SVGSVGBox::create_paintable() const
 
 CSS::SizeWithAspectRatio SVGSVGBox::natural_size() const
 {
-    auto metrics = SVG::SVGSVGElement::negotiate_natural_metrics(dom_node());
+    auto metrics = SVG::SVGSVGElement::negotiate_natural_metrics(dom_node(), CSS::Length::ResolutionContext::for_layout_node(*this));
     return { metrics.width, metrics.height, metrics.aspect_ratio };
 }
 

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -271,7 +271,7 @@ GC::Ref<SVGTransform> SVGSVGElement::create_svg_transform() const
     return SVGTransform::create(realm());
 }
 
-CSS::SizeWithAspectRatio SVGSVGElement::negotiate_natural_metrics(SVG::SVGSVGElement const& svg_root)
+CSS::SizeWithAspectRatio SVGSVGElement::negotiate_natural_metrics(SVG::SVGSVGElement const& svg_root, CSS::Length::ResolutionContext const& resolution_context)
 {
     // https://www.w3.org/TR/SVG2/coords.html#SizingSVGInCSS
 
@@ -281,13 +281,11 @@ CSS::SizeWithAspectRatio SVGSVGElement::negotiate_natural_metrics(SVG::SVGSVGEle
     // If either width or height are not specified, the used value is the initial value 'auto'.
     // 'auto' and percentage lengths must not be used to determine an intrinsic width or intrinsic height.
 
-    if (auto width = svg_root.width_style_value_from_attribute(); width && width->is_length() && width->as_length().length().is_absolute()) {
-        natural_metrics.width = width->as_length().length().absolute_length_to_px();
-    }
+    if (auto width = svg_root.width_style_value_from_attribute(); width && width->is_length())
+        natural_metrics.width = width->as_length().length().to_px(resolution_context);
 
-    if (auto height = svg_root.height_style_value_from_attribute(); height && height->is_length() && height->as_length().length().is_absolute()) {
-        natural_metrics.height = height->as_length().length().absolute_length_to_px();
-    }
+    if (auto height = svg_root.height_style_value_from_attribute(); height && height->is_length())
+        natural_metrics.height = height->as_length().length().to_px(resolution_context);
 
     // The intrinsic aspect ratio must be calculated using the following algorithm. If the algorithm returns null, then there is no intrinsic aspect ratio.
     natural_metrics.aspect_ratio = [&]() -> Optional<CSSPixelFraction> {

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -134,17 +134,21 @@ void SVGSVGElement::update_fallback_view_box_for_svg_as_image()
     Optional<double> width;
     Optional<double> height;
 
+    auto resolution_context = layout_node()
+        ? CSS::Length::ResolutionContext::for_layout_node(*layout_node())
+        : CSS::Length::ResolutionContext::for_document(document());
+
     auto width_attribute = get_attribute_value(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingParams { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };
     if (auto width_value = parse_css_value(parsing_context, width_attribute, CSS::PropertyID::Width)) {
-        if (width_value->is_length() && width_value->as_length().length().is_absolute())
-            width = width_value->as_length().length().absolute_length_to_px().to_double();
+        if (width_value->is_length())
+            width = width_value->as_length().length().to_px(resolution_context).to_double();
     }
 
     auto height_attribute = get_attribute_value(SVG::AttributeNames::height);
     if (auto height_value = parse_css_value(parsing_context, height_attribute, CSS::PropertyID::Height)) {
-        if (height_value->is_length() && height_value->as_length().length().is_absolute())
-            height = height_value->as_length().length().absolute_length_to_px().to_double();
+        if (height_value->is_length())
+            height = height_value->as_length().length().to_px(resolution_context).to_double();
     }
 
     if (width.has_value() && width.value() > 0 && height.has_value() && height.value() > 0) {

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Sizing.h>
 #include <LibWeb/Geometry/DOMMatrix.h>
 #include <LibWeb/Geometry/DOMPoint.h>
@@ -76,7 +77,7 @@ public:
     [[nodiscard]] RefPtr<CSS::StyleValue const> width_style_value_from_attribute() const;
     [[nodiscard]] RefPtr<CSS::StyleValue const> height_style_value_from_attribute() const;
 
-    static CSS::SizeWithAspectRatio negotiate_natural_metrics(SVGSVGElement const&);
+    static CSS::SizeWithAspectRatio negotiate_natural_metrics(SVGSVGElement const&, CSS::Length::ResolutionContext const&);
 
 private:
     SVGSVGElement(DOM::Document&, DOM::QualifiedName);

--- a/Tests/LibWeb/Ref/data/50x50-green-em-size.svg
+++ b/Tests/LibWeb/Ref/data/50x50-green-em-size.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="3.125em" height="3.125em"><rect fill="green" width="50" height="50"/></svg>

--- a/Tests/LibWeb/Ref/expected/svg/natural-size-from-font-relative-svg-attributes-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/natural-size-from-font-relative-svg-attributes-ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<style>
+  div {
+    position: absolute;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+<div style="left: 0"></div>
+<div style="left: 100px"></div>

--- a/Tests/LibWeb/Ref/expected/svg/svg-as-image-fallback-viewbox-from-font-relative-attributes-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/svg-as-image-fallback-viewbox-from-font-relative-attributes-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/svg/natural-size-from-font-relative-svg-attributes.html
+++ b/Tests/LibWeb/Ref/input/svg/natural-size-from-font-relative-svg-attributes.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<link rel="match" href="../../expected/svg/natural-size-from-font-relative-svg-attributes-ref.html" />
+<style>
+  div {
+    position: absolute;
+    top: 0;
+  }
+  svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: green;
+  }
+</style>
+<div style="left: 0; font-size: 100px">
+  <svg viewBox="0 0 32 32" width="1em" height="1em"></svg>
+</div>
+<div style="left: 100px; font-size: 50px">
+  <svg viewBox="0 0 32 32" width="2em" height="2em"></svg>
+</div>

--- a/Tests/LibWeb/Ref/input/svg/svg-as-image-fallback-viewbox-from-font-relative-attributes.html
+++ b/Tests/LibWeb/Ref/input/svg/svg-as-image-fallback-viewbox-from-font-relative-attributes.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/svg-as-image-fallback-viewbox-from-font-relative-attributes-ref.html" />
+<img src="../../data/50x50-green-em-size.svg" style="width: 100px; height: 100px">


### PR DESCRIPTION
Previously, the natural dimensions of an SVG root element were only determined from its width and height attributes when they were absolute lengths. We now also resolve font relative lengths when determining SVG natural dimensions.

Without correct natural dimensions, an SVG whose style replaces the attribute dimensions with cyclic percentages falls back to the default replaced element size of 300x150 during intrinsic sizing. 

This could be seen on http://bbc.co.uk/weather where the chevron image was rendered much larger than it should have been (this behavior started after 58ed231baf2 - before that the chevron didn't appear at all):

Before:

<img width="1399" height="425" alt="image" src="https://github.com/user-attachments/assets/b6db5d44-b60a-4fe3-a0d9-5450afee69d2" />

After:

<img width="1399" height="425" alt="image" src="https://github.com/user-attachments/assets/93bae555-798d-4b6e-b772-57d2655851db" />

(The vertical alignment is still incorrect, but I believe that is a separate issue)
