### PR TITLE
LibMedia: Only re-request if the request head changed

### DIFF
--- a/Libraries/LibMedia/IncrementallyPopulatedStream.cpp
+++ b/Libraries/LibMedia/IncrementallyPopulatedStream.cpp
@@ -91,7 +91,8 @@ void IncrementallyPopulatedStream::add_chunk_at(u64 offset, ReadonlyBytes data)
         next_chunk.data().bytes().copy_to(buffer.bytes().slice(next_chunk.offset() - chunk.offset()));
     }
 
-    begin_new_request_while_locked(chunk.end());
+    if (chunk.end() != new_chunk_end)
+        begin_new_request_while_locked(chunk.end());
     m_state_changed.broadcast();
 }
 


### PR DESCRIPTION
When the if statement for coalescing overlapping chunks was changed to a loop, the re-request conditional on that coalescence was made unconditional instead. That meant that we would spam requests for every chunk received. Let's not do that.