### PR TITLE
LibWeb: Make putImageData replace pixels instead of compositing them

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -864,11 +864,15 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::put_pixels_from_an_image_dat
         __builtin_memcpy(bitmap_snapshot->scanline(y), source_bitmap->scanline(source_rect.y() + y) + source_rect.x(), static_cast<size_t>(source_rect.width()) * sizeof(Gfx::RawPixel));
     canvas_command_list.append(Gfx::CanvasCommands::Save {});
     canvas_command_list.append(Gfx::CanvasCommands::SetTransform { .transform = {} });
+    // NB: Step 7 sets each destination pixel to the source pixel: putImageData replaces the pixels (including their
+    //     alpha), rather than compositing them. Use the Copy operator — so a transparent source pixel overwrites an
+    //     opaque destination pixel, rather than leaving it unchanged.
     canvas_command_list.append(Gfx::CanvasCommands::DrawBitmap {
         .frame = Gfx::DecodedImageFrame { *bitmap_snapshot, Gfx::AlphaType::Unpremultiplied },
         .dst_rect = dst_rect,
         .src_rect = bitmap_snapshot->rect(),
         .filter = {},
+        .compositing_and_blending_operator = Gfx::CompositingAndBlendingOperator::Copy,
     });
     canvas_command_list.append(Gfx::CanvasCommands::Restore {});
 

--- a/Tests/LibWeb/Text/expected/HTML/canvas-putImageData-replaces-pixels.txt
+++ b/Tests/LibWeb/Text/expected/HTML/canvas-putImageData-replaces-pixels.txt
@@ -1,0 +1,3 @@
+PASS
+PASS
+PASS

--- a/Tests/LibWeb/Text/input/HTML/canvas-putImageData-replaces-pixels.html
+++ b/Tests/LibWeb/Text/input/HTML/canvas-putImageData-replaces-pixels.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body><canvas id=c width=2 height=2></canvas>
+<script>
+    test(() => {
+        const ctx = c.getContext('2d');
+        const check = (buf, r, g, b, a) =>
+            println(buf.data[0] === r && buf.data[1] === g && buf.data[2] === b && buf.data[3] === a ? "PASS" : "FAIL " + buf.data);
+
+        // putImageData replaces the destination pixels (a copy), so a fully transparent source
+        // pixel must overwrite an opaque destination pixel rather than compositing over it.
+        ctx.fillStyle = "white";
+        ctx.fillRect(0, 0, 2, 2);
+        const transparent = ctx.createImageData(2, 2); // all zeroes: transparent black
+        ctx.putImageData(transparent, 0, 0);
+        check(ctx.getImageData(0, 0, 1, 1), 0, 0, 0, 0);
+
+        // The dirty-rectangle form replaces pixels the same way.
+        ctx.fillStyle = "white";
+        ctx.fillRect(0, 0, 2, 2);
+        ctx.putImageData(transparent, 0, 0, 0, 0, 2, 2);
+        check(ctx.getImageData(0, 0, 1, 1), 0, 0, 0, 0);
+
+        // An opaque source pixel also replaces the destination.
+        ctx.fillStyle = "white";
+        ctx.fillRect(0, 0, 2, 2);
+        const black = new ImageData(new Uint8ClampedArray([0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255]), 2, 2);
+        ctx.putImageData(black, 0, 0);
+        check(ctx.getImageData(0, 0, 1, 1), 0, 0, 0, 255);
+    });
+</script>


### PR DESCRIPTION
**Problem:** A canvas updated repeatedly with `putImageData` turned solid white when the source frames contained transparent pixels.

**Cause:** `putImageData` was recorded as a `DrawBitmap` canvas command with the default `source-over` operator. The spec defines `putImageData` as a direct copy: set each destination pixel to the source pixel. So, transparent source pixels must overwrite opaque destination ones. Under `source-over`, a transparent source pixel leaves the destination unchanged. So, once a pixel had been drawn opaque, it could never be cleared; animated content filled the canvas with the union of every opaque pixel ever drawn.

**Fix:** Record the `DrawBitmap` with the `Copy` operator — so the destination region is replaced with the source pixels, including their alpha.

Discovered this while working on https://github.com/LadybirdBrowser/ladybird/issues/10442. infinitemac.org’s emulated Mac-desktop screen encodes its black pixels as fully transparent, and this problem caused it to unexpectedly show a permanently-white (empty) screen — rather than actually displaying the painted Mac desktop as expected. So at first it led me to think we had a bug somewhere else that was causing us to not actually drawing anything at all to the canvas — and spend a bunch of time looking for that other (non-existent) bug.
