### PR TITLE
LibWebView: Reset page media state after WebContent crashes

### DIFF
--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1147,6 +1147,20 @@ void ViewImplementation::did_change_audio_play_state(Badge<WebContentClient>, We
         on_audio_play_state_changed(m_audio_play_state);
 }
 
+void ViewImplementation::reset_page_media_state()
+{
+    auto const should_notify_audio_play_state_changed = m_audio_play_state != Web::HTML::AudioPlayState::Paused
+        || m_number_of_elements_playing_audio != 0
+        || m_mute_state != Web::HTML::MuteState::Unmuted;
+
+    m_audio_play_state = Web::HTML::AudioPlayState::Paused;
+    m_number_of_elements_playing_audio = 0;
+    m_mute_state = Web::HTML::MuteState::Unmuted;
+
+    if (should_notify_audio_play_state_changed && on_audio_play_state_changed)
+        on_audio_play_state_changed(m_audio_play_state);
+}
+
 static Optional<size_t> current_top_level_history_entry_index_for_step(Vector<Web::HTML::SessionHistoryEntryDescriptor> const&, Optional<i32> current_step);
 
 void ViewImplementation::apply_web_content_session_history_update(WebContentSessionHistoryUpdateResult const& update)
@@ -1808,6 +1822,8 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
     }
 
     ++m_crash_count;
+    reset_page_media_state();
+
     constexpr size_t max_reasonable_crash_count = 5U;
     if (m_crash_count >= max_reasonable_crash_count) {
         if (!headless_mode) {

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -436,6 +436,7 @@ protected:
         Yes,
     };
     virtual void initialize_client(CreateNewClient = CreateNewClient::Yes);
+    void reset_page_media_state();
 
     enum class LoadErrorPage {
         No,


### PR DESCRIPTION
When replacing a crashed WebContent process, clear the UI process' cached audio play state, playing-element count, and page mute state.

Notify the existing audio state callback when the reset changes visible state so browser chrome removes stale audio or muted indicators.