### PR TITLE
LibWeb: Keep text selection out of distant editors

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -79,6 +79,10 @@ static GC::Ptr<DOM::Node> associated_descendant_editing_host(DOM::Node& node)
         return editing_host && editing_host->is_editing_host() ? editing_host : nullptr;
     }
 
+    Optional<CSSPixelRect> hit_node_rect;
+    if (auto paintable = node.paintable())
+        hit_node_rect = paintable->absolute_rect();
+
     for (auto* ancestor = &node; ancestor; ancestor = ancestor->parent_or_shadow_host()) {
         GC::Ptr<DOM::Node> editing_host;
         bool has_multiple_editing_hosts = false;
@@ -93,8 +97,15 @@ static GC::Ptr<DOM::Node> associated_descendant_editing_host(DOM::Node& node)
             return TraversalDecision::Continue;
         });
 
-        if (editing_host && !has_multiple_editing_hosts)
-            return editing_host;
+        if (editing_host && !has_multiple_editing_hosts) {
+            if (ancestor == &node)
+                return editing_host;
+            auto editing_host_paintable = editing_host->paintable();
+            if (hit_node_rect.has_value() && editing_host_paintable
+                && hit_node_rect->intersects(editing_host_paintable->absolute_rect()))
+                return editing_host;
+        }
+
         if (ancestor != &node && ancestor->is_focusable())
             break;
     }

--- a/Tests/LibWeb/Text/expected/select-text-before-contenteditable.txt
+++ b/Tests/LibWeb/Text/expected/select-text-before-contenteditable.txt
@@ -1,0 +1,2 @@
+selected post text: true
+<BODY>

--- a/Tests/LibWeb/Text/input/select-text-before-contenteditable.html
+++ b/Tests/LibWeb/Text/input/select-text-before-contenteditable.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body {
+        margin: 0;
+        font: 20px SerenitySans, sans-serif;
+    }
+
+    #post {
+        margin: 0;
+        width: 640px;
+    }
+
+    #editor {
+        margin-top: 40px;
+        min-height: 40px;
+        width: 640px;
+    }
+</style>
+<p id="post">Open source is a thankless job and maintainers deserve better</p>
+<div id="editor" contenteditable><p><br></p></div>
+<script>
+    test(() => {
+        document.body.offsetWidth;
+
+        const text = post.firstChild;
+        const range = document.createRange();
+
+        const startOffset = text.data.indexOf("source");
+        range.setStart(text, startOffset);
+        range.setEnd(text, startOffset + 1);
+        const startRect = range.getBoundingClientRect();
+
+        const endOffset = text.data.indexOf("maintainers") + "maintainers".length;
+        range.setStart(text, endOffset - 1);
+        range.setEnd(text, endOffset);
+        const endRect = range.getBoundingClientRect();
+
+        const y = startRect.y + startRect.height / 2;
+        internals.mouseDown(startRect.x + 1, y);
+        internals.mouseMove(endRect.right - 1, y);
+        internals.mouseUp(endRect.right - 1, y);
+
+        const selection = getSelection().toString();
+        println(`selected post text: ${selection.includes("source is a thankless job and maintainers")}`);
+        printElement(document.activeElement);
+    });
+</script>


### PR DESCRIPTION
Mouse selection used the only editing host below an ancestor even when the hit node was unrelated to that editor. On logged-in Reddit, the comment composer could take focus while dragging over post text and leave selection empty.

Only reuse a unique descendant editing host from an ancestor when its paintable rect intersects the hit node. This preserves the placeholder overlay behavior while avoiding distant editors.