### PR TITLE
LibWeb: Honor preload=none for media elements

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -112,7 +112,7 @@ void HTMLMediaElement::initialize(JS::Realm& realm)
 
     m_document_observer->set_document_became_active([this]() {
         // AD-HOC: Restart the fetch from where the stream last received data so that playback can continue.
-        if (m_remote_fetch_data) {
+        if (m_remote_fetch_data && !m_waiting_for_an_implementation_defined_event_to_fetch_the_resource) {
             VERIFY(!m_remote_fetch_data->fetch_controller);
             if (m_remote_fetch_data->stream->next_chunk_start() != m_remote_fetch_data->stream->expected_size())
                 load_remote_resource(UntilEnd { m_remote_fetch_data->stream->next_chunk_start() });
@@ -203,6 +203,13 @@ void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<String>
             create_controls();
         else
             destroy_controls();
+    } else if (name == HTML::AttributeNames::preload || name == HTML::AttributeNames::autoplay) {
+        if (m_waiting_for_an_implementation_defined_event_to_fetch_the_resource
+            && !should_wait_for_an_implementation_defined_event_before_fetching_the_resource()) {
+            // NB: This is an implementation-defined event. See the NB in
+            //     wait_for_an_implementation_defined_event_before_fetching_the_resource().
+            continue_fetching_the_resource_after_an_implementation_defined_event();
+        }
     }
 }
 
@@ -269,6 +276,7 @@ void HTMLMediaElement::adopted_from(DOM::Document& old_document)
 void HTMLMediaElement::cancel_the_fetching_process()
 {
     m_current_fetch_generation++;
+    m_waiting_for_an_implementation_defined_event_to_fetch_the_resource = false;
     if (m_remote_fetch_data && m_remote_fetch_data->stream)
         m_remote_fetch_data->stream->close();
     m_remote_fetch_data.clear();
@@ -1199,19 +1207,84 @@ void HTMLMediaElement::load_url_resource(URL::URL const& url_record, Function<vo
     }));
     m_remote_fetch_data->failure_callback = move(failure_callback);
 
-    set_up_playback_manager_for_remote();
-
     load_remote_resource(EntireResource {});
+}
+
+// https://html.spec.whatwg.org/multipage/media.html#attr-media-preload
+bool HTMLMediaElement::preload_attribute_is_in_none_state() const
+{
+    auto preload = get_attribute(HTML::AttributeNames::preload);
+    return preload.has_value() && preload->equals_ignoring_ascii_case("none"sv);
+}
+
+bool HTMLMediaElement::should_wait_for_an_implementation_defined_event_before_fetching_the_resource() const
+{
+    if (!preload_attribute_is_in_none_state())
+        return false;
+
+    if (!paused())
+        return false;
+
+    if (is_eligible_for_autoplay() && is_allowed_to_play())
+        return false;
+
+    return true;
+}
+
+void HTMLMediaElement::wait_for_an_implementation_defined_event_before_fetching_the_resource(u32 fetch_generation)
+{
+    m_waiting_for_an_implementation_defined_event_to_fetch_the_resource = true;
+
+    // 1. Set the networkState to NETWORK_IDLE.
+    m_network_state = NetworkState::Idle;
+
+    // 2. Queue a media element task given the media element to fire an event named suspend at the element.
+    queue_a_media_element_task([fetch_generation](HTMLMediaElement& self) {
+        if (fetch_generation != self.m_current_fetch_generation
+            || !self.m_waiting_for_an_implementation_defined_event_to_fetch_the_resource) {
+            return;
+        }
+        self.dispatch_event(DOM::Event::create(self.realm(), HTML::EventNames::suspend));
+    });
+
+    // 3. Queue a media element task given the media element to set the element's delaying-the-load-event flag to false. This stops delaying
+    //    the load event.
+    queue_a_media_element_task([fetch_generation](HTMLMediaElement& self) {
+        if (fetch_generation != self.m_current_fetch_generation
+            || !self.m_waiting_for_an_implementation_defined_event_to_fetch_the_resource) {
+            return;
+        }
+        self.m_delaying_the_load_event.clear();
+    });
+
+    // 4. Wait for the task to be run.
+    // 5. Wait for an implementation-defined event (e.g., the user requesting that the media element begin playback).
+    // NB: Step 4 is implemented by letting the media element task queued above clear the load event delayer. Step 5 is
+    //     represented by m_waiting_for_an_implementation_defined_event_to_fetch_the_resource; the callers of
+    //     continue_fetching_the_resource_after_an_implementation_defined_event() provide our implementation-defined events.
+}
+
+void HTMLMediaElement::continue_fetching_the_resource_after_an_implementation_defined_event()
+{
+    if (!m_waiting_for_an_implementation_defined_event_to_fetch_the_resource)
+        return;
+
+    VERIFY(m_remote_fetch_data);
+    m_waiting_for_an_implementation_defined_event_to_fetch_the_resource = false;
+
+    // 6. Set the element's delaying-the-load-event flag back to true (this delays the load event again, in case it hasn't been fired yet).
+    if (document().readiness() != DocumentReadyState::Complete)
+        m_delaying_the_load_event.emplace(document());
+
+    // 7. Set the networkState to NETWORK_LOADING.
+    m_network_state = NetworkState::Loading;
+
+    run_remote_mode_resource_fetch_steps(EntireResource {}, ++m_current_fetch_generation);
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#concept-media-load-resource
 void HTMLMediaElement::load_remote_resource(ByteRange const& byte_range)
 {
-    auto& realm = this->realm();
-    auto& vm = realm.vm();
-
-    auto const& url_record = m_remote_fetch_data->url_record;
-
     auto fetch_generation = ++m_current_fetch_generation;
 
     // 1. Let mode be remote.
@@ -1226,145 +1299,154 @@ void HTMLMediaElement::load_remote_resource(ByteRange const& byte_range)
     // 5. Run the appropriate steps from the following list:
     // -> If mode is remote
     {
-        // FIXME: 1. Optionally, run the following substeps. This is the expected behavior if the user agent intends to not attempt to fetch the resource until
-        //           the user requests it explicitly (e.g. as a way to implement the preload attribute's none keyword).
-        //            1. Set the networkState to NETWORK_IDLE.
-        //            2. Queue a media element task given the media element to fire an event named suspend at the element.
-        //            3. Queue a media element task given the media element to set the element's delaying-the-load-event flag to false. This stops delaying
-        //               the load event.
-        //            4. Wait for the task to be run.
-        //            5. Wait for an implementation-defined event (e.g., the user requesting that the media element begin playback).
-        //            6. Set the element's delaying-the-load-event flag back to true (this delays the load event again, in case it hasn't been fired yet).
-        //            7. Set the networkState to NETWORK_LOADING.
-
-        // 2. Let destination be "audio" if the media element is an audio element, or "video" otherwise.
-        auto destination = is<HTMLAudioElement>(*this)
-            ? Fetch::Infrastructure::Request::Destination::Audio
-            : Fetch::Infrastructure::Request::Destination::Video;
-
-        // 3. Let request be the result of creating a potential-CORS request given current media resource's URL record, destination, and the current state
-        //    of the media element's crossorigin content attribute.
-        auto request = create_potential_CORS_request(vm, url_record, destination, m_crossorigin);
-
-        // 4. Set request's client to the media element's node document's relevant settings object.
-        request->set_client(&document().relevant_settings_object());
-
-        // 5. Set request's initiator type to destination.
-        request->set_initiator_type(destination == Fetch::Infrastructure::Request::Destination::Audio
-                ? Fetch::Infrastructure::Request::InitiatorType::Audio
-                : Fetch::Infrastructure::Request::InitiatorType::Video);
-
-        // 6. Let byteRange, which is "entire resource" or a (number, number or "until end") tuple, be the byte range required to satisfy missing data in
-        //    media data. This value is implementation-defined and may rely on codec, network conditions or other heuristics. The user-agent may determine
-        //    to fetch the resource in full, in which case byteRange would be "entire resource", to fetch from a byte offset until the end, in which case
-        //    byteRange would be (number, "until end"), or to fetch a range between two byte offsets, in which case byteRange would be a (number, number)
-        //    tuple representing the two offsets.
-        // NB: byte_range is passed as a parameter.
-
-        // 7. If byteRange is not "entire resource", then:
-        m_remote_fetch_data->offset = 0;
-
-        if (!byte_range.has<EntireResource>()) {
-            // 1. If byteRange[1] is "until end", then add a range header to request given byteRange[0].
-            if (byte_range.has<UntilEnd>()) {
-                auto const& range = byte_range.get<UntilEnd>();
-                request->add_range_header(range.first, {});
-                m_remote_fetch_data->offset = range.first;
-            } else {
-                // 2. Otherwise, add a range header to request given byteRange[0] and byteRange[1].
-                // NB: We don't currently have any need to request a range with a delimited end.
-                VERIFY_NOT_REACHED();
-            }
+        // 1. Optionally, run the following substeps. This is the expected behavior if the user agent intends to not attempt to fetch the resource until
+        //    the user requests it explicitly (e.g. as a way to implement the preload attribute's none keyword).
+        if (should_wait_for_an_implementation_defined_event_before_fetching_the_resource()) {
+            wait_for_an_implementation_defined_event_before_fetching_the_resource(fetch_generation);
+            return;
         }
 
-        // 8. Fetch request, with processResponse set to the following steps given response response:
-        Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
-
-        fetch_algorithms_input.process_response = [self = GC::Ref(*this), byte_range = move(byte_range), fetch_generation](auto response) mutable {
-            auto& fetch_data = self->m_remote_fetch_data;
-
-            // FIXME: If the response is CORS cross-origin, we must use its internal response to query any of its data. See:
-            //        https://github.com/whatwg/html/issues/9355
-            response = response->unsafe_response();
-
-            // 1. Let global be the media element's node document's relevant global object.
-            auto& global = self->document().realm().global_object();
-
-            if (auto content_length = response->header_list()->extract_length(); content_length.template has<u64>()) {
-                auto actual_length = fetch_data->offset + content_length.template get<u64>();
-                fetch_data->stream->set_expected_size(actual_length);
-            }
-
-            if (auto accept_ranges = response->header_list()->extract_header_list_values("Accept-Ranges"sv); accept_ranges.template has<Vector<ByteString>>())
-                fetch_data->accepts_byte_ranges = accept_ranges.template get<Vector<ByteString>>().contains([](auto const& units) { return units == "bytes"sv; });
-
-            // 4. If the result of verifying response given the current media resource and byteRange is false, then abort these steps.
-            // NOTE: We do this step before creating the updateMedia task so that we can invoke the failure callback.
-            auto maybe_verify_response_failure = self->verify_response_or_get_failure_reason(response, byte_range);
-            if (maybe_verify_response_failure.has_value()) {
-                fetch_data->stream->close();
-                fetch_data->failure_callback(maybe_verify_response_failure.value());
-                return;
-            }
-
-            // 2. Let updateMedia be to queue a media element task given the media element to run the first appropriate steps from the media data processing
-            //    steps list below. (A new task is used for this so that the work described below occurs relative to the appropriate media element event task
-            //    source rather than using the networking task source.)
-            auto update_media = GC::create_function(self->heap(), [weak_self = GC::Weak(self), fetch_generation](ByteBuffer media_data) mutable {
-                if (!weak_self)
-                    return;
-                if (fetch_generation != weak_self->m_current_fetch_generation)
-                    return;
-                auto& fetch_data = weak_self->m_remote_fetch_data;
-
-                // 6. Update the media data with the contents of response's unsafe response obtained in this fashion. response can be CORS-same-origin or
-                //    CORS-cross-origin; this affects whether subtitles referenced in the media data are exposed in the API and, for video elements, whether
-                //    a canvas gets tainted when the video is drawn on it.
-                fetch_data->stream->add_chunk_at(fetch_data->offset, media_data.bytes());
-                fetch_data->offset += media_data.size();
-
-                weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
-                    self.process_media_data(FetchingStatus::Ongoing);
-                });
-            });
-
-            // 3. Let processEndOfMedia be the following step: If the fetching process has completes without errors, including decoding the media data,
-            //    and if all of the data is available to the user agent without network access, then, the user agent must move on to the final step below.
-            //    This might never happen, e.g. when streaming an infinite resource such as web radio, or if the resource is longer than the user agent's
-            //    ability to cache data.
-            auto process_end_of_media = GC::create_function(self->heap(), [weak_self = GC::Weak(self), fetch_generation] {
-                if (!weak_self)
-                    return;
-                if (fetch_generation != weak_self->m_current_fetch_generation)
-                    return;
-
-                weak_self->m_remote_fetch_data->stream->close();
-                weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
-                    self.process_media_data(FetchingStatus::Complete);
-                });
-            });
-
-            // 5. Otherwise, incrementally read response's body given updateMedia, processEndOfMedia, an empty algorithm, and global.
-
-            // AD-HOC: We need to pass a non-empty error algorithm in order to invoke the requisite steps.
-            auto process_body_error = GC::create_function(self->heap(), [weak_self = GC::Weak(self), fetch_generation](JS::Value) {
-                if (!weak_self)
-                    return;
-                if (fetch_generation != weak_self->m_current_fetch_generation)
-                    return;
-
-                weak_self->m_remote_fetch_data->stream->close();
-                weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
-                    self.process_media_data(FetchingStatus::Interrupted);
-                });
-            });
-
-            VERIFY(response->body());
-            response->body()->incrementally_read(update_media, process_end_of_media, process_body_error, GC::Ref { global });
-        };
-
-        m_remote_fetch_data->fetch_controller = Fetch::Fetching::fetch(realm, request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
+        run_remote_mode_resource_fetch_steps(byte_range, fetch_generation);
     }
+}
+
+void HTMLMediaElement::run_remote_mode_resource_fetch_steps(ByteRange byte_range, u32 fetch_generation)
+{
+    auto& realm = this->realm();
+    auto& vm = realm.vm();
+
+    auto const& url_record = m_remote_fetch_data->url_record;
+
+    if (!m_playback_manager)
+        set_up_playback_manager_for_remote();
+
+    // 2. Let destination be "audio" if the media element is an audio element, or "video" otherwise.
+    auto destination = is<HTMLAudioElement>(*this)
+        ? Fetch::Infrastructure::Request::Destination::Audio
+        : Fetch::Infrastructure::Request::Destination::Video;
+
+    // 3. Let request be the result of creating a potential-CORS request given current media resource's URL record, destination, and the current state
+    //    of the media element's crossorigin content attribute.
+    auto request = create_potential_CORS_request(vm, url_record, destination, m_crossorigin);
+
+    // 4. Set request's client to the media element's node document's relevant settings object.
+    request->set_client(&document().relevant_settings_object());
+
+    // 5. Set request's initiator type to destination.
+    request->set_initiator_type(destination == Fetch::Infrastructure::Request::Destination::Audio
+            ? Fetch::Infrastructure::Request::InitiatorType::Audio
+            : Fetch::Infrastructure::Request::InitiatorType::Video);
+
+    // 6. Let byteRange, which is "entire resource" or a (number, number or "until end") tuple, be the byte range required to satisfy missing data in
+    //    media data. This value is implementation-defined and may rely on codec, network conditions or other heuristics. The user-agent may determine
+    //    to fetch the resource in full, in which case byteRange would be "entire resource", to fetch from a byte offset until the end, in which case
+    //    byteRange would be (number, "until end"), or to fetch a range between two byte offsets, in which case byteRange would be a (number, number)
+    //    tuple representing the two offsets.
+    // NB: byte_range is passed as a parameter.
+
+    // 7. If byteRange is not "entire resource", then:
+    m_remote_fetch_data->offset = 0;
+
+    if (!byte_range.has<EntireResource>()) {
+        // 1. If byteRange[1] is "until end", then add a range header to request given byteRange[0].
+        if (byte_range.has<UntilEnd>()) {
+            auto const& range = byte_range.get<UntilEnd>();
+            request->add_range_header(range.first, {});
+            m_remote_fetch_data->offset = range.first;
+        } else {
+            // 2. Otherwise, add a range header to request given byteRange[0] and byteRange[1].
+            // NB: We don't currently have any need to request a range with a delimited end.
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    // 8. Fetch request, with processResponse set to the following steps given response response:
+    Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
+
+    fetch_algorithms_input.process_response = [self = GC::Ref(*this), byte_range = move(byte_range), fetch_generation](auto response) mutable {
+        auto& fetch_data = self->m_remote_fetch_data;
+
+        // FIXME: If the response is CORS cross-origin, we must use its internal response to query any of its data. See:
+        //        https://github.com/whatwg/html/issues/9355
+        response = response->unsafe_response();
+
+        // 1. Let global be the media element's node document's relevant global object.
+        auto& global = self->document().realm().global_object();
+
+        if (auto content_length = response->header_list()->extract_length(); content_length.template has<u64>()) {
+            auto actual_length = fetch_data->offset + content_length.template get<u64>();
+            fetch_data->stream->set_expected_size(actual_length);
+        }
+
+        if (auto accept_ranges = response->header_list()->extract_header_list_values("Accept-Ranges"sv); accept_ranges.template has<Vector<ByteString>>())
+            fetch_data->accepts_byte_ranges = accept_ranges.template get<Vector<ByteString>>().contains([](auto const& units) { return units == "bytes"sv; });
+
+        // 4. If the result of verifying response given the current media resource and byteRange is false, then abort these steps.
+        // NOTE: We do this step before creating the updateMedia task so that we can invoke the failure callback.
+        auto maybe_verify_response_failure = self->verify_response_or_get_failure_reason(response, byte_range);
+        if (maybe_verify_response_failure.has_value()) {
+            fetch_data->stream->close();
+            fetch_data->failure_callback(maybe_verify_response_failure.value());
+            return;
+        }
+
+        // 2. Let updateMedia be to queue a media element task given the media element to run the first appropriate steps from the media data processing
+        //    steps list below. (A new task is used for this so that the work described below occurs relative to the appropriate media element event task
+        //    source rather than using the networking task source.)
+        auto update_media = GC::create_function(self->heap(), [weak_self = GC::Weak(self), fetch_generation](ByteBuffer media_data) mutable {
+            if (!weak_self)
+                return;
+            if (fetch_generation != weak_self->m_current_fetch_generation)
+                return;
+            auto& fetch_data = weak_self->m_remote_fetch_data;
+
+            // 6. Update the media data with the contents of response's unsafe response obtained in this fashion. response can be CORS-same-origin or
+            //    CORS-cross-origin; this affects whether subtitles referenced in the media data are exposed in the API and, for video elements, whether
+            //    a canvas gets tainted when the video is drawn on it.
+            fetch_data->stream->add_chunk_at(fetch_data->offset, media_data.bytes());
+            fetch_data->offset += media_data.size();
+
+            weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.process_media_data(FetchingStatus::Ongoing);
+            });
+        });
+
+        // 3. Let processEndOfMedia be the following step: If the fetching process has completes without errors, including decoding the media data,
+        //    and if all of the data is available to the user agent without network access, then, the user agent must move on to the final step below.
+        //    This might never happen, e.g. when streaming an infinite resource such as web radio, or if the resource is longer than the user agent's
+        //    ability to cache data.
+        auto process_end_of_media = GC::create_function(self->heap(), [weak_self = GC::Weak(self), fetch_generation] {
+            if (!weak_self)
+                return;
+            if (fetch_generation != weak_self->m_current_fetch_generation)
+                return;
+
+            weak_self->m_remote_fetch_data->stream->close();
+            weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.process_media_data(FetchingStatus::Complete);
+            });
+        });
+
+        // 5. Otherwise, incrementally read response's body given updateMedia, processEndOfMedia, an empty algorithm, and global.
+
+        // AD-HOC: We need to pass a non-empty error algorithm in order to invoke the requisite steps.
+        auto process_body_error = GC::create_function(self->heap(), [weak_self = GC::Weak(self), fetch_generation](JS::Value) {
+            if (!weak_self)
+                return;
+            if (fetch_generation != weak_self->m_current_fetch_generation)
+                return;
+
+            weak_self->m_remote_fetch_data->stream->close();
+            weak_self->queue_a_media_element_task([](HTMLMediaElement& self) {
+                self.process_media_data(FetchingStatus::Interrupted);
+            });
+        });
+
+        VERIFY(response->body());
+        response->body()->incrementally_read(update_media, process_end_of_media, process_body_error, GC::Ref { global });
+    };
+
+    m_remote_fetch_data->fetch_controller = Fetch::Fetching::fetch(realm, request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#concept-media-load-resource
@@ -2294,6 +2376,12 @@ void HTMLMediaElement::play_element()
     //    selection algorithm.
     if (m_network_state == NetworkState::Empty)
         select_resource();
+
+    if (m_waiting_for_an_implementation_defined_event_to_fetch_the_resource) {
+        // NB: This is an implementation-defined event. See the NB in
+        //     wait_for_an_implementation_defined_event_before_fetching_the_resource().
+        continue_fetching_the_resource_after_an_implementation_defined_event();
+    }
 
     // 2. If the playback has ended and the direction of playback is forwards, seek to the earliest possible position
     //    of the media resource.

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -216,6 +216,11 @@ private:
     void load_url_resource(URL::URL const&, ESCAPING Function<void(String)> failure_callback);
     void load_remote_resource(ByteRange const&);
     void load_local_resource(MediaProviderObject const&, ESCAPING Function<void(String)> failure_callback);
+    bool preload_attribute_is_in_none_state() const;
+    bool should_wait_for_an_implementation_defined_event_before_fetching_the_resource() const;
+    void wait_for_an_implementation_defined_event_before_fetching_the_resource(u32 fetch_generation);
+    void continue_fetching_the_resource_after_an_implementation_defined_event();
+    void run_remote_mode_resource_fetch_steps(ByteRange, u32 fetch_generation);
 
     Optional<String> verify_response_or_get_failure_reason(GC::Ref<Fetch::Infrastructure::Response>, ByteRange const&);
 
@@ -379,6 +384,7 @@ private:
 
     OwnPtr<RemoteFetchData> m_remote_fetch_data;
     u32 m_current_fetch_generation { 0 };
+    bool m_waiting_for_an_implementation_defined_event_to_fetch_the_resource { false };
 
     OwnPtr<Media::PlaybackManager> m_playback_manager;
     GC::Ptr<VideoTrack> m_selected_video_track;

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -35,7 +35,7 @@ static ErrorOr<Core::Process> launch_process(StringView application, ReadonlySpa
     return result;
 }
 
-static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint, bool headless, bool expose_experimental_interfaces, bool force_cpu_painting, bool disable_sandbox, Optional<StringView> debug_process, Optional<StringView> default_time_zone)
+static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint, bool headless, bool expose_experimental_interfaces, bool force_cpu_painting, bool disable_sandbox, Optional<StringView> debug_process, Optional<StringView> default_time_zone, Optional<StringView> resource_substitution_map_path)
 {
     Vector<ByteString> arguments;
 #if defined(AK_OS_MACOS)
@@ -71,6 +71,9 @@ static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint,
     if (default_time_zone.has_value())
         arguments.append(ByteString::formatted("--default-time-zone={}", default_time_zone.value()));
 
+    if (resource_substitution_map_path.has_value())
+        arguments.append(ByteString::formatted("--resource-map={}", resource_substitution_map_path.value()));
+
     // FIXME: WebDriver does not yet handle the WebContent process switch brought by site isolation.
     if (!Core::Environment::has("LADYBIRD_WEBDRIVER_ENABLE_SITE_ISOLATION"sv))
         arguments.append("--site-isolation=disable"sv);
@@ -97,6 +100,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     bool headless = false;
     Optional<StringView> debug_process;
     Optional<StringView> default_time_zone;
+    Optional<StringView> resource_substitution_map_path;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(listen_address, "IP address to listen on", "listen-address", 'l', "listen_address");
@@ -108,6 +112,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(debug_process, "Wait for a debugger to attach to the given process name (WebContent, RequestServer, etc.)", "debug-process", 0, "process-name");
     args_parser.add_option(headless, "Launch browser without a graphical interface", "headless");
     args_parser.add_option(default_time_zone, "Default time zone", "default-time-zone", 0, "time-zone-id");
+    args_parser.add_option(resource_substitution_map_path, "Path to JSON file mapping URLs to local files", "resource-map", 0, "path");
     args_parser.parse(arguments);
 
     auto ipv4_address = IPv4Address::from_string(listen_address);
@@ -150,7 +155,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         }
 
         auto launch_browser_callback = [&](ByteString const& webdriver_endpoint, bool headless) {
-            auto arguments = create_arguments(webdriver_endpoint, headless, expose_experimental_interfaces, force_cpu_painting, disable_sandbox, debug_process, default_time_zone);
+            auto arguments = create_arguments(webdriver_endpoint, headless, expose_experimental_interfaces, force_cpu_painting, disable_sandbox, debug_process, default_time_zone, resource_substitution_map_path);
             return launch_process("Ladybird"sv, arguments.span());
         };
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -14,6 +14,7 @@ Text/input/Worker/XHttpRequest-responseXML-unavailable-in-worker.html
 Crash/HTML/video-track-switch-during-seek.html
 Text/input/HTML/media-source-buffered.html
 Text/input/HTML/media-source-setup.html
+Text/input/HTML/HTMLMediaElement-preload-none-does-not-fetch.html
 Text/input/css/FontFace-arraybuffer-matching.html
 Text/input/wpt-import/mediacapture-streams/idlharness.https.window.html
 Text/input/css/font-face-load-dedups-same-url.html

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-preload-none-does-not-fetch.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-preload-none-does-not-fetch.txt
@@ -1,0 +1,7 @@
+load event fired
+audio.networkState: 1
+audio.networkState is NETWORK_IDLE: true
+audio.readyState is HAVE_NOTHING: true
+server saw no media request: true
+error event fired after preload change
+server saw media request after preload change: true

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-preload-none-does-not-fetch.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-preload-none-does-not-fetch.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    const mediaPath = `/echo/HTMLMediaElement-preload-none-${crypto.randomUUID()}.mp3`;
+    document.write(`<audio id="audio" preload="none" controls src="${mediaPath}"></audio>`);
+
+    asyncTest(done => {
+        const audio = document.getElementById("audio");
+
+        window.addEventListener("load", async () => {
+            println("load event fired");
+            println(`audio.networkState: ${audio.networkState}`);
+            println(`audio.networkState is NETWORK_IDLE: ${audio.networkState === HTMLMediaElement.NETWORK_IDLE}`);
+            println(`audio.readyState is HAVE_NOTHING: ${audio.readyState === HTMLMediaElement.HAVE_NOTHING}`);
+
+            const response = await fetch(`/recorded-request-headers${mediaPath}`);
+            println(`server saw no media request: ${response.status === 404}`);
+
+            const errorPromise = new Promise(resolve => {
+                audio.addEventListener("error", resolve, { once: true });
+            });
+            audio.preload = "metadata";
+            await errorPromise;
+
+            println("error event fired after preload change");
+            const responseAfterPreloadChange = await fetch(`/recorded-request-headers${mediaPath}`);
+            println(`server saw media request after preload change: ${responseAfterPreloadChange.status === 200}`);
+            done();
+        });
+    });
+</script>


### PR DESCRIPTION
Defer remote media fetches when the preload attribute is in the `None` state. Leave the element at `NETWORK_IDLE`, fire suspend, and clear the `load`-event delayer until playback or a preload/autoplay change asks for data.

This keeps `preload=none` media from blocking the document `load` event. Add a regression test that verifies the media URL is not requested before `load`, then resumes when preload changes.

Fixes an issue on https://daringfireball.net/ where we'd preload a large MP3 file despite being asked not to, delaying the `load` event for much longer than necessary.