### PR TITLE
LibWeb: Ignore `!important` declarations in `@keyframes` rules

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -749,6 +749,11 @@ GC::Ptr<CSSKeyframesRule> Parser::convert_to_keyframes_rule(AtRule const& rule)
 
         PropertiesAndCustomProperties properties;
         qualified_rule.for_each_as_declaration_list("keyframe"_fly_string, [&](auto const& declaration) {
+            // https://drafts.csswg.org/css-animations-1/#keyframes
+            // None of the properties [in the <keyframe-block>'s <declaration-list>] interact with the cascade (so
+            // using !important on them is invalid and will cause the property to be ignored).
+            if (declaration.important == Important::Yes)
+                return;
             extract_property(declaration, properties);
         });
         auto style = CSSStyleProperties::create(realm(), move(properties.properties), move(properties.custom_properties));

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-cascade/important-prop-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-cascade/important-prop-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Cascade Green Right Square Reference File</title>
+<link rel="author" title="David Burns" href="http://www.theautomatedtester.co.uk">
+<style>
+#success {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+  <div>
+    <div id="success"></div>
+  </div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-cascade/important-prop.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-cascade/important-prop.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Cascade: Important vs. Animations</title>
+  <link rel="author" title="David Burns" href="http://www.theautomatedtester.co.uk">
+  <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+  <link rel="help" href="https://drafts.csswg.org/css-cascade/#importance">
+  <link rel="match" href="../../../../expected/wpt-import/css/css-cascade/important-prop-ref.html">
+  <meta name="assert" content="Test passes if normal rules are overridden by animations, important rules override animations, and !important declarations are ignored in animations.">
+  <style>
+  @keyframes override {
+    from, to {
+      background: #f00; color: green;
+      border-color: green; border-color: red !important;
+    }
+  }
+
+  .square {
+    color:#00f;
+    animation: override 1s infinite;
+    width: 80px;
+    height: 80px;
+    border: 10px solid red;
+    text-align: center;
+  }
+  div {
+    background-color:green !important;
+    color: red;
+  }
+  </style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+  <div class="square green">FAIL</div>
+
+</body>
+</html>


### PR DESCRIPTION
Properties inside a keyframe declaration block do not interact with the cascade, so a declaration qualified with `!important` is invalid and must  be ignored. We previously kept these declarations and applied them as part of the animation, so a keyframe value that other engines discard would be honored and could move an element in an unintended direction.

This fixes an issue where the cookie banner on https://open.spotify.com would previously fly in from the wrong direction.