### PR TITLE
LibGfx+LibWeb: Enumerate system fonts with Skia instead of fontconfig

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     Font/FontSupport.cpp
     Font/FontVariationSettings.cpp
     Font/PathFontProvider.cpp
+    Font/SkiaFontProvider.cpp
     Font/Typeface.cpp
     Font/TypefaceSkia.cpp
     Font/WOFF/Loader.cpp

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     Font/FontSupport.cpp
     Font/FontVariationSettings.cpp
     Font/PathFontProvider.cpp
+    Font/SkiaFontProvider.cpp
     Font/Typeface.cpp
     Font/TypefaceSkia.cpp
     Font/WOFF/Loader.cpp

--- a/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -15,10 +15,6 @@
 #    include <FindDirectory.h>
 #endif
 
-#ifdef USE_FONTCONFIG
-#    include <LibGfx/Font/GlobalFontConfig.h>
-#endif
-
 namespace Gfx {
 
 // Key function for SystemFontProvider to emit the vtable here
@@ -76,18 +72,7 @@ void FontDatabase::for_each_typeface_with_family_name(FlyString const& family_na
 
 ErrorOr<Vector<String>> FontDatabase::font_directories()
 {
-#if defined(USE_FONTCONFIG)
-    Vector<String> paths;
-    FcConfig* config = Gfx::GlobalFontConfig::the().get();
-    FcStrList* dirs = FcConfigGetFontDirs(config);
-    while (FcChar8* dir = FcStrListNext(dirs)) {
-        char const* dir_cstring = reinterpret_cast<char const*>(dir);
-        paths.append(TRY(String::from_utf8(StringView { dir_cstring, strlen(dir_cstring) })));
-    }
-    FcStrListDone(dirs);
-    return paths;
-
-#elif defined(AK_OS_HAIKU)
+#if defined(AK_OS_HAIKU)
     Vector<String> paths_vector;
     char** paths;
     size_t paths_count;
@@ -100,34 +85,36 @@ ErrorOr<Vector<String>> FontDatabase::font_directories()
     }
     return paths_vector;
 
-#else
-#    if defined(AK_OS_SERENITY)
+#elif defined(AK_OS_SERENITY)
     return Vector<String> { {
         "/res/fonts"_string,
     } };
 
-#    elif defined(AK_OS_MACOS)
+#elif defined(AK_OS_MACOS)
     return Vector<String> { {
         "/System/Library/Fonts"_string,
         "/Library/Fonts"_string,
         TRY(String::formatted("{}/Library/Fonts"sv, Core::StandardPaths::home_directory())),
     } };
 
-#    elif defined(AK_OS_ANDROID)
+#elif defined(AK_OS_ANDROID)
     return Vector<String> { {
         // FIXME: We should be using the ASystemFontIterator NDK API here.
         // There is no guarantee that this will continue to exist on future versions of Android.
         "/system/fonts"_string,
     } };
 
-#    elif defined(AK_OS_WINDOWS)
+#elif defined(AK_OS_WINDOWS)
     return Vector<String> { {
         TRY(String::formatted(R"({}\Fonts)"sv, getenv("WINDIR"))),
         TRY(String::formatted(R"({}\Microsoft\Windows\Fonts)"sv, getenv("LOCALAPPDATA"))),
     } };
 
-#    else
+#else
     Vector<String> paths;
+
+    auto home_directory = Core::StandardPaths::home_directory();
+    paths.append(TRY(String::formatted("{}/.fonts", home_directory)));
 
     auto user_data_directory = Core::StandardPaths::user_data_directory();
     paths.append(TRY(String::formatted("{}/fonts", user_data_directory)));
@@ -140,7 +127,6 @@ ErrorOr<Vector<String>> FontDatabase::font_directories()
     }
 
     return paths;
-#    endif
 #endif
 }
 

--- a/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -15,10 +15,6 @@
 #    include <FindDirectory.h>
 #endif
 
-#ifdef USE_FONTCONFIG
-#    include <LibGfx/Font/GlobalFontConfig.h>
-#endif
-
 namespace Gfx {
 
 // Key function for SystemFontProvider to emit the vtable here
@@ -128,18 +124,7 @@ void FontDatabase::for_each_typeface_with_family_name(FlyString const& family_na
 
 ErrorOr<Vector<String>> FontDatabase::font_directories()
 {
-#if defined(USE_FONTCONFIG)
-    Vector<String> paths;
-    FcConfig* config = Gfx::GlobalFontConfig::the().get();
-    FcStrList* dirs = FcConfigGetFontDirs(config);
-    while (FcChar8* dir = FcStrListNext(dirs)) {
-        char const* dir_cstring = reinterpret_cast<char const*>(dir);
-        paths.append(TRY(String::from_utf8(StringView { dir_cstring, strlen(dir_cstring) })));
-    }
-    FcStrListDone(dirs);
-    return paths;
-
-#elif defined(AK_OS_HAIKU)
+#if defined(AK_OS_HAIKU)
     Vector<String> paths_vector;
     char** paths;
     size_t paths_count;
@@ -152,34 +137,36 @@ ErrorOr<Vector<String>> FontDatabase::font_directories()
     }
     return paths_vector;
 
-#else
-#    if defined(AK_OS_SERENITY)
+#elif defined(AK_OS_SERENITY)
     return Vector<String> { {
         "/res/fonts"_string,
     } };
 
-#    elif defined(AK_OS_MACOS)
+#elif defined(AK_OS_MACOS)
     return Vector<String> { {
         "/System/Library/Fonts"_string,
         "/Library/Fonts"_string,
         TRY(String::formatted("{}/Library/Fonts"sv, Core::StandardPaths::home_directory())),
     } };
 
-#    elif defined(AK_OS_ANDROID)
+#elif defined(AK_OS_ANDROID)
     return Vector<String> { {
         // FIXME: We should be using the ASystemFontIterator NDK API here.
         // There is no guarantee that this will continue to exist on future versions of Android.
         "/system/fonts"_string,
     } };
 
-#    elif defined(AK_OS_WINDOWS)
+#elif defined(AK_OS_WINDOWS)
     return Vector<String> { {
         TRY(String::formatted(R"({}\Fonts)"sv, getenv("WINDIR"))),
         TRY(String::formatted(R"({}\Microsoft\Windows\Fonts)"sv, getenv("LOCALAPPDATA"))),
     } };
 
-#    else
+#else
     Vector<String> paths;
+
+    auto home_directory = Core::StandardPaths::home_directory();
+    paths.append(TRY(String::formatted("{}/.fonts", home_directory)));
 
     auto user_data_directory = Core::StandardPaths::user_data_directory();
     paths.append(TRY(String::formatted("{}/fonts", user_data_directory)));
@@ -192,7 +179,6 @@ ErrorOr<Vector<String>> FontDatabase::font_directories()
     }
 
     return paths;
-#    endif
 #endif
 }
 

--- a/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -45,6 +45,58 @@ StringView FontDatabase::system_font_provider_name() const
 
 FontDatabase::FontDatabase() = default;
 
+FontVariationSettings default_font_variation_settings(float point_size, unsigned weight, unsigned width)
+{
+    FontVariationSettings variation_settings;
+    variation_settings.set_weight(static_cast<float>(weight));
+    // NB: We use the pixel size for 'opsz'
+    variation_settings.set_optical_sizing(point_size / 0.75f);
+
+    switch (width) {
+    case FontWidth::UltraCondensed:
+        variation_settings.set_width(50);
+        break;
+    case FontWidth::ExtraCondensed:
+        variation_settings.set_width(62.5);
+        break;
+    case FontWidth::Condensed:
+        variation_settings.set_width(75);
+        break;
+    case FontWidth::SemiCondensed:
+        variation_settings.set_width(87.5);
+        break;
+    case FontWidth::Normal:
+        variation_settings.set_width(100);
+        break;
+    case FontWidth::SemiExpanded:
+        variation_settings.set_width(112.5);
+        break;
+    case FontWidth::Expanded:
+        variation_settings.set_width(125);
+        break;
+    case FontWidth::ExtraExpanded:
+        variation_settings.set_width(150);
+        break;
+    case FontWidth::UltraExpanded:
+        variation_settings.set_width(200);
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    return variation_settings;
+}
+
+ShapeFeatures default_shape_features()
+{
+    // NB: These shape features match those applied when all CSS properties are initial values
+    ShapeFeatures shape_features;
+    shape_features.append({ { 'c', 'l', 'i', 'g' }, 1 });
+    shape_features.append({ { 'k', 'e', 'r', 'n' }, 1 });
+    shape_features.append({ { 'l', 'i', 'g', 'a' }, 1 });
+    return shape_features;
+}
+
 RefPtr<Gfx::Font> FontDatabase::get(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings, Optional<Gfx::ShapeFeatures> const& shape_features)
 {
     return m_system_font_provider->get_font(family, point_size, weight, width, slope, font_variation_settings, shape_features);

--- a/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Libraries/LibGfx/Font/FontDatabase.h
@@ -33,6 +33,9 @@ struct CodePointFallbackKey {
     }
 };
 
+FontVariationSettings default_font_variation_settings(float point_size, unsigned weight, unsigned width);
+ShapeFeatures default_shape_features();
+
 class SystemFontProvider {
 public:
     virtual ~SystemFontProvider();

--- a/Libraries/LibGfx/Font/PathFontProvider.cpp
+++ b/Libraries/LibGfx/Font/PathFontProvider.cpp
@@ -88,62 +88,12 @@ void PathFontProvider::load_all_fonts_from_uri(StringView uri)
 
 RefPtr<Gfx::Font> PathFontProvider::get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings, Optional<Gfx::ShapeFeatures> const& shape_features)
 {
-    auto const compute_default_font_variation_settings = [&](unsigned weight, unsigned width) {
-        FontVariationSettings default_font_variation_settings;
-        default_font_variation_settings.set_weight(static_cast<float>(weight));
-        // NB: We use the pixel size for 'opsz'
-        default_font_variation_settings.set_optical_sizing(point_size / 0.75f);
-
-        switch (width) {
-        case FontWidth::UltraCondensed:
-            default_font_variation_settings.set_width(50);
-            break;
-        case FontWidth::ExtraCondensed:
-            default_font_variation_settings.set_width(62.5);
-            break;
-        case FontWidth::Condensed:
-            default_font_variation_settings.set_width(75);
-            break;
-        case FontWidth::SemiCondensed:
-            default_font_variation_settings.set_width(87.5);
-            break;
-        case FontWidth::Normal:
-            default_font_variation_settings.set_width(100);
-            break;
-        case FontWidth::SemiExpanded:
-            default_font_variation_settings.set_width(112.5);
-            break;
-        case FontWidth::Expanded:
-            default_font_variation_settings.set_width(125);
-            break;
-        case FontWidth::ExtraExpanded:
-            default_font_variation_settings.set_width(150);
-            break;
-        case FontWidth::UltraExpanded:
-            default_font_variation_settings.set_width(200);
-            break;
-        default:
-            VERIFY_NOT_REACHED();
-        }
-
-        return default_font_variation_settings;
-    };
-
-    auto const compute_default_shape_features = [&]() {
-        // NB: These shape features match those applied when all CSS properties are initial values
-        Gfx::ShapeFeatures shape_features;
-        shape_features.append({ { 'c', 'l', 'i', 'g' }, 1 });
-        shape_features.append({ { 'k', 'e', 'r', 'n' }, 1 });
-        shape_features.append({ { 'l', 'i', 'g', 'a' }, 1 });
-        return shape_features;
-    };
-
     auto it = m_typeface_by_family.find(family);
     if (it == m_typeface_by_family.end())
         return nullptr;
     for (auto const& typeface : it->value) {
         if (typeface->weight() == weight && typeface->width() == width && typeface->slope() == slope)
-            return typeface->font(point_size, font_variation_settings.value_or_lazy_evaluated([&] { return compute_default_font_variation_settings(weight, width); }), shape_features.value_or_lazy_evaluated([&] { return compute_default_shape_features(); }));
+            return typeface->font(point_size, font_variation_settings.value_or_lazy_evaluated([&] { return default_font_variation_settings(point_size, weight, width); }), shape_features.value_or_lazy_evaluated([&] { return default_shape_features(); }));
     }
 
     return nullptr;

--- a/Libraries/LibGfx/Font/SkiaFontProvider.cpp
+++ b/Libraries/LibGfx/Font/SkiaFontProvider.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/LexicalPath.h>
+#include <LibCore/Resource.h>
+#include <LibGfx/Font/Font.h>
+#include <LibGfx/Font/SkiaFontProvider.h>
+#include <LibGfx/Font/WOFF/Loader.h>
+
+namespace Gfx {
+
+SkiaFontProvider::SkiaFontProvider() = default;
+SkiaFontProvider::~SkiaFontProvider() = default;
+
+void SkiaFontProvider::load_all_fonts_from_uri(StringView uri)
+{
+    auto root_or_error = Core::Resource::load_from_uri(uri);
+    if (root_or_error.is_error()) {
+        if (root_or_error.error().is_errno() && root_or_error.error().code() == ENOENT)
+            return;
+        dbgln("SkiaFontProvider::load_all_fonts_from_uri('{}'): {}", uri, root_or_error.error());
+        return;
+    }
+    auto root = root_or_error.release_value();
+
+    root->for_each_descendant_file([this](Core::Resource const& resource) -> IterationDecision {
+        auto uri = resource.uri();
+        auto path = LexicalPath(uri.bytes_as_string_view());
+        RefPtr<Typeface> typeface;
+        if (path.has_extension(".ttf"sv) || path.has_extension(".ttc"sv) || path.has_extension(".otf"sv)) {
+            if (auto typeface_or_error = Typeface::try_load_from_resource(resource); !typeface_or_error.is_error())
+                typeface = typeface_or_error.release_value();
+        } else if (path.has_extension(".woff"sv)) {
+            if (auto typeface_or_error = WOFF::try_load_from_resource(resource); !typeface_or_error.is_error())
+                typeface = typeface_or_error.release_value();
+        }
+        if (typeface) {
+            auto& family = m_bundled_typefaces.ensure(typeface->family(), [] {
+                return Vector<NonnullRefPtr<Typeface>> {};
+            });
+            family.append(typeface.release_nonnull());
+        }
+        return IterationDecision::Continue;
+    });
+}
+
+Vector<NonnullRefPtr<Typeface>> const& SkiaFontProvider::ensure_system_family_cached(FlyString const& family_name)
+{
+    return m_system_typefaces.ensure(family_name, [&] {
+        Vector<NonnullRefPtr<Typeface>> typefaces;
+        TypefaceSkia::for_each_typeface_in_family(family_name.bytes_as_string_view(), [&](NonnullRefPtr<TypefaceSkia> typeface) {
+            // NB: Skia's fontconfig backend substitutes unknown families with a configured alias. Reject typefaces
+            //     whose real family differs so the CSS fallback chain can try the next candidate instead of silently
+            //     using the substitute.
+            if (typeface->family().bytes_as_string_view().equals_ignoring_ascii_case(family_name.bytes_as_string_view()))
+                typefaces.append(move(typeface));
+        });
+        return typefaces;
+    });
+}
+
+RefPtr<Gfx::Font> SkiaFontProvider::get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings, Optional<Gfx::ShapeFeatures> const& shape_features)
+{
+    auto make_font = [&](Typeface const& typeface) {
+        return typeface.font(point_size,
+            font_variation_settings.value_or_lazy_evaluated([&] { return default_font_variation_settings(point_size, weight, width); }),
+            shape_features.value_or_lazy_evaluated([&] { return default_shape_features(); }));
+    };
+
+    // Bundled fonts take priority over system fonts, and require an exact weight/width/slope match.
+    if (auto it = m_bundled_typefaces.find(family); it != m_bundled_typefaces.end()) {
+        for (auto const& typeface : it->value) {
+            if (typeface->weight() == weight && typeface->width() == width && typeface->slope() == slope)
+                return make_font(*typeface);
+        }
+    }
+
+    for (auto const& typeface : ensure_system_family_cached(family)) {
+        if (typeface->weight() == weight && typeface->width() == width && typeface->slope() == slope)
+            return make_font(*typeface);
+    }
+
+    return nullptr;
+}
+
+void SkiaFontProvider::for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)> callback)
+{
+    if (auto it = m_bundled_typefaces.find(family_name); it != m_bundled_typefaces.end()) {
+        for (auto const& typeface : it->value)
+            callback(*typeface);
+    }
+
+    auto system_typefaces = ensure_system_family_cached(family_name);
+    for (auto const& typeface : system_typefaces)
+        callback(*typeface);
+}
+
+}

--- a/Libraries/LibGfx/Font/SkiaFontProvider.cpp
+++ b/Libraries/LibGfx/Font/SkiaFontProvider.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/LexicalPath.h>
+#include <LibCore/Resource.h>
+#include <LibGfx/Font/Font.h>
+#include <LibGfx/Font/SkiaFontProvider.h>
+#include <LibGfx/Font/WOFF/Loader.h>
+
+namespace Gfx {
+
+SkiaFontProvider::SkiaFontProvider() = default;
+SkiaFontProvider::~SkiaFontProvider() = default;
+
+void SkiaFontProvider::load_all_fonts_from_uri(StringView uri)
+{
+    auto root_or_error = Core::Resource::load_from_uri(uri);
+    if (root_or_error.is_error()) {
+        if (root_or_error.error().is_errno() && root_or_error.error().code() == ENOENT)
+            return;
+        dbgln("SkiaFontProvider::load_all_fonts_from_uri('{}'): {}", uri, root_or_error.error());
+        return;
+    }
+    auto root = root_or_error.release_value();
+
+    root->for_each_descendant_file([this](Core::Resource const& resource) -> IterationDecision {
+        auto uri = resource.uri();
+        auto path = LexicalPath(uri.bytes_as_string_view());
+        RefPtr<Typeface> typeface;
+        if (path.has_extension(".ttf"sv) || path.has_extension(".ttc"sv) || path.has_extension(".otf"sv)) {
+            if (auto typeface_or_error = Typeface::try_load_from_resource(resource); !typeface_or_error.is_error())
+                typeface = typeface_or_error.release_value();
+        } else if (path.has_extension(".woff"sv)) {
+            if (auto typeface_or_error = WOFF::try_load_from_resource(resource); !typeface_or_error.is_error())
+                typeface = typeface_or_error.release_value();
+        }
+        if (typeface) {
+            auto& family = m_bundled_typefaces.ensure(typeface->family(), [] {
+                return Vector<NonnullRefPtr<Typeface>> {};
+            });
+            family.append(typeface.release_nonnull());
+        }
+        return IterationDecision::Continue;
+    });
+}
+
+Vector<NonnullRefPtr<Typeface>> const& SkiaFontProvider::ensure_system_family_cached(FlyString const& family_name)
+{
+    return m_system_typefaces.ensure(family_name, [&] {
+        Vector<NonnullRefPtr<Typeface>> typefaces;
+        TypefaceSkia::for_each_typeface_in_family(family_name.bytes_as_string_view(), [&](NonnullRefPtr<TypefaceSkia> typeface) {
+            // NB: Skia's fontconfig backend substitutes unknown families with a configured alias. Reject typefaces
+            //     whose real family differs so the CSS fallback chain can try the next candidate instead of silently
+            //     using the substitute.
+            if (typeface->family().bytes_as_string_view().equals_ignoring_ascii_case(family_name.bytes_as_string_view()))
+                typefaces.append(move(typeface));
+        });
+        return typefaces;
+    });
+}
+
+RefPtr<Gfx::Font> SkiaFontProvider::get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings, Optional<Gfx::ShapeFeatures> const& shape_features)
+{
+    auto const compute_default_font_variation_settings = [&](unsigned weight, unsigned width) {
+        FontVariationSettings default_font_variation_settings;
+        default_font_variation_settings.set_weight(static_cast<float>(weight));
+        // NB: We use the pixel size for 'opsz'
+        default_font_variation_settings.set_optical_sizing(point_size / 0.75f);
+
+        switch (width) {
+        case FontWidth::UltraCondensed:
+            default_font_variation_settings.set_width(50);
+            break;
+        case FontWidth::ExtraCondensed:
+            default_font_variation_settings.set_width(62.5);
+            break;
+        case FontWidth::Condensed:
+            default_font_variation_settings.set_width(75);
+            break;
+        case FontWidth::SemiCondensed:
+            default_font_variation_settings.set_width(87.5);
+            break;
+        case FontWidth::Normal:
+            default_font_variation_settings.set_width(100);
+            break;
+        case FontWidth::SemiExpanded:
+            default_font_variation_settings.set_width(112.5);
+            break;
+        case FontWidth::Expanded:
+            default_font_variation_settings.set_width(125);
+            break;
+        case FontWidth::ExtraExpanded:
+            default_font_variation_settings.set_width(150);
+            break;
+        case FontWidth::UltraExpanded:
+            default_font_variation_settings.set_width(200);
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+
+        return default_font_variation_settings;
+    };
+
+    auto const compute_default_shape_features = [&]() {
+        // NB: These shape features match those applied when all CSS properties are initial values
+        Gfx::ShapeFeatures default_shape_features;
+        default_shape_features.append({ { 'c', 'l', 'i', 'g' }, 1 });
+        default_shape_features.append({ { 'k', 'e', 'r', 'n' }, 1 });
+        default_shape_features.append({ { 'l', 'i', 'g', 'a' }, 1 });
+        return default_shape_features;
+    };
+
+    auto make_font = [&](Typeface const& typeface) {
+        return typeface.font(point_size,
+            font_variation_settings.value_or_lazy_evaluated([&] { return compute_default_font_variation_settings(weight, width); }),
+            shape_features.value_or_lazy_evaluated([&] { return compute_default_shape_features(); }));
+    };
+
+    // Bundled fonts take priority over system fonts, and require an exact weight/width/slope match.
+    if (auto it = m_bundled_typefaces.find(family); it != m_bundled_typefaces.end()) {
+        for (auto const& typeface : it->value) {
+            if (typeface->weight() == weight && typeface->width() == width && typeface->slope() == slope)
+                return make_font(*typeface);
+        }
+    }
+
+    for (auto const& typeface : ensure_system_family_cached(family)) {
+        if (typeface->weight() == weight && typeface->width() == width && typeface->slope() == slope)
+            return make_font(*typeface);
+    }
+
+    return nullptr;
+}
+
+void SkiaFontProvider::for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)> callback)
+{
+    // Bundled fonts shadow system fonts of the same family name.
+    if (auto it = m_bundled_typefaces.find(family_name); it != m_bundled_typefaces.end()) {
+        for (auto const& typeface : it->value)
+            callback(*typeface);
+        return;
+    }
+
+    for (auto const& typeface : ensure_system_family_cached(family_name))
+        callback(*typeface);
+}
+
+}

--- a/Libraries/LibGfx/Font/SkiaFontProvider.h
+++ b/Libraries/LibGfx/Font/SkiaFontProvider.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <AK/Function.h>
+#include <AK/HashMap.h>
+#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/Typeface.h>
+#include <LibGfx/Font/TypefaceSkia.h>
+
+namespace Gfx {
+
+class SkiaFontProvider final : public SystemFontProvider {
+    AK_MAKE_NONCOPYABLE(SkiaFontProvider);
+    AK_MAKE_NONMOVABLE(SkiaFontProvider);
+
+public:
+    SkiaFontProvider();
+    virtual ~SkiaFontProvider() override;
+
+    void load_all_fonts_from_uri(StringView);
+
+    virtual RefPtr<Gfx::Font> get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings = {}, Optional<Gfx::ShapeFeatures> const& shape_features = {}) override;
+    virtual void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>) override;
+    virtual StringView name() const LIFETIME_BOUND override { return "Skia"sv; }
+
+private:
+    Vector<NonnullRefPtr<Typeface>> const& ensure_system_family_cached(FlyString const& family_name);
+    HashMap<FlyString, Vector<NonnullRefPtr<Typeface>>, AK::ASCIICaseInsensitiveFlyStringTraits> m_bundled_typefaces;
+    HashMap<FlyString, Vector<NonnullRefPtr<Typeface>>, AK::ASCIICaseInsensitiveFlyStringTraits> m_system_typefaces;
+};
+
+}

--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -127,16 +127,17 @@ void Typeface::copy_font_data_from(Typeface const& other)
 
 namespace IPC {
 
-static NonnullRefPtr<Gfx::Typeface const> match_system_typeface(Optional<Gfx::SystemUIFontKind> system_ui_font_kind, String family_name, u16 weight, u16 width, u8 slope)
+static ErrorOr<NonnullRefPtr<Gfx::Typeface const>> match_system_typeface(Optional<Gfx::SystemUIFontKind> system_ui_font_kind, String family_name, u16 weight, u16 width, u8 slope)
 {
     if (system_ui_font_kind.has_value()) {
-        auto typeface = MUST(Gfx::TypefaceSkia::match_system_ui(system_ui_font_kind.value(), 0, weight, width, slope));
+        auto typeface = TRY(Gfx::TypefaceSkia::match_system_ui(system_ui_font_kind.value(), 0, weight, width, slope));
         if (typeface)
             return typeface.release_nonnull();
     }
 
-    auto typeface = MUST(Gfx::TypefaceSkia::match_family_style(family_name.bytes_as_string_view(), weight, width, slope));
-    VERIFY(typeface);
+    auto typeface = TRY(Gfx::TypefaceSkia::match_family_style(family_name.bytes_as_string_view(), weight, width, slope));
+    if (!typeface)
+        return Error::from_string_literal("Typeface IPC data referenced an unknown system font");
     return typeface.release_nonnull();
 }
 

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -104,6 +104,11 @@ static SkFontMgr& font_manager()
     return *font_manager;
 }
 
+void TypefaceSkia::initialize_font_manager()
+{
+    font_manager();
+}
+
 static std::unique_ptr<SkMemoryStream> copy_stream_to_memory_stream(SkStreamAsset& stream)
 {
     auto stream_copy = stream.duplicate();
@@ -307,6 +312,23 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::match_family_style(StringView family
 {
     auto skia_typeface = font_manager().matchFamilyStyle(ByteString(family_name).characters(), SkFontStyle { weight, width, slope_to_skia_slant(slope) });
     return typeface_from_skia_typeface(move(skia_typeface));
+}
+
+void TypefaceSkia::for_each_typeface_in_family(StringView family_name, Function<void(NonnullRefPtr<TypefaceSkia>)> callback)
+{
+    auto style_set = font_manager().matchFamily(ByteString(family_name).characters());
+    if (!style_set)
+        return;
+
+    auto style_count = style_set->count();
+    for (int style_index = 0; style_index < style_count; ++style_index) {
+        auto skia_typeface = style_set->createTypeface(style_index);
+        auto typeface_or_error = typeface_from_skia_typeface(move(skia_typeface));
+        if (typeface_or_error.is_error())
+            continue;
+        if (auto typeface = typeface_or_error.release_value())
+            callback(typeface.release_nonnull());
+    }
 }
 
 ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)

--- a/Libraries/LibGfx/Font/TypefaceSkia.h
+++ b/Libraries/LibGfx/Font/TypefaceSkia.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <LibGfx/Font/Typeface.h>
 
 #ifdef AK_OS_MACOS
@@ -33,6 +34,8 @@ public:
     static ErrorOr<RefPtr<TypefaceSkia>> match_family_style(StringView family_name, u16 weight, u16 width, u8 slope);
     static ErrorOr<RefPtr<TypefaceSkia>> find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji);
     static Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope);
+    static void for_each_typeface_in_family(StringView family_name, Function<void(NonnullRefPtr<TypefaceSkia>)>);
+    static void initialize_font_manager();
 
     RefPtr<TypefaceSkia const> clone_with_variations(Vector<FontVariationAxis> const& axes) const;
 

--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -553,6 +553,9 @@ static char const* syscall_name(long syscall_number)
 #ifdef __NR_bind
         CASE_SYSCALL_NAME(bind);
 #endif
+#ifdef __NR_chmod
+        CASE_SYSCALL_NAME(chmod);
+#endif
 #ifdef __NR_clone
         CASE_SYSCALL_NAME(clone);
 #endif
@@ -576,6 +579,12 @@ static char const* syscall_name(long syscall_number)
 #endif
 #ifdef __NR_fallocate
         CASE_SYSCALL_NAME(fallocate);
+#endif
+#ifdef __NR_fchmod
+        CASE_SYSCALL_NAME(fchmod);
+#endif
+#ifdef __NR_fchmodat
+        CASE_SYSCALL_NAME(fchmodat);
 #endif
 #ifdef __NR_fcntl
         CASE_SYSCALL_NAME(fcntl);
@@ -905,6 +914,25 @@ void SeccompPolicy::allow_filesystem_writes()
     append(SECCOMP_ALLOW);
     append(SECCOMP_LOAD_SYSCALL_NR);
     append(BPF_STMT(BPF_ALU | BPF_ADD | BPF_K, 0));
+}
+
+void SeccompPolicy::deny_file_mode_changes()
+{
+    // Fontconfig changes the mode of any font cache files it rebuilds. Cache rebuilds normally happen before the
+    // sandbox is installed. If one happens later, fail these calls rather than terminating the process, as fontconfig
+    // tolerates a cache that it cannot update.
+#ifdef __NR_chmod
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_chmod, 0, 1));
+    append(SECCOMP_ERRNO(EPERM));
+#endif
+#ifdef __NR_fchmod
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_fchmod, 0, 1));
+    append(SECCOMP_ERRNO(EPERM));
+#endif
+#ifdef __NR_fchmodat
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_fchmodat, 0, 1));
+    append(SECCOMP_ERRNO(EPERM));
+#endif
 }
 
 void SeccompPolicy::allow_file_descriptor_operations()

--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -553,6 +553,9 @@ static char const* syscall_name(long syscall_number)
 #ifdef __NR_bind
         CASE_SYSCALL_NAME(bind);
 #endif
+#ifdef __NR_chmod
+        CASE_SYSCALL_NAME(chmod);
+#endif
 #ifdef __NR_clone
         CASE_SYSCALL_NAME(clone);
 #endif
@@ -576,6 +579,12 @@ static char const* syscall_name(long syscall_number)
 #endif
 #ifdef __NR_fallocate
         CASE_SYSCALL_NAME(fallocate);
+#endif
+#ifdef __NR_fchmod
+        CASE_SYSCALL_NAME(fchmod);
+#endif
+#ifdef __NR_fchmodat
+        CASE_SYSCALL_NAME(fchmodat);
 #endif
 #ifdef __NR_fcntl
         CASE_SYSCALL_NAME(fcntl);
@@ -887,6 +896,25 @@ void SeccompPolicy::allow_filesystem_writes()
     append(SECCOMP_ALLOW);
     append(SECCOMP_LOAD_SYSCALL_NR);
     append(BPF_STMT(BPF_ALU | BPF_ADD | BPF_K, 0));
+}
+
+void SeccompPolicy::deny_file_mode_changes()
+{
+    // Fontconfig changes the mode of the font cache files it maintains while it loads, before the sandbox is
+    // installed. Fail these calls rather than terminating the process, as fontconfig tolerates a cache that it cannot
+    // update.
+#ifdef __NR_chmod
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_chmod, 0, 1));
+    append(SECCOMP_ERRNO(EPERM));
+#endif
+#ifdef __NR_fchmod
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_fchmod, 0, 1));
+    append(SECCOMP_ERRNO(EPERM));
+#endif
+#ifdef __NR_fchmodat
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_fchmodat, 0, 1));
+    append(SECCOMP_ERRNO(EPERM));
+#endif
 }
 
 void SeccompPolicy::allow_file_descriptor_operations()

--- a/Libraries/LibSandbox/Seccomp.h
+++ b/Libraries/LibSandbox/Seccomp.h
@@ -18,6 +18,7 @@ public:
 
     void deny_readonly_filesystem_probes();
     void deny_current_directory_queries();
+    void deny_file_mode_changes();
     void allow_readonly_file_opens();
     void allow_filesystem_metadata_queries();
     void allow_filesystem_writes();

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1340,8 +1340,4 @@ if(NOT BUILD_SHARED_LIBS)
     set_property(SOURCE Loader/ContentBlocker.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_content_blocker_rust_lib})
 endif()
 
-if (HAS_FONTCONFIG)
-    target_link_libraries(LibWeb PRIVATE Fontconfig::Fontconfig)
-endif()
-
 generate_js_bindings(LibWeb)

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1410,8 +1410,4 @@ if(NOT BUILD_SHARED_LIBS)
     set_property(SOURCE Loader/ContentBlocker.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_content_blocker_rust_lib})
 endif()
 
-if (HAS_FONTCONFIG)
-    target_link_libraries(LibWeb PRIVATE Fontconfig::Fontconfig)
-endif()
-
 generate_js_bindings(LibWeb)

--- a/Libraries/LibWeb/Platform/FontPlugin.cpp
+++ b/Libraries/LibWeb/Platform/FontPlugin.cpp
@@ -14,6 +14,7 @@
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
+#include <LibGfx/Font/SkiaFontProvider.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Font/TypefaceSkia.h>
 #include <LibWeb/Platform/FontPlugin.h>
@@ -40,8 +41,11 @@ FontPlugin::FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* font_p
     if (is_layout_test_mode)
         Gfx::force_hinting_for_testing(Gfx::FontHintingStyle::Normal);
 
-    if (!font_provider)
-        font_provider = &static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
+    if (!font_provider) {
+        auto& skia_font_provider = static_cast<Gfx::SkiaFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::SkiaFontProvider>()));
+        skia_font_provider.load_all_fonts_from_uri("resource://fonts"sv);
+        font_provider = &skia_font_provider;
+    }
     if (is<Gfx::PathFontProvider>(*font_provider)) {
         auto& path_font_provider = static_cast<Gfx::PathFontProvider&>(*font_provider);
         // Load anything we can find in the system's font directories

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -120,11 +120,6 @@ if (ENABLE_CRANELIFT_JIT)
     target_compile_definitions(LibWebView PUBLIC HAVE_WASM_COMPILER_SERVICE=1)
 endif()
 
-# Third-party
-if (HAS_FONTCONFIG)
-    target_link_libraries(LibWebView PRIVATE Fontconfig::Fontconfig)
-endif()
-
 if (ENABLE_INSTALL_HEADERS)
     foreach(header ${GENERATED_SOURCES})
         get_filename_component(extension ${header} EXT)

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -107,11 +107,6 @@ compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebUIServer.ipc ${CMAKE_B
 ladybird_lib(LibWebView webview EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibWebView PRIVATE LibCore LibCrypto LibDatabase LibDevTools LibFileSystem LibGfx LibHTTP LibImageDecoderClient LibIPC LibRequests LibJS LibMedia LibWeb LibUnicode LibURL LibSync LibSyntax LibTextCodec LibThreading)
 
-# Third-party
-if (HAS_FONTCONFIG)
-    target_link_libraries(LibWebView PRIVATE Fontconfig::Fontconfig)
-endif()
-
 if (ENABLE_INSTALL_HEADERS)
     foreach(header ${GENERATED_SOURCES})
         get_filename_component(extension ${header} EXT)

--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(Compositor main.cpp)
 
 if (LINUX)
     target_sources(Compositor PRIVATE SandboxLinux.cpp)
+    target_link_libraries(Compositor PRIVATE Fontconfig::Fontconfig)
 elseif (APPLE)
     target_sources(Compositor PRIVATE SandboxMacOS.cpp)
 else()

--- a/Services/Compositor/SandboxLinux.cpp
+++ b/Services/Compositor/SandboxLinux.cpp
@@ -9,20 +9,51 @@
 #include <LibCore/Environment.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/GlobalFontConfig.h>
+#include <LibGfx/Font/TypefaceSkia.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibSandbox/Seccomp.h>
 #include <LibWebView/Utilities.h>
+#include <fontconfig/fontconfig.h>
 
 namespace Compositor {
+
+static ErrorOr<void> add_landlock_paths_for_fontconfig(Vector<Sandbox::LandlockPath>& paths)
+{
+    TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/fonts"sv, Sandbox::LandlockPath::Access::ReadOnly));
+
+    FcConfig* config = Gfx::GlobalFontConfig::the().get();
+
+    FcStrList* font_directories = FcConfigGetFontDirs(config);
+    while (FcChar8* directory = FcStrListNext(font_directories)) {
+        char const* directory_cstring = reinterpret_cast<char const*>(directory);
+        TRY(Sandbox::add_landlock_path_if_exists(paths, StringView { directory_cstring, strlen(directory_cstring) }, Sandbox::LandlockPath::Access::ReadOnly));
+    }
+    FcStrListDone(font_directories);
+
+    FcStrList* cache_directories = FcConfigGetCacheDirs(config);
+    while (FcChar8* directory = FcStrListNext(cache_directories)) {
+        char const* directory_cstring = reinterpret_cast<char const*>(directory);
+        TRY(Sandbox::add_landlock_path_if_exists(paths, StringView { directory_cstring, strlen(directory_cstring) }, Sandbox::LandlockPath::Access::ReadOnly));
+    }
+    FcStrListDone(cache_directories);
+
+    return {};
+}
 
 ErrorOr<void> apply_sandbox(StringView)
 {
     TRY(Sandbox::install_no_new_privileges());
     TRY(Sandbox::configure_runtime());
 
+    // Load Skia's font manager, and with it fontconfig's configuration and font caches, while filesystem access and
+    // the syscalls fontconfig needs are still unrestricted.
+    Gfx::TypefaceSkia::initialize_font_manager();
+
     Vector<Sandbox::LandlockPath> paths;
     for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
         TRY(Sandbox::add_landlock_path_if_exists(paths, path, Sandbox::LandlockPath::Access::ReadOnly));
+    TRY(add_landlock_paths_for_fontconfig(paths));
     TRY(Sandbox::add_landlock_path_if_exists(paths, TRY(String::formatted("{}/fonts", WebView::s_ladybird_resource_root)), Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/lib"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/lib64"sv, Sandbox::LandlockPath::Access::ReadOnly));
@@ -64,6 +95,7 @@ ErrorOr<void> apply_sandbox(StringView)
     TRY(Sandbox::restrict_filesystem_with_landlock(paths.span()));
 
     Sandbox::SeccompPolicy policy;
+    policy.deny_file_mode_changes();
     policy.allow_readonly_file_opens();
     policy.allow_filesystem_metadata_queries();
     policy.allow_filesystem_writes();

--- a/Services/Compositor/SandboxLinux.cpp
+++ b/Services/Compositor/SandboxLinux.cpp
@@ -4,25 +4,62 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/LexicalPath.h>
 #include <Compositor/Sandbox.h>
 #include <LibCore/Directory.h>
 #include <LibCore/Environment.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/GlobalFontConfig.h>
+#include <LibGfx/Font/TypefaceSkia.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibSandbox/Seccomp.h>
 #include <LibWebView/Utilities.h>
+#include <fontconfig/fontconfig.h>
 
 namespace Compositor {
+
+static ErrorOr<void> add_landlock_paths_for_fontconfig(Vector<Sandbox::LandlockPath>& paths)
+{
+    TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/fonts"sv, Sandbox::LandlockPath::Access::ReadOnly));
+
+    FcConfig* config = Gfx::GlobalFontConfig::the().get();
+
+    FcStrList* font_directories = FcConfigGetFontDirs(config);
+    while (FcChar8* directory = FcStrListNext(font_directories)) {
+        char const* directory_cstring = reinterpret_cast<char const*>(directory);
+        TRY(Sandbox::add_landlock_path_if_exists(paths, StringView { directory_cstring, strlen(directory_cstring) }, Sandbox::LandlockPath::Access::ReadOnly));
+    }
+    FcStrListDone(font_directories);
+
+    FcStrList* cache_directories = FcConfigGetCacheDirs(config);
+    while (FcChar8* directory = FcStrListNext(cache_directories)) {
+        char const* directory_cstring = reinterpret_cast<char const*>(directory);
+        TRY(Sandbox::add_landlock_path_if_exists(paths, StringView { directory_cstring, strlen(directory_cstring) }, Sandbox::LandlockPath::Access::ReadOnly));
+    }
+    FcStrListDone(cache_directories);
+
+    // Fontconfig rebuilds stale font caches in the per-user cache directory at runtime.
+    auto user_cache_directory = LexicalPath::join(Core::StandardPaths::cache_directory(), "fontconfig"sv).string();
+    TRY(Core::Directory::create(user_cache_directory, Core::Directory::CreateDirectories::Yes, 0755));
+    TRY(Sandbox::add_landlock_path_if_exists(paths, user_cache_directory, Sandbox::LandlockPath::Access::ReadWrite));
+
+    return {};
+}
 
 ErrorOr<void> apply_sandbox(StringView)
 {
     TRY(Sandbox::install_no_new_privileges());
     TRY(Sandbox::configure_runtime());
 
+    // Load Skia's font manager, and with it fontconfig's configuration and font caches, while filesystem access and
+    // the syscalls fontconfig needs are still unrestricted.
+    Gfx::TypefaceSkia::initialize_font_manager();
+
     Vector<Sandbox::LandlockPath> paths;
     for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
         TRY(Sandbox::add_landlock_path_if_exists(paths, path, Sandbox::LandlockPath::Access::ReadOnly));
+    TRY(add_landlock_paths_for_fontconfig(paths));
     TRY(Sandbox::add_landlock_path_if_exists(paths, TRY(String::formatted("{}/fonts", WebView::s_ladybird_resource_root)), Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/lib"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/lib64"sv, Sandbox::LandlockPath::Access::ReadOnly));
@@ -64,6 +101,7 @@ ErrorOr<void> apply_sandbox(StringView)
     TRY(Sandbox::restrict_filesystem_with_landlock(paths.span()));
 
     Sandbox::SeccompPolicy policy;
+    policy.deny_file_mode_changes();
     policy.allow_readonly_file_opens();
     policy.allow_filesystem_metadata_queries();
     policy.allow_filesystem_writes();

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -53,9 +53,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
         Gfx::FontDatabase::the().set_force_freetype_rasterization(true);
     }
-    for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
-        font_provider.load_all_fonts_from_uri(TRY(String::formatted("file://{}", path)));
-    font_provider.load_all_fonts_from_uri("resource://fonts"sv);
 
     if (!force_cpu_painting)
         Gfx::SkiaBackendContext::initialize_gpu_backend();

--- a/Services/RendererSandboxLinux.cpp
+++ b/Services/RendererSandboxLinux.cpp
@@ -9,12 +9,38 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/GlobalFontConfig.h>
+#include <LibGfx/Font/TypefaceSkia.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibSandbox/Seccomp.h>
 #include <LibWebView/Utilities.h>
 #include <Services/RendererSandbox.h>
+#include <fontconfig/fontconfig.h>
 
 namespace RendererSandbox {
+
+static ErrorOr<void> add_landlock_paths_for_fontconfig(Vector<Sandbox::LandlockPath>& paths)
+{
+    TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/fonts"sv, Sandbox::LandlockPath::Access::ReadOnly));
+
+    FcConfig* config = Gfx::GlobalFontConfig::the().get();
+
+    FcStrList* font_directories = FcConfigGetFontDirs(config);
+    while (FcChar8* directory = FcStrListNext(font_directories)) {
+        char const* directory_cstring = reinterpret_cast<char const*>(directory);
+        TRY(Sandbox::add_landlock_path_if_exists(paths, StringView { directory_cstring, strlen(directory_cstring) }, Sandbox::LandlockPath::Access::ReadOnly));
+    }
+    FcStrListDone(font_directories);
+
+    FcStrList* cache_directories = FcConfigGetCacheDirs(config);
+    while (FcChar8* directory = FcStrListNext(cache_directories)) {
+        char const* directory_cstring = reinterpret_cast<char const*>(directory);
+        TRY(Sandbox::add_landlock_path_if_exists(paths, StringView { directory_cstring, strlen(directory_cstring) }, Sandbox::LandlockPath::Access::ReadOnly));
+    }
+    FcStrListDone(cache_directories);
+
+    return {};
+}
 
 ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringView>)
 {
@@ -35,6 +61,11 @@ ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringVie
     for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
         TRY(Sandbox::add_landlock_path_if_exists(paths, path, Sandbox::LandlockPath::Access::ReadOnly));
 
+    // Load Skia's font manager, and with it fontconfig's configuration and font caches, while filesystem access and
+    // the syscalls fontconfig needs are still unrestricted.
+    Gfx::TypefaceSkia::initialize_font_manager();
+    TRY(add_landlock_paths_for_fontconfig(paths));
+
     auto pulse_runtime_path = LexicalPath::join(TRY(Core::StandardPaths::runtime_directory()), "pulse"sv).string();
     TRY(Core::Directory::create(pulse_runtime_path, Core::Directory::CreateDirectories::Yes, 0700));
     TRY(Sandbox::add_landlock_path_if_exists(paths, pulse_runtime_path, Sandbox::LandlockPath::Access::ReadWrite));
@@ -43,6 +74,7 @@ ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringVie
     TRY(Sandbox::restrict_filesystem_with_landlock(paths.span()));
 
     Sandbox::SeccompPolicy policy;
+    policy.deny_file_mode_changes();
     policy.allow_readonly_file_opens();
     policy.allow_filesystem_metadata_queries();
     policy.allow_filesystem_writes();

--- a/Services/RendererSandboxLinux.cpp
+++ b/Services/RendererSandboxLinux.cpp
@@ -10,12 +10,43 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/GlobalFontConfig.h>
+#include <LibGfx/Font/TypefaceSkia.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibSandbox/Seccomp.h>
 #include <LibWebView/Utilities.h>
 #include <Services/RendererSandbox.h>
+#include <fontconfig/fontconfig.h>
 
 namespace RendererSandbox {
+
+static ErrorOr<void> add_landlock_paths_for_fontconfig(Vector<Sandbox::LandlockPath>& paths)
+{
+    TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/fonts"sv, Sandbox::LandlockPath::Access::ReadOnly));
+
+    FcConfig* config = Gfx::GlobalFontConfig::the().get();
+
+    FcStrList* font_directories = FcConfigGetFontDirs(config);
+    while (FcChar8* directory = FcStrListNext(font_directories)) {
+        char const* directory_cstring = reinterpret_cast<char const*>(directory);
+        TRY(Sandbox::add_landlock_path_if_exists(paths, StringView { directory_cstring, strlen(directory_cstring) }, Sandbox::LandlockPath::Access::ReadOnly));
+    }
+    FcStrListDone(font_directories);
+
+    FcStrList* cache_directories = FcConfigGetCacheDirs(config);
+    while (FcChar8* directory = FcStrListNext(cache_directories)) {
+        char const* directory_cstring = reinterpret_cast<char const*>(directory);
+        TRY(Sandbox::add_landlock_path_if_exists(paths, StringView { directory_cstring, strlen(directory_cstring) }, Sandbox::LandlockPath::Access::ReadOnly));
+    }
+    FcStrListDone(cache_directories);
+
+    // Fontconfig rebuilds stale font caches in the per-user cache directory at runtime.
+    auto user_cache_directory = LexicalPath::join(Core::StandardPaths::cache_directory(), "fontconfig"sv).string();
+    TRY(Core::Directory::create(user_cache_directory, Core::Directory::CreateDirectories::Yes, 0755));
+    TRY(Sandbox::add_landlock_path_if_exists(paths, user_cache_directory, Sandbox::LandlockPath::Access::ReadWrite));
+
+    return {};
+}
 
 ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringView>)
 {
@@ -36,6 +67,11 @@ ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringVie
     for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
         TRY(Sandbox::add_landlock_path_if_exists(paths, path, Sandbox::LandlockPath::Access::ReadOnly));
 
+    // Load Skia's font manager, and with it fontconfig's configuration and font caches, while filesystem access and
+    // the syscalls fontconfig needs are still unrestricted.
+    Gfx::TypefaceSkia::initialize_font_manager();
+    TRY(add_landlock_paths_for_fontconfig(paths));
+
     if (auto cranelift_compiler_path = Core::Environment::get("LADYBIRD_CRANELIFT_COMPILER"sv); cranelift_compiler_path.has_value()) {
         TRY(Sandbox::add_landlock_path_if_exists(paths, *cranelift_compiler_path, Sandbox::LandlockPath::Access::ReadAndExecute));
     } else {
@@ -51,6 +87,7 @@ ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringVie
     TRY(Sandbox::restrict_filesystem_with_landlock(paths.span()));
 
     Sandbox::SeccompPolicy policy;
+    policy.deny_file_mode_changes();
     policy.allow_readonly_file_opens();
     policy.allow_filesystem_metadata_queries();
     policy.allow_filesystem_writes();

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(WebContent main.cpp)
 
 if (LINUX)
     target_sources(WebContent PRIVATE ../RendererSandboxLinux.cpp)
+    target_link_libraries(WebContent PRIVATE Fontconfig::Fontconfig)
 elseif (APPLE)
     target_sources(WebContent PRIVATE ../RendererSandboxMacOS.cpp)
 else()

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(WebContent main.cpp)
 
 if (LINUX)
     target_sources(WebContent PRIVATE ../RendererSandboxLinux.cpp)
+    target_link_libraries(WebContent PRIVATE Fontconfig::Fontconfig)
 elseif (APPLE)
     target_sources(WebContent PRIVATE ../RendererSandboxMacOS.cpp)
 else()

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -15,6 +15,7 @@
 #include <LibCrypto/OpenSSLForward.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
+#include <LibGfx/Font/SkiaFontProvider.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibIPC/TransportHandle.h>
 #include <LibMain/Main.h>
@@ -206,12 +207,18 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     if (file_origins_are_tuple_origins)
         URL::set_file_scheme_urls_have_tuple_origins();
 
-    auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
+    Gfx::SystemFontProvider* font_provider = nullptr;
     if (force_fontconfig) {
-        font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+        auto& path_font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
+        path_font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+        path_font_provider.load_all_fonts_from_uri("resource://fonts"sv);
+        font_provider = &path_font_provider;
         Gfx::FontDatabase::the().set_force_freetype_rasterization(true);
+    } else {
+        auto& skia_font_provider = static_cast<Gfx::SkiaFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::SkiaFontProvider>()));
+        skia_font_provider.load_all_fonts_from_uri("resource://fonts"sv);
+        font_provider = &skia_font_provider;
     }
-    font_provider.load_all_fonts_from_uri("resource://fonts"sv);
 
     WebContent::PageClient::set_is_headless(is_headless);
 
@@ -236,7 +243,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Web::HTML::Window::set_internals_object_exposed(expose_internals_object);
     Web::HTML::UniversalGlobalScopeMixin::set_experimental_interfaces_exposed(expose_experimental_interfaces);
 
-    Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(enable_test_mode, &font_provider));
+    Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(enable_test_mode, font_provider));
 
     Web::Bindings::initialize_main_thread_vm(Web::HTML::AgentType::SimilarOriginWindow);
 

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -15,6 +15,7 @@
 #include <LibCrypto/OpenSSLForward.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
+#include <LibGfx/Font/SkiaFontProvider.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibIPC/TransportHandle.h>
 #include <LibMain/Main.h>
@@ -211,12 +212,18 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     if (file_origins_are_tuple_origins)
         URL::set_file_scheme_urls_have_tuple_origins();
 
-    auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
+    Gfx::SystemFontProvider* font_provider = nullptr;
     if (force_fontconfig) {
-        font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+        auto& path_font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
+        path_font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+        path_font_provider.load_all_fonts_from_uri("resource://fonts"sv);
+        font_provider = &path_font_provider;
         Gfx::FontDatabase::the().set_force_freetype_rasterization(true);
+    } else {
+        auto& skia_font_provider = static_cast<Gfx::SkiaFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::SkiaFontProvider>()));
+        skia_font_provider.load_all_fonts_from_uri("resource://fonts"sv);
+        font_provider = &skia_font_provider;
     }
-    font_provider.load_all_fonts_from_uri("resource://fonts"sv);
 
     WebContent::PageClient::set_is_headless(is_headless);
 
@@ -241,7 +248,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Web::HTML::Window::set_internals_object_exposed(expose_internals_object);
     Web::HTML::UniversalGlobalScopeMixin::set_experimental_interfaces_exposed(expose_experimental_interfaces);
 
-    Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(enable_test_mode, &font_provider));
+    Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(enable_test_mode, font_provider));
 
     Web::Bindings::initialize_main_thread_vm(Web::Bindings::AgentType::SimilarOriginWindow);
 

--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(WebWorker main.cpp)
 
 if (LINUX)
     target_sources(WebWorker PRIVATE ../RendererSandboxLinux.cpp)
+    target_link_libraries(WebWorker PRIVATE Fontconfig::Fontconfig)
 elseif (APPLE)
     target_sources(WebWorker PRIVATE ../RendererSandboxMacOS.cpp)
 else()

--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(WebWorker main.cpp)
 
 if (LINUX)
     target_sources(WebWorker PRIVATE ../RendererSandboxLinux.cpp)
+    target_link_libraries(WebWorker PRIVATE Fontconfig::Fontconfig)
 elseif (APPLE)
     target_sources(WebWorker PRIVATE ../RendererSandboxMacOS.cpp)
 else()


### PR DESCRIPTION
This PR adds a font provider that resolves system fonts on demand through the Skia font manager instead of scanning font directories up front. Bundled fonts are loaded eagerly and shadow system fonts of the same family name. Typefaces whose resolved family name differs from the requested family are rejected, so fontconfig alias substitutions do not satisfy named family lookups and the existing CSS font fallback logic continues to be  used. 

Processes now install the Skia-backed system font provider by default. The old path-based provider remains available behind `--force-fontconfig`, which the test runner also uses for deterministic font selection.

This removes the last direct fontconfig users: the global fontconfig wrapper is gone and the fallback font directory list is now assembled per platform. Fontconfig remains a build dependency because Skia's font manager resolves fonts through it.