### PR TITLE
LibGfx: Do not paint default ignorable glyphs

### DIFF
--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -14,6 +14,7 @@
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/TextLayout.h>
+#include <LibUnicode/CharacterTypes.h>
 #include <core/SkFont.h>
 #include <core/SkTextBlob.h>
 #include <harfbuzz/hb.h>
@@ -56,7 +57,11 @@ void GlyphRun::ensure_text_blob(float scale) const
         return;
 
     auto sk_font = m_font->skia_font(scale);
-    auto glyph_count = m_glyphs.size();
+    size_t glyph_count = 0;
+    for (auto const& glyph : m_glyphs) {
+        if (glyph.should_paint)
+            ++glyph_count;
+    }
 
     m_cached_text_blob = make<CachedTextBlob>();
     m_cached_text_blob->scale = scale;
@@ -68,10 +73,14 @@ void GlyphRun::ensure_text_blob(float scale) const
     auto const& run = builder.allocRunPos(sk_font, glyph_count);
 
     float font_ascent = m_font->pixel_metrics().ascent;
-    for (size_t i = 0; i < glyph_count; ++i) {
-        run.glyphs[i] = m_glyphs[i].glyph_id;
-        run.pos[i * 2] = m_glyphs[i].position.x() * scale;
-        run.pos[i * 2 + 1] = (m_glyphs[i].position.y() + font_ascent) * scale;
+    size_t painted_glyph_index = 0;
+    for (auto const& glyph : m_glyphs) {
+        if (!glyph.should_paint)
+            continue;
+        run.glyphs[painted_glyph_index] = glyph.glyph_id;
+        run.pos[painted_glyph_index * 2] = glyph.position.x() * scale;
+        run.pos[painted_glyph_index * 2 + 1] = (glyph.position.y() + font_ascent) * scale;
+        ++painted_glyph_index;
     }
 
     m_cached_text_blob->blob = builder.make();
@@ -227,7 +236,15 @@ static NonnullOwnPtr<ShapedGlyphs> build_origin_relative_shape(Utf16View const& 
         return string.length_in_code_units() - starting_offset;
     };
 
+    auto should_paint_glyph = [&](auto index) {
+        auto starting_offset = glyph_info[index].cluster;
+        if (starting_offset >= string.length_in_code_units())
+            return true;
+        return !Unicode::code_point_has_default_ignorable_code_point_property(string.code_point_at(starting_offset));
+    };
+
     for (size_t i = 0; i < glyph_count; ++i) {
+        bool should_paint = should_paint_glyph(i);
         auto position = point
             - FloatPoint { 0, metrics.ascent }
             + FloatPoint { positions[i].x_offset, positions[i].y_offset } / text_shaping_resolution;
@@ -235,9 +252,13 @@ static NonnullOwnPtr<ShapedGlyphs> build_origin_relative_shape(Utf16View const& 
         glyphs.unchecked_append({
             .position = position,
             .length_in_code_units = glyph_length_in_code_units(i),
-            .glyph_width = positions[i].x_advance / text_shaping_resolution + letter_spacing,
+            .glyph_width = should_paint ? positions[i].x_advance / text_shaping_resolution + letter_spacing : 0,
             .glyph_id = glyph_info[i].codepoint,
+            .should_paint = should_paint,
         });
+
+        if (!should_paint)
+            continue;
 
         point += FloatPoint { positions[i].x_advance, positions[i].y_advance } / text_shaping_resolution;
 

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -28,6 +28,7 @@ struct DrawGlyph {
     size_t length_in_code_units { 0 };
     float glyph_width { 0.0 };
     u32 glyph_id { 0 };
+    bool should_paint { true };
 };
 
 struct ShapedGlyphs {

--- a/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Libraries/LibUnicode/CharacterTypes.cpp
@@ -268,6 +268,11 @@ bool code_point_has_emoji_presentation_property(u32 code_point)
     return code_point_has_property(code_point, UCHAR_EMOJI_PRESENTATION);
 }
 
+bool code_point_has_default_ignorable_code_point_property(u32 code_point)
+{
+    return code_point_has_property(code_point, UCHAR_DEFAULT_IGNORABLE_CODE_POINT);
+}
+
 bool code_point_has_identifier_start_property(u32 code_point)
 {
     return u_isIDStart(static_cast<UChar32>(code_point));

--- a/Libraries/LibUnicode/CharacterTypes.h
+++ b/Libraries/LibUnicode/CharacterTypes.h
@@ -35,6 +35,7 @@ bool code_point_has_property(u32 code_point, Property property, CaseSensitivity 
 bool code_point_has_emoji_property(u32 code_point);
 bool code_point_has_emoji_modifier_base_property(u32 code_point);
 bool code_point_has_emoji_presentation_property(u32 code_point);
+bool code_point_has_default_ignorable_code_point_property(u32 code_point);
 bool code_point_has_identifier_start_property(u32 code_point);
 bool code_point_has_identifier_continue_property(u32 code_point);
 bool code_point_has_regional_indicator_property(u32 code_point);

--- a/Tests/LibWeb/Ref/expected/default-ignorable-code-points-not-painted-ref.html
+++ b/Tests/LibWeb/Ref/expected/default-ignorable-code-points-not-painted-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+body {
+    font: 24px Arial;
+}
+input, div {
+    box-sizing: border-box;
+    display: block;
+    width: 400px;
+    margin: 12px;
+    padding: 6px 8px;
+    font: inherit;
+}
+input::placeholder {
+    color: black;
+    opacity: 1;
+}
+</style>
+<input placeholder="Search in r/programming">
+<div>Search in r/programming</div>

--- a/Tests/LibWeb/Ref/input/default-ignorable-code-points-not-painted.html
+++ b/Tests/LibWeb/Ref/input/default-ignorable-code-points-not-painted.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/default-ignorable-code-points-not-painted-ref.html" />
+<style>
+body {
+    font: 24px Arial;
+}
+input, div {
+    box-sizing: border-box;
+    display: block;
+    width: 400px;
+    margin: 12px;
+    padding: 6px 8px;
+    font: inherit;
+}
+input::placeholder {
+    color: black;
+    opacity: 1;
+}
+</style>
+<input placeholder="Search in &#8296;r/programming&#8297;">
+<div>Search in &#8296;r/programming&#8297;</div>


### PR DESCRIPTION
Default ignorable code points such as bidi isolates can be shaped into last-resort glyphs when the selected font does not provide an invisible glyph. Keep glyph records for text bookkeeping, but mark those glyphs as non-painting and avoid advancing by them when HarfBuzz gives them their own glyph.

Add ref coverage for bidi isolates in regular text and input placeholder text so they render the same as the surrounding text without isolates.

Fixes this visual glitch when logged into Reddit:

<img width="669" height="53" alt="Screenshot 2026-07-09 at 13 13 41" src="https://github.com/user-attachments/assets/0e3bb33b-37bd-46c4-97a7-bf25fc680e60" />
