### PR TITLE
LibWeb: Invalidate stacking contexts when clearing paintables

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1377,6 +1377,9 @@ void Node::add_paintable(RefPtr<Painting::Paintable> paintable)
 
 void Node::clear_paintables()
 {
+    if (!m_paintable.is_empty())
+        document().invalidate_stacking_context_tree();
+
     invalidate_paint_caches(*this);
     for (auto& paintable : m_paintable) {
         if (paintable->parent())


### PR DESCRIPTION
A stacking context keeps weak references back to its paintable, but child contexts are owned by their parent context. Clearing a layout node's paintables can therefore leave an existing root stacking context with child contexts whose paintables have already gone away.

Invalidate the document stacking context tree before removing paintables from a layout node, so the next paint rebuilds the tree instead of walking stale child contexts.