### PR TITLE
Copy atomic inline offsets to used values after last-line

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -526,6 +526,10 @@ void InlineFormattingContext::generate_line_boxes()
         }
     }
 
+    line_builder.update_last_line();
+
+    // NB: This must happen after update_last_line() so that last-line alignment
+    //     adjustments are reflected in the used values of atomic inlines.
     for (auto& line_box : line_boxes) {
         for (auto& fragment : line_box.fragments()) {
             if (fragment.layout_node().is_inline_block()) {
@@ -535,8 +539,6 @@ void InlineFormattingContext::generate_line_boxes()
             }
         }
     }
-
-    line_builder.update_last_line();
 
     if (m_layout_mode == LayoutMode::Normal) {
         for (auto const* box : absolute_boxes) {

--- a/Tests/LibWeb/Layout/expected/abspos-static-position-containing-block-inline-situation.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-static-position-containing-block-inline-situation.txt
@@ -3,8 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     InlineNode <body> at [8,12] [8+0+0 0 0+0+8] [8+0+0 0 0+0+8]
       frag 0 from BlockContainer start: 0, length: 0, rect: [8,12 0x0] baseline: 0
       BlockContainer <main> at [8,12] inline-block [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
-        BlockContainer <div> at [8,0] positioned [0+0+0 36.84375 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 5, rect: [8,0 36.84375x16] baseline: 12.796875
+        BlockContainer <div> at [8,12] positioned [0+0+0 36.84375 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [8,12 36.84375x16] baseline: 12.796875
               "hello"
           TextNode <#text> (not painted)
 
@@ -12,7 +12,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (InlineNode<BODY>) [8,12 0x0]
       PaintableWithLines (BlockContainer<MAIN>) [8,12 0x0]
-        PaintableWithLines (BlockContainer<DIV>) [8,0 36.84375x16]
+        PaintableWithLines (BlockContainer<DIV>) [8,12 36.84375x16]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x16] (z-index: auto)

--- a/Tests/LibWeb/Text/expected/abspos-escaping-baseline-shifted-inline-block.txt
+++ b/Tests/LibWeb/Text/expected/abspos-escaping-baseline-shifted-inline-block.txt
@@ -1,0 +1,3 @@
+short offset: 250,80
+abs offset: 20,0
+abs position matches short position: false

--- a/Tests/LibWeb/Text/expected/abspos-escaping-baseline-shifted-inline-block.txt
+++ b/Tests/LibWeb/Text/expected/abspos-escaping-baseline-shifted-inline-block.txt
@@ -1,3 +1,3 @@
 short offset: 250,80
-abs offset: 20,0
-abs position matches short position: false
+abs offset: 250,80
+abs position matches short position: true

--- a/Tests/LibWeb/Text/input/abspos-escaping-baseline-shifted-inline-block.html
+++ b/Tests/LibWeb/Text/input/abspos-escaping-baseline-shifted-inline-block.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    #outer {
+        position: relative;
+        width: 300px;
+        height: 200px;
+        font-size: 0;
+        text-align: right;
+        background-color: magenta;
+    }
+    #tall {
+        display: inline-block;
+        width: 20px;
+        height: 100px;
+        background-color: orange;
+    }
+    #short {
+        display: inline-block;
+        width: 50px;
+        height: 20px;
+        background-color: lightblue;
+    }
+    #abs {
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        background-color: lawngreen;
+    }
+</style>
+<div id="outer">
+    <span id="tall"></span><span id="short"><div id="abs"></div></span>
+</div>
+<script>
+    // #abs escapes its non-positioned inline-block parent (#short) up to the
+    // relative-positioned #outer. #short sits on a line that is right-aligned
+    // (horizontal shift) and baseline-aligned next to a taller sibling
+    // (vertical shift), and both shifts are applied to the line's fragments
+    // after the fragment offsets have been copied into the inline-block's
+    // used values. The static position of #abs is the top-left corner of
+    // #short's content box, so #abs must end up exactly at #short's position.
+    test(() => {
+        const outerRect = document.getElementById("outer").getBoundingClientRect();
+        const shortRect = document.getElementById("short").getBoundingClientRect();
+        const absRect = document.getElementById("abs").getBoundingClientRect();
+        println(`short offset: ${shortRect.x - outerRect.x},${shortRect.y - outerRect.y}`);
+        println(`abs offset: ${absRect.x - outerRect.x},${absRect.y - outerRect.y}`);
+        println(`abs position matches short position: ${absRect.x === shortRect.x && absRect.y === shortRect.y}`);
+    });
+</script>


### PR DESCRIPTION
The inline formatting context copied fragment offsets into the used
values of atomic inlines before the final update_last_line() call, so
last-line text-align and baseline alignment adjustments never reached
UsedValues::offset. Committing the layout re-reads offsets from the
fragments, which masked the staleness for the atomic inline itself, but
in-layout consumers saw the stale value. In particular, an absolutely
positioned box escaping a non-positioned atomic inline resolves its
static position through the atomic inline's used offset via
LayoutState::cumulative_offset(), and ended up misplaced by the full
alignment shift.

Move the copy after update_last_line() so used values always match the
final fragment positions.