### PR TITLE
LibWeb: Support image-set() in generated content

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1509,8 +1509,11 @@ ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(
             } else if (item->is_counter()) {
                 content_data.counter_style_dependencies.append(item->as_counter().counter_style()->as_counter_style().resolve_counter_style(element_reference.style_scope()));
                 content_data.data.append(item->as_counter().resolve(element_reference));
-            } else if (item->is_image()) {
-                content_data.data.append(NonnullRefPtr { const_cast<ImageStyleValue&>(item->as_image()) });
+            } else if (item->is_image() || item->is_image_set()) {
+                // https://drafts.csswg.org/css-content-3/#typedef-content-list
+                // https://drafts.csswg.org/css-images-4/#typedef-image
+                // <content-list> accepts <image>, and image-set() is an <image>.
+                content_data.data.append(NonnullRefPtr { const_cast<AbstractImageStyleValue&>(item->as_abstract_image()) });
             } else {
                 // TODO: Implement images, and other things.
                 dbgln("`{}` is not supported in `content` (yet?)", item->to_string(SerializationMode::Normal));

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -508,7 +508,7 @@ struct ContentData {
         List,
     } type { Type::Normal };
 
-    Vector<Variant<String, NonnullRefPtr<ImageStyleValue>>> data;
+    Vector<Variant<String, NonnullRefPtr<AbstractImageStyleValue>>> data;
     Vector<ValueComparingRefPtr<CounterStyle const>> counter_style_dependencies;
     Optional<String> alt_text {};
 };

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -22,6 +22,8 @@
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ImageSetStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ParentNode.h>
@@ -186,21 +188,17 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
 }
 
 class GeneratedContentImageProvider final
-    : public ImageProvider
-    , public CSS::ImageStyleValue::Client {
+    : public ImageProvider {
 public:
-    virtual ~GeneratedContentImageProvider() override
-    {
-        unregister_image_style_value_client();
-    }
+    virtual ~GeneratedContentImageProvider() override = default;
 
     virtual void layout_node_was_detached() const override
     {
-        unregister_image_style_value_client();
+        m_image_client = nullptr;
         m_layout_node = nullptr;
     }
 
-    static NonnullOwnPtr<GeneratedContentImageProvider> create(DOM::Document& document, NonnullRefPtr<CSS::ImageStyleValue> image)
+    static NonnullOwnPtr<GeneratedContentImageProvider> create(DOM::Document& document, NonnullRefPtr<CSS::AbstractImageStyleValue> image)
     {
         return adopt_own(*new GeneratedContentImageProvider(document, move(image)));
     }
@@ -212,39 +210,87 @@ public:
 
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override
     {
-        if (auto document = this->document())
-            return m_image->image_data(*document);
+        if (auto document = m_document.ptr()) {
+            if (auto const* image = selected_image_style_value())
+                return image->image_data(*document);
+        }
         return nullptr;
     }
 
+    virtual Optional<CSSPixels> intrinsic_width() const override
+    {
+        if (auto document = m_document.ptr())
+            return m_image->natural_width(*document);
+        return {};
+    }
+
+    virtual Optional<CSSPixels> intrinsic_height() const override
+    {
+        if (auto document = m_document.ptr())
+            return m_image->natural_height(*document);
+        return {};
+    }
+
+    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override
+    {
+        if (auto document = m_document.ptr())
+            return m_image->natural_aspect_ratio(*document);
+        return {};
+    }
+
 private:
-    GeneratedContentImageProvider(DOM::Document& document, NonnullRefPtr<CSS::ImageStyleValue> image)
-        : Client(document, image)
+    class ImageClient final : public CSS::ImageStyleValue::Client {
+    public:
+        ImageClient(GeneratedContentImageProvider const& owner, DOM::Document& document, CSS::ImageStyleValue const& image)
+            : CSS::ImageStyleValue::Client(document, image)
+            , m_owner(owner)
+        {
+        }
+
+        virtual ~ImageClient() override
+        {
+            image_style_value_finalize();
+        }
+
+        virtual void image_style_value_did_update(CSS::ImageStyleValue&) override
+        {
+            if (!m_owner.m_layout_node)
+                return;
+            m_owner.m_layout_node->set_needs_layout_update(DOM::SetNeedsLayoutReason::GeneratedContentImageFinishedLoading);
+        }
+
+    private:
+        GeneratedContentImageProvider const& m_owner;
+    };
+
+    GeneratedContentImageProvider(DOM::Document& document, NonnullRefPtr<CSS::AbstractImageStyleValue> image)
+        : m_document(document)
         , m_image(move(image))
     {
+        if (auto const* image = selected_image_style_value())
+            m_image_client = make<ImageClient>(*this, document, *image);
     }
 
-    virtual void image_style_value_did_update(CSS::ImageStyleValue&) override
+    CSS::ImageStyleValue const* selected_image_style_value() const
     {
-        if (!m_layout_node)
-            return;
-        m_layout_node->set_needs_layout_update(DOM::SetNeedsLayoutReason::GeneratedContentImageFinishedLoading);
+        if (m_image->is_image())
+            return &m_image->as_image();
+
+        if (m_image->is_image_set()) {
+            if (auto const* selected_image = m_image->as_image_set().selected_image(); selected_image && selected_image->is_image())
+                return &selected_image->as_image();
+        }
+
+        return nullptr;
     }
 
-    void unregister_image_style_value_client() const
-    {
-        if (!m_registered_as_image_style_value_client)
-            return;
-        const_cast<GeneratedContentImageProvider&>(*this).image_style_value_finalize();
-        m_registered_as_image_style_value_client = false;
-    }
-
+    GC::Weak<DOM::Document> m_document;
     mutable WeakPtr<Layout::Node> m_layout_node;
-    NonnullRefPtr<CSS::ImageStyleValue> m_image;
-    mutable bool m_registered_as_image_style_value_client { true };
+    NonnullRefPtr<CSS::AbstractImageStyleValue> m_image;
+    mutable OwnPtr<ImageClient> m_image_client;
 };
 
-static NonnullRefPtr<ImageBox> create_content_image_box(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style, CSS::ImageStyleValue& image)
+static NonnullRefPtr<ImageBox> create_content_image_box(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::ComputedProperties const& style, CSS::AbstractImageStyleValue& image)
 {
     image.load_any_resources(document);
     auto image_provider = GeneratedContentImageProvider::create(document, image);
@@ -572,7 +618,7 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
                 if (auto const* string = item.get_pointer<String>()) {
                     layout_node = make_ref_counted<GeneratedTextNode>(document, Utf16String::from_utf8(*string));
                 } else {
-                    auto& image = *item.get<NonnullRefPtr<CSS::ImageStyleValue>>();
+                    auto& image = *item.get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
                     layout_node = create_content_image_box(document, nullptr, *pseudo_element_style, image);
                 }
                 layout_node->set_generated_for(pseudo_element, element);
@@ -597,11 +643,11 @@ RefPtr<NodeWithStyle> TreeBuilder::create_content_replacement_if_needed(DOM::Ele
 
     if (content.type != CSS::ContentData::Type::List
         || content.data.size() != 1
-        || !content.data.first().has<NonnullRefPtr<CSS::ImageStyleValue>>()) {
+        || !content.data.first().has<NonnullRefPtr<CSS::AbstractImageStyleValue>>()) {
         return {};
     }
 
-    auto& image = *content.data.first().get<NonnullRefPtr<CSS::ImageStyleValue>>();
+    auto& image = *content.data.first().get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
     return create_content_image_box(element.document(), element, style, image);
 }
 

--- a/Tests/LibWeb/Layout/expected/content-image-set.txt
+++ b/Tests/LibWeb/Layout/expected/content-image-set.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 216 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 200 0+0+8] children: not-inline
+      BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 200 0+0+0] children: inline
+        InlineNode <(anonymous)> at [8,8] [0+0+0 200 0+0+0] [0+0+0 200 0+0+0]
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
+          ImageBox <(anonymous)> at [8,8] [0+0+0 200 0+0+0] [0+0+0 200 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x200]
+        PaintableWithLines (InlineNode(anonymous)) [8,8 200x200]
+          ImagePaintable (ImageBox(anonymous)) [8,8 200x200]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x216] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/content-image-set.html
+++ b/Tests/LibWeb/Layout/input/content-image-set.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html><style>
+    div::before {
+        content: image-set(url("400.png") 2x);
+    }
+</style><body><div></div>


### PR DESCRIPTION
Treat `image-set()` values in content as image content instead of falling through to the unsupported diagnostic.

Store generated content images as abstract image values so `image-set()` can select and load its candidate. Let the generated content image provider observe the selected URL image and ask the abstract image for intrinsic dimensions, preserving `image-set` resolution in layout.

Add a layout test that renders content: `image-set(url(...) 2x)` as a 200x200 generated `ImageBox` from the existing 400px fixture.

Fixes this extreme spam on GMail:

```
668649.011 WebContent(95567): `image-set(url("") 1x, url("") 2x)` is not supported in `content` (yet?)
```