### PR TITLE
LibWebView: Use light inactive macOS web selections

### DIFF
--- a/Libraries/LibWebView/PlatformColors.h
+++ b/Libraries/LibWebView/PlatformColors.h
@@ -12,5 +12,7 @@
 namespace WebView {
 
 WEBVIEW_API Gfx::Color macos_web_selection_color();
+WEBVIEW_API Gfx::Color macos_web_inactive_selection_color();
+WEBVIEW_API Gfx::Color macos_web_inactive_selection_text_color();
 
 }

--- a/Libraries/LibWebView/PlatformColorsMacOS.cpp
+++ b/Libraries/LibWebView/PlatformColorsMacOS.cpp
@@ -13,4 +13,14 @@ Gfx::Color macos_web_selection_color()
     return Gfx::Color(128, 188, 254, 153);
 }
 
+Gfx::Color macos_web_inactive_selection_color()
+{
+    return Gfx::Color(183, 183, 183, 153);
+}
+
+Gfx::Color macos_web_inactive_selection_text_color()
+{
+    return Gfx::Color::Black;
+}
+
 }

--- a/UI/AppKit/Interface/Palette.mm
+++ b/UI/AppKit/Interface/Palette.mm
@@ -41,8 +41,8 @@ Core::AnonymousBuffer create_system_palette()
     palette.set_flag(Gfx::FlagRole::IsDark, is_dark);
     palette.set_color(Gfx::ColorRole::Accent, ns_color_to_gfx_color([NSColor controlAccentColor]));
     palette.set_color(Gfx::ColorRole::Selection, WebView::macos_web_selection_color());
-    palette.set_color(Gfx::ColorRole::InactiveSelection, ns_color_to_gfx_color([NSColor unemphasizedSelectedTextBackgroundColor]));
-    palette.set_color(Gfx::ColorRole::InactiveSelectionText, ns_color_to_gfx_color([NSColor unemphasizedSelectedTextColor]));
+    palette.set_color(Gfx::ColorRole::InactiveSelection, WebView::macos_web_inactive_selection_color());
+    palette.set_color(Gfx::ColorRole::InactiveSelectionText, WebView::macos_web_inactive_selection_text_color());
     // FIXME: There are more system colors we currently don't use (https://developer.apple.com/documentation/appkit/nscolor/3000782-controlaccentcolor?language=objc)
 
     return theme;

--- a/UI/Qt/MacWindow.h
+++ b/UI/Qt/MacWindow.h
@@ -25,8 +25,6 @@ void install_always_active_window_control_hover_tracking(QWidget&, void (*hover_
 void install_appkit_event_capture();
 void make_appkit_window_first_responder(QWidget&);
 bool start_appkit_window_drag(QWidget&);
-Gfx::Color appkit_web_inactive_selection_color();
-Gfx::Color appkit_web_inactive_selection_text_color();
 #endif
 
 }

--- a/UI/Qt/MacWindow.mm
+++ b/UI/Qt/MacWindow.mm
@@ -6,7 +6,6 @@
 
 #include <UI/Qt/MacWindow.h>
 
-#include <LibGfx/Color.h>
 #include <QAbstractNativeEventFilter>
 #include <QColor>
 #include <QCoreApplication>
@@ -66,19 +65,6 @@
 namespace Ladybird {
 
 static NSEvent* s_latest_window_drag_event;
-
-static Gfx::Color ns_color_to_gfx_color(NSColor* color)
-{
-    auto* rgb_color = [color colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
-    if (rgb_color != nil)
-        return {
-            static_cast<u8>([rgb_color redComponent] * 255),
-            static_cast<u8>([rgb_color greenComponent] * 255),
-            static_cast<u8>([rgb_color blueComponent] * 255),
-            static_cast<u8>([rgb_color alphaComponent] * 255)
-        };
-    return {};
-}
 
 static bool is_window_drag_on_gesture_enabled()
 {
@@ -276,16 +262,6 @@ bool start_appkit_window_drag(QWidget& widget)
 
     [window performWindowDragWithEvent:event];
     return true;
-}
-
-Gfx::Color appkit_web_inactive_selection_color()
-{
-    return ns_color_to_gfx_color([NSColor unemphasizedSelectedTextBackgroundColor]);
-}
-
-Gfx::Color appkit_web_inactive_selection_text_color()
-{
-    return ns_color_to_gfx_color([NSColor unemphasizedSelectedTextColor]);
 }
 
 }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -942,8 +942,8 @@ static Core::AnonymousBuffer make_system_theme_from_qt_palette(QWidget& widget, 
     translate(Gfx::ColorRole::ButtonText, QPalette::ColorRole::ButtonText);
 #ifdef AK_OS_MACOS
     palette.set_color(Gfx::ColorRole::Selection, WebView::macos_web_selection_color());
-    palette.set_color(Gfx::ColorRole::InactiveSelection, appkit_web_inactive_selection_color());
-    palette.set_color(Gfx::ColorRole::InactiveSelectionText, appkit_web_inactive_selection_text_color());
+    palette.set_color(Gfx::ColorRole::InactiveSelection, WebView::macos_web_inactive_selection_color());
+    palette.set_color(Gfx::ColorRole::InactiveSelectionText, WebView::macos_web_inactive_selection_text_color());
 #else
     translate(Gfx::ColorRole::Selection, QPalette::ColorRole::Highlight);
 


### PR DESCRIPTION
Do not feed AppKit's unemphasized selected text color into web selection painting on macOS. In dark mode that color is an opaque dark gray, which makes inactive page selections look unlike other browsers.

Share explicit macOS web selection colors through LibWebView so the Qt and AppKit frontends both use a translucent light gray inactive fill with black inactive selection text.