### PR TITLE
LibCore: Stop emulating POSIX on Windows

### DIFF
--- a/AK/Windows.h
+++ b/AK/Windows.h
@@ -13,7 +13,9 @@
 
 #include <AK/Assertions.h>
 #include <AK/Diagnostics.h>
+#include <AK/Error.h>
 #include <AK/Platform.h>
+#include <AK/Vector.h>
 
 #ifdef AK_OS_WINDOWS
 #    define timeval dummy_timeval
@@ -83,6 +85,23 @@ inline struct SystemApi {
 #    pragma comment(lib, "ws2_32.lib")
 #    include <io.h>
 #    include <stdlib.h>
+
+// Converts UTF-8 text to a null-terminated UTF-16 string for use with wide-char Win32 APIs.
+inline ErrorOr<Vector<wchar_t>> to_wide_string(StringView utf8)
+{
+    int length = 0;
+    if (!utf8.is_empty()) {
+        length = MultiByteToWideChar(CP_UTF8, 0, utf8.characters_without_null_termination(), static_cast<int>(utf8.length()), nullptr, 0);
+        if (length == 0)
+            return Error::from_windows_error();
+    }
+
+    Vector<wchar_t> result;
+    TRY(result.try_resize(length + 1));
+    if (length > 0)
+        MultiByteToWideChar(CP_UTF8, 0, utf8.characters_without_null_termination(), static_cast<int>(utf8.length()), result.data(), length);
+    return result;
+}
 
 // Cached SYSTEM_INFO::dwAllocationGranularity — the required alignment for MapViewOfFile offsets.
 inline size_t system_allocation_granularity()

--- a/AK/Windows.h
+++ b/AK/Windows.h
@@ -84,6 +84,17 @@ inline struct SystemApi {
 #    include <io.h>
 #    include <stdlib.h>
 
+// Cached SYSTEM_INFO::dwAllocationGranularity — the required alignment for MapViewOfFile offsets.
+inline size_t system_allocation_granularity()
+{
+    static size_t granularity = [] {
+        SYSTEM_INFO system_info {};
+        GetSystemInfo(&system_info);
+        return static_cast<size_t>(system_info.dwAllocationGranularity);
+    }();
+    return granularity;
+}
+
 inline void initiate_wsa()
 {
     WSADATA wsa;

--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -12,7 +12,6 @@ set(SOURCES
     EventReceiver.cpp
     File.cpp
     ImmutableBytes.cpp
-    MappedFile.cpp
     MimeData.cpp
     Notifier.cpp
     ReportTime.cpp
@@ -34,6 +33,7 @@ if (WIN32)
         AnonymousBufferWindows.cpp
         EventLoopImplementationWindows.cpp
         LocalServerWindows.cpp
+        MappedFileWindows.cpp
         ProcessWindows.cpp
         SocketWindows.cpp
         SocketpairWindows.cpp
@@ -46,6 +46,7 @@ else()
         AnonymousBuffer.cpp
         EventLoopImplementationUnix.cpp
         LocalServer.cpp
+        MappedFile.cpp
         Process.cpp
         Socket.cpp
         System.cpp

--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -32,6 +32,7 @@ if (WIN32)
     list(APPEND SOURCES
         AnonymousBufferWindows.cpp
         EventLoopImplementationWindows.cpp
+        FileWindows.cpp
         LocalServerWindows.cpp
         MappedFileWindows.cpp
         ProcessWindows.cpp
@@ -45,6 +46,7 @@ else()
     list(APPEND SOURCES
         AnonymousBuffer.cpp
         EventLoopImplementationUnix.cpp
+        FilePosix.cpp
         LocalServer.cpp
         MappedFile.cpp
         Process.cpp

--- a/Libraries/LibCore/Directory.cpp
+++ b/Libraries/LibCore/Directory.cpp
@@ -82,16 +82,31 @@ ErrorOr<void> Directory::ensure_directory(LexicalPath const& path, mode_t creati
     return {};
 }
 
+#ifdef AK_OS_WINDOWS
 ErrorOr<NonnullOwnPtr<File>> Directory::open(StringView filename, File::OpenMode mode) const
 {
-    auto fd = TRY(System::openat(m_directory_fd, filename, File::open_mode_to_options(mode)));
+    // Windows has no fd-relative file APIs, so open by joined path instead.
+    return File::open(LexicalPath::join(m_path.string(), filename).string(), mode);
+}
+
+ErrorOr<struct stat> Directory::stat(StringView filename) const
+{
+    return System::stat(LexicalPath::join(m_path.string(), filename).string());
+}
+#else
+ErrorOr<NonnullOwnPtr<File>> Directory::open(StringView filename, File::OpenMode mode) const
+{
+    // NOTE: openat()'s creation mode defaulted to 0, which made files created through
+    //       Directory::open() unreadable and unwritable; use the same default as File::open().
+    auto fd = TRY(System::openat(m_directory_fd, filename, File::open_mode_to_options(mode), 0644));
     return File::adopt_fd(fd, mode);
 }
 
-ErrorOr<struct stat> Directory::stat(StringView filename, int flags) const
+ErrorOr<struct stat> Directory::stat(StringView filename) const
 {
-    return System::fstatat(m_directory_fd, filename, flags);
+    return System::fstatat(m_directory_fd, filename, 0);
 }
+#endif
 
 ErrorOr<struct stat> Directory::stat() const
 {

--- a/Libraries/LibCore/Directory.cpp
+++ b/Libraries/LibCore/Directory.cpp
@@ -7,6 +7,10 @@
 #include <LibCore/Directory.h>
 #include <LibCore/System.h>
 
+#ifdef AK_OS_WINDOWS
+#    include <AK/Windows.h>
+#endif
+
 namespace Core {
 
 // We assume that the fd is a valid directory.
@@ -41,7 +45,7 @@ ErrorOr<void> Directory::chown(uid_t uid, gid_t gid)
 
 ErrorOr<bool> Directory::is_valid_directory(int fd)
 {
-    auto stat = TRY(System::fstat(fd));
+    auto stat = TRY(File::fstat(fd));
     return stat.st_mode & S_IFDIR;
 }
 
@@ -62,9 +66,12 @@ ErrorOr<Directory> Directory::create(LexicalPath path, CreateDirectories create_
 {
     if (create_directories == CreateDirectories::Yes)
         TRY(ensure_directory(path, creation_mode));
-    // FIXME: doesn't work on Linux probably
-    auto fd = TRY(System::open(path.string(), O_CLOEXEC));
-    return adopt_fd(fd, move(path));
+    // Validate before leaking the fd out of the File, so that failure (e.g. ENOTDIR
+    // for an existing regular file) doesn't leak it.
+    auto file = TRY(File::open(path.string(), File::OpenMode::Read));
+    if (!TRY(is_valid_directory(file->fd())))
+        return Error::from_errno(ENOTDIR);
+    return Directory { file->leak_fd(), move(path) };
 }
 
 ErrorOr<void> Directory::ensure_directory(LexicalPath const& path, mode_t creation_mode)
@@ -74,11 +81,17 @@ ErrorOr<void> Directory::ensure_directory(LexicalPath const& path, mode_t creati
 
     TRY(ensure_directory(path.parent(), creation_mode));
 
-    auto return_value = System::mkdir(path.string(), creation_mode);
     // We don't care if the directory already exists.
+#ifdef AK_OS_WINDOWS
+    // NOTE: Windows directories have no POSIX permission bits; creation_mode is ignored.
+    auto wide_path = TRY(to_wide_string(path.string()));
+    if (!CreateDirectoryW(wide_path.data(), nullptr) && GetLastError() != ERROR_ALREADY_EXISTS)
+        return Error::from_windows_error();
+#else
+    auto return_value = System::mkdir(path.string(), creation_mode);
     if (return_value.is_error() && return_value.error().code() != EEXIST)
         return return_value;
-
+#endif
     return {};
 }
 
@@ -91,7 +104,7 @@ ErrorOr<NonnullOwnPtr<File>> Directory::open(StringView filename, File::OpenMode
 
 ErrorOr<struct stat> Directory::stat(StringView filename) const
 {
-    return System::stat(LexicalPath::join(m_path.string(), filename).string());
+    return File::stat(LexicalPath::join(m_path.string(), filename).string());
 }
 #else
 ErrorOr<NonnullOwnPtr<File>> Directory::open(StringView filename, File::OpenMode mode) const
@@ -110,7 +123,7 @@ ErrorOr<struct stat> Directory::stat(StringView filename) const
 
 ErrorOr<struct stat> Directory::stat() const
 {
-    return System::fstat(m_directory_fd);
+    return File::fstat(m_directory_fd);
 }
 
 ErrorOr<void> Directory::for_each_entry(DirIterator::Flags flags, Core::Directory::ForEachEntryCallback callback)

--- a/Libraries/LibCore/Directory.h
+++ b/Libraries/LibCore/Directory.h
@@ -39,7 +39,7 @@ public:
     static ErrorOr<Directory> adopt_fd(int fd, LexicalPath path);
 
     ErrorOr<NonnullOwnPtr<File>> open(StringView filename, File::OpenMode mode) const;
-    ErrorOr<struct stat> stat(StringView filename, int flags) const;
+    ErrorOr<struct stat> stat(StringView filename) const;
     ErrorOr<struct stat> stat() const;
     int fd() const { return m_directory_fd; }
 

--- a/Libraries/LibCore/File.cpp
+++ b/Libraries/LibCore/File.cpp
@@ -209,6 +209,11 @@ ErrorOr<void> File::truncate(size_t length)
     return System::ftruncate(m_fd, length);
 }
 
+ErrorOr<struct stat> File::stat() const
+{
+    return System::fstat(m_fd);
+}
+
 #if !defined(AK_OS_WINDOWS)
 ErrorOr<void> File::set_blocking(bool enabled)
 {

--- a/Libraries/LibCore/File.cpp
+++ b/Libraries/LibCore/File.cpp
@@ -67,88 +67,12 @@ ErrorOr<NonnullOwnPtr<File>> File::open_file_or_standard_stream(StringView filen
     }
 }
 
-int File::open_mode_to_options(OpenMode mode)
-{
-    int flags = 0;
-    if (has_flag(mode, OpenMode::ReadWrite)) {
-        flags |= O_RDWR | O_CREAT;
-    } else if (has_flag(mode, OpenMode::Read)) {
-        flags |= O_RDONLY;
-    } else if (has_flag(mode, OpenMode::Write)) {
-        flags |= O_WRONLY | O_CREAT;
-        bool should_truncate = !has_any_flag(mode, OpenMode::Append | OpenMode::MustBeNew);
-        if (should_truncate)
-            flags |= O_TRUNC;
-    }
-
-    if (has_flag(mode, OpenMode::Append))
-        flags |= O_APPEND;
-    if (has_flag(mode, OpenMode::Truncate))
-        flags |= O_TRUNC;
-    if (has_flag(mode, OpenMode::MustBeNew))
-        flags |= O_EXCL;
-    if (!has_flag(mode, OpenMode::KeepOnExec))
-        flags |= O_CLOEXEC;
-    if (has_flag(mode, OpenMode::Nonblocking)) {
-#if !defined(AK_OS_WINDOWS)
-        flags |= O_NONBLOCK;
-#else
-        dbgln("Core::File::OpenMode::Nonblocking is not implemented");
-        VERIFY_NOT_REACHED();
-#endif
-    }
-
-    // Some open modes, like `ReadWrite` imply the ability to create the file if it doesn't exist.
-    // Certain applications may not want this privilege, and for compatibility reasons, this is
-    // the easiest way to add this option.
-    if (has_flag(mode, OpenMode::DontCreate))
-        flags &= ~O_CREAT;
-
-    return flags;
-}
-
-ErrorOr<void> File::open_path(StringView filename, mode_t permissions)
-{
-    VERIFY(m_fd == -1);
-    auto flags = open_mode_to_options(m_mode);
-
-    m_fd = TRY(System::open(filename, flags, permissions));
-    return {};
-}
-
-ErrorOr<Bytes> File::read_some(Bytes buffer)
-{
-    if (!has_flag(m_mode, OpenMode::Read)) {
-        // NOTE: POSIX says that if the fd is not open for reading, the call
-        //       will return EBADF. Since we already know whether we can or
-        //       can't read the file, let's avoid a syscall.
-        return Error::from_errno(EBADF);
-    }
-
-    auto nread = TRY(System::read(m_fd, buffer));
-    m_last_read_was_eof = nread == 0;
-    m_file_offset += nread;
-    return buffer.trim(nread);
-}
-
 ErrorOr<ByteBuffer> File::read_until_eof(size_t block_size)
 {
     // Note: This is used as a heuristic, it's not valid for devices or virtual files.
-    auto const potential_file_size = TRY(System::fstat(m_fd)).st_size;
+    auto const potential_file_size = TRY(stat()).st_size;
 
     return read_until_eof_impl(block_size, potential_file_size);
-}
-
-ErrorOr<size_t> File::write_some(ReadonlyBytes buffer)
-{
-    if (!has_flag(m_mode, OpenMode::Write)) {
-        // NOTE: Same deal as Read.
-        return Error::from_errno(EBADF);
-    }
-
-    auto nwritten = TRY(System::write(m_fd, buffer));
-    m_file_offset += nwritten;
-    return nwritten;
 }
 
 bool File::is_eof() const { return m_last_read_was_eof; }
@@ -172,60 +96,9 @@ void File::close()
     m_fd = -1;
 }
 
-ErrorOr<size_t> File::seek(i64 offset, SeekMode mode)
-{
-    int syscall_mode;
-    switch (mode) {
-    case SeekMode::SetPosition:
-        syscall_mode = SEEK_SET;
-        break;
-    case SeekMode::FromCurrentPosition:
-        syscall_mode = SEEK_CUR;
-        break;
-    case SeekMode::FromEndPosition:
-        syscall_mode = SEEK_END;
-        break;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-
-    size_t seek_result = TRY(System::lseek(m_fd, offset, syscall_mode));
-    m_file_offset = seek_result;
-    m_last_read_was_eof = false;
-    return seek_result;
-}
-
 ErrorOr<size_t> File::tell() const
 {
     return m_file_offset;
 }
-
-ErrorOr<void> File::truncate(size_t length)
-{
-    if (length > static_cast<size_t>(NumericLimits<off_t>::max()))
-        return Error::from_string_literal("Length is larger than the maximum supported length");
-
-    m_file_offset = min(length, m_file_offset);
-    return System::ftruncate(m_fd, length);
-}
-
-ErrorOr<struct stat> File::stat() const
-{
-    return System::fstat(m_fd);
-}
-
-#if !defined(AK_OS_WINDOWS)
-ErrorOr<void> File::set_blocking(bool enabled)
-{
-    // NOTE: This assumes the fd is actually a socket (FIONBIO), which is only coherent on POSIX,
-    //       where fds are interchangeable; on Windows a file HANDLE is never a SOCKET, so this
-    //       method is POSIX-only. Some systems also don't support changing the blocking state of
-    //       certain POSIX objects (message queues, pipes, etc) after their creation.
-    //       Therefore, this method shouldn't be used in Lagom.
-    // https://github.com/SerenityOS/serenity/pull/18965#discussion_r1207951840
-    int value = enabled ? 0 : 1;
-    return System::ioctl(fd(), FIONBIO, &value);
-}
-#endif
 
 }

--- a/Libraries/LibCore/File.cpp
+++ b/Libraries/LibCore/File.cpp
@@ -209,13 +209,18 @@ ErrorOr<void> File::truncate(size_t length)
     return System::ftruncate(m_fd, length);
 }
 
+#if !defined(AK_OS_WINDOWS)
 ErrorOr<void> File::set_blocking(bool enabled)
 {
-    // NOTE: This works fine on Serenity, but some systems out there don't support changing the blocking state of certain POSIX objects (message queues, pipes, etc) after their creation.
-    // Therefore, this method shouldn't be used in Lagom.
+    // NOTE: This assumes the fd is actually a socket (FIONBIO), which is only coherent on POSIX,
+    //       where fds are interchangeable; on Windows a file HANDLE is never a SOCKET, so this
+    //       method is POSIX-only. Some systems also don't support changing the blocking state of
+    //       certain POSIX objects (message queues, pipes, etc) after their creation.
+    //       Therefore, this method shouldn't be used in Lagom.
     // https://github.com/SerenityOS/serenity/pull/18965#discussion_r1207951840
     int value = enabled ? 0 : 1;
     return System::ioctl(fd(), FIONBIO, &value);
 }
+#endif
 
 }

--- a/Libraries/LibCore/File.h
+++ b/Libraries/LibCore/File.h
@@ -12,6 +12,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Stream.h>
 #include <LibCore/Export.h>
+#include <sys/stat.h>
 
 namespace Core {
 
@@ -67,6 +68,8 @@ public:
     virtual ErrorOr<size_t> seek(i64 offset, SeekMode) override;
     virtual ErrorOr<size_t> tell() const override;
     virtual ErrorOr<void> truncate(size_t length) override;
+
+    ErrorOr<struct stat> stat() const;
 
 #if !defined(AK_OS_WINDOWS)
     // Sets the blocking mode of the file. If blocking mode is disabled, reads

--- a/Libraries/LibCore/File.h
+++ b/Libraries/LibCore/File.h
@@ -14,6 +14,16 @@
 #include <LibCore/Export.h>
 #include <sys/stat.h>
 
+#ifdef AK_OS_WINDOWS
+// The CRT's <sys/stat.h> lacks the POSIX file-type classification macros.
+#    ifndef S_ISDIR
+#        define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#    endif
+#    ifndef S_ISREG
+#        define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#    endif
+#endif
+
 namespace Core {
 
 class CORE_API File final : public SeekableStream {
@@ -71,6 +81,9 @@ public:
 
     ErrorOr<struct stat> stat() const;
 
+    static ErrorOr<struct stat> stat(StringView path);
+    static ErrorOr<struct stat> fstat(int fd);
+
 #if !defined(AK_OS_WINDOWS)
     // Sets the blocking mode of the file. If blocking mode is disabled, reads
     // will fail with EAGAIN when there's no data available to read, and writes
@@ -97,7 +110,10 @@ public:
             close();
     }
 
+#if !defined(AK_OS_WINDOWS)
+    // Translates an OpenMode into O_* flags; only meaningful for the POSIX backend.
     static int open_mode_to_options(OpenMode mode);
+#endif
 
 private:
     File(OpenMode mode, ShouldCloseFileDescriptor should_close = ShouldCloseFileDescriptor::Yes)

--- a/Libraries/LibCore/File.h
+++ b/Libraries/LibCore/File.h
@@ -68,12 +68,14 @@ public:
     virtual ErrorOr<size_t> tell() const override;
     virtual ErrorOr<void> truncate(size_t length) override;
 
+#if !defined(AK_OS_WINDOWS)
     // Sets the blocking mode of the file. If blocking mode is disabled, reads
     // will fail with EAGAIN when there's no data available to read, and writes
     // will fail with EAGAIN when the data cannot be written without blocking
     // (due to the send buffer being full, for example).
     // See also Socket::set_blocking.
     ErrorOr<void> set_blocking(bool enabled);
+#endif
 
     int leak_fd()
     {

--- a/Libraries/LibCore/FilePosix.cpp
+++ b/Libraries/LibCore/FilePosix.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+
+#include <unistd.h>
+
+namespace Core {
+
+int File::open_mode_to_options(OpenMode mode)
+{
+    int flags = 0;
+    if (has_flag(mode, OpenMode::ReadWrite)) {
+        flags |= O_RDWR | O_CREAT;
+    } else if (has_flag(mode, OpenMode::Read)) {
+        flags |= O_RDONLY;
+    } else if (has_flag(mode, OpenMode::Write)) {
+        flags |= O_WRONLY | O_CREAT;
+        bool should_truncate = !has_any_flag(mode, OpenMode::Append | OpenMode::MustBeNew);
+        if (should_truncate)
+            flags |= O_TRUNC;
+    }
+
+    if (has_flag(mode, OpenMode::Append))
+        flags |= O_APPEND;
+    if (has_flag(mode, OpenMode::Truncate))
+        flags |= O_TRUNC;
+    if (has_flag(mode, OpenMode::MustBeNew))
+        flags |= O_EXCL;
+    if (!has_flag(mode, OpenMode::KeepOnExec))
+        flags |= O_CLOEXEC;
+    if (has_flag(mode, OpenMode::Nonblocking))
+        flags |= O_NONBLOCK;
+
+    // Some open modes, like `ReadWrite` imply the ability to create the file if it doesn't exist.
+    // Certain applications may not want this privilege, and for compatibility reasons, this is
+    // the easiest way to add this option.
+    if (has_flag(mode, OpenMode::DontCreate))
+        flags &= ~O_CREAT;
+
+    return flags;
+}
+
+ErrorOr<void> File::open_path(StringView filename, mode_t permissions)
+{
+    VERIFY(m_fd == -1);
+    auto flags = open_mode_to_options(m_mode);
+
+    m_fd = TRY(System::open(filename, flags, permissions));
+    return {};
+}
+
+ErrorOr<Bytes> File::read_some(Bytes buffer)
+{
+    if (!has_flag(m_mode, OpenMode::Read)) {
+        return Error::from_errno(EBADF);
+    }
+
+    auto nread = TRY(System::read(m_fd, buffer));
+    m_last_read_was_eof = nread == 0;
+    m_file_offset += nread;
+    return buffer.trim(nread);
+}
+
+ErrorOr<size_t> File::write_some(ReadonlyBytes buffer)
+{
+    if (!has_flag(m_mode, OpenMode::Write)) {
+        // NOTE: Same deal as Read.
+        return Error::from_errno(EBADF);
+    }
+
+    auto nwritten = TRY(System::write(m_fd, buffer));
+    m_file_offset += nwritten;
+    return nwritten;
+}
+
+ErrorOr<size_t> File::seek(i64 offset, SeekMode mode)
+{
+    int syscall_mode;
+    switch (mode) {
+    case SeekMode::SetPosition:
+        syscall_mode = SEEK_SET;
+        break;
+    case SeekMode::FromCurrentPosition:
+        syscall_mode = SEEK_CUR;
+        break;
+    case SeekMode::FromEndPosition:
+        syscall_mode = SEEK_END;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    size_t seek_result = TRY(System::lseek(m_fd, offset, syscall_mode));
+    m_file_offset = seek_result;
+    m_last_read_was_eof = false;
+    return seek_result;
+}
+
+ErrorOr<void> File::truncate(size_t length)
+{
+    if (length > static_cast<size_t>(NumericLimits<off_t>::max()))
+        return Error::from_string_literal("Length is larger than the maximum supported length");
+
+    m_file_offset = min(length, m_file_offset);
+    return System::ftruncate(m_fd, length);
+}
+
+ErrorOr<struct stat> File::stat() const
+{
+    return System::fstat(m_fd);
+}
+
+ErrorOr<struct stat> File::stat(StringView path)
+{
+    return System::stat(path);
+}
+
+ErrorOr<struct stat> File::fstat(int fd)
+{
+    return System::fstat(fd);
+}
+
+ErrorOr<void> File::set_blocking(bool enabled)
+{
+    return System::set_socket_blocking(fd(), enabled);
+}
+
+}

--- a/Libraries/LibCore/FileWindows.cpp
+++ b/Libraries/LibCore/FileWindows.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/File.h>
+
+#include <AK/Windows.h>
+
+namespace Core {
+
+// Maps the CreateFileW/GetFileAttributesExW failures that Windows-reachable callers
+// match on into errno space.
+// FIXME: Replace ad-hoc errno matching with a portable error taxonomy.
+static Error open_error_from_windows_error()
+{
+    auto error = GetLastError();
+    switch (error) {
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
+    case ERROR_INVALID_NAME:
+        return Error::from_errno(ENOENT);
+    case ERROR_ACCESS_DENIED:
+        return Error::from_errno(EACCES);
+    case ERROR_FILE_EXISTS:
+    case ERROR_ALREADY_EXISTS:
+        return Error::from_errno(EEXIST);
+    default:
+        return Error::from_windows_error(error);
+    }
+}
+
+static i64 unix_time_from_filetime(FILETIME file_time)
+{
+    // Seconds between the Windows epoch (1601-01-01) and the Unix epoch (1970-01-01).
+    static constexpr i64 windows_to_unix_epoch_offset_seconds = 11'644'473'600;
+    auto hundreds_of_nanoseconds = static_cast<i64>((static_cast<u64>(file_time.dwHighDateTime) << 32) | file_time.dwLowDateTime);
+    return hundreds_of_nanoseconds / 10'000'000 - windows_to_unix_epoch_offset_seconds;
+}
+
+ErrorOr<void> File::open_path(StringView filename, mode_t)
+{
+    VERIFY(m_fd == -1);
+
+    // NOTE: Windows files have no POSIX permission bits, so the mode argument is ignored
+    //       instead of being approximated.
+
+    if (has_flag(m_mode, OpenMode::Nonblocking)) {
+        dbgln("Core::File::OpenMode::Nonblocking is not implemented on Windows");
+        VERIFY_NOT_REACHED();
+    }
+
+    DWORD desired_access = 0;
+    if (has_flag(m_mode, OpenMode::Read))
+        desired_access |= GENERIC_READ;
+    if (has_flag(m_mode, OpenMode::Write)) {
+        // FILE_APPEND_DATA without FILE_WRITE_DATA makes WriteFile() always append,
+        // which matches POSIX O_APPEND semantics.
+        if (has_flag(m_mode, OpenMode::Append))
+            desired_access |= FILE_APPEND_DATA | SYNCHRONIZE;
+        else
+            desired_access |= GENERIC_WRITE;
+    }
+
+    // Mirror the POSIX backend's flag policy: write modes create unless DontCreate,
+    // write-only implies truncation unless appending or exclusive.
+    bool const may_create = has_flag(m_mode, OpenMode::Write) && !has_flag(m_mode, OpenMode::DontCreate);
+    bool should_truncate = has_flag(m_mode, OpenMode::Truncate);
+    if (!has_flag(m_mode, OpenMode::ReadWrite) && has_flag(m_mode, OpenMode::Write) && !has_any_flag(m_mode, OpenMode::Append | OpenMode::MustBeNew))
+        should_truncate = true;
+
+    DWORD creation_disposition;
+    if (has_flag(m_mode, OpenMode::MustBeNew) && may_create)
+        creation_disposition = CREATE_NEW;
+    else if (may_create)
+        creation_disposition = should_truncate ? CREATE_ALWAYS : OPEN_ALWAYS;
+    else
+        creation_disposition = should_truncate ? TRUNCATE_EXISTING : OPEN_EXISTING;
+
+    SECURITY_ATTRIBUTES security_attributes = {};
+    security_attributes.nLength = sizeof(security_attributes);
+    security_attributes.bInheritHandle = has_flag(m_mode, OpenMode::KeepOnExec);
+
+    auto wide_filename = TRY(to_wide_string(filename));
+
+    // Share as permissively as POSIX opens do. FILE_FLAG_BACKUP_SEMANTICS allows opening
+    // directories, which Core::Directory and the file:// directory listing depend on.
+    HANDLE handle = CreateFileW(
+        wide_filename.data(),
+        desired_access,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        &security_attributes,
+        creation_disposition,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+        nullptr);
+    if (handle == INVALID_HANDLE_VALUE)
+        return open_error_from_windows_error();
+
+    m_fd = to_fd(handle);
+    return {};
+}
+
+ErrorOr<Bytes> File::read_some(Bytes buffer)
+{
+    if (!has_flag(m_mode, OpenMode::Read)) {
+        // NOTE: The POSIX backend also refuses reads on write-only files without a syscall.
+        return Error::from_errno(EBADF);
+    }
+
+    DWORD n_read = 0;
+    if (!ReadFile(to_handle(m_fd), buffer.data(), buffer.size(), &n_read, nullptr)) {
+        auto error = GetLastError();
+        // Reading a pipe whose write end has closed fails with ERROR_BROKEN_PIPE once
+        // drained; POSIX read() reports that (and end-of-file) as reading 0 bytes.
+        if (error != ERROR_BROKEN_PIPE && error != ERROR_HANDLE_EOF)
+            return Error::from_windows_error(error);
+        n_read = 0;
+    }
+    m_last_read_was_eof = n_read == 0;
+    m_file_offset += n_read;
+    return buffer.trim(n_read);
+}
+
+ErrorOr<size_t> File::write_some(ReadonlyBytes buffer)
+{
+    if (!has_flag(m_mode, OpenMode::Write)) {
+        // NOTE: Same deal as Read.
+        return Error::from_errno(EBADF);
+    }
+
+    DWORD n_written = 0;
+    if (!WriteFile(to_handle(m_fd), buffer.data(), buffer.size(), &n_written, nullptr))
+        return Error::from_windows_error();
+    m_file_offset += n_written;
+    return n_written;
+}
+
+ErrorOr<size_t> File::seek(i64 offset, SeekMode mode)
+{
+    DWORD move_method;
+    switch (mode) {
+    case SeekMode::SetPosition:
+        move_method = FILE_BEGIN;
+        break;
+    case SeekMode::FromCurrentPosition:
+        move_method = FILE_CURRENT;
+        break;
+    case SeekMode::FromEndPosition:
+        move_method = FILE_END;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    LARGE_INTEGER new_pointer = {};
+    if (!SetFilePointerEx(to_handle(m_fd), { .QuadPart = offset }, &new_pointer, move_method))
+        return Error::from_windows_error();
+    m_file_offset = new_pointer.QuadPart;
+    m_last_read_was_eof = false;
+    return m_file_offset;
+}
+
+ErrorOr<void> File::truncate(size_t length)
+{
+    if (length > static_cast<size_t>(NumericLimits<i64>::max()))
+        return Error::from_string_literal("Length is larger than the maximum supported length");
+
+    // Truncates or extends without moving the file pointer; like POSIX ftruncate(),
+    // the caller-visible position is left unchanged (it may end up past EOF).
+    FILE_END_OF_FILE_INFO end_of_file_info = {};
+    end_of_file_info.EndOfFile.QuadPart = static_cast<LONGLONG>(length);
+    if (!SetFileInformationByHandle(to_handle(m_fd), FileEndOfFileInfo, &end_of_file_info, sizeof(end_of_file_info)))
+        return Error::from_windows_error();
+    return {};
+}
+
+ErrorOr<struct stat> File::stat() const
+{
+    return fstat(m_fd);
+}
+
+static struct stat stat_from_file_information(DWORD attributes, u64 file_size, FILETIME creation_time, FILETIME last_access_time, FILETIME last_write_time)
+{
+    struct stat st = {};
+    if (attributes & FILE_ATTRIBUTE_DIRECTORY)
+        st.st_mode = S_IFDIR | 0755;
+    else
+        st.st_mode = S_IFREG | ((attributes & FILE_ATTRIBUTE_READONLY) ? 0444 : 0644);
+    st.st_size = static_cast<decltype(st.st_size)>(file_size);
+    st.st_nlink = 1;
+    st.st_atime = unix_time_from_filetime(last_access_time);
+    st.st_mtime = unix_time_from_filetime(last_write_time);
+    st.st_ctime = unix_time_from_filetime(creation_time);
+    return st;
+}
+
+// FIXME: Unlike POSIX stat(), this doesn't follow symlinks (reparse points).
+ErrorOr<struct stat> File::stat(StringView path)
+{
+    auto wide_path = TRY(to_wide_string(path));
+    WIN32_FILE_ATTRIBUTE_DATA attribute_data = {};
+    if (!GetFileAttributesExW(wide_path.data(), GetFileExInfoStandard, &attribute_data))
+        return open_error_from_windows_error();
+
+    return stat_from_file_information(
+        attribute_data.dwFileAttributes,
+        (static_cast<u64>(attribute_data.nFileSizeHigh) << 32) | attribute_data.nFileSizeLow,
+        attribute_data.ftCreationTime,
+        attribute_data.ftLastAccessTime,
+        attribute_data.ftLastWriteTime);
+}
+
+ErrorOr<struct stat> File::fstat(int fd)
+{
+    BY_HANDLE_FILE_INFORMATION file_information = {};
+    if (!GetFileInformationByHandle(to_handle(fd), &file_information))
+        return Error::from_windows_error();
+
+    auto st = stat_from_file_information(
+        file_information.dwFileAttributes,
+        (static_cast<u64>(file_information.nFileSizeHigh) << 32) | file_information.nFileSizeLow,
+        file_information.ftCreationTime,
+        file_information.ftLastAccessTime,
+        file_information.ftLastWriteTime);
+    st.st_nlink = static_cast<decltype(st.st_nlink)>(file_information.nNumberOfLinks);
+    st.st_dev = file_information.dwVolumeSerialNumber;
+    return st;
+}
+
+}

--- a/Libraries/LibCore/LocalServerWindows.cpp
+++ b/Libraries/LibCore/LocalServerWindows.cpp
@@ -58,8 +58,7 @@ bool LocalServer::listen(ByteString const& address)
         return false;
 
     m_fd = MUST(Core::System::socket(AF_LOCAL, SOCK_STREAM, 0));
-    int option = 1;
-    MUST(Core::System::ioctl(m_fd, FIONBIO, &option));
+    MUST(Core::System::set_socket_blocking(m_fd, false));
     auto const ret = SetHandleInformation(to_handle(m_fd), HANDLE_FLAG_INHERIT, 0);
     VERIFY(ret != 0);
 

--- a/Libraries/LibCore/MappedFileWindows.cpp
+++ b/Libraries/LibCore/MappedFileWindows.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Checked.h>
+#include <AK/ScopeGuard.h>
+#include <LibCore/File.h>
+#include <LibCore/MappedFile.h>
+#include <LibCore/System.h>
+
+#include <AK/Windows.h>
+
+namespace Core {
+
+static constexpr size_t to_end_of_file = NumericLimits<size_t>::max();
+
+ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map(StringView path, Mode mode)
+{
+    auto open_mode = mode == Mode::ReadOnly
+        ? File::OpenMode::Read
+        : File::OpenMode::ReadWrite | File::OpenMode::DontCreate;
+    auto file = TRY(File::open(path, open_mode));
+    return map_from_fd_and_close(file->leak_fd(), path, mode);
+}
+
+ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_file(NonnullOwnPtr<Core::File> stream, StringView path)
+{
+    return map_from_fd_and_close(stream->leak_fd(), path);
+}
+
+ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, StringView path, Mode mode)
+{
+    return map_from_fd_range_and_close(fd, path, 0, to_end_of_file, mode);
+}
+
+ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_range_and_close(int fd, StringView, off_t offset, size_t size, Mode mode)
+{
+    ScopeGuard fd_close_guard = [fd] {
+        (void)System::close(fd);
+    };
+
+    if (offset < 0 || !AK::is_within_range<size_t>(offset))
+        return Error::from_errno(EINVAL);
+
+    LARGE_INTEGER large_file_size = {};
+    if (!GetFileSizeEx(to_handle(fd), &large_file_size))
+        return Error::from_windows_error();
+
+    auto file_size = static_cast<size_t>(large_file_size.QuadPart);
+    auto requested_offset = static_cast<size_t>(offset);
+    if (requested_offset > file_size)
+        return Error::from_errno(EINVAL);
+    if (size == to_end_of_file)
+        size = file_size - requested_offset;
+    else if (size > file_size - requested_offset)
+        return Error::from_errno(EINVAL);
+
+    if (size == 0)
+        return adopt_own(*new MappedFile(nullptr, 0, nullptr, 0, mode));
+
+    // MapViewOfFile requires the offset to be aligned to the system allocation granularity.
+    auto aligned_offset = align_down_to(requested_offset, system_allocation_granularity());
+    auto offset_in_mapping = requested_offset - aligned_offset;
+
+    Checked<size_t> view_size = offset_in_mapping;
+    view_size += size;
+    if (view_size.has_overflow())
+        return Error::from_errno(EOVERFLOW);
+
+    // Like the POSIX backend, read-only mappings are shared and writable mappings are
+    // copy-on-write, so writes through a MappedFile never reach the underlying file.
+    HANDLE file_mapping = CreateFileMappingW(to_handle(fd), nullptr, mode == Mode::ReadOnly ? PAGE_READONLY : PAGE_WRITECOPY, 0, 0, nullptr);
+    if (!file_mapping)
+        return Error::from_windows_error();
+    ScopeGuard file_mapping_guard = [&] { CloseHandle(file_mapping); };
+
+    void* view = MapViewOfFile(file_mapping, mode == Mode::ReadOnly ? FILE_MAP_READ : FILE_MAP_COPY, static_cast<DWORD>(aligned_offset >> 32), static_cast<DWORD>(aligned_offset & 0xFFFFFFFF), view_size.value());
+    if (!view)
+        return Error::from_windows_error();
+
+    auto* data = static_cast<u8*>(view) + offset_in_mapping;
+    return adopt_own(*new MappedFile(view, view_size.value(), data, size, mode));
+}
+
+MappedFile::MappedFile(void* mapping, size_t mapping_size, void* data, size_t size, Mode mode)
+    : FixedMemoryStream(Bytes { data, size }, mode)
+    , m_mapping(mapping)
+    , m_mapping_size(mapping_size)
+    , m_data(data)
+    , m_size(size)
+{
+}
+
+MappedFile::~MappedFile()
+{
+    if (!m_mapping)
+        return;
+
+    if (!UnmapViewOfFile(m_mapping))
+        dbgln("Failed to unmap MappedFile (@ {:p}, {} bytes): {}", m_mapping, m_mapping_size, Error::from_windows_error());
+}
+
+}

--- a/Libraries/LibCore/Process.cpp
+++ b/Libraries/LibCore/Process.cpp
@@ -264,6 +264,11 @@ void Process::terminate_immediately(int status)
     VERIFY_NOT_REACHED();
 }
 
+ErrorOr<void> Process::terminate_process(pid_t pid, TerminationMode mode)
+{
+    return System::kill(pid, mode == TerminationMode::Graceful ? SIGTERM : SIGKILL);
+}
+
 ErrorOr<String> Process::get_name()
 {
 #if defined(AK_OS_SERENITY)

--- a/Libraries/LibCore/Process.h
+++ b/Libraries/LibCore/Process.h
@@ -67,6 +67,12 @@ public:
 
     [[noreturn]] static void terminate_immediately(int status);
 
+    enum class TerminationMode {
+        Graceful,
+        Forceful,
+    };
+    static ErrorOr<void> terminate_process(pid_t, TerminationMode);
+
     static void wait_for_debugger_and_break();
     static ErrorOr<bool> is_being_debugged();
 

--- a/Libraries/LibCore/ProcessWindows.cpp
+++ b/Libraries/LibCore/ProcessWindows.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <AK/Utf16View.h>
 #include <AK/Vector.h>
@@ -106,6 +107,33 @@ void Process::terminate_immediately(int status)
     // DLL detach notifications and the other ExitProcess() teardown paths.
     TerminateProcess(GetCurrentProcess(), static_cast<UINT>(status));
     VERIFY_NOT_REACHED();
+}
+
+ErrorOr<void> Process::terminate_process(pid_t pid, TerminationMode mode)
+{
+    if (mode == TerminationMode::Graceful) {
+        // There is no SIGTERM equivalent on Windows; the closest honest approximation is
+        // asking every top-level window of the process to close. Console or windowless
+        // processes will not observe this.
+        if (!EnumWindows([](HWND hwnd, LPARAM l_param) -> BOOL {
+                DWORD window_pid = 0;
+                GetWindowThreadProcessId(hwnd, &window_pid);
+                if (window_pid == static_cast<DWORD>(l_param))
+                    PostMessage(hwnd, WM_CLOSE, 0, 0);
+                return TRUE;
+            },
+                pid))
+            return Error::from_windows_error();
+        return {};
+    }
+
+    HANDLE handle = OpenProcess(PROCESS_TERMINATE, FALSE, static_cast<DWORD>(pid));
+    if (!handle)
+        return Error::from_windows_error();
+    ScopeGuard close_handle = [&] { CloseHandle(handle); };
+    if (!TerminateProcess(handle, 1))
+        return Error::from_windows_error();
+    return {};
 }
 
 // Get the full path of the executable file of the current process

--- a/Libraries/LibCore/ResourceImplementation.cpp
+++ b/Libraries/LibCore/ResourceImplementation.cpp
@@ -6,9 +6,9 @@
 
 #include <AK/NeverDestroyed.h>
 #include <LibCore/DirIterator.h>
+#include <LibCore/File.h>
 #include <LibCore/ResourceImplementation.h>
 #include <LibCore/ResourceImplementationFile.h>
-#include <LibCore/System.h>
 
 namespace Core {
 
@@ -57,7 +57,7 @@ ErrorOr<NonnullRefPtr<Resource>> ResourceImplementation::load_from_uri(StringVie
     if (uri.starts_with(file_scheme)) {
         auto path = uri.substring_view(file_scheme.length());
         auto utf8_path = TRY(String::from_utf8(path));
-        auto st = TRY(System::stat(utf8_path));
+        auto st = TRY(File::stat(utf8_path));
         if (S_ISDIR(st.st_mode))
             return adopt_ref(*new Resource(utf8_path, Resource::Scheme::File, Resource::DirectoryTag {}, st.st_mtime));
         auto mapped_file = TRY(MappedFile::map(path));

--- a/Libraries/LibCore/ResourceImplementationFile.cpp
+++ b/Libraries/LibCore/ResourceImplementationFile.cpp
@@ -7,9 +7,9 @@
 #include <AK/LexicalPath.h>
 #include <AK/StringView.h>
 #include <LibCore/DirIterator.h>
+#include <LibCore/File.h>
 #include <LibCore/Resource.h>
 #include <LibCore/ResourceImplementationFile.h>
-#include <LibCore/System.h>
 
 namespace Core {
 
@@ -27,7 +27,7 @@ ErrorOr<NonnullRefPtr<Resource>> ResourceImplementationFile::load_from_resource_
     auto path = TRY(String::from_utf8(uri.substring_view(resource_scheme.length())));
     auto full_path = TRY(String::from_byte_string(LexicalPath::join(m_base_directory, path).string()));
 
-    auto st = TRY(System::stat(full_path));
+    auto st = TRY(File::stat(full_path));
 
     if (S_ISDIR(st.st_mode))
         return make_directory_resource(move(path), st.st_mtime);

--- a/Libraries/LibCore/SocketWindows.cpp
+++ b/Libraries/LibCore/SocketWindows.cpp
@@ -118,7 +118,8 @@ ErrorOr<size_t> PosixSocketHelper::pending_bytes() const
     }
 
     u_long value = 0;
-    TRY(System::ioctl(m_fd, FIONREAD, &value));
+    if (::ioctlsocket(m_fd, FIONREAD, &value) == SOCKET_ERROR)
+        return Error::from_windows_error();
     return value;
 }
 

--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -525,6 +525,12 @@ ErrorOr<int> socket(int domain, int type, int protocol)
     return fd;
 }
 
+ErrorOr<void> set_socket_blocking(int socket, bool enabled)
+{
+    int value = enabled ? 0 : 1;
+    return ioctl(socket, FIONBIO, &value);
+}
+
 ErrorOr<void> bind(int sockfd, struct sockaddr const* address, socklen_t address_length)
 {
     if (::bind(sockfd, address, address_length) < 0)

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -80,8 +80,11 @@ ErrorOr<struct stat> fstatat(int fd, StringView path, int flags);
 ErrorOr<int> openat(int fd, StringView path, int options, mode_t mode = 0);
 #endif
 CORE_API ErrorOr<int> fcntl(int fd, int command, ...);
+#if !defined(AK_OS_WINDOWS)
+// POSIX-only: Windows code maps files through Core::MappedFile's native backend.
 ErrorOr<void*> mmap(void* address, size_t, int protection, int flags, int fd, off_t, size_t alignment = 0, StringView name = {});
 ErrorOr<void> munmap(void* address, size_t);
+#endif
 CORE_API ErrorOr<void*> reserve_address_space(size_t size);
 CORE_API ErrorOr<void> commit_memory(void* address, size_t size);
 CORE_API ErrorOr<void> decommit_memory(void* address, size_t size);

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -74,7 +74,11 @@ CORE_API ErrorOr<sig_t> signal(int signal, sig_t handler);
 CORE_API ErrorOr<sighandler_t> signal(int signal, sighandler_t handler);
 #endif
 CORE_API ErrorOr<struct stat> fstat(int fd);
+#if !defined(AK_OS_WINDOWS)
+// There are no fd-relative path APIs on Windows; use path-based operations instead.
 ErrorOr<struct stat> fstatat(int fd, StringView path, int flags);
+ErrorOr<int> openat(int fd, StringView path, int options, mode_t mode = 0);
+#endif
 CORE_API ErrorOr<int> fcntl(int fd, int command, ...);
 ErrorOr<void*> mmap(void* address, size_t, int protection, int flags, int fd, off_t, size_t alignment = 0, StringView name = {});
 ErrorOr<void> munmap(void* address, size_t);
@@ -84,7 +88,6 @@ CORE_API ErrorOr<void> decommit_memory(void* address, size_t size);
 CORE_API ErrorOr<void> release_address_space(void* address, size_t size);
 ErrorOr<int> anon_create(size_t size, int options);
 CORE_API ErrorOr<int> open(StringView path, int options, mode_t mode = 0);
-ErrorOr<int> openat(int fd, StringView path, int options, mode_t mode = 0);
 CORE_API ErrorOr<void> close(int fd);
 ErrorOr<void> ftruncate(int fd, off_t length);
 CORE_API ErrorOr<struct stat> stat(StringView path);

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -100,7 +100,11 @@ CORE_API ErrorOr<size_t> write(int fd, ReadonlyBytes buffer);
 CORE_API ErrorOr<int> dup(int source_fd);
 ErrorOr<int> dup2(int source_fd, int destination_fd);
 CORE_API ErrorOr<ByteString> getcwd();
+#if !defined(AK_OS_WINDOWS)
+// POSIX-only: the Windows emulation silently assumed the fd was a socket.
+// Use set_socket_blocking() (or the socket classes) for portable code.
 CORE_API ErrorOr<void> ioctl(int fd, unsigned request, ...);
+#endif
 ErrorOr<struct termios> tcgetattr(int fd);
 ErrorOr<void> tcsetattr(int fd, int optional_actions, struct termios const&);
 CORE_API ErrorOr<void> chmod(StringView pathname, mode_t mode);
@@ -135,6 +139,7 @@ CORE_API ErrorOr<void> setsockopt(int sockfd, int level, int option, void const*
 ErrorOr<void> getsockname(int sockfd, struct sockaddr*, socklen_t*);
 ErrorOr<void> getpeername(int sockfd, struct sockaddr*, socklen_t*);
 CORE_API ErrorOr<void> socketpair(int domain, int type, int protocol, int sv[2]);
+CORE_API ErrorOr<void> set_socket_blocking(int socket, bool enabled);
 
 CORE_API ErrorOr<void> access(StringView pathname, int mode, int flags = 0);
 ErrorOr<ByteString> readlink(StringView pathname);

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -145,8 +145,9 @@ CORE_API ErrorOr<void> access(StringView pathname, int mode, int flags = 0);
 ErrorOr<ByteString> readlink(StringView pathname);
 CORE_API ErrorOr<int> poll(Span<struct pollfd>, int timeout);
 
-CORE_API ErrorOr<void> kill(pid_t, int signal);
 #if !defined(AK_OS_WINDOWS)
+// POSIX-only: use Core::Process::terminate_process() in portable code.
+CORE_API ErrorOr<void> kill(pid_t, int signal);
 CORE_API ErrorOr<void> chown(StringView pathname, uid_t uid, gid_t gid);
 ErrorOr<pid_t> posix_spawn(StringView path, posix_spawn_file_actions_t const* file_actions, posix_spawnattr_t const* attr, char* const arguments[], char* const envp[]);
 ErrorOr<pid_t> posix_spawnp(StringView path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -61,68 +61,81 @@ struct sockaddr;
 
 namespace Core::System {
 
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_HAIKU)
+#if !defined(AK_OS_WINDOWS)
+
+#    if !defined(AK_OS_MACOS) && !defined(AK_OS_HAIKU)
 ErrorOr<int> accept4(int sockfd, struct sockaddr*, socklen_t*, int flags);
-#endif
+#    endif
 
 ErrorOr<void> sigaction(int signal, struct sigaction const* action, struct sigaction* old_action);
-#if defined(AK_OS_SOLARIS)
+#    if defined(AK_OS_SOLARIS)
 CORE_API ErrorOr<SIG_TYP> signal(int signal, SIG_TYP handler);
-#elif defined(AK_OS_BSD_GENERIC)
+#    elif defined(AK_OS_BSD_GENERIC)
 CORE_API ErrorOr<sig_t> signal(int signal, sig_t handler);
-#else
+#    else
 CORE_API ErrorOr<sighandler_t> signal(int signal, sighandler_t handler);
-#endif
+#    endif
 CORE_API ErrorOr<struct stat> fstat(int fd);
-#if !defined(AK_OS_WINDOWS)
-// There are no fd-relative path APIs on Windows; use path-based operations instead.
 ErrorOr<struct stat> fstatat(int fd, StringView path, int flags);
 ErrorOr<int> openat(int fd, StringView path, int options, mode_t mode = 0);
-#endif
 CORE_API ErrorOr<int> fcntl(int fd, int command, ...);
-#if !defined(AK_OS_WINDOWS)
-// POSIX-only: Windows code maps files through Core::MappedFile's native backend.
 ErrorOr<void*> mmap(void* address, size_t, int protection, int flags, int fd, off_t, size_t alignment = 0, StringView name = {});
 ErrorOr<void> munmap(void* address, size_t);
-#endif
-CORE_API ErrorOr<void*> reserve_address_space(size_t size);
-CORE_API ErrorOr<void> commit_memory(void* address, size_t size);
-CORE_API ErrorOr<void> decommit_memory(void* address, size_t size);
-CORE_API ErrorOr<void> release_address_space(void* address, size_t size);
 ErrorOr<int> anon_create(size_t size, int options);
 CORE_API ErrorOr<int> open(StringView path, int options, mode_t mode = 0);
-CORE_API ErrorOr<void> close(int fd);
 ErrorOr<void> ftruncate(int fd, off_t length);
 CORE_API ErrorOr<struct stat> stat(StringView path);
 CORE_API ErrorOr<struct stat> lstat(StringView path);
 CORE_API ErrorOr<size_t> read(int fd, Bytes buffer);
 CORE_API ErrorOr<size_t> write(int fd, ReadonlyBytes buffer);
-CORE_API ErrorOr<int> dup(int source_fd);
 ErrorOr<int> dup2(int source_fd, int destination_fd);
-CORE_API ErrorOr<ByteString> getcwd();
-#if !defined(AK_OS_WINDOWS)
-// POSIX-only: the Windows emulation silently assumed the fd was a socket.
-// Use set_socket_blocking() (or the socket classes) for portable code.
 CORE_API ErrorOr<void> ioctl(int fd, unsigned request, ...);
-#endif
 ErrorOr<struct termios> tcgetattr(int fd);
 ErrorOr<void> tcsetattr(int fd, int optional_actions, struct termios const&);
 CORE_API ErrorOr<void> chmod(StringView pathname, mode_t mode);
 ErrorOr<off_t> lseek(int fd, off_t, int whence);
-
-CORE_API ErrorOr<bool> isatty(int fd);
 CORE_API ErrorOr<void> link(StringView old_path, StringView new_path);
 CORE_API ErrorOr<void> symlink(StringView target, StringView link_path);
 CORE_API ErrorOr<void> mkdir(StringView path, mode_t);
-CORE_API ErrorOr<void> chdir(StringView path);
 CORE_API ErrorOr<void> rmdir(StringView path);
 CORE_API ErrorOr<int> mkstemp(Span<char> pattern);
 CORE_API ErrorOr<void> fchmod(int fd, mode_t mode);
 CORE_API ErrorOr<void> rename(StringView old_path, StringView new_path);
 CORE_API ErrorOr<void> unlink(StringView path);
 CORE_API ErrorOr<void> utimensat(int fd, StringView path, struct timespec const times[2], int flag);
-CORE_API ErrorOr<Array<int, 2>> pipe2(int flags);
+CORE_API ErrorOr<void> access(StringView pathname, int mode, int flags = 0);
+ErrorOr<ByteString> readlink(StringView pathname);
+CORE_API ErrorOr<int> poll(Span<struct pollfd>, int timeout);
+// Use Core::Process::terminate_process() in portable code.
+CORE_API ErrorOr<void> kill(pid_t, int signal);
+CORE_API ErrorOr<void> chown(StringView pathname, uid_t uid, gid_t gid);
+ErrorOr<pid_t> posix_spawn(StringView path, posix_spawn_file_actions_t const* file_actions, posix_spawnattr_t const* attr, char* const arguments[], char* const envp[]);
+ErrorOr<pid_t> posix_spawnp(StringView path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);
 
+struct WaitPidResult {
+    pid_t pid;
+    int status;
+};
+CORE_API ErrorOr<WaitPidResult> waitpid(pid_t waitee, int options = 0);
+CORE_API ErrorOr<void> fchown(int fd, uid_t, gid_t);
+
+ErrorOr<rlimit> get_resource_limits(int resource);
+CORE_API ErrorOr<void> set_resource_limits(int resource, rlim_t limit);
+
+#endif
+
+CORE_API ErrorOr<void*> reserve_address_space(size_t size);
+CORE_API ErrorOr<void> commit_memory(void* address, size_t size);
+CORE_API ErrorOr<void> decommit_memory(void* address, size_t size);
+CORE_API ErrorOr<void> release_address_space(void* address, size_t size);
+
+CORE_API ErrorOr<void> close(int fd);
+CORE_API ErrorOr<int> dup(int source_fd);
+CORE_API ErrorOr<Array<int, 2>> pipe2(int flags);
+CORE_API ErrorOr<void> set_close_on_exec(int fd, bool enabled);
+CORE_API bool is_socket(int fd);
+
+// The socket section is portable: Winsock *is* the BSD socket API.
 CORE_API ErrorOr<int> socket(int domain, int type, int protocol);
 CORE_API ErrorOr<void> bind(int sockfd, struct sockaddr const*, socklen_t);
 CORE_API ErrorOr<void> listen(int sockfd, int backlog);
@@ -140,42 +153,17 @@ ErrorOr<void> getsockname(int sockfd, struct sockaddr*, socklen_t*);
 ErrorOr<void> getpeername(int sockfd, struct sockaddr*, socklen_t*);
 CORE_API ErrorOr<void> socketpair(int domain, int type, int protocol, int sv[2]);
 CORE_API ErrorOr<void> set_socket_blocking(int socket, bool enabled);
-
-CORE_API ErrorOr<void> access(StringView pathname, int mode, int flags = 0);
-ErrorOr<ByteString> readlink(StringView pathname);
-CORE_API ErrorOr<int> poll(Span<struct pollfd>, int timeout);
-
-#if !defined(AK_OS_WINDOWS)
-// POSIX-only: use Core::Process::terminate_process() in portable code.
-CORE_API ErrorOr<void> kill(pid_t, int signal);
-CORE_API ErrorOr<void> chown(StringView pathname, uid_t uid, gid_t gid);
-ErrorOr<pid_t> posix_spawn(StringView path, posix_spawn_file_actions_t const* file_actions, posix_spawnattr_t const* attr, char* const arguments[], char* const envp[]);
-ErrorOr<pid_t> posix_spawnp(StringView path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);
-
-struct WaitPidResult {
-    pid_t pid;
-    int status;
-};
-CORE_API ErrorOr<WaitPidResult> waitpid(pid_t waitee, int options = 0);
-CORE_API ErrorOr<void> fchown(int fd, uid_t, gid_t);
-#endif
-
 ErrorOr<AddressInfoVector> getaddrinfo(char const* nodename, char const* servname, struct addrinfo const& hints);
 
+// Process and miscellaneous helpers; operation-named, native on all platforms.
+CORE_API ErrorOr<ByteString> getcwd();
+CORE_API ErrorOr<void> chdir(StringView path);
+CORE_API ErrorOr<bool> isatty(int fd);
 CORE_API unsigned hardware_concurrency();
 CORE_API u64 physical_memory_bytes();
-
 CORE_API ErrorOr<ByteString> current_executable_path();
-
-#if !defined(AK_OS_WINDOWS)
-ErrorOr<rlimit> get_resource_limits(int resource);
-CORE_API ErrorOr<void> set_resource_limits(int resource, rlim_t limit);
-#endif
-
 CORE_API int getpid();
-CORE_API bool is_socket(int fd);
 CORE_API ErrorOr<void> sleep_ms(u32 milliseconds);
-CORE_API ErrorOr<void> set_close_on_exec(int fd, bool enabled);
 
 CORE_API ErrorOr<size_t> transfer_file_through_socket(int source_fd, int target_fd, size_t source_offset, size_t source_length);
 

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -13,12 +13,13 @@
 
 #include <AK/Array.h>
 #include <AK/ByteString.h>
+#include <AK/Checked.h>
 #include <AK/ScopeGuard.h>
+#include <LibCore/MappedFile.h>
 #include <LibCore/Process.h>
 #include <LibCore/SocketAddress.h>
 #include <LibCore/System.h>
 #include <direct.h>
-#include <sys/mman.h>
 
 #include <AK/Windows.h>
 #include <ws2tcpip.h>
@@ -174,25 +175,6 @@ ErrorOr<void> rename(StringView old_path, StringView new_path)
     ByteString new_path_string = new_path;
     if (!MoveFileExA(old_path_string.characters(), new_path_string.characters(), MOVEFILE_REPLACE_EXISTING))
         return Error::from_windows_error();
-    return {};
-}
-
-ErrorOr<void*> mmap(void* address, size_t size, int protection, int flags, int file_handle, off_t offset, size_t alignment, StringView)
-{
-    // custom alignment is not supported
-    VERIFY(!alignment);
-    int fd = _open_osfhandle(TRY(dup(file_handle)), 0);
-    ScopeGuard guard = [&] { _close(fd); };
-    void* ptr = ::mmap(address, size, protection, flags, fd, offset);
-    if (ptr == MAP_FAILED)
-        return Error::from_syscall("mmap"sv, errno);
-    return ptr;
-}
-
-ErrorOr<void> munmap(void* address, size_t size)
-{
-    if (::munmap(address, size) < 0)
-        return Error::from_syscall("munmap"sv, errno);
     return {};
 }
 
@@ -450,22 +432,11 @@ ErrorOr<size_t> transfer_file_through_socket(int source_fd, int target_fd, size_
     // FIXME: We could use TransmitFile (https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nf-mswsock-transmitfile)
     //        here. But in order to transmit a subset of the file, we have to use overlapped IO.
 
-    static auto allocation_granularity = []() {
-        SYSTEM_INFO system_info {};
-        GetSystemInfo(&system_info);
+    if (!AK::is_within_range<off_t>(source_offset))
+        return Error::from_errno(EOVERFLOW);
 
-        return system_info.dwAllocationGranularity;
-    }();
-
-    // MapViewOfFile requires the offset to be aligned to the system allocation granularity, so we must handle that here.
-    auto aligned_source_offset = (source_offset / allocation_granularity) * allocation_granularity;
-    auto offset_adjustment = source_offset - aligned_source_offset;
-    auto mapped_source_length = source_length + offset_adjustment;
-
-    auto* mapped = TRY(mmap(nullptr, mapped_source_length, PROT_READ, MAP_SHARED, source_fd, aligned_source_offset));
-    ScopeGuard guard { [&]() { (void)munmap(mapped, mapped_source_length); } };
-
-    return send(target_fd, { static_cast<u8*>(mapped) + offset_adjustment, source_length }, 0);
+    auto mapped_file = TRY(MappedFile::map_from_fd_range_and_close(TRY(dup(source_fd)), {}, static_cast<off_t>(source_offset), source_length));
+    return send(target_fd, mapped_file->bytes(), 0);
 }
 
 }

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -405,25 +405,6 @@ ErrorOr<AddressInfoVector> getaddrinfo(char const* nodename, char const* servnam
     return AddressInfoVector { move(addresses), results };
 }
 
-ErrorOr<void> kill(pid_t pid, int signal)
-{
-    if (signal == SIGTERM) {
-        if (!EnumWindows([](HWND hwnd, LPARAM l_param) -> BOOL {
-                DWORD window_pid = 0;
-                GetWindowThreadProcessId(hwnd, &window_pid);
-                if (window_pid == static_cast<DWORD>(l_param)) {
-                    PostMessage(hwnd, WM_CLOSE, 0, 0);
-                }
-                return TRUE;
-            },
-                pid))
-            return Error::from_windows_error();
-    } else {
-        return Error::from_string_literal("Unsupported signal value");
-    }
-    return {};
-}
-
 ErrorOr<size_t> transfer_file_through_socket(int source_fd, int target_fd, size_t source_offset, size_t source_length)
 {
     // FIXME: We could use TransmitFile (https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nf-mswsock-transmitfile)

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -97,13 +97,10 @@ ErrorOr<struct stat> fstat(int handle)
     return st;
 }
 
-ErrorOr<void> ioctl(int fd, unsigned request, ...)
+ErrorOr<void> set_socket_blocking(int socket, bool enabled)
 {
-    va_list ap;
-    va_start(ap, request);
-    u_long* arg = va_arg(ap, u_long*);
-    va_end(ap);
-    if (::ioctlsocket(fd, request, arg) == SOCKET_ERROR)
+    u_long value = enabled ? 0 : 1;
+    if (::ioctlsocket(socket, FIONBIO, &value) == SOCKET_ERROR)
         return Error::from_windows_error();
     return {};
 }

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -14,7 +14,6 @@
 #include <AK/Array.h>
 #include <AK/ByteString.h>
 #include <AK/Checked.h>
-#include <AK/ScopeGuard.h>
 #include <LibCore/MappedFile.h>
 #include <LibCore/Process.h>
 #include <LibCore/SocketAddress.h>
@@ -28,16 +27,6 @@ namespace Core::System {
 
 int windows_socketpair(SOCKET socks[2], int make_overlapped);
 
-ErrorOr<int> open(StringView path, int options, mode_t mode)
-{
-    ByteString str = path;
-    int fd = _open(str.characters(), options | O_BINARY | _O_OBTAIN_DIR, mode);
-    if (fd < 0)
-        return Error::from_syscall("open"sv, errno);
-    ScopeGuard guard = [&] { _close(fd); };
-    return dup(_get_osfhandle(fd));
-}
-
 ErrorOr<void> close(int handle)
 {
     if (is_socket(handle)) {
@@ -48,53 +37,6 @@ ErrorOr<void> close(int handle)
             return Error::from_windows_error();
     }
     return {};
-}
-
-ErrorOr<size_t> read(int handle, Bytes buffer)
-{
-    DWORD n_read = 0;
-    if (!ReadFile(to_handle(handle), buffer.data(), buffer.size(), &n_read, NULL))
-        return Error::from_windows_error();
-    return n_read;
-}
-
-ErrorOr<size_t> write(int handle, ReadonlyBytes buffer)
-{
-    DWORD n_written = 0;
-    if (!WriteFile(to_handle(handle), buffer.data(), buffer.size(), &n_written, NULL))
-        return Error::from_windows_error();
-    return n_written;
-}
-
-ErrorOr<off_t> lseek(int handle, off_t offset, int origin)
-{
-    static_assert(FILE_BEGIN == SEEK_SET && FILE_CURRENT == SEEK_CUR && FILE_END == SEEK_END, "SetFilePointerEx origin values are incompatible with lseek");
-    LARGE_INTEGER new_pointer = {};
-    if (!SetFilePointerEx(to_handle(handle), { .QuadPart = offset }, &new_pointer, origin))
-        return Error::from_windows_error();
-    return new_pointer.QuadPart;
-}
-
-ErrorOr<void> ftruncate(int handle, off_t length)
-{
-    auto position = TRY(lseek(handle, 0, SEEK_CUR));
-    ScopeGuard restore_position = [&] { MUST(lseek(handle, position, SEEK_SET)); };
-
-    TRY(lseek(handle, length, SEEK_SET));
-
-    if (!SetEndOfFile(to_handle(handle)))
-        return Error::from_windows_error();
-    return {};
-}
-
-ErrorOr<struct stat> fstat(int handle)
-{
-    struct stat st = {};
-    int fd = _open_osfhandle(TRY(dup(handle)), 0);
-    ScopeGuard guard = [&] { _close(fd); };
-    if (::fstat(fd, &st) < 0)
-        return Error::from_syscall("fstat"sv, errno);
-    return st;
 }
 
 ErrorOr<void> set_socket_blocking(int socket, bool enabled)
@@ -121,57 +63,6 @@ ErrorOr<void> chdir(StringView path)
     ByteString path_string = path;
     if (::_chdir(path_string.characters()) < 0)
         return Error::from_syscall("chdir"sv, errno);
-    return {};
-}
-
-ErrorOr<struct stat> stat(StringView path)
-{
-    struct stat st = {};
-    ByteString path_string = path;
-    if (::stat(path_string.characters(), &st) < 0)
-        return Error::from_syscall("stat"sv, errno);
-    return st;
-}
-
-ErrorOr<void> rmdir(StringView path)
-{
-    ByteString path_string = path;
-    if (_rmdir(path_string.characters()) < 0)
-        return Error::from_syscall("rmdir"sv, errno);
-    return {};
-}
-
-ErrorOr<void> unlink(StringView path)
-{
-    ByteString path_string = path;
-    if (_unlink(path_string.characters()) < 0)
-        return Error::from_syscall("unlink"sv, errno);
-    return {};
-}
-
-ErrorOr<void> link(StringView old_path, StringView new_path)
-{
-    ByteString old_path_string = old_path;
-    ByteString new_path_string = new_path;
-    if (!CreateHardLinkA(new_path_string.characters(), old_path_string.characters(), nullptr))
-        return Error::from_windows_error();
-    return {};
-}
-
-ErrorOr<void> mkdir(StringView path, mode_t)
-{
-    ByteString str = path;
-    if (_mkdir(str.characters()) < 0)
-        return Error::from_syscall("mkdir"sv, errno);
-    return {};
-}
-
-ErrorOr<void> rename(StringView old_path, StringView new_path)
-{
-    ByteString old_path_string = old_path;
-    ByteString new_path_string = new_path;
-    if (!MoveFileExA(old_path_string.characters(), new_path_string.characters(), MOVEFILE_REPLACE_EXISTING))
-        return Error::from_windows_error();
     return {};
 }
 

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -177,18 +177,6 @@ ErrorOr<void> rename(StringView old_path, StringView new_path)
     return {};
 }
 
-ErrorOr<int> openat(int, StringView, int, mode_t)
-{
-    dbgln("Core::System::openat() is not implemented");
-    VERIFY_NOT_REACHED();
-}
-
-ErrorOr<struct stat> fstatat(int, StringView, int)
-{
-    dbgln("Core::System::fstatat() is not implemented");
-    VERIFY_NOT_REACHED();
-}
-
 ErrorOr<void*> mmap(void* address, size_t size, int protection, int flags, int file_handle, off_t offset, size_t alignment, StringView)
 {
     // custom alignment is not supported

--- a/Libraries/LibCore/TCPServerWindows.cpp
+++ b/Libraries/LibCore/TCPServerWindows.cpp
@@ -22,8 +22,8 @@ ErrorOr<NonnullRefPtr<TCPServer>> TCPServer::try_create()
         MUST(Core::System::close(fd));
     } };
 
+    TRY(Core::System::set_socket_blocking(fd, false));
     int option = 1;
-    TRY(Core::System::ioctl(fd, FIONBIO, &option));
     TRY(Core::System::setsockopt(fd, SOL_SOCKET, SO_OOBINLINE, &option, sizeof(option)));
     if (SetHandleInformation(to_handle(fd), HANDLE_FLAG_INHERIT, 0) == 0)
         return Error::from_windows_error();
@@ -72,8 +72,7 @@ ErrorOr<void> TCPServer::set_blocking(bool const blocking)
     // NOTE: Blocking does not seem to be supported. Error code returned is WSAEINVAL
     if (!blocking)
         return Error::from_string_literal("Core::TCPServer: WinSock2 does not support blocking");
-    int option = 1;
-    TRY(Core::System::ioctl(m_fd, FIONBIO, &option));
+    TRY(Core::System::set_socket_blocking(m_fd, false));
     return {};
 }
 

--- a/Libraries/LibCore/UDPServerWindows.cpp
+++ b/Libraries/LibCore/UDPServerWindows.cpp
@@ -18,8 +18,7 @@ namespace Core {
 UDPServer::UDPServer()
 {
     m_fd = MUST(Core::System::socket(AF_INET, SOCK_DGRAM, 0));
-    int option = 1;
-    MUST(Core::System::ioctl(m_fd, FIONBIO, &option));
+    MUST(Core::System::set_socket_blocking(m_fd, false));
     auto const ret = SetHandleInformation(to_handle(m_fd), HANDLE_FLAG_INHERIT, 0);
     VERIFY(ret != 0);
 }

--- a/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Libraries/LibFileSystem/FileSystem.cpp
@@ -12,7 +12,7 @@
 #include <LibFileSystem/FileSystem.h>
 
 #if defined(AK_OS_WINDOWS)
-#    include <windows.h>
+#    include <AK/Windows.h>
 #else
 #    include <sys/statvfs.h>
 
@@ -333,6 +333,20 @@ bool can_delete_or_move(StringView path)
     return user_id == 0 || directory_stat.st_uid == user_id || stat_or_empty(path).st_uid == user_id;
 }
 #endif // !AK_OS_WINDOWS
+
+#ifdef AK_OS_WINDOWS
+ErrorOr<void> move_file(StringView destination_path, StringView source_path, PreserveMode)
+{
+    // NOTE: Unlike POSIX rename(), MoveFileExW is not guaranteed to replace an existing
+    //       destination atomically. MOVEFILE_COPY_ALLOWED provides the cross-volume
+    //       copy-and-delete fallback that the POSIX implementation does by hand.
+    auto wide_source_path = TRY(to_wide_string(source_path));
+    auto wide_destination_path = TRY(to_wide_string(destination_path));
+    if (!MoveFileExW(wide_source_path.data(), wide_destination_path.data(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED))
+        return Error::from_windows_error();
+    return {};
+}
+#endif
 
 ErrorOr<void> remove(StringView path, RecursionMode mode)
 {

--- a/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Libraries/LibFileSystem/FileSystem.cpp
@@ -8,10 +8,13 @@
 #include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/DirIterator.h>
+#include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
 
 #if defined(AK_OS_WINDOWS)
+#    include <direct.h>
+
 #    include <AK/Windows.h>
 #else
 #    include <sys/statvfs.h>
@@ -29,6 +32,49 @@
 #endif
 
 namespace FileSystem {
+
+static ErrorOr<struct stat> stat_path(StringView path)
+{
+    return Core::File::stat(path);
+}
+
+static ErrorOr<struct stat> stat_fd(int fd)
+{
+    return Core::File::fstat(fd);
+}
+
+// LibFileSystem is the portable home for path operations, so it is the one place
+// (outside LibCore's own backends) still allowed to reach for platform primitives.
+// On Windows these forward to the CRT for now.
+// FIXME: Nativize the Windows half (DeleteFileW etc.) and map both platforms'
+//        errors into a portable taxonomy.
+#ifdef AK_OS_WINDOWS
+static ErrorOr<void> remove_file(StringView path)
+{
+    ByteString path_string = path;
+    if (::_unlink(path_string.characters()) < 0)
+        return Error::from_syscall("unlink"sv, errno);
+    return {};
+}
+
+static ErrorOr<void> remove_directory(StringView path)
+{
+    ByteString path_string = path;
+    if (::_rmdir(path_string.characters()) < 0)
+        return Error::from_syscall("rmdir"sv, errno);
+    return {};
+}
+#else
+static ErrorOr<void> remove_file(StringView path)
+{
+    return Core::System::unlink(path);
+}
+
+static ErrorOr<void> remove_directory(StringView path)
+{
+    return Core::System::rmdir(path);
+}
+#endif
 
 ErrorOr<ByteString> current_working_directory()
 {
@@ -71,17 +117,17 @@ ErrorOr<ByteString> real_path(StringView path)
 
 bool exists(StringView path)
 {
-    return !Core::System::stat(path).is_error();
+    return !stat_path(path).is_error();
 }
 
 bool exists(int fd)
 {
-    return !Core::System::fstat(fd).is_error();
+    return !stat_fd(fd).is_error();
 }
 
 bool is_regular_file(StringView path)
 {
-    auto st_or_error = Core::System::stat(path);
+    auto st_or_error = stat_path(path);
     if (st_or_error.is_error())
         return false;
     auto st = st_or_error.release_value();
@@ -90,7 +136,7 @@ bool is_regular_file(StringView path)
 
 bool is_regular_file(int fd)
 {
-    auto st_or_error = Core::System::fstat(fd);
+    auto st_or_error = stat_fd(fd);
     if (st_or_error.is_error())
         return false;
     auto st = st_or_error.release_value();
@@ -99,7 +145,7 @@ bool is_regular_file(int fd)
 
 bool is_directory(StringView path)
 {
-    auto st_or_error = Core::System::stat(path);
+    auto st_or_error = stat_path(path);
     if (st_or_error.is_error())
         return false;
     auto st = st_or_error.release_value();
@@ -108,7 +154,7 @@ bool is_directory(StringView path)
 
 bool is_directory(int fd)
 {
-    auto st_or_error = Core::System::fstat(fd);
+    auto st_or_error = stat_fd(fd);
     if (st_or_error.is_error())
         return false;
     auto st = st_or_error.release_value();
@@ -350,7 +396,7 @@ ErrorOr<void> move_file(StringView destination_path, StringView source_path, Pre
 
 ErrorOr<void> remove(StringView path, RecursionMode mode)
 {
-    if (is_directory(path) && mode == RecursionMode::Allowed) {
+    if (mode == RecursionMode::Allowed && is_directory(path)) {
         auto di = Core::DirIterator(path, Core::DirIterator::SkipParentAndBaseDir);
         if (di.has_error())
             return di.error();
@@ -358,9 +404,9 @@ ErrorOr<void> remove(StringView path, RecursionMode mode)
         while (di.has_next())
             TRY(remove(di.next_full_path(), RecursionMode::Allowed));
 
-        TRY(Core::System::rmdir(path));
+        TRY(remove_directory(path));
     } else {
-        TRY(Core::System::unlink(path));
+        TRY(remove_file(path));
     }
 
     return {};
@@ -368,13 +414,13 @@ ErrorOr<void> remove(StringView path, RecursionMode mode)
 
 ErrorOr<off_t> size_from_stat(StringView path)
 {
-    auto st = TRY(Core::System::stat(path));
+    auto st = TRY(stat_path(path));
     return st.st_size;
 }
 
 ErrorOr<off_t> size_from_fstat(int fd)
 {
-    auto st = TRY(Core::System::fstat(fd));
+    auto st = TRY(stat_fd(fd));
     return st.st_size;
 }
 

--- a/Libraries/LibHTTP/Cache/CacheEntry.cpp
+++ b/Libraries/LibHTTP/Cache/CacheEntry.cpp
@@ -231,7 +231,7 @@ ErrorOr<void> CacheEntryWriter::flush_impl(NonnullRefPtr<HeaderList> request_hea
 
     TRY(m_file->flush_buffer());
     m_file.clear();
-    TRY(Core::System::rename(m_temporary_path->string(), m_path->string()));
+    TRY(FileSystem::move_file(m_path->string(), m_temporary_path->string()));
     remove_temporary_file.disarm();
 
     int body_fd = -1;

--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -279,7 +279,7 @@ ErrorOr<bool> DiskCache::store_associated_data(URL::URL const& url, StringView m
         TRY(file->write_until_depleted(data));
     }
 
-    TRY(Core::System::rename(temporary_path.string(), path.string()));
+    TRY(FileSystem::move_file(path.string(), temporary_path.string()));
     remove_temporary_file.disarm();
     m_index.update_associated_data_size(cache_key, *vary_key, TRY(compute_associated_data_size(m_cache_directory, cache_key, *vary_key)));
     remove_entries_exceeding_cache_limit();

--- a/Libraries/LibWasm/CMakeLists.txt
+++ b/Libraries/LibWasm/CMakeLists.txt
@@ -39,7 +39,7 @@ else()
 endif()
 
 ladybird_lib(LibWasm wasm EXPLICIT_SYMBOL_EXPORT)
-target_link_libraries(LibWasm PRIVATE LibCore PUBLIC LibSync LibGC)
+target_link_libraries(LibWasm PRIVATE LibCore LibFileSystem PUBLIC LibSync LibGC)
 
 target_compile_definitions(LibWasm PRIVATE
     WASM_COMPILED_FAULT_RECOVERY_SUPPORTED=${WASM_COMPILED_FAULT_RECOVERY_SUPPORTED}

--- a/Libraries/LibWasm/CraneliftBridge.cpp
+++ b/Libraries/LibWasm/CraneliftBridge.cpp
@@ -13,6 +13,7 @@
 #include <CraneliftFFI.h>
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibWasm/AbstractMachine/BytecodeInterpreter.h>
 #include <LibWasm/AbstractMachine/Configuration.h>
 #include <LibWasm/Printer/Printer.h>
@@ -1121,7 +1122,7 @@ static StringView resolve_cranelift_compiler_path()
     // Lookup order: LADYBIRD_CRANELIFT_COMPILER, compile-time path, sibling-of-self.
     static NeverDestroyed<ByteString> s_path = []() -> ByteString {
         auto file_exists = [](ByteString const& path) {
-            return !Core::System::stat(path).is_error();
+            return FileSystem::exists(path);
         };
 
         if (auto const* env = getenv("LADYBIRD_CRANELIFT_COMPILER"); env && *env) {

--- a/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -39,11 +39,13 @@ ErrorOr<String> load_file_directory_page(URL::URL const& url)
         names.append(dt.next_path());
     quick_sort(names);
 
+    auto directory = TRY(Core::Directory::create(lexical_path, Core::Directory::CreateDirectories::No));
+
     StringBuilder contents;
     contents.append("<table>"sv);
     for (auto& name : names) {
         auto path = lexical_path.append(name);
-        auto maybe_st = Core::System::stat(path.string());
+        auto maybe_st = directory.stat(name);
         if (!maybe_st.is_error()) {
             auto st = maybe_st.release_value();
             auto is_directory = S_ISDIR(st.st_mode);

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -271,12 +271,6 @@ void ResourceLoader::handle_file_load_request(LoadRequest& request, FileHandler 
             return;
         }
 
-        auto st_or_error = Core::System::fstat(fd);
-        if (st_or_error.is_error()) {
-            on_error(ByteString::formatted("{}", st_or_error.error()));
-            return;
-        }
-
         auto maybe_file = Core::File::adopt_fd(fd, Core::File::OpenMode::Read);
         if (maybe_file.is_error()) {
             on_error(ByteString::formatted("{}", maybe_file.error()));
@@ -284,6 +278,12 @@ void ResourceLoader::handle_file_load_request(LoadRequest& request, FileHandler 
         }
 
         auto file = maybe_file.release_value();
+
+        auto st_or_error = file->stat();
+        if (st_or_error.is_error()) {
+            on_error(ByteString::formatted("{}", st_or_error.error()));
+            return;
+        }
         auto maybe_data = file->read_until_eof();
         if (maybe_data.is_error()) {
             on_error(ByteString::formatted("{}", maybe_data.error()));

--- a/Libraries/LibWebView/BrowserProcess.cpp
+++ b/Libraries/LibWebView/BrowserProcess.cpp
@@ -158,9 +158,8 @@ BrowserProcess::~BrowserProcess()
     if (m_pid_file) {
         MUST(m_pid_file->truncate(0));
 #if defined(AK_OS_WINDOWS)
-        // NOTE: On Windows, System::open() duplicates the underlying OS file handle,
-        // so we need to explicitly close said handle, otherwise the unlink() call fails due
-        // to permission errors and we crash on shutdown.
+        // NOTE: On Windows, be conservative and close the pid file's handle before
+        // removing the file; removal of an open file requires cooperative sharing modes.
         m_pid_file->close();
 #endif
         MUST(FileSystem::remove(m_pid_path, FileSystem::RecursionMode::Disallowed));

--- a/Libraries/LibWebView/BrowserProcess.cpp
+++ b/Libraries/LibWebView/BrowserProcess.cpp
@@ -9,6 +9,7 @@
 #include <LibCore/Process.h>
 #include <LibCore/Socket.h>
 #include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibIPC/Transport.h>
 #if defined(AK_OS_MACOS)
@@ -162,11 +163,11 @@ BrowserProcess::~BrowserProcess()
         // to permission errors and we crash on shutdown.
         m_pid_file->close();
 #endif
-        MUST(Core::System::unlink(m_pid_path));
+        MUST(FileSystem::remove(m_pid_path, FileSystem::RecursionMode::Disallowed));
     }
 
     if (!m_socket_path.is_empty())
-        MUST(Core::System::unlink(m_socket_path));
+        MUST(FileSystem::remove(m_socket_path, FileSystem::RecursionMode::Disallowed));
 }
 
 UIProcessClient::UIProcessClient(NonnullOwnPtr<IPC::Transport> transport)

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -8,7 +8,7 @@
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
-#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
@@ -228,7 +228,7 @@ void FileDownloader::finish_download(u64 id)
 
     active->file = nullptr;
 
-    if (auto result = Core::System::rename(active->temporary_destination.string(), download->destination.string()); result.is_error()) {
+    if (auto result = FileSystem::move_file(download->destination.string(), active->temporary_destination.string()); result.is_error()) {
         fail_download(id, MUST(String::formatted("Unable to save downloaded file: {}", result.error())));
         return;
     }
@@ -287,7 +287,7 @@ void FileDownloader::discard_active_download(u64 id)
         active->on_cancel();
 
     active->file = nullptr;
-    (void)Core::System::unlink(active->temporary_destination.string());
+    (void)FileSystem::remove(active->temporary_destination.string(), FileSystem::RecursionMode::Disallowed);
 
     Core::deferred_invoke([this, id] {
         m_active_downloads.remove(id);

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/Socket.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibWebView/Process.h>
 
 #include <fcntl.h>
@@ -113,7 +114,7 @@ ErrorOr<Process::ProcessAndIPCTransport> Process::spawn_and_connect_to_process(C
 
 ErrorOr<Optional<pid_t>> Process::get_process_pid(StringView process_name, StringView pid_path)
 {
-    if (Core::System::stat(pid_path).is_error())
+    if (!FileSystem::exists(pid_path))
         return OptionalNone {};
 
     Optional<pid_t> pid;
@@ -135,7 +136,7 @@ ErrorOr<Optional<pid_t>> Process::get_process_pid(StringView process_name, Strin
 
     if (!pid.has_value()) {
         warnln("{} PID file '{}' exists, but with an invalid PID", process_name, pid_path);
-        TRY(Core::System::unlink(pid_path));
+        TRY(FileSystem::remove(pid_path, FileSystem::RecursionMode::Disallowed));
         return OptionalNone {};
     }
 
@@ -160,7 +161,7 @@ ErrorOr<Optional<pid_t>> Process::get_process_pid(StringView process_name, Strin
 
     if (process_not_found) {
         warnln("{} PID file '{}' exists with PID {}, but process cannot be found", process_name, pid_path, *pid);
-        TRY(Core::System::unlink(pid_path));
+        TRY(FileSystem::remove(pid_path, FileSystem::RecursionMode::Disallowed));
         return OptionalNone {};
     }
 
@@ -170,8 +171,8 @@ ErrorOr<Optional<pid_t>> Process::get_process_pid(StringView process_name, Strin
 // This is heavily based on how SystemServer's Service creates its socket.
 ErrorOr<int> Process::create_ipc_socket(ByteString const& socket_path)
 {
-    if (!Core::System::stat(socket_path).is_error())
-        TRY(Core::System::unlink(socket_path));
+    if (FileSystem::exists(socket_path))
+        TRY(FileSystem::remove(socket_path, FileSystem::RecursionMode::Disallowed));
 
 #if defined(AK_OS_WINDOWS)
     auto socket_fd = TRY(Core::System::socket(AF_LOCAL, SOCK_STREAM, 0));

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -175,8 +175,7 @@ ErrorOr<int> Process::create_ipc_socket(ByteString const& socket_path)
 
 #if defined(AK_OS_WINDOWS)
     auto socket_fd = TRY(Core::System::socket(AF_LOCAL, SOCK_STREAM, 0));
-    int option = 1;
-    TRY(Core::System::ioctl(socket_fd, FIONBIO, &option));
+    TRY(Core::System::set_socket_blocking(socket_fd, false));
     if (SetHandleInformation(to_handle(socket_fd), HANDLE_FLAG_INHERIT, 0) == 0)
         return Error::from_windows_error();
 #else

--- a/Libraries/LibWebView/ProcessManager.cpp
+++ b/Libraries/LibWebView/ProcessManager.cpp
@@ -6,9 +6,8 @@
 
 #include <AK/String.h>
 #include <LibCore/EventLoop.h>
-#include <LibCore/System.h>
+#include <LibCore/Process.h>
 #include <LibWebView/ProcessManager.h>
-#include <signal.h>
 
 namespace WebView {
 
@@ -148,13 +147,8 @@ void ProcessManager::force_exit_after_timeout(pid_t pid, int timeout_ms)
         if (!process.has_value())
             return;
 
-#if defined(AK_OS_WINDOWS)
-        constexpr auto signal = SIGTERM;
-#else
-        constexpr auto signal = SIGKILL;
-#endif
         dbgln("Force-killing unresponsive {} process {}", process_name_from_type(process->type()), pid);
-        auto result = Core::System::kill(pid, signal);
+        auto result = Core::Process::terminate_process(pid, Core::Process::TerminationMode::Forceful);
         if (result.is_error())
             dbgln("Failed to force-kill process {}: {}", pid, result.error());
     });

--- a/Services/RequestServer/RequestPipe.cpp
+++ b/Services/RequestServer/RequestPipe.cpp
@@ -47,9 +47,8 @@ ErrorOr<RequestPipe> RequestPipe::create()
 {
     int socket_fds[2] {};
     TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds));
-    int option = 1;
-    TRY(Core::System::ioctl(socket_fds[0], FIONBIO, &option));
-    TRY(Core::System::ioctl(socket_fds[1], FIONBIO, &option));
+    TRY(Core::System::set_socket_blocking(socket_fds[0], false));
+    TRY(Core::System::set_socket_blocking(socket_fds[1], false));
 
     // Increase socket buffer sizes from OS default (~8KB on macOS) to allow
     // larger writes/reads per syscall, significantly improving throughput for

--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -22,6 +22,7 @@
 #endif
 #include <LibCore/System.h>
 #include <LibCore/Timer.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibIPC/Transport.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/WebDriver/Proxy.h>
@@ -229,7 +230,7 @@ void Session::close()
     m_web_content_mach_port_server = nullptr;
 #else
     if (!m_web_content_endpoint.is_empty())
-        MUST(Core::System::unlink(m_web_content_endpoint));
+        MUST(FileSystem::remove(m_web_content_endpoint, FileSystem::RecursionMode::Disallowed));
 #endif
     m_web_content_endpoint = {};
 
@@ -427,7 +428,7 @@ ErrorOr<void> Session::create_server(NonnullRefPtr<ServerPromise> promise)
 
     return {};
 #else
-    (void)Core::System::unlink(m_web_content_endpoint);
+    (void)FileSystem::remove(m_web_content_endpoint, FileSystem::RecursionMode::Disallowed);
 
     auto server = Core::LocalServer::construct();
     server->listen(m_web_content_endpoint);

--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -20,6 +20,7 @@
 #    include <LibIPC/TransportBootstrapMach.h>
 #    include <LibWebView/Utilities.h>
 #endif
+#include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibCore/Timer.h>
 #include <LibFileSystem/FileSystem.h>
@@ -224,7 +225,7 @@ void Session::close()
     m_pending_connections.clear();
 
     if (m_browser_process.has_value())
-        MUST(Core::System::kill(m_browser_process->pid(), SIGTERM));
+        MUST(Core::Process::terminate_process(m_browser_process->pid(), Core::Process::TerminationMode::Graceful));
 
 #if defined(AK_OS_MACOS)
     m_web_content_mach_port_server = nullptr;

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     TestLibCoreAnonymousBuffer.cpp
     TestLibCoreArgsParser.cpp
     TestLibCoreDeferredInvoke.cpp
+    TestLibCoreDirectory.cpp
     TestLibCoreEventLoop.cpp
     TestLibCoreMappedFile.cpp
     TestLibCoreMimeType.cpp
@@ -20,6 +21,7 @@ foreach(source IN LISTS TEST_SOURCES)
     ladybird_test("${source}" LibCore)
 endforeach()
 
+target_link_libraries(TestLibCoreDirectory PRIVATE LibFileSystem)
 target_link_libraries(TestLibCorePromise PRIVATE LibSync LibThreading)
 target_link_libraries(TestLibCoreStream PRIVATE LibSync LibThreading)
 

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -23,7 +23,7 @@ endforeach()
 
 target_link_libraries(TestLibCoreDirectory PRIVATE LibFileSystem)
 target_link_libraries(TestLibCorePromise PRIVATE LibSync LibThreading)
-target_link_libraries(TestLibCoreStream PRIVATE LibSync LibThreading)
+target_link_libraries(TestLibCoreStream PRIVATE LibFileSystem LibSync LibThreading)
 
 if(NOT WIN32)
     # These tests use the .txt files in the current directory

--- a/Tests/LibCore/TestLibCoreDirectory.cpp
+++ b/Tests/LibCore/TestLibCoreDirectory.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteString.h>
+#include <AK/LexicalPath.h>
+#include <LibCore/Directory.h>
+#include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibTest/TestCase.h>
+
+static ErrorOr<Core::Directory> create_temp_directory()
+{
+    auto path = LexicalPath::join(Core::StandardPaths::tempfile_directory(), ByteString::formatted("test-libcore-directory-{}", Core::System::getpid()));
+    return Core::Directory::create(path, Core::Directory::CreateDirectories::Yes);
+}
+
+TEST_CASE(directory_open_and_stat)
+{
+    constexpr auto text = "Hello from Core::Directory!"sv;
+    ByteString directory_path;
+
+    {
+        auto directory = TRY_OR_FAIL(create_temp_directory());
+        directory_path = directory.path().string();
+
+        {
+            auto file = TRY_OR_FAIL(directory.open("test-file.txt"sv, Core::File::OpenMode::Write));
+            TRY_OR_FAIL(file->write_until_depleted(text.bytes()));
+        }
+
+        {
+            auto file = TRY_OR_FAIL(directory.open("test-file.txt"sv, Core::File::OpenMode::Read));
+            auto contents = TRY_OR_FAIL(file->read_until_eof());
+            EXPECT_EQ(StringView { contents.bytes() }, text);
+        }
+
+        auto file_stat = TRY_OR_FAIL(directory.stat("test-file.txt"sv));
+        EXPECT(S_ISREG(file_stat.st_mode));
+        EXPECT_EQ(static_cast<size_t>(file_stat.st_size), text.length());
+
+        auto directory_stat = TRY_OR_FAIL(directory.stat());
+        EXPECT(S_ISDIR(directory_stat.st_mode));
+
+        EXPECT(directory.stat("nonexistent-file.txt"sv).is_error());
+        EXPECT(directory.open("nonexistent-file.txt"sv, Core::File::OpenMode::Read).is_error());
+    }
+
+    TRY_OR_FAIL(FileSystem::remove(directory_path, FileSystem::RecursionMode::Allowed));
+}

--- a/Tests/LibCore/TestLibCoreMappedFile.cpp
+++ b/Tests/LibCore/TestLibCoreMappedFile.cpp
@@ -12,9 +12,7 @@
 #include <LibCore/ImmutableBytes.h>
 #include <LibCore/MappedFile.h>
 #include <LibCore/StandardPaths.h>
-#include <LibCore/System.h>
 #include <LibTest/TestCase.h>
-#include <fcntl.h>
 
 TEST_CASE(mapped_file_open)
 {
@@ -110,8 +108,7 @@ BENCHMARK_CASE(file_tell)
 
 TEST_CASE(mapped_file_adopt_fd)
 {
-    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
-    EXPECT(rc >= 0);
+    int rc = TRY_OR_FAIL(Core::File::open("./long_lines.txt"sv, Core::File::OpenMode::Read))->leak_fd();
 
     auto file = TRY_OR_FAIL(Core::MappedFile::map_from_fd_and_close(rc, "./long_lines.txt"sv));
 
@@ -131,8 +128,7 @@ TEST_CASE(mapped_file_adopt_fd)
 
 TEST_CASE(mapped_file_adopt_fd_range)
 {
-    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
-    EXPECT(rc >= 0);
+    int rc = TRY_OR_FAIL(Core::File::open("./long_lines.txt"sv, Core::File::OpenMode::Read))->leak_fd();
 
     auto file = TRY_OR_FAIL(Core::MappedFile::map_from_fd_range_and_close(rc, "./long_lines.txt"sv, 500, 16));
 
@@ -147,8 +143,7 @@ TEST_CASE(mapped_file_adopt_fd_range)
 
 TEST_CASE(mapped_file_adopt_empty_fd_range)
 {
-    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
-    EXPECT(rc >= 0);
+    int rc = TRY_OR_FAIL(Core::File::open("./long_lines.txt"sv, Core::File::OpenMode::Read))->leak_fd();
 
     auto file = TRY_OR_FAIL(Core::MappedFile::map_from_fd_range_and_close(rc, "./long_lines.txt"sv, 500, 0));
 
@@ -159,8 +154,7 @@ TEST_CASE(mapped_file_adopt_empty_fd_range)
 
 TEST_CASE(mapped_file_adopt_invalid_fd_range)
 {
-    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
-    EXPECT(rc >= 0);
+    int rc = TRY_OR_FAIL(Core::File::open("./long_lines.txt"sv, Core::File::OpenMode::Read))->leak_fd();
 
     auto maybe_file = Core::MappedFile::map_from_fd_range_and_close(rc, "./long_lines.txt"sv, 8700, 16);
     EXPECT(maybe_file.is_error());
@@ -169,8 +163,7 @@ TEST_CASE(mapped_file_adopt_invalid_fd_range)
 
 TEST_CASE(immutable_bytes_from_mapped_file_range)
 {
-    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
-    EXPECT(rc >= 0);
+    int rc = TRY_OR_FAIL(Core::File::open("./long_lines.txt"sv, Core::File::OpenMode::Read))->leak_fd();
 
     auto bytes = TRY_OR_FAIL(Core::ImmutableBytes::map_from_fd_range_and_close(rc, "./long_lines.txt"sv, 500, 16));
 

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -19,7 +19,6 @@
 #include <LibFileSystem/FileSystem.h>
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
-#include <fcntl.h>
 
 #include <AK/Windows.h>
 
@@ -135,8 +134,7 @@ TEST_CASE(file_buffered_write_and_seek)
 
 TEST_CASE(file_adopt_fd)
 {
-    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
-    EXPECT(rc >= 0);
+    int rc = TRY_OR_FAIL(Core::File::open("./long_lines.txt"sv, Core::File::OpenMode::Read))->leak_fd();
 
     auto file = TRY_OR_FAIL(Core::File::adopt_fd(rc, Core::File::OpenMode::Read));
 

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -16,6 +16,7 @@
 #include <LibCore/TCPServer.h>
 #include <LibCore/Timer.h>
 #include <LibCore/UDPServer.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
 #include <fcntl.h>
@@ -343,8 +344,8 @@ TEST_CASE(local_socket_read)
     Core::EventLoop event_loop;
 
     auto socket_path = ByteString::formatted("{}/{}", Core::StandardPaths::tempfile_directory(), "test-socket"sv);
-    if (!Core::System::stat(socket_path).is_error())
-        TRY_OR_FAIL(Core::System::unlink(socket_path));
+    if (FileSystem::exists(socket_path))
+        TRY_OR_FAIL(FileSystem::remove(socket_path, FileSystem::RecursionMode::Disallowed));
 
     auto local_server = Core::LocalServer::construct();
     EXPECT(local_server->listen(socket_path));
@@ -395,8 +396,8 @@ TEST_CASE(local_socket_write)
     Core::EventLoop event_loop;
 
     auto socket_path = ByteString::formatted("{}/{}", Core::StandardPaths::tempfile_directory(), "test-socket"sv);
-    if (!Core::System::stat(socket_path).is_error())
-        TRY_OR_FAIL(Core::System::unlink(socket_path));
+    if (FileSystem::exists(socket_path))
+        TRY_OR_FAIL(FileSystem::remove(socket_path, FileSystem::RecursionMode::Disallowed));
 
     auto local_server = Core::LocalServer::construct();
     EXPECT(local_server->listen(socket_path));

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,6 +1,6 @@
 ladybird_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
 ladybird_test(test-primitive-string.cpp LibJS LIBS LibJS LibGC)
-ladybird_test(test-bytecode-cache.cpp LibJS LIBS LibCrypto LibGC LibJS)
+ladybird_test(test-bytecode-cache.cpp LibJS LIBS LibCrypto LibFileSystem LibGC LibJS)
 
 ladybird_testjs_test(test-js.cpp test-js LIBS LibGC)
 set_tests_properties(test-js PROPERTIES ENVIRONMENT "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}")

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibCrypto/Hash/SHA2.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -940,7 +941,7 @@ TEST_CASE(bytecode_cache_materializes_from_mapped_blob)
     auto test_data = create_bytecode_cache_blob("let f = function mapped() { return 'hello'; }; f();"_string);
     auto path = ByteString::formatted("{}/bytecode-cache-test-{}.blob", Core::StandardPaths::tempfile_directory(), Core::System::getpid());
     ScopeGuard remove_file = [&] {
-        (void)Core::System::unlink(path);
+        (void)FileSystem::remove(path, FileSystem::RecursionMode::Disallowed);
     };
 
     {

--- a/Tests/LibWeb/test-web/CaptureFile.cpp
+++ b/Tests/LibWeb/test-web/CaptureFile.cpp
@@ -13,7 +13,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
 #include <LibCore/Directory.h>
-#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibGfx/Color.h>
 
 namespace TestWeb {
@@ -40,9 +40,9 @@ ErrorOr<bool> CaptureFile::transfer_to_output_file()
     if (m_writer_path.is_empty())
         return false;
 
-    (void)Core::System::unlink(m_destination_path);
+    (void)FileSystem::remove(m_destination_path, FileSystem::RecursionMode::Disallowed);
     ScopeGuard cleanup = [&] {
-        (void)Core::System::unlink(m_writer_path);
+        (void)FileSystem::remove(m_writer_path, FileSystem::RecursionMode::Disallowed);
         m_writer_path = {};
         m_destination_path = {};
     };

--- a/Tests/LibWeb/test-web/Debug.cpp
+++ b/Tests/LibWeb/test-web/Debug.cpp
@@ -79,7 +79,8 @@ void maybe_attach_on_fail_fast_timeout(pid_t pid)
     outln("- Press Enter to continue shutdown + exit"sv);
     outln("- Type 'gdb' then Enter to attach with gdb first"sv);
     outln("- Type 'lldb' then Enter to attach with lldb first"sv);
-    MUST(Core::System::write(1, "> "sv.bytes()));
+    out("> "sv);
+    (void)fflush(stdout);
 
     auto standard_input_or_error = Core::File::standard_input();
     if (standard_input_or_error.is_error())

--- a/Tests/LibWeb/test-web/TestRunCapture.cpp
+++ b/Tests/LibWeb/test-web/TestRunCapture.cpp
@@ -20,8 +20,17 @@ namespace TestWeb {
 
 static ByteString format_elapsed_time(UnixDateTime run_start_time);
 static ByteString format_exit_status(Optional<int> exit_status);
-static void setup_capture_notifier(RefPtr<Core::Notifier>& notifier, int fd, bool drain_available, Function<void(StringView)> on_output);
-static bool drain_capture_output(int fd, bool drain_available, Function<void(StringView)> const& on_output);
+static void setup_capture_notifier(RefPtr<Core::Notifier>& notifier, Core::File& file, bool drain_available, Function<void(StringView)> on_output);
+static bool drain_capture_output(Core::File& file, bool drain_available, Function<void(StringView)> const& on_output);
+
+// Best-effort tee of a captured message to a raw fd (an original stdout/stderr).
+static void write_to_fd(int fd, StringView message)
+{
+    auto file_or_error = Core::File::adopt_fd(fd, Core::File::OpenMode::Write, Core::File::ShouldCloseFileDescriptor::No);
+    if (file_or_error.is_error())
+        return;
+    (void)file_or_error.value()->write_until_depleted(message.bytes());
+}
 
 TestRunCapture::TestRunCapture()
     : m_run_started_at(UnixDateTime::now())
@@ -35,6 +44,7 @@ TestRunCapture::TestRunCapture()
     };
     m_previous_on_process_exited = move(process_manager.on_process_exited);
     process_manager.on_process_exited = [this](WebView::Process&& process, Optional<int> exit_status) {
+        close_view_capture_notifiers(process.pid());
         consume_helper_capture(process.pid());
         log_helper_message(
             { process.type(), process.pid() },
@@ -68,7 +78,7 @@ TestRunCapture::TestRunCapture()
     m_stderr_capture.original_fd = dup_stderr_fd;
     m_stderr_capture.reader = MUST(Core::File::adopt_fd(read_fd, Core::File::OpenMode::Read));
     int browser_pid = Core::System::getpid();
-    setup_capture_notifier(m_stderr_capture.notifier, m_stderr_capture.reader->fd(), true, [this, browser_pid](StringView message) {
+    setup_capture_notifier(m_stderr_capture.notifier, *m_stderr_capture.reader, true, [this, browser_pid](StringView message) {
         log_helper_message({ WebView::ProcessType::Browser, browser_pid }, m_stderr_capture.original_fd.value_or(STDERR_FILENO), message);
     });
 #endif
@@ -92,7 +102,7 @@ TestRunCapture::ViewOutputCapture* TestRunCapture::output_capture_for_view(TestW
 void TestRunCapture::log_helper_message(HelperOutputSource source, int tee_fd, StringView message)
 {
     if (Application::the().verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT)
-        (void)Core::System::write(tee_fd, message.bytes());
+        write_to_fd(tee_fd, message);
 
     bool const should_append_header = !m_last_helper_source.has_value()
         || m_last_helper_source->type != source.type
@@ -139,18 +149,20 @@ void TestRunCapture::setup_output_capture_for_view(TestWebView& view, ViewOutput
     if (!output_capture.stdout_file && !output_capture.stderr_file)
         return;
 
+    view_capture.web_content_pid = process->pid();
+
     if (output_capture.stdout_file) {
-        setup_capture_notifier(view_capture.stdout_notifier, output_capture.stdout_file->fd(), false, [&view_capture](StringView message) {
+        setup_capture_notifier(view_capture.stdout_notifier, *output_capture.stdout_file, false, [&view_capture](StringView message) {
             if (Application::the().verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT)
-                (void)Core::System::write(STDOUT_FILENO, message.bytes());
+                write_to_fd(STDOUT_FILENO, message);
             view_capture.output.write(message);
         });
     }
 
     if (output_capture.stderr_file) {
-        setup_capture_notifier(view_capture.stderr_notifier, output_capture.stderr_file->fd(), false, [this, &view_capture](StringView message) {
+        setup_capture_notifier(view_capture.stderr_notifier, *output_capture.stderr_file, false, [this, &view_capture](StringView message) {
             if (Application::the().verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT)
-                (void)Core::System::write(m_stderr_capture.original_fd.value_or(STDERR_FILENO), message.bytes());
+                write_to_fd(m_stderr_capture.original_fd.value_or(STDERR_FILENO), message);
             view_capture.output.write(message);
         });
     }
@@ -206,7 +218,7 @@ void TestRunCapture::restore_stderr()
 
     (void)fflush(stderr);
     int browser_pid = Core::System::getpid();
-    (void)drain_capture_output(m_stderr_capture.reader->fd(), true, [this, browser_pid](StringView message) {
+    (void)drain_capture_output(*m_stderr_capture.reader, true, [this, browser_pid](StringView message) {
         log_helper_message({ WebView::ProcessType::Browser, browser_pid }, m_stderr_capture.original_fd.value_or(STDERR_FILENO), message);
     });
     auto original_stderr_fd = m_stderr_capture.original_fd.release_value();
@@ -242,13 +254,13 @@ void TestRunCapture::setup_output_capture_for_helper_process(WebView::Process& p
 
     if (output_capture.stdout_file) {
         helper_capture->stdout_reader = move(output_capture.stdout_file);
-        setup_capture_notifier(helper_capture->stdout_notifier, helper_capture->stdout_reader->fd(), false, [this, capture = helper_capture_ptr](StringView message) {
+        setup_capture_notifier(helper_capture->stdout_notifier, *helper_capture->stdout_reader, false, [this, capture = helper_capture_ptr](StringView message) {
             log_helper_message({ capture->type, capture->pid }, STDOUT_FILENO, message);
         });
     }
     if (output_capture.stderr_file) {
         helper_capture->stderr_reader = move(output_capture.stderr_file);
-        setup_capture_notifier(helper_capture->stderr_notifier, helper_capture->stderr_reader->fd(), false, [this, capture = helper_capture_ptr](StringView message) {
+        setup_capture_notifier(helper_capture->stderr_notifier, *helper_capture->stderr_reader, false, [this, capture = helper_capture_ptr](StringView message) {
             log_helper_message(
                 { capture->type, capture->pid },
                 m_stderr_capture.original_fd.value_or(STDERR_FILENO),
@@ -270,34 +282,34 @@ static ByteString format_elapsed_time(UnixDateTime run_start_time)
     return ByteString::formatted("{}.{:02}s", seconds, centiseconds);
 }
 
-static void setup_capture_notifier(RefPtr<Core::Notifier>& notifier, int fd, bool drain_available, Function<void(StringView)> on_output)
+static void setup_capture_notifier(RefPtr<Core::Notifier>& notifier, Core::File& file, bool drain_available, Function<void(StringView)> on_output)
 {
-    notifier = Core::Notifier::construct(fd, Core::Notifier::Type::Read);
+    notifier = Core::Notifier::construct(file.fd(), Core::Notifier::Type::Read);
     auto* notifier_slot = &notifier;
-    notifier->on_activation = [fd, drain_available, on_output = move(on_output), notifier_slot]() mutable {
-        bool const reached_eof = drain_capture_output(fd, drain_available, on_output);
+    notifier->on_activation = [&file, drain_available, on_output = move(on_output), notifier_slot]() mutable {
+        bool const reached_eof = drain_capture_output(file, drain_available, on_output);
         if (reached_eof && *notifier_slot)
             (*notifier_slot)->set_enabled(false);
     };
 }
 
-static bool drain_capture_output(int fd, bool drain_available, Function<void(StringView)> const& on_output)
+static bool drain_capture_output(Core::File& file, bool drain_available, Function<void(StringView)> const& on_output)
 {
     for (;;) {
         char buffer[4096];
-        auto nread = Core::System::read(fd, Bytes { buffer, sizeof(buffer) });
+        auto nread = file.read_some(Bytes { buffer, sizeof(buffer) });
         if (nread.is_error())
             return false;
 
-        if (nread.value() > 0) {
-            on_output(StringView { buffer, nread.value() });
+        if (!nread.value().is_empty()) {
+            on_output(StringView { nread.value() });
             if (!drain_available)
                 return false;
 
             continue;
         }
 
-        return nread.value() == 0;
+        return true;
     }
 }
 
@@ -313,17 +325,36 @@ void TestRunCapture::consume_helper_capture(pid_t pid)
     helper_capture->stderr_notifier->set_enabled(false);
 
     if (helper_capture->stdout_reader) {
-        (void)drain_capture_output(helper_capture->stdout_reader->fd(), true, [this, type = helper_capture->type, pid = helper_capture->pid](StringView message) {
+        (void)drain_capture_output(*helper_capture->stdout_reader, true, [this, type = helper_capture->type, pid = helper_capture->pid](StringView message) {
             log_helper_message({ type, pid }, STDOUT_FILENO, message);
         });
     }
     if (helper_capture->stderr_reader) {
-        (void)drain_capture_output(helper_capture->stderr_reader->fd(), true, [this, type = helper_capture->type, pid = helper_capture->pid](StringView message) {
+        (void)drain_capture_output(*helper_capture->stderr_reader, true, [this, type = helper_capture->type, pid = helper_capture->pid](StringView message) {
             log_helper_message({ type, pid }, m_stderr_capture.original_fd.value_or(STDERR_FILENO), message);
         });
     }
     helper_capture->stdout_notifier->close();
     helper_capture->stderr_notifier->close();
+}
+
+void TestRunCapture::close_view_capture_notifiers(pid_t pid)
+{
+    // The view-capture notifier callbacks reference Core::File objects owned by the
+    // WebView::Process, which is destroyed when the process exits; the deferred
+    // WebContentClient::die() path that destroys the capture can race that, so stop
+    // the notifiers as soon as the process is gone.
+    for (auto& entry : m_test_output_captures) {
+        auto& view_capture = *entry.value;
+        if (view_capture.web_content_pid != pid)
+            continue;
+        if (view_capture.stdout_notifier)
+            view_capture.stdout_notifier->close();
+        if (view_capture.stderr_notifier)
+            view_capture.stderr_notifier->close();
+        view_capture.stdout_notifier = nullptr;
+        view_capture.stderr_notifier = nullptr;
+    }
 }
 
 void TestRunCapture::destroy_view_capture_of(TestWebView const& view)

--- a/Tests/LibWeb/test-web/TestRunCapture.h
+++ b/Tests/LibWeb/test-web/TestRunCapture.h
@@ -40,6 +40,7 @@ public:
 private:
     struct ViewOutputCapture {
         CaptureFile output;
+        pid_t web_content_pid { -1 };
         RefPtr<Core::Notifier> stdout_notifier;
         RefPtr<Core::Notifier> stderr_notifier;
     };
@@ -70,6 +71,7 @@ private:
     void setup_output_capture_for_helper_process(WebView::Process&);
     void setup_output_capture_for_view(TestWebView&, ViewOutputCapture&);
     void consume_helper_capture(pid_t pid);
+    void close_view_capture_notifiers(pid_t pid);
     void destroy_view_capture_of(TestWebView const& view);
 
     Function<void(WebView::Process&&, Optional<int> exit_status)> m_previous_on_process_exited;


### PR DESCRIPTION
Core::System mirrors the POSIX syscall API, and on Windows every one of those
mirrors is an emulation in SystemWindows.cpp — a silent semantic approximation
wearing an exact-looking POSIX signature:

- open() routes through CRT _open, then re-dups the OS handle back out of the
  CRT fd — losing share-mode control and non-blocking semantics; mode_t
  permissions are fiction.
- ioctl() silently assumes its argument is a socket (ioctlsocket).
- kill() is an EnumWindows/WM_CLOSE walk that only understands SIGTERM.
- mmap()/munmap() exist only via the vcpkg mman shim.
- openat()/fstatat() are VERIFY_NOT_REACHED() stubs — Core::Directory::open()
  and Directory::stat(filename) crash on Windows today.
- Path emulations return raw GetLastError() values while the socket layer maps
  WSA codes into errno space, so error.code() == EWOULDBLOCK-style matching only
  works by accident of which backend produced the error.

This PR adopts the shape every mature cross-platform runtime converged on: the portable API is operations on owning objects with Ladybird-defined semantics; the POSIX syscall mirror becomes
POSIX-only. Ladybird already has the object layer — Core::File, Core::MappedFile,
Core::Directory, Core::Process, LibFileSystem — so this closes the gaps and flips the gate rather than inventing anything new.