### PR TITLE
Fix controlled contenteditable editing on X.com

### DIFF
--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/TextOffsetMapping.h>
+#include <LibWeb/Selection/Selection.h>
 
 namespace Web::DOM {
 
@@ -102,9 +103,17 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
     // NOTE: We do this later so that the mutation observer may notify UI clients of this node's new value.
     queue_mutation_record(MutationType::characterData, {}, {}, old_data.to_utf8_but_should_be_ported_to_utf16(), {}, {}, nullptr, nullptr);
 
+    GC::Ptr<Range> selection_range_to_preserve;
+    if (m_data == old_data && document().preserve_selection_offsets_during_identical_character_data_replacement()) {
+        if (auto selection = document().get_selection())
+            selection_range_to_preserve = selection->range();
+    }
+
     // 8. For each live range whose start node is node and start offset is greater than offset but less than or equal to
     //    offset plus count, set its start offset to offset.
     for (auto* range : Range::live_ranges()) {
+        if (range == selection_range_to_preserve)
+            continue;
         if (range->start_container() == this && range->start_offset() > offset && range->start_offset() <= (offset + count))
             range->set_start_offset(offset);
     }
@@ -112,6 +121,8 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
     // 9. For each live range whose end node is node and end offset is greater than offset but less than or equal to
     //    offset plus count, set its end offset to offset.
     for (auto* range : Range::live_ranges()) {
+        if (range == selection_range_to_preserve)
+            continue;
         if (range->end_container() == this && range->end_offset() > offset && range->end_offset() <= (offset + count))
             range->set_end_offset(offset);
     }
@@ -119,6 +130,8 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
     // 10. For each live range whose start node is node and start offset is greater than offset plus count, increase its
     //     start offset by data’s length and decrease it by count.
     for (auto* range : Range::live_ranges()) {
+        if (range == selection_range_to_preserve)
+            continue;
         if (range->start_container() == this && range->start_offset() > (offset + count))
             range->set_start_offset(range->start_offset() + data.length_in_code_units() - count);
     }
@@ -126,6 +139,8 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
     // 11. For each live range whose end node is node and end offset is greater than offset plus count, increase its end
     //     offset by data’s length and decrease it by count.
     for (auto* range : Range::live_ranges()) {
+        if (range == selection_range_to_preserve)
+            continue;
         if (range->end_container() == this && range->end_offset() > (offset + count))
             range->set_end_offset(range->end_offset() + data.length_in_code_units() - count);
     }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -773,7 +773,12 @@ public:
     void set_previous_document_unload_timing(DocumentUnloadTimingInfo const& previous_document_unload_timing) { m_previous_document_unload_timing = previous_document_unload_timing; }
 
     // https://w3c.github.io/editing/docs/execCommand/
+    enum class DispatchInputEvent {
+        No,
+        Yes,
+    };
     WebIDL::ExceptionOr<bool> exec_command(FlyString const& command, bool show_ui, Utf16String const& value);
+    WebIDL::ExceptionOr<bool> exec_command_internal(FlyString const& command, bool show_ui, Utf16String const& value, DispatchInputEvent);
     WebIDL::ExceptionOr<bool> query_command_enabled(FlyString const& command);
     WebIDL::ExceptionOr<bool> query_command_indeterm(FlyString const& command);
     WebIDL::ExceptionOr<bool> query_command_state(FlyString const& command);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -235,6 +235,7 @@ public:
     //         dom_tree_version() to understand whether either the DOM tree structure or contents were changed.
     u64 character_data_version() const { return m_character_data_version; }
     void bump_character_data_version() { ++m_character_data_version; }
+    bool preserve_selection_offsets_during_identical_character_data_replacement() const { return m_preserve_selection_offsets_during_identical_character_data_replacement; }
 
     WebIDL::ExceptionOr<void> populate_with_html_head_and_body();
 
@@ -1613,6 +1614,7 @@ private:
     GC::Ref<EditingHostManager> m_editing_host_manager;
 
     bool m_inside_exec_command { false };
+    bool m_preserve_selection_offsets_during_identical_character_data_replacement { false };
 
     // https://w3c.github.io/editing/docs/execCommand/#default-single-line-container-name
     FlyString m_default_single_line_container_name { HTML::TagNames::div };

--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -172,7 +172,7 @@ void EditingHostManager::decrement_cursor_position_to_previous_line(CollapseSele
         selection->move_offset_to_previous_line(collapse == CollapseSelection::Yes);
 }
 
-void EditingHostManager::handle_delete(FlyString const& input_type)
+void EditingHostManager::handle_delete(FlyString const& input_type, DispatchInputEvent dispatch_input_event)
 {
     // https://w3c.github.io/editing/docs/execCommand/#additional-requirements
     // When the user instructs the user agent to delete the previous character inside an editing host, such as by
@@ -182,7 +182,7 @@ void EditingHostManager::handle_delete(FlyString const& input_type)
     // the Delete key while the cursor is in an editable node, the user agent must call execCommand("forwarddelete") on
     // the relevant document.
     auto command = input_type == UIEvents::InputTypes::deleteContentBackward ? Editing::CommandNames::delete_ : Editing::CommandNames::forwardDelete;
-    auto editing_result = m_document->exec_command(command, false, {});
+    auto editing_result = m_document->exec_command_internal(command, false, {}, dispatch_input_event == DispatchInputEvent::Yes ? DOM::Document::DispatchInputEvent::Yes : DOM::Document::DispatchInputEvent::No);
     if (editing_result.is_exception())
         dbgln("handle_delete(): editing resulted in exception: {}", editing_result.exception());
 }

--- a/Libraries/LibWeb/DOM/EditingHostManager.h
+++ b/Libraries/LibWeb/DOM/EditingHostManager.h
@@ -23,7 +23,7 @@ public:
     [[nodiscard]] static GC::Ref<EditingHostManager> create(JS::Realm&, GC::Ref<Document>);
 
     virtual void handle_insert(FlyString const& input_type, Utf16String const&) override;
-    virtual void handle_delete(FlyString const& input_type) override;
+    virtual void handle_delete(FlyString const& input_type, DispatchInputEvent = DispatchInputEvent::Yes) override;
     virtual EventResult handle_return_key(FlyString const& ui_input_type) override;
     virtual void select_all() override;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset) override;

--- a/Libraries/LibWeb/DOM/InputEventsTarget.h
+++ b/Libraries/LibWeb/DOM/InputEventsTarget.h
@@ -21,7 +21,11 @@ public:
 
     virtual void handle_insert(FlyString const& input_type, Utf16String const&) = 0;
     virtual EventResult handle_return_key(FlyString const& input_type) = 0;
-    virtual void handle_delete(FlyString const& input_type) = 0;
+    enum class DispatchInputEvent {
+        No,
+        Yes,
+    };
+    virtual void handle_delete(FlyString const& input_type, DispatchInputEvent = DispatchInputEvent::Yes) = 0;
 
     virtual void select_all() = 0;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset) = 0;

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -130,6 +130,8 @@ WebIDL::ExceptionOr<bool> Document::exec_command(FlyString const& command, [[may
 
         auto event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, event_init);
         event->set_is_trusted(true);
+
+        TemporaryChange preserve_selection_offsets { m_preserve_selection_offsets_during_identical_character_data_replacement, true };
         affected_editing_host->dispatch_event(event);
     }
 

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -20,6 +20,11 @@ namespace Web::DOM {
 // https://w3c.github.io/editing/docs/execCommand/#execcommand()
 WebIDL::ExceptionOr<bool> Document::exec_command(FlyString const& command, [[maybe_unused]] bool show_ui, Utf16String const& value)
 {
+    return exec_command_internal(command, show_ui, value, DispatchInputEvent::Yes);
+}
+
+WebIDL::ExceptionOr<bool> Document::exec_command_internal(FlyString const& command, [[maybe_unused]] bool show_ui, Utf16String const& value, DispatchInputEvent dispatch_input_event)
+{
     // AD-HOC: This is not directly mentioned in the spec, but all major browsers limit editing API calls to HTML documents
     if (!is_html_document())
         return WebIDL::InvalidStateError::create(realm(), "execCommand is only supported on HTML documents"_utf16);
@@ -119,7 +124,7 @@ WebIDL::ExceptionOr<bool> Document::exec_command(FlyString const& command, [[may
     //    value of command, and its data attribute initialized to null.
     bool tree_was_modified = dom_tree_version() != old_dom_tree_version
         || character_data_version() != old_character_data_version;
-    if (tree_was_modified && affected_editing_host) {
+    if (tree_was_modified && affected_editing_host && dispatch_input_event == DispatchInputEvent::Yes) {
         Bindings::InputEventInit event_init {};
         event_init.bubbles = true;
         event_init.input_type = command_definition.mapped_value.to_string();

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -1070,7 +1070,7 @@ void FormAssociatedTextControlElement::handle_insert(FlyString const& input_type
     scroll_cursor_into_view();
 }
 
-void FormAssociatedTextControlElement::handle_delete(FlyString const& input_type)
+void FormAssociatedTextControlElement::handle_delete(FlyString const& input_type, DispatchInputEvent dispatch_input_event)
 {
     auto text_node = form_associated_element_to_text_node();
     if (!text_node || !static_cast<FormAssociatedElement&>(text_control_to_html_element()).is_mutable())
@@ -1092,7 +1092,8 @@ void FormAssociatedTextControlElement::handle_delete(FlyString const& input_type
     MUST(set_range_text({}, selection_start, selection_end, Bindings::SelectionMode::End));
 
     text_node->invalidate_style(DOM::StyleInvalidationReason::EditingDeletion);
-    did_edit_text_node(input_type, {});
+    if (dispatch_input_event == DispatchInputEvent::Yes)
+        did_edit_text_node(input_type, {});
     scroll_cursor_into_view();
 }
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -257,7 +257,7 @@ public:
     virtual GC::Ptr<DOM::Element> text_control_scroll_container() = 0;
 
     virtual void handle_insert(FlyString const& input_type, Utf16String const&) override;
-    virtual void handle_delete(FlyString const& input_type) override;
+    virtual void handle_delete(FlyString const& input_type, DispatchInputEvent = DispatchInputEvent::Yes) override;
     virtual void select_all() override;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset) override;
     virtual void set_selection_focus(GC::Ref<DOM::Node>, size_t offset) override;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1004,6 +1004,15 @@ static bool should_ignore_keydown_event(u32 code_point, u32 modifiers, bool shou
     return false;
 }
 
+static Optional<FlyString> input_type_for_delete_key(UIEvents::KeyCode key)
+{
+    if (key == UIEvents::KeyCode::Key_Backspace)
+        return UIEvents::InputTypes::deleteContentBackward;
+    if (key == UIEvents::KeyCode::Key_Delete)
+        return UIEvents::InputTypes::deleteContentForward;
+    return {};
+}
+
 EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u32 code_point, bool repeat, bool should_insert_text)
 {
     if (!m_navigable->active_document())
@@ -1014,9 +1023,29 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     if (should_ignore_device_input_event() && m_mousedown_target_is_drag_candidate && key == UIEvents::KeyCode::Key_Escape)
         return cancel_drag_and_drop_event(m_last_known_mouse_visual_viewport_position.value_or({}), m_last_known_mouse_screen_position, UIEvents::MouseButton::Primary, m_last_known_mouse_buttons, modifiers);
 
+    auto handle_delete_key = [&](InputEventsTarget& target, InputEventsTarget::DispatchInputEvent dispatch_input_event) -> Optional<EventResult> {
+        auto input_type = input_type_for_delete_key(key);
+        if (!input_type.has_value())
+            return {};
+
+        auto beforeinput_result = input_event(UIEvents::EventNames::beforeinput, input_type.value(), m_navigable, code_point);
+        if (beforeinput_result == EventResult::Cancelled)
+            return beforeinput_result;
+
+        target.handle_delete(input_type.value(), dispatch_input_event);
+        return EventResult::Handled;
+    };
+
     auto dispatch_result = fire_keyboard_event(UIEvents::EventNames::keydown, m_navigable, key, modifiers, code_point, repeat);
-    if (dispatch_result != EventResult::Accepted)
+    if (dispatch_result == EventResult::Cancelled) {
+        if (auto document = m_navigable->active_document(); document && document->is_fully_active()) {
+            if (auto* target = document->active_input_events_target()) {
+                if (auto delete_result = handle_delete_key(*target, InputEventsTarget::DispatchInputEvent::No); delete_result.has_value())
+                    return delete_result.value();
+            }
+        }
         return dispatch_result;
+    }
 
     // https://w3c.github.io/uievents/#event-type-keypress
     // If supported by a user agent, this event MUST be dispatched when a key is pressed down, if and only if that key
@@ -1067,17 +1096,8 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     }
 
     if (auto* target = document->active_input_events_target()) {
-        if (key == UIEvents::KeyCode::Key_Backspace) {
-            FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::deleteContentBackward, m_navigable, code_point));
-            target->handle_delete(UIEvents::InputTypes::deleteContentBackward);
-            return EventResult::Handled;
-        }
-
-        if (key == UIEvents::KeyCode::Key_Delete) {
-            FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::deleteContentForward, m_navigable, code_point));
-            target->handle_delete(UIEvents::InputTypes::deleteContentForward);
-            return EventResult::Handled;
-        }
+        if (auto delete_result = handle_delete_key(*target, InputEventsTarget::DispatchInputEvent::Yes); delete_result.has_value())
+            return delete_result.value();
 
 #if defined(AK_OS_MACOS)
         if ((modifiers & UIEvents::Mod_Super) != 0) {
@@ -1433,11 +1453,43 @@ void EventHandler::process_auto_scroll()
         m_middle_button_scroll_handler->perform_tick();
 }
 
-static GC::RootVector<GC::Ref<DOM::StaticRange>> target_ranges_for_input_event(DOM::Document const& document)
+static GC::Ptr<DOM::StaticRange> collapsed_delete_target_range_for_input_event(DOM::Document const& document, DOM::Range const& range, FlyString const& input_type)
+{
+    if (!range.start_container()->is_editable_or_editing_host())
+        return nullptr;
+
+    auto* text_node = as_if<DOM::Text>(*range.start_container());
+    if (!text_node)
+        return nullptr;
+
+    auto offset = range.start_offset();
+    if (input_type == UIEvents::InputTypes::deleteContentBackward && offset > 0) {
+        auto start_offset = text_node->grapheme_segmenter().previous_boundary(offset).value_or(offset - 1);
+        return document.realm().create<DOM::StaticRange>(*text_node, start_offset, *text_node, offset);
+    }
+
+    if (input_type == UIEvents::InputTypes::deleteContentForward && offset < text_node->length()) {
+        auto end_offset = text_node->grapheme_segmenter().next_boundary(offset).value_or(offset + 1);
+        return document.realm().create<DOM::StaticRange>(*text_node, offset, *text_node, end_offset);
+    }
+
+    return nullptr;
+}
+
+static GC::RootVector<GC::Ref<DOM::StaticRange>> target_ranges_for_input_event(DOM::Document const& document, FlyString const& input_type)
 {
     GC::RootVector<GC::Ref<DOM::StaticRange>> target_ranges;
-    if (auto selection = document.get_selection(); selection && !selection->is_collapsed()) {
+    if (auto selection = document.get_selection(); selection) {
         if (auto range = selection->range()) {
+            if (selection->is_collapsed()) {
+                if (auto delete_target_range = collapsed_delete_target_range_for_input_event(document, *range, input_type)) {
+                    target_ranges.append(*delete_target_range);
+                    return target_ranges;
+                }
+
+                if (input_type != UIEvents::InputTypes::insertText)
+                    return target_ranges;
+            }
             auto static_range = document.realm().create<DOM::StaticRange>(range->start_container(), range->start_offset(), range->end_container(), range->end_offset());
             target_ranges.append(static_range);
         }
@@ -1499,11 +1551,11 @@ EventResult EventHandler::input_event(FlyString const& event_name, FlyString con
                 return input_event(event_name, input_type, *navigable_container.content_navigable(), move(code_point_or_string));
         }
 
-        auto event = UIEvents::InputEvent::create_from_platform_event(document->realm(), event_name, input_event_init, target_ranges_for_input_event(*document));
+        auto event = UIEvents::InputEvent::create_from_platform_event(document->realm(), event_name, input_event_init, target_ranges_for_input_event(*document, input_type));
         return focused_area->dispatch_event(event) ? EventResult::Accepted : EventResult::Cancelled;
     }
 
-    auto event = UIEvents::InputEvent::create_from_platform_event(document->realm(), event_name, input_event_init, target_ranges_for_input_event(*document));
+    auto event = UIEvents::InputEvent::create_from_platform_event(document->realm(), event_name, input_event_init, target_ranges_for_input_event(*document, input_type));
 
     if (auto* body = document->body())
         return body->dispatch_event(event) ? EventResult::Accepted : EventResult::Cancelled;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -69,6 +69,105 @@ namespace Web {
     if (auto event_result = (expression); event_result == EventResult::Cancelled) \
         return event_result;
 
+static GC::Ptr<DOM::Node> associated_descendant_editing_host(DOM::Node& node)
+{
+    if (node.is_editing_host())
+        return node;
+    if (node.is_editable()) {
+        auto editing_host = node.editing_host();
+        return editing_host && editing_host->is_editing_host() ? editing_host : nullptr;
+    }
+
+    for (auto* ancestor = &node; ancestor; ancestor = ancestor->parent_or_shadow_host()) {
+        GC::Ptr<DOM::Node> editing_host;
+        bool has_multiple_editing_hosts = false;
+        ancestor->for_each_in_subtree([&](GC::Ref<DOM::Node> descendant) {
+            if (!descendant->is_editing_host())
+                return TraversalDecision::Continue;
+            if (editing_host) {
+                has_multiple_editing_hosts = true;
+                return TraversalDecision::Break;
+            }
+            editing_host = descendant;
+            return TraversalDecision::Continue;
+        });
+
+        if (editing_host && !has_multiple_editing_hosts)
+            return editing_host;
+        if (ancestor != &node && ancestor->is_focusable())
+            break;
+    }
+
+    return nullptr;
+}
+
+static GC::Ptr<DOM::Node> first_editable_leaf_descendant(DOM::Node& root)
+{
+    GC::Ptr<DOM::Node> result;
+    root.for_each_in_subtree([&](GC::Ref<DOM::Node> descendant) {
+        if (descendant->is_uninteresting_whitespace_node())
+            return TraversalDecision::Continue;
+        if (!descendant->is_editable())
+            return TraversalDecision::Continue;
+
+        bool has_editable_descendant = false;
+        descendant->for_each_in_subtree([&](GC::Ref<DOM::Node> child) {
+            if (child.ptr() == descendant.ptr())
+                return TraversalDecision::Continue;
+            if (child->is_uninteresting_whitespace_node())
+                return TraversalDecision::Continue;
+            if (!child->is_editable())
+                return TraversalDecision::Continue;
+            has_editable_descendant = true;
+            return TraversalDecision::Break;
+        });
+        if (has_editable_descendant)
+            return TraversalDecision::Continue;
+
+        result = descendant;
+        return TraversalDecision::Break;
+    });
+    return result;
+}
+
+static Optional<Painting::CaretPosition> caret_position_from_editable_hit_node(DOM::Node& hit_node)
+{
+    GC::Ptr<DOM::Node> boundary_node;
+    if (hit_node.is_editable_or_editing_host())
+        boundary_node = hit_node;
+    else if (auto editing_host = associated_descendant_editing_host(hit_node)) {
+        boundary_node = first_editable_leaf_descendant(*editing_host);
+        if (!boundary_node)
+            boundary_node = editing_host;
+    } else {
+        return {};
+    }
+
+    auto paintable = boundary_node->paintable();
+    if (!paintable)
+        paintable = hit_node.paintable();
+    if (!paintable)
+        return {};
+
+    return Painting::CaretPosition {
+        .paintable = *paintable,
+        .boundary = { *boundary_node, 0 },
+    };
+}
+
+static bool should_use_caret_position_from_editable_hit_node(Optional<Painting::CaretPosition> const& caret_position, DOM::Node& hit_node, DOM::Node& editing_host)
+{
+    if (!hit_node.is_inclusive_descendant_of(editing_host))
+        return true;
+    if (!caret_position.has_value())
+        return true;
+    if (!caret_position->boundary.node->is_inclusive_descendant_of(editing_host))
+        return true;
+    if (caret_position->boundary.node.ptr() == &editing_host && first_editable_leaf_descendant(editing_host))
+        return true;
+    return false;
+}
+
 EventHandler::EventHandler(Badge<HTML::LocalNavigable>, HTML::LocalNavigable& navigable)
     : m_navigable(navigable)
     , m_drag_and_drop_event_handler(make<DragAndDropEventHandler>())
@@ -1618,7 +1717,17 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
     // focusable area with focus trigger set to "click".
     // NOTE: Note that focusing is not an activation behavior, i.e. calling the click() method on an element or
     //       dispatching a synthetic click event on it won't cause the element to get focused.
-    if (auto focus_candidate = focus_candidate_for_position(viewport_position))
+    GC::Ptr<DOM::Node> editable_hit_node_before_focus;
+    if (auto hit_before_focus = document.hit_test(visual_viewport_position, Painting::HitTestType::Exact); hit_before_focus.has_value()) {
+        if (auto* hit_node = hit_before_focus->dom_node())
+            editable_hit_node_before_focus = *hit_node;
+    }
+    auto editing_host_before_focus = editable_hit_node_before_focus ? associated_descendant_editing_host(*editable_hit_node_before_focus) : nullptr;
+
+    auto focus_candidate = editing_host_before_focus;
+    if (!focus_candidate)
+        focus_candidate = focus_candidate_for_position(viewport_position);
+    if (focus_candidate)
         HTML::run_focusing_steps(focus_candidate, nullptr, HTML::FocusTrigger::Click);
     else if (auto focused_area = document.focused_area())
         HTML::run_unfocusing_steps(focused_area);
@@ -1630,6 +1739,10 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
 
     // NB: Now we can do selection with a caret-position hit test.
     auto caret_position = document.caret_position_from_point_for_selection_start(visual_viewport_position);
+    if (editable_hit_node_before_focus && editing_host_before_focus && should_use_caret_position_from_editable_hit_node(caret_position, *editable_hit_node_before_focus, *editing_host_before_focus)) {
+        if (editable_hit_node_before_focus)
+            caret_position = caret_position_from_editable_hit_node(*editable_hit_node_before_focus);
+    }
     if (!caret_position.has_value())
         return;
 

--- a/Libraries/LibWeb/UIEvents/InputEvent.cpp
+++ b/Libraries/LibWeb/UIEvents/InputEvent.cpp
@@ -16,6 +16,7 @@ GC::Ref<InputEvent> InputEvent::create_from_platform_event(JS::Realm& realm, Fly
 {
     auto event = realm.create<InputEvent>(realm, event_name, event_init, target_ranges);
     event->set_bubbles(true);
+    event->set_composed(true);
     if (event_name == "beforeinput"_fly_string) {
         event->set_cancelable(true);
     }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -491,10 +491,10 @@ void ViewImplementation::did_finish_handling_input_event(Badge<WebContentClient>
 {
     auto event = m_pending_input_events.dequeue();
 
-    if (event_result == Web::EventResult::Handled)
+    if (event_result == Web::EventResult::Handled || event_result == Web::EventResult::Cancelled)
         return;
 
-    // Here we handle events that were not consumed or cancelled by the WebContent. Propagate the event back
+    // Here we handle events that were not consumed by the WebContent. Propagate the event back
     // to the concrete view implementation.
     event.visit(
         [this](Web::KeyEvent const& event) {

--- a/Tests/LibWeb/Text/expected/Editing/click-empty-editable-after-focus-layout-change.txt
+++ b/Tests/LibWeb/Text/expected/Editing/click-empty-editable-after-focus-layout-change.txt
@@ -1,0 +1,10 @@
+beforeinput composed: true
+input composed: true
+activeElement: editor
+editor text: a
+block text: a
+selection anchor: #text
+selection anchor offset: 1
+beforeinput target ranges: 0-0, 1-1, 2-2, 3-3, 3-4, 2-3, 1-2
+input types: insertText, insertText, insertText, insertText
+input selection offsets: 1, 2, 3, 4

--- a/Tests/LibWeb/Text/expected/UIEvents/inputevent-gettargetranges.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/inputevent-gettargetranges.txt
@@ -1,2 +1,2 @@
 Target range count: 1. Start offset: 1, End offset: 3
-No target ranges
+Target range count: 1. Start offset: 1, End offset: 2

--- a/Tests/LibWeb/Text/input/Editing/click-empty-editable-after-focus-layout-change.html
+++ b/Tests/LibWeb/Text/input/Editing/click-empty-editable-after-focus-layout-change.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #wrapper {
+        margin: 20px;
+        position: relative;
+        width: 300px;
+        height: 80px;
+    }
+
+    #placeholder {
+        position: absolute;
+        inset: 0;
+        color: gray;
+        z-index: 1;
+    }
+
+    #editor {
+        position: absolute;
+        inset: 0;
+        outline: none;
+        white-space: pre-wrap;
+    }
+
+    #editor.focused {
+        transform: translateY(120px);
+    }
+</style>
+<div id="wrapper">
+    <div id="placeholder">Placeholder</div>
+    <div id="editor" contenteditable="true" tabindex="0">
+        <div id="contents">
+            <div id="block"></div>
+        </div>
+    </div>
+</div>
+<script>
+    asyncTest(async done => {
+        const beforeInputTargetRanges = [];
+        const inputSelectionOffsets = [];
+        const inputTypes = [];
+        editor.addEventListener("beforeinput", event => {
+            const range = event.getTargetRanges()[0];
+            beforeInputTargetRanges.push(`${range.startOffset}-${range.endOffset}`);
+            if (beforeInputTargetRanges.length === 1)
+                println(`beforeinput composed: ${event.composed}`);
+        });
+        editor.addEventListener("input", event => {
+            inputTypes.push(event.inputType);
+            inputSelectionOffsets.push(getSelection().anchorOffset);
+            if (inputSelectionOffsets.length === 1)
+                println(`input composed: ${event.composed}`);
+
+            if (block.firstChild)
+                block.firstChild.data = block.textContent;
+        });
+
+        editor.addEventListener("keydown", event => {
+            if (event.key === "Backspace")
+                event.preventDefault();
+        });
+
+        editor.addEventListener("focus", () => {
+            editor.classList.add("focused");
+        });
+
+        internals.click(40, 40);
+        await animationFrame();
+
+        for (const character of "abcd") {
+            internals.sendText(editor, character);
+        }
+        for (let i = 0; i < 3; ++i) {
+            internals.sendKey(editor, "Backspace");
+        }
+        await animationFrame();
+
+        const selection = getSelection();
+        println(`activeElement: ${document.activeElement.id}`);
+        println(`editor text: ${editor.textContent.trim()}`);
+        println(`block text: ${block.textContent.trim()}`);
+        println(`selection anchor: ${selection.anchorNode.nodeType === Node.TEXT_NODE ? "#text" : selection.anchorNode.id}`);
+        println(`selection anchor offset: ${selection.anchorOffset}`);
+        println(`beforeinput target ranges: ${beforeInputTargetRanges.join(", ")}`);
+        println(`input types: ${inputTypes.join(", ")}`);
+        println(`input selection offsets: ${inputSelectionOffsets.join(", ")}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Fixes a cluster of `contenteditable` issues exposed by X.com's composer.

- Treat cancelled WebContent input events as consumed so platform fallback handling does not replay them.
- Preserve the editable hit target across focus-triggered layout changes, allowing clicks on editor placeholders or wrappers to focus the editing host and place the caret inside it.
- Keep the active selection stable while controlled editors reconcile input by writing identical text node data.
- Handle cancelled editable Backspace/Delete by running the delete operation after `beforeinput` without dispatching a duplicate generated `input` event.
- Report collapsed delete target ranges for `beforeinput`.

Adds an X-like regression covering placeholder focus, typing, same-text reconciliation, and cancelled Backspace handling.