### PR TITLE
LibCore: Rework timers in the Windows event loop

### DIFF
--- a/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/BinaryHeap.h>
 #include <AK/HashMap.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/Singleton.h>
@@ -18,6 +17,7 @@
 #include <LibCore/Platform/ScopedAutoreleasePool.h>
 #include <LibCore/System.h>
 #include <LibCore/ThreadEventQueue.h>
+#include <LibCore/TimeoutSet.h>
 #include <LibSync/Mutex.h>
 #include <LibSync/Once.h>
 #include <LibSync/RWLock.h>
@@ -30,7 +30,6 @@ namespace Core {
 namespace {
 
 struct ThreadData;
-class TimeoutSet;
 
 thread_local ThreadData* s_this_thread_data;
 static pthread_key_t s_this_thread_data_key;
@@ -76,136 +75,6 @@ bool has_flag(int value, int flag)
 {
     return (value & flag) == flag;
 }
-
-class EventLoopTimeout {
-public:
-    static constexpr ssize_t INVALID_INDEX = NumericLimits<ssize_t>::max();
-
-    EventLoopTimeout() { }
-    virtual ~EventLoopTimeout() = default;
-
-    virtual void fire(TimeoutSet& timeout_set, MonotonicTime time) = 0;
-
-    MonotonicTime fire_time() const { return m_fire_time; }
-
-    void absolutize(Badge<TimeoutSet>, MonotonicTime current_time)
-    {
-        m_fire_time = current_time + m_duration;
-    }
-
-    ssize_t& index(Badge<TimeoutSet>) { return m_index; }
-    void set_index(Badge<TimeoutSet>, ssize_t index) { m_index = index; }
-
-    bool is_scheduled() const { return m_index != INVALID_INDEX; }
-
-    void set_sequence_id(u64 id) { m_sequence_id = id; }
-    u64 sequence_id() const { return m_sequence_id; }
-
-protected:
-    union {
-        AK::Duration m_duration;
-        MonotonicTime m_fire_time;
-    };
-
-private:
-    ssize_t m_index = INVALID_INDEX;
-    u64 m_sequence_id { 0 };
-};
-
-class TimeoutSet {
-public:
-    TimeoutSet() = default;
-
-    Optional<MonotonicTime> next_timer_expiration()
-    {
-        if (!m_heap.is_empty()) {
-            return m_heap.peek_min()->fire_time();
-        } else {
-            return {};
-        }
-    }
-
-    void absolutize_relative_timeouts(MonotonicTime current_time)
-    {
-        for (auto timeout : m_scheduled_timeouts) {
-            timeout->absolutize({}, current_time);
-            m_heap.insert(timeout);
-        }
-        m_scheduled_timeouts.clear();
-    }
-
-    size_t fire_expired(MonotonicTime current_time)
-    {
-        size_t fired_count = 0;
-        while (!m_heap.is_empty()) {
-            auto& timeout = *m_heap.peek_min();
-
-            if (timeout.fire_time() <= current_time) {
-                ++fired_count;
-                m_heap.pop_min();
-                timeout.set_index({}, EventLoopTimeout::INVALID_INDEX);
-                timeout.fire(*this, current_time);
-            } else {
-                break;
-            }
-        }
-        return fired_count;
-    }
-
-    void schedule_relative(EventLoopTimeout* timeout)
-    {
-        timeout->set_sequence_id(m_next_sequence_id++);
-        timeout->set_index({}, -1 - static_cast<ssize_t>(m_scheduled_timeouts.size()));
-        m_scheduled_timeouts.append(timeout);
-    }
-
-    void schedule_absolute(EventLoopTimeout* timeout)
-    {
-        timeout->set_sequence_id(m_next_sequence_id++);
-        m_heap.insert(timeout);
-    }
-
-    void unschedule(EventLoopTimeout* timeout)
-    {
-        if (timeout->index({}) < 0) {
-            size_t i = -1 - timeout->index({});
-            size_t j = m_scheduled_timeouts.size() - 1;
-            VERIFY(m_scheduled_timeouts[i] == timeout);
-            swap(m_scheduled_timeouts[i], m_scheduled_timeouts[j]);
-            swap(m_scheduled_timeouts[i]->index({}), m_scheduled_timeouts[j]->index({}));
-            (void)m_scheduled_timeouts.take_last();
-        } else {
-            m_heap.pop(timeout->index({}));
-        }
-        timeout->set_index({}, EventLoopTimeout::INVALID_INDEX);
-    }
-
-    void clear()
-    {
-        for (auto* timeout : m_heap.nodes_in_arbitrary_order())
-            timeout->set_index({}, EventLoopTimeout::INVALID_INDEX);
-        m_heap.clear();
-        for (auto* timeout : m_scheduled_timeouts)
-            timeout->set_index({}, EventLoopTimeout::INVALID_INDEX);
-        m_scheduled_timeouts.clear();
-    }
-
-private:
-    IntrusiveBinaryHeap<
-        EventLoopTimeout*,
-        decltype([](EventLoopTimeout* a, EventLoopTimeout* b) {
-            if (a->fire_time() == b->fire_time())
-                return a->sequence_id() < b->sequence_id();
-            return a->fire_time() < b->fire_time();
-        }),
-        decltype([](EventLoopTimeout* timeout, size_t index) {
-            timeout->set_index({}, static_cast<ssize_t>(index));
-        }),
-        8>
-        m_heap;
-    Vector<EventLoopTimeout*, 8> m_scheduled_timeouts;
-    u64 m_next_sequence_id { 0 };
-};
 
 class EventLoopTimer final : public EventLoopTimeout {
 public:

--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -8,13 +8,16 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/Atomic.h>
 #include <AK/Diagnostics.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/Time.h>
 #include <AK/Windows.h>
 #include <LibCore/EventLoopImplementationWindows.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/ThreadEventQueue.h>
+#include <LibCore/TimeoutSet.h>
 #include <LibCore/Timer.h>
 #include <LibSync/Mutex.h>
 #include <LibSync/MutexProtected.h>
@@ -79,16 +82,61 @@ struct EventLoopWake final : CompletionPacket {
     OwnHandle wait_event;
 };
 
-struct EventLoopTimer final : CompletionPacket {
+// All timers of a thread share one waitable timer, armed for the earliest deadline. Own bookkeeping (rather than a
+// kernel timer object per Core timer) is used because the kernel delivers simultaneously signaled wait completion
+// packets in LIFO order, while timers that are due together must fire in registration order.
+struct EventLoopMasterTimer final : CompletionPacket {
 
-    ~EventLoopTimer()
+    ~EventLoopMasterTimer()
     {
         CancelWaitableTimer(timer.handle);
+        if (wait_packet_associated) {
+            NTSTATUS status = g_system.NtCancelWaitCompletionPacket(wait_packet.handle, TRUE);
+            VERIFY(NT_SUCCESS(status));
+        }
     }
 
     OwnHandle timer;
     OwnHandle wait_packet;
-    bool is_periodic;
+    bool wait_packet_associated { false };
+};
+
+class EventLoopTimer final : public EventLoopTimeout {
+public:
+    EventLoopTimer() = default;
+
+    void reload(MonotonicTime const& now) { m_fire_time = now + interval; }
+
+    virtual void fire(TimeoutSet& timeout_set, MonotonicTime current_time) override
+    {
+        auto strong_owner = owner.strong_ref();
+
+        if (!strong_owner)
+            return;
+
+        if (should_reload) {
+            MonotonicTime next_fire_time = m_fire_time + interval;
+            if (next_fire_time <= current_time) {
+                next_fire_time = current_time + interval;
+            }
+            m_fire_time = next_fire_time;
+            if (next_fire_time != current_time) {
+                timeout_set.schedule_absolute(this);
+            } else {
+                // NOTE: Unfortunately we need to treat timeouts with the zero interval in a
+                //       special way. TimeoutSet::schedule_absolute for them will result in an
+                //       infinite loop. TimeoutSet::schedule_relative, on the other hand, will do a
+                //       correct thing of scheduling them for the next iteration of the loop.
+                m_duration = {};
+                timeout_set.schedule_relative(this);
+            }
+        }
+
+        ThreadEventQueue::current().post_event(strong_owner, Event::Type::Timer);
+    }
+
+    AK::Duration interval;
+    bool should_reload { false };
     WeakPtr<EventReceiver> owner;
 };
 
@@ -122,7 +170,8 @@ struct ThreadData {
     }
 
     ThreadData()
-        : wake_data(make<EventLoopWake>())
+        : master_timer(make<EventLoopMasterTimer>())
+        , wake_data(make<EventLoopWake>())
     {
         wake_data->type = CompletionType::Wake;
         wake_data->wait_event.handle = CreateEvent(NULL, FALSE, FALSE, NULL);
@@ -135,6 +184,15 @@ struct ThreadData {
         VERIFY(NT_SUCCESS(status));
         status = g_system.NtAssociateWaitCompletionPacket(wake_data->wait_packet.handle, iocp.handle, wake_data->wait_event.handle, wake_data.ptr(), NULL, 0, 0, NULL);
         VERIFY(NT_SUCCESS(status));
+
+        master_timer->type = CompletionType::Timer;
+        // A high-resolution timer avoids rounding short deadlines up to the default ~16ms timer tick.
+        master_timer->timer.handle = CreateWaitableTimerExW(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+        if (!master_timer->timer.handle)
+            master_timer->timer.handle = CreateWaitableTimerExW(NULL, NULL, 0, TIMER_ALL_ACCESS);
+        VERIFY(master_timer->timer.handle);
+        status = g_system.NtCreateWaitCompletionPacket(&master_timer->wait_packet.handle, GENERIC_READ | GENERIC_WRITE, NULL);
+        VERIFY(NT_SUCCESS(status));
     }
     ~ThreadData()
     {
@@ -145,14 +203,54 @@ struct ThreadData {
     OwnHandle iocp;
 
     // These are only used to register and unregister. The event loop doesn't access these.
-    HashMap<intptr_t, NonnullOwnPtr<EventLoopTimer>> timers;
     HashMap<Notifier*, NonnullOwnPtr<EventLoopNotifier>> notifiers;
+
+    // Owns the timer allocations; ids stay valid until unregister_timer even after a one-shot timer fires.
+    HashMap<intptr_t, NonnullOwnPtr<EventLoopTimer>> timers;
+    TimeoutSet timeouts;
+    // The deadline the master timer is currently armed for, to skip redundant SetWaitableTimer calls.
+    Optional<MonotonicTime> armed_deadline;
+    NonnullOwnPtr<EventLoopMasterTimer> master_timer;
 
     // The wake completion packet is posted to the thread's event loop to wake it.
     NonnullOwnPtr<EventLoopWake> wake_data;
 };
 
 static Sync::MutexProtected<HashMap<pid_t, NonnullOwnPtr<EventLoopProcess>>> s_processes;
+
+// Arms (or disarms) the thread's shared waitable timer for the earliest pending deadline.
+static void arm_master_timer(ThreadData& thread_data)
+{
+    auto& master_timer = *thread_data.master_timer;
+
+    auto earliest = thread_data.timeouts.next_timer_expiration();
+
+    if (!earliest.has_value()) {
+        if (thread_data.armed_deadline.has_value()) {
+            CancelWaitableTimer(master_timer.timer.handle);
+            thread_data.armed_deadline = {};
+        }
+        return;
+    }
+
+    if (thread_data.armed_deadline == earliest)
+        return;
+
+    LARGE_INTEGER due_time = {};
+    // Measured in 0.1μs intervals; negative means relative to now. Round up so the timer doesn't fire
+    // before the deadline (and wake the loop with nothing due), and clamp to at least one interval so
+    // an already-passed deadline stays a relative time.
+    due_time.QuadPart = -AK::max<i64>(((*earliest - MonotonicTime::now()).to_nanoseconds() + 99) / 100, 1);
+    BOOL succeeded = SetWaitableTimer(master_timer.timer.handle, &due_time, 0, NULL, NULL, FALSE);
+    VERIFY(succeeded);
+    thread_data.armed_deadline = earliest;
+
+    if (!master_timer.wait_packet_associated) {
+        NTSTATUS status = g_system.NtAssociateWaitCompletionPacket(master_timer.wait_packet.handle, thread_data.iocp.handle, master_timer.timer.handle, &master_timer, NULL, 0, 0, NULL);
+        VERIFY(NT_SUCCESS(status));
+        master_timer.wait_packet_associated = true;
+    }
+}
 
 EventLoopImplementationWindows::EventLoopImplementationWindows()
     : m_wake_event(ThreadData::the()->wake_data->wait_event.handle)
@@ -208,13 +306,19 @@ size_t EventLoopImplementationWindows::pump(PumpMode pump_mode)
                 continue;
             }
             if (packet->type == CompletionType::Timer) {
-                auto* timer = static_cast<EventLoopTimer*>(packet);
-                if (auto owner = timer->owner.strong_ref())
-                    event_queue.post_event(owner, Event::Type::Timer);
-                if (timer->is_periodic) {
-                    NTSTATUS status = g_system.NtAssociateWaitCompletionPacket(timer->wait_packet.handle, thread_data->iocp.handle, timer->timer.handle, timer, NULL, 0, 0, NULL);
-                    VERIFY(NT_SUCCESS(status));
-                }
+                auto* master_timer = static_cast<EventLoopMasterTimer*>(packet);
+                master_timer->wait_packet_associated = false;
+                thread_data->armed_deadline = {};
+
+                // TimeoutSet fires due timers in registration order for equal deadlines. (This cannot rely on
+                // kernel wakeup order: simultaneously signaled wait completion packets are delivered in LIFO
+                // order.)
+                auto now = MonotonicTime::now();
+                thread_data->timeouts.fire_expired(now);
+                // Zero-interval reloads are rescheduled relative to defer them to the next pump.
+                thread_data->timeouts.absolutize_relative_timeouts(now);
+
+                arm_master_timer(*thread_data);
                 continue;
             }
             if (packet->type == CompletionType::Notifer) {
@@ -324,47 +428,32 @@ intptr_t EventLoopManagerWindows::register_timer(EventReceiver& object, int mill
     VERIFY(milliseconds >= 0);
     auto* thread_data = ThreadData::the();
     VERIFY(thread_data);
-    auto& timers = thread_data->timers;
 
-    // FIXME: This is a temporary fix for issue #3641
-    bool manual_reset = static_cast<Timer&>(object).is_single_shot();
-    HANDLE timer = CreateWaitableTimer(NULL, manual_reset, NULL);
-    VERIFY(timer);
+    auto timer = make<EventLoopTimer>();
+    timer->owner = object.make_weak_ptr();
+    timer->interval = AK::Duration::from_milliseconds(milliseconds);
+    timer->should_reload = should_reload;
+    timer->reload(MonotonicTime::now());
+    thread_data->timeouts.schedule_absolute(timer.ptr());
 
-    auto timer_data = make<EventLoopTimer>();
-    timer_data->type = CompletionType::Timer;
-    timer_data->timer.handle = timer;
-    timer_data->owner = object.make_weak_ptr();
-    timer_data->is_periodic = should_reload;
-    VERIFY(timer_data->timer.handle);
-
-    NTSTATUS status = g_system.NtCreateWaitCompletionPacket(&timer_data->wait_packet.handle, GENERIC_READ | GENERIC_WRITE, NULL);
-    VERIFY(NT_SUCCESS(status));
-
-    LARGE_INTEGER first_time = {};
-    // Measured in 0.1μs intervals, negative means starting from now
-    first_time.QuadPart = -10'000LL * milliseconds;
-    BOOL succeeded = SetWaitableTimer(timer_data->timer.handle, &first_time, should_reload ? milliseconds : 0, NULL, NULL, FALSE);
-    VERIFY(succeeded);
-
-    status = g_system.NtAssociateWaitCompletionPacket(timer_data->wait_packet.handle, thread_data->iocp.handle, timer_data->timer.handle, timer_data.ptr(), NULL, 0, 0, NULL);
-    VERIFY(NT_SUCCESS(status));
-
-    auto timer_id = reinterpret_cast<intptr_t>(timer_data.ptr());
-    VERIFY(!timers.get(timer_id).has_value());
-    timers.set(timer_id, move(timer_data));
+    // Ids are process-wide unique so a stale id (e.g. one unregistered from the wrong thread) can never
+    // match another thread's timer.
+    static Atomic<intptr_t> next_timer_id { 1 };
+    auto timer_id = next_timer_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed);
+    thread_data->timers.set(timer_id, move(timer));
+    arm_master_timer(*thread_data);
     return timer_id;
 }
 
 void EventLoopManagerWindows::unregister_timer(intptr_t timer_id)
 {
     if (auto* thread_data = ThreadData::the()) {
-        auto maybe_timer = thread_data->timers.take(timer_id);
-        if (!maybe_timer.has_value())
+        auto timer = thread_data->timers.take(timer_id);
+        if (!timer.has_value())
             return;
-        auto timer = move(maybe_timer.value());
-        NTSTATUS status = g_system.NtCancelWaitCompletionPacket(timer->wait_packet.handle, TRUE);
-        VERIFY(NT_SUCCESS(status));
+        if ((*timer)->is_scheduled())
+            thread_data->timeouts.unschedule(timer->ptr());
+        arm_master_timer(*thread_data);
     }
 }
 

--- a/Libraries/LibCore/TimeoutSet.h
+++ b/Libraries/LibCore/TimeoutSet.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/BinaryHeap.h>
+#include <AK/NumericLimits.h>
+#include <AK/Optional.h>
+#include <AK/Time.h>
+#include <AK/Vector.h>
+
+namespace Core {
+
+class TimeoutSet;
+
+class EventLoopTimeout {
+public:
+    static constexpr ssize_t INVALID_INDEX = NumericLimits<ssize_t>::max();
+
+    EventLoopTimeout() { }
+    virtual ~EventLoopTimeout() = default;
+
+    virtual void fire(TimeoutSet& timeout_set, MonotonicTime time) = 0;
+
+    MonotonicTime fire_time() const { return m_fire_time; }
+
+    void absolutize(Badge<TimeoutSet>, MonotonicTime current_time)
+    {
+        m_fire_time = current_time + m_duration;
+    }
+
+    ssize_t& index(Badge<TimeoutSet>) { return m_index; }
+    void set_index(Badge<TimeoutSet>, ssize_t index) { m_index = index; }
+
+    bool is_scheduled() const { return m_index != INVALID_INDEX; }
+
+    void set_sequence_id(u64 id) { m_sequence_id = id; }
+    u64 sequence_id() const { return m_sequence_id; }
+
+protected:
+    union {
+        AK::Duration m_duration;
+        MonotonicTime m_fire_time;
+    };
+
+private:
+    ssize_t m_index = INVALID_INDEX;
+    u64 m_sequence_id { 0 };
+};
+
+class TimeoutSet {
+public:
+    TimeoutSet() = default;
+
+    Optional<MonotonicTime> next_timer_expiration()
+    {
+        if (!m_heap.is_empty()) {
+            return m_heap.peek_min()->fire_time();
+        } else {
+            return {};
+        }
+    }
+
+    void absolutize_relative_timeouts(MonotonicTime current_time)
+    {
+        for (auto timeout : m_scheduled_timeouts) {
+            timeout->absolutize({}, current_time);
+            m_heap.insert(timeout);
+        }
+        m_scheduled_timeouts.clear();
+    }
+
+    size_t fire_expired(MonotonicTime current_time)
+    {
+        size_t fired_count = 0;
+        while (!m_heap.is_empty()) {
+            auto& timeout = *m_heap.peek_min();
+
+            if (timeout.fire_time() <= current_time) {
+                ++fired_count;
+                m_heap.pop_min();
+                timeout.set_index({}, EventLoopTimeout::INVALID_INDEX);
+                timeout.fire(*this, current_time);
+            } else {
+                break;
+            }
+        }
+        return fired_count;
+    }
+
+    void schedule_relative(EventLoopTimeout* timeout)
+    {
+        timeout->set_sequence_id(m_next_sequence_id++);
+        timeout->set_index({}, -1 - static_cast<ssize_t>(m_scheduled_timeouts.size()));
+        m_scheduled_timeouts.append(timeout);
+    }
+
+    void schedule_absolute(EventLoopTimeout* timeout)
+    {
+        timeout->set_sequence_id(m_next_sequence_id++);
+        m_heap.insert(timeout);
+    }
+
+    void unschedule(EventLoopTimeout* timeout)
+    {
+        if (timeout->index({}) < 0) {
+            size_t i = -1 - timeout->index({});
+            size_t j = m_scheduled_timeouts.size() - 1;
+            VERIFY(m_scheduled_timeouts[i] == timeout);
+            swap(m_scheduled_timeouts[i], m_scheduled_timeouts[j]);
+            swap(m_scheduled_timeouts[i]->index({}), m_scheduled_timeouts[j]->index({}));
+            (void)m_scheduled_timeouts.take_last();
+        } else {
+            m_heap.pop(timeout->index({}));
+        }
+        timeout->set_index({}, EventLoopTimeout::INVALID_INDEX);
+    }
+
+    void clear()
+    {
+        for (auto* timeout : m_heap.nodes_in_arbitrary_order())
+            timeout->set_index({}, EventLoopTimeout::INVALID_INDEX);
+        m_heap.clear();
+        for (auto* timeout : m_scheduled_timeouts)
+            timeout->set_index({}, EventLoopTimeout::INVALID_INDEX);
+        m_scheduled_timeouts.clear();
+    }
+
+private:
+    struct TimeoutFiresBefore {
+        bool operator()(EventLoopTimeout* a, EventLoopTimeout* b) const
+        {
+            if (a->fire_time() == b->fire_time())
+                return a->sequence_id() < b->sequence_id();
+            return a->fire_time() < b->fire_time();
+        }
+    };
+
+    struct UpdateTimeoutIndex {
+        void operator()(EventLoopTimeout* timeout, size_t index) const
+        {
+            timeout->set_index({}, static_cast<ssize_t>(index));
+        }
+    };
+
+    IntrusiveBinaryHeap<EventLoopTimeout*, TimeoutFiresBefore, UpdateTimeoutIndex, 8> m_heap;
+    Vector<EventLoopTimeout*, 8> m_scheduled_timeouts;
+    u64 m_next_sequence_id { 0 };
+};
+
+}

--- a/Tests/LibCore/TestLibCoreEventLoop.cpp
+++ b/Tests/LibCore/TestLibCoreEventLoop.cpp
@@ -5,7 +5,10 @@
  */
 
 #include <AK/OwnPtr.h>
+#include <AK/Time.h>
+#include <AK/Vector.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/Timer.h>
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
 
@@ -41,4 +44,84 @@ TEST_CASE(wake_after_thread_exit)
     }
 
     worker_loop.clear();
+}
+
+TEST_CASE(single_shot_timer_fires_once)
+{
+    Core::EventLoop loop;
+    int count = 0;
+    auto timer = Core::Timer::create_single_shot(10, [&] {
+        ++count;
+        loop.quit(0);
+    });
+    timer->start();
+    loop.exec();
+    EXPECT_EQ(count, 1);
+    loop.pump(Core::EventLoop::WaitMode::PollForEvents);
+    EXPECT_EQ(count, 1);
+}
+
+TEST_CASE(zero_interval_repeating_timer)
+{
+    Core::EventLoop loop;
+    int count = 0;
+    auto timer = Core::Timer::create_repeating(0, [&] {
+        if (++count == 5)
+            loop.quit(0);
+    });
+    timer->start();
+    loop.exec();
+    EXPECT_EQ(count, 5);
+}
+
+TEST_CASE(repeating_timer_keeps_cadence)
+{
+    Core::EventLoop loop;
+    int count = 0;
+    auto start = MonotonicTime::now();
+    auto timer = Core::Timer::create_repeating(10, [&] {
+        if (++count == 20)
+            loop.quit(0);
+    });
+    timer->start();
+    loop.exec();
+    auto elapsed_ms = (MonotonicTime::now() - start).to_milliseconds();
+    EXPECT_EQ(count, 20);
+    // 20 fires at a fixed 10ms cadence take ~200ms; rescheduling from the processing time
+    // instead of the previous deadline accumulates latency and overshoots substantially.
+    EXPECT(elapsed_ms >= 190);
+    EXPECT(elapsed_ms <= 350);
+}
+
+TEST_CASE(equal_deadlines_fire_in_registration_order)
+{
+    Core::EventLoop loop;
+    Vector<int> order;
+    Vector<NonnullRefPtr<Core::Timer>> timers;
+    for (int i = 0; i < 8; ++i) {
+        timers.append(Core::Timer::create_single_shot(20, [&order, &loop, i] {
+            order.append(i);
+            if (order.size() == 8)
+                loop.quit(0);
+        }));
+    }
+    for (auto& timer : timers)
+        timer->start();
+    loop.exec();
+    EXPECT_EQ(order.size(), 8uz);
+    for (int i = 0; i < 8; ++i)
+        EXPECT_EQ(order[i], i);
+}
+
+TEST_CASE(stopped_timer_does_not_fire)
+{
+    Core::EventLoop loop;
+    int stopped_count = 0;
+    auto stopped_timer = Core::Timer::create_single_shot(10, [&] { ++stopped_count; });
+    stopped_timer->start();
+    stopped_timer->stop();
+    auto quit_timer = Core::Timer::create_single_shot(50, [&] { loop.quit(0); });
+    quit_timer->start();
+    loop.exec();
+    EXPECT_EQ(stopped_count, 0);
 }


### PR DESCRIPTION
Timers were implemented as one waitable timer object per Core timer, which was broken in several ways:

- SetWaitableTimer() treats a period of 0 as one-shot, so periodic 0ms timers fired exactly once. Among other things, this broke setInterval(f, 0).
- Simultaneously signaled wait completion packets are delivered in LIFO order, so timers with equal deadlines fired in reverse registration order, breaking the ordering guarantees of setTimeout().
- The default timer resolution rounded short deadlines up to the ~16ms timer tick.

Replace this with the bookkeeping the Unix event loop already uses: TimeoutSet, extracted into LibCore/TimeoutSet.h and shared by both implementations, keeps timers in a binary heap keyed by deadline and registration order. One high-resolution waitable timer per thread is armed for the earliest pending deadline (skipping the kernel call when that deadline is unchanged), and when it fires, all due timers are dispatched in heap order. Periodic timers reschedule from their previous deadline rather than the processing time, so event-loop latency does not accumulate as drift, and a due timer whose owner is gone is not rescheduled. Timer ids are process-wide unique counters that stay valid until unregistration, so a stale id can never remove an unrelated timer. This also removes the manual-reset workaround for issue #3641, which no longer applies.

Fixes setInterval.html, setTimeout-equal-delay-registration-order.html, and input-stepup.html on Windows.