### PR TITLE
UI/Qt+LibWeb: Fix keyboard focus and scrolling on macOS

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1102,12 +1102,13 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     auto arrow_key_scroll_distance = 100;
     auto page_scroll_distance = document->window()->inner_height() - (document->window()->outer_height() - document->window()->inner_height());
 
+    auto const modifiers_without_keypad = modifiers & ~UIEvents::Mod_Keypad;
     switch (key) {
     case UIEvents::KeyCode::Key_Up:
     case UIEvents::KeyCode::Key_Down:
-        if (modifiers && modifiers != UIEvents::KeyModifier::Mod_PlatformCtrl)
+        if (modifiers_without_keypad && modifiers_without_keypad != UIEvents::KeyModifier::Mod_PlatformCtrl)
             break;
-        if (modifiers) {
+        if (modifiers_without_keypad) {
             if (key == UIEvents::KeyCode::Key_Up)
                 document->scroll_to_the_beginning_of_the_document();
             else
@@ -1119,19 +1120,19 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     case UIEvents::KeyCode::Key_Left:
     case UIEvents::KeyCode::Key_Right:
 #if defined(AK_OS_MACOS)
-        if (modifiers && modifiers != UIEvents::KeyModifier::Mod_Super)
+        if (modifiers_without_keypad && modifiers_without_keypad != UIEvents::KeyModifier::Mod_Super)
 #else
-        if (modifiers && modifiers != UIEvents::KeyModifier::Mod_Alt)
+        if (modifiers_without_keypad && modifiers_without_keypad != UIEvents::KeyModifier::Mod_Alt)
 #endif
             break;
-        if (modifiers)
+        if (modifiers_without_keypad)
             document->page().traverse_the_history_by_delta(key == UIEvents::KeyCode::Key_Left ? -1 : 1);
         else
             document->window()->scroll_by(key == UIEvents::KeyCode::Key_Left ? -arrow_key_scroll_distance : arrow_key_scroll_distance, 0);
         return EventResult::Handled;
     case UIEvents::KeyCode::Key_PageUp:
     case UIEvents::KeyCode::Key_PageDown:
-        if (modifiers != UIEvents::KeyModifier::Mod_None)
+        if (modifiers_without_keypad != UIEvents::KeyModifier::Mod_None)
             break;
         document->window()->scroll_by(0, key == UIEvents::KeyCode::Key_PageUp ? -page_scroll_distance : page_scroll_distance);
         return EventResult::Handled;

--- a/Tests/LibWeb/Text/expected/keyboard-scroll-with-keypad-modifier.txt
+++ b/Tests/LibWeb/Text/expected/keyboard-scroll-with-keypad-modifier.txt
@@ -1,0 +1,2 @@
+before: 0
+after: 100

--- a/Tests/LibWeb/Text/input/keyboard-scroll-with-keypad-modifier.html
+++ b/Tests/LibWeb/Text/input/keyboard-scroll-with-keypad-modifier.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    div {
+        height: 2000px;
+    }
+</style>
+<div></div>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        println(`before: ${window.scrollY}`);
+        internals.sendKey(document.body, "Down", internals.MOD_KEYPAD);
+        println(`after: ${window.scrollY}`);
+    });
+</script>

--- a/UI/Qt/FindInPageWidget.cpp
+++ b/UI/Qt/FindInPageWidget.cpp
@@ -78,7 +78,7 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     m_exit_button->setToolTip("Close Search Bar");
     m_exit_button->setFlat(true);
     connect(m_exit_button, &QPushButton::clicked, this, [this] {
-        setVisible(false);
+        close_bar();
     });
 
     m_match_case = new QCheckBox(this);
@@ -143,7 +143,7 @@ void FindInPageWidget::keyPressEvent(QKeyEvent* event)
 {
     switch (event->key()) {
     case Qt::Key_Escape:
-        setVisible(false);
+        close_bar();
         break;
     case Qt::Key_Return:
         if (event->modifiers().testFlag(Qt::ShiftModifier))
@@ -155,6 +155,12 @@ void FindInPageWidget::keyPressEvent(QKeyEvent* event)
         event->ignore();
         break;
     }
+}
+
+void FindInPageWidget::close_bar()
+{
+    setVisible(false);
+    m_content_view->setFocus();
 }
 
 void FindInPageWidget::focusInEvent(QFocusEvent* event)

--- a/UI/Qt/FindInPageWidget.h
+++ b/UI/Qt/FindInPageWidget.h
@@ -42,6 +42,7 @@ private:
     virtual void showEvent(QShowEvent*) override;
     virtual void hideEvent(QHideEvent*) override;
 
+    void close_bar();
     void find_text_changed();
     void update_chrome_style();
 

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -381,6 +381,7 @@ void LocationEdit::keyPressEvent(QKeyEvent* event)
         if (m_url.has_value())
             setText(serialized_url());
         clearFocus();
+        emit focus_return_requested();
         return;
     }
 

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -44,6 +44,9 @@ public:
     void set_url_is_hidden(bool);
     void show_autocomplete();
 
+signals:
+    void focus_return_requested();
+
 private:
     virtual void changeEvent(QEvent* event) override;
     virtual void focusInEvent(QFocusEvent* event) override;

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -746,6 +746,9 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     QObject::connect(m_location_edit, &QLineEdit::returnPressed, this, &Tab::location_edit_return_pressed);
+    QObject::connect(m_location_edit, &LocationEdit::focus_return_requested, this, [this] {
+        view().setFocus();
+    });
 
     view().on_title_change = [this](auto const& title) {
         m_title = qstring_from_utf16_string(title);

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -455,6 +455,9 @@ static bool is_browser_reserved_shortcut(QKeyEvent const& event)
         return true;
 
 #if defined(AK_OS_MACOS)
+    if (modifiers == Qt::ControlModifier && key == Qt::Key_H)
+        return true;
+
     if (modifiers == Qt::MetaModifier && key == Qt::Key_Tab)
         return true;
 


### PR DESCRIPTION
Fix a few related keyboard handling issues in the Qt UI on macOS.

This makes plain arrow-key scrolling work when Qt reports arrow keys with the keypad modifier, and adds coverage for that path. It also returns focus to the web view after dismissing the location editor or find-in-page bar, so keyboard scrolling and page shortcuts keep working after leaving browser chrome.

Also reserve Command+H so the native macOS Hide shortcut works while web content has focus.