### PR TITLE
Meta/WPT.sh: Forcefully terminate hanging processes

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -316,6 +316,36 @@ cleanup_run_infra() {
     done
 }
 
+clear_processes_using_path() {
+    local path="$1"
+    local signal="$2"
+    local action="$3"
+    local timeout_seconds="$4"
+    local deadline=$((SECONDS + timeout_seconds))
+    local pids_in_use
+
+    readarray -t pids_in_use < <(sudo_and_ask "" lsof -t "$path" 2>/dev/null | sort -nu)
+    if [ "${#pids_in_use[@]}" = 0 ]; then
+        return 0
+    fi
+
+    echo "Trying to $action procs holding $path: ${pids_in_use[*]}"
+    kill "-$signal" "${pids_in_use[@]}" 2>/dev/null || true
+    while true; do
+        readarray -t pids_in_use < <(sudo_and_ask "" lsof -t "$path" 2>/dev/null | sort -nu)
+        if [ "${#pids_in_use[@]}" = 0 ]; then
+            return 0
+        fi
+
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "Timed out waiting for procs holding $path to exit: ${pids_in_use[*]}"
+            return 1
+        fi
+
+        sleep 0.1
+    done
+}
+
 cleanup_run_dirs() {
     readarray -t dirs < <(ls "${BUILD_DIR}/wpt" 2>/dev/null)
     if [ "${#dirs}" = 0 ]; then
@@ -325,13 +355,15 @@ cleanup_run_dirs() {
     echo "Cleaning run dirs: ${dirs[*]}"
     for dir in "${dirs[@]}"; do
         mount_path="${BUILD_DIR}/wpt/$dir/merged"
-        for _ in $(seq 1 5); do
-            readarray -t pids_in_use < <(sudo_and_ask "" lsof "$mount_path" 2>/dev/null | cut -f2 -d' ')
-            [ "${#pids_in_use[@]}" = 0 ] && break
-                echo Trying to kill procs: "${pids_in_use[@]}"
-                kill -INT "${pids_in_use[@]}" 2>/dev/null || true
-        done
-        sudo_and_ask "" umount "$mount_path" || true
+        if ! mountpoint -q "$mount_path"; then
+            continue
+        fi
+
+        clear_processes_using_path "$mount_path" TERM terminate 5 \
+            || clear_processes_using_path "$mount_path" KILL kill 5 \
+            || true
+
+        sudo_and_ask "" umount "$mount_path" || echo "Failed to unmount $mount_path"
     done
     rm -fr "${BUILD_DIR}/wpt"
 }


### PR DESCRIPTION
We were sending the INT signal to processes that were still involved with a mount point we're trying to unmount and ignoring the outcome if that failed.

Instead, send the TERM signal and follow up with a KILL if the processes did not terminate themselves. This should prevent our WPT runner from ending up in a state where it is unable to proceed with new runs.