### PR TITLE
LibWeb: Size abspos intrinsic heights against the box's own width

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1562,6 +1562,15 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         return height;
     };
 
+    // Intrinsic (fit-content/min-content/max-content) heights depend on the box's own used width,
+    // which was already resolved above, not on the width of the containing block. Absolutely
+    // positioned boxes routinely have a used width narrower than their containing block (e.g. a
+    // fixed-position dialog sized to 400px inside a 1300px viewport), and measuring their content
+    // at the containing block width lets text that should wrap stay on one line, underestimating
+    // the height. Feed the box's own width to the intrinsic-height calculations.
+    auto available_space_for_intrinsic_height = available_space;
+    available_space_for_intrinsic_height.width = AvailableSize::make_definite(state.content_width());
+
     // Compute the height based on box type and CSS properties:
     // https://www.w3.org/TR/css-sizing-3/#box-sizing
     auto used_height = try_compute_height([&] -> CSS::LengthOrAuto {
@@ -1569,14 +1578,14 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             return CSS::Length::make_px(compute_table_box_height_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (should_treat_height_as_auto(box, available_space, containing_block_constraints))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_height(box, available_space, box.computed_values().height(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_height(box, available_space_for_intrinsic_height, box.computed_values().height(), containing_block_constraints));
     }());
 
     // If the tentative used height is greater than 'max-height', the rules above are applied again,
     // but this time using the computed value of 'max-height' as the computed value for 'height'.
     auto const& computed_max_height = box.computed_values().max_height();
     if (!used_height.is_auto() && !computed_max_height.is_none()) {
-        auto max_height = calculate_inner_height(box, available_space, computed_max_height, containing_block_constraints);
+        auto max_height = calculate_inner_height(box, available_space_for_intrinsic_height, computed_max_height, containing_block_constraints);
         if (used_height.to_px_or_zero() > max_height)
             used_height = try_compute_height(CSS::Length::make_px(max_height));
     }
@@ -1585,7 +1594,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // but this time using the value of 'min-height' as the computed value for 'height'.
     auto const& computed_min_height = box.computed_values().min_height();
     if (!used_height.is_auto() && !computed_min_height.is_auto()) {
-        auto min_height = calculate_inner_height(box, available_space, computed_min_height, containing_block_constraints);
+        auto min_height = calculate_inner_height(box, available_space_for_intrinsic_height, computed_min_height, containing_block_constraints);
         if (used_height.to_px_or_zero() < min_height)
             used_height = try_compute_height(CSS::Length::make_px(min_height));
     }

--- a/Tests/LibWeb/Layout/expected/abspos-fit-content-height-uses-own-width.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-fit-content-height-uses-own-width.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: inline
+      BlockContainer <div#box> at [0,0] positioned [0+0+0 200 0+0+0] [0+0+0 30 30+0+0] [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 37, rect: [0,0 193.578125x10] baseline: 8
+            "This paragraph is long enough that it"
+        frag 1 from TextNode start: 38, length: 37, rect: [0,10 192.328125x10] baseline: 8
+            "has to wrap onto several lines inside"
+        frag 2 from TextNode start: 76, length: 21, rect: [0,20 111.390625x10] baseline: 8
+            "the narrow fixed box."
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>#box) [0,0 200x60]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] (z-index: auto)
+  SC for BlockContainer<DIV>#box [0,0 200x30] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/abspos-fit-content-height-uses-own-width.html
+++ b/Tests/LibWeb/Layout/input/abspos-fit-content-height-uses-own-width.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html><style>
+    * { box-sizing: border-box; }
+    #box {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 200px;
+        height: fit-content;
+        padding-bottom: 30px;
+        font: 10px/1 SerenitySans;
+    }
+</style><div id="box">This paragraph is long enough that it has to wrap onto several lines inside the narrow fixed box.</div>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/keyword-sizes-on-abspos.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/keyword-sizes-on-abspos.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 60 tests
 
-34 Pass
-26 Fail
+43 Pass
+17 Fail
 Pass	.test 1
 Pass	.test 2
 Fail	.test 3
@@ -35,19 +35,19 @@ Pass	.test 28
 Pass	.test 29
 Fail	.test 30
 Pass	.test 31
-Fail	.test 32
-Fail	.test 33
-Fail	.test 34
+Pass	.test 32
+Pass	.test 33
+Pass	.test 34
 Pass	.test 35
 Pass	.test 36
-Fail	.test 37
-Fail	.test 38
-Fail	.test 39
+Pass	.test 37
+Pass	.test 38
+Pass	.test 39
 Fail	.test 40
 Pass	.test 41
-Fail	.test 42
-Fail	.test 43
-Fail	.test 44
+Pass	.test 42
+Pass	.test 43
+Pass	.test 44
 Fail	.test 45
 Pass	.test 46
 Pass	.test 47


### PR DESCRIPTION
An absolutely positioned box with a fit-content, min-content or max-content height was measured against its containing block's width rather than its own resolved width. A box narrower than its containing block, such as a fixed-position dialog constrained to a few hundred pixels inside the viewport, therefore measured its contents as if they had the full containing-block width available: text that should wrap stayed on one line and the computed height came out too short, clipping the bottom of the content (including trailing padding).

The used width is already resolved by the time the height is computed, so feed that width to the intrinsic-height calculations instead of the containing block width.

This was visible on the cookie-consent dialog on thebodyshop.se, whose action buttons were pushed flush against a clipped bottom edge. It also fixes nine subtests of the keyword-sizes-on-abspos WPT test.

Visual progression on https://thebodyshop.se/

Before:

<img width="2464" height="1586" alt="Screenshot at 2026-07-07 12-37-12" src="https://github.com/user-attachments/assets/00819bd0-5da5-4212-849e-ec3fa043d2a7" />

After:

<img width="2464" height="1586" alt="Screenshot at 2026-07-07 12-38-26" src="https://github.com/user-attachments/assets/b0b5d70f-d23d-435d-b259-27bdb8854f42" />