### PR TITLE
UI/Qt: Avoid native ancestors for vertical tabs

### DIFF
--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1527,6 +1527,7 @@ TabWidget::TabWidget(QWidget* parent)
     m_vertical_tab_bar_column = new QWidget(this);
     m_vertical_tab_bar_column->setObjectName("LadybirdVerticalTabBar");
 #if defined(AK_OS_MACOS)
+    m_vertical_tab_bar_column->setAttribute(Qt::WA_DontCreateNativeAncestors);
     m_vertical_tab_bar_column->setAttribute(Qt::WA_NativeWindow);
 #endif
     m_vertical_tab_bar_column_layout = new QVBoxLayout(m_vertical_tab_bar_column);
@@ -1545,6 +1546,7 @@ TabWidget::TabWidget(QWidget* parent)
     m_vertical_tabs_resize_handle = new QWidget(this);
     m_vertical_tabs_resize_handle->setObjectName("LadybirdVerticalTabsResizeHandle");
 #if defined(AK_OS_MACOS)
+    m_vertical_tabs_resize_handle->setAttribute(Qt::WA_DontCreateNativeAncestors);
     m_vertical_tabs_resize_handle->setAttribute(Qt::WA_NativeWindow);
 #endif
     m_vertical_tabs_resize_handle->setCursor(Qt::SizeHorCursor);


### PR DESCRIPTION
Vertical tabs on macOS use native child widgets so their overlay can stay above the native web content view. However, Qt propagates WA_NativeWindow to widget ancestors unless WA_DontCreateNativeAncestors is set first.

That propagation made TabWidget gain a native QWidgetWindow. When a context menu opened, QMenu tried to use that non-top-level window as its transient parent. QWindow rejected it and logged that TabWidgetClassWindow must be a top level window.

Set WA_DontCreateNativeAncestors on the vertical tabs overlay widgets before WA_NativeWindow. This keeps those widgets native without forcing TabWidget to become native too.

This gets rid of all the `QWidgetWindow(0xc014d57a0, name="Ladybird::TabWidgetClassWindow") must be a top level window.` console warnings when opening context menus.