### PR TITLE
Meta/WPT.sh: Use `id_hash` instead of `hash` for test chunk assignment

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -573,7 +573,7 @@ run_wpt_chunked() {
             run \
             --this-chunk="$((i + 1))" \
             --total-chunks="$procs" \
-            --chunk-type=hash \
+            --chunk-type=id_hash \
             -f \
             --browser-version="1.0-$(ladybird_git_hash)"
             --processes="$concurrency" \


### PR DESCRIPTION
Using `--chunk-type=id_hash` is very similar to `=hash`, with the added benefit of adding variants into the mix. For example, a single test that spawns 10 variants would be executed as part of a single chunk. Now, each variant would (ideally) be assigned to a different chunk.

This is an attempt at somewhat reducing the long tail in our WPT runtime, during which there are just a couple of WPT runners working on their remaining tests:

<img width="941" height="272" alt="image" src="https://github.com/user-attachments/assets/5ead9b64-ad08-4ae9-87bf-6f276469c47e" />

On my machine, running the `editing` WPT tests category with `id_hash` instead of `hash` brings down the runtime from ~3m17 to  ~2m48, a reduction of about 29 seconds (-15%).