### PR TITLE
Meta/WPT.sh: Remove WPT run directories with sudo

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -365,7 +365,8 @@ cleanup_run_dirs() {
 
         sudo_and_ask "" umount "$mount_path" || echo "Failed to unmount $mount_path"
     done
-    rm -fr "${BUILD_DIR}/wpt"
+    # Overlayfs can leave root-owned internal state in the workdir because we mount it via sudo.
+    sudo_and_ask "" rm -fr "${BUILD_DIR}/wpt"
 }
 
 cleanup_merge_dirs_and_infra() {


### PR DESCRIPTION
After a chunked WPT run unmounts its overlayfs mounts, cleanup can leave behind root-owned overlayfs workdir state that the next run cannot remove as the runner user. Previously, failed unmounts were ignored, so later runs could keep reusing still-mounted overlay directories. Since the overlay is mounted via sudo, remove the WPT run directory with the same privilege level after unmounting it.