### PR TITLE
LibWeb: Consume repaint requests when presenting instead of recording 

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4279,7 +4279,6 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
     if (!has_compositor_context())
         return false;
 
-    m_needs_repaint = false;
     auto document = active_document();
     if (!document)
         return false;
@@ -4360,6 +4359,8 @@ void LocalNavigable::paint_next_frame()
     };
     if (should_defer_main_thread_present_for_async_scroll())
         return;
+
+    m_needs_repaint = false;
 
     if (!record_display_list_and_scroll_state(paint_config))
         return;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -635,6 +635,11 @@ bool Internals::headless()
     return page().client().is_headless();
 }
 
+bool Internals::needs_repaint()
+{
+    return page().top_level_traversable()->needs_repaint();
+}
+
 String Internals::dump_display_list()
 {
     return window().associated_document().dump_display_list();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -107,6 +107,8 @@ public:
 
     bool headless();
 
+    bool needs_repaint();
+
     String dump_display_list();
     String dump_accessibility_tree();
     String dump_layout_tree(GC::Ref<DOM::Node>);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -96,6 +96,8 @@ interface Internals {
 
     readonly attribute boolean headless;
 
+    readonly attribute boolean needsRepaint;
+
     DOMString dumpDisplayList();
     DOMString dumpAccessibilityTree();
     DOMString dumpLayoutTree(Node node);

--- a/Tests/LibWeb/Text/expected/hit_testing/hit-test-preserves-pending-repaint.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/hit-test-preserves-pending-repaint.txt
@@ -1,0 +1,1 @@
+needsRepaint after mouse move: true

--- a/Tests/LibWeb/Text/input/hit_testing/hit-test-preserves-pending-repaint.html
+++ b/Tests/LibWeb/Text/input/hit_testing/hit-test-preserves-pending-repaint.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<div id="box" style="width: 100px; height: 100px;"></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        // Mutating the DOM schedules a repaint and makes the cached hit-test display list stale.
+        const span = document.createElement("span");
+        span.textContent = "x";
+        document.body.appendChild(span);
+
+        // Hit testing from mouse movement rebuilds the hit-test display list. This must not
+        // consume the pending repaint, otherwise the next rendering update presents nothing.
+        internals.mouseMove(50, 50);
+
+        println(`needsRepaint after mouse move: ${internals.needsRepaint}`);
+    });
+</script>


### PR DESCRIPTION
Previously, recording the display list cleared the navigable's repaint flag, but hit testing and screenshot capture record without presenting a frame, so they consumed repaint requests that were never fulfilled. On pages that mutate on every frame, the hit test triggered by each mouse move event swallowed the pending repaint, so the displayed page
froze for as long as the mouse kept moving.

We now clear the flag in the presenting caller instead, before recording, to avoid clearing the flag when we shouldn't.

Fixes the issue reported here: https://github.com/LadybirdBrowser/ladybird/issues/4623#issuecomment-4883433263, where moving the mouse over the in-progress animation on https://kabutops.com would cause it to freeze.