### PR TITLE
LibWeb: Cache rasterizations of nested display lists in the Skia player

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -1027,11 +1027,74 @@ void DisplayListPlayerSkia::play_command(AddRoundedRectClip const& command)
 void DisplayListPlayerSkia::play_command(PaintNestedDisplayList const& command)
 {
     auto& canvas = surface().canvas();
+    auto const& nested_display_list = resource_storage().display_list_resource(command.display_list_id);
+
+    // Nested display lists (used for SVG images and mask contents) are immutable and are replayed with identical
+    // commands on every compositor frame between content updates; some carry huge command streams (thousands of
+    // paths, dozens of layers) and can be far larger than the viewport. Rasterize a list into an offscreen surface
+    // and reuse the snapshot, instead of re-encoding the entire vector command stream on every frame. Each list
+    // keeps a small set of rasters in the per-client resource storage, keyed by display list id and removed
+    // together with the display list itself; the same list can be painted at several places in one frame (repeated
+    // SVG images, atlases), and each place then hits its own raster. Only draw from the cache when the canvas
+    // transform is an integer translation, so the cached raster is pixel-identical to replaying the commands.
+    // Lists that are painted for the first time or whose blending could read page content painted underneath them
+    // replay directly (see should_cache_nested_display_list_raster).
+    auto total_matrix = canvas.getTotalMatrix();
+    bool is_integer_translation = total_matrix.isTranslate()
+        && total_matrix.getTranslateX() == SkScalarFloorToScalar(total_matrix.getTranslateX())
+        && total_matrix.getTranslateY() == SkScalarFloorToScalar(total_matrix.getTranslateY());
+
+    if (m_skia_backend_context && is_integer_translation && !command.rect.is_empty()) {
+        auto device_clip_bounds = canvas.getDeviceClipBounds();
+        auto translation = Gfx::IntPoint { static_cast<int>(total_matrix.getTranslateX()), static_cast<int>(total_matrix.getTranslateY()) };
+        auto clip_in_local_space = Gfx::IntRect { device_clip_bounds.x(), device_clip_bounds.y(), device_clip_bounds.width(), device_clip_bounds.height() }.translated(-translation);
+        auto visible_rect = command.rect.intersected(clip_in_local_space);
+        if (visible_rect.is_empty())
+            return;
+
+        auto visible_rect_in_list_space = visible_rect.translated(-command.rect.location());
+        Gfx::IntRect raster_rect;
+        auto cached_image = resource_storage().cached_nested_display_list_raster(command.display_list_id, m_skia_backend_context, visible_rect_in_list_space, raster_rect);
+        if (!cached_image && resource_storage().should_cache_nested_display_list_raster(command.display_list_id)) {
+            // Small lists are rasterized whole, so lists painted as many little slices (atlases, repeated
+            // images) hit one raster for every slice. Larger lists are rasterized at the visible portion.
+            auto list_bounds = Gfx::IntRect { {}, command.rect.size() };
+            constexpr size_t max_full_list_raster_bytes = 16 * MiB;
+            constexpr int max_full_list_raster_dimension = 16384;
+            auto full_list_bytes = static_cast<size_t>(list_bounds.width()) * list_bounds.height() * 4;
+            bool rasterize_whole_list = full_list_bytes <= max_full_list_raster_bytes
+                && list_bounds.width() <= max_full_list_raster_dimension
+                && list_bounds.height() <= max_full_list_raster_dimension;
+            auto raster_candidate_rect = rasterize_whole_list ? list_bounds : visible_rect_in_list_space;
+            constexpr size_t max_raster_bytes = 128 * MiB;
+            if (static_cast<size_t>(raster_candidate_rect.width()) * raster_candidate_rect.height() * 4 <= max_raster_bytes) {
+                auto offscreen_surface = Gfx::PaintingSurface::create_with_size(
+                    raster_candidate_rect.size(), Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_skia_backend_context);
+                offscreen_surface->canvas().clear(SK_ColorTRANSPARENT);
+                offscreen_surface->canvas().translate(-raster_candidate_rect.x(), -raster_candidate_rect.y());
+                execute_display_list_into_surface(
+                    *nested_display_list.display_list, nested_display_list.visual_context_tree, *offscreen_surface);
+                offscreen_surface->canvas().resetMatrix();
+                auto image = offscreen_surface->sk_surface().makeImageSnapshot();
+                if (image) {
+                    resource_storage().add_cached_nested_display_list_raster(command.display_list_id, m_skia_backend_context, raster_candidate_rect, image);
+                    cached_image = move(image);
+                    raster_rect = raster_candidate_rect;
+                }
+            }
+        }
+        if (cached_image) {
+            auto source_rect = visible_rect_in_list_space.translated(-raster_rect.location());
+            canvas.drawImageRect(cached_image.get(), to_skia_rect(source_rect), to_skia_rect(visible_rect),
+                SkSamplingOptions(), nullptr, SkCanvas::kStrict_SrcRectConstraint);
+            return;
+        }
+    }
+
     canvas.save();
     canvas.clipRect(to_skia_rect(command.rect));
     canvas.translate(command.rect.x(), command.rect.y());
     ScrollStateSnapshot scroll_state_snapshot;
-    auto const& nested_display_list = resource_storage().display_list_resource(command.display_list_id);
     execute_nested_display_list(
         *nested_display_list.display_list,
         nested_display_list.visual_context_tree,

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -42,6 +42,39 @@ struct DisplayListCachedSkiaImageResource {
     sk_sp<SkImage> image;
 };
 
+struct DisplayListCachedNestedRasterResource {
+    explicit DisplayListCachedNestedRasterResource(RefPtr<Gfx::SkiaBackendContext> skia_backend_context)
+        : skia_backend_context(move(skia_backend_context))
+    {
+    }
+
+    struct Raster {
+        Gfx::IntRect rect_in_list_space;
+        sk_sp<SkImage> image;
+        MonotonicTime last_used { MonotonicTime::now() };
+
+        size_t byte_size() const { return static_cast<size_t>(rect_in_list_space.width()) * rect_in_list_space.height() * 4; }
+    };
+
+    size_t total_byte_size() const
+    {
+        size_t total = 0;
+        for (auto const& raster : rasters)
+            total += raster.byte_size();
+        return total;
+    }
+
+    RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
+    Optional<bool> requires_direct_replay;
+    bool was_painted { false };
+
+    // The same display list can be painted at several places in one frame (repeated SVG images, atlas-style
+    // lists painted in many small slices), each with its own visible sub-rectangle, so a single list keeps a
+    // bounded set of rasters, most recently used first.
+    static constexpr size_t max_rasters = 32;
+    Vector<Raster> rasters;
+};
+
 static sk_sp<SkImage> create_skia_image(Gfx::DecodedImageFrame const& frame, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
 {
     auto raster_image = Gfx::sk_image_from_bitmap(frame.bitmap(), frame.color_space());
@@ -182,6 +215,151 @@ sk_sp<SkImage> DisplayListResourceStorage::cached_skia_image_for_display_list(Di
 void DisplayListResourceStorage::set_cached_skia_image_for_display_list(DisplayListResourceId id, Gfx::IntSize tile_size, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context, sk_sp<SkImage> image) const
 {
     m_display_list_cached_skia_images.set(id.value(), make<DisplayListCachedSkiaImageResource>(tile_size, skia_backend_context, move(image)));
+}
+
+sk_sp<SkImage> DisplayListResourceStorage::cached_nested_display_list_raster(DisplayListResourceId id, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context, Gfx::IntRect visible_rect_in_list_space, Gfx::IntRect& raster_rect_in_list_space) const
+{
+    auto cached_resource = m_display_list_cached_nested_rasters.find(id.value());
+    if (cached_resource == m_display_list_cached_nested_rasters.end())
+        return nullptr;
+
+    auto& resource = *cached_resource->value;
+    if (resource.skia_backend_context.ptr() != skia_backend_context.ptr())
+        return nullptr;
+
+    for (size_t i = 0; i < resource.rasters.size(); ++i) {
+        if (!resource.rasters[i].rect_in_list_space.contains(visible_rect_in_list_space))
+            continue;
+        if (i != 0) {
+            auto raster = move(resource.rasters[i]);
+            resource.rasters.remove(i);
+            resource.rasters.prepend(move(raster));
+        }
+        resource.rasters.first().last_used = MonotonicTime::now();
+        raster_rect_in_list_space = resource.rasters.first().rect_in_list_space;
+        return resource.rasters.first().image;
+    }
+    return {};
+}
+
+void DisplayListResourceStorage::add_cached_nested_display_list_raster(DisplayListResourceId id, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context, Gfx::IntRect rect_in_list_space, sk_sp<SkImage> image) const
+{
+    VERIFY(image);
+    auto& resource = *m_display_list_cached_nested_rasters.ensure(id.value(), [&] {
+        return make<DisplayListCachedNestedRasterResource>(skia_backend_context);
+    });
+
+    if (resource.skia_backend_context.ptr() != skia_backend_context.ptr()) {
+        resource.rasters.clear();
+        resource.skia_backend_context = skia_backend_context;
+    }
+
+    // When the budget is exceeded, evict rasters that are not part of the active working set (not used
+    // recently). If everything is recently used, the live working set genuinely exceeds the budget; then skip
+    // caching this raster instead of evicting hot entries, so an oversized page degrades to direct replay for
+    // the overflow instead of thrashing the whole cache. Additions are rare by design, so the total is simply
+    // recomputed here instead of being tracked incrementally.
+    constexpr size_t max_nested_raster_cache_bytes = 512 * MiB;
+    auto total_bytes = static_cast<size_t>(rect_in_list_space.width()) * rect_in_list_space.height() * 4;
+    for (auto const& it : m_display_list_cached_nested_rasters)
+        total_bytes += it.value->total_byte_size();
+    if (total_bytes > max_nested_raster_cache_bytes) {
+        auto now = MonotonicTime::now();
+        for (auto& it : m_display_list_cached_nested_rasters) {
+            it.value->rasters.remove_all_matching([&](auto const& raster) {
+                if (now - raster.last_used < AK::Duration::from_milliseconds(250))
+                    return false;
+                total_bytes -= raster.byte_size();
+                return true;
+            });
+        }
+        if (total_bytes > max_nested_raster_cache_bytes)
+            return;
+    }
+
+    if (resource.rasters.size() == DisplayListCachedNestedRasterResource::max_rasters)
+        resource.rasters.take_last();
+    resource.rasters.prepend({ rect_in_list_space, move(image) });
+}
+
+bool DisplayListResourceStorage::should_cache_nested_display_list_raster(DisplayListResourceId id) const
+{
+    // Only rasterize a list that has been painted before: content that is re-recorded for every update gets a
+    // fresh id each time and would waste a full rasterization per recording, while anything replayed more than
+    // once converges to cache hits after its second paint.
+    auto& resource = *m_display_list_cached_nested_rasters.ensure(id.value(), [&] {
+        return make<DisplayListCachedNestedRasterResource>(nullptr);
+    });
+    if (!exchange(resource.was_painted, true))
+        return false;
+    HashTable<u64> visited_display_lists;
+    return !nested_display_list_requires_direct_replay(id, visited_display_lists);
+}
+
+// Determines whether reusing a rasterization of the display list can produce different pixels than replaying it
+// in place on every frame. That is the case when a destination-reading operation (a non-normal blend mode or a
+// backdrop filter) can see canvas content painted before the display list began, or when the list draws live
+// content that changes underneath its immutable command stream (video frames are updated in place under a stable
+// resource id, canvas surfaces and composited child contexts are resolved at replay time). Destination-reading
+// operations enclosed in a save layer recorded within the list only ever read within-list content, so they do
+// not require direct replay. The verdict is intrinsic to the list and memoized alongside its cached rasters.
+bool DisplayListResourceStorage::nested_display_list_requires_direct_replay(DisplayListResourceId id, HashTable<u64>& visited_display_lists) const
+{
+    auto& resource = *m_display_list_cached_nested_rasters.ensure(id.value(), [&] {
+        return make<DisplayListCachedNestedRasterResource>(nullptr);
+    });
+    if (resource.requires_direct_replay.has_value())
+        return *resource.requires_direct_replay;
+
+    visited_display_lists.set(id.value());
+    auto const& list_resource = display_list_resource(id);
+
+    bool requires_direct_replay = false;
+    for (auto const& node : list_resource.visual_context_tree.nodes()) {
+        if (auto const* effects = node.data.get_pointer<EffectsData>(); effects && effects->blend_mode != Gfx::CompositingAndBlendingOperator::Normal)
+            requires_direct_replay = true;
+    }
+
+    Vector<bool, 32> save_stack_entry_is_layer;
+    u64 layer_depth = 0;
+    DisplayList::for_each_command_header(list_resource.display_list->command_bytes(), [&](DisplayListCommandHeader const& header, ReadonlyBytes payload) {
+        if (requires_direct_replay)
+            return;
+        visit_display_list_command(header.type, payload, [&](auto const& command) {
+            using Command = RemoveCVReference<decltype(command)>;
+            if constexpr (IsSame<Command, Save>) {
+                save_stack_entry_is_layer.append(false);
+            } else if constexpr (IsSame<Command, SaveLayer>) {
+                save_stack_entry_is_layer.append(true);
+                ++layer_depth;
+            } else if constexpr (IsSame<Command, ApplyEffects>) {
+                if (layer_depth == 0 && command.compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal)
+                    requires_direct_replay = true;
+                save_stack_entry_is_layer.append(true);
+                ++layer_depth;
+            } else if constexpr (IsSame<Command, Restore>) {
+                if (!save_stack_entry_is_layer.is_empty() && save_stack_entry_is_layer.take_last())
+                    --layer_depth;
+            } else if constexpr (IsSame<Command, ApplyBackdropFilter>) {
+                if (layer_depth == 0 && command.has_backdrop_filter)
+                    requires_direct_replay = true;
+            } else if constexpr (IsSame<Command, DrawVideoFrame> || IsSame<Command, DrawCanvas> || IsSame<Command, DrawCompositedContext>) {
+                requires_direct_replay = true;
+            } else if constexpr (IsSame<Command, PaintNestedDisplayList>) {
+                // NB: A nested list's live content matters at any depth, and its unisolated destination reads
+                //     matter when this command is not enclosed in a layer; recursing unconditionally is slightly
+                //     conservative for the latter. Pattern tile display lists are always rasterized into
+                //     standalone surfaces and cannot read the destination, so they are not followed.
+                if (visited_display_lists.set(command.display_list_id.value()) == HashSetResult::InsertedNewEntry) {
+                    if (m_display_lists.contains(command.display_list_id.value()))
+                        requires_direct_replay = nested_display_list_requires_direct_replay(command.display_list_id, visited_display_lists);
+                }
+            }
+        });
+    });
+
+    resource.requires_direct_replay = requires_direct_replay;
+    return requires_direct_replay;
 }
 
 static ReadonlyBytes inline_data(ReadonlyBytes payload, DisplayListDataSpan span)
@@ -364,6 +542,8 @@ void DisplayListResourceStorage::apply_transaction(DisplayListResourceTransactio
         m_display_lists.remove(id.value());
     for (auto id : transaction.display_list_ids_to_remove)
         m_display_list_cached_skia_images.remove(id.value());
+    for (auto id : transaction.display_list_ids_to_remove)
+        m_display_list_cached_nested_rasters.remove(id.value());
 }
 
 void DisplayListResourceStorage::retain_only(DisplayListResourceSet const& resource_set)
@@ -386,6 +566,10 @@ void DisplayListResourceStorage::retain_only(DisplayListResourceSet const& resou
             && !m_display_list_cache_reference_counts.contains(id);
     });
     m_display_list_cached_skia_images.remove_all_matching([&](auto id, auto const&) {
+        return !resource_set.display_lists.contains(DisplayListResourceId { id })
+            && !m_display_list_cache_reference_counts.contains(id);
+    });
+    m_display_list_cached_nested_rasters.remove_all_matching([&](auto id, auto const&) {
         return !resource_set.display_lists.contains(DisplayListResourceId { id })
             && !m_display_list_cache_reference_counts.contains(id);
     });

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -58,6 +58,7 @@ struct DisplayListVideoFrameResource {
 
 struct DisplayListStoredImageFrameResource;
 struct DisplayListCachedSkiaImageResource;
+struct DisplayListCachedNestedRasterResource;
 
 struct DisplayListResource {
     DisplayListResource(NonnullRefPtr<DisplayList>, AccumulatedVisualContextTree);
@@ -112,6 +113,9 @@ public:
     sk_sp<SkImage> skia_image_for_image_frame(ImageFrameResourceId, RefPtr<Gfx::SkiaBackendContext> const&) const;
     sk_sp<SkImage> cached_skia_image_for_display_list(DisplayListResourceId, Gfx::IntSize, RefPtr<Gfx::SkiaBackendContext> const&) const;
     void set_cached_skia_image_for_display_list(DisplayListResourceId, Gfx::IntSize, RefPtr<Gfx::SkiaBackendContext> const&, sk_sp<SkImage>) const;
+    sk_sp<SkImage> cached_nested_display_list_raster(DisplayListResourceId, RefPtr<Gfx::SkiaBackendContext> const&, Gfx::IntRect visible_rect_in_list_space, Gfx::IntRect& raster_rect_in_list_space) const;
+    void add_cached_nested_display_list_raster(DisplayListResourceId, RefPtr<Gfx::SkiaBackendContext> const&, Gfx::IntRect rect_in_list_space, sk_sp<SkImage>) const;
+    bool should_cache_nested_display_list_raster(DisplayListResourceId) const;
     RefPtr<Media::VideoFrame const> video_frame(VideoFrameResourceId id) const { return m_video_frames.get(id.value()).value(); }
     DisplayListResource const& display_list_resource(DisplayListResourceId id) const { return m_display_lists.get(id.value()).value(); }
     DisplayList const& display_list(DisplayListResourceId id) const { return *display_list_resource(id).display_list; }
@@ -119,12 +123,14 @@ public:
 
 private:
     void collect_referenced_resources(ReadonlyBytes command_bytes, DisplayListResourceSet&) const;
+    bool nested_display_list_requires_direct_replay(DisplayListResourceId, HashTable<u64>& visited_display_lists) const;
 
     HashMap<u64, NonnullRefPtr<Gfx::Font const>> m_fonts;
     HashMap<u64, NonnullOwnPtr<DisplayListStoredImageFrameResource>> m_image_frames;
     HashMap<u64, RefPtr<Media::VideoFrame const>> m_video_frames;
     HashMap<u64, DisplayListResource> m_display_lists;
     mutable HashMap<u64, NonnullOwnPtr<DisplayListCachedSkiaImageResource>> m_display_list_cached_skia_images;
+    mutable HashMap<u64, NonnullOwnPtr<DisplayListCachedNestedRasterResource>> m_display_list_cached_nested_rasters;
 
     HashMap<u64, size_t> m_font_cache_reference_counts;
     HashMap<u64, size_t> m_image_frame_cache_reference_counts;

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -155,10 +155,8 @@ void SVGDecodedImageData::prune_cached_display_list_resources() const
     auto& resource_storage = m_document->navigable()->display_list_resource_storage();
 
     Painting::DisplayListResourceSet retained_resources;
-    for (auto const& cached_display_list : m_cached_display_lists) {
-        retained_resources.include(
-            resource_storage.collect_referenced_resources(*cached_display_list.value.display_list));
-    }
+    for (auto const& cached_display_list : m_cached_display_lists)
+        retained_resources.include(cached_display_list.value.referenced_resources);
     resource_storage.retain_only(retained_resources);
 }
 
@@ -167,8 +165,7 @@ Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list
     auto& resource_storage = m_document->navigable()->display_list_resource_storage();
 
     if (auto it = m_cached_display_lists.find(size); it != m_cached_display_lists.end()) {
-        auto referenced_resources = resource_storage.collect_referenced_resources(*it->value.display_list);
-        copy_referenced_resources_to(destination_resource_storage, resource_storage, referenced_resources);
+        copy_referenced_resources_to(destination_resource_storage, resource_storage, it->value.referenced_resources);
         return Painting::DisplayListResource { *it->value.display_list, it->value.visual_context_tree };
     }
 
@@ -195,7 +192,7 @@ Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list
     VERIFY(document_paintable);
     auto visual_context_tree = document_paintable->visual_context_tree();
     auto display_list_resource = Painting::DisplayListResource { *display_list, visual_context_tree };
-    m_cached_display_lists.set(size, CachedDisplayList { NonnullRefPtr<Painting::DisplayList> { *display_list }, move(visual_context_tree) });
+    m_cached_display_lists.set(size, CachedDisplayList { NonnullRefPtr<Painting::DisplayList> { *display_list }, move(visual_context_tree), move(referenced_resources) });
     prune_cached_display_list_resources();
     return display_list_resource;
 }

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -58,6 +58,8 @@ private:
     struct CachedDisplayList {
         NonnullRefPtr<Painting::DisplayList> display_list;
         Painting::AccumulatedVisualContextTree visual_context_tree;
+        // Precomputed by collect_referenced_resources(); the display list is immutable, so this never changes.
+        Painting::DisplayListResourceSet referenced_resources;
     };
     mutable HashMap<Gfx::IntSize, CachedDisplayList> m_cached_display_lists;
 


### PR DESCRIPTION
Nested display lists (SVG images and mask contents) were replayed as full vector command streams on every compositor frame. On Google Sheets, one such list is 1.3 MB of commands with 1934 path fills and 71 save layers, costing over 130 ms of Metal command encoding per present at 5120x2880.

Display lists are immutable and the compositor replays the same ones every frame between content updates, so we now cache their rasterizations as `SkImage` snapshots in the per-client resource storage, keyed by display list id and pruned together with the lists themselves. The cache only engages for integer-translation transforms, so cached rasters stay pixel-identical to replaying the commands.

A list is only rasterized on its second paint (content that is re-recorded per update never wastes a raster), each list keeps a small MRU set of rasters (the same list is often painted at several places per frame), small lists are rasterized whole so atlas-style slicing hits one raster, and when over budget we evict idle rasters or just stop caching instead of thrashing. Lists that read the destination (`mix-blend-mode`, backdrop filters) or draw live content (video, canvas, composited child contexts) always replay directly.

The first commit makes `SVGDecodedImageData` cache the referenced resource set per cached display list, killing a per-paint 1.3 MB command re-walk.

Scrolling a large real-world Sheets document at 5120x2880 goes from 26.9 fps with frequent 100+ ms frames on master to 44.2 fps with p90 27 ms and zero steady-state rasterization traffic.

Before:

https://github.com/user-attachments/assets/a5dfc82d-a502-4678-923e-e0e6e471875a

After:

https://github.com/user-attachments/assets/5d79c249-816d-490f-801c-2827afb43028
