### PR TITLE
LibWeb: Update an offscreen canvas's computed style for font resolution

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
@@ -97,11 +97,9 @@ void CanvasTextDrawingStyles<CanvasType>::set_font(StringView font)
     Optional<DOM::AbstractElement> inheritance_parent;
 
     if constexpr (SameAs<CanvasType, HTML::HTMLCanvasElement>) {
-        canvas_element.document().update_style_if_needed_for_element(DOM::AbstractElement { canvas_element });
+        canvas_element.document().update_style_for_element(DOM::AbstractElement { canvas_element });
 
         if (canvas_element.navigable() && canvas_element.is_connected()) {
-            VERIFY(canvas_element.computed_properties());
-
             // NOTE: Since we can't set a math depth directly here we always use the inherited value for the computed value
             computed_math_depth = canvas_element.computed_properties()->math_depth();
 

--- a/Tests/LibWeb/Text/expected/canvas/font-in-display-none-subtree.txt
+++ b/Tests/LibWeb/Text/expected/canvas/font-in-display-none-subtree.txt
@@ -1,0 +1,2 @@
+24px serif
+32px monospace

--- a/Tests/LibWeb/Text/input/canvas/font-in-display-none-subtree.html
+++ b/Tests/LibWeb/Text/input/canvas/font-in-display-none-subtree.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<div id="hidden" style="display: none; font-size: 16px"></div>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        // Let the initial full style pass settle so the display:none subtree is clean.
+        // After this, an incremental style update skips descent into display:none, so a
+        // freshly-inserted canvas there never gets eagerly-computed style.
+        await animationFrame();
+        await animationFrame();
+
+        // Insert a canvas into the already-settled display:none subtree. Its computed
+        // properties stay null until set_font resolves them on demand, which used to crash.
+        const canvas = document.createElement("canvas");
+        document.getElementById("hidden").appendChild(canvas);
+        const ctx = canvas.getContext("2d");
+
+        // Absolute size: must not crash and round-trips.
+        ctx.font = "24px serif";
+        println(ctx.font);
+
+        // Relative units resolve against the canvas's inherited computed font-size (16px).
+        ctx.font = "2em monospace";
+        println(ctx.font);
+    });
+</script>


### PR DESCRIPTION
Otherwise, we crash here for canvases in a display:none tree. This was occurring at https://liquipedia.net/overwatch/Spacestation_Gaming.