### PR TITLE
Tests: Restore page focus in the page-focus-dirty-layout test

### DIFF
--- a/Tests/LibWeb/Text/input/page-focus-dirty-layout.html
+++ b/Tests/LibWeb/Text/input/page-focus-dirty-layout.html
@@ -8,6 +8,9 @@
         target.appendChild(document.createElement("div"));
         internals.setPageFocus(false);
 
+        // Restore page focus — so later tests reusing this process don't inherit has_focus=false.
+        internals.setPageFocus(true);
+
         println("PASS");
     });
 </script>


### PR DESCRIPTION
**Problem:** Frequent CI failures for `*-caret` tests.

**Cause:** A `page-focus-dirty-layout` test that does `setPageFocus(false)` was added in c7f0881. The `*-caret` tests which ran after it rely on the `has_focus=true` default to paint the caret and focus ring — but that `has_focus=false` setting leaked into those other tests.

**Fix:** Restore page focus at the end of the test — matching the existing behavior of the sibling `page-focus-rendering` test.
