### PR TITLE
LibWeb: Resolve SVG fallback viewBox lengths against the document

### DIFF
--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -134,9 +134,7 @@ void SVGSVGElement::update_fallback_view_box_for_svg_as_image()
     Optional<double> width;
     Optional<double> height;
 
-    auto resolution_context = layout_node()
-        ? CSS::Length::ResolutionContext::for_layout_node(*layout_node())
-        : CSS::Length::ResolutionContext::for_document(document());
+    auto resolution_context = CSS::Length::ResolutionContext::for_document(document());
 
     auto width_attribute = get_attribute_value(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingParams { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };

--- a/Tests/LibWeb/Crash/SVG/svg-width-attribute-change-with-dirty-layout.html
+++ b/Tests/LibWeb/Crash/SVG/svg-width-attribute-change-with-dirty-layout.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<svg id="s" width="100" height="100"></svg>
+<script>
+    const svg = document.getElementById("s");
+    svg.getBoundingClientRect();
+    document.body.appendChild(document.createElement("div"));
+    svg.setAttribute("width", "200");
+</script>


### PR DESCRIPTION
Previously, the fallback viewBox for an SVG used as an image resolved font-relative width and height lengths against the element's layout node when one existed. Attribute changes can occur while layout is dirty, so reading the layout node causes an assertion failure failure. Resolving against the document avoids touching the layout tree and produces the same result regardless of when the attributes are set.