### PR TITLE
UI: Make right-clicking on URL-like text treat it like a link

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -2308,10 +2308,73 @@ bool EventHandler::select_context_menu_text(DOM::Document& document, CSSPixelPoi
     if (user_select == CSS::UserSelect::None)
         return false;
 
-    auto selected_text = initiate_word_selection(document, *caret_position, user_select);
+    auto selected_text = select_context_menu_url_token(document, *caret_position, user_select)
+        || initiate_word_selection(document, *caret_position, user_select);
     if (selected_text)
         stop_updating_selection();
     return selected_text;
+}
+
+bool EventHandler::select_context_menu_url_token(DOM::Document& document, Painting::CaretPosition const& caret_position, CSS::UserSelect user_select)
+{
+    auto* hit_node = as_if<DOM::Text>(*caret_position.boundary.node);
+    if (!hit_node)
+        return false;
+
+    if (hit_node->is_password_input())
+        return false;
+
+    auto const& text = hit_node->data();
+    auto length = text.length_in_code_units();
+    auto hit_index = min(caret_position.boundary.offset, length);
+    if (length == 0)
+        return false;
+
+    auto is_url_code_unit = [](char16_t code_unit) {
+        if (code_unit > 0x7f)
+            return false;
+        if (is_ascii_space(code_unit))
+            return false;
+        return !first_is_one_of(code_unit, '"', '\'', '`', '<', '>');
+    };
+
+    auto is_url_leading_punctuation = [](char16_t code_unit) {
+        return first_is_one_of(code_unit, '"', '\'', '`', '(', '[', '{', '<');
+    };
+
+    auto is_url_trailing_punctuation = [](char16_t code_unit) {
+        return first_is_one_of(code_unit, '"', '\'', '`', '.', ',', ';', ':', '!', '?', ')', ']', '}', '>');
+    };
+
+    size_t token_start = hit_index;
+    while (token_start > 0 && is_url_code_unit(text.code_unit_at(token_start - 1)))
+        --token_start;
+
+    size_t token_end = hit_index;
+    while (token_end < length && is_url_code_unit(text.code_unit_at(token_end)))
+        ++token_end;
+
+    while (token_start < token_end && is_url_leading_punctuation(text.code_unit_at(token_start)))
+        ++token_start;
+    while (token_end > token_start && is_url_trailing_punctuation(text.code_unit_at(token_end - 1)))
+        --token_end;
+
+    if (token_start == token_end)
+        return false;
+
+    constexpr auto url_punctuation = Array<u32, 4> { '.', ':', '/', '@' };
+    if (!text.substring_view(token_start, token_end - token_start).contains_any_of(url_punctuation))
+        return false;
+
+    if (auto* target = document.active_input_events_target(hit_node)) {
+        target->set_selection_anchor(*hit_node, token_start);
+        target->set_selection_focus(*hit_node, token_end);
+    } else if (auto selection = document.get_selection()) {
+        set_user_selection(hit_node, token_start, hit_node, token_end, selection, user_select);
+        document.set_needs_repaint(Badge<EventHandler> {});
+    }
+
+    return true;
 }
 
 void EventHandler::update_mouse_selection(CSSPixelPoint visual_viewport_position)

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1908,6 +1908,8 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, MouseEventCo
 
             m_navigable->page().did_request_media_context_menu(media_element.unique_id(), top_level_viewport_position, "", modifiers, menu);
         } else {
+            select_context_menu_text(document, coordinates.visual_viewport_position);
+
             auto for_input_events_target = document->active_input_events_target() ? ContextMenuForInputEventsTarget::Yes : ContextMenuForInputEventsTarget::No;
             m_navigable->page().client().page_did_request_context_menu(top_level_viewport_position, for_input_events_target);
         }
@@ -2275,6 +2277,41 @@ bool EventHandler::initiate_paragraph_selection(DOM::Document& document, Paintin
 
     m_selection_mode = SelectionMode::Paragraph;
     return true;
+}
+
+bool EventHandler::select_context_menu_text(DOM::Document& document, CSSPixelPoint visual_viewport_position)
+{
+    auto caret_position = document.caret_position_from_point_for_selection_start(visual_viewport_position);
+    if (!caret_position.has_value())
+        return false;
+
+    auto is_inside_current_selection = [](DOM::Document& document, Painting::CaretPosition const& caret_position) {
+        auto selection = document.get_selection();
+        if (!selection || selection->is_collapsed())
+            return false;
+
+        auto range = selection->range();
+        if (!range)
+            return false;
+
+        auto position = range->compare_point(caret_position.boundary.node, caret_position.boundary.offset);
+        if (position.is_error())
+            return false;
+
+        return position.value() == 0;
+    };
+
+    if (is_inside_current_selection(document, *caret_position))
+        return false;
+
+    auto user_select = user_select_used_value_for_caret_position(*caret_position);
+    if (user_select == CSS::UserSelect::None)
+        return false;
+
+    auto selected_text = initiate_word_selection(document, *caret_position, user_select);
+    if (selected_text)
+        stop_updating_selection();
+    return selected_text;
 }
 
 void EventHandler::update_mouse_selection(CSSPixelPoint visual_viewport_position)

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -118,6 +118,7 @@ private:
     bool initiate_word_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
     bool initiate_paragraph_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
     bool select_context_menu_text(DOM::Document&, CSSPixelPoint visual_viewport_position);
+    bool select_context_menu_url_token(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
 
     void update_mouse_selection(CSSPixelPoint visual_viewport_position);
     void apply_mouse_selection(CSSPixelPoint visual_viewport_position);

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -117,6 +117,7 @@ private:
     bool initiate_character_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect, bool shift_held);
     bool initiate_word_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
     bool initiate_paragraph_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
+    bool select_context_menu_text(DOM::Document&, CSSPixelPoint visual_viewport_position);
 
     void update_mouse_selection(CSSPixelPoint visual_viewport_position);
     void apply_mouse_selection(CSSPixelPoint visual_viewport_position);

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CharacterTypes.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibFileSystem/FileSystem.h>
@@ -78,6 +79,18 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
 bool location_looks_like_url(StringView location, AppendTLD append_tld)
 {
     return sanitize_url(location, {}, append_tld).has_value();
+}
+
+Optional<URL::URL> url_from_text(StringView text)
+{
+    auto trimmed_text = text.trim_whitespace();
+    if (trimmed_text.is_empty() || trimmed_text.is_whitespace())
+        return {};
+
+    if (trimmed_text.starts_with('.') || trimmed_text.starts_with('/'))
+        return {};
+
+    return sanitize_url(trimmed_text);
 }
 
 static String normalized_web_url_for_autocomplete_comparison(URL::URL const& url)

--- a/Libraries/LibWebView/URL.h
+++ b/Libraries/LibWebView/URL.h
@@ -21,6 +21,7 @@ enum class AppendTLD {
 };
 WEBVIEW_API Optional<URL::URL> sanitize_url(StringView, Optional<SearchEngine> const& search_engine = {}, AppendTLD = AppendTLD::No);
 WEBVIEW_API bool location_looks_like_url(StringView, AppendTLD = AppendTLD::No);
+WEBVIEW_API Optional<URL::URL> url_from_text(StringView);
 WEBVIEW_API Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls);
 WEBVIEW_API String url_for_display(URL::URL const&);
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2199,15 +2199,27 @@ void ViewImplementation::initialize_context_menus()
         client().async_toggle_media_fullscreen_state(page_id());
     });
 
+    auto add_open_url_actions = [this](Menu& menu) {
+        menu.add_action(*m_open_in_new_tab_action);
+        if (m_open_in_new_window_action)
+            menu.add_action(*m_open_in_new_window_action);
+        if (m_open_in_new_private_window_action)
+            menu.add_action(*m_open_in_new_private_window_action);
+    };
+
+    auto add_text_edit_actions = [&application](Menu& menu) {
+        menu.add_action(application.cut_selection_action());
+        menu.add_action(application.copy_selection_action());
+        menu.add_action(application.paste_action());
+        menu.add_action(application.select_all_action());
+    };
+
     m_page_context_menu = Menu::create("Page Context Menu"sv);
     m_page_context_menu->add_action(*m_navigate_back_action);
     m_page_context_menu->add_action(*m_navigate_forward_action);
     m_page_context_menu->add_action(application.reload_action());
     m_page_context_menu->add_separator();
-    m_page_context_menu->add_action(application.cut_selection_action());
-    m_page_context_menu->add_action(application.copy_selection_action());
-    m_page_context_menu->add_action(application.paste_action());
-    m_page_context_menu->add_action(application.select_all_action());
+    add_text_edit_actions(*m_page_context_menu);
     m_page_context_menu->add_separator();
     m_page_context_menu->add_action(*m_search_selected_text_action);
     m_page_context_menu->add_separator();
@@ -2217,16 +2229,19 @@ void ViewImplementation::initialize_context_menus()
     m_page_context_menu->add_action(application.view_source_action());
 
     m_link_context_menu = Menu::create("Link Context Menu"sv);
-    m_link_context_menu->add_action(*m_open_in_new_tab_action);
-    if (m_open_in_new_window_action)
-        m_link_context_menu->add_action(*m_open_in_new_window_action);
-    if (m_open_in_new_private_window_action)
-        m_link_context_menu->add_action(*m_open_in_new_private_window_action);
+    add_open_url_actions(*m_link_context_menu);
     m_link_context_menu->add_separator();
     m_link_context_menu->add_action(*m_download_linked_file_action);
     m_link_context_menu->add_action(*m_download_linked_file_as_action);
     m_link_context_menu->add_separator();
     m_link_context_menu->add_action(*m_copy_url_action);
+
+    m_selected_text_link_context_menu = Menu::create("Selected Text Link Context Menu"sv);
+    add_open_url_actions(*m_selected_text_link_context_menu);
+    m_selected_text_link_context_menu->add_separator();
+    add_text_edit_actions(*m_selected_text_link_context_menu);
+    m_selected_text_link_context_menu->add_separator();
+    m_selected_text_link_context_menu->add_action(*m_search_selected_text_action);
 
     m_image_context_menu = Menu::create("Image Context Menu"sv);
     m_image_context_menu->add_action(*m_open_image_action);
@@ -2262,6 +2277,7 @@ void ViewImplementation::did_request_page_context_menu(Badge<WebContentClient>, 
 
     auto const& search_engine = Application::settings().search_engine();
     m_search_text = search_engine.has_value() ? selected_text_with_whitespace_collapsed() : OptionalNone {};
+    auto selected_text_url = url_from_text(selected_text());
 
     ScopeGuard guard { [&]() {
         cut_selection_action.set_visible(true);
@@ -2273,6 +2289,13 @@ void ViewImplementation::did_request_page_context_menu(Badge<WebContentClient>, 
         m_search_selected_text_action->set_visible(true);
     } else {
         m_search_selected_text_action->set_visible(false);
+    }
+
+    if (selected_text_url.has_value() && m_selected_text_link_context_menu->on_activation) {
+        m_context_menu_url = selected_text_url.release_value();
+        m_open_in_new_tab_action->set_text("Open in New Tab"sv);
+        m_selected_text_link_context_menu->on_activation(to_widget_position(content_position));
+        return;
     }
 
     if (m_page_context_menu->on_activation)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -368,6 +368,7 @@ public:
 
     Menu& page_context_menu() { return *m_page_context_menu; }
     Menu& link_context_menu() { return *m_link_context_menu; }
+    Menu& selected_text_link_context_menu() { return *m_selected_text_link_context_menu; }
     Menu& image_context_menu() { return *m_image_context_menu; }
     Menu& media_context_menu() { return *m_media_context_menu; }
 
@@ -490,6 +491,7 @@ protected:
 
     RefPtr<Menu> m_page_context_menu;
     RefPtr<Menu> m_link_context_menu;
+    RefPtr<Menu> m_selected_text_link_context_menu;
     RefPtr<Menu> m_image_context_menu;
     RefPtr<Menu> m_media_context_menu;
 

--- a/Tests/LibWeb/Text/expected/context-menu-selects-text.txt
+++ b/Tests/LibWeb/Text/expected/context-menu-selects-text.txt
@@ -1,4 +1,5 @@
 plain word: "ordinary"
+url token: "ladybird.org/path?x=1"
 canceled context menu: ""
 existing selection preserved: "existing"
 existing selection replaced: "other"

--- a/Tests/LibWeb/Text/expected/context-menu-selects-text.txt
+++ b/Tests/LibWeb/Text/expected/context-menu-selects-text.txt
@@ -1,0 +1,6 @@
+plain word: "ordinary"
+canceled context menu: ""
+existing selection preserved: "existing"
+existing selection replaced: "other"
+image preserves selection: "existing"
+user-select none: ""

--- a/Tests/LibWeb/Text/input/context-menu-selects-text.html
+++ b/Tests/LibWeb/Text/input/context-menu-selects-text.html
@@ -7,6 +7,7 @@
     }
 </style>
 <div id="word">ordinary</div>
+<div id="url">ladybird.org/path?x=1</div>
 <div id="prevented">prevented</div>
 <div id="existing">existing selection</div>
 <div id="other">other target</div>
@@ -25,6 +26,10 @@
     test(() => {
         rightClick(word);
         println(`plain word: "${selectedText()}"`);
+
+        getSelection().removeAllRanges();
+        rightClick(url);
+        println(`url token: "${selectedText()}"`);
 
         getSelection().removeAllRanges();
         prevented.addEventListener("contextmenu", event => event.preventDefault());

--- a/Tests/LibWeb/Text/input/context-menu-selects-text.html
+++ b/Tests/LibWeb/Text/input/context-menu-selects-text.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body {
+        font: 20px SerenitySans, sans-serif;
+        line-height: 32px;
+    }
+</style>
+<div id="word">ordinary</div>
+<div id="prevented">prevented</div>
+<div id="existing">existing selection</div>
+<div id="other">other target</div>
+<img id="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" style="width: 20px; height: 20px;">
+<div id="none" style="user-select: none;">hidden.org</div>
+<script>
+    function rightClick(element) {
+        const rect = element.getBoundingClientRect();
+        internals.click(rect.left + 8, rect.top + rect.height / 2, 1, internals.BUTTON_RIGHT);
+    }
+
+    function selectedText() {
+        return internals.selectedTextForClipboard();
+    }
+
+    test(() => {
+        rightClick(word);
+        println(`plain word: "${selectedText()}"`);
+
+        getSelection().removeAllRanges();
+        prevented.addEventListener("contextmenu", event => event.preventDefault());
+        rightClick(prevented);
+        println(`canceled context menu: "${selectedText()}"`);
+
+        const range = document.createRange();
+        range.setStart(existing.firstChild, 0);
+        range.setEnd(existing.firstChild, 8);
+        getSelection().removeAllRanges();
+        getSelection().addRange(range);
+        rightClick(existing);
+        println(`existing selection preserved: "${selectedText()}"`);
+
+        getSelection().removeAllRanges();
+        getSelection().addRange(range);
+        rightClick(other);
+        println(`existing selection replaced: "${selectedText()}"`);
+
+        getSelection().removeAllRanges();
+        getSelection().addRange(range);
+        rightClick(image);
+        println(`image preserves selection: "${selectedText()}"`);
+
+        getSelection().removeAllRanges();
+        rightClick(none);
+        println(`user-select none: "${selectedText()}"`);
+    });
+</script>

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -60,6 +60,18 @@ static void expect_location_does_not_look_like_url(StringView location, WebView:
     EXPECT(!WebView::location_looks_like_url(location, append_tld));
 }
 
+static void expect_context_menu_text_url(StringView text, StringView expected_url)
+{
+    auto url = WebView::url_from_text(text);
+    EXPECT(url.has_value());
+    EXPECT_EQ(url->to_string(), expected_url);
+}
+
+static void expect_context_menu_text_not_url(StringView text)
+{
+    EXPECT(!WebView::url_from_text(text).has_value());
+}
+
 static void expect_autocomplete_urls_match(StringView left, StringView right)
 {
     EXPECT(WebView::autocomplete_urls_match(left, right));
@@ -264,6 +276,21 @@ TEST_CASE(location_looks_like_url)
     expect_location_does_not_look_like_url("example.def"sv);
 
     expect_location_looks_like_url("example"sv, WebView::AppendTLD::Yes);
+}
+
+TEST_CASE(context_menu_url_text)
+{
+    expect_context_menu_text_url("ladybird.org"sv, "https://ladybird.org/"sv);
+    expect_context_menu_text_url("www.ladybird.org/path?x=1"sv, "https://www.ladybird.org/path?x=1"sv);
+    expect_context_menu_text_url("localhost:8000"sv, "https://localhost:8000/"sv);
+    expect_context_menu_text_url("https://ladybird.org"sv, "https://ladybird.org/"sv);
+
+    expect_context_menu_text_not_url("ladybird"sv);
+    expect_context_menu_text_not_url("ladybird org"sv);
+    expect_context_menu_text_not_url("ladybird.org hello"sv);
+    expect_context_menu_text_not_url("./Meta/ladybird.py"sv);
+    expect_context_menu_text_not_url("../ladybird.org"sv);
+    expect_context_menu_text_not_url("/tmp/ladybird.org"sv);
 }
 
 TEST_CASE(autocomplete_url_matching)

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -106,6 +106,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 @property (nonatomic, weak) id<LadybirdWebViewObserver> observer;
 @property (nonatomic, strong) NSMenu* page_context_menu;
 @property (nonatomic, strong) NSMenu* link_context_menu;
+@property (nonatomic, strong) NSMenu* selected_text_link_context_menu;
 @property (nonatomic, strong) NSMenu* image_context_menu;
 @property (nonatomic, strong) NSMenu* media_context_menu;
 @property (nonatomic, strong) NSMenu* select_dropdown;
@@ -191,6 +192,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 
         self.page_context_menu = Ladybird::create_context_menu(self, [self view].page_context_menu());
         self.link_context_menu = Ladybird::create_context_menu(self, [self view].link_context_menu());
+        self.selected_text_link_context_menu = Ladybird::create_context_menu(self, [self view].selected_text_link_context_menu());
         self.image_context_menu = Ladybird::create_context_menu(self, [self view].image_context_menu());
         self.media_context_menu = Ladybird::create_context_menu(self, [self view].media_context_menu());
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -655,6 +655,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     m_page_context_menu = create_context_menu(*this, view(), view().page_context_menu());
     m_link_context_menu = create_context_menu(*this, view(), view().link_context_menu());
+    m_selected_text_link_context_menu = create_context_menu(*this, view(), view().selected_text_link_context_menu());
     m_image_context_menu = create_context_menu(*this, view(), view().image_context_menu());
     m_media_context_menu = create_context_menu(*this, view(), view().media_context_menu());
 

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -168,6 +168,7 @@ private:
     QMenu* m_context_menu { nullptr };
     QMenu* m_page_context_menu { nullptr };
     QMenu* m_link_context_menu { nullptr };
+    QMenu* m_selected_text_link_context_menu { nullptr };
     QMenu* m_image_context_menu { nullptr };
     QMenu* m_media_context_menu { nullptr };
     QMenu* m_select_dropdown { nullptr };


### PR DESCRIPTION
It's a comfy feature in other browsers that you can right-click on some text that features a URL but that isn't an `<a>`, and get the same menu options as if it was a real link. So, let's add it to Ladybird!

Out of the browsers I tested, Safari had the nicest UX for this: Right clicking automatically selects the current word or URL, so you don't have to manually select it first. So that's what I've implemented here.

<img width="1065" height="645" alt="Screenshot 2026-07-08 at 15 45 57" src="https://github.com/user-attachments/assets/82a84448-6037-4e9b-9ded-48bd216e1175" />