### PR TITLE
LibWeb: Match the last resort fallback font to the requested weight

### DIFF
--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -653,6 +653,10 @@ NonnullRefPtr<Gfx::FontCascadeList const> FontComputer::compute_font_for_style_v
     // NB: @font-feature-values can't apply to the default font since it's not loaded from CSS
     auto default_font = Platform::FontPlugin::the().default_font(font_size_in_pt, variation, font_feature_data.to_shape_features({}));
     if (font_list->is_empty()) {
+        if (auto fallback_font_list = find_font(Platform::FontPlugin::the().generic_font_name(Platform::GenericFont::UiSansSerif, weight, slope)))
+            font_list->extend(*fallback_font_list);
+    }
+    if (font_list->is_empty()) {
         // This is needed to make sure we check default font before reaching to emojis.
         font_list->add(*default_font);
     }

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -17,6 +17,7 @@ Text/input/HTML/media-source-setup.html
 Text/input/css/FontFace-arraybuffer-matching.html
 Text/input/wpt-import/mediacapture-streams/idlharness.https.window.html
 Text/input/css/font-face-load-dedups-same-url.html
+Text/input/css/unrecognized-font-family-fallback-honors-weight.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_url.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_write.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_write_single.html

--- a/Tests/LibWeb/Text/expected/css/unrecognized-font-family-fallback-honors-weight.txt
+++ b/Tests/LibWeb/Text/expected/css/unrecognized-font-family-fallback-honors-weight.txt
@@ -1,0 +1,2 @@
+unrecognized-family bold matches sans-serif bold: true
+unrecognized-family bold matches the registered bold face: true

--- a/Tests/LibWeb/Text/input/css/unrecognized-font-family-fallback-honors-weight.html
+++ b/Tests/LibWeb/Text/input/css/unrecognized-font-family-fallback-honors-weight.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const fontData = await fetch("../../../Assets/Lato-Bold.ttf").then(response => response.arrayBuffer());
+        const face = new FontFace("SerenitySans", fontData, { weight: "bold" });
+        document.fonts.add(face);
+        await face.loaded;
+
+        const measureWidth = (fontFamily, fontWeight) => {
+            const span = document.createElement("span");
+            span.style.fontFamily = fontFamily;
+            span.style.fontWeight = fontWeight;
+            span.style.fontSize = "40px";
+            span.textContent = "Strong";
+            document.body.appendChild(span);
+            return span.offsetWidth;
+        };
+
+        const unrecognizedBold = measureWidth("non-existent-font", "bold");
+        const sansSerifBold = measureWidth("sans-serif", "bold");
+        const directBold = measureWidth("SerenitySans", "bold");
+
+        println(`unrecognized-family bold matches sans-serif bold: ${unrecognizedBold === sansSerifBold}`);
+        println(`unrecognized-family bold matches the registered bold face: ${unrecognizedBold === directBold}`);
+    });
+</script>


### PR DESCRIPTION
When every specified font family fails to match, the fallback used the default font, which is always regular weight and upright. Bold or italic text under an unrecognized family therefore lost its weight and slope. Resolve the last-resort family through the weight- and slope-aware matching path instead, falling back to the default font only when that too yields nothing.

Fixes #10375