### PR TITLE
Support macOS dictionary lookup

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -422,6 +422,9 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
 
         if (delta.x().abs() >= DRAG_THRESHOLD || delta.y().abs() >= DRAG_THRESHOLD) {
             auto result = handle_drag_and_drop_event(DragEvent::Type::DragStart, visual_viewport_position, screen_position, UIEvents::MouseButton::Primary, buttons, modifiers, {});
+#if defined(AK_OS_MACOS)
+            bool should_start_selection_from_preserved_mousedown = m_mousedown_preserved_selection && result != EventResult::Handled;
+#endif
 
             if (result == EventResult::Handled) {
                 set_page_cursor(m_navigable->page(), Gfx::StandardCursor::Drag);
@@ -439,6 +442,11 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
             document->update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseMove);
             if (!paint_root())
                 return EventResult::Accepted;
+
+#if defined(AK_OS_MACOS)
+            if (should_start_selection_from_preserved_mousedown)
+                start_selection_from_preserved_mousedown(*document);
+#endif
         }
     }
 
@@ -1734,6 +1742,10 @@ GC::Ptr<DOM::Node> EventHandler::focus_candidate_for_position(CSSPixelPoint visu
     return focus_dom_node;
 }
 
+#if defined(AK_OS_MACOS)
+static bool selection_contains_position(DOM::Document&, Painting::CaretPosition const&);
+#endif
+
 void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count)
 {
     if (m_middle_button_scroll_handler) {
@@ -1769,6 +1781,46 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
         return;
 #endif
 
+    auto caret_position = prepare_mouse_selection(document, visual_viewport_position, viewport_position);
+    if (!caret_position.has_value())
+        return;
+
+    // https://drafts.csswg.org/css-ui/#valdef-user-select-none
+    // Attempting to start a selection in an element where user-select is none, such as by clicking in it or starting a
+    // drag in it, must not cause a pre-existing selection to become unselected or to be affected in any way.
+    auto user_select = user_select_used_value_for_caret_position(*caret_position);
+    if (user_select == CSS::UserSelect::None)
+        return;
+
+#if defined(AK_OS_MACOS)
+    if (click_count == 1 && !(modifiers & UIEvents::KeyModifier::Mod_Shift) && selection_contains_position(document, *caret_position)) {
+        m_mousedown_preserved_selection = true;
+        return;
+    }
+#endif
+
+    auto selection_started = [&] {
+        if (click_count == 3)
+            return initiate_paragraph_selection(document, *caret_position, user_select);
+        if (click_count == 2)
+            return initiate_word_selection(document, *caret_position, user_select);
+
+        return initiate_character_selection(document, *caret_position, user_select, modifiers & UIEvents::KeyModifier::Mod_Shift);
+    }();
+    if (!selection_started)
+        return;
+    VERIFY(m_selection_mode != SelectionMode::None);
+
+    if (auto container = AutoScrollHandler::find_scrollable_ancestor(*caret_position->paintable))
+        m_auto_scroll_handler = make<AutoScrollHandler>(m_navigable, *container);
+}
+
+Optional<Painting::CaretPosition> EventHandler::prepare_mouse_selection(DOM::Document& document, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position)
+{
+    document.update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseDown);
+    if (!paint_root())
+        return {};
+
     // https://html.spec.whatwg.org/multipage/interaction.html#data-model:click-focusable-5
     // When a user activates a click focusable focusable area, the user agent must run the focusing steps on that
     // focusable area with focus trigger set to "click".
@@ -1792,7 +1844,7 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
     // NB: Focusing may have invalidated layout.
     document.update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseDown);
     if (!paint_root())
-        return;
+        return {};
 
     // NB: Now we can do selection with a caret-position hit test.
     auto caret_position = document.caret_position_from_point_for_selection_start(visual_viewport_position);
@@ -1801,30 +1853,120 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
             caret_position = caret_position_from_editable_hit_node(*editable_hit_node_before_focus);
     }
     if (!caret_position.has_value())
+        return {};
+
+    return caret_position;
+}
+
+#if defined(AK_OS_MACOS)
+bool EventHandler::select_word_for_dictionary_lookup(CSSPixelPoint visual_viewport_position)
+{
+    auto document = m_navigable->active_document();
+    if (!document)
+        return false;
+
+    document->update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseDown);
+    if (!paint_root())
+        return false;
+
+    auto result = target_for_mouse_position(visual_viewport_position);
+    if (!result.has_value())
+        return false;
+
+    if (auto dispatch_result = dispatch_event_to_nested_navigable(*result->paintable, visual_viewport_position, [](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
+            return event_handler.select_word_for_dictionary_lookup(position) ? EventResult::Handled : EventResult::Dropped;
+        });
+        dispatch_result.has_value()) {
+        return *dispatch_result == EventResult::Handled;
+    }
+
+    auto viewport_position = document->visual_viewport()->map_to_layout_viewport(visual_viewport_position);
+    return select_word_at_position(*document, visual_viewport_position, viewport_position);
+}
+
+static bool form_control_selection_contains_position(InputEventsTarget& target, Painting::CaretPosition const& caret_position)
+{
+    auto cell = target.as_cell();
+    if (!is<DOM::Node>(*cell))
+        return false;
+
+    auto& node = as<DOM::Node>(*cell);
+    auto const* form_control = as_if<HTML::FormAssociatedTextControlElement>(node);
+    if (!form_control)
+        return false;
+
+    auto selection_start = form_control->selection_start();
+    auto selection_end = form_control->selection_end();
+    return selection_start != selection_end
+        && caret_position.boundary.offset >= selection_start
+        && caret_position.boundary.offset <= selection_end;
+}
+
+static bool selection_contains_position(DOM::Document& document, Painting::CaretPosition const& caret_position)
+{
+    if (auto* target = document.active_input_events_target(&*caret_position.boundary.node)) {
+        if (form_control_selection_contains_position(*target, caret_position))
+            return true;
+    }
+
+    auto selection = document.get_selection();
+    if (!selection || selection->is_collapsed())
+        return false;
+
+    auto range = selection->range();
+    if (!range)
+        return false;
+
+    auto contains_position = range->is_point_in_range(*caret_position.boundary.node, caret_position.boundary.offset);
+    if (contains_position.is_error())
+        return false;
+
+    return contains_position.value();
+}
+
+bool EventHandler::select_word_at_position(DOM::Document& document, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position)
+{
+    auto caret_position = prepare_mouse_selection(document, visual_viewport_position, viewport_position);
+    if (!caret_position.has_value())
+        return false;
+
+    if (selection_contains_position(document, *caret_position))
+        return true;
+
+    auto user_select = user_select_used_value_for_caret_position(*caret_position);
+    if (user_select == CSS::UserSelect::None)
+        return false;
+
+    if (initiate_word_selection(document, *caret_position, user_select)) {
+        stop_updating_selection();
+        return true;
+    }
+    return false;
+}
+
+void EventHandler::start_selection_from_preserved_mousedown(DOM::Document& document)
+{
+    m_mousedown_preserved_selection = false;
+
+    if (!m_mousedown_visual_viewport_position.has_value())
         return;
 
-    // https://drafts.csswg.org/css-ui/#valdef-user-select-none
-    // Attempting to start a selection in an element where user-select is none, such as by clicking in it or starting a
-    // drag in it, must not cause a pre-existing selection to become unselected or to be affected in any way.
+    auto viewport_position = document.visual_viewport()->map_to_layout_viewport(*m_mousedown_visual_viewport_position);
+    auto caret_position = prepare_mouse_selection(document, *m_mousedown_visual_viewport_position, viewport_position);
+    if (!caret_position.has_value())
+        return;
+
     auto user_select = user_select_used_value_for_caret_position(*caret_position);
     if (user_select == CSS::UserSelect::None)
         return;
 
-    auto selection_started = [&] {
-        if (click_count == 3)
-            return initiate_paragraph_selection(document, *caret_position, user_select);
-        if (click_count == 2)
-            return initiate_word_selection(document, *caret_position, user_select);
-
-        return initiate_character_selection(document, *caret_position, user_select, modifiers & UIEvents::KeyModifier::Mod_Shift);
-    }();
-    if (!selection_started)
+    if (!initiate_character_selection(document, *caret_position, user_select, false))
         return;
-    VERIFY(m_selection_mode != SelectionMode::None);
 
     if (auto container = AutoScrollHandler::find_scrollable_ancestor(*caret_position->paintable))
         m_auto_scroll_handler = make<AutoScrollHandler>(m_navigable, *container);
 }
+#endif
 
 void EventHandler::run_activation_behavior(GC::Ref<DOM::Node> node, unsigned button, unsigned modifiers)
 {
@@ -2521,6 +2663,9 @@ void EventHandler::clear_mousedown_tracking()
     m_mousedown_visual_viewport_position = {};
     m_mousedown_click_count = 0;
     m_mousedown_target_is_drag_candidate = false;
+#if defined(AK_OS_MACOS)
+    m_mousedown_preserved_selection = false;
+#endif
 }
 
 void EventHandler::stop_updating_selection()

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -48,6 +48,9 @@ public:
     EventResult handle_mouseup(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
     EventResult handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false, Optional<AsyncScrollOperation>* async_scroll_operation = nullptr);
     EventResult handle_mouseleave();
+#if defined(AK_OS_MACOS)
+    bool select_word_for_dictionary_lookup(CSSPixelPoint visual_viewport_position);
+#endif
     void update_hover_after_scroll();
     GC::Ptr<DOM::Node> target_node_for_mouse_position(CSSPixelPoint);
 
@@ -114,11 +117,16 @@ private:
     void maybe_show_context_menu(GC::Ref<DOM::Node>, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
     bool maybe_request_paste_for_middle_click(DOM::Document&, CSSPixelPoint visual_viewport_position);
 
+    Optional<Painting::CaretPosition> prepare_mouse_selection(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);
     bool initiate_character_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect, bool shift_held);
     bool initiate_word_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
     bool initiate_paragraph_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
     bool select_context_menu_text(DOM::Document&, CSSPixelPoint visual_viewport_position);
     bool select_context_menu_url_token(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
+#if defined(AK_OS_MACOS)
+    bool select_word_at_position(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);
+    void start_selection_from_preserved_mousedown(DOM::Document&);
+#endif
 
     void update_mouse_selection(CSSPixelPoint visual_viewport_position);
     void apply_mouse_selection(CSSPixelPoint visual_viewport_position);
@@ -174,6 +182,9 @@ private:
     Optional<CSSPixelPoint> m_mousedown_visual_viewport_position;
     int m_mousedown_click_count { 0 };
     bool m_mousedown_target_is_drag_candidate { false };
+#if defined(AK_OS_MACOS)
+    bool m_mousedown_preserved_selection { false };
+#endif
 
     // https://w3c.github.io/pointerevents/#the-pointerdown-event
     // The PREVENT MOUSE EVENT flag.

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -342,6 +342,13 @@ EventResult Page::handle_mouseleave()
     return top_level_traversable()->event_handler().handle_mouseleave();
 }
 
+#if defined(AK_OS_MACOS)
+bool Page::select_word_for_dictionary_lookup(DevicePixelPoint position)
+{
+    return top_level_traversable()->event_handler().select_word_for_dictionary_lookup(device_to_css_point(position));
+}
+#endif
+
 UniqueNodeID Page::node_id_at_position(DevicePixelPoint position)
 {
     auto node = top_level_traversable()->event_handler().target_node_for_mouse_position(device_to_css_point(position));

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -130,6 +130,9 @@ public:
     EventResult handle_mousedown(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count);
     EventResult handle_mousemove(DevicePixelPoint, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult handle_mouseleave();
+#if defined(AK_OS_MACOS)
+    bool select_word_for_dictionary_lookup(DevicePixelPoint);
+#endif
     UniqueNodeID node_id_at_position(DevicePixelPoint);
     EventResult handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false, Optional<AsyncScrollOperation>* async_scroll_operation = nullptr);
 

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     CompositorClient.cpp
     ConsoleOutput.cpp
     CookieJar.cpp
+    DictionaryLookup.cpp
     DOMNodeProperties.cpp
     DownloadPresentation.cpp
     FileDownloader.cpp

--- a/Libraries/LibWebView/DictionaryLookup.cpp
+++ b/Libraries/LibWebView/DictionaryLookup.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWebView/DictionaryLookup.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::DictionaryLookupTextStyle const& style)
+{
+    TRY(encoder.encode(style.font_family));
+    TRY(encoder.encode(style.ui_point_size));
+    TRY(encoder.encode(style.weight));
+    TRY(encoder.encode(style.slope));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::DictionaryLookupTextStyle> IPC::decode(Decoder& decoder)
+{
+    auto font_family = TRY(decoder.decode<String>());
+    auto ui_point_size = TRY(decoder.decode<float>());
+    auto weight = TRY(decoder.decode<u16>());
+    auto slope = TRY(decoder.decode<u8>());
+
+    return WebView::DictionaryLookupTextStyle { move(font_family), ui_point_size, weight, slope };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::DictionaryLookup const& lookup)
+{
+    TRY(encoder.encode(lookup.text));
+    TRY(encoder.encode(lookup.style));
+    TRY(encoder.encode(lookup.baseline_origin));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::DictionaryLookup> IPC::decode(Decoder& decoder)
+{
+    auto text = TRY(decoder.decode<String>());
+    auto style = TRY(decoder.decode<Optional<WebView::DictionaryLookupTextStyle>>());
+    auto baseline_origin = TRY(decoder.decode<Optional<Gfx::IntPoint>>());
+
+    return WebView::DictionaryLookup { move(text), move(style), move(baseline_origin) };
+}

--- a/Libraries/LibWebView/DictionaryLookup.h
+++ b/Libraries/LibWebView/DictionaryLookup.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibGfx/Point.h>
+#include <LibIPC/Forward.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+struct WEBVIEW_API DictionaryLookupTextStyle {
+    String font_family;
+    float ui_point_size { 0 };
+    u16 weight { 0 };
+    u8 slope { 0 };
+};
+
+struct WEBVIEW_API DictionaryLookup {
+    String text;
+    Optional<DictionaryLookupTextStyle> style;
+    Optional<Gfx::IntPoint> baseline_origin;
+};
+
+}
+
+namespace IPC {
+
+template<>
+WEBVIEW_API ErrorOr<void> encode(Encoder&, WebView::DictionaryLookupTextStyle const&);
+
+template<>
+WEBVIEW_API ErrorOr<WebView::DictionaryLookupTextStyle> decode(Decoder&);
+
+template<>
+WEBVIEW_API ErrorOr<void> encode(Encoder&, WebView::DictionaryLookup const&);
+
+template<>
+WEBVIEW_API ErrorOr<WebView::DictionaryLookup> decode(Decoder&);
+
+}

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -40,6 +40,8 @@ struct BookmarkItem;
 struct BrowserOptions;
 struct ConsoleOutput;
 struct CookieStorageKey;
+struct DictionaryLookup;
+struct DictionaryLookupTextStyle;
 struct DOMNodeProperties;
 struct Mutation;
 struct ProcessHandle;

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -36,6 +36,7 @@ enum class ActionID {
     Paste,
     SelectAll,
 
+    LookUpSelectedText,
     SearchSelectedText,
 
     TakeVisibleScreenshot,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -629,6 +629,34 @@ Optional<String> ViewImplementation::selected_text_with_whitespace_collapsed()
     return selected_text;
 }
 
+Optional<DictionaryLookup> ViewImplementation::selected_text_for_dictionary_lookup()
+{
+    auto lookup = client().get_selected_text_for_lookup(page_id());
+    if (!lookup.has_value())
+        return {};
+
+    auto selected_text = MUST(Web::Infra::strip_and_collapse_whitespace(lookup->text));
+    if (selected_text.is_empty())
+        return {};
+
+    lookup->text = move(selected_text);
+    return lookup;
+}
+
+bool ViewImplementation::look_up_selected_text_at(Gfx::IntPoint widget_position)
+{
+    if (!on_request_dictionary_lookup)
+        return false;
+
+    auto lookup = selected_text_for_dictionary_lookup();
+    if (!lookup.has_value())
+        return false;
+
+    auto lookup_position = lookup->baseline_origin.has_value() ? to_widget_position(*lookup->baseline_origin) : widget_position;
+    on_request_dictionary_lookup(*lookup, lookup_position);
+    return true;
+}
+
 void ViewImplementation::select_all()
 {
     client().async_select_all(page_id());
@@ -2099,6 +2127,14 @@ void ViewImplementation::initialize_context_menus()
     });
     m_search_selected_text_action->set_visible(false);
 
+    m_look_up_selected_text_action = Action::create("Look Up"sv, ActionID::LookUpSelectedText, [this] {
+        if (!m_look_up.has_value() || !on_request_dictionary_lookup)
+            return;
+
+        on_request_dictionary_lookup(*m_look_up, m_look_up_position);
+    });
+    m_look_up_selected_text_action->set_visible(false);
+
     auto take_and_save_screenshot = [this](auto type) {
         take_screenshot(type)
             ->when_resolved([](auto const& path) {
@@ -2214,6 +2250,7 @@ void ViewImplementation::initialize_context_menus()
     };
 
     m_page_context_menu = Menu::create("Page Context Menu"sv);
+    m_page_context_menu->add_action(*m_look_up_selected_text_action);
     m_page_context_menu->add_action(*m_navigate_back_action);
     m_page_context_menu->add_action(*m_navigate_forward_action);
     m_page_context_menu->add_action(application.reload_action());
@@ -2228,6 +2265,7 @@ void ViewImplementation::initialize_context_menus()
     m_page_context_menu->add_action(application.view_source_action());
 
     m_link_context_menu = Menu::create("Link Context Menu"sv);
+    m_link_context_menu->add_action(*m_look_up_selected_text_action);
     add_open_url_actions(*m_link_context_menu);
     m_link_context_menu->add_separator();
     m_link_context_menu->add_action(*m_download_linked_file_action);
@@ -2236,6 +2274,7 @@ void ViewImplementation::initialize_context_menus()
     m_link_context_menu->add_action(*m_copy_url_action);
 
     m_selected_text_link_context_menu = Menu::create("Selected Text Link Context Menu"sv);
+    m_selected_text_link_context_menu->add_action(*m_look_up_selected_text_action);
     add_open_url_actions(*m_selected_text_link_context_menu);
     m_selected_text_link_context_menu->add_separator();
     add_text_edit_actions(*m_selected_text_link_context_menu);
@@ -2243,6 +2282,7 @@ void ViewImplementation::initialize_context_menus()
     m_selected_text_link_context_menu->add_action(*m_search_selected_text_action);
 
     m_image_context_menu = Menu::create("Image Context Menu"sv);
+    m_image_context_menu->add_action(*m_look_up_selected_text_action);
     m_image_context_menu->add_action(*m_open_image_action);
     m_image_context_menu->add_action(*m_open_in_new_tab_action);
     m_image_context_menu->add_separator();
@@ -2252,6 +2292,7 @@ void ViewImplementation::initialize_context_menus()
     m_image_context_menu->add_action(*m_copy_url_action);
 
     m_media_context_menu = Menu::create("Media Context Menu"sv);
+    m_media_context_menu->add_action(*m_look_up_selected_text_action);
     m_media_context_menu->add_action(*m_media_play_action);
     m_media_context_menu->add_action(*m_media_pause_action);
     m_media_context_menu->add_action(*m_media_mute_action);
@@ -2385,14 +2426,28 @@ void ViewImplementation::initialize_context_menus()
     m_bookmark_folder_context_menu->add_action(add_bookmark_folder_action);
 }
 
+void ViewImplementation::update_look_up_selected_text_action(Optional<DictionaryLookup> const& lookup, Gfx::IntPoint content_position)
+{
+    m_look_up = on_request_dictionary_lookup ? lookup : OptionalNone {};
+    m_look_up_position = to_widget_position(content_position);
+    if (m_look_up.has_value() && m_look_up->baseline_origin.has_value())
+        m_look_up_position = to_widget_position(*m_look_up->baseline_origin);
+    m_look_up_selected_text_action->set_visible(m_look_up.has_value());
+}
+
 void ViewImplementation::did_request_page_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, Web::ContextMenuForInputEventsTarget for_input_events_target)
 {
     auto& cut_selection_action = Application::the().cut_selection_action();
     cut_selection_action.set_visible(for_input_events_target == Web::ContextMenuForInputEventsTarget::Yes);
 
     auto const& search_engine = Application::settings().search_engine();
-    m_search_text = search_engine.has_value() ? selected_text_with_whitespace_collapsed() : OptionalNone {};
-    auto selected_text_url = url_from_text(selected_text());
+    auto lookup = on_request_dictionary_lookup ? selected_text_for_dictionary_lookup() : OptionalNone {};
+    auto selected_text = lookup.map([](auto const& lookup) { return lookup.text; });
+    if (!selected_text.has_value())
+        selected_text = selected_text_with_whitespace_collapsed();
+    m_search_text = search_engine.has_value() ? selected_text : OptionalNone {};
+    auto selected_text_url = selected_text.has_value() ? url_from_text(*selected_text) : OptionalNone {};
+    update_look_up_selected_text_action(lookup, content_position);
 
     ScopeGuard guard { [&]() {
         cut_selection_action.set_visible(true);
@@ -2420,6 +2475,7 @@ void ViewImplementation::did_request_page_context_menu(Badge<WebContentClient>, 
 void ViewImplementation::did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, URL::URL url)
 {
     m_context_menu_url = move(url);
+    update_look_up_selected_text_action(on_request_dictionary_lookup ? selected_text_for_dictionary_lookup() : OptionalNone {}, content_position);
 
     m_open_in_new_tab_action->set_text("Open in New Tab"sv);
 
@@ -2454,6 +2510,7 @@ void ViewImplementation::did_request_image_context_menu(Badge<WebContentClient>,
 {
     m_context_menu_url = move(url);
     m_image_context_menu_bitmap = move(bitmap);
+    update_look_up_selected_text_action(on_request_dictionary_lookup ? selected_text_for_dictionary_lookup() : OptionalNone {}, content_position);
 
     m_open_in_new_tab_action->set_text("Open Image in New Tab"sv);
     m_copy_url_action->set_text("Copy Image URL"sv);
@@ -2467,6 +2524,7 @@ void ViewImplementation::did_request_image_context_menu(Badge<WebContentClient>,
 void ViewImplementation::did_request_media_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, Web::Page::MediaContextMenu menu)
 {
     m_context_menu_url = move(menu.media_url);
+    update_look_up_selected_text_action(on_request_dictionary_lookup ? selected_text_for_dictionary_lookup() : OptionalNone {}, content_position);
 
     m_open_in_new_tab_action->set_text(menu.is_video ? "Open Video in New Tab"sv : "Open Audio in new Tab"sv);
     m_copy_url_action->set_text(menu.is_video ? "Copy Video URL"sv : "Copy Audio URL"sv);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -649,6 +649,12 @@ bool ViewImplementation::look_up_selected_text_at(Gfx::IntPoint widget_position)
         return false;
 
     auto lookup = selected_text_for_dictionary_lookup();
+    if (!lookup.has_value()) {
+        if (!client().select_word_for_dictionary_lookup(page_id(), to_content_position(widget_position).to_type<Web::DevicePixels>()))
+            return false;
+
+        lookup = selected_text_for_dictionary_lookup();
+    }
     if (!lookup.has_value())
         return false;
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -46,6 +46,7 @@
 #include <LibWebView/BookmarkStore.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/DOMNodeProperties.h>
+#include <LibWebView/DictionaryLookup.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/PrivateBrowsing.h>
@@ -150,6 +151,8 @@ public:
     ByteString selected_text();
     ByteString cut_selected_text();
     Optional<String> selected_text_with_whitespace_collapsed();
+    Optional<DictionaryLookup> selected_text_for_dictionary_lookup();
+    bool look_up_selected_text_at(Gfx::IntPoint widget_position);
     void select_all();
     void find_in_page(String const& query, CaseSensitivity = CaseSensitivity::CaseInsensitive);
     void find_in_page_next_match();
@@ -308,6 +311,7 @@ public:
     void remove_navigation_listener(u64 listener_id);
 
     Function<void(ByteString const& path, i32)> on_request_file;
+    Function<void(DictionaryLookup const&, Gfx::IntPoint)> on_request_dictionary_lookup;
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
     Function<void(Gfx::Cursor const&)> on_cursor_change;
     Function<void(Gfx::IntPoint, ByteString const&)> on_request_tooltip_override;
@@ -460,6 +464,7 @@ protected:
     void update_bookmark_action();
 
     void initialize_context_menus();
+    void update_look_up_selected_text_action(Optional<DictionaryLookup> const& lookup, Gfx::IntPoint content_position);
     enum class PromptForPath : u8 {
         No,
         Yes,
@@ -509,6 +514,10 @@ protected:
     RefPtr<Action> m_toggle_bookmark_action;
 
     RefPtr<Action> m_reset_zoom_action;
+
+    RefPtr<Action> m_look_up_selected_text_action;
+    Optional<DictionaryLookup> m_look_up;
+    Gfx::IntPoint m_look_up_position;
 
     RefPtr<Action> m_search_selected_text_action;
     Optional<String> m_search_text;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -43,10 +43,12 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
+#include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/HTML/AutoplaySettings.h>
 #include <LibWeb/HTML/BroadcastChannel.h>
 #include <LibWeb/HTML/BrowsingContext.h>
@@ -64,6 +66,7 @@
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Layout/FlexLayoutData.h>
 #include <LibWeb/Layout/GridLayoutData.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/ContentBlocker.h>
 #include <LibWeb/Loader/ProxyMappings.h>
@@ -74,7 +77,9 @@
 #include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
+#include <LibWeb/Selection/Selection.h>
 #include <LibWebView/Attribute.h>
+#include <LibWebView/DictionaryLookup.h>
 #include <LibWebView/ViewImplementation.h>
 #include <WebContent/CompositorConnection.h>
 #include <WebContent/ConnectionFromClient.h>
@@ -2029,6 +2034,87 @@ Messages::WebContentServer::GetSelectedTextResponse ConnectionFromClient::get_se
     if (auto page = this->page(page_id); page.has_value())
         return page->page().focused_navigable().selected_text().to_byte_string();
     return ByteString {};
+}
+
+static WebView::DictionaryLookupTextStyle dictionary_lookup_text_style_from_layout_node(Web::Layout::Node const& layout_node, double zoom_level)
+{
+    auto const& font = layout_node.first_available_font();
+    return {
+        .font_family = font.family().to_string(),
+        .ui_point_size = font.pixel_size() * static_cast<float>(zoom_level),
+        .weight = font.weight(),
+        .slope = font.slope(),
+    };
+}
+
+static Web::Layout::Node const* layout_node_for_dictionary_lookup(Web::DOM::Node const& node)
+{
+    for (auto const* current = &node; current; current = current->parent_or_shadow_host_node()) {
+        auto const* layout_node = current->layout_node();
+        if (layout_node && layout_node->has_style_or_parent_with_style())
+            return layout_node;
+    }
+
+    return nullptr;
+}
+
+static Optional<Gfx::IntPoint> dictionary_lookup_baseline_origin_for_range(Web::DOM::Range& range, Web::Page& page, Web::Layout::Node const& layout_node)
+{
+    auto& document = range.start_container()->document();
+    auto navigable = document.navigable();
+    if (!navigable)
+        return {};
+
+    auto to_top_level_viewport_point = [&](Web::CSSPixelPoint point) {
+        auto scroll_offset = navigable->viewport_scroll_offset();
+        Web::CSSPixelPoint viewport_point { point.x() - scroll_offset.x(), point.y() - scroll_offset.y() };
+        return navigable->to_top_level_position(viewport_point);
+    };
+
+    auto rect = range.get_bounding_client_rect();
+    if (rect->width() <= 0 || rect->height() <= 0)
+        return {};
+
+    auto const& font = layout_node.first_available_font();
+    Web::CSSPixelPoint baseline_origin {
+        Web::CSSPixels::nearest_value_for(rect->x()),
+        Web::CSSPixels::nearest_value_for(rect->y() + font.pixel_metrics().ascent),
+    };
+    return page.css_to_device_point(to_top_level_viewport_point(baseline_origin)).to_type<int>();
+}
+
+Messages::WebContentServer::GetSelectedTextForLookupResponse ConnectionFromClient::get_selected_text_for_lookup(u64 page_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return Optional<WebView::DictionaryLookup> {};
+
+    auto& navigable = page->page().focused_navigable();
+    auto text = navigable.selected_text();
+    if (text.is_empty())
+        return Optional<WebView::DictionaryLookup> {};
+
+    auto document = navigable.active_document();
+    auto range = document ? document->get_selection()->range() : nullptr;
+    auto const* layout_node = range ? layout_node_for_dictionary_lookup(range->start_container()) : nullptr;
+    if (!layout_node && document) {
+        if (auto active_element = document->active_element())
+            layout_node = layout_node_for_dictionary_lookup(*active_element);
+    }
+
+    Optional<WebView::DictionaryLookupTextStyle> style;
+    Optional<Gfx::IntPoint> baseline_origin;
+    if (layout_node) {
+        style = dictionary_lookup_text_style_from_layout_node(*layout_node, navigable.page().client().zoom_level());
+        if (range)
+            baseline_origin = dictionary_lookup_baseline_origin_for_range(*range, page->page(), *layout_node);
+    }
+
+    return WebView::DictionaryLookup {
+        .text = move(text),
+        .style = move(style),
+        .baseline_origin = baseline_origin,
+    };
 }
 
 Messages::WebContentServer::CutSelectedTextResponse ConnectionFromClient::cut_selected_text(u64 page_id)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2117,6 +2117,18 @@ Messages::WebContentServer::GetSelectedTextForLookupResponse ConnectionFromClien
     };
 }
 
+Messages::WebContentServer::SelectWordForDictionaryLookupResponse ConnectionFromClient::select_word_for_dictionary_lookup(u64 page_id, Web::DevicePixelPoint position)
+{
+#if defined(AK_OS_MACOS)
+    if (auto page = this->page(page_id); page.has_value())
+        return page->page().select_word_for_dictionary_lookup(position);
+#else
+    (void)page_id;
+    (void)position;
+#endif
+    return false;
+}
+
 Messages::WebContentServer::CutSelectedTextResponse ConnectionFromClient::cut_selected_text(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -202,6 +202,7 @@ private:
 
     virtual Messages::WebContentServer::GetSelectedTextResponse get_selected_text(u64 page_id) override;
     virtual Messages::WebContentServer::GetSelectedTextForLookupResponse get_selected_text_for_lookup(u64 page_id) override;
+    virtual Messages::WebContentServer::SelectWordForDictionaryLookupResponse select_word_for_dictionary_lookup(u64 page_id, Web::DevicePixelPoint position) override;
     virtual Messages::WebContentServer::CutSelectedTextResponse cut_selected_text(u64 page_id) override;
     virtual void select_all(u64 page_id) override;
 

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -201,6 +201,7 @@ private:
     virtual void request_internal_page_info(u64 page_id, WebView::PageInfoType) override;
 
     virtual Messages::WebContentServer::GetSelectedTextResponse get_selected_text(u64 page_id) override;
+    virtual Messages::WebContentServer::GetSelectedTextForLookupResponse get_selected_text_for_lookup(u64 page_id) override;
     virtual Messages::WebContentServer::CutSelectedTextResponse cut_selected_text(u64 page_id) override;
     virtual void select_all(u64 page_id) override;
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -27,6 +27,7 @@
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWeb/WebDriver/Response.h>
 #include <LibWebView/Attribute.h>
+#include <LibWebView/DictionaryLookup.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/Settings.h>
@@ -134,6 +135,7 @@ endpoint WebContentServer
     request_internal_page_info(u64 page_id, WebView::PageInfoType type) =|
 
     get_selected_text(u64 page_id) => (ByteString selection)
+    get_selected_text_for_lookup(u64 page_id) => (Optional<WebView::DictionaryLookup> lookup)
     cut_selected_text(u64 page_id) => (ByteString selection)
     select_all(u64 page_id) =|
     paste(u64 page_id, Utf16String text) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -136,6 +136,7 @@ endpoint WebContentServer
 
     get_selected_text(u64 page_id) => (ByteString selection)
     get_selected_text_for_lookup(u64 page_id) => (Optional<WebView::DictionaryLookup> lookup)
+    select_word_for_dictionary_lookup(u64 page_id, Web::DevicePixelPoint position) => (bool selected)
     cut_selected_text(u64 page_id) => (ByteString selection)
     select_all(u64 page_id) =|
     paste(u64 page_id, Utf16String text) =|

--- a/Tests/LibWeb/Text/expected/UIEvents/right-click-selection.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/right-click-selection.txt
@@ -1,0 +1,3 @@
+PASS: right-click selection matches platform behavior
+PASS: right-click preserves existing selection
+PASS: primary mousedown preserves existing selection on macOS

--- a/Tests/LibWeb/Text/input/UIEvents/right-click-selection.html
+++ b/Tests/LibWeb/Text/input/UIEvents/right-click-selection.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    font: 16px Arial;
+}
+</style>
+<div id="target"><span id="alpha">alpha</span> <span id="beta">beta</span> gamma</div>
+<script src="../include.js"></script>
+<script>
+    function clickCenter(element) {
+        const rect = element.getBoundingClientRect();
+        internals.click(rect.left + rect.width / 2, rect.top + rect.height / 2, 1, internals.BUTTON_RIGHT);
+    }
+
+    function center(element) {
+        const rect = element.getBoundingClientRect();
+        return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    }
+
+    function selectAlphaBeta() {
+        getSelection().removeAllRanges();
+
+        const range = document.createRange();
+        range.setStart(alpha.firstChild, 0);
+        range.setEnd(beta.firstChild, beta.firstChild.length);
+        getSelection().addRange(range);
+    }
+
+    test(() => {
+        clickCenter(alpha);
+
+        const selection = getSelection().toString();
+        println(selection === "" || selection === "alpha"
+            ? "PASS: right-click selection matches platform behavior"
+            : `FAIL: expected either no selection or "alpha", got "${selection}"`);
+
+        selectAlphaBeta();
+        clickCenter(beta);
+
+        println(getSelection().toString() === "alpha beta"
+            ? "PASS: right-click preserves existing selection"
+            : `FAIL: expected existing selection, got "${getSelection()}"`);
+
+        selectAlphaBeta();
+        const betaCenter = center(beta);
+        internals.mouseDown(betaCenter.x, betaCenter.y);
+
+        println(!navigator.platform.includes("Mac") || getSelection().toString() === "alpha beta"
+            ? "PASS: primary mousedown preserves existing selection on macOS"
+            : `FAIL: expected existing selection, got "${getSelection()}"`);
+
+        internals.mouseUp(betaCenter.x, betaCenter.y);
+    });
+</script>

--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(ladybird_impl STATIC
     Interface/Tab.mm
     Interface/TabController.mm
     Utilities/Conversions.mm
+    Utilities/DictionaryLookup.mm
 )
 target_include_directories(ladybird_impl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -19,6 +19,7 @@
 #import <QuartzCore/CAMetalLayer.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <Utilities/Conversions.h>
+#import <Utilities/DictionaryLookup.h>
 
 #if !__has_feature(objc_arc)
 #    error "This project requires ARC"
@@ -101,6 +102,8 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
     // key is pressed. Instead, we only receive an event that the modifier flags have changed, and we must determine for
     // ourselves whether the modifier key was pressed or released.
     NSEventModifierFlags m_modifier_flags;
+
+    NSInteger m_last_pressure_stage;
 }
 
 @property (nonatomic, weak) id<LadybirdWebViewObserver> observer;
@@ -209,6 +212,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         [self addGestureRecognizer:self.pinch_recognizer];
 
         m_modifier_flags = 0;
+        m_last_pressure_stage = 0;
     }
 
     return self;
@@ -459,6 +463,15 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
                 [self.observer onCreateNewTab:urls[i] activateTab:Web::HTML::ActivateTab::No];
             }
         }
+    };
+
+    m_web_view_bridge->on_request_dictionary_lookup = [weak_self](auto const& lookup, auto position) {
+        LadybirdWebView* self = weak_self;
+        if (self == nil) {
+            return;
+        }
+
+        Ladybird::show_dictionary_lookup(self, lookup, Ladybird::gfx_point_to_ns_point(position));
     };
 
     m_web_view_bridge->on_cursor_change = [weak_self](auto cursor) {
@@ -1172,6 +1185,25 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
     // The origin of a NSScrollView is the lower-left corner, with the y-axis extending upwards. Instead,
     // we want the origin to be the top-left corner, with the y-axis extending downward.
     return YES;
+}
+
+- (void)quickLookWithEvent:(NSEvent*)event
+{
+    auto position = Ladybird::ns_point_to_gfx_point([self convertPoint:[event locationInWindow] fromView:nil]);
+    if (!m_web_view_bridge->look_up_selected_text_at(position))
+        [super quickLookWithEvent:event];
+}
+
+- (void)pressureChangeWithEvent:(NSEvent*)event
+{
+    auto stage = [event stage];
+    if (m_last_pressure_stage == 1 && stage == 2) {
+        auto* user_defaults = [NSUserDefaults standardUserDefaults];
+        if ([user_defaults integerForKey:@"com.apple.trackpad.forceClick"] == 1)
+            [self quickLookWithEvent:event];
+    }
+
+    m_last_pressure_stage = stage;
 }
 
 - (void)mouseExited:(NSEvent*)event

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -255,6 +255,7 @@ static void initialize_native_icon(WebView::Action& action, id control)
         [control setKeyEquivalent:@"a"];
         break;
 
+    case WebView::ActionID::LookUpSelectedText:
     case WebView::ActionID::SearchSelectedText:
         set_control_image(control, @"magnifyingglass");
         break;

--- a/UI/AppKit/Utilities/DictionaryLookup.h
+++ b/UI/AppKit/Utilities/DictionaryLookup.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWebView/Forward.h>
+
+#import <Cocoa/Cocoa.h>
+
+namespace Ladybird {
+
+void show_dictionary_lookup(NSView*, WebView::DictionaryLookup const&, NSPoint);
+
+}

--- a/UI/AppKit/Utilities/DictionaryLookup.mm
+++ b/UI/AppKit/Utilities/DictionaryLookup.mm
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <LibWebView/DictionaryLookup.h>
+
+#import <UI/AppKit/Utilities/DictionaryLookup.h>
+
+namespace Ladybird {
+
+static NSString* ns_string_from_ak_string(String const& string)
+{
+    auto view = string.bytes_as_string_view();
+    return [[NSString alloc] initWithBytes:view.characters_without_null_termination()
+                                    length:view.length()
+                                  encoding:NSUTF8StringEncoding];
+}
+
+static NSFontWeight ns_font_weight_from_css_weight(u16 weight)
+{
+    if (weight >= 900)
+        return NSFontWeightBlack;
+    if (weight >= 800)
+        return NSFontWeightHeavy;
+    if (weight >= 700)
+        return NSFontWeightBold;
+    if (weight >= 600)
+        return NSFontWeightSemibold;
+    if (weight >= 500)
+        return NSFontWeightMedium;
+    return NSFontWeightRegular;
+}
+
+static NSFont* ns_font_from_dictionary_lookup_text_style(WebView::DictionaryLookupTextStyle const& style)
+{
+    if (style.ui_point_size <= 0)
+        return nil;
+
+    auto traits = style.slope == 0 ? 0 : NSFontItalicTrait;
+    auto* family = ns_string_from_ak_string(style.font_family);
+    auto* font = [[NSFontManager sharedFontManager] fontWithFamily:family
+                                                            traits:traits
+                                                            weight:style.weight / 100
+                                                              size:style.ui_point_size];
+    if (font)
+        return font;
+
+    font = [NSFont systemFontOfSize:style.ui_point_size weight:ns_font_weight_from_css_weight(style.weight)];
+    if (style.slope != 0)
+        font = [[NSFontManager sharedFontManager] convertFont:font toHaveTrait:NSItalicFontMask];
+    return font;
+}
+
+static NSAttributedString* attributed_string_for_dictionary_lookup(WebView::DictionaryLookup const& lookup)
+{
+    auto* ns_text = ns_string_from_ak_string(lookup.text);
+    if (!lookup.style.has_value())
+        return [[NSAttributedString alloc] initWithString:ns_text];
+
+    auto* font = ns_font_from_dictionary_lookup_text_style(*lookup.style);
+    if (!font)
+        return [[NSAttributedString alloc] initWithString:ns_text];
+
+    return [[NSAttributedString alloc] initWithString:ns_text attributes:@ { NSFontAttributeName : font }];
+}
+
+void show_dictionary_lookup(NSView* view, WebView::DictionaryLookup const& lookup, NSPoint position)
+{
+    if (!view || lookup.text.is_empty())
+        return;
+
+    [view showDefinitionForAttributedString:attributed_string_for_dictionary_lookup(lookup) atPoint:position];
+}
+
+}

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(ladybird PRIVATE Qt::Core Qt::Gui Qt::Widgets)
 
 if (APPLE)
     target_sources(ladybird PRIVATE
+        ../AppKit/Utilities/DictionaryLookup.mm
         MacWindow.mm
         WebContentViewMac.mm
     )

--- a/UI/Qt/MacWindow.h
+++ b/UI/Qt/MacWindow.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <AK/Platform.h>
+#include <LibGfx/Forward.h>
+#include <LibWebView/Forward.h>
 
 class QWidget;
 class QColor;
@@ -25,6 +27,9 @@ void install_always_active_window_control_hover_tracking(QWidget&, void (*hover_
 void install_appkit_event_capture();
 void make_appkit_window_first_responder(QWidget&);
 bool start_appkit_window_drag(QWidget&);
+void show_appkit_dictionary_lookup(QWidget&, WebView::DictionaryLookup const&, Gfx::IntPoint);
+Gfx::Color appkit_web_inactive_selection_color();
+Gfx::Color appkit_web_inactive_selection_text_color();
 #endif
 
 }

--- a/UI/Qt/MacWindow.mm
+++ b/UI/Qt/MacWindow.mm
@@ -6,6 +6,8 @@
 
 #include <UI/Qt/MacWindow.h>
 
+#include <LibGfx/Color.h>
+#include <LibGfx/Point.h>
 #include <QAbstractNativeEventFilter>
 #include <QColor>
 #include <QCoreApplication>
@@ -13,9 +15,11 @@
 #include <QPointer>
 #include <QRect>
 #include <QWidget>
+#include <UI/Qt/WebContentView.h>
 
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
+#import <UI/AppKit/Utilities/DictionaryLookup.h>
 #import <objc/runtime.h>
 
 @interface LadybirdWindowControlHoverTracker : NSObject
@@ -65,6 +69,20 @@
 namespace Ladybird {
 
 static NSEvent* s_latest_window_drag_event;
+static NSInteger s_last_pressure_stage;
+
+static Gfx::Color ns_color_to_gfx_color(NSColor* color)
+{
+    auto* rgb_color = [color colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
+    if (rgb_color != nil)
+        return {
+            static_cast<u8>([rgb_color redComponent] * 255),
+            static_cast<u8>([rgb_color greenComponent] * 255),
+            static_cast<u8>([rgb_color blueComponent] * 255),
+            static_cast<u8>([rgb_color alphaComponent] * 255)
+        };
+    return {};
+}
 
 static bool is_window_drag_on_gesture_enabled()
 {
@@ -110,6 +128,94 @@ static bool should_start_window_drag_for_gesture(NSEvent* event)
     return true;
 }
 
+static NSPoint widget_position_to_ns_point(QWidget& widget, Gfx::IntPoint position)
+{
+    auto* view = reinterpret_cast<NSView*>(widget.winId());
+    if (!view)
+        return {};
+
+    auto device_pixel_ratio = widget.devicePixelRatioF();
+    auto point = NSMakePoint(position.x() / device_pixel_ratio, position.y() / device_pixel_ratio);
+    if (![view isFlipped])
+        point.y = NSHeight(view.bounds) - point.y;
+    return point;
+}
+
+static Optional<Gfx::IntPoint> widget_position_for_appkit_event(QWidget& widget, NSEvent* event)
+{
+    auto* view = reinterpret_cast<NSView*>(widget.winId());
+    if (!view || !event.window)
+        return {};
+
+    auto point = [view convertPoint:event.locationInWindow fromView:nil];
+    if (![view isFlipped])
+        point.y = NSHeight(view.bounds) - point.y;
+
+    auto device_pixel_ratio = widget.devicePixelRatioF();
+    return Gfx::IntPoint {
+        static_cast<int>(point.x * device_pixel_ratio),
+        static_cast<int>(point.y * device_pixel_ratio),
+    };
+}
+
+static WebContentView* web_content_view_for_appkit_event(NSEvent* event)
+{
+    if (!event.window)
+        return nullptr;
+
+    auto* content_view = event.window.contentView;
+    if (!content_view)
+        return nullptr;
+
+    auto point = [content_view convertPoint:event.locationInWindow fromView:nil];
+    for (auto* view = [content_view hitTest:point]; view; view = view.superview) {
+        auto* widget = QWidget::find(reinterpret_cast<WId>(view));
+        if (!widget)
+            continue;
+        if (auto* web_content_view = qobject_cast<WebContentView*>(widget))
+            return web_content_view;
+    }
+
+    return nullptr;
+}
+
+static bool should_perform_dictionary_lookup_for_event(NSEvent* event)
+{
+    if (!event)
+        return false;
+
+    switch (event.type) {
+    case NSEventTypeQuickLook:
+        return true;
+    case NSEventTypePressure: {
+        auto stage = event.stage;
+        auto should_lookup = s_last_pressure_stage == 1
+            && stage == 2
+            && [[NSUserDefaults standardUserDefaults] integerForKey:@"com.apple.trackpad.forceClick"] == 1;
+        s_last_pressure_stage = stage;
+        return should_lookup;
+    }
+    default:
+        return false;
+    }
+}
+
+static bool perform_dictionary_lookup_for_event(NSEvent* event)
+{
+    if (!should_perform_dictionary_lookup_for_event(event))
+        return false;
+
+    auto* view = web_content_view_for_appkit_event(event);
+    if (!view)
+        return false;
+
+    auto position = widget_position_for_appkit_event(*view, event);
+    if (!position.has_value())
+        return false;
+
+    return view->look_up_selected_text_at(*position);
+}
+
 class LadybirdAppKitEventCaptureFilter final : public QAbstractNativeEventFilter {
 public:
     virtual bool nativeEventFilter(QByteArray const& event_type, void* message, qintptr*) override
@@ -118,6 +224,9 @@ public:
             return false;
 
         auto* event = static_cast<NSEvent*>(message);
+        if (perform_dictionary_lookup_for_event(event))
+            return true;
+
         if (should_start_window_drag_for_gesture(event)) {
             [event.window performWindowDragWithEvent:event];
             return true;
@@ -262,6 +371,22 @@ bool start_appkit_window_drag(QWidget& widget)
 
     [window performWindowDragWithEvent:event];
     return true;
+}
+
+void show_appkit_dictionary_lookup(QWidget& widget, WebView::DictionaryLookup const& lookup, Gfx::IntPoint position)
+{
+    auto* view = reinterpret_cast<NSView*>(widget.winId());
+    show_dictionary_lookup(view, lookup, widget_position_to_ns_point(widget, position));
+}
+
+Gfx::Color appkit_web_inactive_selection_color()
+{
+    return ns_color_to_gfx_color([NSColor unemphasizedSelectedTextBackgroundColor]);
+}
+
+Gfx::Color appkit_web_inactive_selection_text_color()
+{
+    return ns_color_to_gfx_color([NSColor unemphasizedSelectedTextColor]);
 }
 
 }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -137,6 +137,12 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
         update_cursor(cursor);
     };
 
+#ifdef AK_OS_MACOS
+    on_request_dictionary_lookup = [this](auto const& lookup, auto position) {
+        show_appkit_dictionary_lookup(*this, lookup, position);
+    };
+#endif
+
     on_request_tooltip_override = [this](auto position, auto const& tooltip) {
         m_tooltip_override = true;
         if (m_tooltip_hover_timer.isActive())


### PR DESCRIPTION
Adds macOS system dictionary lookup support for selected text in Ladybird.

This wires the shared lookup plumbing through LibWebView and WebContent, then connects it to the macOS Qt and AppKit frontends. On macOS, selected text can now be looked up from the context menu, and Force Touch / Quick Look lookup can open the native dictionary popover using the selected text geometry.

The branch also matches platform selection behavior around lookup:

- Right-clicking a word on macOS selects that word before showing the context menu.
- Existing multi-word selections are preserved when opening the context menu.
- Force Touch lookup selects the word under the press when there is no current selection.
- Pressing inside an existing selection preserves that selection for lookup, while still falling back to regular text selection if the press becomes a drag.

<img width="793" height="669" alt="Screenshot 2026-07-09 at 01 04 50" src="https://github.com/user-attachments/assets/f97c0e72-7fe8-4e2c-a826-334362d01043" />
