### PR TITLE
LibWeb: Allow navigable containers to hold base Navigables

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4356,7 +4356,7 @@ bool Document::has_focus() const
         auto focused_area = candidate->focused_area();
         if (auto* navigable_container = as_if<HTML::NavigableContainer>(focused_area.ptr())) {
             if (auto content_navigable = navigable_container->content_navigable()) {
-                candidate = content_navigable->active_document();
+                candidate = as<HTML::LocalNavigable>(*content_navigable).active_document();
                 continue;
             }
         }
@@ -4814,7 +4814,7 @@ Vector<GC::Root<HTML::LocalNavigable>> Document::descendant_navigables()
                 return TraversalDecision::Continue;
 
             // 2. Extend navigables with navigableContainer's content navigable's active document's inclusive descendant navigables.
-            auto document = navigable_container.content_navigable()->active_document();
+            auto document = as<HTML::LocalNavigable>(*navigable_container.content_navigable()).active_document();
             // AD-HOC: If the descendant navigable doesn't have an active document, just skip over it.
             if (!document)
                 return TraversalDecision::Continue;
@@ -5030,7 +5030,7 @@ void Document::destroy()
     // Not in the spec:
     for (auto& navigable_container : HTML::NavigableContainer::all_instances()) {
         if (&navigable_container->document() == this && navigable_container->content_navigable()) {
-            auto& child_navigable = *navigable_container->content_navigable();
+            auto& child_navigable = as<HTML::LocalNavigable>(*navigable_container->content_navigable());
             child_navigable.set_has_been_destroyed();
             child_navigable.remove_from_all_local_navigables();
         }

--- a/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Libraries/LibWeb/HTML/Focus.cpp
@@ -311,7 +311,7 @@ static DOM::Node* get_focusable_area(DOM::Node& focus_target, FocusTrigger focus
     if (auto* navigable_container = as_if<NavigableContainer>(&focus_target)) {
         if (!is_inert_for_focus(*navigable_container) && navigable_container->meets_focusable_area_rendering_requirements()) {
             if (auto content_navigable = navigable_container->content_navigable())
-                return content_navigable->active_document();
+                return as<LocalNavigable>(*content_navigable).active_document();
         }
     }
 
@@ -368,7 +368,7 @@ void run_focusing_steps(DOM::Node* new_focus_target, DOM::Node* fallback_target,
     // 3. If new focus target is a navigable container with non-null content navigable, then set new focus target to the content navigable's active document.
     if (auto* navigable_container = as_if<NavigableContainer>(*new_focus_target)) {
         if (auto content_navigable = navigable_container->content_navigable())
-            new_focus_target = content_navigable->active_document();
+            new_focus_target = as<LocalNavigable>(*content_navigable).active_document();
     }
 
     // 4. If new focus target is a focusable area and its DOM anchor is inert, then return.

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -223,9 +223,7 @@ void run_iframe_load_event_steps(HTMLIFrameElement& element)
         return;
     }
 
-    // 2. Let childDocument be element's content navigable's active document.
-    [[maybe_unused]] auto child_document = element.content_navigable()->active_document();
-
+    // FIXME: 2. Let childDocument be element's content navigable's active document.
     // FIXME: 3. If childDocument has its mute iframe load flag set, then return.
 
     // 4. If element's pending resource-timing start time is not null:

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -468,7 +468,7 @@ void HTMLObjectElement::run_object_representation_handler_steps(Fetch::Infrastru
         // If response's URL does not match about:blank, then navigate the element's content navigable to response's URL
         // using the element's node document, with historyHandling set to "replace".
         if (response.url().has_value() && !url_matches_about_blank(*response.url())) {
-            MUST(m_content_navigable->navigate({
+            MUST(as<HTML::LocalNavigable>(*m_content_navigable).navigate({
                 .url = *response.url(),
                 .source_document = document(),
                 .history_handling = Bindings::NavigationHistoryBehavior::Replace,

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -2631,7 +2631,7 @@ GC::Ptr<DOM::Node> LocalTraversableNavigable::currently_focused_area()
     while (candidate->focused_area()
         && is<NavigableContainer>(candidate->focused_area().ptr())
         && as<NavigableContainer>(*candidate->focused_area()).content_navigable()) {
-        candidate = as<NavigableContainer>(*candidate->focused_area()).content_navigable()->active_document();
+        candidate = as<LocalNavigable>(*as<NavigableContainer>(*candidate->focused_area()).content_navigable()).active_document();
     }
 
     // 4. If candidate's focused area is non-null, set candidate to candidate's focused area.

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -149,7 +149,7 @@ DOM::Document const* NavigableContainer::content_document() const
         return nullptr;
 
     // 2. Let document be container's content navigable's active document.
-    auto document = m_content_navigable->active_document();
+    auto document = as<LocalNavigable>(*m_content_navigable).active_document();
 
     // AD-HOC: The active document can be null during navigation, after the old document
     //         has been destroyed but before the new document has been set.
@@ -169,7 +169,7 @@ DOM::Document const* NavigableContainer::content_document_without_origin_check()
     if (!m_content_navigable)
         return nullptr;
 
-    return m_content_navigable->active_document();
+    return as<LocalNavigable>(*m_content_navigable).active_document();
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-media-getsvgdocument
@@ -229,15 +229,16 @@ Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_ifr
     //         navigable's ongoing_navigation, causing the real navigation to be dropped when its populate completion
     //         callback checks ongoing_navigation != navigation_id. Non-blank src navigations must still be processed
     //         here, and will be queued by LocalNavigable::navigate() until the child navigable is ready for navigation.
+    auto& local_navigable = as<LocalNavigable>(*m_content_navigable);
+
     if (url_matches_about_blank(url) && initial_insertion == InitialInsertion::Yes
-        && (m_content_navigable->has_pending_navigations()
-            || !m_content_navigable->ongoing_navigation().has<Empty>())) {
+        && (local_navigable.has_pending_navigations() || !local_navigable.ongoing_navigation().has<Empty>())) {
         return {};
     }
 
     // 4. If url matches about:blank and initialInsertion is true, then perform the URL and history update steps given element's content navigable's active document and url.
     if (url_matches_about_blank(url) && initial_insertion == InitialInsertion::Yes) {
-        auto& document = *m_content_navigable->active_document();
+        auto& document = *local_navigable.active_document();
         perform_url_and_history_update_steps(document, url);
     }
 
@@ -255,7 +256,8 @@ void NavigableContainer::navigate_an_iframe_or_frame(URL::URL url, ReferrerPolic
     // AD-HOC: Only apply this check during initial insertion. For subsequent attribute-driven navigations,
     //         the previous document may have parsed and run scripts but not yet fired its load event;
     //         forcing "replace" in that case would incorrectly discard the history entry.
-    if (initial_insertion == InitialInsertion::Yes && m_content_navigable->active_document() && !m_content_navigable->active_document()->is_completely_loaded()) {
+    auto& local_navigable = as<LocalNavigable>(*m_content_navigable);
+    if (initial_insertion == InitialInsertion::Yes && local_navigable.active_document() && !local_navigable.active_document()->is_completely_loaded()) {
         history_handling = Bindings::NavigationHistoryBehavior::Replace;
     }
 
@@ -276,7 +278,7 @@ void NavigableContainer::navigate_an_iframe_or_frame(URL::URL url, ReferrerPolic
     if (srcdoc_string.has_value())
         document_resource = srcdoc_string.value();
 
-    MUST(m_content_navigable->navigate({
+    MUST(local_navigable.navigate({
         .url = move(url),
         .source_document = document(),
         .document_resource = document_resource,
@@ -301,33 +303,37 @@ void NavigableContainer::destroy_the_child_navigable()
     // Therefore, it is moved to run in afterAllDestruction callback of "destroy a document and its descendants"
     // when all queued tasks are done.
     // "Has been destroyed" flag is used instead to check whether navigable is already destroyed.
-    if (navigable->has_been_destroyed())
+    auto& local_navigable = as<LocalNavigable>(*navigable);
+
+    if (local_navigable.has_been_destroyed())
         return;
-    navigable->set_has_been_destroyed();
+    local_navigable.set_has_been_destroyed();
 
     // AD-HOC: Clear the navigable's "is delaying load events" flag.
     //         This removes the DocumentLoadEventDelayer on the parent document that was
     //         created when the navigable started loading (navigate algorithm step 15).
     //         Without this, the delayer lingers until GC collects the LocalNavigable, which can
     //         block the parent document's load event indefinitely.
-    navigable->set_delaying_load_events(false);
+    local_navigable.set_delaying_load_events(false);
 
     // AD-HOC: Clear the navigation load event guard that may have been set by
     //         finalize_a_cross_document_navigation. Without this, the guard's
     //         DocumentLoadEventDelayer on the parent document persists until GC,
     //         blocking the parent's load event indefinitely.
-    navigable->clear_navigation_load_event_guard();
+    local_navigable.clear_navigation_load_event_guard();
 
     // 4. Inform the navigation API about child navigable destruction given navigable.
-    navigable->inform_the_navigation_api_about_child_navigable_destruction();
+    local_navigable.inform_the_navigation_api_about_child_navigable_destruction();
 
     auto after_document_destruction = GC::create_function(heap(), [this, navigable] {
+        auto& local_navigable = as<LocalNavigable>(*navigable);
+
         // 3. Set container's content navigable to null.
         m_content_navigable = nullptr;
         document().schedule_html_parser_end_check();
 
         // Not in the spec:
-        navigable->remove_from_all_local_navigables();
+        local_navigable.remove_from_all_local_navigables();
 
         // 6. Let parentDocState be container's node navigable's active session history entry's document state.
         auto parent_doc_state = this->navigable()->active_session_history_entry()->document_state();
@@ -356,7 +362,7 @@ void NavigableContainer::destroy_the_child_navigable()
     //         container, we reach step 5 with navigable's active document already null. We
     //         treat the destroy step as a no-op in that case and proceed with the remaining
     //         post-destruction cleanup.
-    if (auto active_document = navigable->active_document())
+    if (auto active_document = local_navigable.active_document())
         active_document->destroy_a_document_and_its_descendants(after_document_destruction);
     else
         after_document_destruction->function()();
@@ -378,15 +384,17 @@ bool NavigableContainer::currently_delays_the_load_event() const
         return false;
 
     // - element's content navigable's active document is not ready for post-load tasks;
-    if (!m_content_navigable->active_document()->ready_for_post_load_tasks())
+    auto& local_navigable = as<LocalNavigable>(*m_content_navigable);
+
+    if (!local_navigable.active_document()->ready_for_post_load_tasks())
         return true;
 
     // - element's content navigable's is delaying load events is true; or
-    if (m_content_navigable->is_delaying_load_events())
+    if (local_navigable.is_delaying_load_events())
         return true;
 
     // - anything is delaying the load event of element's content navigable's active document.
-    if (m_content_navigable->active_document()->anything_is_delaying_the_load_event())
+    if (local_navigable.active_document()->anything_is_delaying_the_load_event())
         return true;
 
     return false;
@@ -396,7 +404,7 @@ bool NavigableContainer::content_navigable_has_session_history_entry_and_ready_f
 {
     if (!content_navigable())
         return false;
-    return m_content_navigable->has_session_history_entry_and_ready_for_navigation();
+    return as<LocalNavigable>(*m_content_navigable).has_session_history_entry_and_ready_for_navigation();
 }
 
 void NavigableContainer::set_potentially_delays_the_load_event(bool value)
@@ -408,9 +416,10 @@ void NavigableContainer::set_potentially_delays_the_load_event(bool value)
 
 void NavigableContainer::set_content_navigable_has_session_history_entry_and_ready_for_navigation()
 {
-    if (!content_navigable())
+    auto content_navigable = this->content_navigable();
+    if (!content_navigable)
         return;
-    content_navigable()->set_has_session_history_entry_and_ready_for_navigation();
+    as<LocalNavigable>(*content_navigable).set_has_session_history_entry_and_ready_for_navigation();
     document().schedule_html_parser_end_check();
 }
 

--- a/Libraries/LibWeb/HTML/NavigableContainer.h
+++ b/Libraries/LibWeb/HTML/NavigableContainer.h
@@ -24,8 +24,8 @@ public:
 
     static HashTable<NavigableContainer*>& all_instances();
 
-    GC::Ptr<LocalNavigable> content_navigable() { return m_content_navigable; }
-    GC::Ptr<LocalNavigable const> content_navigable() const { return m_content_navigable.ptr(); }
+    GC::Ptr<Navigable> content_navigable() { return m_content_navigable; }
+    GC::Ptr<Navigable const> content_navigable() const { return m_content_navigable; }
 
     DOM::Document const* content_document() const;
     DOM::Document const* content_document_without_origin_check() const;
@@ -57,7 +57,7 @@ protected:
     void create_new_child_navigable();
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#content-navigable
-    GC::Ptr<LocalNavigable> m_content_navigable { nullptr };
+    GC::Ptr<Navigable> m_content_navigable { nullptr };
 
     void set_potentially_delays_the_load_event(bool value);
 

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -52,6 +52,7 @@
 #include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/HTMLObjectElement.h>
+#include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
 #include <LibWeb/HTML/Location.h>
 #include <LibWeb/HTML/MessageEvent.h>
@@ -1968,9 +1969,10 @@ JS::Value Window::named_item_value(FlyString const& name) const
         // 1. Let container be the first navigable container in window's associated Document's descendants whose content navigable is in objects.
         GC::Ptr<NavigableContainer> container = nullptr;
         mutable_this.associated_document().for_each_in_subtree_of_type<HTML::NavigableContainer>([&](HTML::NavigableContainer& navigable_container) {
-            if (!navigable_container.content_navigable())
+            auto content_navigable = navigable_container.content_navigable();
+            if (!content_navigable)
                 return TraversalDecision::Continue;
-            if (objects.navigables.contains_slow(GC::Ref { *navigable_container.content_navigable() })) {
+            if (objects.navigables.contains_slow(GC::Ref { as<LocalNavigable>(*content_navigable) })) {
                 container = navigable_container;
                 return TraversalDecision::Break;
             }

--- a/Libraries/LibWeb/IndexedDB/Inspection.cpp
+++ b/Libraries/LibWeb/IndexedDB/Inspection.cpp
@@ -98,7 +98,7 @@ static Vector<IndexedDatabaseDocument> indexed_database_documents_for_inspection
         if (!content_navigable)
             return TraversalDecision::Continue;
 
-        auto content_document = content_navigable->active_document();
+        auto content_document = as<HTML::LocalNavigable>(*content_navigable).active_document();
         if (!content_document)
             return TraversalDecision::Continue;
 

--- a/Libraries/LibWeb/Layout/NavigableContainerViewport.cpp
+++ b/Libraries/LibWeb/Layout/NavigableContainerViewport.cpp
@@ -50,7 +50,7 @@ void NavigableContainerViewport::did_set_content_size()
 
     if (auto content_navigable = dom_node().content_navigable()) {
         auto content_size = paintable_box()->content_size();
-        content_navigable->set_viewport_size(content_size);
+        as<HTML::LocalNavigable>(*content_navigable).set_viewport_size(content_size);
         document().page().client().page_did_update_child_frame_viewport(content_navigable->id(), paintable_box()->absolute_rect());
     }
 }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -219,7 +219,7 @@ static Optional<EventResult> dispatch_event_to_nested_navigable(Painting::Painta
     if (auto* navigable_paintable = as_if<Painting::NavigableContainerViewportPaintable>(paintable)) {
         auto position = navigable_paintable->transform_to_local_coordinates(viewport_position) - navigable_paintable->absolute_rect().location();
         if (auto content_navigable = as_if<HTML::NavigableContainer>(*node)->content_navigable()) {
-            return dispatch(content_navigable->event_handler(), position);
+            return dispatch(as<HTML::LocalNavigable>(*content_navigable).event_handler(), position);
         }
         return EventResult::Dropped;
     }
@@ -1514,7 +1514,7 @@ EventResult EventHandler::fire_keyboard_event(FlyString const& event_name, HTML:
         if (is<HTML::NavigableContainer>(*focused_area)) {
             auto& navigable_container = as<HTML::NavigableContainer>(*focused_area);
             if (navigable_container.content_navigable())
-                return fire_keyboard_event(event_name, *navigable_container.content_navigable(), key, modifiers, code_point, repeat);
+                return fire_keyboard_event(event_name, as<HTML::LocalNavigable>(*navigable_container.content_navigable()), key, modifiers, code_point, repeat);
         }
 
         auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point, repeat);
@@ -1553,7 +1553,7 @@ EventResult EventHandler::input_event(FlyString const& event_name, FlyString con
         if (is<HTML::NavigableContainer>(*focused_area)) {
             auto& navigable_container = as<HTML::NavigableContainer>(*focused_area);
             if (navigable_container.content_navigable())
-                return input_event(event_name, input_type, *navigable_container.content_navigable(), move(code_point_or_string));
+                return input_event(event_name, input_type, as<HTML::LocalNavigable>(*navigable_container.content_navigable()), move(code_point_or_string));
         }
 
         auto event = UIEvents::InputEvent::create_from_platform_event(document->realm(), event_name, input_event_init, target_ranges_for_input_event(*document, input_type));

--- a/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
@@ -41,19 +41,20 @@ void NavigableContainerViewportPaintable::paint(DisplayListRecordingContext& con
         auto const& navigable_container = this->navigable_container();
         auto content_navigable = navigable_container.content_navigable();
         VERIFY(content_navigable);
-        if (content_navigable->has_been_destroyed())
+        auto& local_navigable = as<HTML::LocalNavigable>(*content_navigable);
+        if (local_navigable.has_been_destroyed())
             return;
 
         auto context_id = document().page().client().compositor_context_id_for_remote_child_frame(content_navigable->id());
         if (!context_id.has_value()) {
-            if (!content_navigable->has_compositor_context())
+            if (!local_navigable.has_compositor_context())
                 return;
 
             auto* hosted_document = const_cast<DOM::Document*>(navigable_container.content_document_without_origin_check());
             if (hosted_document && hosted_document->is_render_blocked())
                 return;
 
-            context_id = content_navigable->compositor_context().id();
+            context_id = local_navigable.compositor_context().id();
         }
 
         context.display_list_recorder().save();
@@ -65,7 +66,7 @@ void NavigableContainerViewportPaintable::paint(DisplayListRecordingContext& con
         context.display_list_recorder().restore();
 
         if constexpr (HIGHLIGHT_FOCUSED_FRAME_DEBUG) {
-            if (content_navigable->is_focused()) {
+            if (local_navigable.is_focused()) {
                 context.display_list_recorder().draw_rect(clip_rect.to_type<int>(), Color::Cyan);
             }
         }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1182,7 +1182,7 @@ static void append_grid_layouts_for_node_and_frame_descendants(Web::DOM::Node& r
         if (!content_navigable)
             return Web::TraversalDecision::Continue;
 
-        auto content_document = content_navigable->active_document();
+        auto content_document = as<Web::HTML::LocalNavigable>(*content_navigable).active_document();
         if (!content_document)
             return Web::TraversalDecision::Continue;
 

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -848,7 +848,7 @@ Messages::WebDriverClient::SwitchToFrameResponse WebDriverConnection::switch_to_
 
             // 5. Set the current browsing context with session and element's content navigable's active browsing context.
             auto& navigable_container = static_cast<Web::HTML::NavigableContainer&>(*element);
-            set_current_browsing_context(*navigable_container.content_navigable()->active_browsing_context());
+            set_current_browsing_context(*as<Web::HTML::LocalNavigable>(*navigable_container.content_navigable()).active_browsing_context());
 
             async_driver_execution_complete(JsonValue {});
         });


### PR DESCRIPTION
Widen NavigableContainer's content navigable storage and accessors from LocalNavigable to Navigable so containers can eventually hold RemoteNavigable proxies. Many of these sites being casted to a LocalNavigable will need to be adjusted as part of support for site isolation, but get the shape of this API in place now.