### PR TITLE
LibWeb: Apply CSS-wide keyword meaning to substituted custom properties

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -5736,6 +5736,23 @@ NonnullRefPtr<StyleValue const> Parser::resolve_unresolved_style_value(ParsingPa
     return parser.resolve_unresolved_style_value(abstract_element, guarded_contexts, property, unresolved);
 }
 
+// If a component value sequence is a single CSS-wide keyword (inherit/initial/unset/revert/revert-layer),
+// returns that keyword.
+static Optional<Keyword> single_css_wide_keyword(Vector<ComponentValue> const& values)
+{
+    TokenStream tokens { values };
+    tokens.discard_whitespace();
+    if (!tokens.has_next_token())
+        return {};
+    auto const& token = tokens.consume_a_token();
+    tokens.discard_whitespace();
+    if (tokens.has_next_token() || !token.is(Token::Type::Ident))
+        return {};
+    if (!is_css_wide_keyword(token.token().ident()))
+        return {};
+    return keyword_from_string(token.token().ident());
+}
+
 // https://drafts.csswg.org/css-values-5/#property-replacement
 NonnullRefPtr<StyleValue const> Parser::resolve_unresolved_style_value(DOM::AbstractElement element, GuardedSubstitutionContexts& guarded_contexts, PropertyNameAndID const& property, UnresolvedStyleValue const& unresolved)
 {
@@ -5766,6 +5783,14 @@ NonnullRefPtr<StyleValue const> Parser::resolve_unresolved_style_value(DOM::Abst
     // NB: Custom properties have no grammar as such, so we skip this step for them.
     // FIXME: Parse according to @property syntax once we support that.
     if (property.is_custom_property()) {
+        // A CSS-wide keyword produced by substitution (e.g. as a var() fallback) is surfaced as the keyword itself
+        // rather than as literal tokens, so that custom property resolution applies its inherit/initial/unset/revert
+        // meaning instead of storing the raw "inherit"/etc. text.
+        if (unresolved.contains_arbitrary_substitution_function()) {
+            if (auto keyword = single_css_wide_keyword(result); keyword.has_value())
+                return KeywordStyleValue::create(keyword.value());
+        }
+
         auto contains_attr_tainted_values = result.first_matching([](auto const& component_value) { return component_value.contains_attr_tainted_value(); }).has_value();
         auto source_text_mode = unresolved.contains_arbitrary_substitution_function() && !contains_attr_tainted_values
             ? UnresolvedStyleValue::SourceTextMode::TrimLeading

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3621,6 +3621,16 @@ static NonnullRefPtr<StyleValue const> compute_value_of_custom_property_impl(DOM
         auto parsing_params = Parser::ParsingParams { document };
         parsing_params.computed_style_for_custom_property_resolution = computed_style_for_custom_property_resolution;
         resolved_value = Parser::Parser::resolve_unresolved_style_value(parsing_params, abstract_element, PropertyNameAndID::from_name(name).release_value(), unresolved, guarded_contexts);
+
+        // A CSS-wide keyword produced by substitution takes on that keyword's meaning for the custom property,
+        // exactly as a literally-specified one would (handled above before substitution).
+        if (resolved_value->is_initial())
+            return document.custom_property_initial_value(name);
+        if (resolved_value->is_inherit())
+            return compute_inherited_custom_property_value(abstract_element, name, guarded_contexts);
+        if (resolved_value->is_unset())
+            return registration.has_value() && !registration->inherit ? document.custom_property_initial_value(name) : compute_inherited_custom_property_value(abstract_element, name, guarded_contexts);
+        // FIXME: Implement reverting custom properties for is_revert() / is_revert_layer().
     }
 
     auto invalid_custom_property_fallback_value = [&](NonnullRefPtr<StyleValue const> invalid_value) {

--- a/Tests/LibWeb/Text/expected/css/variable-css-wide-keyword-substitution.txt
+++ b/Tests/LibWeb/Text/expected/css/variable-css-wide-keyword-substitution.txt
@@ -1,0 +1,7 @@
+substituted inherit, no ancestor -> empty: true
+substituted inherit, no ancestor -> outer var() falls back (red): true
+substituted inherit inherits ancestor value: true
+substituted inherit inherits ancestor value -> color green: true
+substituted initial -> empty: true
+substituted initial -> outer var() falls back (green): true
+non-keyword substitution preserved: true

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-css-wide-keywords.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-css-wide-keywords.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 30 tests
 
-18 Pass
-12 Fail
+24 Pass
+6 Fail
 Pass	`initial` as a value for an unregistered custom property
 Pass	`inherit` as a value for an unregistered custom property
 Pass	`unset` as a value for an unregistered custom property
@@ -19,14 +19,14 @@ Fail	`revert` as a value for a non-inheriting registered custom property
 Fail	`revert` as a value for an inheriting registered custom property
 Pass	`revert-layer` as a value for a non-inheriting registered custom property
 Pass	`revert-layer` as a value for an inheriting registered custom property
-Fail	`initial` as a `var()` fallback for an unregistered custom property
-Fail	`inherit` as a `var()` fallback for an unregistered custom property
-Fail	`unset` as a `var()` fallback for an unregistered custom property
-Fail	`revert` as a `var()` fallback for an unregistered custom property
+Pass	`initial` as a `var()` fallback for an unregistered custom property
+Pass	`inherit` as a `var()` fallback for an unregistered custom property
+Pass	`unset` as a `var()` fallback for an unregistered custom property
+Pass	`revert` as a `var()` fallback for an unregistered custom property
 Fail	`revert-layer` as a `var()` fallback for an unregistered custom property
 Pass	`initial` as a `var()` fallback for a non-inheriting registered custom property
-Fail	`initial` as a `var()` fallback for an inheriting registered custom property
-Fail	`inherit` as a `var()` fallback for a non-inheriting registered custom property
+Pass	`initial` as a `var()` fallback for an inheriting registered custom property
+Pass	`inherit` as a `var()` fallback for a non-inheriting registered custom property
 Pass	`inherit` as a `var()` fallback for an inheriting registered custom property
 Pass	`unset` as a `var()` fallback for a non-inheriting registered custom property
 Pass	`unset` as a `var()` fallback for an inheriting registered custom property

--- a/Tests/LibWeb/Text/input/css/variable-css-wide-keyword-substitution.html
+++ b/Tests/LibWeb/Text/input/css/variable-css-wide-keyword-substitution.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<div id="parent" style="--inherited: green">
+    <div id="empty" style="--x: var(--undefined, inherit); color: var(--x, red)">text</div>
+    <div id="inherits-real" style="--inherited: var(--undefined, inherit); color: var(--inherited, red)">text</div>
+    <div id="initial" style="--y: var(--undefined, initial); color: var(--y, green)">text</div>
+    <div id="not-keyword" style="--z: var(--undefined, blue); color: var(--z, red)">text</div>
+</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const read = (id, prop) => getComputedStyle(document.getElementById(id)).getPropertyValue(prop);
+
+        // A CSS-wide keyword produced by substitution (as a var() fallback) keeps its keyword meaning.
+        // `inherit` with no ancestor value resolves empty, so the outer var() falls back.
+        println("substituted inherit, no ancestor -> empty: " + (read("empty", "--x") === ""));
+        println("substituted inherit, no ancestor -> outer var() falls back (red): " +
+            (read("empty", "color") === "rgb(255, 0, 0)"));
+
+        // `inherit` with an ancestor value actually inherits that value (not guaranteed-invalid).
+        println("substituted inherit inherits ancestor value: " +
+            (read("inherits-real", "--inherited").trim() === "green"));
+        println("substituted inherit inherits ancestor value -> color green: " +
+            (read("inherits-real", "color") === "rgb(0, 128, 0)"));
+
+        // `initial` on an unregistered custom property is guaranteed-invalid, so the outer var() falls back.
+        println("substituted initial -> empty: " + (read("initial", "--y") === ""));
+        println("substituted initial -> outer var() falls back (green): " +
+            (read("initial", "color") === "rgb(0, 128, 0)"));
+
+        // A non-keyword substituted value is preserved.
+        println("non-keyword substitution preserved: " + (read("not-keyword", "--z").trim() === "blue"));
+    });
+</script>


### PR DESCRIPTION
A CSS-wide keyword (`inherit`, `initial`, `unset`, `revert`) only kept its keyword meaning on a custom property when it was written literally. When one arrived through substitution, for example as a `var()` fallback like `var(--x, inherit)`, we stored it as the literal token `inherit` instead. Downstream `var()` references then substituted that token verbatim rather than treating the custom property as guaranteed-invalid or inheriting a value, so fallbacks that other engines take were skipped.

This surfaced on https://thebodyshop.se: the cookie dialog's font-family is built from `var(--default-font-family, ui-sans-serif, ...)` where `--default-font-family` resolves to a substituted inherit. Because we kept the literal token, the dialog inherited the page's single-weight brand font instead of falling back to `ui-sans-serif`, so its title could never render bold.

Surface a substituted single CSS-wide keyword as the keyword value and apply its `inherit`/`initial`/`unset` meaning during custom property resolution, matching a literally-specified keyword. This fixes six more subtests of the variable-css-wide-keywords WPT test (the remaining failures are the still-unimplemented revert behavior for custom properties). Add a text test covering substituted `inherit` with and without an ancestor value, substituted `initial`, and a non-keyword substitution.

Fixes boldness in cookie popup titles on https://thebodyshop.se/

Before:

<img width="2464" height="1586" alt="Screenshot at 2026-07-07 12-38-26" src="https://github.com/user-attachments/assets/eabe0af9-86c0-4a74-9d83-e4831e323481" />

After:

<img width="2464" height="1586" alt="Screenshot at 2026-07-07 15-15-11" src="https://github.com/user-attachments/assets/7f5f50d8-9cbf-4aee-8c8c-0a268a31484b" />