### PR TITLE
UI/Qt: Improve macOS integration and bookmark actions

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -577,10 +577,41 @@ void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTa
         view->load(url);
 }
 
+void Application::open_urls_in_new_tabs(ReadonlySpan<URL::URL> urls) const
+{
+    for (auto const& url : urls)
+        open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
+}
+
 void Application::open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab activate_tab) const
 {
     if (auto bookmark = m_bookmark_store.find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
         open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
+}
+
+static void collect_bookmark_urls(BookmarkItem::Folder const& folder, Vector<URL::URL>& urls)
+{
+    for (auto const& child : folder.children) {
+        child.data.visit(
+            [&](BookmarkItem::Bookmark const& bookmark) {
+                urls.append(bookmark.url);
+            },
+            [&](BookmarkItem::Folder const& child_folder) {
+                collect_bookmark_urls(child_folder, urls);
+            });
+    }
+}
+
+void Application::open_bookmark_folder_in_new_tabs(String const& folder_id) const
+{
+    auto folder = m_bookmark_store.find_item_by_id(folder_id);
+    if (!folder.has_value() || !folder->is_folder())
+        return;
+
+    Vector<URL::URL> urls;
+    collect_bookmark_urls(folder->folder(), urls);
+
+    open_urls_in_new_tabs(urls);
 }
 
 void Application::open_bookmark_in_new_window(String const& bookmark_id, IsPrivate is_private)

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -147,9 +147,11 @@ public:
 
     virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }
     virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const;
+    virtual void open_urls_in_new_tabs(ReadonlySpan<URL::URL>) const;
     virtual void open_url_in_new_window(URL::URL const&, IsPrivate) { }
 
     void open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab) const;
+    void open_bookmark_folder_in_new_tabs(String const& folder_id) const;
     void open_bookmark_in_new_window(String const& bookmark_id, IsPrivate);
 
     Main::Arguments const& command_line_arguments() const { return m_arguments; }

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -52,6 +52,7 @@ enum class ActionID {
     ToggleBookmarksBar,
     BookmarkItem,
 
+    OpenAllBookmarksInTabs,
     AddBookmark,
     AddBookmarkAllTabs,
     AddBookmarkFolder,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2425,6 +2425,13 @@ void ViewImplementation::initialize_context_menus()
     m_bookmark_context_menu->add_action(add_bookmark_folder_action);
 
     m_bookmark_folder_context_menu = Menu::create("Bookmark Folder Context Menu"sv);
+    m_bookmark_folder_context_menu->add_action(Action::create("Open All in Tabs"sv, ActionID::OpenAllBookmarksInTabs, []() {
+        auto& application = Application::the();
+
+        if (auto bookmark_id = application.bookmark_item_id_for_context_menu(); bookmark_id.has_value())
+            application.open_bookmark_folder_in_new_tabs(bookmark_id->id);
+    }));
+    m_bookmark_folder_context_menu->add_separator();
     m_bookmark_folder_context_menu->add_action(Action::create("Edit Folder..."sv, ActionID::EditBookmarkFolder, []() {
         auto& application = Application::the();
 

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -25,6 +25,7 @@ private:
 
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
     virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const override;
+    virtual void open_urls_in_new_tabs(ReadonlySpan<URL::URL>) const override;
     virtual void open_url_in_new_window(URL::URL const&, WebView::IsPrivate) override;
 
     virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -97,6 +97,22 @@ void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTa
                      tabLocation:TabLocation::after_tab(active_tab)];
 }
 
+void Application::open_urls_in_new_tabs(ReadonlySpan<URL::URL> urls) const
+{
+    ApplicationDelegate* delegate = [NSApp delegate];
+    auto* active_tab = [delegate activeTab];
+    auto* previous_tab = active_tab;
+
+    for (auto const& url : urls) {
+        auto location = previous_tab ? TabLocation::after_tab(previous_tab) : TabLocation::end();
+        auto* controller = [delegate createNewTab:url
+                                          fromTab:active_tab
+                                      activateTab:Web::HTML::ActivateTab::No
+                                      tabLocation:location];
+        previous_tab = (Tab*)[controller window];
+    }
+}
+
 void Application::open_url_in_new_window(URL::URL const& url, WebView::IsPrivate)
 {
     ApplicationDelegate* delegate = [NSApp delegate];

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -116,6 +116,13 @@ public:
                 break;
 
             auto const& open_event = *static_cast<QFileOpenEvent const*>(event);
+            auto const qurl = open_event.url();
+            if (!qurl.isEmpty()) {
+                if (auto url = WebView::sanitize_url(ak_byte_string_from_qbytearray(qurl.toEncoded())); url.has_value())
+                    application.on_open_file(url.release_value());
+                break;
+            }
+
             auto file = ak_string_from_qstring(open_event.file());
 
             if (auto file_url = WebView::sanitize_url(file); file_url.has_value())

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -630,6 +630,32 @@ void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTa
     active_window().new_tab_from_url(url, activate_tab, BrowserWindow::TabLocation::after_current_tab());
 }
 
+void Application::open_urls_in_new_tabs(ReadonlySpan<URL::URL> urls) const
+{
+    if (urls.is_empty())
+        return;
+
+    if (!m_active_window) {
+        Vector<URL::URL> initial_urls;
+        initial_urls.ensure_capacity(urls.size());
+        for (auto const& url : urls)
+            initial_urls.append(url);
+
+        const_cast<Application&>(*this).new_window(initial_urls);
+        return;
+    }
+
+    auto& window = active_window();
+    auto* previous_tab = window.current_tab();
+    for (auto const& url : urls) {
+        auto location = previous_tab
+            ? BrowserWindow::TabLocation::after_tab(*previous_tab)
+            : BrowserWindow::TabLocation::end();
+        auto& tab = window.new_tab_from_url(url, Web::HTML::ActivateTab::No, location);
+        previous_tab = &tab;
+    }
+}
+
 void Application::open_url_in_new_window(URL::URL const& url, WebView::IsPrivate is_private)
 {
     new_window({ url }, configuration_for_new_window(), BrowserWindow::IsPopupWindow::No, is_private);

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -35,6 +35,7 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QPointer>
 #include <QSizePolicy>
 #include <QStandardPaths>
 #include <QTimer>
@@ -242,6 +243,19 @@ public:
         update_reopen_recently_closed_action();
         update_application_menu_bar_tab_menus();
     }
+
+    void create_dock_menu()
+    {
+        if (m_dock_menu)
+            return;
+
+        m_dock_menu = new QMenu(m_application_menu_bar);
+        QObject::connect(m_dock_menu, &QMenu::aboutToShow, this, [this] {
+            rebuild_dock_menu();
+        });
+        rebuild_dock_menu();
+        m_dock_menu->setAsDockMenu();
+    }
 #endif
 
 #if defined(AK_OS_MACOS)
@@ -270,6 +284,54 @@ public:
 
 private:
 #if defined(AK_OS_MACOS)
+    void rebuild_dock_menu()
+    {
+        m_dock_menu->clear();
+
+        auto* new_window_action = m_dock_menu->addAction("New Window");
+        QObject::connect(new_window_action, &QAction::triggered, m_dock_menu, [] {
+            Application::the().open_new_window(WebView::IsPrivate::No);
+        });
+
+        auto* new_private_window_action = m_dock_menu->addAction("New Private Window");
+        QObject::connect(new_private_window_action, &QAction::triggered, m_dock_menu, [] {
+            Application::the().open_new_window(WebView::IsPrivate::Yes);
+        });
+
+        bool added_window_separator = false;
+        for (auto* widget : QApplication::topLevelWidgets()) {
+            auto* window = as_if<BrowserWindow>(widget);
+            if (!window)
+                continue;
+
+            if (!added_window_separator) {
+                m_dock_menu->addSeparator();
+                added_window_separator = true;
+            }
+
+            auto title = window->windowTitle();
+            title.replace("&", "&&");
+            auto* action = m_dock_menu->addAction(title);
+            action->setCheckable(true);
+            action->setChecked(window == Application::the().active_window_if_any());
+
+            QPointer<BrowserWindow> window_pointer = window;
+            QObject::connect(action, &QAction::triggered, m_dock_menu, [window = window_pointer] {
+                if (!window)
+                    return;
+
+                if (window->isMinimized())
+                    window->showNormal();
+                else
+                    window->show();
+
+                window->raise();
+                window->activateWindow();
+                Application::the().set_active_window(*window);
+            });
+        }
+    }
+
     QAction* add_application_menu_action(QMenu& menu, QString const& text, QList<QKeySequence> shortcuts)
     {
         auto* action = new QAction(text, m_application_menu_bar);
@@ -290,6 +352,7 @@ private:
     QMenu* m_history_menu { nullptr };
     QMenu* m_inspect_menu { nullptr };
     QMenu* m_debug_menu { nullptr };
+    QMenu* m_dock_menu { nullptr };
     QAction* m_reopen_recently_closed_tab_action { nullptr };
 #endif
 };
@@ -495,8 +558,10 @@ bool Application::confirm_cancel_active_downloads(QWidget* parent)
 void Application::initialize_macos_application_menu()
 {
 #if defined(AK_OS_MACOS)
-    if (m_application)
+    if (m_application) {
         static_cast<LadybirdQApplication*>(m_application.ptr())->create_application_menu_bar();
+        static_cast<LadybirdQApplication*>(m_application.ptr())->create_dock_menu();
+    }
 #endif
 }
 

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -68,6 +68,7 @@ private:
 
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
     virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const override;
+    virtual void open_urls_in_new_tabs(ReadonlySpan<URL::URL>) const override;
     virtual void open_url_in_new_window(URL::URL const&, WebView::IsPrivate) override;
 
     virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -16,6 +16,10 @@
 #include <QCoreApplication>
 #include <QtGlobal>
 
+#if defined(AK_OS_MACOS)
+#    include <UI/Qt/MacWindow.h>
+#endif
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 #    include <QStyleHints>
 #endif
@@ -68,7 +72,14 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
         app->on_open_file = [&](auto const& file_url) {
             if (auto* window = app->active_window_if_any()) {
-                window->view().load(file_url);
+                auto& view = window->view();
+                if (auto* tab = window->current_tab())
+                    tab->set_url_is_hidden(false);
+                view.load(file_url);
+#if defined(AK_OS_MACOS)
+                Ladybird::make_appkit_window_first_responder(view);
+#endif
+                view.setFocus();
                 return;
             }
             app->new_window({ file_url });


### PR DESCRIPTION
This improves the Qt frontend’s macOS integration and bookmark folder workflows.

Qt now handles macOS `QFileOpenEvent`s, focuses the web view after URLs are opened from the system, and exposes Dock menu actions for creating normal and private windows.

The branch also adds "Open All in Tabs" to bookmark folder context menus, opening folder bookmarks in order while keeping the current tab active.