### PR TITLE
LibWeb: Add ReplicatedNavigableState for site isolation

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -674,6 +674,7 @@ set(SOURCES
     HTML/PreloadEntry.cpp
     HTML/PromiseRejectionEvent.cpp
     HTML/RadioNodeList.cpp
+    HTML/ReplicatedNavigableState.cpp
     HTML/SandboxingFlagSet.cpp
     HTML/Scripting/Agent.cpp
     HTML/Scripting/ClassicScript.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5544,7 +5544,7 @@ void Document::make_active()
     if (current_navigable && current_navigable->is_top_level_traversable()) {
         page().client().page_did_change_active_document_in_top_level_browsing_context(*this);
     } else if (current_navigable) {
-        page().client().page_did_commit_child_frame_navigation(current_navigable->id(), url(), current_navigable->replicated_state());
+        page().client().page_did_commit_child_frame_navigation(current_navigable->id(), current_navigable->replicated_state());
     }
 
     // 3. Set window's relevant settings object's execution ready flag.

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5544,7 +5544,7 @@ void Document::make_active()
     if (current_navigable && current_navigable->is_top_level_traversable()) {
         page().client().page_did_change_active_document_in_top_level_browsing_context(*this);
     } else if (current_navigable) {
-        page().client().page_did_commit_child_frame_navigation(current_navigable->id(), url());
+        page().client().page_did_commit_child_frame_navigation(current_navigable->id(), url(), current_navigable->replicated_state());
     }
 
     // 3. Set window's relevant settings object's execution ready flag.

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -885,7 +885,7 @@ class XMLSerializer;
 
 enum class AllowMultipleFiles;
 enum class RequireWellFormed;
-enum class SandboxingFlagSet;
+enum class SandboxingFlagSet : u32;
 
 struct Agent;
 struct BroadcastChannelMessage;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -940,6 +940,17 @@ Optional<URL::Origin> LocalNavigable::active_document_origin() const
     return m_active_document->origin();
 }
 
+ReplicatedNavigableState LocalNavigable::replicated_state() const
+{
+    VERIFY(m_active_document);
+    return {
+        .target_name = target_name(),
+        .active_document_url = m_active_document->url(),
+        .active_document_origin = m_active_document->origin(),
+        .active_document_is_fully_active = m_active_document->is_fully_active(),
+    };
+}
+
 Optional<UniqueNodeID> LocalNavigable::active_document_id() const
 {
     if (!m_active_document)

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -27,6 +27,7 @@
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/PaintConfig.h>
+#include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
 #include <LibWeb/HTML/SourceSnapshotParams.h>
 #include <LibWeb/HTML/StructuredSerializeTypes.h>
@@ -112,6 +113,7 @@ public:
 
     virtual Optional<URL::URL> active_document_url() const override;
     virtual Optional<URL::Origin> active_document_origin() const override;
+    ReplicatedNavigableState replicated_state() const;
 
     RefPtr<SessionHistoryEntry> get_the_target_history_entry(int target_step) const;
     RefPtr<SessionHistoryEntry> get_the_target_history_entry_if_present(int target_step) const;

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -106,7 +106,7 @@ void NavigableContainer::create_new_child_navigable()
     // 9. Set element's content navigable to navigable.
     m_content_navigable = navigable;
 
-    page.client().page_did_create_child_frame(parent_navigable->id(), navigable->id());
+    page.client().page_did_create_child_frame(parent_navigable->id(), navigable->id(), navigable->replicated_state());
 
     // 10. Let historyEntry be navigable's active session history entry.
     auto history_entry = navigable->active_session_history_entry();

--- a/Libraries/LibWeb/HTML/ReplicatedNavigableState.cpp
+++ b/Libraries/LibWeb/HTML/ReplicatedNavigableState.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/HTML/ReplicatedNavigableState.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::ReplicatedNavigableState const& state)
+{
+    TRY(encoder.encode(state.target_name));
+    TRY(encoder.encode(state.active_document_origin));
+    TRY(encoder.encode(state.active_document_is_fully_active));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::ReplicatedNavigableState> decode(Decoder& decoder)
+{
+    return Web::HTML::ReplicatedNavigableState {
+        .target_name = TRY(decoder.decode<String>()),
+        .active_document_origin = TRY(decoder.decode<URL::Origin>()),
+        .active_document_is_fully_active = TRY(decoder.decode<bool>()),
+    };
+}
+
+}

--- a/Libraries/LibWeb/HTML/ReplicatedNavigableState.cpp
+++ b/Libraries/LibWeb/HTML/ReplicatedNavigableState.cpp
@@ -14,6 +14,7 @@ template<>
 ErrorOr<void> encode(Encoder& encoder, Web::HTML::ReplicatedNavigableState const& state)
 {
     TRY(encoder.encode(state.target_name));
+    TRY(encoder.encode(state.active_document_url));
     TRY(encoder.encode(state.active_document_origin));
     TRY(encoder.encode(state.active_document_is_fully_active));
     return {};
@@ -24,6 +25,7 @@ ErrorOr<Web::HTML::ReplicatedNavigableState> decode(Decoder& decoder)
 {
     return Web::HTML::ReplicatedNavigableState {
         .target_name = TRY(decoder.decode<String>()),
+        .active_document_url = TRY(decoder.decode<URL::URL>()),
         .active_document_origin = TRY(decoder.decode<URL::Origin>()),
         .active_document_is_fully_active = TRY(decoder.decode<bool>()),
     };

--- a/Libraries/LibWeb/HTML/ReplicatedNavigableState.h
+++ b/Libraries/LibWeb/HTML/ReplicatedNavigableState.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <LibIPC/Forward.h>
+#include <LibURL/Origin.h>
+#include <LibWeb/Export.h>
+
+namespace Web::HTML {
+
+struct ReplicatedNavigableState {
+    String target_name;
+    URL::Origin active_document_origin;
+    bool active_document_is_fully_active { false };
+};
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::ReplicatedNavigableState const&);
+template<>
+WEB_API ErrorOr<Web::HTML::ReplicatedNavigableState> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/HTML/ReplicatedNavigableState.h
+++ b/Libraries/LibWeb/HTML/ReplicatedNavigableState.h
@@ -9,12 +9,14 @@
 #include <AK/String.h>
 #include <LibIPC/Forward.h>
 #include <LibURL/Origin.h>
+#include <LibURL/URL.h>
 #include <LibWeb/Export.h>
 
 namespace Web::HTML {
 
 struct ReplicatedNavigableState {
     String target_name;
+    URL::URL active_document_url;
     URL::Origin active_document_origin;
     bool active_document_is_fully_active { false };
 };

--- a/Libraries/LibWeb/HTML/SandboxingFlagSet.h
+++ b/Libraries/LibWeb/HTML/SandboxingFlagSet.h
@@ -13,7 +13,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/origin.html#sandboxing-flag-set
-enum class SandboxingFlagSet {
+enum class SandboxingFlagSet : u32 {
     SandboxedNavigation = 1u << 0u,
     SandboxedAuxiliaryNavigation = 1u << 1u,
     SandboxedTopLevelNavigationWithoutUserActivation = 1u << 2u,

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -451,7 +451,7 @@ public:
     virtual void request_new_process_for_child_frame_navigation(HTML::NavigableId, URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
     virtual void page_did_create_child_frame(HTML::NavigableId, HTML::NavigableId, HTML::ReplicatedNavigableState const&) { }
     virtual void page_did_update_child_frame_viewport(HTML::NavigableId, CSSPixelRect) { }
-    virtual void page_did_commit_child_frame_navigation(HTML::NavigableId, URL::URL const&, HTML::ReplicatedNavigableState const&) { }
+    virtual void page_did_commit_child_frame_navigation(HTML::NavigableId, HTML::ReplicatedNavigableState const&) { }
     virtual void page_did_destroy_child_frame(HTML::NavigableId) { }
     virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(HTML::NavigableId) const { return {}; }
     virtual String dump_site_isolation_process_tree_for_testing() { return {}; }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -47,6 +47,7 @@
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/NavigableId.h>
 #include <LibWeb/HTML/POSTResource.h>
+#include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -448,9 +449,9 @@ public:
     }
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
     virtual void request_new_process_for_child_frame_navigation(HTML::NavigableId, URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
-    virtual void page_did_create_child_frame(HTML::NavigableId, HTML::NavigableId) { }
+    virtual void page_did_create_child_frame(HTML::NavigableId, HTML::NavigableId, HTML::ReplicatedNavigableState const&) { }
     virtual void page_did_update_child_frame_viewport(HTML::NavigableId, CSSPixelRect) { }
-    virtual void page_did_commit_child_frame_navigation(HTML::NavigableId, URL::URL const&) { }
+    virtual void page_did_commit_child_frame_navigation(HTML::NavigableId, URL::URL const&, HTML::ReplicatedNavigableState const&) { }
     virtual void page_did_destroy_child_frame(HTML::NavigableId) { }
     virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(HTML::NavigableId) const { return {}; }
     virtual String dump_site_isolation_process_tree_for_testing() { return {}; }

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -148,6 +148,11 @@ void CanonicalNavigable::set_viewport(Web::DevicePixelRect viewport_rect, double
     }
 }
 
+void CanonicalNavigable::set_replicated_state(Web::HTML::ReplicatedNavigableState state)
+{
+    m_replicated_state = move(state);
+}
+
 void CanonicalNavigable::did_commit_navigation(URL::URL url)
 {
     m_last_committed_url = move(url);

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -153,21 +153,10 @@ void CanonicalNavigable::set_replicated_state(Web::HTML::ReplicatedNavigableStat
     m_replicated_state = move(state);
 }
 
-void CanonicalNavigable::did_commit_navigation(URL::URL url)
+void CanonicalNavigable::did_commit_navigation(Web::HTML::ReplicatedNavigableState replicated_state)
 {
-    m_last_committed_url = move(url);
+    set_replicated_state(move(replicated_state));
     m_pending_navigation.clear();
-}
-
-Optional<URL::URL> CanonicalNavigable::document_url() const
-{
-    if (m_last_committed_url.has_value())
-        return m_last_committed_url;
-
-    if (m_pending_navigation.has_value())
-        return m_pending_navigation->target_url;
-
-    return {};
 }
 
 void CanonicalNavigable::record_pending_navigation(URL::URL const& url, HostLocality target_locality, Optional<u64> remote_page_id)

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -18,6 +18,7 @@
 #include <AK/Weakable.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/Export.h>
 #include <LibWebView/Forward.h>
@@ -77,6 +78,9 @@ public:
     double device_pixel_ratio() const { return m_device_pixel_ratio; }
     void set_viewport(Web::DevicePixelRect, double device_pixel_ratio);
 
+    Optional<Web::HTML::ReplicatedNavigableState> const& replicated_state() const { return m_replicated_state; }
+    void set_replicated_state(Web::HTML::ReplicatedNavigableState);
+
     void did_commit_navigation(URL::URL);
     Optional<URL::URL> document_url() const;
 
@@ -92,6 +96,7 @@ private:
     CanonicalNavigable* m_parent { nullptr };
     Vector<NonnullOwnPtr<CanonicalNavigable>> m_children;
 
+    Optional<Web::HTML::ReplicatedNavigableState> m_replicated_state;
     Optional<URL::URL> m_last_committed_url;
     Optional<PendingNavigation> m_pending_navigation;
     Optional<Web::DevicePixelRect> m_viewport_rect;

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -81,8 +81,7 @@ public:
     Optional<Web::HTML::ReplicatedNavigableState> const& replicated_state() const { return m_replicated_state; }
     void set_replicated_state(Web::HTML::ReplicatedNavigableState);
 
-    void did_commit_navigation(URL::URL);
-    Optional<URL::URL> document_url() const;
+    void did_commit_navigation(Web::HTML::ReplicatedNavigableState);
 
     void record_pending_navigation(URL::URL const&, HostLocality, Optional<u64> remote_page_id = {});
     void clear_pending_navigation() { m_pending_navigation.clear(); }
@@ -97,7 +96,6 @@ private:
     Vector<NonnullOwnPtr<CanonicalNavigable>> m_children;
 
     Optional<Web::HTML::ReplicatedNavigableState> m_replicated_state;
-    Optional<URL::URL> m_last_committed_url;
     Optional<PendingNavigation> m_pending_navigation;
     Optional<Web::DevicePixelRect> m_viewport_rect;
     double m_device_pixel_ratio { 1 };

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -516,6 +516,10 @@ HistoryTraversalDecision CanonicalTraversable::traverse_the_history_by_delta(int
     if (!target.has_value())
         return { .outcome = { .status = HistoryTraversalStatus::NoEntry } };
 
+    // FIXME: This pre-flight prediction exists only because WebContent applies the history step itself, so the UI must
+    //        choose between delegating the traversal to the current process and driving a cross-process load before
+    //        sending anything. Once the UI process owns apply-the-history-step and issues per-navigable load commands,
+    //        placement is decided per command and this prediction goes away.
     auto will_replace_web_content_process = SiteIsolationManager::the().navigation_requires_process_swap(current_url, target->target_top_level_entry->url);
     auto pending_traversal = PendingSessionHistoryTraversal {
         .target_step = target->target_step,

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <LibWebView/CanonicalTraversable.h>
-#include <LibWebView/SiteIsolation.h>
+#include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace WebView {
@@ -516,7 +516,7 @@ HistoryTraversalDecision CanonicalTraversable::traverse_the_history_by_delta(int
     if (!target.has_value())
         return { .outcome = { .status = HistoryTraversalStatus::NoEntry } };
 
-    auto will_replace_web_content_process = !is_url_suitable_for_same_process_navigation(current_url, target->target_top_level_entry->url);
+    auto will_replace_web_content_process = SiteIsolationManager::the().navigation_requires_process_swap(current_url, target->target_top_level_entry->url);
     auto pending_traversal = PendingSessionHistoryTraversal {
         .target_step = target->target_step,
         .target_step_index = target->target_step_index,
@@ -582,7 +582,7 @@ URL::URL CanonicalTraversable::prepare_to_load_session_history_traversal_target_
             .target_step = target.target_step,
             .target_step_index = target.target_step_index,
             .will_change_top_level_entry = target.changes_top_level_entry,
-            .will_replace_web_content_process = !is_url_suitable_for_same_process_navigation(current_url, target.target_top_level_entry->url),
+            .will_replace_web_content_process = SiteIsolationManager::the().navigation_requires_process_swap(current_url, target.target_top_level_entry->url),
             .stage = PendingSessionHistoryTraversal::Stage::LoadingEntryFromUIProcess,
             .on_cancelation_check_complete = nullptr,
         };

--- a/Libraries/LibWebView/SiteIsolation.cpp
+++ b/Libraries/LibWebView/SiteIsolation.cpp
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibURL/URL.h>
-#include <LibWeb/Fetch/Infrastructure/URL.h>
-#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWebView/SiteIsolation.h>
 
 namespace WebView {
@@ -37,36 +34,14 @@ StringView site_isolation_mode_to_string(SiteIsolationMode mode)
     VERIFY_NOT_REACHED();
 }
 
+SiteIsolationMode site_isolation_mode()
+{
+    return s_site_isolation_mode;
+}
+
 void set_site_isolation_mode(SiteIsolationMode mode)
 {
     s_site_isolation_mode = mode;
-}
-
-bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target)
-{
-    if (s_site_isolation_mode == SiteIsolationMode::Disabled)
-        return true;
-
-    if (target == Web::NavigationTarget::IFrame && s_site_isolation_mode != SiteIsolationMode::IFrame)
-        return true;
-
-    // Allow navigating from about:blank to any site.
-    if (Web::HTML::url_matches_about_blank(current_url))
-        return true;
-
-    // Make sure JavaScript URLs run in the same process.
-    if (target_url.scheme() == "javascript"sv)
-        return true;
-
-    // Allow cross-scheme non-HTTP(S) navigation. Disallow cross-scheme HTTP(s) navigation.
-    auto current_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(current_url.scheme());
-    auto target_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(target_url.scheme());
-
-    if (!current_url_is_http || !target_url_is_http)
-        return !current_url_is_http && !target_url_is_http;
-
-    // Disallow cross-site HTTP(S) navigation.
-    return current_url.origin().is_same_site(target_url.origin());
 }
 
 }

--- a/Libraries/LibWebView/SiteIsolation.h
+++ b/Libraries/LibWebView/SiteIsolation.h
@@ -8,8 +8,6 @@
 
 #include <AK/Optional.h>
 #include <AK/StringView.h>
-#include <LibURL/Forward.h>
-#include <LibWeb/Page/Page.h>
 #include <LibWebView/Forward.h>
 
 namespace WebView {
@@ -22,7 +20,7 @@ enum class SiteIsolationMode {
 
 [[nodiscard]] WEBVIEW_API Optional<SiteIsolationMode> site_isolation_mode_from_string(StringView);
 [[nodiscard]] WEBVIEW_API StringView site_isolation_mode_to_string(SiteIsolationMode);
+[[nodiscard]] WEBVIEW_API SiteIsolationMode site_isolation_mode();
 WEBVIEW_API void set_site_isolation_mode(SiteIsolationMode);
-[[nodiscard]] WEBVIEW_API bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget = Web::NavigationTarget::TopLevel);
 
 }

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -7,6 +7,8 @@
 #include <LibWebView/SiteIsolationManager.h>
 
 #include <AK/StringBuilder.h>
+#include <LibWeb/Fetch/Infrastructure/URL.h>
+#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/SiteIsolation.h>
 #include <LibWebView/ViewImplementation.h>
@@ -30,6 +32,33 @@ static URL::URL embedding_page_url_for_child_frame_navigation(CanonicalNavigable
     return fallback_url;
 }
 
+bool SiteIsolationManager::navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target) const
+{
+    if (site_isolation_mode() == SiteIsolationMode::Disabled)
+        return false;
+
+    if (target == Web::NavigationTarget::IFrame && site_isolation_mode() != SiteIsolationMode::IFrame)
+        return false;
+
+    // Allow navigating from about:blank to any site.
+    if (Web::HTML::url_matches_about_blank(current_url))
+        return false;
+
+    // Make sure JavaScript URLs run in the same process.
+    if (target_url.scheme() == "javascript"sv)
+        return false;
+
+    // Allow cross-scheme non-HTTP(S) navigation. Disallow cross-scheme HTTP(s) navigation.
+    auto current_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(current_url.scheme());
+    auto target_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(target_url.scheme());
+
+    if (!current_url_is_http || !target_url_is_http)
+        return current_url_is_http || target_url_is_http;
+
+    // Disallow cross-site HTTP(S) navigation.
+    return !current_url.origin().is_same_site(target_url.origin());
+}
+
 Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(WebContentClient& parent_client, u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
 {
     Optional<CanonicalNavigable&> child_frame;
@@ -39,9 +68,9 @@ Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(W
     if (child_frame.has_value())
         current_url = embedding_page_url_for_child_frame_navigation(*child_frame, current_url);
 
-    auto decision = WebView::is_url_suitable_for_same_process_navigation(current_url, target_url, target)
-        ? Web::NavigationProcessDecision::Local
-        : Web::NavigationProcessDecision::Remote;
+    auto decision = navigation_requires_process_swap(current_url, target_url, target)
+        ? Web::NavigationProcessDecision::Remote
+        : Web::NavigationProcessDecision::Local;
 
     if (child_frame.has_value()) {
         auto target_locality = decision == Web::NavigationProcessDecision::Local

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -22,16 +22,6 @@ SiteIsolationManager& SiteIsolationManager::the()
     return manager;
 }
 
-static URL::URL embedding_page_url_for_child_frame_navigation(CanonicalNavigable const& child_frame, URL::URL const& fallback_url)
-{
-    if (auto const* parent = child_frame.parent()) {
-        if (auto url = parent->document_url(); url.has_value())
-            return *url;
-    }
-
-    return fallback_url;
-}
-
 bool SiteIsolationManager::navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target) const
 {
     if (site_isolation_mode() == SiteIsolationMode::Disabled)
@@ -59,16 +49,32 @@ bool SiteIsolationManager::navigation_requires_process_swap(URL::URL const& curr
     return !current_url.origin().is_same_site(target_url.origin());
 }
 
+bool SiteIsolationManager::child_frame_navigation_requires_process_swap(CanonicalNavigable const& child_frame, URL::URL const& current_url, URL::URL const& target_url) const
+{
+    if (site_isolation_mode() != SiteIsolationMode::IFrame)
+        return false;
+
+    // Use origin-based same-site checks for HTTP(S). about:blank, srcdoc, and data: need the initiator origin, so fall
+    // back to using a URL decision for now.
+    if (Web::Fetch::Infrastructure::is_http_or_https_scheme(target_url.scheme())) {
+        if (auto const* parent_frame = child_frame.parent(); parent_frame && parent_frame->replicated_state().has_value())
+            return !parent_frame->replicated_state()->active_document_origin.is_same_site(target_url.origin());
+    }
+
+    return navigation_requires_process_swap(current_url, target_url, Web::NavigationTarget::IFrame);
+}
+
 Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(WebContentClient& parent_client, u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
 {
     Optional<CanonicalNavigable&> child_frame;
     if (target == Web::NavigationTarget::IFrame && frame_id.has_value())
         child_frame = parent_client.child_frame(page_id, *frame_id);
 
-    if (child_frame.has_value())
-        current_url = embedding_page_url_for_child_frame_navigation(*child_frame, current_url);
+    auto requires_process_swap = child_frame.has_value()
+        ? child_frame_navigation_requires_process_swap(*child_frame, current_url, target_url)
+        : navigation_requires_process_swap(current_url, target_url, target);
 
-    auto decision = navigation_requires_process_swap(current_url, target_url, target)
+    auto decision = requires_process_swap
         ? Web::NavigationProcessDecision::Remote
         : Web::NavigationProcessDecision::Local;
 

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -30,6 +30,7 @@ public:
     };
 
     Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
+    [[nodiscard]] bool navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget = Web::NavigationTarget::TopLevel) const;
 
     void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::NavigableId frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
     void transition_child_frame_to_local(CanonicalNavigable&);

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -31,6 +31,7 @@ public:
 
     Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
     [[nodiscard]] bool navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget = Web::NavigationTarget::TopLevel) const;
+    [[nodiscard]] bool child_frame_navigation_requires_process_swap(CanonicalNavigable const& child_frame, URL::URL const& current_url, URL::URL const& target_url) const;
 
     void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::NavigableId frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
     void transition_child_frame_to_local(CanonicalNavigable&);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -119,7 +119,6 @@ void ViewImplementation::set_url(URL::URL url)
 
     auto previous_host = current_host();
     m_url = move(url);
-    m_top_level_traversable.did_commit_navigation(m_url);
     update_bookmark_action();
 
     if (current_host() != previous_host)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -532,7 +532,7 @@ void WebContentClient::did_update_child_frame_viewport(u64 page_id, Web::HTML::N
         child_frame->set_viewport(viewport_rect, device_pixel_ratio);
 }
 
-void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Web::HTML::ReplicatedNavigableState replicated_state)
+void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
@@ -541,8 +541,7 @@ void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML:
     if (child_frame->has_remote_host())
         SiteIsolationManager::the().transition_child_frame_to_local(*child_frame);
 
-    child_frame->set_replicated_state(move(replicated_state));
-    child_frame->did_commit_navigation(move(url));
+    child_frame->did_commit_navigation(move(replicated_state));
 }
 
 void WebContentClient::did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state)
@@ -551,7 +550,7 @@ void WebContentClient::did_change_top_level_active_document(u64 page_id, Web::HT
     if (!navigable)
         return;
 
-    navigable->set_replicated_state(move(replicated_state));
+    navigable->did_commit_navigation(move(replicated_state));
 }
 
 void WebContentClient::did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id)
@@ -735,8 +734,6 @@ void WebContentClient::did_finish_loading(u64 page_id, URL::URL url)
             if (listener.on_load_finish)
                 listener.on_load_finish(client_url);
         }
-    } else if (auto* child_frame = embedded_page_host(page_id)) {
-        child_frame->did_commit_navigation(url);
     }
 }
 
@@ -834,7 +831,6 @@ void WebContentClient::did_change_url(u64 page_id, URL::URL url)
         if (view->on_url_change)
             view->on_url_change(url);
     } else if (auto* child_frame = embedded_page_host(page_id)) {
-        child_frame->did_commit_navigation(url);
         child_frame->reporting_client().async_run_iframe_load_event_steps(child_frame->reporting_page_id(), child_frame->id());
     }
 }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -516,13 +516,14 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
     SiteIsolationManager::the().transition_child_frame_to_remote(*this, page_id, frame_id, move(remote_client), remote_page_id);
 }
 
-void WebContentClient::did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id)
+void WebContentClient::did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state)
 {
     auto* host = navigable_for_page(page_id);
     if (!host)
         return;
 
-    host->top_level_traversable().insert(*this, page_id, move(parent_frame_id), move(frame_id), *host);
+    auto& child_frame = host->top_level_traversable().insert(*this, page_id, move(parent_frame_id), move(frame_id), *host);
+    child_frame.set_replicated_state(move(replicated_state));
 }
 
 void WebContentClient::did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
@@ -531,7 +532,7 @@ void WebContentClient::did_update_child_frame_viewport(u64 page_id, Web::HTML::N
         child_frame->set_viewport(viewport_rect, device_pixel_ratio);
 }
 
-void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url)
+void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Web::HTML::ReplicatedNavigableState replicated_state)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
@@ -540,7 +541,17 @@ void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML:
     if (child_frame->has_remote_host())
         SiteIsolationManager::the().transition_child_frame_to_local(*child_frame);
 
+    child_frame->set_replicated_state(move(replicated_state));
     child_frame->did_commit_navigation(move(url));
+}
+
+void WebContentClient::did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state)
+{
+    auto* navigable = navigable_for_page(page_id);
+    if (!navigable)
+        return;
+
+    navigable->set_replicated_state(move(replicated_state));
 }
 
 void WebContentClient::did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -124,7 +124,7 @@ private:
     virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
     virtual void did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
-    virtual void did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Web::HTML::ReplicatedNavigableState replicated_state) override;
+    virtual void did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) override;
     virtual void did_start_webdriver_navigation(u64 page_id, URL::URL url) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -30,6 +30,7 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -121,9 +122,10 @@ private:
     virtual Messages::WebContentClient::DecideNavigationProcessResponse decide_navigation_process(u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget) override;
     virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
     virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
-    virtual void did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id) override;
+    virtual void did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
-    virtual void did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url) override;
+    virtual void did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Web::HTML::ReplicatedNavigableState replicated_state) override;
+    virtual void did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) override;
     virtual void did_start_webdriver_navigation(u64 page_id, URL::URL url) override;
     virtual void did_finish_loading(u64 page_id, URL::URL) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -47,7 +47,6 @@
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Streams/ReadableStreamDefaultReader.h>
 #include <LibWeb/WebIDL/Promise.h>
-#include <LibWebView/SiteIsolation.h>
 #include <LibWebView/ViewImplementation.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/DevToolsConsoleClient.h>
@@ -200,12 +199,7 @@ Web::HTML::NavigableId PageClient::allocate_navigable_id()
 
 Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target, Optional<Web::HTML::NavigableId> frame_id) const
 {
-    if (target != Web::NavigationTarget::TopLevel)
-        return client().decide_navigation_process(m_id, move(frame_id), current_url, target_url, target);
-
-    return WebView::is_url_suitable_for_same_process_navigation(current_url, target_url, Web::NavigationTarget::TopLevel)
-        ? Web::NavigationProcessDecision::Local
-        : Web::NavigationProcessDecision::Remote;
+    return client().decide_navigation_process(m_id, move(frame_id), current_url, target_url, target);
 }
 
 void PageClient::request_new_process_for_navigation(URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -221,9 +221,9 @@ void PageClient::request_new_process_for_child_frame_navigation(Web::HTML::Navig
     client().async_did_request_new_process_for_child_frame_navigation(m_id, frame_id, url, move(document_resource), history_handling);
 }
 
-void PageClient::page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id)
+void PageClient::page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const& replicated_state)
 {
-    client().async_did_create_child_frame(m_id, parent_frame_id, frame_id);
+    client().async_did_create_child_frame(m_id, parent_frame_id, frame_id, replicated_state);
 }
 
 void PageClient::page_did_update_child_frame_viewport(Web::HTML::NavigableId frame_id, Web::CSSPixelRect viewport_rect)
@@ -231,9 +231,9 @@ void PageClient::page_did_update_child_frame_viewport(Web::HTML::NavigableId fra
     client().async_did_update_child_frame_viewport(m_id, frame_id, page().css_to_device_rect(viewport_rect), page().client().device_pixel_ratio());
 }
 
-void PageClient::page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const& url)
+void PageClient::page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const& url, Web::HTML::ReplicatedNavigableState const& replicated_state)
 {
-    client().async_did_commit_child_frame_navigation(m_id, frame_id, url);
+    client().async_did_commit_child_frame_navigation(m_id, frame_id, url, replicated_state);
 }
 
 void PageClient::page_did_destroy_child_frame(Web::HTML::NavigableId frame_id)
@@ -557,6 +557,9 @@ void PageClient::page_did_change_active_document_in_top_level_browsing_context(W
     auto& realm = document.realm();
 
     clear_pending_dom_mutations();
+
+    if (auto navigable = document.navigable())
+        client().async_did_change_top_level_active_document(m_id, navigable->replicated_state());
 
     if (m_web_ui && &m_web_ui->document() != &document)
         m_web_ui.clear();

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -225,9 +225,9 @@ void PageClient::page_did_update_child_frame_viewport(Web::HTML::NavigableId fra
     client().async_did_update_child_frame_viewport(m_id, frame_id, page().css_to_device_rect(viewport_rect), page().client().device_pixel_ratio());
 }
 
-void PageClient::page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const& url, Web::HTML::ReplicatedNavigableState const& replicated_state)
+void PageClient::page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const& replicated_state)
 {
-    client().async_did_commit_child_frame_navigation(m_id, frame_id, url, replicated_state);
+    client().async_did_commit_child_frame_navigation(m_id, frame_id, replicated_state);
 }
 
 void PageClient::page_did_destroy_child_frame(Web::HTML::NavigableId frame_id)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -156,7 +156,7 @@ private:
     virtual void request_new_process_for_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
     virtual void page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
     virtual void page_did_update_child_frame_viewport(Web::HTML::NavigableId frame_id, Web::CSSPixelRect) override;
-    virtual void page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const&, Web::HTML::ReplicatedNavigableState const&) override;
+    virtual void page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
     virtual void page_did_destroy_child_frame(Web::HTML::NavigableId frame_id) override;
     virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(Web::HTML::NavigableId) const override;
     virtual String dump_site_isolation_process_tree_for_testing() override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -16,6 +16,7 @@
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/Page/Page.h>
@@ -153,9 +154,9 @@ private:
     virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget, Optional<Web::HTML::NavigableId> frame_id) const override;
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
     virtual void request_new_process_for_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
-    virtual void page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id) override;
+    virtual void page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
     virtual void page_did_update_child_frame_viewport(Web::HTML::NavigableId frame_id, Web::CSSPixelRect) override;
-    virtual void page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const&) override;
+    virtual void page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const&, Web::HTML::ReplicatedNavigableState const&) override;
     virtual void page_did_destroy_child_frame(Web::HTML::NavigableId frame_id) override;
     virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(Web::HTML::NavigableId) const override;
     virtual String dump_site_isolation_process_tree_for_testing() override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -51,7 +51,7 @@ endpoint WebContentClient
     did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
     did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
-    did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Web::HTML::ReplicatedNavigableState replicated_state) =|
+    did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
     did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
     did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) =|
     did_start_webdriver_navigation(u64 page_id, URL::URL url) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -48,9 +49,10 @@ endpoint WebContentClient
     decide_navigation_process(u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target) => (Web::NavigationProcessDecision decision)
     did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
-    did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id) =|
+    did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
     did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
-    did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url) =|
+    did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Web::HTML::ReplicatedNavigableState replicated_state) =|
+    did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
     did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) =|
     did_start_webdriver_navigation(u64 page_id, URL::URL url) =|
     did_start_loading(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling) =|


### PR DESCRIPTION
Introduce a shared representation of the per-navigable state that the UI
process will own for each canonical navigable. This will also be is the
state RemoteNavigable will need as its local mirror of a document hosted
in another process.

This is some further progress for site isolation, next step is to actually
try and hook up RemoteNavigable using ReplicatedNavigableState