### PR TITLE
LibWeb: Don't rebuild shared style caches that are already populated

### DIFF
--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -161,6 +161,14 @@ StyleCache& StyleScope::ensure_style_cache() const
 void StyleScope::build_rule_cache()
 {
     auto& style_cache = ensure_style_cache();
+
+    // OPTIMIZATION: If ensure_style_cache() returned the shared single-constructed-sheet cache and another
+    //               scope has already populated it, its contents are valid for this scope as well: the cache
+    //               only depends on the sheet and document-wide state, and any change to either invalidates
+    //               the shared cache itself (see CSSStyleSheet::invalidate_shared_style_cache()).
+    if (style_cache.rule_cache)
+        return;
+
     style_cache.rule_cache = make<StyleRuleCache>();
     populate_rule_cache(*style_cache.rule_cache);
 }
@@ -187,6 +195,12 @@ void StyleScope::populate_rule_cache(StyleRuleCache& rule_cache)
 void StyleScope::build_style_invalidation_data()
 {
     auto& style_cache = ensure_style_cache();
+
+    // OPTIMIZATION: Same as in build_rule_cache(): a shared cache populated by another scope using the
+    //               same single constructed sheet is valid for this scope as well.
+    if (style_cache.style_invalidation_data)
+        return;
+
     style_cache.style_invalidation_data = make<StyleInvalidationData>();
     populate_style_invalidation_data(*style_cache.style_invalidation_data);
     style_cache.style_invalidation_data->did_finish_building();


### PR DESCRIPTION
When a shadow root's `StyleScope` resolves to the shared style cache of its single constructed stylesheet, `build_rule_cache()` and `build_style_invalidation_data()` would unconditionally rebuild the cache contents, even when another scope using the same sheet had already populated them. Since every new shadow root adopting a sheet starts with an empty scope cache pointer, each new component instance on pages using constructed stylesheets (e.g. Lit apps) rebuilt the shared rule cache and style invalidation data from scratch.

The shared cache contents only depend on the sheet and document-wide state, and any change to either already invalidates the shared cache itself through `CSSStyleSheet::invalidate_shared_style_cache()`, so a populated shared cache is valid as-is for every scope that resolves to it.

On https://reddit.com/r/programming this cuts style invalidation data builds from 748 to 226 and rule cache builds from 600 to 200 during page load, removing about 4 seconds of CPU work in WebContent (14.6s down to 10.6s over a 20 second load on my old Linux box.)