### PR TITLE
LibWeb: Density-correct srcset image intrinsic sizes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -359,12 +359,33 @@ void HTMLImageElement::set_height(WebIDL::UnsignedLong height)
     set_attribute_value(HTML::AttributeNames::height, String::number(height));
 }
 
+static float current_pixel_density_or_default(ImageRequest const& image_request)
+{
+    auto density = image_request.current_pixel_density();
+    if (density <= 0)
+        return 1.0f;
+    return density;
+}
+
+static Optional<CSSPixels> density_correct_dimension(Optional<CSSPixels> dimension, float density)
+{
+    if (!dimension.has_value())
+        return {};
+    return CSSPixels::nearest_value_for(dimension->to_double() / density);
+}
+
+// https://html.spec.whatwg.org/multipage/images.html#density-corrected-intrinsic-width-and-height
+// To determine the density-corrected natural width and height of an img element img:
+// - Let density be img's current request's current pixel density.
+// - If the current request's preferred density-corrected dimensions are not null, divide those dimensions by density.
+// - Otherwise, divide the image's intrinsic width and intrinsic height by density.
+// The intrinsic ratio is not density-corrected, since dividing both dimensions by the same density leaves it unchanged.
+
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-naturalwidth
 unsigned HTMLImageElement::natural_width() const
 {
     // 1. If the image is not available, then return 0.
     // 2. Return the respective component of the image's density-corrected natural width and height, in CSS pixels. [CSS]
-    // FIXME: Implement density-corrected algorithm.
     if (auto width = intrinsic_width(); width.has_value() && *width > 0)
         return width->to_int();
     return 0;
@@ -375,7 +396,6 @@ unsigned HTMLImageElement::natural_height() const
 {
     // 1. If the image is not available, then return 0.
     // 2. Return the respective component of the image's density-corrected natural width and height, in CSS pixels. [CSS]
-    // FIXME: Implement density-corrected algorithm.
     if (auto height = intrinsic_height(); height.has_value() && *height > 0)
         return height->to_int();
     return 0;
@@ -850,6 +870,7 @@ after_step_7:
         // 17. Set image request to a new image request whose current URL is urlString.
         auto image_request = ImageRequest::create(document().realm(), document().page());
         image_request->set_current_url(document().realm(), move(utf16_url_string));
+        image_request->set_current_pixel_density(pixel_density.value_or(1.0f));
 
         // 18. If the current request's state is unavailable or broken, then set the current request to image request.
         //     Otherwise, set the pending request to image request.
@@ -1087,6 +1108,7 @@ void HTMLImageElement::react_to_changes_in_the_environment()
     // 12. ⌛ Let image request be a new image request whose current URL is urlString
     auto image_request = ImageRequest::create(document().realm(), document().page());
     image_request->set_current_url(document().realm(), Utf16String::from_utf8(*url_string));
+    image_request->set_current_pixel_density(pixel_density.value_or(1.0f));
 
     // 13. ⌛ Set the element's pending request to image request.
     m_pending_request = image_request;
@@ -1103,7 +1125,6 @@ void HTMLImageElement::react_to_changes_in_the_environment()
                 return;
 
             // 2. Set the img element's last selected source to selected source and the img element's current pixel density to selected pixel density.
-            // FIXME: pixel density
             m_last_selected_source = selected_source;
 
             // 3. Set the image request's state to completely available.
@@ -1399,6 +1420,50 @@ GC::Ptr<DecodedImageData> HTMLImageElement::decoded_image_data() const
     if (!m_current_request)
         return nullptr;
     return m_current_request->image_data();
+}
+
+Optional<CSSPixels> HTMLImageElement::intrinsic_width() const
+{
+    if (!m_current_request)
+        return {};
+
+    auto density = current_pixel_density_or_default(*m_current_request);
+    if (auto const& dimensions = m_current_request->preferred_density_corrected_dimensions(); dimensions.has_value())
+        return CSSPixels::nearest_value_for(dimensions->width() / density);
+
+    if (auto const& data = decoded_image_data())
+        return density_correct_dimension(data->intrinsic_width(), density);
+    return {};
+}
+
+Optional<CSSPixels> HTMLImageElement::intrinsic_height() const
+{
+    if (!m_current_request)
+        return {};
+
+    auto density = current_pixel_density_or_default(*m_current_request);
+    if (auto const& dimensions = m_current_request->preferred_density_corrected_dimensions(); dimensions.has_value())
+        return CSSPixels::nearest_value_for(dimensions->height() / density);
+
+    if (auto const& data = decoded_image_data())
+        return density_correct_dimension(data->intrinsic_height(), density);
+    return {};
+}
+
+Optional<CSSPixelFraction> HTMLImageElement::intrinsic_aspect_ratio() const
+{
+    if (!m_current_request)
+        return {};
+
+    if (auto const& dimensions = m_current_request->preferred_density_corrected_dimensions(); dimensions.has_value()) {
+        if (dimensions->width() > 0 && dimensions->height() > 0)
+            return CSSPixelFraction(dimensions->width(), dimensions->height());
+        return {};
+    }
+
+    if (auto const& data = decoded_image_data())
+        return data->intrinsic_aspect_ratio();
+    return {};
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -108,6 +108,9 @@ public:
 
     // ^Layout::ImageProvider
     virtual GC::Ptr<DecodedImageData> decoded_image_data() const override;
+    virtual Optional<CSSPixels> intrinsic_width() const override;
+    virtual Optional<CSSPixels> intrinsic_height() const override;
+    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Libraries/LibWeb/Layout/ImageProvider.h
@@ -24,10 +24,10 @@ public:
 
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const = 0;
 
-    Optional<CSSPixels> intrinsic_width() const;
-    Optional<CSSPixels> intrinsic_height() const;
+    virtual Optional<CSSPixels> intrinsic_width() const;
+    virtual Optional<CSSPixels> intrinsic_height() const;
     Optional<CSSPixelSize> intrinsic_size() const;
-    Optional<CSSPixelFraction> intrinsic_aspect_ratio() const;
+    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const;
 
     Optional<Gfx::DecodedImageFrame> current_image_frame(Optional<Gfx::IntSize> size = {}) const;
     Optional<Gfx::DecodedImageFrame> default_image_frame(Optional<Gfx::IntSize> size = {}) const;

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -121,9 +121,7 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
             // https://drafts.csswg.org/css-images/#the-object-fit
             auto object_fit = m_is_svg_image ? CSS::ObjectFit::Contain : computed_values().object_fit();
 
-            auto intrinsic_size = m_image_provider.intrinsic_size()
-                                      .map([](auto size) { return size.template to_type<int>(); })
-                                      .value_or(image_int_rect_device_pixels.size());
+            auto intrinsic_size = m_image_provider.intrinsic_size().value_or(image_rect.size());
 
             auto draw_rect = get_replaced_box_painting_area(*this, context, object_fit, intrinsic_size);
             if (!draw_rect.is_empty()) {

--- a/Libraries/LibWeb/Painting/ReplacedElementCommon.cpp
+++ b/Libraries/LibWeb/Painting/ReplacedElementCommon.cpp
@@ -12,7 +12,7 @@
 
 namespace Web::Painting {
 
-Gfx::IntRect get_replaced_box_painting_area(Paintable const& paintable, DisplayListRecordingContext const& context, CSS::ObjectFit object_fit, Gfx::IntSize content_size)
+Gfx::IntRect get_replaced_box_painting_area(Paintable const& paintable, DisplayListRecordingContext const& context, CSS::ObjectFit object_fit, CSSPixelSize content_size)
 {
     if (content_size.is_empty())
         return {};
@@ -23,7 +23,7 @@ Gfx::IntRect get_replaced_box_painting_area(Paintable const& paintable, DisplayL
 
     auto paintable_rect_device_pixels = context.rounded_device_rect(paintable_rect);
 
-    auto bitmap_aspect_ratio = CSSPixels(content_size.height()) / content_size.width();
+    auto bitmap_aspect_ratio = content_size.height() / content_size.width();
     auto image_aspect_ratio = paintable_rect.height() / paintable_rect.width();
 
     auto scale_x = CSSPixelFraction(1);
@@ -66,8 +66,8 @@ Gfx::IntRect get_replaced_box_painting_area(Paintable const& paintable, DisplayL
         break;
     }
 
-    auto scaled_bitmap_width = CSSPixels(content_size.width()) * scale_x;
-    auto scaled_bitmap_height = CSSPixels(content_size.height()) * scale_y;
+    auto scaled_bitmap_width = content_size.width() * scale_x;
+    auto scaled_bitmap_height = content_size.height() * scale_y;
 
     auto residual_horizontal = paintable_rect.width() - scaled_bitmap_width;
     auto residual_vertical = paintable_rect.height() - scaled_bitmap_height;

--- a/Libraries/LibWeb/Painting/ReplacedElementCommon.h
+++ b/Libraries/LibWeb/Painting/ReplacedElementCommon.h
@@ -9,9 +9,10 @@
 #include <LibGfx/Forward.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {
 
-Gfx::IntRect get_replaced_box_painting_area(Paintable const& paintable, DisplayListRecordingContext const& context, CSS::ObjectFit object_fit, Gfx::IntSize content_size);
+Gfx::IntRect get_replaced_box_painting_area(Paintable const&, DisplayListRecordingContext const&, CSS::ObjectFit, CSSPixelSize content_size);
 
 }

--- a/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -21,6 +21,11 @@
 
 namespace Web::Painting {
 
+static CSSPixelSize to_css_pixel_size(Gfx::IntSize size)
+{
+    return CSSPixelSize { CSSPixels(size.width()), CSSPixels(size.height()) };
+}
+
 NonnullRefPtr<VideoPaintable> VideoPaintable::create(Layout::VideoBox const& layout_box)
 {
     return adopt_ref(*new VideoPaintable(layout_box));
@@ -54,7 +59,7 @@ void VideoPaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
 
     auto paint_bitmap = [&](auto const& bitmap) {
         auto frame = Gfx::DecodedImageFrame { bitmap };
-        auto dst_rect = get_replaced_box_painting_area(*this, context, computed_values().object_fit(), bitmap.size());
+        auto dst_rect = get_replaced_box_painting_area(*this, context, computed_values().object_fit(), to_css_pixel_size(bitmap.size()));
         if (dst_rect.is_empty())
             return;
         auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), frame.size(), dst_rect.size());
@@ -74,7 +79,7 @@ void VideoPaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
         else
             return;
 
-        auto dst_rect = get_replaced_box_painting_area(*this, context, computed_values().object_fit(), src_size);
+        auto dst_rect = get_replaced_box_painting_area(*this, context, computed_values().object_fit(), to_css_pixel_size(src_size));
         if (dst_rect.is_empty())
             return;
         auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), src_size, dst_rect.size());

--- a/Tests/LibWeb/Text/expected/HTML/image-srcset-density-corrected-intrinsic-size.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-srcset-density-corrected-intrinsic-size.txt
@@ -1,0 +1,3 @@
+currentSrc: 120.png?density=2
+natural size: 60x60
+layout size: 60x60

--- a/Tests/LibWeb/Text/input/HTML/image-srcset-density-corrected-intrinsic-size.html
+++ b/Tests/LibWeb/Text/input/HTML/image-srcset-density-corrected-intrinsic-size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        internals.setDevicePixelRatio(2);
+
+        const img = document.createElement("img");
+        img.srcset = "../../../Assets/120.png?density=2 2x";
+        img.onload = () => {
+            println(`currentSrc: ${img.currentSrc.substring(img.currentSrc.lastIndexOf("/") + 1)}`);
+            println(`natural size: ${img.naturalWidth}x${img.naturalHeight}`);
+            println(`layout size: ${img.offsetWidth}x${img.offsetHeight}`);
+            done();
+        };
+        document.body.appendChild(img);
+    });
+</script>


### PR DESCRIPTION
Store the selected srcset density on image requests so that the selected resource can be interpreted in CSS pixels after it loads.

Use the request's current pixel density when reporting an img element's intrinsic dimensions, including naturalWidth and naturalHeight, and when layout asks for the natural image size. Keep the object-fit painting helper in CSS pixels until the final device pixel rectangle so fractional density-corrected sizes do not truncate to zero.

Add coverage for a 2x srcset image rendering at its density-corrected natural size.

Fixes this issue on https://xkcd.com/

<img width="1533" height="1099" alt="Screenshot_2026-07-09_at_6 51 04_AM" src="https://github.com/user-attachments/assets/3bcc1d6c-d077-4d83-9340-1d6afca076e3" />
