### PR TITLE
LibWebView+UI/Qt: A couple of private window niceties

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -655,6 +655,12 @@ void Application::maybe_close_private_browsing_session()
     m_private_browsing_session = nullptr;
 }
 
+void Application::reset_private_browsing_session()
+{
+    m_file_downloader.cancel_private_downloads();
+    m_private_browsing_session = nullptr;
+}
+
 Web::Compositor::CompositorContextId Application::allocate_compositor_context_id()
 {
     VERIFY(m_next_page_or_compositor_context_id > 0);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -583,11 +583,6 @@ void Application::open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML:
         open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
 }
 
-void Application::open_url_in_new_window(URL::URL const& url)
-{
-    dbgln("open_url_in_new_window() is unsupported on this platform (url: {})", url);
-}
-
 ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id)
 {
     auto request_server_handle = TRY(connect_new_request_server_client(is_private));

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -104,6 +104,7 @@ public:
     u64 allocate_page_id();
 
     void maybe_close_private_browsing_session();
+    void reset_private_browsing_session();
 
     Web::Compositor::CompositorContextId allocate_compositor_context_id();
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -76,6 +76,7 @@ public:
 
     virtual bool supports_vertical_tabs() const { return false; }
     virtual bool supports_server_side_window_decorations() const { return false; }
+    virtual bool supports_private_browsing_windows() const { return false; }
     void tab_settings_changed(Badge<ApplicationSettingsObserver>);
 
     static BookmarkStore& bookmark_store() { return the().m_bookmark_store; }
@@ -119,13 +120,15 @@ public:
     void notify_compositor_presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
 
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
-    virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }
     virtual bool activate_tab_with_url(URL::URL const&) const { return false; }
+
+    virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }
     virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const;
+    virtual void open_url_in_new_window(URL::URL const&, IsPrivate) { }
+
     void open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab) const;
 
     Main::Arguments const& command_line_arguments() const { return m_arguments; }
-    virtual void open_url_in_new_window(URL::URL const& url);
 
     void add_child_process(Process&&);
 

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -67,9 +67,9 @@ static String status_to_error_string(Optional<Requests::NetworkError> const& net
     return MUST(String::formatted("Received error response code {} while downloading file", *response_code));
 }
 
-u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination, IsPrivate is_private)
+u64 FileDownloader::download_file(IsPrivate is_private, URL::URL const& url, LexicalPath destination)
 {
-    auto download_id = start_download(url, move(destination));
+    auto download_id = start_download(is_private, url, move(destination));
     auto* active = active_download(download_id);
     if (!active)
         return download_id;
@@ -91,9 +91,9 @@ u64 FileDownloader::download_file(URL::URL const& url, LexicalPath destination, 
     return download_id;
 }
 
-u64 FileDownloader::adopt_download(URL::URL const& url, LexicalPath destination, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ReadonlyBytes initial_data)
+u64 FileDownloader::adopt_download(IsPrivate is_private, URL::URL const& url, LexicalPath destination, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ReadonlyBytes initial_data)
 {
-    auto download_id = start_download(url, move(destination), total_size);
+    auto download_id = start_download(is_private, url, move(destination), total_size);
     auto* active = active_download(download_id);
     if (!active)
         return download_id;
@@ -160,12 +160,13 @@ void FileDownloader::attach_request_to_download(u64 download_id, NonnullRefPtr<R
         });
 }
 
-u64 FileDownloader::start_download(URL::URL const& url, LexicalPath destination, Optional<u64> total_size)
+u64 FileDownloader::start_download(IsPrivate is_private, URL::URL const& url, LexicalPath destination, Optional<u64> total_size)
 {
     auto download_id = m_next_download_id++;
 
     m_downloads.append(Download {
         .id = download_id,
+        .is_private = is_private,
         .url = url,
         .destination = move(destination),
         .total_size = total_size,

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -315,6 +315,24 @@ void FileDownloader::cancel_active_downloads()
         cancel_download(id);
 }
 
+void FileDownloader::cancel_private_downloads()
+{
+    for (size_t i = m_downloads.size(); i > 0; --i) {
+        auto const& download = m_downloads[i - 1];
+
+        if (download.status != DownloadStatus::InProgress)
+            continue;
+        if (download.is_private == IsPrivate::No)
+            continue;
+
+        auto id = download.id;
+        cancel_download(id);
+
+        m_downloads.remove(i - 1);
+        notify_download_removed(id);
+    }
+}
+
 void FileDownloader::cancel_download(u64 id)
 {
     auto* download = mutable_download_or_null(id);

--- a/Libraries/LibWebView/FileDownloader.h
+++ b/Libraries/LibWebView/FileDownloader.h
@@ -63,6 +63,7 @@ public:
     void append_download_data(u64 id, ReadonlyBytes);
     void finish_download(u64 id);
     void cancel_active_downloads();
+    void cancel_private_downloads();
     void cancel_download(u64 id);
     void fail_download(u64 id, String);
     Vector<u64> prune_inactive_downloads();

--- a/Libraries/LibWebView/FileDownloader.h
+++ b/Libraries/LibWebView/FileDownloader.h
@@ -43,6 +43,7 @@ public:
         Optional<double> progress() const;
 
         u64 id { 0 };
+        IsPrivate is_private { IsPrivate::No };
         URL::URL url;
         LexicalPath destination;
         DownloadStatus status { DownloadStatus::InProgress };
@@ -54,9 +55,9 @@ public:
     FileDownloader();
     ~FileDownloader();
 
-    u64 download_file(URL::URL const&, LexicalPath, IsPrivate);
-    u64 adopt_download(URL::URL const&, LexicalPath, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ReadonlyBytes initial_data = {});
-    u64 start_download(URL::URL const&, LexicalPath, Optional<u64> total_size = {});
+    u64 download_file(IsPrivate, URL::URL const&, LexicalPath);
+    u64 adopt_download(IsPrivate, URL::URL const&, LexicalPath, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ReadonlyBytes initial_data = {});
+    u64 start_download(IsPrivate, URL::URL const&, LexicalPath, Optional<u64> total_size = {});
     bool has_active_downloads() const;
     void set_cancel_callback(u64 id, Function<void()>);
     void append_download_data(u64 id, ReadonlyBytes);

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -67,6 +67,7 @@ enum class ActionID {
 
     OpenInNewTab,
     OpenInNewWindow,
+    OpenInNewPrivateWindow,
     DownloadLinkedFile,
     DownloadLinkedFileAs,
     CopyURL,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2282,7 +2282,7 @@ void ViewImplementation::download_context_menu_url(PromptForPath prompt_for_path
     if (download_path.is_error())
         return;
 
-    Application::the().file_downloader().download_file(m_context_menu_url, download_path.release_value(), is_private());
+    Application::the().file_downloader().download_file(is_private(), m_context_menu_url, download_path.release_value());
 }
 
 void ViewImplementation::did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, URL::URL url, Optional<Gfx::ShareableBitmap> bitmap)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2108,9 +2108,16 @@ void ViewImplementation::initialize_context_menus()
     m_open_in_new_tab_action = Action::create("Open in New Tab"sv, ActionID::OpenInNewTab, [this]() {
         Application::the().open_url_in_new_tab(m_context_menu_url, Web::HTML::ActivateTab::No);
     });
-    m_open_in_new_window_action = Action::create("Open in New Window"sv, ActionID::OpenInNewWindow, [this]() {
-        Application::the().open_url_in_new_window(m_context_menu_url);
-    });
+    if (m_is_private == IsPrivate::No) {
+        m_open_in_new_window_action = Action::create("Open in New Window"sv, ActionID::OpenInNewWindow, [this]() {
+            Application::the().open_url_in_new_window(m_context_menu_url, IsPrivate::No);
+        });
+    }
+    if (application.supports_private_browsing_windows()) {
+        m_open_in_new_private_window_action = Action::create("Open in New Private Window"sv, ActionID::OpenInNewPrivateWindow, [this]() {
+            Application::the().open_url_in_new_window(m_context_menu_url, IsPrivate::Yes);
+        });
+    }
     m_download_linked_file_action = Action::create("Download Linked File"sv, ActionID::DownloadLinkedFile, [this]() {
         download_context_menu_url(PromptForPath::No);
     });
@@ -2195,7 +2202,10 @@ void ViewImplementation::initialize_context_menus()
 
     m_link_context_menu = Menu::create("Link Context Menu"sv);
     m_link_context_menu->add_action(*m_open_in_new_tab_action);
-    m_link_context_menu->add_action(*m_open_in_new_window_action);
+    if (m_open_in_new_window_action)
+        m_link_context_menu->add_action(*m_open_in_new_window_action);
+    if (m_open_in_new_private_window_action)
+        m_link_context_menu->add_action(*m_open_in_new_private_window_action);
     m_link_context_menu->add_separator();
     m_link_context_menu->add_action(*m_download_linked_file_action);
     m_link_context_menu->add_action(*m_download_linked_file_as_action);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -58,8 +58,9 @@ Optional<ViewImplementation&> ViewImplementation::find_view_by_id(u64 id)
     return {};
 }
 
-ViewImplementation::ViewImplementation()
-    : m_document_cookie_version_buffer(Core::create_shared_version_buffer())
+ViewImplementation::ViewImplementation(IsPrivate is_private)
+    : m_is_private(is_private)
+    , m_document_cookie_version_buffer(Core::create_shared_version_buffer())
     , m_view_id(s_view_count++)
 {
     all_views().set(m_view_id, this);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -507,6 +507,7 @@ protected:
 
     RefPtr<Action> m_open_in_new_tab_action;
     RefPtr<Action> m_open_in_new_window_action;
+    RefPtr<Action> m_open_in_new_private_window_action;
     RefPtr<Action> m_download_linked_file_action;
     RefPtr<Action> m_download_linked_file_as_action;
     RefPtr<Action> m_copy_url_action;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -393,7 +393,7 @@ protected:
     static constexpr auto ZOOM_MAX_LEVEL = 5.0;
     static constexpr auto ZOOM_STEP = 0.1;
 
-    ViewImplementation();
+    explicit ViewImplementation(IsPrivate = IsPrivate::No);
 
     u64 page_id() const;
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -621,7 +621,7 @@ Messages::WebContentClient::DidStartDownloadWithoutRequestResponse WebContentCli
         return { Optional<u64> {} };
 
     auto& file_downloader = Application::the().file_downloader();
-    auto download_id = file_downloader.start_download(url, destination.release_value(), total_size);
+    auto download_id = file_downloader.start_download(is_private(), url, destination.release_value(), total_size);
     if (!is_download_in_progress(file_downloader, download_id))
         return { Optional<u64> {} };
 
@@ -647,7 +647,7 @@ Messages::WebContentClient::DidStartDownloadResponse WebContentClient::did_start
         return { Optional<u64> {} };
 
     auto& file_downloader = Application::the().file_downloader();
-    auto download_id = file_downloader.adopt_download(url, destination.release_value(), total_size, request_server_client_id, request_server_request_id, initial_data.bytes());
+    auto download_id = file_downloader.adopt_download(is_private(), url, destination.release_value(), total_size, request_server_client_id, request_server_request_id, initial_data.bytes());
     if (!is_download_in_progress(file_downloader, download_id))
         return { Optional<u64> {} };
 

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -22,7 +22,7 @@ private:
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
-    virtual void open_url_in_new_window(URL::URL const& url) override;
+    virtual void open_url_in_new_window(URL::URL const&, WebView::IsPrivate) override;
 
     virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -61,7 +61,7 @@ Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML
     return [[tab web_view] view];
 }
 
-void Application::open_url_in_new_window(URL::URL const& url)
+void Application::open_url_in_new_window(URL::URL const& url, WebView::IsPrivate)
 {
     ApplicationDelegate* delegate = [NSApp delegate];
     (void)[delegate createNewTab:url fromTab:nil activateTab:Web::HTML::ActivateTab::Yes];

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -516,6 +516,13 @@ Optional<WebView::ViewImplementation&> Application::active_web_view() const
     return {};
 }
 
+bool Application::activate_tab_with_url(URL::URL const& url) const
+{
+    if (!m_active_window)
+        return false;
+    return m_active_window->activate_tab_with_url(url);
+}
+
 Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML::ActivateTab activate_tab) const
 {
     if (!m_active_window) {
@@ -539,17 +546,9 @@ void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTa
     active_window().new_tab_from_url(url, activate_tab);
 }
 
-bool Application::activate_tab_with_url(URL::URL const& url) const
+void Application::open_url_in_new_window(URL::URL const& url, WebView::IsPrivate is_private)
 {
-    if (!m_active_window)
-        return false;
-    return m_active_window->activate_tab_with_url(url);
-}
-
-void Application::open_url_in_new_window(URL::URL const& url)
-{
-    auto is_private = m_active_window ? m_active_window->is_private() : WebView::IsPrivate::No;
-    this->new_window({ url }, configuration_for_new_window(), BrowserWindow::IsPopupWindow::No, is_private);
+    new_window({ url }, configuration_for_new_window(), BrowserWindow::IsPopupWindow::No, is_private);
 }
 
 Optional<ByteString> Application::ask_user_for_download_path(ByteString const& file) const

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -394,6 +394,18 @@ void Application::open_new_window(WebView::IsPrivate is_private)
     new_window({ WebView::Application::settings().new_tab_page_url() }, configuration_for_new_window(), BrowserWindow::IsPopupWindow::No, is_private);
 }
 
+void Application::restart_private_browsing_session()
+{
+    WebView::Application::the().reset_private_browsing_session();
+
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (auto* window = as_if<BrowserWindow>(widget); window && window->is_private() == WebView::IsPrivate::Yes)
+            window->close();
+    }
+
+    open_new_window(WebView::IsPrivate::Yes);
+}
+
 void Application::focus_location_editor()
 {
     if (!m_active_window) {

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -39,6 +39,7 @@ public:
     WindowConfiguration configuration_for_new_window() const;
     void open_new_tab();
     void open_new_window(WebView::IsPrivate);
+    void restart_private_browsing_session();
     void focus_location_editor();
     void reopen_recently_closed_tab();
     void open_file();

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -63,10 +63,11 @@ private:
     virtual Core::EventLoop& create_platform_event_loop() override;
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
+    virtual bool activate_tab_with_url(URL::URL const&) const override;
+
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
     virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const override;
-    virtual bool activate_tab_with_url(URL::URL const&) const override;
-    virtual void open_url_in_new_window(URL::URL const& url) override;
+    virtual void open_url_in_new_window(URL::URL const&, WebView::IsPrivate) override;
 
     virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
@@ -83,6 +84,8 @@ private:
 
     virtual bool supports_vertical_tabs() const override { return true; }
     virtual bool supports_server_side_window_decorations() const override { return true; }
+    virtual bool supports_private_browsing_windows() const override { return true; }
+
     virtual Vector<WebView::BookmarkItem::Bookmark> bookmarks_for_all_tabs() const override;
     virtual void update_tabs_display() const override;
 

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -336,8 +336,12 @@ QString toolbar_container_style_sheet(QPalette const& palette)
     auto disabled_text = style_sheet_color(chrome_muted_text(palette));
     auto close_hover = style_sheet_color(chrome_destructive_hover());
     auto close_text = style_sheet_color(chrome_destructive_text());
-    auto badge_surface = style_sheet_color(dark ? QColor(0x19, 0x0c, 0x4a) : QColor(0xe0, 0xd4, 0xff));
-    auto badge_border = style_sheet_color(dark ? QColor(0x9c, 0x90, 0xc8) : QColor(0x6c, 0x5f, 0x93));
+    auto badge_surface_color = dark ? QColor(0x19, 0x0c, 0x4a) : QColor(0xe0, 0xd4, 0xff);
+    auto badge_border_color = dark ? QColor(0x9c, 0x90, 0xc8) : QColor(0x6c, 0x5f, 0x93);
+    auto badge_surface = style_sheet_color(badge_surface_color);
+    auto badge_border = style_sheet_color(badge_border_color);
+    auto badge_surface_hover = style_sheet_color(mix(badge_surface_color, badge_border_color, dark ? 0.28 : 0.22));
+    auto badge_surface_pressed = style_sheet_color(mix(badge_surface_color, badge_border_color, dark ? 0.45 : 0.38));
 
     return qformatted(R"(
 QWidget#LadybirdToolbarContainer {{
@@ -382,13 +386,21 @@ QWidget#LadybirdNavigationToolbar QToolButton::menu-indicator {{
     image: none;
 }}
 
-QLabel#LadybirdPrivateBadge {{
+QPushButton#LadybirdPrivateBadge {{
     color: {5};
     background: {10};
     border: 1px solid {11};
     border-radius: 10px;
-    padding: 0 8px;
+    padding: 0 10px;
     font-weight: 600;
+}}
+
+QPushButton#LadybirdPrivateBadge:hover {{
+    background: {12};
+}}
+
+QPushButton#LadybirdPrivateBadge:pressed {{
+    background: {13};
 }}
 
 QWidget#LadybirdToolbarWindowControlsSeparator {{
@@ -433,7 +445,7 @@ QWidget#LadybirdNavigationToolbar QToolButton#LadybirdCloseWindowButton[pressedO
     background: transparent;
 }}
 )",
-        background, surface_hover, surface_pressed, control_border, separator, text, disabled_text, close_hover, close_text, window_controls_separator, badge_surface, badge_border);
+        background, surface_hover, surface_pressed, control_border, separator, text, disabled_text, close_hover, close_text, window_controls_separator, badge_surface, badge_border, badge_surface_hover, badge_surface_pressed);
 }
 
 QString menu_bar_style_sheet(QPalette const& palette)
@@ -1013,6 +1025,76 @@ QProgressBar#LadybirdDownloadProgress::chunk {{
 }}
 )",
         surface, recessed_surface, hover_surface, border, text, muted_text, accent);
+}
+
+QString private_session_popover_style_sheet(QPalette const& palette)
+{
+    auto text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_text(palette));
+    auto surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface(palette));
+    auto border = ChromeStyle::style_sheet_color(ChromeStyle::chrome_border(palette));
+    auto muted_text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_muted_text(palette));
+    auto control_border = ChromeStyle::style_sheet_color(ChromeStyle::chrome_control_border(palette));
+    auto hover_surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface_hover(palette));
+    auto pressed_surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface_pressed(palette));
+
+    auto accent = ChromeStyle::chrome_accent(palette);
+    auto accent_color = ChromeStyle::style_sheet_color(accent);
+    auto accent_hover = ChromeStyle::style_sheet_color(ChromeStyle::mix(accent, QColor(Qt::black), 0.12));
+    auto accent_pressed = ChromeStyle::style_sheet_color(ChromeStyle::mix(accent, QColor(Qt::black), 0.22));
+
+    return qformatted(R"(
+QFrame#LadybirdPrivateSessionPopover {{
+    color: {0};
+    background: {1};
+    border: 1px solid {2};
+    border-radius: 8px;
+}}
+
+QLabel#LadybirdPrivateSessionPopoverTitle {{
+    color: {0};
+    font-weight: 600;
+}}
+
+QLabel#LadybirdPrivateSessionPopoverBody {{
+    color: {3};
+}}
+
+QPushButton#LadybirdPrivateSessionCancelButton {{
+    color: {0};
+    background: {1};
+    border: 1px solid {4};
+    border-radius: 6px;
+    padding: 5px 12px;
+}}
+
+QPushButton#LadybirdPrivateSessionCancelButton:hover {{
+    background: {5};
+}}
+
+QPushButton#LadybirdPrivateSessionCancelButton:pressed {{
+    background: {6};
+}}
+
+QPushButton#LadybirdPrivateSessionRestartButton {{
+    color: #ffffff;
+    background: {7};
+    border: 1px solid {7};
+    border-radius: 6px;
+    padding: 5px 12px;
+    font-weight: 600;
+}}
+
+QPushButton#LadybirdPrivateSessionRestartButton:hover {{
+    background: {8};
+    border-color: {8};
+}}
+
+QPushButton#LadybirdPrivateSessionRestartButton:pressed {{
+    background: {9};
+    border-color: {9};
+}}
+)",
+        text, surface, border, muted_text, control_border, hover_surface, pressed_surface, accent_color, accent_hover, accent_pressed);
 }
 
 }

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -954,4 +954,65 @@ QListView#LadybirdAutocompleteList {{
         surface, border, text);
 }
 
+QString downloads_popover_style_sheet(QPalette const& palette)
+{
+    auto surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface(palette));
+    auto recessed_surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface_recessed(palette));
+    auto hover_surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface_hover(palette));
+    auto border = ChromeStyle::style_sheet_color(ChromeStyle::chrome_border(palette));
+    auto text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_text(palette));
+    auto muted_text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_muted_text(palette));
+    auto accent = ChromeStyle::style_sheet_color(ChromeStyle::chrome_accent(palette));
+
+    return qformatted(R"(
+QFrame#LadybirdDownloadsPopover {{
+    color: {4};
+    background: {0};
+    border: 1px solid {3};
+    border-radius: 8px;
+}}
+
+QScrollArea#LadybirdDownloadsPopoverScroll,
+QWidget#LadybirdDownloadsPopoverRows {{
+    background: transparent;
+    border: 0;
+}}
+
+QLabel#LadybirdDownloadsPopoverTitle,
+QLabel#LadybirdDownloadFileName {{
+    color: {4};
+    font-weight: 600;
+}}
+
+QLabel#LadybirdDownloadStatus,
+QLabel#LadybirdDownloadsEmpty {{
+    color: {5};
+}}
+
+QFrame#LadybirdDownloadRow {{
+    background: {0};
+    border: 1px solid {3};
+    border-radius: 6px;
+}}
+
+QFrame#LadybirdDownloadRow:hover {{
+    background: {2};
+}}
+
+QProgressBar#LadybirdDownloadProgress {{
+    background: {1};
+    border: 0;
+    border-radius: 2px;
+    min-height: 4px;
+    max-height: 4px;
+}}
+
+QProgressBar#LadybirdDownloadProgress::chunk {{
+    background: {6};
+    border-radius: 2px;
+}}
+)",
+        surface, recessed_surface, hover_surface, border, text, muted_text, accent);
+}
+
 }

--- a/UI/Qt/ChromeStyle.h
+++ b/UI/Qt/ChromeStyle.h
@@ -39,5 +39,6 @@ QString find_in_page_style_sheet(QPalette const&);
 QString devtools_banner_style_sheet(QPalette const&);
 QString tab_widget_style_sheet(QPalette const&);
 QString autocomplete_popup_style_sheet(QPalette const&);
+QString downloads_popover_style_sheet(QPalette const&);
 
 }

--- a/UI/Qt/ChromeStyle.h
+++ b/UI/Qt/ChromeStyle.h
@@ -40,5 +40,6 @@ QString devtools_banner_style_sheet(QPalette const&);
 QString tab_widget_style_sheet(QPalette const&);
 QString autocomplete_popup_style_sheet(QPalette const&);
 QString downloads_popover_style_sheet(QPalette const&);
+QString private_session_popover_style_sheet(QPalette const&);
 
 }

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -197,6 +197,7 @@ static constexpr int TOOLBAR_LOCATION_EDIT_SIDE_GAP = 32;
 static constexpr int TOOLBAR_WINDOW_CONTROLS_RIGHT_MARGIN = 4;
 static constexpr int DOWNLOADS_POPOVER_WIDTH = 380;
 static constexpr int DOWNLOADS_POPOVER_MAX_HEIGHT = 360;
+static constexpr int PRIVATE_SESSION_POPOVER_WIDTH = 320;
 
 class ElidedLabel final : public QLabel {
 public:
@@ -459,6 +460,70 @@ private:
     Vector<DownloadRow*> m_download_rows;
 };
 
+class PrivateSessionPopover final : public QFrame {
+public:
+    explicit PrivateSessionPopover(QWidget* parent)
+        : QFrame(parent, Qt::Popup | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint)
+    {
+        setObjectName("LadybirdPrivateSessionPopover");
+#if defined(AK_OS_MACOS)
+        setAttribute(Qt::WA_NativeWindow);
+#endif
+        setFrameShape(QFrame::StyledPanel);
+        setFrameShadow(QFrame::Raised);
+        setAutoFillBackground(true);
+        setFixedWidth(PRIVATE_SESSION_POPOVER_WIDTH);
+
+        auto* layout = new QVBoxLayout(this);
+        layout->setContentsMargins(16, 14, 16, 14);
+        layout->setSpacing(10);
+
+        auto* title = new QLabel("Start a fresh private session?", this);
+        title->setObjectName("LadybirdPrivateSessionPopoverTitle");
+        title->setWordWrap(true);
+        layout->addWidget(title);
+
+        auto* body = new QLabel("This closes all private windows and deletes history and other site data from the current private browsing session.", this);
+        body->setObjectName("LadybirdPrivateSessionPopoverBody");
+        body->setWordWrap(true);
+        layout->addWidget(body);
+
+        auto* button_row = new QWidget(this);
+        auto* button_layout = new QHBoxLayout(button_row);
+        button_layout->setContentsMargins(0, 0, 0, 0);
+        button_layout->setSpacing(8);
+        button_layout->addStretch();
+
+        auto* cancel_button = new QPushButton("Cancel", button_row);
+        cancel_button->setObjectName("LadybirdPrivateSessionCancelButton");
+        cancel_button->setFocusPolicy(Qt::NoFocus);
+        QObject::connect(cancel_button, &QPushButton::clicked, this, [this] {
+            close();
+        });
+        button_layout->addWidget(cancel_button);
+
+        auto* restart_button = new QPushButton("Restart Private Session", button_row);
+        restart_button->setObjectName("LadybirdPrivateSessionRestartButton");
+        restart_button->setDefault(true);
+        QObject::connect(restart_button, &QPushButton::clicked, this, [this] {
+            close();
+            if (on_confirm)
+                on_confirm();
+        });
+        button_layout->addWidget(restart_button);
+
+        layout->addWidget(button_row);
+    }
+
+    void update_chrome_style(QPalette const& palette)
+    {
+        setPalette(palette);
+        setStyleSheet(ChromeStyle::private_session_popover_style_sheet(palette));
+    }
+
+    Function<void()> on_confirm;
+};
+
 Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
     : QWidget(window)
     , m_window(window)
@@ -540,12 +605,16 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         show_downloads_popover();
     });
 
-    m_private_badge = new QLabel("Private", m_toolbar);
+    m_private_badge = new QPushButton("Private", m_toolbar);
     m_private_badge->setObjectName("LadybirdPrivateBadge");
-    m_private_badge->setAlignment(Qt::AlignCenter);
     m_private_badge->setFixedHeight(22);
     m_private_badge->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_private_badge->setFocusPolicy(Qt::NoFocus);
+    m_private_badge->setToolTip("Close all private windows and start a fresh private browsing session");
     m_private_badge->setVisible(m_window->is_private() == WebView::IsPrivate::Yes);
+    QObject::connect(m_private_badge, &QPushButton::clicked, this, [this] {
+        show_private_session_popover();
+    });
 
     m_hamburger_button = new HamburgerButton(m_toolbar);
     m_hamburger_button->setText("Show &Menu");
@@ -1363,6 +1432,48 @@ void Tab::update_vertical_tabs_toolbar_button_placement()
         m_left_toggle_vertical_tabs_expanded_button->setVisible(show_left_button);
     if (m_right_toggle_vertical_tabs_expanded_button)
         m_right_toggle_vertical_tabs_expanded_button->setVisible(show_right_button);
+}
+
+void Tab::show_private_session_popover()
+{
+    if (!m_private_badge || !m_private_badge->isVisible())
+        return;
+
+    if (!m_private_session_popover) {
+        m_private_session_popover = new PrivateSessionPopover(this);
+        m_private_session_popover->on_confirm = [] {
+            Application::the().restart_private_browsing_session();
+        };
+    }
+
+    m_private_session_popover->update_chrome_style(palette());
+    position_private_session_popover();
+    m_private_session_popover->show();
+    position_private_session_popover();
+    m_private_session_popover->raise();
+}
+
+void Tab::position_private_session_popover()
+{
+    if (!m_private_session_popover || !m_private_badge)
+        return;
+
+    m_private_session_popover->adjustSize();
+
+    auto anchor_position = m_private_badge->mapToGlobal(m_private_badge->rect().bottomRight());
+    auto popup_position = QPoint(anchor_position.x() - m_private_session_popover->width(), anchor_position.y() + 4);
+
+    if (auto* screen = QGuiApplication::screenAt(anchor_position)) {
+        auto available_geometry = screen->availableGeometry();
+        if (popup_position.x() < available_geometry.left())
+            popup_position.setX(available_geometry.left());
+        if (popup_position.x() + m_private_session_popover->width() > available_geometry.right())
+            popup_position.setX(available_geometry.right() - m_private_session_popover->width() + 1);
+        if (popup_position.y() + m_private_session_popover->height() > available_geometry.bottom())
+            popup_position.setY(m_private_badge->mapToGlobal(m_private_badge->rect().topRight()).y() - m_private_session_popover->height() - 4);
+    }
+
+    m_private_session_popover->move(popup_position);
 }
 
 void Tab::show_find_in_page()

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -198,67 +198,6 @@ static constexpr int TOOLBAR_WINDOW_CONTROLS_RIGHT_MARGIN = 4;
 static constexpr int DOWNLOADS_POPOVER_WIDTH = 380;
 static constexpr int DOWNLOADS_POPOVER_MAX_HEIGHT = 360;
 
-static QString downloads_popover_style_sheet(QPalette const& palette)
-{
-    auto surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface(palette));
-    auto recessed_surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface_recessed(palette));
-    auto hover_surface = ChromeStyle::style_sheet_color(ChromeStyle::chrome_surface_hover(palette));
-    auto border = ChromeStyle::style_sheet_color(ChromeStyle::chrome_border(palette));
-    auto text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_text(palette));
-    auto muted_text = ChromeStyle::style_sheet_color(ChromeStyle::chrome_muted_text(palette));
-    auto accent = ChromeStyle::style_sheet_color(ChromeStyle::chrome_accent(palette));
-
-    return qformatted(R"(
-QFrame#LadybirdDownloadsPopover {{
-    color: {4};
-    background: {0};
-    border: 1px solid {3};
-    border-radius: 8px;
-}}
-
-QScrollArea#LadybirdDownloadsPopoverScroll,
-QWidget#LadybirdDownloadsPopoverRows {{
-    background: transparent;
-    border: 0;
-}}
-
-QLabel#LadybirdDownloadsPopoverTitle,
-QLabel#LadybirdDownloadFileName {{
-    color: {4};
-    font-weight: 600;
-}}
-
-QLabel#LadybirdDownloadStatus,
-QLabel#LadybirdDownloadsEmpty {{
-    color: {5};
-}}
-
-QFrame#LadybirdDownloadRow {{
-    background: {0};
-    border: 1px solid {3};
-    border-radius: 6px;
-}}
-
-QFrame#LadybirdDownloadRow:hover {{
-    background: {2};
-}}
-
-QProgressBar#LadybirdDownloadProgress {{
-    background: {1};
-    border: 0;
-    border-radius: 2px;
-    min-height: 4px;
-    max-height: 4px;
-}}
-
-QProgressBar#LadybirdDownloadProgress::chunk {{
-    background: {6};
-    border-radius: 2px;
-}}
-)",
-        surface, recessed_surface, hover_surface, border, text, muted_text, accent);
-}
-
 class ElidedLabel final : public QLabel {
 public:
     explicit ElidedLabel(QString text, Qt::TextElideMode elide_mode, QWidget* parent = nullptr)
@@ -437,7 +376,7 @@ public:
     void update_chrome_style(QPalette const& palette)
     {
         setPalette(palette);
-        setStyleSheet(downloads_popover_style_sheet(palette));
+        setStyleSheet(ChromeStyle::downloads_popover_style_sheet(palette));
     }
 
     bool set_downloads(ReadonlySpan<WebView::FileDownloader::Download> downloads)

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -523,6 +523,23 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     tab_layout->addWidget(m_view);
     tab_layout->addWidget(m_find_in_page);
 
+    m_navigate_back_action = create_application_action(*this, view().navigate_back_action());
+    m_navigate_forward_action = create_application_action(*this, view().navigate_forward_action());
+    m_reload_action = create_application_action(*this, application.reload_action());
+    m_toggle_vertical_tabs_expanded_action = create_application_action(*this, application.toggle_vertical_tabs_expanded_action());
+    m_open_downloads_page_action = create_application_action(*this, application.open_downloads_page_action());
+
+    m_downloads_button = new DownloadsButton(m_toolbar);
+    m_downloads_button->setText("Downloads");
+    m_downloads_button->setAutoRaise(true);
+    m_downloads_button->setFocusPolicy(Qt::NoFocus);
+    m_downloads_button->setIconSize({ 20, 20 });
+    m_downloads_button->setFixedSize(36, 36);
+    m_downloads_button->setVisible(m_open_downloads_page_action->isVisible());
+    QObject::connect(m_downloads_button, &QToolButton::clicked, this, [this] {
+        show_downloads_popover();
+    });
+
     m_private_badge = new QLabel("Private", m_toolbar);
     m_private_badge->setObjectName("LadybirdPrivateBadge");
     m_private_badge->setAlignment(Qt::AlignCenter);
@@ -541,12 +558,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_hamburger_button->setPopupMode(QToolButton::InstantPopup);
     m_hamburger_button->setMenu(&m_window->hamburger_menu());
     connect_hamburger_menu();
-
-    m_navigate_back_action = create_application_action(*this, view().navigate_back_action());
-    m_navigate_forward_action = create_application_action(*this, view().navigate_forward_action());
-    m_reload_action = create_application_action(*this, application.reload_action());
-    m_toggle_vertical_tabs_expanded_action = create_application_action(*this, application.toggle_vertical_tabs_expanded_action());
-    m_open_downloads_page_action = create_application_action(*this, application.open_downloads_page_action());
 
     m_toolbar_window_controls_separator = new QWidget(m_toolbar);
     m_toolbar_window_controls_separator->setObjectName("LadybirdToolbarWindowControlsSeparator");
@@ -607,21 +618,13 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_location_edit->set_zoom_action(create_application_action(*m_location_edit, view().reset_zoom_action(), IncludeActionIcon::No));
     location_edit_layout->addWidget(m_location_edit);
     toolbar_layout->addWidget(location_edit_container, 1);
-    toolbar_layout->addWidget(m_private_badge, 0, Qt::AlignVCenter);
     m_right_toggle_vertical_tabs_expanded_button = create_toolbar_button(*m_toolbar, *m_toggle_vertical_tabs_expanded_action);
     toolbar_layout->addWidget(m_right_toggle_vertical_tabs_expanded_button, 0, Qt::AlignTop);
-    m_downloads_button = new DownloadsButton(m_toolbar);
-    m_downloads_button->setText("Downloads");
-    m_downloads_button->setAutoRaise(true);
-    m_downloads_button->setFocusPolicy(Qt::NoFocus);
-    m_downloads_button->setIconSize({ 20, 20 });
-    m_downloads_button->setFixedSize(36, 36);
-    m_downloads_button->setVisible(m_open_downloads_page_action->isVisible());
-    QObject::connect(m_downloads_button, &QToolButton::clicked, this, [this] {
-        show_downloads_popover();
-    });
+
     toolbar_layout->addWidget(m_downloads_button, 0, Qt::AlignTop);
+    toolbar_layout->addWidget(m_private_badge, 0, Qt::AlignVCenter);
     toolbar_layout->addWidget(m_hamburger_button, 0, Qt::AlignTop);
+
     if (use_right_custom_window_controls()) {
         toolbar_layout->addWidget(m_toolbar_window_controls_separator, 0, Qt::AlignVCenter);
         toolbar_layout->addWidget(m_toolbar_window_controls, 0, Qt::AlignVCenter);

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -19,6 +19,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QPointer>
+#include <QPushButton>
 #include <QToolButton>
 #include <QWidget>
 
@@ -28,6 +29,7 @@ namespace Ladybird {
 class BrowserWindow;
 enum class ChromeIcon;
 class DownloadsPopover;
+class PrivateSessionPopover;
 class WindowControlButton;
 
 class HyperlinkLabel final : public QLabel {
@@ -122,6 +124,8 @@ private:
     void update_downloads_popover();
     void show_downloads_popover();
     void position_downloads_popover();
+    void show_private_session_popover();
+    void position_private_session_popover();
     void set_loading(bool);
     void update_tab_icon();
     int tab_index();
@@ -142,10 +146,11 @@ private:
     WindowControlButton* m_maximize_window_button { nullptr };
     WindowControlButton* m_close_window_button { nullptr };
     BookmarksBar* m_bookmarks_bar { nullptr };
-    QLabel* m_private_badge { nullptr };
+    QPushButton* m_private_badge { nullptr };
     QToolButton* m_hamburger_button { nullptr };
     QToolButton* m_downloads_button { nullptr };
     QPointer<DownloadsPopover> m_downloads_popover;
+    QPointer<PrivateSessionPopover> m_private_session_popover;
     LocationEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
     FindInPageWidget* m_find_in_page { nullptr };

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -69,6 +69,7 @@ static QWidget* initial_web_content_view_parent([[maybe_unused]] QWidget* window
 
 WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index, WebContentViewInitialState initial_state)
     : WebContentViewBase(initial_web_content_view_parent(window))
+    , WebView::ViewImplementation(initial_state.is_private)
 {
 #ifdef LADYBIRD_QT_USE_METAL_RHI_WIDGET
     // Keep the QRhiWidget out of the top-level QWidget backing store. If it is
@@ -94,7 +95,6 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
 #endif
 
     m_device_pixel_ratio = devicePixelRatio();
-    m_is_private = initial_state.is_private;
     m_maximum_frames_per_second = initial_state.maximum_frames_per_second;
     m_display_id = initial_state.display_id;
 


### PR DESCRIPTION
* Reposition the "Private" badge so it doesn't jump around as downloads start.
* Clicking the "Private" window label now shows an open to restart the private session.
* Add a context menu action to open windows in a new private window.

<img width="365" height="216" alt="badge" src="https://github.com/user-attachments/assets/1ed175b3-4e9e-4960-8c3e-c4dd2a2cd415" />

<img width="434" height="259" alt="context" src="https://github.com/user-attachments/assets/6ecd2f1d-1c22-4c16-ab07-5b17ab24a5a6" />
