### PR TITLE
LibWeb: Expose named cross-origin child frames

### DIFF
--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1900,8 +1900,20 @@ OrderedHashMap<FlyString, GC::Ref<LocalNavigable>> Window::document_tree_child_n
         // 1. Let name be navigable's target name.
         // 2. If navigable's active document's origin is same origin with window's relevant settings object's origin, then append name to names.
         auto document = navigable->active_document();
-        if (document && document->origin().is_same_origin(relevant_settings_object(*this).origin()))
+        if (document && document->origin().is_same_origin(relevant_settings_object(*this).origin())) {
             names.set(name, *navigable);
+            continue;
+        }
+
+        // NB: Browsers also expose cross-origin children whose target name matches their
+        //     container's name content attribute. This keeps <iframe name=...> accessible
+        //     through parent.frames.name while still excluding names introduced only by a
+        //     cross-origin child changing window.name.
+        if (auto container = navigable->container()) {
+            auto container_name = container->name();
+            if (container_name.has_value() && *container_name == name)
+                names.set(name, *navigable);
+        }
     }
 
     return names;

--- a/Tests/LibWeb/Text/expected/HTML/cross-origin-parent-named-frame.txt
+++ b/Tests/LibWeb/Text/expected/HTML/cross-origin-parent-named-frame.txt
@@ -1,0 +1,1 @@
+SecurityError: Can't access property 'a-recaptcha' on cross-origin object

--- a/Tests/LibWeb/Text/expected/HTML/cross-origin-parent-named-frame.txt
+++ b/Tests/LibWeb/Text/expected/HTML/cross-origin-parent-named-frame.txt
@@ -1,1 +1,1 @@
-SecurityError: Can't access property 'a-recaptcha' on cross-origin object
+PASS

--- a/Tests/LibWeb/Text/input/HTML/cross-origin-parent-named-frame.html
+++ b/Tests/LibWeb/Text/input/HTML/cross-origin-parent-named-frame.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<iframe name="a-recaptcha"></iframe>
+<script>
+    asyncTest(done => {
+        const namedFrame = document.querySelector("iframe");
+        const callerFrame = document.createElement("iframe");
+
+        function waitForMessage(predicate) {
+            return new Promise(resolve => {
+                window.addEventListener("message", function listener(event) {
+                    if (!predicate(event.data))
+                        return;
+                    window.removeEventListener("message", listener);
+                    resolve(event.data);
+                });
+            });
+        }
+
+        namedFrame.src = "data:text/html,<script>parent.postMessage('named-ready', '*')<" + "/script>";
+
+        waitForMessage(data => data === "named-ready").then(() => {
+            const script = `
+                let result = "FAIL";
+                try {
+                    const namedFrame = parent.frames["a-recaptcha"];
+                    result = namedFrame === parent.frames[0] ? "PASS" : "FAIL: wrong WindowProxy";
+                } catch (e) {
+                    result = e.name + ": " + e.message;
+                }
+                parent.postMessage(result, "*");
+            `;
+
+            callerFrame.src = "data:text/html,<script>" + encodeURIComponent(script) + "<" + "/script>";
+            document.body.append(callerFrame);
+            return waitForMessage(data => data !== "named-ready");
+        }).then(result => {
+            println(result);
+            done();
+        });
+    });
+</script>


### PR DESCRIPTION
Match other browsers' behavior for named access on Window by exposing child frames whose target name matches the embedding element's name content attribute. This allows a cross-origin child to look up a sibling frame through parent.frames, as used by reCAPTCHA, while still excluding names introduced only by a cross-origin child changing window.name.