### PR TITLE
LibWeb: Factor device pixel ratio into srcset image selection

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -38,6 +38,7 @@
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/SharedResourceRequest.h>
 #include <LibWeb/HTML/SupportedImageTypes.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Painting/Paintable.h>
@@ -1365,7 +1366,10 @@ Optional<ImageSourceAndPixelDensity> HTMLImageElement::select_an_image_source()
         return {};
 
     // 3. Return the result of selecting an image from el's source set.
-    return m_source_set.select_an_image_source();
+    auto device_pixel_ratio = 1.0;
+    if (auto window = document().window())
+        device_pixel_ratio = window->device_pixel_ratio();
+    return m_source_set.select_an_image_source(device_pixel_ratio);
 }
 
 void HTMLImageElement::set_source_set(SourceSet source_set)

--- a/Libraries/LibWeb/HTML/SourceSet.cpp
+++ b/Libraries/LibWeb/HTML/SourceSet.cpp
@@ -34,7 +34,7 @@ static double pixel_density(ImageSource const& image_source)
 }
 
 // https://html.spec.whatwg.org/multipage/images.html#select-an-image-source-from-a-source-set
-ImageSourceAndPixelDensity SourceSet::select_an_image_source()
+ImageSourceAndPixelDensity SourceSet::select_an_image_source(double device_pixel_ratio)
 {
     // 1. If an entry b in sourceSet has the same associated pixel density descriptor as an earlier entry a in sourceSet,
     //    then remove entry b.
@@ -52,14 +52,15 @@ ImageSourceAndPixelDensity SourceSet::select_an_image_source()
     }
 
     // 2. In an implementation-defined manner, choose one image source from sourceSet. Let selectedSource be this choice.
-    //    In our case, select the lowest density greater than 1, otherwise the greatest density available.
+    //    NB: Match other engines by selecting the lowest density that is at least the display's device pixel ratio,
+    //        otherwise the greatest density available.
     // 3. Return selectedSource and its associated pixel density.
 
     quick_sort(unique_pixel_density_sources, [](auto& a, auto& b) {
         return pixel_density(a) < pixel_density(b);
     });
     for (auto const& source : unique_pixel_density_sources) {
-        if (pixel_density(source) >= 1) {
+        if (pixel_density(source) >= device_pixel_ratio) {
             return { source, pixel_density(source) };
         }
     }

--- a/Libraries/LibWeb/HTML/SourceSet.h
+++ b/Libraries/LibWeb/HTML/SourceSet.h
@@ -39,7 +39,7 @@ struct SourceSet {
     [[nodiscard]] bool is_empty() const;
 
     // https://html.spec.whatwg.org/multipage/images.html#select-an-image-source-from-a-source-set
-    [[nodiscard]] ImageSourceAndPixelDensity select_an_image_source();
+    [[nodiscard]] ImageSourceAndPixelDensity select_an_image_source(double device_pixel_ratio);
 
     // https://html.spec.whatwg.org/multipage/images.html#normalise-the-source-densities
     void normalize_source_densities(DOM::Element const&);

--- a/Tests/LibWeb/Text/expected/HTML/image-srcset-device-pixel-ratio.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-srcset-device-pixel-ratio.txt
@@ -1,0 +1,3 @@
+At 1x: 120.png?density=1
+At 2x: 120.png?density=2
+At 3x: 120.png?density=3

--- a/Tests/LibWeb/Text/input/HTML/image-srcset-device-pixel-ratio.html
+++ b/Tests/LibWeb/Text/input/HTML/image-srcset-device-pixel-ratio.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        function basename(url) {
+            return url.substring(url.lastIndexOf("/") + 1);
+        }
+
+        function selectedSourceAt(dpr) {
+            return new Promise((resolve) => {
+                internals.setDevicePixelRatio(dpr);
+                const img = document.createElement("img");
+                img.srcset =
+                    "../../../Assets/120.png?density=1 1x, " +
+                    "../../../Assets/120.png?density=2 2x, " +
+                    "../../../Assets/120.png?density=3 3x";
+                img.onload = () => {
+                    resolve(basename(img.currentSrc));
+                    img.remove();
+                };
+                document.body.appendChild(img);
+            });
+        }
+
+        println("At 1x: " + (await selectedSourceAt(1)));
+        println("At 2x: " + (await selectedSourceAt(2)));
+        println("At 3x: " + (await selectedSourceAt(3)));
+        done();
+    });
+</script>


### PR DESCRIPTION
When selecting an image source from a srcset, we always returned the lowest candidate density that was at least 1, ignoring the display's device pixel ratio. On a high-DPI display this picked the 1x candidate even when a sharper one was available, so responsive images rendered blurry on HiDPI screens while other engines chose the higher-resolution source.

Thread the document's device pixel ratio into select_an_image_source and compare candidate densities against it instead of a hardcoded 1. Behavior at a device pixel ratio of 1 is unchanged.

Add a text test that selects sources at device pixel ratios 1, 2 and 3 via `internals.setDevicePixelRatio` and confirms the matching candidate is chosen.

Visual progression on https://thebodyshop.se/

Before:
<img width="2464" height="1586" alt="Screenshot at 2026-07-07 12-12-26" src="https://github.com/user-attachments/assets/1db5ec4a-6000-4cd5-86e4-8507b7e726fb" />

After:
<img width="2464" height="1586" alt="Screenshot at 2026-07-07 12-01-09" src="https://github.com/user-attachments/assets/d746a82c-0cf3-4df3-b2ea-9d95709d4504" />
