### PR TITLE
LibWeb: Do not start transitions on previously unrendered elements

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -85,8 +85,10 @@ ComputedProperties::Builder::Builder(ComputedProperties const& style)
     m_data->raw_cascaded_font_size = style.data().raw_cascaded_font_size;
     m_depends_on_viewport_metrics = style.depends_on_viewport_metrics();
     m_font_metrics_depend_on_viewport_metrics = style.font_metrics_depend_on_viewport_metrics();
+    m_in_display_none_subtree = style.in_display_none_subtree();
     m_style->m_depends_on_viewport_metrics = m_depends_on_viewport_metrics;
     m_style->m_font_metrics_depend_on_viewport_metrics = m_font_metrics_depend_on_viewport_metrics;
+    m_style->m_in_display_none_subtree = m_in_display_none_subtree;
     if (style.m_animated_properties)
         m_style->m_animated_properties = adopt_ref(*new AnimatedProperties(*style.m_animated_properties));
 }
@@ -95,6 +97,7 @@ NonnullRefPtr<ComputedProperties> ComputedProperties::Builder::build() &&
 {
     m_style->m_depends_on_viewport_metrics = m_depends_on_viewport_metrics;
     m_style->m_font_metrics_depend_on_viewport_metrics = m_font_metrics_depend_on_viewport_metrics;
+    m_style->m_in_display_none_subtree = m_in_display_none_subtree;
     return move(m_style);
 }
 
@@ -282,6 +285,12 @@ void ComputedProperties::Builder::set_font_metrics_depend_on_viewport_metrics()
 {
     m_font_metrics_depend_on_viewport_metrics = true;
     m_style->m_font_metrics_depend_on_viewport_metrics = true;
+}
+
+void ComputedProperties::Builder::set_in_display_none_subtree()
+{
+    m_in_display_none_subtree = true;
+    m_style->m_in_display_none_subtree = true;
 }
 
 void ComputedProperties::set_depends_on_viewport_metrics(Badge<StyleComputer>)

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -93,6 +93,7 @@ public:
         void set_property_inherited(PropertyID, Inherited);
         void set_depends_on_viewport_metrics();
         void set_font_metrics_depend_on_viewport_metrics();
+        void set_in_display_none_subtree();
         void set_has_pseudo_element_style(PseudoElement);
 
         void set_property(PropertyID, NonnullRefPtr<StyleValue const> value, Inherited = Inherited::No, Important = Important::No);
@@ -118,6 +119,7 @@ public:
         NonnullRefPtr<ComputedProperties> m_style;
         bool m_depends_on_viewport_metrics { false };
         bool m_font_metrics_depend_on_viewport_metrics { false };
+        bool m_in_display_none_subtree { false };
     };
 
     static NonnullRefPtr<ComputedProperties> create(Builder&&);
@@ -146,6 +148,10 @@ public:
     bool is_animated_property_result_of_transition(PropertyID property_id) const;
     bool depends_on_viewport_metrics() const { return m_depends_on_viewport_metrics; }
     bool font_metrics_depend_on_viewport_metrics() const { return m_font_metrics_depend_on_viewport_metrics; }
+    // Whether the element this style was computed for has computed display none, or is a descendant of one that does.
+    bool in_display_none_subtree() const { return m_in_display_none_subtree; }
+    void set_in_display_none_subtree(Badge<DOM::Element>) { m_in_display_none_subtree = true; }
+    void set_in_display_none_subtree(Badge<DOM::SyntheticPseudoElement>) { m_in_display_none_subtree = true; }
     bool has_pseudo_element_style(PseudoElement) const;
     void set_depends_on_viewport_metrics(Badge<StyleComputer>);
     void set_font_metrics_depend_on_viewport_metrics(Badge<StyleComputer>);
@@ -371,6 +377,7 @@ private:
     RefPtr<AnimatedProperties> m_animated_properties;
     bool m_depends_on_viewport_metrics { false };
     bool m_font_metrics_depend_on_viewport_metrics { false };
+    bool m_in_display_none_subtree { false };
 
     mutable RefPtr<Gfx::FontCascadeList const> m_cached_computed_font_list;
     mutable RefPtr<Gfx::Font const> m_cached_first_available_computed_font;

--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -722,6 +722,8 @@ ValueComparingRefPtr<StyleValue const> interpolate_property(DOM::Element& elemen
             auto to_is_hidden = to->to_keyword() == Keyword::Hidden;
 
             if (from_is_hidden || to_is_hidden) {
+                if (allow_discrete == AllowDiscrete::No)
+                    return {};
                 auto non_hidden_value = from_is_hidden ? to : from;
                 if (delta <= 0)
                     return from;
@@ -748,6 +750,8 @@ ValueComparingRefPtr<StyleValue const> interpolate_property(DOM::Element& elemen
             auto to_is_none = to->as_display().display().is_none();
 
             if (from_is_none || to_is_none) {
+                if (allow_discrete == AllowDiscrete::No)
+                    return {};
                 auto non_none_value = from_is_none ? to : from;
                 if (delta <= 0)
                     return from;

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3302,12 +3302,29 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
     if (!abstract_element.pseudo_element().has_value())
         abstract_element.element().adjust_computed_style(builder);
 
+    bool parent_style_in_display_none_subtree = false;
+    if (auto parent = abstract_element.element_to_inherit_style_from(); parent.has_value()) {
+        if (auto parent_style = parent->computed_properties())
+            parent_style_in_display_none_subtree = parent_style->in_display_none_subtree();
+    }
+
     // Transition declarations [css-transitions-1]
     // Theoretically this should be part of the cascade, but it works with computed values, which we don't have until now.
     compute_transitioned_properties(computed_style, abstract_element);
     if (auto previous_style = abstract_element.computed_properties()) {
-        start_needed_transitions(*previous_style, builder, abstract_element);
+        // https://drafts.csswg.org/css-transitions-2/#defining-before-change-style
+        // In Level 1 of this specification, transitions can only start during a style change event for elements which
+        // have a defined before-change style established by the previous style change event. That means a transition
+        // could not be started on an element that was not being rendered for the previous style change event.
+        // FIXME: If an element does not have a before-change style for a given style change event, the starting style
+        //        is used instead of the before-change style to compare with the after-change style to start
+        //        transitions.
+        if (!previous_style->in_display_none_subtree() && !parent_style_in_display_none_subtree)
+            start_needed_transitions(*previous_style, builder, abstract_element);
     }
+
+    if (parent_style_in_display_none_subtree || builder.display().is_none())
+        builder.set_in_display_none_subtree();
 
     return CSS::ComputedProperties::create(move(builder));
 }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1128,6 +1128,15 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style(bool& did_cha
         });
     }
 
+    // NB: Elements inside a display:none subtree keep their last computed style without being recomputed, so
+    //     crossing the display:none boundary must update those styles for all descendants.
+    if (old_computed_properties && old_computed_properties->display().is_none() != m_computed_properties->display().is_none()) {
+        if (m_computed_properties->display().is_none())
+            set_in_display_none_subtree_on_descendant_styles();
+        else if (!m_computed_properties->in_display_none_subtree())
+            mark_descendants_with_stale_styles_for_style_update();
+    }
+
     invalidation |= recompute_pseudo_element_styles(did_change_custom_properties, had_list_marker, old_computed_properties.ptr());
 
     if (invalidation.is_none()) {
@@ -1138,6 +1147,41 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style(bool& did_cha
     apply_computed_style_to_layout_node_if_needed(invalidation);
 
     return invalidation;
+}
+
+void Element::set_in_display_none_subtree_on_descendant_styles()
+{
+    for_each_shadow_including_descendant([](auto& node) {
+        auto* element = as_if<Element>(node);
+        if (!element)
+            return TraversalDecision::Continue;
+        auto const& style = element->m_computed_properties;
+        if (!style)
+            return TraversalDecision::SkipChildrenAndContinue;
+        if (style->in_display_none_subtree())
+            return TraversalDecision::SkipChildrenAndContinue;
+        style->set_in_display_none_subtree(Badge<Element> {});
+        element->for_each_synthetic_pseudo_element([](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
+            pseudo_element.set_computed_properties_in_display_none_subtree();
+        });
+        return TraversalDecision::Continue;
+    });
+}
+
+void Element::mark_descendants_with_stale_styles_for_style_update()
+{
+    for_each_shadow_including_descendant([](auto& node) {
+        auto* element = as_if<Element>(node);
+        if (!element)
+            return TraversalDecision::Continue;
+        auto const& style = element->m_computed_properties;
+        if (!style)
+            return TraversalDecision::SkipChildrenAndContinue;
+        if (style->display().is_none())
+            return TraversalDecision::SkipChildrenAndContinue;
+        element->set_needs_style_update(true);
+        return TraversalDecision::Continue;
+    });
 }
 
 CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style(ScheduleAnimationUpdate schedule_animation_update)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -687,6 +687,8 @@ private:
     void exit_fullscreen_on_element_removal();
     CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedProperties const* old_originating_style);
     void apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
+    void set_in_display_none_subtree_on_descendant_styles();
+    void mark_descendants_with_stale_styles_for_style_update();
 
     WebIDL::ExceptionOr<GC::Ptr<Node>> insert_adjacent(StringView where, GC::Ref<Node> node);
 

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -56,6 +56,12 @@ void SyntheticPseudoElement::set_computed_properties(RefPtr<CSS::ComputedPropert
     m_computed_properties = value;
 }
 
+void SyntheticPseudoElement::set_computed_properties_in_display_none_subtree()
+{
+    if (m_computed_properties)
+        m_computed_properties->set_in_display_none_subtree(Badge<SyntheticPseudoElement> {});
+}
+
 RefPtr<CSS::CustomPropertyData const> SyntheticPseudoElement::custom_property_data() const
 {
     if (!m_custom_property_data)

--- a/Libraries/LibWeb/DOM/PseudoElement.h
+++ b/Libraries/LibWeb/DOM/PseudoElement.h
@@ -55,6 +55,7 @@ public:
     RefPtr<CSS::ComputedProperties const> computed_properties() const override;
     void update_animated_properties(Badge<Web::Animations::KeyframeEffect> const&, DOM::AbstractElement, Web::Animations::KeyframeEffect&, Web::Animations::AnimationUpdateContext&) override;
     void set_computed_properties(RefPtr<CSS::ComputedProperties> value);
+    void set_computed_properties_in_display_none_subtree();
 
     RefPtr<CSS::CustomPropertyData const> custom_property_data() const override;
     void set_custom_property_data(RefPtr<CSS::CustomPropertyData const> value) override;

--- a/Tests/LibWeb/Text/expected/css/display-transitions-require-allow-discrete.txt
+++ b/Tests/LibWeb/Text/expected/css/display-transitions-require-allow-discrete.txt
@@ -1,0 +1,4 @@
+display without allow-discrete: none
+transitions on display without allow-discrete: 0
+content-visibility without allow-discrete: hidden
+transitions on content-visibility without allow-discrete: 0

--- a/Tests/LibWeb/Text/expected/css/transitions-not-started-after-mutations-in-display-none-subtree.txt
+++ b/Tests/LibWeb/Text/expected/css/transitions-not-started-after-mutations-in-display-none-subtree.txt
@@ -1,0 +1,6 @@
+opacity of descendant mutated while hidden: 0
+animations on descendant mutated while hidden: 0
+opacity read while hidden: 0
+animations on descendant read while hidden: 0
+animations on descendant mutated after reveal: 1
+animations on descendant mutated while being hidden: 0

--- a/Tests/LibWeb/Text/expected/css/transitions-not-started-when-revealed-from-display-none.txt
+++ b/Tests/LibWeb/Text/expected/css/transitions-not-started-when-revealed-from-display-none.txt
@@ -1,0 +1,5 @@
+opacity of element revealed from display none: 1
+animations on element revealed from display none: 0
+opacity of descendant of revealed subtree: 1
+animations on descendant of revealed subtree: 0
+animations on element rendered throughout: 1

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/display-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/display-interpolation.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 138 tests
 
-134 Pass
-4 Fail
+138 Pass
 Pass	CSS Transitions: property <display> from [block] to [none] at (-1) should be [block]
 Pass	CSS Transitions: property <display> from [block] to [none] at (0) should be [block]
 Pass	CSS Transitions: property <display> from [block] to [none] at (0.1) should be [block]
@@ -28,14 +27,14 @@ Pass	Web Animations: property <display> from [block] to [none] at (0.1) should b
 Pass	Web Animations: property <display> from [block] to [none] at (0.9) should be [block]
 Pass	Web Animations: property <display> from [block] to [none] at (1) should be [none]
 Pass	Web Animations: property <display> from [block] to [none] at (1.5) should be [none]
-Fail	CSS Transitions: property <display> from [none] to [block] at (-1) should be [block]
-Fail	CSS Transitions: property <display> from [none] to [block] at (0) should be [block]
+Pass	CSS Transitions: property <display> from [none] to [block] at (-1) should be [block]
+Pass	CSS Transitions: property <display> from [none] to [block] at (0) should be [block]
 Pass	CSS Transitions: property <display> from [none] to [block] at (0.1) should be [block]
 Pass	CSS Transitions: property <display> from [none] to [block] at (0.9) should be [block]
 Pass	CSS Transitions: property <display> from [none] to [block] at (1) should be [block]
 Pass	CSS Transitions: property <display> from [none] to [block] at (1.5) should be [block]
-Fail	CSS Transitions with transition: all: property <display> from [none] to [block] at (-1) should be [block]
-Fail	CSS Transitions with transition: all: property <display> from [none] to [block] at (0) should be [block]
+Pass	CSS Transitions with transition: all: property <display> from [none] to [block] at (-1) should be [block]
+Pass	CSS Transitions with transition: all: property <display> from [none] to [block] at (0) should be [block]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [block] at (0.1) should be [block]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [block] at (0.9) should be [block]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [block] at (1) should be [block]

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-display/animations/display-interpolation-none.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-display/animations/display-interpolation-none.txt
@@ -1,0 +1,30 @@
+Harness status: OK
+
+Found 25 tests
+
+25 Pass
+Pass	CSS Transitions: property <display> from [none] to [flex] at (-0.3) should be [flex]
+Pass	CSS Transitions: property <display> from [none] to [flex] at (0) should be [flex]
+Pass	CSS Transitions: property <display> from [none] to [flex] at (0.3) should be [flex]
+Pass	CSS Transitions: property <display> from [none] to [flex] at (0.5) should be [flex]
+Pass	CSS Transitions: property <display> from [none] to [flex] at (0.6) should be [flex]
+Pass	CSS Transitions: property <display> from [none] to [flex] at (1) should be [flex]
+Pass	CSS Transitions: property <display> from [none] to [flex] at (1.5) should be [flex]
+Pass	CSS Transitions: property <display> from [flex] to [none] at (-1) should be [flex]
+Pass	CSS Transitions: property <display> from [flex] to [none] at (0) should be [flex]
+Pass	CSS Transitions: property <display> from [flex] to [none] at (0.3) should be [flex]
+Pass	CSS Transitions: property <display> from [flex] to [none] at (0.5) should be [flex]
+Pass	CSS Transitions: property <display> from [flex] to [none] at (0.7) should be [flex]
+Pass	CSS Transitions: property <display> from [flex] to [none] at (1) should be [none]
+Pass	CSS Animations: property <display> from [none] to [flex] at (-1) should be [none]
+Pass	CSS Animations: property <display> from [none] to [flex] at (0) should be [none]
+Pass	CSS Animations: property <display> from [none] to [flex] at (0.3) should be [flex]
+Pass	CSS Animations: property <display> from [none] to [flex] at (0.5) should be [flex]
+Pass	CSS Animations: property <display> from [none] to [flex] at (1) should be [flex]
+Pass	CSS Animations: property <display> from [none] to [flex] at (2) should be [flex]
+Pass	Web Animations: property <display> from [none] to [flex] at (-1) should be [none]
+Pass	Web Animations: property <display> from [none] to [flex] at (0) should be [none]
+Pass	Web Animations: property <display> from [none] to [flex] at (0.3) should be [flex]
+Pass	Web Animations: property <display> from [none] to [flex] at (0.5) should be [flex]
+Pass	Web Animations: property <display> from [none] to [flex] at (1) should be [flex]
+Pass	Web Animations: property <display> from [none] to [flex] at (2) should be [flex]

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-display/animations/display-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-display/animations/display-interpolation.txt
@@ -2,31 +2,31 @@ Harness status: OK
 
 Found 42 tests
 
-20 Pass
-22 Fail
-Fail	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (-0.3) should be [flex]
-Fail	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0) should be [flex]
+28 Pass
+14 Fail
+Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (-0.3) should be [flex]
+Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0.3) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0.5) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0.6) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (1) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (1.5) should be [flex]
-Fail	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (-0.3) should be [flex]
-Fail	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (0) should be [flex]
+Pass	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (-0.3) should be [flex]
+Pass	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (0) should be [flex]
 Pass	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (0.3) should be [flex]
 Pass	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (0.5) should be [flex]
 Pass	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (0.6) should be [flex]
 Pass	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (1) should be [flex]
 Pass	CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <display> from [none] to [flex] at (1.5) should be [flex]
-Fail	CSS Transitions: property <display> from [none] to [flex] at (-0.3) should be [flex]
-Fail	CSS Transitions: property <display> from [none] to [flex] at (0) should be [flex]
+Pass	CSS Transitions: property <display> from [none] to [flex] at (-0.3) should be [flex]
+Pass	CSS Transitions: property <display> from [none] to [flex] at (0) should be [flex]
 Pass	CSS Transitions: property <display> from [none] to [flex] at (0.3) should be [flex]
 Pass	CSS Transitions: property <display> from [none] to [flex] at (0.5) should be [flex]
 Pass	CSS Transitions: property <display> from [none] to [flex] at (0.6) should be [flex]
 Pass	CSS Transitions: property <display> from [none] to [flex] at (1) should be [flex]
 Pass	CSS Transitions: property <display> from [none] to [flex] at (1.5) should be [flex]
-Fail	CSS Transitions with transition: all: property <display> from [none] to [flex] at (-0.3) should be [flex]
-Fail	CSS Transitions with transition: all: property <display> from [none] to [flex] at (0) should be [flex]
+Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (-0.3) should be [flex]
+Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (0) should be [flex]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (0.3) should be [flex]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (0.5) should be [flex]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (0.6) should be [flex]

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/display-none-no-animations.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/display-none-no-animations.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Transitions and animations should not occur on display:none elements.

--- a/Tests/LibWeb/Text/input/css/display-transitions-require-allow-discrete.html
+++ b/Tests/LibWeb/Text/input/css/display-transitions-require-allow-discrete.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #plain-display, #plain-content-visibility {
+        transition: all 1s;
+    }
+</style>
+<div id="plain-display"></div>
+<div id="plain-content-visibility"></div>
+<script>
+    test(() => {
+        const plainDisplay = document.getElementById("plain-display");
+        getComputedStyle(plainDisplay).display;
+        plainDisplay.style.display = "none";
+        println("display without allow-discrete: " + getComputedStyle(plainDisplay).display);
+        println("transitions on display without allow-discrete: " + plainDisplay.getAnimations().length);
+
+        const plainContentVisibility = document.getElementById("plain-content-visibility");
+        getComputedStyle(plainContentVisibility).contentVisibility;
+        plainContentVisibility.style.contentVisibility = "hidden";
+        println("content-visibility without allow-discrete: " + getComputedStyle(plainContentVisibility).contentVisibility);
+        println("transitions on content-visibility without allow-discrete: " + plainContentVisibility.getAnimations().length);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/transitions-not-started-after-mutations-in-display-none-subtree.html
+++ b/Tests/LibWeb/Text/input/css/transitions-not-started-after-mutations-in-display-none-subtree.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .grandchild {
+        opacity: 1;
+        transition: opacity 0.5s linear;
+    }
+</style>
+<div id="container1"><div><div class="grandchild" id="g1"></div></div></div>
+<div id="container2"><div><div class="grandchild" id="g2"></div></div></div>
+<div id="container3"><div><div class="grandchild" id="g3"></div></div></div>
+<div id="container4"><div><div class="grandchild" id="g4"></div></div></div>
+<script>
+    asyncTest(async done => {
+        const nextFrame = () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        // Resolve the before-change style for all elements while they are rendered.
+        getComputedStyle(g1).opacity;
+        await nextFrame();
+
+        // A property changed on a descendant while its subtree was hidden must not transition when revealed.
+        container1.style.display = "none";
+        await nextFrame();
+        g1.style.opacity = "0";
+        await nextFrame();
+        container1.style.display = "block";
+        await nextFrame();
+        println("opacity of descendant mutated while hidden: " + getComputedStyle(g1).opacity);
+        println("animations on descendant mutated while hidden: " + g1.getAnimations().length);
+
+        // Reading the computed style of a mutated descendant while still hidden must not start a transition and
+        // must observe the new value.
+        container2.style.display = "none";
+        await nextFrame();
+        g2.style.opacity = "0";
+        await nextFrame();
+        println("opacity read while hidden: " + getComputedStyle(g2).opacity);
+        println("animations on descendant read while hidden: " + g2.getAnimations().length);
+
+        // A property changed after the subtree was hidden and revealed again must still transition.
+        container3.style.display = "none";
+        await nextFrame();
+        container3.style.display = "block";
+        await nextFrame();
+        g3.style.opacity = "0";
+        await nextFrame();
+        println("animations on descendant mutated after reveal: " + g3.getAnimations().length);
+
+        // A property changed in the same style change event that hides the subtree must not transition.
+        container4.style.display = "none";
+        g4.style.opacity = "0";
+        await nextFrame();
+        println("animations on descendant mutated while being hidden: " + g4.getAnimations().length);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/transitions-not-started-when-revealed-from-display-none.html
+++ b/Tests/LibWeb/Text/input/css/transitions-not-started-when-revealed-from-display-none.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #revealed-element {
+        opacity: 0;
+        display: none;
+        transition: opacity 100s linear;
+    }
+    .shown #revealed-element {
+        opacity: 1;
+        display: block;
+    }
+
+    #hidden-subtree {
+        display: none;
+    }
+    .shown #hidden-subtree {
+        display: block;
+    }
+
+    #descendant {
+        opacity: 0;
+        transition: opacity 100s linear;
+    }
+    .shown #descendant {
+        opacity: 1;
+    }
+
+    #control {
+        opacity: 0;
+        transition: opacity 100s linear;
+    }
+    .shown #control {
+        opacity: 1;
+    }
+</style>
+<div id="container">
+    <div id="revealed-element"></div>
+    <div id="hidden-subtree">
+        <div id="descendant"></div>
+    </div>
+    <div id="control"></div>
+</div>
+<script>
+    test(() => {
+        const revealedElement = document.getElementById("revealed-element");
+        const descendant = document.getElementById("descendant");
+        const control = document.getElementById("control");
+
+        // Resolve the before-change style.
+        getComputedStyle(revealedElement).opacity;
+        getComputedStyle(descendant).opacity;
+        getComputedStyle(control).opacity;
+
+        document.getElementById("container").classList.add("shown");
+
+        println(`opacity of element revealed from display none: ${getComputedStyle(revealedElement).opacity}`);
+        println(`animations on element revealed from display none: ${revealedElement.getAnimations().length}`);
+        println(`opacity of descendant of revealed subtree: ${getComputedStyle(descendant).opacity}`);
+        println(`animations on descendant of revealed subtree: ${descendant.getAnimations().length}`);
+        getComputedStyle(control).opacity;
+        println(`animations on element rendered throughout: ${control.getAnimations().length}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-display/animations/display-interpolation-none.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-display/animations/display-interpolation-none.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<meta name="assert" content="display: none is animatable with a non-none underlying value">
+<title>display interpolation</title>
+<link rel="help" href="https://www.w3.org/TR/CSS2/visuren.html#display-prop">
+<link rel="help" href="https://www.w3.org/TR/css-animations-2/#owning-element-section">
+<meta name="assert" content="display supports animation">
+
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/interpolation-testcommon.js"></script>
+
+<body>
+  <script>
+    /* none -> non-none: not allowed, since animations/transitions can't start when display is none. */
+    test_not_animatable({
+      property: 'display',
+      behavior: 'allow-discrete',
+      from: 'none',
+      to: 'flex',
+      underlying: 'none',
+      target_names: ['CSS Transitions']
+    });
+    /* non-none -> none: allowed. Value will remain non-none until transition finishes */
+    test_interpolation({
+      property: 'display',
+      behavior: 'allow-discrete',
+      from: 'flex',
+      to: 'none',
+      underlying: 'flex',
+      target_names: ['CSS Transitions']
+    }, [
+      { at: -1, expect: "flex" },
+      { at: 0, expect: "flex" },
+      { at: 0.3, expect: "flex" },
+      { at: 0.5, expect: "flex" },
+      { at: 0.7, expect: "flex" }, /* prefers the non-none value */
+      { at: 1, expect: "none" },
+    ]);
+    test_interpolation({
+      property: 'display',
+      from: 'none',
+      to: 'flex',
+      underlying: 'block',
+      target_names: ['CSS Animations', 'Web Animations']
+    }, [
+      { at: -1, expect: "none" },
+      { at: 0, expect: "none" },
+      { at: 0.3, expect: "flex" }, /* prefers the non-none value */
+      { at: 0.5, expect: "flex" },
+      { at: 1, expect: "flex" },
+      { at: 2, expect: "flex" }
+    ]);
+  </script>
+</body>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/display-none-no-animations.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/display-none-no-animations.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel=help href="mailto:jarhar@chromium.org">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id=target>target</div>
+<style>
+#target {
+  display: none;
+  transition: 1s;
+  color: red;
+}
+#target.animated {
+  transition: 1s;
+  color: green;
+}
+</style>
+
+<script>
+test(() => {
+  target.addEventListener('transitionstart', () => {
+    assert_unreached('transitionstart should not be fired.');
+  });
+  target.classList.add('animated');
+  assert_equals(target.getAnimations().length, 0,
+    'There should not be any animations running.');
+}, 'Transitions and animations should not occur on display:none elements.');
+</script>


### PR DESCRIPTION
Transitions may only start during a style change event for elements that have a before-change style established by the previous style change event. An element that was not being rendered at that event has
no before-change style. Previously, transitions started whenever an element had any previous computed style, so revealing a `display:none` subtree started transitions from the hidden state instead of jumping
directly to the new style.

Computed style now records whether it was computed inside a `display:none` subtree, and no transitions start when the previous style or the parent's current style carries this flag. Since styles
inside a hidden subtree are kept without recomputation, hiding an element flags the styles of its descendants, and revealing it schedules them for recomputation so that stale styles from the hidden period are
never used as a before-change style.

I've also included a related change to ensure the `display`  and `content-visibility` properties respect `allow-discrete`. While these have a custom animation type for this purpose the animation type is considered discrete.

Fixes #9392