### PR TITLE
LibWeb: Use UI-assigned NavigableId across WebContent processes

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -637,6 +637,7 @@ set(SOURCES
     HTML/MimeType.cpp
     HTML/MimeTypeArray.cpp
     HTML/Navigable.cpp
+    HTML/NavigableId.cpp
     HTML/NavigableContainer.cpp
     HTML/NavigateEvent.cpp
     HTML/Navigation.cpp

--- a/Libraries/LibWeb/HTML/DocumentState.h
+++ b/Libraries/LibWeb/HTML/DocumentState.h
@@ -13,6 +13,7 @@
 #include <LibWeb/Export.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/SerializedPolicyContainer.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
@@ -26,7 +27,7 @@ public:
     ~DocumentState();
 
     struct NestedHistory {
-        String id;
+        NavigableId id;
         Vector<NonnullRefPtr<SessionHistoryEntry>> entries;
     };
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -739,8 +739,7 @@ void LocalNavigable::set_current_session_history_entry(RefPtr<SessionHistoryEntr
 // https://html.spec.whatwg.org/multipage/document-sequences.html#initialize-the-navigable
 void LocalNavigable::initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document)
 {
-    static int next_id = 0;
-    set_id(String::number(next_id++));
+    set_id(page().client().allocate_navigable_id());
 
     // 1. Assert: documentState's document is non-null.
     // NOTE: DocumentState no longer owns the document; it is passed separately and owned by the LocalNavigable.
@@ -2621,7 +2620,7 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                 auto& page_client = active_browsing_context()->page().client();
                 auto is_top_level_navigation = is_top_level_traversable();
                 auto target = is_top_level_navigation ? NavigationTarget::TopLevel : NavigationTarget::IFrame;
-                auto frame_id = is_top_level_navigation ? Optional<String> {} : Optional<String> { id() };
+                auto frame_id = is_top_level_navigation ? Optional<NavigableId> {} : Optional<NavigableId> { id() };
                 auto process_decision = page_client.decide_navigation_process(this->active_document()->url(), url, target, move(frame_id));
                 if (process_decision == NavigationProcessDecision::Remote && is_top_level_navigation) {
                     page_client.request_new_process_for_navigation(url, document_resource, history_handling);

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -73,6 +73,7 @@ public:
     using NavigationParamsVariant = Variant<NullOrError, GC::Ref<NavigationParams>, GC::Ref<NonFetchSchemeNavigationParams>>;
 
     void initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document);
+    void set_id_for_session_history_reconstruction(NavigableId id) { set_id(id); }
 
     void register_navigation_observer(Badge<NavigationObserver>, NavigationObserver&);
     void unregister_navigation_observer(Badge<NavigationObserver>, NavigationObserver&);

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -240,12 +240,24 @@ static void populate_nested_histories_from_ui_process(DocumentState& document_st
 {
     auto& nested_histories = document_state.nested_histories();
     if (nested_histories.size() == nested_history_descriptors.size()) {
-        // NB: The UI process keeps session history across WebContent process
-        //     swaps, but nested history ids are process-local navigable ids. When
-        //     rebuilding history for an already-loaded document, preserve the live
-        //     ids created by the new WebContent process.
-        for (size_t i = 0; i < nested_history_descriptors.size(); ++i)
-            nested_history_descriptors[i].id = nested_histories[i].id;
+        // FIXME: This is temporary glue for the current load-then-seed ordering.
+        //        A replacement WebContent process can create live child navigables
+        //        before the UI process sends its canonical session-history tree.
+        //        Now that nested history ids are canonical NavigableIds, the UI id
+        //        must win; retarget the already-created child to match it. The
+        //        longer-term model should avoid creating a distinct temporary id
+        //        for a child the UI process already knows about.
+        for (size_t i = 0; i < nested_history_descriptors.size(); ++i) {
+            auto previous_id = nested_histories[i].id;
+            auto canonical_id = nested_history_descriptors[i].id;
+            if (previous_id == canonical_id)
+                continue;
+
+            for (auto& navigable : all_local_navigables()) {
+                if (navigable->id() == previous_id)
+                    navigable->set_id_for_session_history_reconstruction(canonical_id);
+            }
+        }
     }
     nested_histories.clear();
     nested_histories.ensure_capacity(nested_history_descriptors.size());

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -12,6 +12,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/NavigableId.h>
 
 namespace Web::HTML {
 
@@ -23,7 +24,7 @@ public:
     virtual ~Navigable() override;
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-id
-    String const& id() const { return m_id; }
+    NavigableId id() const { return m_id; }
 
     GC::Ptr<Navigable> parent() const { return m_parent; }
 
@@ -37,13 +38,13 @@ public:
 
 protected:
     Navigable() = default;
-    void set_id(String id) { m_id = move(id); }
+    void set_id(NavigableId id) { m_id = id; }
     void set_parent(GC::Ptr<Navigable> parent) { m_parent = parent; }
 
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    String m_id;
+    NavigableId m_id;
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-parent
     GC::Ptr<Navigable> m_parent;

--- a/Libraries/LibWeb/HTML/NavigableId.cpp
+++ b/Libraries/LibWeb/HTML/NavigableId.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/HTML/NavigableId.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigableId const& id)
+{
+    TRY(encoder.encode(id.namespace_id));
+    TRY(encoder.encode(id.local_id));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::NavigableId> decode(Decoder& decoder)
+{
+    return Web::HTML::NavigableId {
+        .namespace_id = TRY(decoder.decode<u64>()),
+        .local_id = TRY(decoder.decode<u64>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigableIdAllocator const& allocator)
+{
+    TRY(encoder.encode(allocator.namespace_id));
+    TRY(encoder.encode(allocator.next_local_id));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::NavigableIdAllocator> decode(Decoder& decoder)
+{
+    return Web::HTML::NavigableIdAllocator {
+        .namespace_id = TRY(decoder.decode<u64>()),
+        .next_local_id = TRY(decoder.decode<u64>()),
+    };
+}
+
+}

--- a/Libraries/LibWeb/HTML/NavigableId.h
+++ b/Libraries/LibWeb/HTML/NavigableId.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Format.h>
+#include <AK/HashFunctions.h>
+#include <AK/Optional.h>
+#include <AK/Traits.h>
+#include <AK/Types.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Export.h>
+
+namespace Web::HTML {
+
+struct NavigableId {
+    u64 namespace_id { 0 };
+    u64 local_id { 0 };
+
+    bool operator==(NavigableId const&) const = default;
+};
+
+struct NavigableIdAllocator {
+    u64 namespace_id { 0 };
+    u64 next_local_id { 1 };
+
+    NavigableId allocate()
+    {
+        VERIFY(namespace_id > 0);
+        VERIFY(next_local_id > 0);
+        return NavigableId {
+            .namespace_id = namespace_id,
+            .local_id = next_local_id++,
+        };
+    }
+};
+
+}
+
+template<>
+struct AK::Traits<Web::HTML::NavigableId> : public DefaultTraits<Web::HTML::NavigableId> {
+    static unsigned hash(Web::HTML::NavigableId const& id)
+    {
+        return pair_int_hash(Traits<u64>::hash(id.namespace_id), Traits<u64>::hash(id.local_id));
+    }
+};
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::NavigableId const&);
+template<>
+WEB_API ErrorOr<Web::HTML::NavigableId> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::NavigableIdAllocator const&);
+template<>
+WEB_API ErrorOr<Web::HTML::NavigableIdAllocator> decode(Decoder&);
+
+}
+
+template<>
+struct AK::Formatter<Web::HTML::NavigableId> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::HTML::NavigableId const& id)
+    {
+        return Formatter<FormatString>::format(builder, "{}:{}"sv, id.namespace_id, id.local_id);
+    }
+};

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
@@ -463,8 +463,8 @@ ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SessionHistoryNestedHisto
 template<>
 ErrorOr<Web::HTML::SessionHistoryNestedHistoryDescriptor> IPC::decode(Decoder& decoder)
 {
-    auto id = TRY(decoder.decode<String>());
+    auto id = TRY(decoder.decode<Web::HTML::NavigableId>());
     auto entries = TRY(decoder.decode<Vector<Web::HTML::SessionHistoryEntryDescriptor>>());
 
-    return Web::HTML::SessionHistoryNestedHistoryDescriptor { move(id), move(entries) };
+    return Web::HTML::SessionHistoryNestedHistoryDescriptor { id, move(entries) };
 }

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.h
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.h
@@ -18,6 +18,7 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/DocumentState.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/StructuredSerializeTypes.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
@@ -82,7 +83,7 @@ struct SessionHistoryEntryDescriptor {
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#nested-history
 struct SessionHistoryNestedHistoryDescriptor {
-    String id;
+    NavigableId id;
     Vector<SessionHistoryEntryDescriptor> entries;
 };
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
 #include <AK/JsonValue.h>
 #include <AK/Queue.h>
@@ -44,6 +45,7 @@
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
@@ -440,17 +442,17 @@ public:
         [[maybe_unused]] URL::URL const& current_url,
         [[maybe_unused]] URL::URL const& target_url,
         [[maybe_unused]] NavigationTarget target = NavigationTarget::TopLevel,
-        [[maybe_unused]] Optional<String> frame_id = {}) const
+        [[maybe_unused]] Optional<HTML::NavigableId> frame_id = {}) const
     {
         return NavigationProcessDecision::Local;
     }
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
-    virtual void request_new_process_for_child_frame_navigation(String const&, URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
-    virtual void page_did_create_child_frame(String const&, String const&) { }
-    virtual void page_did_update_child_frame_viewport(String const&, CSSPixelRect) { }
-    virtual void page_did_commit_child_frame_navigation(String const&, URL::URL const&) { }
-    virtual void page_did_destroy_child_frame(String const&) { }
-    virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(String const&) const { return {}; }
+    virtual void request_new_process_for_child_frame_navigation(HTML::NavigableId, URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
+    virtual void page_did_create_child_frame(HTML::NavigableId, HTML::NavigableId) { }
+    virtual void page_did_update_child_frame_viewport(HTML::NavigableId, CSSPixelRect) { }
+    virtual void page_did_commit_child_frame_navigation(HTML::NavigableId, URL::URL const&) { }
+    virtual void page_did_destroy_child_frame(HTML::NavigableId) { }
+    virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(HTML::NavigableId) const { return {}; }
     virtual String dump_site_isolation_process_tree_for_testing() { return {}; }
     virtual Gfx::Palette palette() const = 0;
     virtual DevicePixelRect screen_rect() const = 0;
@@ -468,6 +470,10 @@ public:
     {
         if (page_presentation_registration == Compositor::PagePresentationRegistration::Yes)
             return Compositor::compositor_context_id_for_page(id());
+        VERIFY_NOT_REACHED();
+    }
+    virtual HTML::NavigableId allocate_navigable_id()
+    {
         VERIFY_NOT_REACHED();
     }
     virtual void request_frame() = 0;

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -87,6 +87,7 @@ public:
     GC::Weak<SVGDecodedImageData> m_svg_image_data;
 
     virtual u64 id() const override { VERIFY_NOT_REACHED(); }
+    virtual HTML::NavigableId allocate_navigable_id() override { return m_host_page->client().allocate_navigable_id(); }
     virtual Page& page() override { return *m_svg_page; }
     virtual Page const& page() const override { return *m_svg_page; }
     virtual bool is_connection_open() const override { return false; }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -583,13 +583,16 @@ void Application::open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML:
         open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
 }
 
-ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id)
+ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id, Optional<Web::HTML::NavigableId> root_navigable_id)
 {
     auto request_server_handle = TRY(connect_new_request_server_client(is_private));
     auto image_decoder_handle = TRY(connect_new_image_decoder_client());
 
-    auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id));
-    client->async_initialize(initial_page_id);
+    auto navigable_id_allocator = allocate_navigable_id_allocator();
+    auto root_id = root_navigable_id.value_or(navigable_id_allocator.allocate());
+
+    auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id, root_id));
+    client->async_initialize(initial_page_id, root_id, navigable_id_allocator);
     if (view.has_value())
         client->assign_view({}, *view);
 
@@ -604,6 +607,12 @@ u64 Application::allocate_page_id()
 {
     VERIFY(m_next_page_or_compositor_context_id > 0);
     return m_next_page_or_compositor_context_id++;
+}
+
+Web::HTML::NavigableIdAllocator Application::allocate_navigable_id_allocator()
+{
+    VERIFY(m_next_navigable_id_namespace > 0);
+    return Web::HTML::NavigableIdAllocator { .namespace_id = m_next_navigable_id_namespace++ };
 }
 
 PrivateBrowsingSession& Application::ensure_private_browsing_session()
@@ -815,10 +824,10 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process
     return create_web_content_client(view, IsPrivate::No, allocate_page_id());
 }
 
-ErrorOr<Application::ChildFrameWebContentProcess> Application::launch_child_frame_web_content_process(IsPrivate is_private)
+ErrorOr<Application::ChildFrameWebContentProcess> Application::launch_child_frame_web_content_process(IsPrivate is_private, Web::HTML::NavigableId root_navigable_id)
 {
     auto page_id = allocate_page_id();
-    auto client = TRY(create_web_content_client({}, is_private, page_id));
+    auto client = TRY(create_web_content_client({}, is_private, page_id, root_navigable_id));
     return ChildFrameWebContentProcess {
         .client = move(client),
         .page_id = page_id,

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -29,6 +29,7 @@
 #include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWebView/BookmarkStore.h>
 #include <LibWebView/FileDownloader.h>
 #include <LibWebView/Forward.h>
@@ -101,8 +102,9 @@ public:
         NonnullRefPtr<WebContentClient> client;
         u64 page_id { 0 };
     };
-    ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process(IsPrivate);
+    ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process(IsPrivate, Web::HTML::NavigableId root_navigable_id);
     u64 allocate_page_id();
+    Web::HTML::NavigableIdAllocator allocate_navigable_id_allocator();
 
     void maybe_close_private_browsing_session();
     void reset_private_browsing_session();
@@ -273,7 +275,7 @@ protected:
     Main::Arguments& arguments() { return m_arguments; }
 
 private:
-    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, IsPrivate, u64 initial_page_id);
+    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, IsPrivate, u64 initial_page_id, Optional<Web::HTML::NavigableId> root_navigable_id = {});
     PrivateBrowsingSession& ensure_private_browsing_session();
     ErrorOr<void> launch_services();
     void launch_spare_web_content_process();
@@ -399,6 +401,7 @@ private:
     RefPtr<WebContentClient> m_spare_web_content_process;
     bool m_has_queued_task_to_launch_spare_web_content_process { false };
     u64 m_next_page_or_compositor_context_id { 1 };
+    u64 m_next_navigable_id_namespace { 1 };
 
     RefPtr<Database::Database> m_database;
     RefPtr<Database::Database> m_history_database;

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -12,9 +12,9 @@
 
 namespace WebView {
 
-CanonicalNavigable::CanonicalNavigable(String id, String parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id)
-    : m_id(move(id))
-    , m_parent_id(move(parent_id))
+CanonicalNavigable::CanonicalNavigable(Web::HTML::NavigableId id, Optional<Web::HTML::NavigableId> parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id)
+    : m_id(id)
+    , m_parent_id(parent_id)
     , m_reporting_client(move(reporting_client))
     , m_reporting_page_id(reporting_page_id)
 {

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -17,6 +17,7 @@
 #include <AK/Vector.h>
 #include <AK/Weakable.h>
 #include <LibURL/URL.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/Export.h>
 #include <LibWebView/Forward.h>
@@ -37,13 +38,14 @@ public:
         Optional<u64> remote_page_id;
     };
 
-    CanonicalNavigable(String id, String parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id);
+    CanonicalNavigable(Web::HTML::NavigableId id, Optional<Web::HTML::NavigableId> parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id);
     virtual ~CanonicalNavigable();
 
     virtual bool is_top_level_traversable() const { return false; }
 
-    String const& id() const { return m_id; }
-    String const& parent_id() const { return m_parent_id; }
+    Web::HTML::NavigableId id() const { return m_id; }
+    Optional<Web::HTML::NavigableId> parent_id() const { return m_parent_id; }
+    void set_id(Web::HTML::NavigableId id) { m_id = id; }
 
     // The WebContent process and page whose document tree contains this frame. When the
     // frame is local, this process also hosts the frame's active document.
@@ -83,8 +85,8 @@ public:
     bool has_matching_pending_navigation(URL::URL const&, HostLocality) const;
 
 private:
-    String m_id;
-    String m_parent_id;
+    Web::HTML::NavigableId m_id;
+    Optional<Web::HTML::NavigableId> m_parent_id;
     RefPtr<WebContentClient> m_reporting_client;
     u64 m_reporting_page_id { 0 };
     CanonicalNavigable* m_parent { nullptr };

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -11,41 +11,41 @@
 namespace WebView {
 
 CanonicalTraversable::CanonicalTraversable()
-    : CanonicalNavigable(String {}, String {}, nullptr, 0)
+    : CanonicalNavigable({}, {}, nullptr, 0)
 {
 }
 
-CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, String parent_frame_id, String frame_id, CanonicalNavigable& fallback_parent)
+CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, CanonicalNavigable& fallback_parent)
 {
-    if (auto existing_navigable = find(page_id, frame_id); existing_navigable.has_value())
+    if (auto existing_navigable = find(frame_id); existing_navigable.has_value())
         remove(*existing_navigable);
 
-    auto navigable = make<CanonicalNavigable>(move(frame_id), move(parent_frame_id), &reporting_client, page_id);
+    auto navigable = make<CanonicalNavigable>(frame_id, parent_frame_id, &reporting_client, page_id);
 
     // A frame's parent frame is always created (and thus reported) before the frame
     // itself, so if the parent is not in the index, the parent is the top-level document
     // of the reporting page: the fallback parent.
     auto* parent = &fallback_parent;
-    if (auto indexed_parent = find(page_id, navigable->parent_id()); indexed_parent.has_value())
+    if (auto indexed_parent = find(parent_frame_id); indexed_parent.has_value())
         parent = &*indexed_parent;
 
     auto& navigable_ref = parent->append_child(move(navigable));
-    m_navigable_index.set(NavigableKey { page_id, navigable_ref.id() }, navigable_ref.make_weak_ptr());
+    m_navigable_index.set(navigable_ref.id(), navigable_ref.make_weak_ptr());
     return navigable_ref;
 }
 
-Optional<CanonicalNavigable&> CanonicalTraversable::find(u64 page_id, StringView frame_id)
+Optional<CanonicalNavigable&> CanonicalTraversable::find(Web::HTML::NavigableId frame_id)
 {
-    auto navigable = m_navigable_index.get(NavigableKey { page_id, MUST(String::from_utf8(frame_id)) });
+    auto navigable = m_navigable_index.get(frame_id);
     if (!navigable.has_value() || !navigable.value())
         return {};
 
     return *navigable.value();
 }
 
-Optional<CanonicalNavigable const&> CanonicalTraversable::find(u64 page_id, StringView frame_id) const
+Optional<CanonicalNavigable const&> CanonicalTraversable::find(Web::HTML::NavigableId frame_id) const
 {
-    auto navigable = m_navigable_index.get(NavigableKey { page_id, MUST(String::from_utf8(frame_id)) });
+    auto navigable = m_navigable_index.get(frame_id);
     if (!navigable.has_value() || !navigable.value())
         return {};
 
@@ -65,7 +65,7 @@ void CanonicalTraversable::remove(CanonicalNavigable& navigable)
 void CanonicalTraversable::remove_from_index(CanonicalNavigable& navigable)
 {
     navigable.for_each_in_inclusive_subtree([&](CanonicalNavigable& child) {
-        m_navigable_index.remove(NavigableKey { child.reporting_page_id(), child.id() });
+        m_navigable_index.remove(child.id());
         return IterationDecision::Continue;
     });
 }

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -205,20 +205,13 @@ struct PageLoadPreparation {
 class WEBVIEW_API CanonicalTraversable final
     : public CanonicalNavigable {
 public:
-    struct NavigableKey {
-        u64 page_id { 0 };
-        String frame_id;
-
-        bool operator==(NavigableKey const&) const = default;
-    };
-
     CanonicalTraversable();
 
     virtual bool is_top_level_traversable() const override { return true; }
 
-    CanonicalNavigable& insert(WebContentClient& reporting_client, u64 page_id, String parent_frame_id, String frame_id, CanonicalNavigable& fallback_parent);
-    Optional<CanonicalNavigable&> find(u64 page_id, StringView frame_id);
-    Optional<CanonicalNavigable const&> find(u64 page_id, StringView frame_id) const;
+    CanonicalNavigable& insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, CanonicalNavigable& fallback_parent);
+    Optional<CanonicalNavigable&> find(Web::HTML::NavigableId frame_id);
+    Optional<CanonicalNavigable const&> find(Web::HTML::NavigableId frame_id) const;
     void remove(CanonicalNavigable&);
 
     TraversableSessionHistory const& session_history() const { return m_session_history; }
@@ -267,7 +260,7 @@ private:
     WebContentSessionHistoryUpdateResult update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot, URL::URL const& current_url);
     WebContentSessionHistoryUpdateResult adopt_web_content_session_history_after_rejected_seed(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
 
-    HashMap<NavigableKey, WeakPtr<CanonicalNavigable>> m_navigable_index;
+    HashMap<Web::HTML::NavigableId, WeakPtr<CanonicalNavigable>> m_navigable_index;
     TraversableSessionHistory m_session_history;
     Web::HTML::VisibilityState m_system_visibility_state { Web::HTML::VisibilityState::Hidden };
     bool m_current_web_content_session_history_matches_mirror { false };
@@ -276,18 +269,6 @@ private:
     u64 m_next_traverse_history_step_cancelation_check_request_id { 0 };
     Optional<URL::URL> m_session_history_entry_url_loading_from_ui_process;
     PendingWebContentSessionHistorySeed m_pending_web_content_session_history_seed;
-};
-
-}
-
-namespace AK {
-
-template<>
-struct Traits<WebView::CanonicalTraversable::NavigableKey> : public DefaultTraits<WebView::CanonicalTraversable::NavigableKey> {
-    static unsigned hash(WebView::CanonicalTraversable::NavigableKey const& key)
-    {
-        return pair_int_hash(Traits<u64>::hash(key.page_id), key.frame_id.hash());
-    }
 };
 
 }

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -82,7 +82,7 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate is_private, u64 initial_page_id)
+ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate is_private, u64 initial_page_id, Web::HTML::NavigableId root_navigable_id)
 {
     auto const& browser_options = WebView::Application::browser_options();
     auto const& web_content_options = WebView::Application::web_content_options();
@@ -142,7 +142,7 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsP
         arguments.append("--mach-server-name"sv);
         arguments.append(server.value());
     }
-    return launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), is_private, initial_page_id);
+    return launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), is_private, initial_page_id, root_navigable_id);
 }
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process()

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -12,6 +12,7 @@
 #include <LibImageDecoderClient/Client.h>
 #include <LibRequests/RequestClient.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/WebContentClient.h>
@@ -19,7 +20,7 @@
 
 namespace WebView {
 
-WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate, u64 initial_page_id);
+WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate, u64 initial_page_id, Web::HTML::NavigableId root_navigable_id);
 
 WEBVIEW_API ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process();
 WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process();

--- a/Libraries/LibWebView/HistoryDebug.cpp
+++ b/Libraries/LibWebView/HistoryDebug.cpp
@@ -108,7 +108,7 @@ static JsonArray history_json_nested_histories(Vector<Web::HTML::SessionHistoryN
             serialized_entries.must_append(history_json_entry(entry));
 
         JsonObject serialized_nested_history;
-        serialized_nested_history.set("id"sv, nested_history.id);
+        serialized_nested_history.set("id"sv, MUST(String::formatted("{}", nested_history.id)));
         serialized_nested_history.set("entries"sv, move(serialized_entries));
         serialized_nested_histories.must_append(move(serialized_nested_history));
     }

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -30,7 +30,7 @@ static URL::URL embedding_page_url_for_child_frame_navigation(CanonicalNavigable
     return fallback_url;
 }
 
-Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(WebContentClient& parent_client, u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
+Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(WebContentClient& parent_client, u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
 {
     Optional<CanonicalNavigable&> child_frame;
     if (target == Web::NavigationTarget::IFrame && frame_id.has_value())
@@ -163,7 +163,7 @@ HashMap<pid_t, pid_t> SiteIsolationManager::remote_frame_process_embedders() con
     return embedders;
 }
 
-void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)
+void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::NavigableId frame_id, NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)
 {
     auto child_frame = parent_client.child_frame(page_id, frame_id);
     if (!child_frame.has_value())

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -29,9 +29,9 @@ public:
         Web::DevicePixelRect viewport_rect;
     };
 
-    Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
+    Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
 
-    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, StringView frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
+    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::NavigableId frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
     void transition_child_frame_to_local(CanonicalNavigable&);
 
     void remove_child_frame_subtree(CanonicalNavigable&);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -73,10 +73,11 @@ static bool is_download_in_progress(FileDownloader const& file_downloader, u64 d
     return download.has_value() && download->status == FileDownloader::DownloadStatus::InProgress;
 }
 
-WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, IsPrivate is_private, u64 initial_page_id)
+WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, IsPrivate is_private, u64 initial_page_id, Web::HTML::NavigableId root_navigable_id)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
     , m_is_private(is_private)
     , m_initial_page_id(initial_page_id)
+    , m_root_navigable_id(root_navigable_id)
 {
     VERIFY(m_initial_page_id > 0);
     clients().set(this);
@@ -163,6 +164,7 @@ void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
     VERIFY(m_views.is_empty());
     VERIFY(view.is_private() == m_is_private);
     view.m_client_state.page_index = m_initial_page_id;
+    view.traversable().set_id(m_root_navigable_id);
     m_views.set(m_initial_page_id, view);
 }
 
@@ -274,13 +276,13 @@ CanonicalNavigable* WebContentClient::navigable_for_page(u64 page_id)
     return nullptr;
 }
 
-Optional<CanonicalNavigable&> WebContentClient::child_frame(u64 page_id, StringView frame_id)
+Optional<CanonicalNavigable&> WebContentClient::child_frame(u64 page_id, Web::HTML::NavigableId frame_id)
 {
     auto* host = navigable_for_page(page_id);
     if (!host)
         return {};
 
-    return host->top_level_traversable().find(page_id, frame_id);
+    return host->top_level_traversable().find(frame_id);
 }
 
 void WebContentClient::close_server_if_unused()
@@ -475,12 +477,12 @@ void WebContentClient::did_request_new_process_for_navigation(u64 page_id, URL::
         view->create_new_process_for_cross_site_navigation(url, move(document_resource), history_handling);
 }
 
-Messages::WebContentClient::DecideNavigationProcessResponse WebContentClient::decide_navigation_process(u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
+Messages::WebContentClient::DecideNavigationProcessResponse WebContentClient::decide_navigation_process(u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
 {
     return SiteIsolationManager::the().decide_navigation_process(*this, page_id, move(frame_id), move(current_url), move(target_url), target);
 }
 
-void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 page_id, String frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
@@ -488,7 +490,7 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
     if (!child_frame->has_matching_pending_navigation(url, CanonicalNavigable::HostLocality::Remote))
         return;
 
-    auto remote_process_or_error = Application::the().launch_child_frame_web_content_process(m_is_private);
+    auto remote_process_or_error = Application::the().launch_child_frame_web_content_process(m_is_private, frame_id);
     if (remote_process_or_error.is_error()) {
         warnln("Unable to create WebContent process for child frame navigation: {}", remote_process_or_error.error());
         child_frame->clear_pending_navigation();
@@ -514,7 +516,7 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
     SiteIsolationManager::the().transition_child_frame_to_remote(*this, page_id, frame_id, move(remote_client), remote_page_id);
 }
 
-void WebContentClient::did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id)
+void WebContentClient::did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id)
 {
     auto* host = navigable_for_page(page_id);
     if (!host)
@@ -523,13 +525,13 @@ void WebContentClient::did_create_child_frame(u64 page_id, String parent_frame_i
     host->top_level_traversable().insert(*this, page_id, move(parent_frame_id), move(frame_id), *host);
 }
 
-void WebContentClient::did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
+void WebContentClient::did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
 {
     if (auto child_frame = this->child_frame(page_id, frame_id); child_frame.has_value())
         child_frame->set_viewport(viewport_rect, device_pixel_ratio);
 }
 
-void WebContentClient::did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url)
+void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
@@ -541,7 +543,7 @@ void WebContentClient::did_commit_child_frame_navigation(u64 page_id, String fra
     child_frame->did_commit_navigation(move(url));
 }
 
-void WebContentClient::did_destroy_child_frame(u64 page_id, String frame_id)
+void WebContentClient::did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id)
 {
     if (auto child_frame = this->child_frame(page_id, frame_id); child_frame.has_value())
         SiteIsolationManager::the().remove_child_frame_subtree(*child_frame);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -29,6 +29,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -61,7 +62,7 @@ public:
     static size_t client_count() { return clients().size(); }
     static Optional<WebContentClient&> client_for_compositor_context_id(Web::Compositor::CompositorContextId);
 
-    WebContentClient(NonnullOwnPtr<IPC::Transport>, IsPrivate, u64 initial_page_id);
+    WebContentClient(NonnullOwnPtr<IPC::Transport>, IsPrivate, u64 initial_page_id, Web::HTML::NavigableId root_navigable_id);
     ~WebContentClient();
 
     IsPrivate is_private() const { return m_is_private; }
@@ -83,7 +84,7 @@ public:
     CanonicalNavigable* embedded_page_host(u64 page_id);
     CanonicalNavigable* navigable_for_page(u64 page_id);
 
-    Optional<CanonicalNavigable&> child_frame(u64 page_id, StringView frame_id);
+    Optional<CanonicalNavigable&> child_frame(u64 page_id, Web::HTML::NavigableId frame_id);
 
     bool has_views() const { return !m_views.is_empty(); }
 
@@ -117,13 +118,13 @@ private:
 
     virtual Messages::WebContentClient::AllocateCompositorContextIdResponse allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration) override;
     virtual void did_destroy_compositor_context(Web::Compositor::CompositorContextId) override;
-    virtual Messages::WebContentClient::DecideNavigationProcessResponse decide_navigation_process(u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget) override;
+    virtual Messages::WebContentClient::DecideNavigationProcessResponse decide_navigation_process(u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget) override;
     virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
-    virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, String frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
-    virtual void did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id) override;
-    virtual void did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
-    virtual void did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url) override;
-    virtual void did_destroy_child_frame(u64 page_id, String frame_id) override;
+    virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
+    virtual void did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id) override;
+    virtual void did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
+    virtual void did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url) override;
+    virtual void did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) override;
     virtual void did_start_webdriver_navigation(u64 page_id, URL::URL url) override;
     virtual void did_finish_loading(u64 page_id, URL::URL) override;
     virtual void did_request_refresh(u64 page_id) override;
@@ -270,6 +271,7 @@ private:
     HashMap<u64, String> m_history_recorded_urls_for_current_load;
     Optional<i32> m_compositor_connection_id;
     u64 m_initial_page_id { 0 };
+    Web::HTML::NavigableId m_root_navigable_id;
 
     ProcessHandle m_process_handle;
     RefPtr<Core::Timer> m_detached_page_close_timer;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -119,9 +119,9 @@ Messages::WebContentServer::InitTransportResponse ConnectionFromClient::init_tra
     VERIFY_NOT_REACHED();
 }
 
-void ConnectionFromClient::initialize(u64 initial_page_id)
+void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator navigable_id_allocator)
 {
-    m_page_host->initialize(initial_page_id);
+    m_page_host->initialize(initial_page_id, root_navigable_id, navigable_id_allocator);
 }
 
 void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id)
@@ -136,13 +136,13 @@ void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Co
     compositor_context.set_parent_context(parent_context_id);
 }
 
-void ConnectionFromClient::set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
+void ConnectionFromClient::set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::NavigableId frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->set_remote_child_frame_compositor_context(move(frame_id), context_id);
+        page->set_remote_child_frame_compositor_context(frame_id, context_id);
 }
 
-void ConnectionFromClient::run_iframe_load_event_steps(u64 page_id, String frame_id)
+void ConnectionFromClient::run_iframe_load_event_steps(u64 page_id, Web::HTML::NavigableId frame_id)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->run_iframe_load_event_steps(frame_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -71,7 +71,7 @@ private:
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;
 
     virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
-    virtual void initialize(u64 initial_page_id) override;
+    virtual void initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator navigable_id_allocator) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
     virtual void set_window_handle(u64 page_id, String handle) override;
@@ -92,9 +92,9 @@ private:
     virtual void load_html_with_url(u64 page_id, ByteString, URL::URL) override;
     virtual void reload(u64 page_id) override;
     virtual void cancel_download(u64 page_id, u64 download_id) override;
-    virtual void run_iframe_load_event_steps(u64 page_id, String frame_id) override;
+    virtual void run_iframe_load_event_steps(u64 page_id, Web::HTML::NavigableId frame_id) override;
     virtual void set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId>) override;
-    virtual void set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId>) override;
+    virtual void set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::NavigableId frame_id, Optional<Web::Compositor::CompositorContextId>) override;
     virtual void traverse_the_history_to_step(u64 page_id, i32 step) override;
     virtual void check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) override;
     virtual void set_top_level_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, size_t current_top_level_entry_index, bool allow_reconstructing_current_entry) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -95,15 +95,16 @@ void PageClient::set_should_report_session_history_updates_in_test_mode(bool sho
     s_should_report_session_history_updates_in_test_mode = should_report;
 }
 
-GC::Ref<PageClient> PageClient::create(JS::VM& vm, PageHost& page_host, u64 id)
+GC::Ref<PageClient> PageClient::create(JS::VM& vm, PageHost& page_host, u64 id, Optional<Web::HTML::NavigableId> pending_root_navigable_id)
 {
-    return vm.heap().allocate<PageClient>(page_host, id);
+    return vm.heap().allocate<PageClient>(page_host, id, pending_root_navigable_id);
 }
 
-PageClient::PageClient(PageHost& owner, u64 id)
+PageClient::PageClient(PageHost& owner, u64 id, Optional<Web::HTML::NavigableId> pending_root_navigable_id)
     : m_owner(owner)
     , m_page(Web::Page::create(Web::Bindings::main_thread_vm(), *this))
     , m_id(id)
+    , m_pending_root_navigable_id(pending_root_navigable_id)
 {
     m_page->set_async_scrolling_enabled(s_async_scrolling_enabled);
     setup_palette();
@@ -186,7 +187,18 @@ bool PageClient::is_connection_open() const
     return client().is_open();
 }
 
-Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target, Optional<String> frame_id) const
+Web::HTML::NavigableId PageClient::allocate_navigable_id()
+{
+    if (m_pending_root_navigable_id.has_value()) {
+        auto id = *m_pending_root_navigable_id;
+        m_pending_root_navigable_id.clear();
+        return id;
+    }
+
+    return m_owner.allocate_navigable_id();
+}
+
+Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target, Optional<Web::HTML::NavigableId> frame_id) const
 {
     if (target != Web::NavigationTarget::TopLevel)
         return client().decide_navigation_process(m_id, move(frame_id), current_url, target_url, target);
@@ -204,47 +216,47 @@ void PageClient::request_new_process_for_navigation(URL::URL const& url, Variant
     client().async_did_request_new_process_for_navigation(m_id, url, move(document_resource), history_handling);
 }
 
-void PageClient::request_new_process_for_child_frame_navigation(String const& frame_id, URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void PageClient::request_new_process_for_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
     client().async_did_request_new_process_for_child_frame_navigation(m_id, frame_id, url, move(document_resource), history_handling);
 }
 
-void PageClient::page_did_create_child_frame(String const& parent_frame_id, String const& frame_id)
+void PageClient::page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id)
 {
     client().async_did_create_child_frame(m_id, parent_frame_id, frame_id);
 }
 
-void PageClient::page_did_update_child_frame_viewport(String const& frame_id, Web::CSSPixelRect viewport_rect)
+void PageClient::page_did_update_child_frame_viewport(Web::HTML::NavigableId frame_id, Web::CSSPixelRect viewport_rect)
 {
     client().async_did_update_child_frame_viewport(m_id, frame_id, page().css_to_device_rect(viewport_rect), page().client().device_pixel_ratio());
 }
 
-void PageClient::page_did_commit_child_frame_navigation(String const& frame_id, URL::URL const& url)
+void PageClient::page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const& url)
 {
     client().async_did_commit_child_frame_navigation(m_id, frame_id, url);
 }
 
-void PageClient::page_did_destroy_child_frame(String const& frame_id)
+void PageClient::page_did_destroy_child_frame(Web::HTML::NavigableId frame_id)
 {
     m_remote_child_frame_compositor_contexts.remove(frame_id);
     client().async_did_destroy_child_frame(m_id, frame_id);
 }
 
-void PageClient::set_remote_child_frame_compositor_context(String frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
+void PageClient::set_remote_child_frame_compositor_context(Web::HTML::NavigableId frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
 {
     if (context_id.has_value())
-        m_remote_child_frame_compositor_contexts.set(move(frame_id), *context_id);
+        m_remote_child_frame_compositor_contexts.set(frame_id, *context_id);
     else
         m_remote_child_frame_compositor_contexts.remove(frame_id);
     request_frame();
 }
 
-Optional<Web::Compositor::CompositorContextId> PageClient::compositor_context_id_for_remote_child_frame(String const& frame_id) const
+Optional<Web::Compositor::CompositorContextId> PageClient::compositor_context_id_for_remote_child_frame(Web::HTML::NavigableId frame_id) const
 {
     return m_remote_child_frame_compositor_contexts.get(frame_id);
 }
 
-void PageClient::run_iframe_load_event_steps(String const& frame_id)
+void PageClient::run_iframe_load_event_steps(Web::HTML::NavigableId frame_id)
 {
     auto active_document = page().top_level_traversable()->active_document();
     if (!active_document)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/Page/Page.h>
@@ -33,7 +34,7 @@ class PageClient final : public Web::PageClient {
     GC_DECLARE_ALLOCATOR(PageClient);
 
 public:
-    static GC::Ref<PageClient> create(JS::VM& vm, PageHost& page_host, u64 id);
+    static GC::Ref<PageClient> create(JS::VM& vm, PageHost& page_host, u64 id, Optional<Web::HTML::NavigableId> pending_root_navigable_id = {});
 
     virtual ~PageClient() override;
 
@@ -56,6 +57,7 @@ public:
     virtual void did_handle_input_event(u64 page_id, Web::InputEvent const&) override;
     virtual void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled) override;
     virtual Web::Compositor::CompositorContextId allocate_compositor_context_id(Web::Compositor::PagePresentationRegistration) override;
+    virtual Web::HTML::NavigableId allocate_navigable_id() override;
 
     void set_palette_impl(Gfx::PaletteImpl&);
     void set_viewport(Web::DevicePixelSize const&, double device_pixel_ratio);
@@ -130,8 +132,8 @@ public:
     void send_current_needs_beforeunload_check();
     void wait_for_webdriver_navigation_completion(Optional<u64> page_load_timeout, Function<void(Web::WebDriver::Response)>);
     void did_complete_webdriver_navigation_completion(u64 request_id, Web::WebDriver::Response);
-    void run_iframe_load_event_steps(String const& frame_id);
-    void set_remote_child_frame_compositor_context(String, Optional<Web::Compositor::CompositorContextId>);
+    void run_iframe_load_event_steps(Web::HTML::NavigableId);
+    void set_remote_child_frame_compositor_context(Web::HTML::NavigableId, Optional<Web::Compositor::CompositorContextId>);
     void cancel_download(u64 download_id);
     void clear_pending_dom_mutations();
     void did_delete_all_cookies(u64 request_id);
@@ -142,20 +144,20 @@ private:
         WebView::Mutation mutation;
     };
 
-    PageClient(PageHost&, u64 id);
+    PageClient(PageHost&, u64 id, Optional<Web::HTML::NavigableId>);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
     // ^PageClient
     virtual bool is_connection_open() const override;
-    virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget, Optional<String> frame_id) const override;
+    virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget, Optional<Web::HTML::NavigableId> frame_id) const override;
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
-    virtual void request_new_process_for_child_frame_navigation(String const& frame_id, URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
-    virtual void page_did_create_child_frame(String const& parent_frame_id, String const& frame_id) override;
-    virtual void page_did_update_child_frame_viewport(String const& frame_id, Web::CSSPixelRect) override;
-    virtual void page_did_commit_child_frame_navigation(String const& frame_id, URL::URL const&) override;
-    virtual void page_did_destroy_child_frame(String const& frame_id) override;
-    virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(String const&) const override;
+    virtual void request_new_process_for_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
+    virtual void page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id) override;
+    virtual void page_did_update_child_frame_viewport(Web::HTML::NavigableId frame_id, Web::CSSPixelRect) override;
+    virtual void page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const&) override;
+    virtual void page_did_destroy_child_frame(Web::HTML::NavigableId frame_id) override;
+    virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(Web::HTML::NavigableId) const override;
     virtual String dump_site_isolation_process_tree_for_testing() override;
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_all_screen_rects[m_main_screen_index]; }
@@ -309,7 +311,8 @@ private:
     RefPtr<Core::Timer> m_frame_timer;
     Optional<double> m_last_frame_dispatch_time;
     Queue<PendingDOMMutation> m_pending_dom_mutations;
-    HashMap<String, Web::Compositor::CompositorContextId> m_remote_child_frame_compositor_contexts;
+    HashMap<Web::HTML::NavigableId, Web::Compositor::CompositorContextId> m_remote_child_frame_compositor_contexts;
+    Optional<Web::HTML::NavigableId> m_pending_root_navigable_id;
 
     u64 m_devtools_client_count { 0 };
 };

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -23,19 +23,26 @@ PageHost::PageHost(ConnectionFromClient& client)
 {
 }
 
-void PageHost::initialize(u64 initial_page_id)
+void PageHost::initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator navigable_id_allocator)
 {
     VERIFY(m_pages.is_empty());
-    auto& first_page = create_page(initial_page_id);
+    m_navigable_id_allocator = navigable_id_allocator;
+    auto& first_page = create_page(initial_page_id, root_navigable_id);
     Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank());
 }
 
-PageClient& PageHost::create_page(u64 page_id)
+PageClient& PageHost::create_page(u64 page_id, Optional<Web::HTML::NavigableId> pending_root_navigable_id)
 {
     VERIFY(page_id > 0);
     VERIFY(!m_pages.contains(page_id));
-    m_pages.set(page_id, PageClient::create(Web::Bindings::main_thread_vm(), *this, page_id));
+    m_pages.set(page_id, PageClient::create(Web::Bindings::main_thread_vm(), *this, page_id, pending_root_navigable_id));
     return *m_pages.get(page_id).value();
+}
+
+Web::HTML::NavigableId PageHost::allocate_navigable_id()
+{
+    VERIFY(m_navigable_id_allocator.has_value());
+    return m_navigable_id_allocator->allocate();
 }
 
 void PageHost::remove_page(Badge<PageClient>, u64 page_id)

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -13,6 +13,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <LibGC/Root.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <WebContent/Forward.h>
 
 namespace Web {
@@ -35,10 +36,11 @@ public:
     static NonnullOwnPtr<PageHost> create(ConnectionFromClient& client) { return adopt_own(*new PageHost(client)); }
     virtual ~PageHost();
 
-    void initialize(u64 initial_page_id);
+    void initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator);
     Optional<PageClient&> page(u64 page_id);
-    PageClient& create_page(u64 page_id);
+    PageClient& create_page(u64 page_id, Optional<Web::HTML::NavigableId> pending_root_navigable_id = {});
     void remove_page(Badge<PageClient>, u64 page_id);
+    Web::HTML::NavigableId allocate_navigable_id();
 
     ConnectionFromClient& client() const { return m_client; }
     void ensure_compositor_host();
@@ -53,6 +55,7 @@ private:
     ConnectionFromClient& m_client;
     OwnPtr<Web::Compositor::CompositorHost> m_compositor_host;
     HashMap<u64, GC::Root<PageClient>> m_pages;
+    Optional<Web::HTML::NavigableIdAllocator> m_navigable_id_allocator;
 };
 
 }

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -21,6 +21,7 @@
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -44,13 +45,13 @@ endpoint WebContentClient
     allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
     did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
 
-    decide_navigation_process(u64 page_id, Optional<String> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target) => (Web::NavigationProcessDecision decision)
+    decide_navigation_process(u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target) => (Web::NavigationProcessDecision decision)
     did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
-    did_request_new_process_for_child_frame_navigation(u64 page_id, String frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
-    did_create_child_frame(u64 page_id, String parent_frame_id, String frame_id) =|
-    did_update_child_frame_viewport(u64 page_id, String frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
-    did_commit_child_frame_navigation(u64 page_id, String frame_id, URL::URL url) =|
-    did_destroy_child_frame(u64 page_id, String frame_id) =|
+    did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
+    did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id) =|
+    did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
+    did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url) =|
+    did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) =|
     did_start_webdriver_navigation(u64 page_id, URL::URL url) =|
     did_start_loading(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     did_cancel_loading(u64 page_id, URL::URL url) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -15,6 +15,7 @@
 #include <LibWeb/HTML/AutoplayPolicy.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/VisibilityState.h>
@@ -34,7 +35,7 @@
 endpoint WebContentServer
 {
     init_transport(int peer_pid) => (int peer_pid)
-    initialize(u64 initial_page_id) =|
+    initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator navigable_id_allocator) =|
     close_server() =|
 
     get_window_handle(u64 page_id) => (String handle)
@@ -60,9 +61,9 @@ endpoint WebContentServer
     load_html_with_url(u64 page_id, ByteString html, URL::URL url) =|
     reload(u64 page_id) =|
     cancel_download(u64 page_id, u64 download_id) =|
-    run_iframe_load_event_steps(u64 page_id, String frame_id) =|
+    run_iframe_load_event_steps(u64 page_id, Web::HTML::NavigableId frame_id) =|
     set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id) =|
-    set_remote_child_frame_compositor_context(u64 page_id, String frame_id, Optional<Web::Compositor::CompositorContextId> context_id) =|
+    set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::NavigableId frame_id, Optional<Web::Compositor::CompositorContextId> context_id) =|
     traverse_the_history_to_step(u64 page_id, i32 step) =|
     check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) =|
     set_top_level_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries,

--- a/Tests/LibWeb/TestSessionHistoryEntry.cpp
+++ b/Tests/LibWeb/TestSessionHistoryEntry.cpp
@@ -7,7 +7,13 @@
 #include <LibJS/Runtime/VM.h>
 #include <LibTest/TestCase.h>
 #include <LibURL/Parser.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
+
+static Web::HTML::NavigableId frame_1_id()
+{
+    return { 1, 1 };
+}
 
 static URL::URL parse_url(StringView url)
 {
@@ -31,7 +37,7 @@ TEST_CASE(post_load_seed_match_allows_ui_owned_nested_histories)
     nested_entry.step = 1;
     nested_entry.url = parse_url("https://frame.example/"sv);
     seed_descriptor.document_state.nested_histories.append({
-        .id = MUST(String::from_utf8("frame-1"sv)),
+        .id = frame_1_id(),
         .entries = { move(nested_entry) },
     });
 
@@ -50,7 +56,7 @@ TEST_CASE(descriptor_creation_preserves_nested_history_with_only_pending_entries
     pending_child_entry->set_document_state(Web::HTML::DocumentState::create());
 
     top_level_document_state->nested_histories().append({
-        .id = MUST(String::from_utf8("frame-1"sv)),
+        .id = frame_1_id(),
         .entries = { pending_child_entry },
     });
 
@@ -63,6 +69,6 @@ TEST_CASE(descriptor_creation_preserves_nested_history_with_only_pending_entries
     auto descriptor = Web::HTML::create_session_history_entry_descriptor(top_level_entry, creation_state);
 
     EXPECT_EQ(descriptor.document_state.nested_histories.size(), 1u);
-    EXPECT_EQ(descriptor.document_state.nested_histories[0].id, "frame-1"sv);
+    EXPECT_EQ(descriptor.document_state.nested_histories[0].id, frame_1_id());
     EXPECT(descriptor.document_state.nested_histories[0].entries.is_empty());
 }

--- a/Tests/LibWebView/TestSessionHistory.cpp
+++ b/Tests/LibWebView/TestSessionHistory.cpp
@@ -6,13 +6,25 @@
 
 #include <LibTest/TestCase.h>
 #include <LibURL/Parser.h>
+#include <LibWeb/HTML/NavigableId.h>
 #include <LibWebView/HistoryDebug.h>
 #include <LibWebView/SessionHistory.h>
+
+static Web::HTML::NavigableId navigable_id(StringView id)
+{
+    if (id == "frame-1"sv)
+        return { 1, 1 };
+    if (id == "frame"sv)
+        return { 1, 2 };
+    if (id == "1"sv)
+        return { 2, 1 };
+    VERIFY_NOT_REACHED();
+}
 
 static Web::HTML::SessionHistoryNestedHistoryDescriptor nested_history(StringView id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries)
 {
     return {
-        .id = MUST(String::from_utf8(id)),
+        .id = navigable_id(id),
         .entries = move(entries),
     };
 }
@@ -203,7 +215,7 @@ static void expect_step_to_restore(Optional<i32> step, i32 expected_step)
 static void expect_nested_history(Web::HTML::SessionHistoryEntryDescriptor const& entry, size_t index, StringView expected_id, size_t expected_size)
 {
     VERIFY(index < entry.document_state.nested_histories.size());
-    EXPECT_EQ(entry.document_state.nested_histories[index].id, MUST(String::from_utf8(expected_id)));
+    EXPECT_EQ(entry.document_state.nested_histories[index].id, navigable_id(expected_id));
     EXPECT_EQ(entry.document_state.nested_histories[index].entries.size(), expected_size);
 }
 
@@ -1640,7 +1652,7 @@ TEST_CASE(history_log_entries_marks_current_entries_steps_and_reload_pending)
     EXPECT_EQ(history_log_entries(history), ByteString { "entries=[0:0:https://a.example/, *1:1:https://b.example/ "
                                                          "document_state={id=0, resource=post}, 2:2:https://c.example/ "
                                                          "document_state={id=1, reload_pending=true, target_name=main} "
-                                                         "nested={frame=[3:https://frame.example/]}] "
+                                                         "nested={1:2=[3:https://frame.example/]}] "
                                                          "used_steps=[0:0, *1:1, 2:2, 3:3]"sv });
 
     auto current_entry = history.current_entry();
@@ -1672,7 +1684,7 @@ TEST_CASE(history_log_entries_marks_nested_histories)
 
     EXPECT_EQ(history_log_entries(history), ByteString { "entries=[0:0:https://a.example/, *1:1:https://b.example/ "
                                                          "document_state={id=1, target_name=main} "
-                                                         "nested={frame=[2:https://frame.example/]}] "
+                                                         "nested={1:2=[2:https://frame.example/]}] "
                                                          "used_steps=[0:0, 1:1, *2:2]"sv });
 }
 


### PR DESCRIPTION
Introduce a typed NavigableId made from a UI-assigned namespace and a process local counter, and use it instead of string frame IDs for navigables, nested session history, and child frame IPC.

This gives the UI process a ID for a navigable even when its backing WebContent process changes. That is needed for site isolation as an iframe that moves into a remote process must keep the same child navigable ID, while the new WebContent process still needs to allocate fresh descendant IDs without synchronous IPC.

The UI process now creates a NavigableIdAllocator for each WebContent process and passes both the allocator and the process root navigable ID during initialization. For normal top-level pages the root ID is freshly allocated; for remote child-frame processes it is the existing child frame's ID.

CanonicalTraversable is keyed by NavigableId alone, allowing the same logical navigable to survive page/process chang