### PR TITLE
LibWeb: Add legacy WheelEvent wheelDelta aliases

### DIFF
--- a/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/WheelEvent.h>
 #include <LibWeb/HTML/EventNames.h>
@@ -17,12 +18,19 @@ namespace Web::UIEvents {
 
 GC_DEFINE_ALLOCATOR(WheelEvent);
 
+static WebIDL::Long legacy_wheel_delta_from_delta(double delta)
+{
+    return AK::clamp_to<WebIDL::Long>(-delta);
+}
+
 WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, Bindings::WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
     : MouseEvent(realm, event_name, event_init, page_x, page_y, offset_x, offset_y)
     , m_delta_x(event_init.delta_x)
     , m_delta_y(event_init.delta_y)
     , m_delta_z(event_init.delta_z)
     , m_delta_mode(event_init.delta_mode)
+    , m_wheel_delta_x(event_init.wheel_delta_x ? event_init.wheel_delta_x : legacy_wheel_delta_from_delta(event_init.delta_x))
+    , m_wheel_delta_y(event_init.wheel_delta_y ? event_init.wheel_delta_y : legacy_wheel_delta_from_delta(event_init.delta_y))
 {
 }
 

--- a/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -40,6 +40,9 @@ public:
     double delta_y() const { return m_delta_y; }
     double delta_z() const { return m_delta_z; }
     WebIDL::UnsignedLong delta_mode() const { return m_delta_mode; }
+    WebIDL::Long wheel_delta_x() const { return m_wheel_delta_x; }
+    WebIDL::Long wheel_delta_y() const { return m_wheel_delta_y; }
+    WebIDL::Long wheel_delta() const { return m_wheel_delta_y ? m_wheel_delta_y : m_wheel_delta_x; }
 
 private:
     WheelEvent(JS::Realm&, FlyString const& event_name, Bindings::WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);
@@ -50,6 +53,8 @@ private:
     double m_delta_y { 0 };
     double m_delta_z { 0 };
     WebIDL::UnsignedLong m_delta_mode { WheelDeltaMode::DOM_DELTA_PIXEL };
+    WebIDL::Long m_wheel_delta_x { 0 };
+    WebIDL::Long m_wheel_delta_y { 0 };
 };
 
 }

--- a/Libraries/LibWeb/UIEvents/WheelEvent.idl
+++ b/Libraries/LibWeb/UIEvents/WheelEvent.idl
@@ -12,6 +12,11 @@ interface WheelEvent : MouseEvent {
     readonly attribute double deltaY;
     readonly attribute double deltaZ;
     readonly attribute unsigned long deltaMode;
+
+    // Non-standard legacy MouseWheelEvent API replaced by standard WheelEvent API.
+    readonly attribute long wheelDeltaX;
+    readonly attribute long wheelDeltaY;
+    readonly attribute long wheelDelta;
 };
 
 // https://w3c.github.io/pointerevents/#idl-wheeleventinit
@@ -20,4 +25,8 @@ dictionary WheelEventInit : MouseEventInit {
     double deltaY = 0;
     double deltaZ = 0;
     unsigned long deltaMode = 0;
+
+    // Non-standard legacy members that we still support for backward compatibility.
+    long wheelDeltaX = 0;
+    long wheelDeltaY = 0;
 };

--- a/Tests/LibWeb/Text/expected/UIEvents/WheelEvent-construction.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/WheelEvent-construction.txt
@@ -2,6 +2,9 @@ deltaX: 0
 deltaY: 0
 deltaZ: 0
 deltaMode: 0
+wheelDeltaX: 0
+wheelDeltaY: 0
+wheelDelta: 0
 view: null
 screenX: 0
 screenY: 0
@@ -16,6 +19,9 @@ deltaX: 10
 deltaY: 20
 deltaZ: 35
 deltaMode: 2
+wheelDeltaX: -10
+wheelDeltaY: -20
+wheelDelta: -20
 view: null
 screenX: 1
 screenY: 2
@@ -25,3 +31,20 @@ ctrlKey: true
 altKey: true
 shiftKey: false
 metaKey: true
+
+deltaX: 10
+deltaY: 20
+deltaZ: 0
+deltaMode: 0
+wheelDeltaX: 30
+wheelDeltaY: 40
+wheelDelta: 40
+view: null
+screenX: 0
+screenY: 0
+clientX: 0
+clientY: 0
+ctrlKey: false
+altKey: false
+shiftKey: false
+metaKey: false

--- a/Tests/LibWeb/Text/expected/UIEvents/wheel-event-legacy-deltas.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/wheel-event-legacy-deltas.txt
@@ -1,0 +1,4 @@
+wheelDeltaX: 0
+wheelDeltaY: -100
+wheelDelta: -100
+scrollY: 100

--- a/Tests/LibWeb/Text/input/UIEvents/WheelEvent-construction.html
+++ b/Tests/LibWeb/Text/input/UIEvents/WheelEvent-construction.html
@@ -6,6 +6,9 @@
         println("deltaY: " + wheelEvent.deltaY);
         println("deltaZ: " + wheelEvent.deltaZ);
         println("deltaMode: " + wheelEvent.deltaMode);
+        println("wheelDeltaX: " + wheelEvent.wheelDeltaX);
+        println("wheelDeltaY: " + wheelEvent.wheelDeltaY);
+        println("wheelDelta: " + wheelEvent.wheelDelta);
         println("view: " + wheelEvent.view);
         println("screenX: " + wheelEvent.screenX);
         println("screenY: " + wheelEvent.screenY);
@@ -33,6 +36,13 @@
             altKey: true,
             shiftKey: false,
             metaKey: true,
+        }));
+        println('');
+        dumpWheelEvent(new WheelEvent('wheel', {
+            deltaX: 10,
+            deltaY: 20,
+            wheelDeltaX: 30,
+            wheelDeltaY: 40,
         }));
     });
 </script>

--- a/Tests/LibWeb/Text/input/UIEvents/wheel-event-legacy-deltas.html
+++ b/Tests/LibWeb/Text/input/UIEvents/wheel-event-legacy-deltas.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+        height: 2000px;
+    }
+</style>
+<script>
+    promiseTest(async () => {
+        let wheelDeltaX = null;
+        let wheelDeltaY = null;
+        let wheelDelta = null;
+
+        window.addEventListener("wheel", event => {
+            wheelDeltaX = event.wheelDeltaX;
+            wheelDeltaY = event.wheelDeltaY;
+            wheelDelta = event.wheelDelta;
+            window.scrollBy(-event.wheelDeltaX, -event.wheelDeltaY);
+            event.preventDefault();
+        }, { passive: false });
+
+        await internals.wheel(50, 50, 0, 100);
+
+        println(`wheelDeltaX: ${wheelDeltaX}`);
+        println(`wheelDeltaY: ${wheelDeltaY}`);
+        println(`wheelDelta: ${wheelDelta}`);
+        println(`scrollY: ${window.scrollY}`);
+    });
+</script>


### PR DESCRIPTION
Add `wheelDeltaX`, `wheelDeltaY`, and `wheelDelta` accessors, plus the matching `WheelEventInit` fields.

Use negative legacy values for down and right scrolling so old smooth-scroll handlers can prevent default and still drive scrolling.

Cover constructor behavior and a Bookspry-style listener that reads legacy deltas, calls `scrollBy()`, and prevents default.

Fixes broken wheel scrolling on https://bookspry.com/