### PR TITLE
Everywhere: Standardize use of "the Ladybird developers" in SPDX headers

### DIFF
--- a/AK/NonnullRawPtr.h
+++ b/AK/NonnullRawPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/AK/Random.cpp
+++ b/AK/Random.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  * Copyright (c) 2025-2026, Colleirose <criticskate@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Documentation/EditorConfiguration/QtCreatorConfiguration.md
+++ b/Documentation/EditorConfiguration/QtCreatorConfiguration.md
@@ -70,7 +70,7 @@ In order to so, create a new file anywhere, for example `license-template.creato
 
 ```
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibCompress/Brotli.cpp
+++ b/Libraries/LibCompress/Brotli.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibCompress/Brotli.h
+++ b/Libraries/LibCompress/Brotli.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/Actors/CookiesActor.cpp
+++ b/Libraries/LibDevTools/Actors/CookiesActor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/Actors/CookiesActor.h
+++ b/Libraries/LibDevTools/Actors/CookiesActor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/Actors/IndexedDBActor.cpp
+++ b/Libraries/LibDevTools/Actors/IndexedDBActor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/Actors/IndexedDBActor.h
+++ b/Libraries/LibDevTools/Actors/IndexedDBActor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Ladybird developers.
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.h
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Ladybird developers.
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/Actors/StorageActor.cpp
+++ b/Libraries/LibDevTools/Actors/StorageActor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/Actors/StorageActor.h
+++ b/Libraries/LibDevTools/Actors/StorageActor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/IndexedDBSerialization.cpp
+++ b/Libraries/LibDevTools/IndexedDBSerialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/IndexedDBSerialization.h
+++ b/Libraries/LibDevTools/IndexedDBSerialization.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/StorageHelpers.cpp
+++ b/Libraries/LibDevTools/StorageHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibDevTools/StorageHelpers.h
+++ b/Libraries/LibDevTools/StorageHelpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibGC/Rootable.h
+++ b/Libraries/LibGC/Rootable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibGfx/BitmapExport.cpp
+++ b/Libraries/LibGfx/BitmapExport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibGfx/BitmapExport.h
+++ b/Libraries/LibGfx/BitmapExport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibGfx/Direct3DContext.cpp
+++ b/Libraries/LibGfx/Direct3DContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibGfx/Direct3DContext.h
+++ b/Libraries/LibGfx/Direct3DContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibIPC/AutoCloseFileDescriptor.cpp
+++ b/Libraries/LibIPC/AutoCloseFileDescriptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Ladybird developers.
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibIPC/AutoCloseFileDescriptor.h
+++ b/Libraries/LibIPC/AutoCloseFileDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Ladybird developers.
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/AsmIntGen/src/main.rs
+++ b/Libraries/LibJS/AsmIntGen/src/main.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/AsmIntGen/src/parser.rs
+++ b/Libraries/LibJS/AsmIntGen/src/parser.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/AsmIntGen/src/registers.rs
+++ b/Libraries/LibJS/AsmIntGen/src/registers.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/AsmIntGen/src/shared.rs
+++ b/Libraries/LibJS/AsmIntGen/src/shared.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmSlowPaths.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmSlowPaths.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/Runtime/InterpreterStack.cpp
+++ b/Libraries/LibJS/Runtime/InterpreterStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibJS/Runtime/InterpreterStack.h
+++ b/Libraries/LibJS/Runtime/InterpreterStack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibMedia/Audio/AudioDevices.cpp
+++ b/Libraries/LibMedia/Audio/AudioDevices.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibMedia/Audio/AudioDevices.h
+++ b/Libraries/LibMedia/Audio/AudioDevices.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibMedia/Containers/Matroska/ElementIDs.h
+++ b/Libraries/LibMedia/Containers/Matroska/ElementIDs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibRequests/NetworkError.h
+++ b/Libraries/LibRequests/NetworkError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibThreading/ThreadPool.cpp
+++ b/Libraries/LibThreading/ThreadPool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibThreading/ThreadPool.h
+++ b/Libraries/LibThreading/ThreadPool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibURL/RustIntegration.cpp
+++ b/Libraries/LibURL/RustIntegration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibURL/RustIntegration.h
+++ b/Libraries/LibURL/RustIntegration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Bindings/InterfaceObject.cpp
+++ b/Libraries/LibWeb/Bindings/InterfaceObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Bindings/InterfaceObject.h
+++ b/Libraries/LibWeb/Bindings/InterfaceObject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/CharacterTypes.h
+++ b/Libraries/LibWeb/CSS/CharacterTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/AdoptedStyleSheetInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/AdoptedStyleSheetInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/AdoptedStyleSheetInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/AdoptedStyleSheetInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/AncestorTraversal.h
+++ b/Libraries/LibWeb/CSS/Invalidation/AncestorTraversal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/AttributeInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/AttributeInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/AttributeInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/AttributeInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/CustomElementInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/CustomElementInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/CustomElementInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/CustomElementInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/ElementStateInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/ElementStateInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/ElementStateInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/ElementStateInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/EmbeddedContentInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/EmbeddedContentInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/EmbeddedContentInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/EmbeddedContentInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/FormControlInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/FormControlInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/FormControlInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/FormControlInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationFeatureCollector.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationFeatureCollector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationFeatureCollector.h
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationFeatureCollector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/InvalidationSetMatcher.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/InvalidationSetMatcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/InvalidationSetMatcher.h
+++ b/Libraries/LibWeb/CSS/Invalidation/InvalidationSetMatcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/LanguageInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/LanguageInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/LanguageInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/LanguageInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/LinkInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/LinkInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/LinkInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/LinkInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/MediaQueryInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/MediaQueryInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/MediaQueryInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/MediaQueryInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/NodeInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/NodeInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/NodeInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/NodeInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/PartInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/PartInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/PartInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/PartInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/PseudoClassInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/PseudoClassInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/PseudoClassInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/PseudoClassInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/SlotInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/SlotInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/SlotInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/SlotInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/StructuralMutationInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/StructuralMutationInvalidator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Invalidation/StructuralMutationInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/StructuralMutationInvalidator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Parser/RustTokenizer.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RustTokenizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/Parser/RustTokenizer.h
+++ b/Libraries/LibWeb/CSS/Parser/RustTokenizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/PreferredContrast.cpp
+++ b/Libraries/LibWeb/CSS/PreferredContrast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/PreferredContrast.h
+++ b/Libraries/LibWeb/CSS/PreferredContrast.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/PreferredMotion.cpp
+++ b/Libraries/LibWeb/CSS/PreferredMotion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/PreferredMotion.h
+++ b/Libraries/LibWeb/CSS/PreferredMotion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/SelectorInsights.h
+++ b/Libraries/LibWeb/CSS/SelectorInsights.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/StyleValues/ColorSchemeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ColorSchemeStyleValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/StyleValues/ContrastColorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ContrastColorStyleValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/StyleValues/ContrastColorStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ContrastColorStyleValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/StyleValues/LightDarkStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/LightDarkStyleValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  * Copyright (c) 2026, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Libraries/LibWeb/CSS/StyleValues/LightDarkStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LightDarkStyleValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/CSS/StyleValues/ScrollbarGutterStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ScrollbarGutterStyleValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Compositor/Types.h
+++ b/Libraries/LibWeb/Compositor/Types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/BarProp.cpp
+++ b/Libraries/LibWeb/HTML/BarProp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Ladybird developers.
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/BarProp.h
+++ b/Libraries/LibWeb/HTML/BarProp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Ladybird developers.
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/Canvas/CanvasSettings.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/Canvas/SerializeBitmap.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/SerializeBitmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/Canvas/SerializeBitmap.h
+++ b/Libraries/LibWeb/HTML/Canvas/SerializeBitmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/CloseWatcher.cpp
+++ b/Libraries/LibWeb/HTML/CloseWatcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  * Copyright (c) 2024, Felipe Muñoz Mazur <felipe.munoz.mazur@protonmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Libraries/LibWeb/HTML/CloseWatcher.h
+++ b/Libraries/LibWeb/HTML/CloseWatcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/CloseWatcherManager.cpp
+++ b/Libraries/LibWeb/HTML/CloseWatcherManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/CloseWatcherManager.h
+++ b/Libraries/LibWeb/HTML/CloseWatcherManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/ElementInternals.cpp
+++ b/Libraries/LibWeb/HTML/ElementInternals.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/ElementInternals.h
+++ b/Libraries/LibWeb/HTML/ElementInternals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, the Ladybird developers.
+ * Copyright (c) 2024-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/OffscreenCanvas.cpp
+++ b/Libraries/LibWeb/HTML/OffscreenCanvas.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/OffscreenCanvas.h
+++ b/Libraries/LibWeb/HTML/OffscreenCanvas.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.h
+++ b/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/WorkerAgentForward.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentForward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/WorkerAgentTypes.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/WorkerAgentTypes.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/IndexedDB/Inspection.cpp
+++ b/Libraries/LibWeb/IndexedDB/Inspection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/IndexedDB/Inspection.h
+++ b/Libraries/LibWeb/IndexedDB/Inspection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/IndexedDB/TransactionChanges.h
+++ b/Libraries/LibWeb/IndexedDB/TransactionChanges.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Layout/FlexLayoutData.h
+++ b/Libraries/LibWeb/Layout/FlexLayoutData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Layout/GridLayoutData.h
+++ b/Libraries/LibWeb/Layout/GridLayoutData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Layout/LayoutInput.h
+++ b/Libraries/LibWeb/Layout/LayoutInput.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaDeviceInfo.cpp
+++ b/Libraries/LibWeb/MediaCapture/MediaDeviceInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaDeviceInfo.h
+++ b/Libraries/LibWeb/MediaCapture/MediaDeviceInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaDevices.cpp
+++ b/Libraries/LibWeb/MediaCapture/MediaDevices.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaDevices.h
+++ b/Libraries/LibWeb/MediaCapture/MediaDevices.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaStream.cpp
+++ b/Libraries/LibWeb/MediaCapture/MediaStream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaStream.h
+++ b/Libraries/LibWeb/MediaCapture/MediaStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaStreamTrack.cpp
+++ b/Libraries/LibWeb/MediaCapture/MediaStreamTrack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaStreamTrack.h
+++ b/Libraries/LibWeb/MediaCapture/MediaStreamTrack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaStreamTrackEvent.cpp
+++ b/Libraries/LibWeb/MediaCapture/MediaStreamTrackEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/MediaCapture/MediaStreamTrackEvent.h
+++ b/Libraries/LibWeb/MediaCapture/MediaStreamTrackEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Painting/ChromeWidget.h
+++ b/Libraries/LibWeb/Painting/ChromeWidget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Painting/FlexboxInspectorOverlay.h
+++ b/Libraries/LibWeb/Painting/FlexboxInspectorOverlay.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Painting/Forward.h
+++ b/Libraries/LibWeb/Painting/Forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, the Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Painting/GridInspectorOverlay.h
+++ b/Libraries/LibWeb/Painting/GridInspectorOverlay.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Painting/ResizeHandle.cpp
+++ b/Libraries/LibWeb/Painting/ResizeHandle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Painting/ResizeHandle.h
+++ b/Libraries/LibWeb/Painting/ResizeHandle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/Painting/Scrollbar.h
+++ b/Libraries/LibWeb/Painting/Scrollbar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/RefCountedTreeNode.h
+++ b/Libraries/LibWeb/RefCountedTreeNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/WebIDL/OverloadTypes.cpp
+++ b/Libraries/LibWeb/WebIDL/OverloadTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/WebIDL/OverloadTypes.h
+++ b/Libraries/LibWeb/WebIDL/OverloadTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWebView/CompositorClient.cpp
+++ b/Libraries/LibWebView/CompositorClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWebView/CompositorClient.h
+++ b/Libraries/LibWebView/CompositorClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWebView/DownloadPresentation.cpp
+++ b/Libraries/LibWebView/DownloadPresentation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWebView/DownloadPresentation.h
+++ b/Libraries/LibWebView/DownloadPresentation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWebView/WorkerProcessManager.cpp
+++ b/Libraries/LibWebView/WorkerProcessManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWebView/WorkerProcessManager.h
+++ b/Libraries/LibWebView/WorkerProcessManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibXML/Parser/Parser.cpp
+++ b/Libraries/LibXML/Parser/Parser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibXML/Parser/Parser.h
+++ b/Libraries/LibXML/Parser/Parser.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Meta/CMake/flatpak/generate-cargo-sources.py
+++ b/Meta/CMake/flatpak/generate-cargo-sources.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026, Ladybird developers
+
+# Copyright (c) 2026-present, the Ladybird developers.
+#
 # SPDX-License-Identifier: BSD-2-Clause
 
 # Generate cargo-sources.json for Flatpak builds from Cargo.lock.

--- a/Meta/CMake/freedesktop/org.ladybird.Ladybird.metainfo.xml.in
+++ b/Meta/CMake/freedesktop/org.ladybird.Ladybird.metainfo.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2025, the Ladybird developers. -->
+<!-- Copyright 2025-present, the Ladybird developers. -->
 <component type="desktop-application">
   <id>org.ladybird.Ladybird</id>
 

--- a/Meta/Linters/check_flatpak.py
+++ b/Meta/Linters/check_flatpak.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2025, The Ladybird contributors
+# Copyright (c) 2026-present, the Ladybird developers.
 #
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/Meta/Linters/check_style.py
+++ b/Meta/Linters/check_style.py
@@ -21,6 +21,8 @@ GOOD_LICENSE_HEADER_PATTERN = re.compile(
     + " \\*/\n"
     + "\n"
 )
+COPYRIGHT_HEADER_PATTERN = re.compile("^/\\*\n(?:(?! \\*/\n).)*Copyright(?:(?! \\*/\n).)* \\*/\n", re.DOTALL)
+GOOD_LADYBIRD_COPYRIGHT_PATTERN = re.compile("^ \\* Copyright \\(c\\) [0-9]{4}-present, the Ladybird developers\\.$")
 LICENSE_HEADER_CHECK_EXCLUDES = {
     "AK/Checked.h",
     "AK/Function.h",
@@ -89,8 +91,21 @@ def find_matching_prefix(filename, prefix_list):
     return matching_prefixes[0] if matching_prefixes else None
 
 
+def find_bad_ladybird_copyright_lines(file_content):
+    license_header_match = COPYRIGHT_HEADER_PATTERN.search(file_content)
+    if license_header_match is None:
+        return []
+
+    return [
+        line
+        for line in license_header_match.group(0).splitlines()
+        if "Copyright" in line and "Ladybird" in line and GOOD_LADYBIRD_COPYRIGHT_PATTERN.match(line) is None
+    ]
+
+
 def run():
     errors_license = []
+    errors_ladybird_copyright = {}
     errors_pragma_once_bad = []
     errors_pragma_once_missing = []
     errors_include_libc = []
@@ -106,6 +121,9 @@ def run():
         if not is_in_prefix_list(filename, LICENSE_HEADER_CHECK_EXCLUDES):
             if not GOOD_LICENSE_HEADER_PATTERN.search(file_content):
                 errors_license.append(filename)
+        bad_ladybird_copyright_lines = find_bad_ladybird_copyright_lines(file_content)
+        if bad_ladybird_copyright_lines:
+            errors_ladybird_copyright[filename] = bad_ladybird_copyright_lines
         if filename.endswith(".rs"):
             continue
         if filename.endswith(".h"):
@@ -153,6 +171,12 @@ def run():
     have_errors = False
     if errors_license:
         print("Files with bad licenses:", " ".join(errors_license))
+        have_errors = True
+    if errors_ladybird_copyright:
+        for file in errors_ladybird_copyright:
+            print(f"{file} contains non-standard Ladybird copyright header lines:")
+            for line in errors_ladybird_copyright[file]:
+                print(f"  {line}")
         have_errors = True
     if errors_pragma_once_missing:
         print("Files without #pragma once:", " ".join(errors_pragma_once_missing))

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/Forward.h
+++ b/Services/Compositor/Forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/VSyncScheduler.cpp
+++ b/Services/Compositor/VSyncScheduler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/VSyncScheduler.h
+++ b/Services/Compositor/VSyncScheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/ViewportScrollbarController.cpp
+++ b/Services/Compositor/ViewportScrollbarController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/ViewportScrollbarController.h
+++ b/Services/Compositor/ViewportScrollbarController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/AK/TestGenericShorthands.cpp
+++ b/Tests/AK/TestGenericShorthands.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Ladybird developers.
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibCompress/TestBrotli.cpp
+++ b/Tests/LibCompress/TestBrotli.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibCore/TestLibCoreMimeType.cpp
+++ b/Tests/LibCore/TestLibCoreMimeType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, the Ladybird developers.
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibCrypto/TestHMAC.cpp
+++ b/Tests/LibCrypto/TestHMAC.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the Ladybird developers.
+ * Copyright (c) 2021-present, the Ladybird developers.
  * Copyright (c) 2025, Altomani Gianluca <altomanigianluca@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Tests/LibDNS/TestDNSMessage.cpp
+++ b/Tests/LibDNS/TestDNSMessage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibGfx/TestBitmapExport.cpp
+++ b/Tests/LibGfx/TestBitmapExport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Ladybird contributors
+ * Copyright (c) 2025-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibGfx/TestBitmapSequence.cpp
+++ b/Tests/LibGfx/TestBitmapSequence.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibGfx/TestFont.cpp
+++ b/Tests/LibGfx/TestFont.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibGfx/TestShareableBitmap.cpp
+++ b/Tests/LibGfx/TestShareableBitmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Ladybird contributors
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibHTTP/TestCacheIndex.cpp
+++ b/Tests/LibHTTP/TestCacheIndex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibHTTP/TestCacheUtilities.cpp
+++ b/Tests/LibHTTP/TestCacheUtilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibIPC/TestConnection.cpp
+++ b/Tests/LibIPC/TestConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibIPC/TestTransportSocket.cpp
+++ b/Tests/LibIPC/TestTransportSocket.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibMedia/TestFFmpegAudioNormalization.cpp
+++ b/Tests/LibMedia/TestFFmpegAudioNormalization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/TestCSSStyleSheetInvalidation.cpp
+++ b/Tests/LibWeb/TestCSSStyleSheetInvalidation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026-present, The Ladybird developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/TestRefCountedTreeNode.cpp
+++ b/Tests/LibWeb/TestRefCountedTreeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, the Ladybird developers.
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/test-web/CaptureFile.cpp
+++ b/Tests/LibWeb/test-web/CaptureFile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird Developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/test-web/CaptureFile.h
+++ b/Tests/LibWeb/test-web/CaptureFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird Developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/test-web/Debug.cpp
+++ b/Tests/LibWeb/test-web/Debug.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird Developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/test-web/Debug.h
+++ b/Tests/LibWeb/test-web/Debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird Developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/test-web/Display.cpp
+++ b/Tests/LibWeb/test-web/Display.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird Developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/test-web/Display.h
+++ b/Tests/LibWeb/test-web/Display.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird Developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/test-web/TestRunCapture.cpp
+++ b/Tests/LibWeb/test-web/TestRunCapture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird Developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Tests/LibWeb/test-web/TestRunCapture.h
+++ b/Tests/LibWeb/test-web/TestRunCapture.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, The Ladybird Developers
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */


### PR DESCRIPTION
Before this, in our SPDX license headers, we had:

* 430 instances of "the Ladybird developers."
* 39 instances of "the Ladybird developers"
* 17 instances of "The Ladybird developers"
* 1 instance of "Ladybird developers"
* 50 instances of "Ladybird contributors"
* 1 instance of "The Ladybird contributors"

Let's standardize on "the Ladybird developers.", and add the "-present" suffix to the copyright year.