### PR TITLE
UI: Open new tabs after the current tab

### DIFF
--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -22,6 +22,7 @@ private:
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
+    virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const override;
     virtual void open_url_in_new_window(URL::URL const&, WebView::IsPrivate) override;
 
     virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -61,10 +61,24 @@ Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML
     return [[tab web_view] view];
 }
 
+void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTab activate_tab) const
+{
+    ApplicationDelegate* delegate = [NSApp delegate];
+    auto* active_tab = [delegate activeTab];
+
+    (void)[delegate createNewTab:url
+                         fromTab:active_tab
+                     activateTab:activate_tab
+                     tabLocation:TabLocation::after_tab(active_tab)];
+}
+
 void Application::open_url_in_new_window(URL::URL const& url, WebView::IsPrivate)
 {
     ApplicationDelegate* delegate = [NSApp delegate];
-    (void)[delegate createNewTab:url fromTab:nil activateTab:Web::HTML::ActivateTab::Yes];
+    (void)[delegate createNewTab:url
+                         fromTab:nil
+                     activateTab:Web::HTML::ActivateTab::Yes
+                     tabLocation:TabLocation::end()];
 }
 
 Optional<ByteString> Application::ask_user_for_download_path(ByteString const& file) const

--- a/UI/AppKit/Application/ApplicationDelegate.h
+++ b/UI/AppKit/Application/ApplicationDelegate.h
@@ -16,6 +16,31 @@
 @class Tab;
 @class TabController;
 
+class TabLocation {
+private:
+    enum class Kind {
+        End,
+        AfterTab,
+    };
+
+public:
+    static TabLocation end() { return { Kind::End, nil }; }
+    static TabLocation after_tab(Tab* _Nullable tab) { return { Kind::AfterTab, tab }; }
+
+    bool is_after_tab() const { return m_kind == Kind::AfterTab; }
+    Tab* _Nullable tab() const { return m_tab; }
+
+private:
+    TabLocation(Kind kind, Tab* _Nullable tab)
+        : m_kind(kind)
+        , m_tab(tab)
+    {
+    }
+
+    Kind m_kind;
+    Tab* _Nullable m_tab { nil };
+};
+
 @interface ApplicationDelegate : NSObject <NSApplicationDelegate>
 
 - (nullable instancetype)init;
@@ -25,7 +50,8 @@
 
 - (nonnull TabController*)createNewTab:(Optional<URL::URL> const&)url
                                fromTab:(nullable Tab*)tab
-                           activateTab:(Web::HTML::ActivateTab)activate_tab;
+                           activateTab:(Web::HTML::ActivateTab)activate_tab
+                           tabLocation:(TabLocation)tab_location;
 
 - (nonnull TabController*)createChildTab:(Optional<URL::URL> const&)url
                                  fromTab:(nonnull Tab*)tab

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -84,8 +84,13 @@
 - (TabController*)createNewTab:(Optional<URL::URL> const&)url
                        fromTab:(Tab*)tab
                    activateTab:(Web::HTML::ActivateTab)activate_tab
+                   tabLocation:(TabLocation)tab_location
 {
-    auto* controller = [self createNewTab:activate_tab fromTab:tab];
+    auto* controller = [[TabController alloc] init];
+    [self initializeTabController:controller
+                      activateTab:activate_tab
+                          fromTab:tab
+                      tabLocation:tab_location];
 
     if (url.has_value()) {
         [controller loadURL:*url];
@@ -194,7 +199,8 @@
 {
     [self createNewTab:WebView::Application::settings().new_tab_page_url()
                fromTab:nil
-           activateTab:Web::HTML::ActivateTab::Yes];
+           activateTab:Web::HTML::ActivateTab::Yes
+           tabLocation:TabLocation::end()];
 }
 
 - (nonnull TabController*)createChildTab:(Web::HTML::ActivateTab)activate_tab
@@ -213,14 +219,43 @@
                     activateTab:(Web::HTML::ActivateTab)activate_tab
                         fromTab:(nullable Tab*)tab
 {
+    [self initializeTabController:controller
+                      activateTab:activate_tab
+                          fromTab:tab
+                      tabLocation:TabLocation::end()];
+}
+
+- (void)initializeTabController:(TabController*)controller
+                    activateTab:(Web::HTML::ActivateTab)activate_tab
+                        fromTab:(nullable Tab*)tab
+                    tabLocation:(TabLocation)tab_location
+{
+    Optional<NSUInteger> insertion_index;
+    NSWindowTabGroup* tab_group = nil;
+
+    auto* tab_for_location = tab_location.is_after_tab() ? tab_location.tab() : tab;
+    if (tab_for_location) {
+        tab_group = [tab_for_location tabGroup];
+
+        if (tab_location.is_after_tab()) {
+            auto* windows = [tab_group windows];
+            auto tab_index = [windows indexOfObject:tab_for_location];
+            if (tab_index != NSNotFound)
+                insertion_index = tab_index + 1;
+        }
+    }
+
     [controller showWindow:nil];
 
-    if (tab) {
-        [[tab tabGroup] addWindow:controller.window];
+    if (tab_for_location) {
+        if (insertion_index.has_value())
+            [tab_group insertWindow:controller.window atIndex:insertion_index.value()];
+        else
+            [tab_group addWindow:controller.window];
 
         // FIXME: Can we create the tabbed window above without it becoming active in the first place?
         if (activate_tab == Web::HTML::ActivateTab::No) {
-            [tab orderFront:nil];
+            [tab_for_location orderFront:nil];
         }
     }
 
@@ -406,7 +441,8 @@
 
         auto* controller = [self createNewTab:url
                                       fromTab:tab
-                                  activateTab:activate_tab];
+                                  activateTab:activate_tab
+                                  tabLocation:TabLocation::end()];
 
         tab = (Tab*)[controller window];
     }

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -356,7 +356,8 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
 
     auto* controller = [delegate createNewTab:url
                                       fromTab:self
-                                  activateTab:activate_tab];
+                                  activateTab:activate_tab
+                                  tabLocation:TabLocation::end()];
 
     auto* tab = (Tab*)[controller window];
     return [[tab web_view] handle];

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -940,7 +940,8 @@ private:
 
     [delegate createNewTab:WebView::Application::settings().new_tab_page_url()
                    fromTab:[self tab]
-               activateTab:Web::HTML::ActivateTab::Yes];
+               activateTab:Web::HTML::ActivateTab::Yes
+               tabLocation:TabLocation::end()];
 
     self.tab.titlebarAppearsTransparent = YES;
 }

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -29,7 +29,8 @@ static void open_urls_from_client(Vector<URL::URL> const& urls, WebView::NewWind
 
         auto* controller = [delegate createNewTab:url
                                           fromTab:tab
-                                      activateTab:activate_tab];
+                                      activateTab:activate_tab
+                                      tabLocation:TabLocation::end()];
 
         tab = (Tab*)[controller window];
     }

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -383,7 +383,7 @@ void Application::open_new_tab()
         return;
     }
 
-    auto& tab = m_active_window->new_tab_from_url(WebView::Application::settings().new_tab_page_url(), Web::HTML::ActivateTab::Yes);
+    auto& tab = m_active_window->new_tab_from_url(WebView::Application::settings().new_tab_page_url(), Web::HTML::ActivateTab::Yes, BrowserWindow::TabLocation::end());
     tab.set_url_is_hidden(true);
     tab.focus_location_editor();
 }
@@ -425,10 +425,12 @@ void Application::reopen_recently_closed_tab()
             auto& window = new_window(recently_closed_entry->urls);
             window.activate_tab(static_cast<int>(recently_closed_entry->active_tab_index));
         } else if (!recently_closed_entry->urls.is_empty()) {
-            if (!m_active_window || m_active_window->is_private() == WebView::IsPrivate::Yes)
+            if (!m_active_window || m_active_window->is_private() == WebView::IsPrivate::Yes) {
                 new_window({ recently_closed_entry->urls[0] });
-            else
-                m_active_window->new_tab_from_url(recently_closed_entry->urls[0], Web::HTML::ActivateTab::Yes);
+            } else {
+                // FIXME: Reopen the tab in its previous location.
+                m_active_window->new_tab_from_url(recently_closed_entry->urls[0], Web::HTML::ActivateTab::Yes, BrowserWindow::TabLocation::end());
+            }
         }
     }
     update_reopen_recently_closed_actions();
@@ -532,7 +534,7 @@ Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML
         return {};
     }
 
-    auto& tab = active_window().create_new_tab(activate_tab);
+    auto& tab = active_window().create_new_tab(activate_tab, BrowserWindow::TabLocation::end());
     return tab.view();
 }
 
@@ -543,7 +545,7 @@ void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTa
         return;
     }
 
-    active_window().new_tab_from_url(url, activate_tab);
+    active_window().new_tab_from_url(url, activate_tab, BrowserWindow::TabLocation::after_current_tab());
 }
 
 void Application::open_url_in_new_window(URL::URL const& url, WebView::IsPrivate is_private)

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -486,7 +486,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         new_child_tab(Web::HTML::ActivateTab::Yes, *parent_tab, AK::move(page_index));
     } else {
         for (size_t i = 0; i < initial_urls.size(); ++i) {
-            new_tab_from_url(initial_urls[i], (i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No);
+            new_tab_from_url(initial_urls[i], (i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No, TabLocation::end());
         }
     }
 
@@ -556,9 +556,9 @@ void BrowserWindow::on_devtools_disabled()
     m_devtools_banner->hide();
 }
 
-Tab& BrowserWindow::new_tab_from_url(URL::URL const& url, Web::HTML::ActivateTab activate_tab)
+Tab& BrowserWindow::new_tab_from_url(URL::URL const& url, Web::HTML::ActivateTab activate_tab, TabLocation location)
 {
-    auto& tab = create_new_tab(activate_tab);
+    auto& tab = create_new_tab(activate_tab, location);
     tab.navigate(url);
     return tab;
 }
@@ -571,7 +571,7 @@ Tab& BrowserWindow::new_child_tab(Web::HTML::ActivateTab activate_tab, Tab& pare
 Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab, Tab& parent, Optional<u64> page_index)
 {
     if (!page_index.has_value())
-        return create_new_tab(activate_tab);
+        return create_new_tab(activate_tab, TabLocation::end());
 
     auto* tab = new Tab(this, parent.view().client(), page_index.value());
 
@@ -598,7 +598,7 @@ bool BrowserWindow::uses_client_side_decorations()
     return !WebView::Application::settings().config_variable_as_bool(WebView::ConfigVariableID::UseServerSideWindowDecorations);
 }
 
-Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab)
+Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab, TabLocation location)
 {
     auto* tab = new Tab(this);
 
@@ -606,7 +606,25 @@ Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab)
         set_current_tab(tab);
     }
 
-    m_tabs_container->add_tab(tab, "New Tab");
+    switch (location.kind()) {
+    case TabLocation::Kind::End:
+        m_tabs_container->add_tab(tab, "New Tab");
+        break;
+    case TabLocation::Kind::AfterCurrentTab:
+        m_tabs_container->insert_tab(m_tabs_container->current_index() + 1, tab, "New Tab");
+        break;
+    case TabLocation::Kind::AfterTab: {
+        auto insertion_index = m_tabs_container->count();
+        if (auto* source_tab = location.tab(); source_tab) {
+            auto source_tab_index = tab_index(source_tab);
+            if (source_tab_index != -1)
+                insertion_index = source_tab_index + 1;
+        }
+        m_tabs_container->insert_tab(insertion_index, tab, "New Tab");
+        break;
+    }
+    }
+
     if (activate_tab == Web::HTML::ActivateTab::Yes)
         m_tabs_container->set_current_tab(tab);
 
@@ -626,7 +644,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
         m_current_tab->navigate(ak_url_from_qurl(urls[0]));
 
         for (qsizetype i = 1; i < urls.size(); ++i)
-            new_tab_from_url(ak_url_from_qurl(urls[i]), Web::HTML::ActivateTab::No);
+            new_tab_from_url(ak_url_from_qurl(urls[i]), Web::HTML::ActivateTab::No, TabLocation::end());
     });
 
     tab->view().on_new_web_view = [this, tab](auto activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) {

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -94,6 +94,34 @@ public:
         No,
         Yes,
     };
+    class TabLocation {
+        friend class BrowserWindow;
+
+    private:
+        enum class Kind {
+            End,
+            AfterCurrentTab,
+            AfterTab,
+        };
+
+    public:
+        static TabLocation end() { return { Kind::End, nullptr }; }
+        static TabLocation after_current_tab() { return { Kind::AfterCurrentTab, nullptr }; }
+        static TabLocation after_tab(Tab& tab) { return { Kind::AfterTab, &tab }; }
+
+    private:
+        Kind kind() const { return m_kind; }
+        Tab* tab() const { return m_tab; }
+
+        TabLocation(Kind kind, Tab* tab)
+            : m_kind(kind)
+            , m_tab(tab)
+        {
+        }
+
+        Kind m_kind;
+        Tab* m_tab { nullptr };
+    };
 
     BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window = IsPopupWindow::No, WebView::IsPrivate = WebView::IsPrivate::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
     virtual ~BrowserWindow() override;
@@ -104,7 +132,7 @@ public:
     int tab_count() { return m_tabs_container->count(); }
     int tab_index(Tab*);
 
-    Tab& create_new_tab(Web::HTML::ActivateTab activate_tab);
+    Tab& create_new_tab(Web::HTML::ActivateTab activate_tab, TabLocation);
     Tab* current_tab() const { return m_current_tab; }
     bool activate_tab_with_url(URL::URL const&);
     FullscreenMode& fullscreen_mode();
@@ -144,7 +172,7 @@ public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon const& icon);
     void tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState);
-    Tab& new_tab_from_url(URL::URL const&, Web::HTML::ActivateTab);
+    Tab& new_tab_from_url(URL::URL const&, Web::HTML::ActivateTab, TabLocation);
     Tab& new_child_tab(Web::HTML::ActivateTab, Tab& parent, Optional<u64> page_index);
     void activate_tab(int index);
     bool definitely_close_tab(int index);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -964,7 +964,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     auto* duplicate_tab_action = new QAction("&Duplicate Tab", this);
     QObject::connect(duplicate_tab_action, &QAction::triggered, this, [this]() {
-        m_window->new_tab_from_url(view().url(), Web::HTML::ActivateTab::Yes);
+        m_window->new_tab_from_url(view().url(), Web::HTML::ActivateTab::Yes, BrowserWindow::TabLocation::after_tab(*this));
     });
 
     auto* move_to_start_action = new QAction("Move to &Start", this);

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -82,7 +82,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
             auto& window = *app->active_window_if_any();
             for (size_t i = 0; i < urls.size(); ++i) {
-                window.new_tab_from_url(urls[i], (i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No);
+                window.new_tab_from_url(urls[i], (i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No, Ladybird::BrowserWindow::TabLocation::end());
             }
             window.show();
             window.activateWindow();


### PR DESCRIPTION
Instead of new tabs always appearing at the end of the tab list, tabs created from another tab now appear directly after it. This applies to "right-click -> open in new tab", and the "Duplicate tab" option in Qt's tab bar. New tabs created directly (eg, Ctrl-T) appear at the end of the tabs list as before.