### PR TITLE
UI/Qt: Polish bookmark and history menus

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1691,10 +1691,7 @@ void Application::initialize_actions()
         if (!view.has_value())
             return;
 
-        if (auto bookmark = m_bookmark_store.find_bookmark_by_url(view->url()); bookmark.has_value())
-            m_bookmark_store.remove_item(bookmark->id);
-        else
-            m_bookmark_store.add_bookmark(view->url(), view->title().to_utf8(), view->favicon_base64_png());
+        toggle_bookmark_for_view(*view);
     });
     m_bookmarks_menu->add_action(*m_toggle_bookmark_action);
     update_bookmark_action_for_current_web_view();
@@ -1714,9 +1711,9 @@ void Application::initialize_actions()
         if (!bookmark_id.has_value())
             return;
 
-        display_add_bookmark_dialog()
-            ->when_resolved([this, bookmark_id = bookmark_id.release_value()](BookmarkItem::Bookmark bookmark) {
-                m_bookmark_store.add_bookmark(move(bookmark.url), move(bookmark.title), {}, bookmark_id.target_folder_id);
+        display_add_bookmark_dialog(bookmark_id->target_folder_id)
+            ->when_resolved([this](AddBookmarkDialogResult result) {
+                m_bookmark_store.add_bookmark(move(result.bookmark.url), move(result.bookmark.title), move(result.bookmark.favicon_base64_png), move(result.target_folder_id));
             });
     });
     auto add_bookmark_folder_action = Action::create("Add Folder..."sv, ActionID::AddBookmarkFolder, [this]() {
@@ -1953,6 +1950,19 @@ void Application::bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>)
     rebuild_bookmarks_menu();
 }
 
+void Application::toggle_bookmark_for_view(ViewImplementation& view)
+{
+    if (auto bookmark = m_bookmark_store.find_bookmark_by_url(view.url()); bookmark.has_value()) {
+        m_bookmark_store.remove_item(bookmark->id);
+        return;
+    }
+
+    display_add_bookmark_dialog()
+        ->when_resolved([this](AddBookmarkDialogResult result) {
+            m_bookmark_store.add_bookmark(move(result.bookmark.url), move(result.bookmark.title), move(result.bookmark.favicon_base64_png), move(result.target_folder_id));
+        });
+}
+
 void Application::create_bookmark_menu_items(Optional<MenuData> data)
 {
     auto const& [menu, items, target_folder_id] = data.ensure([&]() -> MenuData {
@@ -2012,9 +2022,9 @@ static NonnullRefPtr<T> create_unsupported_rejection()
     return promise;
 }
 
-NonnullRefPtr<Application::BookmarkPromise> Application::display_add_bookmark_dialog() const
+NonnullRefPtr<Application::AddBookmarkPromise> Application::display_add_bookmark_dialog(Optional<String const&>) const
 {
-    return create_unsupported_rejection<BookmarkPromise>();
+    return create_unsupported_rejection<AddBookmarkPromise>();
 }
 
 NonnullRefPtr<Application::BookmarkPromise> Application::display_edit_bookmark_dialog(BookmarkItem::Bookmark const&) const

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1696,6 +1696,20 @@ void Application::initialize_actions()
     m_bookmarks_menu->add_action(*m_toggle_bookmark_action);
     update_bookmark_action_for_current_web_view();
 
+    m_bookmarks_menu->add_action(Action::create("Bookmark All Tabs..."sv, ActionID::AddBookmarkAllTabs, [this]() {
+        auto bookmarks = bookmarks_for_all_tabs();
+        if (bookmarks.is_empty())
+            return;
+
+        auto default_title = suggested_bookmark_all_tabs_folder_title();
+        display_add_bookmark_folder_dialog(default_title)
+            ->when_resolved([this, bookmarks = move(bookmarks)](BookmarkItem::Folder folder) mutable {
+                auto folder_id = m_bookmark_store.add_folder(move(folder.title));
+                for (auto& bookmark : bookmarks)
+                    m_bookmark_store.add_bookmark(move(bookmark.url), move(bookmark.title), move(bookmark.favicon_base64_png), folder_id);
+            });
+    }));
+
     m_toggle_bookmark_bar_action = Action::create_checkable("Show Bookmarks Bar"sv, ActionID::ToggleBookmarksBar, [this]() {
         m_settings.set_show_bookmarks_bar(!m_settings.show_bookmarks_bar());
     });
@@ -2032,7 +2046,7 @@ NonnullRefPtr<Application::BookmarkPromise> Application::display_edit_bookmark_d
     return create_unsupported_rejection<BookmarkPromise>();
 }
 
-NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_add_bookmark_folder_dialog() const
+NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_add_bookmark_folder_dialog(Optional<String const&>) const
 {
     return create_unsupported_rejection<BookmarkFolderPromise>();
 }
@@ -2040,6 +2054,11 @@ NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_add_bookm
 NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_edit_bookmark_folder_dialog(BookmarkItem::Folder const&) const
 {
     return create_unsupported_rejection<BookmarkFolderPromise>();
+}
+
+String Application::suggested_bookmark_all_tabs_folder_title() const
+{
+    return "Saved Tabs"_string;
 }
 
 ErrorOr<void> Application::toggle_devtools_enabled()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -258,11 +258,13 @@ protected:
     virtual NonnullRefPtr<BookmarkPromise> display_edit_bookmark_dialog([[maybe_unused]] BookmarkItem::Bookmark const& current_bookmark) const;
 
     using BookmarkFolderPromise = Core::Promise<BookmarkItem::Folder>;
-    virtual NonnullRefPtr<BookmarkFolderPromise> display_add_bookmark_folder_dialog() const;
+    virtual NonnullRefPtr<BookmarkFolderPromise> display_add_bookmark_folder_dialog(Optional<String const&> default_title = {}) const;
     virtual NonnullRefPtr<BookmarkFolderPromise> display_edit_bookmark_folder_dialog([[maybe_unused]] BookmarkItem::Folder const& current_folder) const;
+    virtual String suggested_bookmark_all_tabs_folder_title() const;
 
     virtual void on_devtools_enabled() const;
     virtual void on_devtools_disabled() const;
+    virtual Vector<BookmarkItem::Bookmark> bookmarks_for_all_tabs() const { return {}; }
 
     Main::Arguments& arguments() { return m_arguments; }
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -205,6 +205,7 @@ public:
     Menu& bookmarks_bar_context_menu() { return *m_bookmarks_bar_context_menu; }
     Menu& bookmark_context_menu() { return *m_bookmark_context_menu; }
     Menu& bookmark_folder_context_menu() { return *m_bookmark_folder_context_menu; }
+    void toggle_bookmark_for_view(ViewImplementation&);
 
     Menu& history_menu() { return *m_history_menu; }
 
@@ -246,8 +247,14 @@ protected:
     };
     virtual Optional<BookmarkID> bookmark_item_id_for_context_menu() const { return {}; }
 
+    struct AddBookmarkDialogResult {
+        BookmarkItem::Bookmark bookmark;
+        Optional<String> target_folder_id;
+    };
+    using AddBookmarkPromise = Core::Promise<AddBookmarkDialogResult>;
+    virtual NonnullRefPtr<AddBookmarkPromise> display_add_bookmark_dialog(Optional<String const&> target_folder_id = {}) const;
+
     using BookmarkPromise = Core::Promise<BookmarkItem::Bookmark>;
-    virtual NonnullRefPtr<BookmarkPromise> display_add_bookmark_dialog() const;
     virtual NonnullRefPtr<BookmarkPromise> display_edit_bookmark_dialog([[maybe_unused]] BookmarkItem::Bookmark const& current_bookmark) const;
 
     using BookmarkFolderPromise = Core::Promise<BookmarkItem::Folder>;

--- a/Libraries/LibWebView/BookmarkStore.cpp
+++ b/Libraries/LibWebView/BookmarkStore.cpp
@@ -280,7 +280,7 @@ void BookmarkStore::add_bookmark(URL::URL url, Optional<String> title, Optional<
     notify_observers();
 }
 
-void BookmarkStore::add_folder(Optional<String> title, Optional<String const&> target_folder_id)
+String BookmarkStore::add_folder(Optional<String> title, Optional<String const&> target_folder_id)
 {
     BookmarkItem item {
         .id = generate_random_uuid(),
@@ -292,10 +292,12 @@ void BookmarkStore::add_folder(Optional<String> title, Optional<String const&> t
         },
     };
 
+    auto id = item.id;
     find_target_folder(m_items, target_folder_id).append(move(item));
 
     persist_bookmarks();
     notify_observers();
+    return id;
 }
 
 void BookmarkStore::import_items(JsonArray const& items_array)

--- a/Libraries/LibWebView/BookmarkStore.h
+++ b/Libraries/LibWebView/BookmarkStore.h
@@ -67,7 +67,7 @@ public:
     void import_items(JsonArray const& items_array);
 
     void add_bookmark(URL::URL url, Optional<String> title, Optional<String> favicon_base64, Optional<String const&> target_folder_id = {});
-    void add_folder(Optional<String> title, Optional<String const&> target_folder_id = {});
+    String add_folder(Optional<String> title, Optional<String const&> target_folder_id = {});
 
     void edit_bookmark(StringView id, URL::URL url, Optional<String> title);
     void edit_folder(StringView id, Optional<String> title);

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -52,6 +52,7 @@ enum class ActionID {
     BookmarkItem,
 
     AddBookmark,
+    AddBookmarkAllTabs,
     AddBookmarkFolder,
     DeleteBookmark,
     DeleteBookmarkFolder,

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -67,6 +67,8 @@ enum class ActionID {
 
     OpenInNewTab,
     OpenInNewWindow,
+    DownloadLinkedFile,
+    DownloadLinkedFileAs,
     CopyURL,
 
     OpenImage,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2110,6 +2110,12 @@ void ViewImplementation::initialize_context_menus()
     m_open_in_new_window_action = Action::create("Open in New Window"sv, ActionID::OpenInNewWindow, [this]() {
         Application::the().open_url_in_new_window(m_context_menu_url);
     });
+    m_download_linked_file_action = Action::create("Download Linked File"sv, ActionID::DownloadLinkedFile, [this]() {
+        download_context_menu_url(PromptForPath::No);
+    });
+    m_download_linked_file_as_action = Action::create("Download Linked File As..."sv, ActionID::DownloadLinkedFileAs, [this]() {
+        download_context_menu_url(PromptForPath::Yes);
+    });
     m_copy_url_action = Action::create("Copy URL"sv, ActionID::CopyURL, [this]() {
         Application::the().insert_clipboard_entry({ url_text_to_copy(m_context_menu_url), "text/plain"_string });
     });
@@ -2118,11 +2124,7 @@ void ViewImplementation::initialize_context_menus()
         load(m_context_menu_url);
     });
     m_save_image_action = Action::create("Save Image As..."sv, ActionID::SaveImage, [this]() {
-        auto download_path = Application::the().path_for_downloaded_file(m_context_menu_url.basename());
-        if (download_path.is_error())
-            return;
-
-        Application::the().file_downloader().download_file(m_context_menu_url, download_path.release_value(), is_private());
+        download_context_menu_url(PromptForPath::Yes);
     });
     m_copy_image_action = Action::create("Copy Image"sv, ActionID::CopyImage, [this]() {
         if (!m_image_context_menu_bitmap.has_value())
@@ -2193,6 +2195,10 @@ void ViewImplementation::initialize_context_menus()
     m_link_context_menu = Menu::create("Link Context Menu"sv);
     m_link_context_menu->add_action(*m_open_in_new_tab_action);
     m_link_context_menu->add_action(*m_open_in_new_window_action);
+    m_link_context_menu->add_separator();
+    m_link_context_menu->add_action(*m_download_linked_file_action);
+    m_link_context_menu->add_action(*m_download_linked_file_as_action);
+    m_link_context_menu->add_separator();
     m_link_context_menu->add_action(*m_copy_url_action);
 
     m_image_context_menu = Menu::create("Image Context Menu"sv);
@@ -2266,6 +2272,17 @@ void ViewImplementation::did_request_link_context_menu(Badge<WebContentClient>, 
 
     if (m_link_context_menu->on_activation)
         m_link_context_menu->on_activation(to_widget_position(content_position));
+}
+
+void ViewImplementation::download_context_menu_url(PromptForPath prompt_for_path)
+{
+    auto download_path = prompt_for_path == PromptForPath::Yes
+        ? Application::the().path_for_downloaded_file(m_context_menu_url.basename())
+        : Application::the().default_path_for_downloaded_file(m_context_menu_url.basename());
+    if (download_path.is_error())
+        return;
+
+    Application::the().file_downloader().download_file(m_context_menu_url, download_path.release_value(), is_private());
 }
 
 void ViewImplementation::did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, URL::URL url, Optional<Gfx::ShareableBitmap> bitmap)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2060,12 +2060,7 @@ void ViewImplementation::initialize_context_menus()
     m_navigate_forward_action->set_enabled(false);
 
     m_toggle_bookmark_action = Action::create("Toggle Bookmark"sv, ActionID::ToggleBookmarkViaToolbar, [this]() {
-        auto& bookmark_store = Application::bookmark_store();
-
-        if (auto bookmark = bookmark_store.find_bookmark_by_url(url()); bookmark.has_value())
-            bookmark_store.remove_item(bookmark->id);
-        else
-            bookmark_store.add_bookmark(url(), title().to_utf8(), favicon_base64_png());
+        Application::the().toggle_bookmark_for_view(*this);
     });
     update_bookmark_action();
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -454,6 +454,11 @@ protected:
     void update_bookmark_action();
 
     void initialize_context_menus();
+    enum class PromptForPath : u8 {
+        No,
+        Yes,
+    };
+    void download_context_menu_url(PromptForPath);
 
     struct SharedBitmap {
         i32 id { -1 };
@@ -502,6 +507,8 @@ protected:
 
     RefPtr<Action> m_open_in_new_tab_action;
     RefPtr<Action> m_open_in_new_window_action;
+    RefPtr<Action> m_download_linked_file_action;
+    RefPtr<Action> m_download_linked_file_as_action;
     RefPtr<Action> m_copy_url_action;
     URL::URL m_context_menu_url;
 

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -37,7 +37,7 @@ private:
     virtual Optional<BookmarkID> bookmark_item_id_for_context_menu() const override;
     virtual NonnullRefPtr<AddBookmarkPromise> display_add_bookmark_dialog(Optional<String const&> target_folder_id = {}) const override;
     virtual NonnullRefPtr<BookmarkPromise> display_edit_bookmark_dialog(WebView::BookmarkItem::Bookmark const& current_bookmark) const override;
-    virtual NonnullRefPtr<BookmarkFolderPromise> display_add_bookmark_folder_dialog() const override;
+    virtual NonnullRefPtr<BookmarkFolderPromise> display_add_bookmark_folder_dialog(Optional<String const&> default_title = {}) const override;
     virtual NonnullRefPtr<BookmarkFolderPromise> display_edit_bookmark_folder_dialog(WebView::BookmarkItem::Folder const& current_folder) const override;
 
     virtual void on_devtools_enabled() const override;

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -35,7 +35,7 @@ private:
     virtual void rebuild_bookmarks_menu() const override;
     virtual void show_bookmark_context_menu(Gfx::IntPoint, Optional<WebView::BookmarkItem const&>, Optional<String const&> target_folder_id) override;
     virtual Optional<BookmarkID> bookmark_item_id_for_context_menu() const override;
-    virtual NonnullRefPtr<BookmarkPromise> display_add_bookmark_dialog() const override;
+    virtual NonnullRefPtr<AddBookmarkPromise> display_add_bookmark_dialog(Optional<String const&> target_folder_id = {}) const override;
     virtual NonnullRefPtr<BookmarkPromise> display_edit_bookmark_dialog(WebView::BookmarkItem::Bookmark const& current_bookmark) const override;
     virtual NonnullRefPtr<BookmarkFolderPromise> display_add_bookmark_folder_dialog() const override;
     virtual NonnullRefPtr<BookmarkFolderPromise> display_edit_bookmark_folder_dialog(WebView::BookmarkItem::Folder const& current_folder) const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -260,12 +260,14 @@ static NSAlert* create_bookmark_dialog(NSString* title, NSView* first_responder,
     return dialog;
 }
 
-template<typename PromiseType>
+template<typename PromiseType, typename ResolveCallback>
 static NonnullRefPtr<PromiseType> display_add_or_edit_bookmark_dialog(
     Tab* parent,
     NSString* title,
     Optional<URL::URL const&> current_url,
-    Optional<String const&> current_title)
+    Optional<String const&> current_title,
+    Optional<String> current_favicon,
+    ResolveCallback resolve_bookmark)
 {
     auto promise = PromiseType::construct();
 
@@ -294,35 +296,52 @@ static NonnullRefPtr<PromiseType> display_add_or_edit_bookmark_dialog(
                        if (auto text = Ladybird::ns_string_to_string([title_field stringValue]); !text.is_empty())
                            bookmark_title = move(text);
 
-                       promise->resolve(WebView::BookmarkItem::Bookmark {
+                       WebView::BookmarkItem::Bookmark bookmark {
                            .url = url.release_value(),
                            .title = move(bookmark_title),
-                           .favicon_base64_png = {},
-                       });
+                           .favicon_base64_png = current_favicon,
+                       };
+                       resolve_bookmark(*promise, move(bookmark));
                    }];
 
     return promise;
 }
 
-NonnullRefPtr<Application::BookmarkPromise> Application::display_add_bookmark_dialog() const
+NonnullRefPtr<Application::AddBookmarkPromise> Application::display_add_bookmark_dialog(Optional<String const&> target_folder_id) const
 {
     ApplicationDelegate* delegate = [NSApp delegate];
 
     Optional<URL::URL> current_url;
     Optional<String> current_title;
+    Optional<String> current_favicon;
+    Optional<String> copied_target_folder_id;
 
     if (auto view = active_web_view(); view.has_value()) {
         current_url = view->url();
         current_title = view->title().to_utf8();
+        current_favicon = view->favicon_base64_png();
     }
+    if (target_folder_id.has_value())
+        copied_target_folder_id = *target_folder_id;
 
-    return display_add_or_edit_bookmark_dialog<BookmarkPromise>([delegate activeTab], @"Add Bookmark", current_url, current_title);
+    return display_add_or_edit_bookmark_dialog<AddBookmarkPromise>(
+        [delegate activeTab], @"Add Bookmark", current_url, current_title, current_favicon,
+        [target_folder_id = move(copied_target_folder_id)](AddBookmarkPromise& promise, WebView::BookmarkItem::Bookmark bookmark) {
+            promise.resolve(AddBookmarkDialogResult {
+                .bookmark = move(bookmark),
+                .target_folder_id = target_folder_id,
+            });
+        });
 }
 
 NonnullRefPtr<Application::BookmarkPromise> Application::display_edit_bookmark_dialog(WebView::BookmarkItem::Bookmark const& current_bookmark) const
 {
     ApplicationDelegate* delegate = [NSApp delegate];
-    return display_add_or_edit_bookmark_dialog<BookmarkPromise>([delegate activeTab], @"Edit Bookmark", current_bookmark.url, current_bookmark.title);
+    return display_add_or_edit_bookmark_dialog<BookmarkPromise>(
+        [delegate activeTab], @"Edit Bookmark", current_bookmark.url, current_bookmark.title, current_bookmark.favicon_base64_png,
+        [](BookmarkPromise& promise, WebView::BookmarkItem::Bookmark bookmark) {
+            promise.resolve(move(bookmark));
+        });
 }
 
 template<typename PromiseType>

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -378,10 +378,10 @@ static NonnullRefPtr<PromiseType> display_add_or_edit_bookmark_folder_dialog(
     return promise;
 }
 
-NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_add_bookmark_folder_dialog() const
+NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_add_bookmark_folder_dialog(Optional<String const&> default_title) const
 {
     ApplicationDelegate* delegate = [NSApp delegate];
-    return display_add_or_edit_bookmark_folder_dialog<BookmarkFolderPromise>([delegate activeTab], @"Add Folder", {});
+    return display_add_or_edit_bookmark_folder_dialog<BookmarkFolderPromise>([delegate activeTab], @"Add Folder", default_title);
 }
 
 NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_edit_bookmark_folder_dialog(WebView::BookmarkItem::Folder const& current_folder) const

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -22,6 +22,7 @@
 
 #include <QAction>
 #include <QClipboard>
+#include <QComboBox>
 #include <QDesktopServices>
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -34,6 +35,7 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QSizePolicy>
 #include <QStandardPaths>
 #include <QTimer>
 
@@ -738,38 +740,77 @@ Optional<Application::BookmarkID> Application::bookmark_item_id_for_context_menu
     return {};
 }
 
-template<typename PromiseType>
+static void add_bookmark_folder_options(QComboBox& folder_combo, ReadonlySpan<WebView::BookmarkItem> items, QString const& prefix, Optional<String const&> selected_folder_id)
+{
+    for (auto const& item : items) {
+        if (!item.is_folder())
+            continue;
+
+        auto title = qstring_from_ak_string(item.folder().title.value_or("(no title)"_string));
+        auto path = prefix.isEmpty() ? title : QString("%1 / %2").arg(prefix, title);
+        folder_combo.addItem(path, qstring_from_ak_string(item.id));
+        if (selected_folder_id.has_value() && item.id == *selected_folder_id)
+            folder_combo.setCurrentIndex(folder_combo.count() - 1);
+
+        add_bookmark_folder_options(folder_combo, item.folder().children, path, selected_folder_id);
+    }
+}
+
+template<typename PromiseType, typename ResolveCallback>
 static NonnullRefPtr<PromiseType> display_add_or_edit_bookmark_dialog(
     QWidget* parent,
     QString const& dialog_title,
     Optional<URL::URL const&> current_url,
-    Optional<String const&> current_title)
+    Optional<String const&> current_title,
+    Optional<String> current_favicon,
+    ResolveCallback resolve_bookmark,
+    bool show_folder_picker,
+    Optional<String const&> selected_folder_id = {})
 {
     auto promise = PromiseType::construct();
 
     auto* dialog = new QDialog(parent);
-    dialog->resize(400, dialog->height());
+    dialog->resize(500, dialog->height());
     dialog->setWindowTitle(dialog_title);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
 
     auto* url_edit = new QLineEdit(dialog);
     auto* title_edit = new QLineEdit(dialog);
+    url_edit->setMinimumWidth(320);
+    url_edit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    title_edit->setMinimumWidth(320);
+    title_edit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    QComboBox* folder_combo = nullptr;
 
     if (current_url.has_value())
         url_edit->setText(qstring_from_ak_string(current_url->serialize()));
     if (current_title.has_value())
         title_edit->setText(qstring_from_ak_string(*current_title));
 
+    if (show_folder_picker) {
+        folder_combo = new QComboBox(dialog);
+        folder_combo->setMinimumWidth(320);
+        folder_combo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        folder_combo->addItem("Bookmarks", QString {});
+        add_bookmark_folder_options(*folder_combo, WebView::Application::bookmark_store().root_items(), {}, selected_folder_id);
+    }
+
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, dialog);
     QObject::connect(buttons, &QDialogButtonBox::accepted, dialog, &QDialog::accept);
     QObject::connect(buttons, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
 
     auto* layout = new QFormLayout(dialog);
+    layout->setContentsMargins(32, 28, 32, 28);
+    layout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
+    layout->setHorizontalSpacing(16);
+    layout->setVerticalSpacing(14);
     layout->addRow("URL:", url_edit);
     layout->addRow("Title:", title_edit);
+    if (folder_combo)
+        layout->addRow("Folder:", folder_combo);
     layout->addRow(buttons);
 
-    QObject::connect(dialog, &QDialog::finished, [promise, url_edit = QPointer { url_edit }, title_edit = QPointer { title_edit }](auto result) {
+    QObject::connect(dialog, &QDialog::finished, [promise, current_favicon = move(current_favicon), resolve_bookmark = move(resolve_bookmark), url_edit = QPointer { url_edit }, title_edit = QPointer { title_edit }, folder_combo = QPointer { folder_combo }](auto result) mutable {
         if (result != QDialog::Accepted || !url_edit || !title_edit) {
             promise->reject(Error::from_errno(ECANCELED));
             return;
@@ -785,33 +826,56 @@ static NonnullRefPtr<PromiseType> display_add_or_edit_bookmark_dialog(
         if (auto title_text = ak_string_from_qstring(title_edit->text()); !title_text.is_empty())
             title = move(title_text);
 
-        promise->resolve(WebView::BookmarkItem::Bookmark {
+        Optional<String> target_folder_id;
+        if (folder_combo) {
+            auto target_folder_id_text = ak_string_from_qstring(folder_combo->currentData().toString());
+            if (!target_folder_id_text.is_empty())
+                target_folder_id = move(target_folder_id_text);
+        }
+
+        WebView::BookmarkItem::Bookmark bookmark {
             .url = url.release_value(),
             .title = move(title),
-            .favicon_base64_png = {},
-        });
+            .favicon_base64_png = move(current_favicon),
+        };
+        resolve_bookmark(*promise, move(bookmark), move(target_folder_id));
     });
 
     dialog->open();
     return promise;
 }
 
-NonnullRefPtr<Application::BookmarkPromise> Application::display_add_bookmark_dialog() const
+NonnullRefPtr<Application::AddBookmarkPromise> Application::display_add_bookmark_dialog(Optional<String const&> target_folder_id) const
 {
     Optional<URL::URL> current_url;
     Optional<String> current_title;
+    Optional<String> current_favicon;
 
     if (auto view = active_web_view(); view.has_value()) {
         current_url = view->url();
         current_title = view->title().to_utf8();
+        current_favicon = view->favicon_base64_png();
     }
 
-    return display_add_or_edit_bookmark_dialog<BookmarkPromise>(active_tab(), "Add Bookmark", current_url, current_title);
+    return display_add_or_edit_bookmark_dialog<AddBookmarkPromise>(
+        active_tab(), "Add Bookmark", current_url, current_title, current_favicon,
+        [](AddBookmarkPromise& promise, WebView::BookmarkItem::Bookmark bookmark, Optional<String> target_folder_id) {
+            promise.resolve(AddBookmarkDialogResult {
+                .bookmark = move(bookmark),
+                .target_folder_id = move(target_folder_id),
+            });
+        },
+        true, target_folder_id);
 }
 
 NonnullRefPtr<Application::BookmarkPromise> Application::display_edit_bookmark_dialog(WebView::BookmarkItem::Bookmark const& current_bookmark) const
 {
-    return display_add_or_edit_bookmark_dialog<BookmarkPromise>(active_tab(), "Edit Bookmark", current_bookmark.url, current_bookmark.title);
+    return display_add_or_edit_bookmark_dialog<BookmarkPromise>(
+        active_tab(), "Edit Bookmark", current_bookmark.url, current_bookmark.title, current_bookmark.favicon_base64_png,
+        [](BookmarkPromise& promise, WebView::BookmarkItem::Bookmark bookmark, Optional<String>) {
+            promise.resolve(move(bookmark));
+        },
+        false);
 }
 
 template<typename PromiseType>

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -214,7 +214,12 @@ public:
         view_menu->addMenu(create_application_menu(*view_menu, application.motion_menu()));
 
         m_application_menu_bar->addMenu(bookmarks_menu());
-        m_application_menu_bar->addMenu(create_application_menu(*m_application_menu_bar, application.history_menu()));
+
+        m_history_menu = create_application_menu(*m_application_menu_bar, application.history_menu());
+        QObject::connect(m_history_menu, &QMenu::aboutToShow, m_application_menu_bar, [this] {
+            update_history_menu(*m_history_menu, Application::the().active_tab() ? &Application::the().active_tab()->view() : nullptr);
+        });
+        m_application_menu_bar->addMenu(m_history_menu);
 
         auto* help_menu = m_application_menu_bar->addMenu("&Help");
         help_menu->addAction(create_application_action(*help_menu, application.open_about_page_action(), IncludeActionIcon::No));
@@ -273,6 +278,7 @@ private:
 #if defined(AK_OS_MACOS)
     QMenuBar* m_application_menu_bar { nullptr };
     QMenu* m_bookmarks_menu { nullptr };
+    QMenu* m_history_menu { nullptr };
     QMenu* m_inspect_menu { nullptr };
     QMenu* m_debug_menu { nullptr };
     QAction* m_reopen_recently_closed_tab_action { nullptr };

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -23,6 +23,7 @@
 #include <QAction>
 #include <QClipboard>
 #include <QComboBox>
+#include <QDate>
 #include <QDesktopServices>
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -740,6 +741,24 @@ Optional<Application::BookmarkID> Application::bookmark_item_id_for_context_menu
     return {};
 }
 
+Vector<WebView::BookmarkItem::Bookmark> Application::bookmarks_for_all_tabs() const
+{
+    Vector<WebView::BookmarkItem::Bookmark> bookmarks;
+
+    if (!m_active_window)
+        return bookmarks;
+
+    m_active_window->for_each_tab([&](Tab& tab) {
+        bookmarks.append(WebView::BookmarkItem::Bookmark {
+            .url = tab.view().url(),
+            .title = tab.title().isEmpty() ? Optional<String> {} : ak_string_from_qstring(tab.title()),
+            .favicon_base64_png = tab.view().favicon_base64_png(),
+        });
+    });
+
+    return bookmarks;
+}
+
 static void add_bookmark_folder_options(QComboBox& folder_combo, ReadonlySpan<WebView::BookmarkItem> items, QString const& prefix, Optional<String const&> selected_folder_id)
 {
     for (auto const& item : items) {
@@ -892,6 +911,8 @@ static NonnullRefPtr<PromiseType> display_add_or_edit_bookmark_folder_dialog(
     dialog->setAttribute(Qt::WA_DeleteOnClose);
 
     auto* title_edit = new QLineEdit(dialog);
+    title_edit->setMinimumWidth(320);
+    title_edit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     if (current_title.has_value())
         title_edit->setText(qstring_from_ak_string(*current_title));
 
@@ -900,6 +921,10 @@ static NonnullRefPtr<PromiseType> display_add_or_edit_bookmark_folder_dialog(
     QObject::connect(buttons, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
 
     auto* layout = new QFormLayout(dialog);
+    layout->setContentsMargins(32, 28, 32, 28);
+    layout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
+    layout->setHorizontalSpacing(16);
+    layout->setVerticalSpacing(14);
     layout->addRow("Title:", title_edit);
     layout->addRow(buttons);
 
@@ -923,14 +948,20 @@ static NonnullRefPtr<PromiseType> display_add_or_edit_bookmark_folder_dialog(
     return promise;
 }
 
-NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_add_bookmark_folder_dialog() const
+NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_add_bookmark_folder_dialog(Optional<String const&> default_title) const
 {
-    return display_add_or_edit_bookmark_folder_dialog<BookmarkFolderPromise>(active_tab(), "Add Folder", {});
+    return display_add_or_edit_bookmark_folder_dialog<BookmarkFolderPromise>(active_tab(), "Add Folder", default_title);
 }
 
 NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_edit_bookmark_folder_dialog(WebView::BookmarkItem::Folder const& current_folder) const
 {
     return display_add_or_edit_bookmark_folder_dialog<BookmarkFolderPromise>(active_tab(), "Edit Folder", current_folder.title);
+}
+
+String Application::suggested_bookmark_all_tabs_folder_title() const
+{
+    auto title = QString("Saved Tabs %1").arg(QDate::currentDate().toString(Qt::ISODate));
+    return ak_string_from_qstring(title);
 }
 
 void Application::on_devtools_enabled() const

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -528,7 +528,7 @@ bool Application::activate_tab_with_url(URL::URL const& url) const
 void Application::open_url_in_new_window(URL::URL const& url)
 {
     auto is_private = m_active_window ? m_active_window->is_private() : WebView::IsPrivate::No;
-    this->new_window({ url }, {}, BrowserWindow::IsPopupWindow::No, is_private);
+    this->new_window({ url }, configuration_for_new_window(), BrowserWindow::IsPopupWindow::No, is_private);
 }
 
 Optional<ByteString> Application::ask_user_for_download_path(ByteString const& file) const

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -87,7 +87,7 @@ private:
     virtual void rebuild_bookmarks_menu() const override;
     virtual void show_bookmark_context_menu(Gfx::IntPoint, Optional<WebView::BookmarkItem const&>, Optional<String const&> target_folder_id) override;
     virtual Optional<BookmarkID> bookmark_item_id_for_context_menu() const override;
-    virtual NonnullRefPtr<BookmarkPromise> display_add_bookmark_dialog() const override;
+    virtual NonnullRefPtr<AddBookmarkPromise> display_add_bookmark_dialog(Optional<String const&> target_folder_id = {}) const override;
     virtual NonnullRefPtr<BookmarkPromise> display_edit_bookmark_dialog(WebView::BookmarkItem::Bookmark const& current_bookmark) const override;
     virtual NonnullRefPtr<BookmarkFolderPromise> display_add_bookmark_folder_dialog() const override;
     virtual NonnullRefPtr<BookmarkFolderPromise> display_edit_bookmark_folder_dialog(WebView::BookmarkItem::Folder const& current_folder) const override;

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -82,6 +82,7 @@ private:
 
     virtual bool supports_vertical_tabs() const override { return true; }
     virtual bool supports_server_side_window_decorations() const override { return true; }
+    virtual Vector<WebView::BookmarkItem::Bookmark> bookmarks_for_all_tabs() const override;
     virtual void update_tabs_display() const override;
 
     virtual void rebuild_bookmarks_menu() const override;
@@ -89,8 +90,9 @@ private:
     virtual Optional<BookmarkID> bookmark_item_id_for_context_menu() const override;
     virtual NonnullRefPtr<AddBookmarkPromise> display_add_bookmark_dialog(Optional<String const&> target_folder_id = {}) const override;
     virtual NonnullRefPtr<BookmarkPromise> display_edit_bookmark_dialog(WebView::BookmarkItem::Bookmark const& current_bookmark) const override;
-    virtual NonnullRefPtr<BookmarkFolderPromise> display_add_bookmark_folder_dialog() const override;
+    virtual NonnullRefPtr<BookmarkFolderPromise> display_add_bookmark_folder_dialog(Optional<String const&> default_title = {}) const override;
     virtual NonnullRefPtr<BookmarkFolderPromise> display_edit_bookmark_folder_dialog(WebView::BookmarkItem::Folder const& current_folder) const override;
+    virtual String suggested_bookmark_all_tabs_folder_title() const override;
 
     virtual void on_devtools_enabled() const override;
     virtual void on_devtools_disabled() const override;

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -391,6 +391,9 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     menuBar()->addMenu(m_bookmarks_menu);
 
     m_history_menu = create_application_menu(*this, application.history_menu());
+    QObject::connect(m_history_menu, &QMenu::aboutToShow, this, [this] {
+        update_history_menu(*m_history_menu, m_current_tab ? &m_current_tab->view() : nullptr);
+    });
     m_hamburger_menu->addMenu(m_history_menu);
     menuBar()->addMenu(m_history_menu);
 

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -115,6 +115,13 @@ public:
     QAction& new_window_action() const { return *m_new_window_action; }
     QAction& find_action() const { return *m_find_in_page_action; }
 
+    template<typename Callback>
+    void for_each_tab(Callback&& callback)
+    {
+        for (int i = 0; i < m_tabs_container->count(); ++i)
+            callback(*m_tabs_container->tab(i));
+    }
+
     void update_tabs_display();
 
     void rebuild_bookmarks_menu();
@@ -185,13 +192,6 @@ private:
     void update_appkit_window_resizability();
     bool should_draw_window_border() const;
     void update_window_border();
-
-    template<typename Callback>
-    void for_each_tab(Callback&& callback)
-    {
-        for (int i = 0; i < m_tabs_container->count(); ++i)
-            callback(*m_tabs_container->tab(i));
-    }
 
     void initialize_tab_buttons(Tab*);
     void create_menu_bar_window_controls();

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibURL/Parser.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/HistoryStore.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/StringUtils.h>
@@ -17,6 +19,9 @@
 #include <QWidget>
 
 namespace Ladybird {
+
+static constexpr auto DYNAMIC_HISTORY_MENU_ITEM_PROPERTY = "LadybirdDynamicHistoryMenuItem";
+static constexpr size_t RECENT_HISTORY_MENU_ITEM_LIMIT = 15;
 
 class ActionObserver final : public WebView::Action::Observer {
 public:
@@ -292,6 +297,40 @@ static void add_items_to_menu(QMenu& qmenu, QWidget& parent, WebView::Menu& menu
     }
 }
 
+static QAction* create_session_history_traversal_menu_action(QMenu& menu, WebContentView& view, WebView::ViewImplementation::SessionHistoryTraversalMenuItem const& item)
+{
+    static constexpr int const MENU_ICON_SIZE = 16;
+
+    auto* action = new QAction(qstring_from_ak_string(item.title), &menu);
+    action->setToolTip(qstring_from_ak_string(item.url));
+    if (item.favicon_base64_png.has_value())
+        action->setIcon(icon_from_base64_png(*item.favicon_base64_png, MENU_ICON_SIZE));
+    else
+        action->setIcon(create_chrome_icon(ChromeIcon::Globe, menu.palette()));
+    QObject::connect(action, &QAction::triggered, &view, [&view, delta = item.delta] {
+        (void)view.traverse_the_history_by_delta(delta);
+    });
+    return action;
+}
+
+static bool append_session_history_traversal_menu_items(QMenu& menu, WebContentView& view, int direction)
+{
+    auto items = view.session_history_traversal_menu_items(direction);
+    if (items.is_empty())
+        return false;
+
+    for (auto const& item : items)
+        menu.addAction(create_session_history_traversal_menu_action(menu, view, item));
+
+    return true;
+}
+
+void populate_session_history_traversal_menu(QMenu& menu, WebContentView& view, int direction)
+{
+    menu.clear();
+    append_session_history_traversal_menu_items(menu, view, direction);
+}
+
 QMenu* create_application_menu(QWidget& parent, WebView::Menu& menu)
 {
     auto* application_menu = new QMenu(qstring_from_ak_string(menu.title()), &parent);
@@ -303,6 +342,81 @@ void repopulate_application_menu(QMenu& menu, QWidget& parent, WebView::Menu& so
 {
     menu.clear();
     add_items_to_menu(menu, parent, source);
+}
+
+static void insert_dynamic_history_action(QMenu& menu, QAction* before, QAction& action)
+{
+    action.setProperty(DYNAMIC_HISTORY_MENU_ITEM_PROPERTY, true);
+    menu.insertAction(before, &action);
+}
+
+static QAction* create_dynamic_history_separator(QMenu& menu)
+{
+    auto* separator = new QAction(&menu);
+    separator->setSeparator(true);
+    return separator;
+}
+
+static QAction* create_history_navigation_action(QMenu& menu, WebContentView& view, WebView::Action& source_action, QKeySequence::StandardKey shortcut)
+{
+    auto* action = new QAction(qstring_from_ak_string(source_action.text()), &menu);
+    action->setEnabled(source_action.enabled());
+    action->setShortcuts(QKeySequence::keyBindings(shortcut));
+    QObject::connect(action, &QAction::triggered, &view, [&source_action] {
+        source_action.activate();
+    });
+    return action;
+}
+
+static QAction* create_recent_history_menu_action(QMenu& menu, WebContentView& view, WebView::HistoryEntry const& entry)
+{
+    static constexpr int const MENU_ICON_SIZE = 16;
+
+    auto title = entry.title.has_value() && !entry.title->is_empty() ? *entry.title : entry.url;
+    auto* action = new QAction(qstring_from_ak_string(title), &menu);
+    action->setToolTip(qstring_from_ak_string(entry.url));
+    if (entry.favicon_base64_png.has_value())
+        action->setIcon(icon_from_base64_png(*entry.favicon_base64_png, MENU_ICON_SIZE));
+    else
+        action->setIcon(create_chrome_icon(ChromeIcon::Globe, menu.palette()));
+
+    auto url = URL::Parser::basic_parse(entry.url);
+    if (url.has_value()) {
+        QObject::connect(action, &QAction::triggered, &view, [&view, url = url.release_value()] {
+            view.load(url);
+        });
+    } else {
+        action->setEnabled(false);
+    }
+
+    return action;
+}
+
+void update_history_menu(QMenu& menu, WebContentView* view)
+{
+    for (auto* action : menu.actions()) {
+        if (action->property(DYNAMIC_HISTORY_MENU_ITEM_PROPERTY).toBool()) {
+            menu.removeAction(action);
+            action->deleteLater();
+        }
+    }
+
+    if (!view)
+        return;
+
+    auto* insertion_point = menu.actions().isEmpty() ? nullptr : menu.actions().first();
+    insert_dynamic_history_action(menu, insertion_point, *create_history_navigation_action(menu, *view, view->navigate_back_action(), QKeySequence::StandardKey::Back));
+    insert_dynamic_history_action(menu, insertion_point, *create_history_navigation_action(menu, *view, view->navigate_forward_action(), QKeySequence::StandardKey::Forward));
+    insert_dynamic_history_action(menu, insertion_point, *create_dynamic_history_separator(menu));
+
+    auto entries = WebView::Application::history_store(view->is_private()).list_entries({}, 0, RECENT_HISTORY_MENU_ITEM_LIMIT);
+    for (auto const& entry : entries) {
+        auto* action = create_recent_history_menu_action(menu, *view, entry);
+        insert_dynamic_history_action(menu, insertion_point, *action);
+    }
+
+    if (!entries.is_empty())
+        insert_dynamic_history_action(menu, insertion_point, *create_dynamic_history_separator(menu));
 }
 
 QMenu* create_context_menu(QWidget& parent, WebContentView& view, WebView::Menu& menu)

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -197,6 +197,9 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
         if (include_action_icon == IncludeActionIcon::Yes)
             qaction.setIcon(create_chrome_icon(action.engaged() ? ChromeIcon::StarFilled : ChromeIcon::Star, palette));
         break;
+    case WebView::ActionID::AddBookmarkAllTabs:
+        qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_D));
+        break;
     case WebView::ActionID::ToggleBookmarksBar:
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_B));
         break;

--- a/UI/Qt/Menu.h
+++ b/UI/Qt/Menu.h
@@ -23,6 +23,8 @@ enum class IncludeActionIcon {
 
 QMenu* create_application_menu(QWidget& parent, WebView::Menu&);
 void repopulate_application_menu(QMenu& menu, QWidget& parent, WebView::Menu& source);
+void update_history_menu(QMenu& menu, WebContentView*);
+void populate_session_history_traversal_menu(QMenu& menu, WebContentView&, int direction);
 
 QMenu* create_context_menu(QWidget& parent, WebContentView&, WebView::Menu&);
 QAction* create_application_action(QWidget& parent, WebView::Action&, IncludeActionIcon = IncludeActionIcon::Yes);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -170,37 +170,18 @@ static QToolButton* create_toolbar_button(QWidget& parent, QAction& action)
     return button;
 }
 
-static void populate_navigation_history_menu(QMenu& menu, WebContentView& view, int direction)
-{
-    static constexpr int const MENU_ICON_SIZE = 16;
-
-    menu.clear();
-
-    for (auto const& item : view.session_history_traversal_menu_items(direction)) {
-        auto* action = menu.addAction(qstring_from_ak_string(item.title));
-        action->setToolTip(qstring_from_ak_string(item.url));
-        if (item.favicon_base64_png.has_value())
-            action->setIcon(icon_from_base64_png(*item.favicon_base64_png, MENU_ICON_SIZE));
-        else
-            action->setIcon(create_chrome_icon(ChromeIcon::Globe, menu.palette()));
-        QObject::connect(action, &QAction::triggered, &view, [&view, delta = item.delta] {
-            (void)view.traverse_the_history_by_delta(delta);
-        });
-    }
-}
-
 static QToolButton* create_navigation_history_toolbar_button(QWidget& parent, QAction& action, WebContentView& view, int direction)
 {
     auto* button = create_toolbar_button(parent, action);
     auto* menu = new QMenu(button);
     QObject::connect(menu, &QMenu::aboutToShow, button, [menu, &view, direction] {
-        populate_navigation_history_menu(*menu, view, direction);
+        populate_session_history_traversal_menu(*menu, view, direction);
     });
     button->setMenu(menu);
     button->setPopupMode(QToolButton::DelayedPopup);
     button->setContextMenuPolicy(Qt::CustomContextMenu);
     QObject::connect(button, &QToolButton::customContextMenuRequested, button, [button, menu, &view, direction](QPoint const&) {
-        populate_navigation_history_menu(*menu, view, direction);
+        populate_session_history_traversal_menu(*menu, view, direction);
         if (!menu->isEmpty())
             button->showMenu();
     });


### PR DESCRIPTION
This collects a set of small Qt UI improvements for browser chrome menus.

It makes new windows opened from link context menus use the same size and cascade behavior as normal new windows, adds recent history entries to the History menu, and improves bookmark workflows. Adding a bookmark now opens a dialog where the URL, title, and target folder can be adjusted, and the Bookmarks menu now has a Bookmark All Tabs action with a suggested dated folder name.

It also adds Download Linked File and Download Linked File As actions to link context menus, reusing the existing download destination handling.