### PR TITLE
UI/Qt: Focus native window container on mouse press

### DIFF
--- a/Tests/UI/Qt/TestNativeWindowContainerFocus.cpp
+++ b/Tests/UI/Qt/TestNativeWindowContainerFocus.cpp
@@ -7,7 +7,9 @@
 #include <LibTest/TestCase.h>
 
 #include <QApplication>
+#include <QMouseEvent>
 #include <QWidget>
+#include <QWindow>
 #include <UI/Qt/NativeWindowContainer.h>
 
 namespace {
@@ -115,7 +117,9 @@ TEST_CASE(container_focus_events_are_forwarded_to_the_host)
 {
     application();
     TestWindow widgets;
-    Ladybird::install_native_window_container_focus_forwarding(widgets.host, widgets.container);
+
+    QWindow native_window;
+    Ladybird::install_native_window_container_focus_forwarding(widgets.host, native_window, widgets.container);
 
     FocusEventRecorder recorder;
     widgets.host.installEventFilter(&recorder);
@@ -135,6 +139,38 @@ TEST_CASE(container_focus_events_are_forwarded_to_the_host)
 
     Ladybird::set_native_window_container_visible(widgets.host, widgets.container, false);
     EXPECT_EQ(QApplication::focusWidget(), &widgets.host);
+    EXPECT_EQ(recorder.last_focus_event, QEvent::FocusIn);
+}
+
+TEST_CASE(native_window_mouse_press_focuses_the_container)
+{
+    application();
+    TestWindow widgets;
+
+    QWindow native_window;
+    Ladybird::install_native_window_container_focus_forwarding(widgets.host, native_window, widgets.container);
+
+    FocusEventRecorder recorder;
+    widgets.host.installEventFilter(&recorder);
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, true);
+    widgets.sibling.setFocus();
+    QApplication::processEvents();
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.sibling);
+
+    recorder.last_focus_event = QEvent::None;
+
+    QMouseEvent mouse_press {
+        QEvent::MouseButtonPress,
+        QPointF { 1, 1 },
+        QPointF { 1, 1 },
+        Qt::LeftButton,
+        Qt::LeftButton,
+        Qt::NoModifier
+    };
+    QApplication::sendEvent(&native_window, &mouse_press);
+
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.container);
     EXPECT_EQ(recorder.last_focus_event, QEvent::FocusIn);
 }
 

--- a/UI/Qt/NativeWindowContainer.cpp
+++ b/UI/Qt/NativeWindowContainer.cpp
@@ -9,6 +9,7 @@
 #include <QCoreApplication>
 #include <QFocusEvent>
 #include <QWidget>
+#include <QWindow>
 
 namespace Ladybird {
 
@@ -19,20 +20,36 @@ public:
     FocusEventForwarder(QWidget& host, QWidget& container)
         : QObject(&container)
         , m_host(host)
+        , m_container(container)
     {
     }
 
 private:
-    virtual bool eventFilter(QObject*, QEvent* event) override
+    virtual bool eventFilter(QObject* watched, QEvent* event) override
     {
-        if (event->type() == QEvent::FocusIn || event->type() == QEvent::FocusOut) {
-            QFocusEvent forwarded_event { event->type(), static_cast<QFocusEvent*>(event)->reason() };
-            QCoreApplication::sendEvent(&m_host, &forwarded_event);
+        switch (event->type()) {
+        case QEvent::FocusIn:
+        case QEvent::FocusOut:
+            if (watched == &m_container) {
+                QFocusEvent forwarded_event { event->type(), static_cast<QFocusEvent*>(event)->reason() };
+                QCoreApplication::sendEvent(&m_host, &forwarded_event);
+            }
+            break;
+
+        case QEvent::MouseButtonPress:
+            if (m_host.focusProxy() == &m_container)
+                m_container.setFocus(Qt::MouseFocusReason);
+            break;
+
+        default:
+            break;
         }
+
         return false;
     }
 
     QWidget& m_host;
+    QWidget& m_container;
 };
 
 }
@@ -58,9 +75,11 @@ void set_native_window_container_visible(QWidget& host, QWidget& container, bool
     }
 }
 
-void install_native_window_container_focus_forwarding(QWidget& host, QWidget& container)
+void install_native_window_container_focus_forwarding(QWidget& host, QWindow& native_window, QWidget& container)
 {
-    container.installEventFilter(new FocusEventForwarder(host, container));
+    auto* forwarder = new FocusEventForwarder(host, container);
+    native_window.installEventFilter(forwarder);
+    container.installEventFilter(forwarder);
 }
 
 }

--- a/UI/Qt/NativeWindowContainer.h
+++ b/UI/Qt/NativeWindowContainer.h
@@ -7,6 +7,7 @@
 #pragma once
 
 class QWidget;
+class QWindow;
 
 namespace Ladybird {
 
@@ -14,6 +15,6 @@ namespace Ladybird {
 // consistent: The container is the host's focus proxy only while it's visible.
 void set_native_window_container_visible(QWidget& host, QWidget& container, bool visible);
 
-void install_native_window_container_focus_forwarding(QWidget& host, QWidget& container);
+void install_native_window_container_focus_forwarding(QWidget& host, QWindow& native_window, QWidget& container);
 
 }

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -904,7 +904,8 @@ void WebContentView::create_vulkan_window()
     m_vulkan_window_container->setMouseTracking(true);
     m_vulkan_window_container->setGeometry(rect());
     m_vulkan_window_container->hide();
-    install_native_window_container_focus_forwarding(*this, *m_vulkan_window_container);
+
+    install_native_window_container_focus_forwarding(*this, *m_vulkan_window, *m_vulkan_window_container);
 }
 
 void WebContentView::set_vulkan_window_container_visible(bool visible)


### PR DESCRIPTION
When the Vulkan web content path uses `QWidget::createWindowContainer`, mouse presses are delivered to the embedded `QWindow`, not the wrapper widget. This meant clicking back into page content after focusing the `LocationEdit` did not move Qt keyboard focus back to `WebContentView`, so typing continued to edit the location box.

Teach `NativeWindowContainer` focus forwarding to also watch the embedded native window and focus the container on mouse press while it is the host's focus proxy.

Fixes #10153