### PR TITLE
LibWeb/Layout: Fix some table layout issues with the GitHub code-review page

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -221,7 +221,6 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
 void TableFormattingContext::compute_outer_content_sizes()
 {
     auto containing_block_width = m_table_constraints.percentage_basis_width.value_or(0);
-    auto containing_block_height = m_table_constraints.percentage_basis_height.value_or(0);
 
     size_t column_index = 0;
     TableGrid::for_each_child_box_matching(table_box(), is_table_column_group, [&](auto& column_group_box) {
@@ -239,6 +238,13 @@ void TableFormattingContext::compute_outer_content_sizes()
             column_index += span;
         });
     });
+
+    initialize_row_content_sizes();
+}
+
+void TableFormattingContext::initialize_row_content_sizes()
+{
+    auto containing_block_height = m_table_constraints.percentage_basis_height.value_or(0);
 
     for (auto& row : m_rows) {
         auto const& computed_values = row.box.computed_values();
@@ -1027,6 +1033,14 @@ void TableFormattingContext::compute_table_height()
             cell_state.set_content_height(independent_formatting_context->automatic_content_height());
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         }
+        if (m_needs_fixed_mode_row_measurement) {
+            auto const& computed_values = cell.box.computed_values();
+            auto min_height = computed_values.min_height().to_px(height_of_containing_block);
+            auto cell_intrinsic_height_offsets = cell_state.border_box_top() + cell_state.border_box_bottom();
+            auto measured_outer_height = max(cell_state.border_box_height(), min_height + cell_intrinsic_height_offsets);
+            cell.outer_min_height = measured_outer_height;
+            cell.outer_max_height = measured_outer_height;
+        }
 
         // https://drafts.csswg.org/css2/#height-layout
         // The baseline of a cell is the baseline of the first in-flow line box in the cell, or the first in-flow
@@ -1044,8 +1058,18 @@ void TableFormattingContext::compute_table_height()
             if (cell.row_span == 1) {
                 row.base_height = max(row.base_height, cell_state.border_box_height());
             }
-            row.base_height = max(row.base_height, m_rows[cell.row_index].min_size);
+            if (!m_needs_fixed_mode_row_measurement)
+                row.base_height = max(row.base_height, m_rows[cell.row_index].min_size);
             row.baseline = max(row.baseline, cell.baseline);
+        }
+    }
+
+    if (m_needs_fixed_mode_row_measurement) {
+        initialize_row_content_sizes();
+        compute_table_measures<Row>();
+        for (auto& row : m_rows) {
+            if (!row.is_collapsed)
+                row.base_height = max(row.base_height, row.min_size);
         }
     }
 
@@ -1811,10 +1835,22 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
     border_conflict_resolution();
 
     auto effective_row_measurement = row_measurement;
+    m_needs_fixed_mode_row_measurement = false;
     // OPTIMIZATION: Row intrinsic measurements are only needed when row height constraints or rowspans can affect
     //               the later row height distribution. Simple tables get their actual row heights from cell layout.
     if (effective_row_measurement == RowMeasurement::Include && can_skip_row_intrinsic_measurement())
         effective_row_measurement = RowMeasurement::Skip;
+    if (effective_row_measurement == RowMeasurement::Include && use_fixed_mode_layout()) {
+        // https://drafts.csswg.org/css-tables-3/#computing-column-measures
+        // For the purpose of measuring a column when laid out in fixed mode ... the min-content and max-content width
+        // of cells is considered zero.
+        //
+        // https://drafts.csswg.org/css-tables-3/#ROWMIN
+        // ROWMIN is defined as the sum of the minimum height of the rows after a first row layout pass.
+        // NB: So defer fixed-mode row measurement until after columns have their used widths.
+        effective_row_measurement = RowMeasurement::Skip;
+        m_needs_fixed_mode_row_measurement = true;
+    }
 
     // Compute the minimum width of each column.
     compute_cell_measures(effective_row_measurement);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1807,8 +1807,20 @@ void TableFormattingContext::seed_table_participant_used_values(ContainingBlockC
         m_state.create(cell.box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
 
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
-        if (child->display().is_table_caption())
-            m_state.create(as<Box>(*child), participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
+        auto* child_box = as_if<Box>(*child);
+        if (!child_box)
+            continue;
+
+        if (child_box->display().is_table_caption()) {
+            m_state.create(*child_box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
+            continue;
+        }
+
+        if (!child_box->is_absolutely_positioned() || m_state.try_get_mutable(*child_box))
+            continue;
+
+        auto& child_box_state = m_state.create(*child_box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
+        child_box_state.set_static_position_rect(calculate_static_position_rect(*child_box));
     }
 }
 
@@ -1877,7 +1889,7 @@ void TableFormattingContext::parent_context_did_dimension_child_root_box()
         return;
 
     context_box().for_each_in_subtree_of_type<Box const>([&](Layout::Box const& box) {
-        if (box.is_absolutely_positioned()) {
+        if (box.is_absolutely_positioned() && !m_state.try_get(box)) {
             // FIXME: calculate_static_position_rect() is not aware of how to correctly calculate static position for
             //        a box nested inside a table, but we need to set some value, so layout_absolutely_positioned_element()
             //        won't crash trying to access it.

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -45,6 +45,7 @@ private:
     CSSPixels compute_capmin();
     void compute_constrainedness();
     void compute_cell_measures(RowMeasurement);
+    void initialize_row_content_sizes();
     void compute_outer_content_sizes();
     template<class RowOrColumn>
     void initialize_table_measures();
@@ -87,6 +88,7 @@ private:
     CSSPixels m_automatic_content_height { 0 };
 
     Optional<AvailableSpace> m_available_space;
+    bool m_needs_fixed_mode_row_measurement { false };
 
     struct Column {
         CSSPixels left_offset { 0 };

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -73,6 +73,14 @@ static bool has_in_flow_block_children(Layout::Node const& layout_node)
     return false;
 }
 
+static bool is_out_of_flow_table_internal_child_of_table_root(Layout::NodeWithStyle const& parent, Layout::Node const& child)
+{
+    return parent.display().is_table_inside()
+        && !child.is_anonymous()
+        && child.is_out_of_flow()
+        && child.display_before_box_type_transformation().is_internal_table();
+}
+
 // The insertion_parent_for_*() functions maintain the invariant that the in-flow children of
 // block-level boxes must be either all block-level or all inline-level.
 
@@ -123,6 +131,11 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
     if (!has_inline_or_in_flow_block_children(*new_parent))
         return *new_parent;
 
+    // Table-internal boxes may have been blockified before insertion, but table fixup still needs to see them as
+    // direct table children instead of grouping them with neighboring table whitespace.
+    if (is_out_of_flow_table_internal_child_of_table_root(*new_parent, layout_node))
+        return *new_parent;
+
     // If the block is out-of-flow,
     if (layout_node.is_out_of_flow()) {
         // And we're appending while the parent's last child is an anonymous block, join that
@@ -151,6 +164,10 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
 
     for (auto child = new_parent->first_child(); child;) {
         auto next_child = child->next_sibling();
+        if (is_out_of_flow_table_internal_child_of_table_root(*new_parent, *child)) {
+            child = next_child;
+            continue;
+        }
         new_parent->remove_child(*child);
         wrapper->append_child(*child);
         child = next_child;
@@ -1393,9 +1410,22 @@ static bool is_table_track_group(CSS::Display display)
         || display.is_table_column_group();
 }
 
+static CSS::Display display_for_table_fixup(Node const& node)
+{
+    // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
+    // For the purposes of these rules, out-of-flow elements are represented as inline elements of zero width and
+    // height. Their containing blocks are chosen accordingly.
+    //
+    // AD-HOC: Table-internal boxes can be blockified before fixup. Use the pre-transformation display for authored
+    // boxes so an out-of-flow table-header-group is still recognized as a proper table child during fixup.
+    if (!node.is_anonymous())
+        return node.display_before_box_type_transformation();
+    return node.display();
+}
+
 static bool is_proper_table_child(Node const& node)
 {
-    auto const display = node.display();
+    auto const display = display_for_table_fixup(node);
     return is_table_track_group(display) || is_table_track(display) || display.is_table_caption();
 }
 
@@ -1432,7 +1462,7 @@ static bool is_not_table_cell(Node const& node)
 
 static bool is_table_row_group_column_group_or_caption(Node const& node)
 {
-    auto const display = node.display();
+    auto const display = display_for_table_fixup(node);
     return is_table_track_group(display) || display.is_table_caption();
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1288,6 +1288,45 @@ void TreeBuilder::fixup_tables(NodeWithStyle& root)
     missing_cells_fixup(table_root_boxes);
 }
 
+static bool is_first_or_last_child_with_table_non_root_sibling_if_any(Node const& node)
+{
+    auto is_table_non_root_box = [](Node const& node) {
+        auto const display = node.display();
+        return display.is_table_row()
+            || display.is_table_column()
+            || display.is_table_row_group()
+            || display.is_table_header_group()
+            || display.is_table_footer_group()
+            || display.is_table_column_group()
+            || display.is_table_cell()
+            || display.is_table_caption();
+    };
+
+    auto previous_sibling = node.previous_sibling();
+    auto next_sibling = node.next_sibling();
+    if (previous_sibling && next_sibling)
+        return false;
+
+    if (previous_sibling && !is_table_non_root_box(*previous_sibling))
+        return false;
+
+    if (next_sibling && !is_table_non_root_box(*next_sibling))
+        return false;
+
+    return true;
+}
+
+// https://drafts.csswg.org/css-tables-3/#tabular-container
+static bool is_tabular_container(Node const& node)
+{
+    auto const& display = node.display();
+    return display.is_table_inside()
+        || display.is_table_row()
+        || display.is_table_row_group()
+        || display.is_table_header_group()
+        || display.is_table_footer_group();
+}
+
 // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
 // 1. Remove irrelevant boxes:
 void TreeBuilder::remove_irrelevant_boxes(NodeWithStyle& root)
@@ -1313,12 +1352,27 @@ void TreeBuilder::remove_irrelevant_boxes(NodeWithStyle& root)
         });
     });
 
-    // FIXME:
-    // 3. Anonymous inline boxes which contain only white space and are between two immediate siblings each of which is a table-non-root box.
+    // FIXME: 3. Anonymous inline boxes which contain only white space and are between two immediate siblings each of
+    //           which is a table-non-root box.
+
     // 4. Anonymous inline boxes which meet all of the following criteria:
     //    - they contain only white space
     //    - they are the first and/or last child of a tabular container
     //    - whose immediate sibling, if any, is a table-non-root box
+    root.for_each_in_inclusive_subtree_of_type<Box>([&](auto& box) {
+        auto* parent = box.parent();
+        if (!parent
+            || !is_tabular_container(*parent)
+            || !is_first_or_last_child_with_table_non_root_sibling_if_any(box)) {
+            return TraversalDecision::Continue;
+        }
+
+        if (is_ignorable_whitespace(box)) {
+            to_remove.append(box);
+            return TraversalDecision::SkipChildrenAndContinue;
+        }
+        return TraversalDecision::Continue;
+    });
 
     for (auto& box : to_remove)
         box->parent()->remove_child(*box);

--- a/Tests/LibWeb/Layout/expected/abspos-relative-to-table-row.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-relative-to-table-row.txt
@@ -3,26 +3,17 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 10 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 6 0+0+778] [0+0+0 10 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 6 0+0+0] [0+0+0 10 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
-            TextNode <#text> (not painted)
           Box <tbody> at [10,10] table-row-group [0+0+0 2 0+0+0] [0+0+0 6 0+0+0] children: not-inline
             Box <tr> at [10,10] table-row [0+0+0 2 0+0+0] [0+0+0 2 0+0+0] children: not-inline
               BlockContainer <td> at [11,11] table-cell [0+0+1 0 1+0+0] [0+0+1 0 1+0+0] [BFC] children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [10,14] positioned table-row [0+0+0 2 0+0+0] [0+0+0 2 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,15] table-cell [0+0+1 0 1+0+0] [0+0+1 0 1+0+0] [BFC] children: not-inline
                 BlockContainer <div> at [11,15] positioned [0+0+0 70.5625 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
                   frag 0 from TextNode start: 0, length: 6, rect: [11,15 70.5625x16] baseline: 12.796875
                       "ABSPOS"
                   TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,18] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/css-table-cell-verticalalign-text-top.txt
+++ b/Tests/LibWeb/Layout/expected/css-table-cell-verticalalign-text-top.txt
@@ -7,20 +7,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 204 0+0+580] [0+0+0 100 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 204 0+0+0] [0+0+0 100 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 204 0+0+0] [0+0+0 100 0+0+0] children: not-inline
             Box <tr> at [8,8] table-row [0+0+0 204 0+0+0] [0+0+0 100 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [10,10] table-cell [0+1+1 200 1+1+0] [0+1+1 16 81+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 15, rect: [10,10 129.296875x16] baseline: 12.796875
                     "Text at the top"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,108] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table-caption-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table-caption-auto-height.txt
@@ -18,8 +18,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             BlockContainer <div.caption-content> at [51,33] [0+1+0 100 0+1+0] [0+1+0 30 0+1+0] children: not-inline
             BlockContainer <(anonymous)> at [50,64] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
               TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,188] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/align-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-is-inherited.txt
@@ -3,179 +3,83 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 176 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <thead> at [10,10] table-header-group [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,10] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+0+1 778 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 9, length: 5, rect: [747.03125,11 41.96875x16] baseline: 12.796875
                     "Right"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,30] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,30] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,30] table-box [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,32] table-row-group [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,32] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,33] table-cell [0+0+1 778 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 9, length: 6, rect: [373.46875,33 53.046875x16] baseline: 12.796875
                     "Center"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,52] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,52] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,52] table-box [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tfoot> at [10,54] table-footer-group [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,54] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,55] table-cell [0+0+1 778 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 9, length: 4, rect: [11,55 32.875x16] baseline: 12.796875
                     "Left"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,74] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,74] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,74] table-box [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,76] table-row-group [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,76] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,77] table-cell [0+0+1 778 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 9, length: 7, rect: [11,77 53.046875x16] baseline: 12.796875
                     "Justify"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,96] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,96] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,96] table-box [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <thead> at [10,98] table-header-group [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,98] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,99] table-cell [0+0+1 778 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 9, length: 5, rect: [747.03125,99 41.96875x16] baseline: 12.796875
                     "Right"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,118] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,118] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,118] table-box [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,120] table-row-group [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,120] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,121] table-cell [0+0+1 778 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 9, length: 6, rect: [373.46875,121 53.046875x16] baseline: 12.796875
                     "Center"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,140] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,140] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,140] table-box [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tfoot> at [10,142] table-footer-group [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,142] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,143] table-cell [0+0+1 778 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 9, length: 4, rect: [11,143 32.875x16] baseline: 12.796875
                     "Left"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,162] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,162] [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,162] table-box [0+0+0 784 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,164] table-row-group [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,164] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,165] table-cell [0+0+1 778 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 9, length: 7, rect: [11,165 53.046875x16] baseline: 12.796875
                     "Justify"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,184] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 98 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 200.328125 0+0+583.671875] [0+0+0 98 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 198.328125 0+1+0] [0+1+0 96 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 198.328125 0+0+0] [0+0+0 96 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 198.328125 0+0+0] [0+0+0 48 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [25,25] table-cell [0+1+15 32.078125 15+1+0] [0+1+15 16 63+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 3, rect: [25,25 32.078125x16] baseline: 12.796875
                     "Top"
@@ -25,21 +21,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [177.0625,25 14.265625x16] baseline: 12.796875
                     "A"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,57] table-row [0+0+0 198.328125 0+0+0] [0+0+0 48 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [177.0625,73] table-cell [0+1+15 14.265625 15+1+0] [0+1+15 16 15+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [177.0625,73 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x114]

--- a/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
+++ b/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
@@ -3,24 +3,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 22 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 20.25 0+0+763.75] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 20.25 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,10] table-row-group [0+0+0 16.25 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,10] table-row [0+0+0 16.25 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+0+1 14.25 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x16] baseline: 12.796875
                     "A"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x38]

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -8,8 +8,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,10] [0+0+0 99.171875 0+0+684.828125] [0+0+0 94 0+0+0] [BFC] children: not-inline
         Box <table#full-table> at [8,26] table-box [0+0+0 99.171875 0+0+0] [0+0+0 62 0+0+16] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <caption> at [8,10] [0+0+0 99.171875 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 5, length: 9, rect: [16.21875,10 82.734375x16] baseline: 12.796875
                 "A Caption"
@@ -17,53 +15,27 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <thead> at [10,28] table-header-group [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,28] table-row [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,29] table-cell [0+0+1 93.171875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 9, rect: [11,29 73.65625x16] baseline: 12.796875
                     "Head Cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tbody> at [10,48] table-row-group [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,48] table-row [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,49] table-cell [0+0+1 93.171875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 9, rect: [11,49 70.234375x16] baseline: 12.796875
                     "Body Cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tfoot> at [10,68] table-footer-group [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,68] table-row [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,69] table-cell [0+0+1 93.171875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 11, rect: [11,69 93.171875x16] baseline: 12.796875
                     "Footer Cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,104] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -14,11 +14,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           TableWrapper <(anonymous)> at [9,9] inline-block [0+0+0 161.90625 0+0+0] [0+0+0 190 0+0+0] [BFC] children: not-inline
             Box <(anonymous)> at [9,9] inline-table table-box [0+0+0 161.90625 0+0+0] [0+0+0 190 0+0+0] [TFC] children: not-inline
               Box <tbody> at [9,9] table-row-group [0+0+0 161.90625 0+0+0] [0+0+0 190 0+0+0] children: not-inline
-                BlockContainer <(anonymous)> (not painted) children: inline
-                  TextNode <#text> (not painted)
                 Box <tr> at [9,9] table-row [0+0+0 161.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                   BlockContainer <td> at [30,20] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                     frag 0 from TextNode start: 0, length: 1, rect: [30,20 14.265625x16] baseline: 12.796875
                         "A"
@@ -35,13 +31,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                     frag 0 from TextNode start: 0, length: 1, rect: [142.1875,20 6.34375x16] baseline: 12.796875
                         "1"
                     TextNode <#text> (not painted)
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text> (not painted)
                 Box <tr> at [9,47] table-row [0+0+0 161.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                   BlockContainer <td> at [30,58] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                     frag 0 from TextNode start: 0, length: 1, rect: [31.96875,58 10.3125x16] baseline: 12.796875
                         "C"
@@ -58,13 +50,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                     frag 0 from TextNode start: 0, length: 1, rect: [140.953125,58 8.8125x16] baseline: 12.796875
                         "2"
                     TextNode <#text> (not painted)
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text> (not painted)
                 Box <tr> at [9,85] table-row [0+0+0 161.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                   BlockContainer <td> at [30,96] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                     frag 0 from TextNode start: 0, length: 1, rect: [31.203125,96 11.859375x16] baseline: 12.796875
                         "E"
@@ -81,13 +69,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                     frag 0 from TextNode start: 0, length: 1, rect: [140.8125,96 9.09375x16] baseline: 12.796875
                         "3"
                     TextNode <#text> (not painted)
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text> (not painted)
                 Box <tr> at [9,123] table-row [0+0+0 161.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                   BlockContainer <td> at [30,134] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                     frag 0 from TextNode start: 0, length: 1, rect: [30.515625,134 13.234375x16] baseline: 12.796875
                         "G"
@@ -104,13 +88,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                     frag 0 from TextNode start: 0, length: 1, rect: [141.484375,134 7.75x16] baseline: 12.796875
                         "4"
                     TextNode <#text> (not painted)
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text> (not painted)
                 Box <tr> at [9,161] table-row [0+0+0 161.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
                   BlockContainer <td> at [30,172] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                     frag 0 from TextNode start: 0, length: 1, rect: [34.828125,172 4.59375x16] baseline: 12.796875
                         "I"
@@ -127,10 +107,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                     frag 0 from TextNode start: 0, length: 1, rect: [141.125,172 8.453125x16] baseline: 12.796875
                         "5"
                     TextNode <#text> (not painted)
-                  BlockContainer <(anonymous)> (not painted) children: inline
-                    TextNode <#text> (not painted)
-                BlockContainer <(anonymous)> (not painted) children: inline
-                  TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
         TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
@@ -3,14 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 84 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 172.671875 0+0+611.328125] [0+0+0 84 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 172.671875 0+0+0] [0+0+0 84 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 172.671875 0+0+0] [0+0+0 84 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [8,8] table-row [0+0+0 172.671875 0+0+0] [0+0+0 42 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [29,21] table-cell [0+1+20 14.265625 20+5+0] [0+1+12 16 12+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [29,21 14.265625x16] baseline: 12.796875
                     "A"
@@ -27,13 +21,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [145.125,20 10.3125x16] baseline: 12.796875
                     "C"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,50] table-row [0+0+0 172.671875 0+0+0] [0+0+0 42 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [29,63] table-cell [0+1+20 16.265625 20+1+0] [0+1+12 16 12+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [29,63 11.140625x16] baseline: 12.796875
                     "D"
@@ -50,12 +40,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [145.125,63 12.546875x16] baseline: 12.796875
                     "F"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -7,61 +7,37 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 60.265625 0+0+723.734375] [0+0+0 156 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 60.265625 0+0+0] [0+0+0 156 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <colgroup> (not painted) table-column-group children: not-inline
             BlockContainer <col> (not painted) children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 60.265625 0+0+0] [0+0+0 156 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [8,8] table-row [0+0+0 60.265625 0+0+0] [0+0+0 40 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [31,21] table-cell [0+5+20 14.265625 20+5+0] [0+5+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x16] baseline: 12.796875
                     "A"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,48] table-row [0+0+0 60.265625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [31,59] table-cell [0+5+20 14.265625 20+5+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [31,59 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,86] table-row [0+0+0 60.265625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [31,97] table-cell [0+5+20 14.265625 20+5+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [31,97 10.3125x16] baseline: 12.796875
                     "C"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,124] table-row [0+0+0 60.265625 0+0+0] [0+0+0 40 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [31,135] table-cell [0+5+20 14.265625 20+5+0] [0+1+10 16 10+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [31,135 11.140625x16] baseline: 12.796875
                     "D"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,164] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-multiple-colgroups.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-multiple-colgroups.txt
@@ -3,8 +3,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 38 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 113.609375 0+0+670.390625] [0+0+0 38 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 113.609375 0+0+0] [0+0+0 38 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <colgroup> (not painted) table-column-group children: not-inline
             BlockContainer <col> (not painted) children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -15,8 +13,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 113.609375 0+0+0] [0+0+0 38 0+0+0] children: not-inline
             Box <tr> at [8,8] table-row [0+0+0 113.609375 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [29,19] table-cell [0+1+20 14.265625 20+8+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [29,19 14.265625x16] baseline: 12.796875
                     "A"
@@ -27,10 +23,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [91.265625,19 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,46] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -3,14 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 126 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 114.8125 0+0+669.1875] [0+0+0 126 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 114.8125 0+0+0] [0+0+0 126 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 114.8125 0+0+0] [0+0+0 126 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr.td-thick-border> at [8,8] table-row [0+0+0 114.8125 0+0+0] [0+0+0 42 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [31,21] table-cell [0+5+20 14.265625 20+1+0] [0+5+10 16 10+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x16] baseline: 12.796875
                     "A"
@@ -21,13 +15,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [87.265625,21 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,50] table-row [0+0+0 114.8125 0+0+0] [0+0+0 42 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [29,63] table-cell [0+1+20 16.265625 20+1+0] [0+5+10 16 10+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [29,63 10.3125x16] baseline: 12.796875
                     "C"
@@ -38,13 +28,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [87.265625,63 11.140625x16] baseline: 12.796875
                     "D"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr.td-thick-border> at [8,92] table-row [0+0+0 114.8125 0+0+0] [0+0+0 42 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [31,105] table-cell [0+5+20 14.265625 20+1+0] [0+5+10 16 10+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [31,105 11.859375x16] baseline: 12.796875
                     "E"
@@ -55,12 +41,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [87.265625,105 12.546875x16] baseline: 12.796875
                     "F"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x142]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -3,11 +3,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 120 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 113.40625 0+0+670.59375] [0+0+0 120 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 113.40625 0+0+0] [0+0+0 120 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <thead> at [8,8] table-header-group [0+0+0 113.40625 0+0+0] [0+0+0 40 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [8,8] table-row [0+0+0 113.40625 0+0+0] [0+0+0 40 0+0+0] children: not-inline
               BlockContainer <td> at [29,19] table-cell [0+1+20 16.265625 20+1+0] [0+1+10 16 10+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [29,19 9.59375x16] baseline: 12.796875
@@ -19,16 +15,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [87.265625,19 6.34375x16] baseline: 12.796875
                     "1"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tbody.thick-border> at [8,48] table-row-group [0+0+0 113.40625 0+0+0] [0+0+0 80 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [8,48] table-row [0+0+0 113.40625 0+0+0] [0+0+0 40 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [31,61] table-cell [0+5+20 14.265625 20+1+0] [0+5+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [31,61 14.265625x16] baseline: 12.796875
                     "A"
@@ -39,13 +29,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [87.265625,61 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,88] table-row [0+0+0 113.40625 0+0+0] [0+0+0 40 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [31,99] table-cell [0+5+20 14.265625 20+1+0] [0+1+10 16 10+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [31,99 10.3125x16] baseline: 12.796875
                     "C"
@@ -56,12 +42,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [87.265625,99 11.140625x16] baseline: 12.796875
                     "D"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x136]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolutions-with-more-cells-than-cols.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolutions-with-more-cells-than-cols.txt
@@ -5,8 +5,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 53.0625 0+0+730.9375] [0+0+0 18 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 53.0625 0+0+0] [0+0+0 18 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <colgroup> (not painted) table-column-group children: not-inline
             BlockContainer <col> (not painted) children: not-inline
             BlockContainer <col> (not painted) children: not-inline
@@ -14,11 +12,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 53.0625 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [8,8] table-row [0+0+0 53.0625 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [9,9] table-cell [0+0+1 14.265625 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [9,9 14.265625x16] baseline: 12.796875
                     "A"
@@ -41,12 +35,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [48.921875,9 11.140625x16] baseline: 12.796875
                     "D"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 76 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 143.609375 0+0+640.390625] [0+0+0 76 0+0+0] [BFC] children: not-inline
         Box <table> at [23,13] table-box [0+5+10 113.609375 10+5+0] [0+5+0 66 0+5+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [33,23] table-row-group [0+0+0 93.609375 0+0+0] [0+0+0 46 0+0+0] children: not-inline
             Box <tr> at [33,23] table-row [0+0+0 93.609375 0+0+0] [0+0+0 46 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [48,38] table-cell [0+5+10 14.265625 10+5+0] [0+5+10 16 10+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [48,38 14.265625x16] baseline: 12.796875
                     "A"
@@ -19,10 +15,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [102.265625,38 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x92]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -7,14 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 243.90625 0+0+540.09375] [0+0+0 252 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 241.90625 0+1+0] [0+1+0 250 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [29,19] table-row-group [0+0+0 201.90625 0+0+0] [0+0+0 230 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [29,19] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,30] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x16] baseline: 12.796875
                     "A"
@@ -31,13 +25,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x16] baseline: 12.796875
                     "1"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,67] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,78] table-cell [0+1+20 88.8125 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [89.25,78 10.3125x16] baseline: 12.796875
                     "C"
@@ -48,13 +38,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [200.953125,78 8.8125x16] baseline: 12.796875
                     "2"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,115] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,126] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [51.203125,126 11.859375x16] baseline: 12.796875
                     "E"
@@ -71,13 +57,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [200.8125,126 9.09375x16] baseline: 12.796875
                     "3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,163] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,174] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [50.515625,174 13.234375x16] baseline: 12.796875
                     "G"
@@ -94,13 +76,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [201.484375,174 7.75x16] baseline: 12.796875
                     "4"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,211] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,222] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [54.828125,222 4.59375x16] baseline: 12.796875
                     "I"
@@ -117,12 +95,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [201.125,222 8.453125x16] baseline: 12.796875
                     "5"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,260] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -7,14 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 243.90625 0+0+540.09375] [0+0+0 252 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 241.90625 0+1+0] [0+1+0 250 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [29,19] table-row-group [0+0+0 201.90625 0+0+0] [0+0+0 230 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [29,19] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,54] table-cell [0+1+20 14.265625 20+1+0] [0+1+34 16 34+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [50,54 14.265625x16] baseline: 12.796875
                     "A"
@@ -31,13 +25,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x16] baseline: 12.796875
                     "1"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,67] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [126.265625,78] table-cell [0+1+20 12.546875 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [126.96875,78 11.140625x16] baseline: 12.796875
                     "D"
@@ -48,13 +38,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [200.953125,78 8.8125x16] baseline: 12.796875
                     "2"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,115] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,126] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [51.203125,126 11.859375x16] baseline: 12.796875
                     "E"
@@ -71,13 +57,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [200.8125,126 9.09375x16] baseline: 12.796875
                     "3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,163] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,174] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [50.515625,174 13.234375x16] baseline: 12.796875
                     "G"
@@ -94,13 +76,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [201.484375,174 7.75x16] baseline: 12.796875
                     "4"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,211] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,222] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [54.828125,222 4.59375x16] baseline: 12.796875
                     "I"
@@ -117,12 +95,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [201.125,222 8.453125x16] baseline: 12.796875
                     "5"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,260] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -8,24 +8,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [125.59375,8] floating [0+0+0 478.234375 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table.middle> at [125.59375,8] table-box [0+0+0 478.234375 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [127.59375,10] table-row-group [0+0+0 474.234375 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [127.59375,10] table-row [0+0+0 474.234375 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [128.59375,11] table-cell [0+0+1 472.234375 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [128.59375,11 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       TextNode <#text> (not painted)
       BlockContainer <div.right> at [603.828125,8] floating [0+0+0 188.15625 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
         frag 0 from TextNode start: 5, length: 1, rect: [603.828125,8 10.3125x16] baseline: 12.796875

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -7,14 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 243.90625 0+0+540.09375] [0+0+0 252 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 241.90625 0+1+0] [0+1+0 250 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [29,19] table-row-group [0+0+0 201.90625 0+0+0] [0+0+0 230 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [29,19] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,30] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x16] baseline: 12.796875
                     "A"
@@ -31,13 +25,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x16] baseline: 12.796875
                     "1"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,67] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,78] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [51.96875,78 10.3125x16] baseline: 12.796875
                     "C"
@@ -54,13 +44,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [200.953125,78 8.8125x16] baseline: 12.796875
                     "2"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,115] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,126] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [51.203125,126 11.859375x16] baseline: 12.796875
                     "E"
@@ -77,13 +63,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [200.8125,126 9.09375x16] baseline: 12.796875
                     "3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,163] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,174] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [50.515625,174 13.234375x16] baseline: 12.796875
                     "G"
@@ -100,13 +82,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [201.484375,174 7.75x16] baseline: 12.796875
                     "4"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [29,211] table-row [0+0+0 201.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [50,222] table-cell [0+1+20 14.265625 20+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [54.828125,222 4.59375x16] baseline: 12.796875
                     "I"
@@ -123,12 +101,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [201.125,222 8.453125x16] baseline: 12.796875
                     "5"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,260] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 248 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 174.296875 0+0+609.703125] [0+0+0 70 0+0+0] [BFC] children: not-inline
         Box <table.table-border-black> at [9,9] table-box [0+1+0 172.296875 0+1+0] [0+1+0 68 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [11,11] table-row-group [0+0+0 168.296875 0+0+0] [0+0+0 64 0+0+0] children: not-inline
             Box <tr> at [11,11] table-row [0+0+0 168.296875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [13,13] table-cell [0+1+1 82.015625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x16] baseline: 12.796875
                     "Firstname"
@@ -19,13 +15,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x16] baseline: 12.796875
                     "Lastname"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [11,33] table-row [0+0+0 168.296875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [13,35] table-cell [0+1+1 82.015625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 5, rect: [13,35 44.65625x16] baseline: 12.796875
                     "Peter"
@@ -36,13 +28,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 7, rect: [101.015625,35 53.671875x16] baseline: 12.796875
                     "Griffin"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [11,55] table-row [0+0+0 168.296875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [13,57] table-cell [0+1+1 82.015625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [13,57 35.125x16] baseline: 12.796875
                     "Lois"
@@ -53,21 +41,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 7, rect: [101.015625,57 53.671875x16] baseline: 12.796875
                     "Griffin"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,78] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,78] [0+0+0 164.296875 0+0+619.703125] [0+0+0 58 0+0+0] [BFC] children: not-inline
         Box <table.table-border-black> at [8,78] table-box [0+0+0 164.296875 0+0+0] [0+0+0 58 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [8,78] table-row-group [0+0+0 164.296875 0+0+0] [0+0+0 58 0+0+0] children: not-inline
             Box <tr> at [8,78] table-row [0+0+0 164.296875 0+0+0] [0+0+0 19 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [9,79] table-cell [0+0+1 82.015625 1+1+0] [0+0+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 9, rect: [9,79 82.015625x16] baseline: 12.796875
                     "Firstname"
@@ -78,13 +58,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 8, rect: [95.015625,79 76.28125x16] baseline: 12.796875
                     "Lastname"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,97] table-row [0+0+0 164.296875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [9,99] table-cell [0+0+1 82.015625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 5, rect: [9,99 44.65625x16] baseline: 12.796875
                     "Peter"
@@ -95,13 +71,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 7, rect: [95.015625,99 53.671875x16] baseline: 12.796875
                     "Griffin"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,117] table-row [0+0+0 164.296875 0+0+0] [0+0+0 19 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [9,119] table-cell [0+0+1 82.015625 1+1+0] [0+1+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [9,119 35.125x16] baseline: 12.796875
                     "Lois"
@@ -112,20 +84,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 7, rect: [95.015625,119 53.671875x16] baseline: 12.796875
                     "Griffin"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,136] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,136] [0+0+0 160.296875 0+0+623.703125] [0+0+0 52 0+0+0] [BFC] children: not-inline
         Box <div.table.border-black> at [8,136] table-box [0+0+0 160.296875 0+0+0] [0+0+0 52 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <div.table-row.border-black> at [8,136] table-row [0+0+0 160.296875 0+0+0] [0+0+0 17 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             BlockContainer <div.table-cell.border-black> at [8,136] table-cell [0+0+0 82.015625 0+1+0] [0+0+0 16 0+1+0] [BFC] children: inline
               frag 0 from TextNode start: 0, length: 9, rect: [8,136 82.015625x16] baseline: 12.796875
                   "Firstname"
@@ -136,13 +100,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               frag 0 from TextNode start: 0, length: 8, rect: [92.015625,136 76.28125x16] baseline: 12.796875
                   "Lastname"
               TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <div.table-row.border-black> at [8,153] table-row [0+0+0 160.296875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             BlockContainer <div.table-cell.border-black> at [8,154] table-cell [0+0+0 82.015625 0+1+0] [0+1+0 16 0+1+0] [BFC] children: inline
               frag 0 from TextNode start: 0, length: 5, rect: [8,154 44.65625x16] baseline: 12.796875
                   "Peter"
@@ -153,13 +113,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               frag 0 from TextNode start: 0, length: 7, rect: [92.015625,154 53.671875x16] baseline: 12.796875
                   "Griffin"
               TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <div.table-row.border-black> at [8,171] table-row [0+0+0 160.296875 0+0+0] [0+0+0 17 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             BlockContainer <div.table-cell.border-black> at [8,172] table-cell [0+0+0 82.015625 0+1+0] [0+1+0 16 0+0+0] [BFC] children: inline
               frag 0 from TextNode start: 0, length: 4, rect: [8,172 35.125x16] baseline: 12.796875
                   "Lois"
@@ -170,20 +126,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               frag 0 from TextNode start: 0, length: 7, rect: [92.015625,172 53.671875x16] baseline: 12.796875
                   "Griffin"
               TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,188] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,188] [0+0+0 168.296875 0+0+615.703125] [0+0+0 68 0+0+0] [BFC] children: not-inline
         Box <div.table.thick-border-black> at [8,188] table-box [0+0+0 168.296875 0+0+0] [0+0+0 68 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <div.table-row.thick-border-black> at [8,188] table-row [0+0+0 168.296875 0+0+0] [0+0+0 21 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             BlockContainer <div.table-cell.thick-border-black> at [8,188] table-cell [0+0+0 82.015625 0+10+0] [0+0+0 16 0+10+0] [BFC] children: inline
               frag 0 from TextNode start: 0, length: 9, rect: [8,188 82.015625x16] baseline: 12.796875
                   "Firstname"
@@ -194,13 +142,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               frag 0 from TextNode start: 0, length: 8, rect: [100.015625,188 76.28125x16] baseline: 12.796875
                   "Lastname"
               TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <div.table-row.thick-border-black> at [8,209] table-row [0+0+0 168.296875 0+0+0] [0+0+0 26 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             BlockContainer <div.table-cell.thick-border-black> at [8,214] table-cell [0+0+0 82.015625 0+10+0] [0+10+0 16 0+10+0] [BFC] children: inline
               frag 0 from TextNode start: 0, length: 5, rect: [8,214 44.65625x16] baseline: 12.796875
                   "Peter"
@@ -211,13 +155,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               frag 0 from TextNode start: 0, length: 7, rect: [100.015625,214 53.671875x16] baseline: 12.796875
                   "Griffin"
               TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <div.table-row.thick-border-black> at [8,235] table-row [0+0+0 168.296875 0+0+0] [0+0+0 21 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             BlockContainer <div.table-cell.thick-border-black> at [8,240] table-cell [0+0+0 82.015625 0+10+0] [0+10+0 16 0+0+0] [BFC] children: inline
               frag 0 from TextNode start: 0, length: 4, rect: [8,240 35.125x16] baseline: 12.796875
                   "Lois"
@@ -228,10 +168,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               frag 0 from TextNode start: 0, length: 7, rect: [100.015625,240 53.671875x16] baseline: 12.796875
                   "Griffin"
               TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,256] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -5,8 +5,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 78 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 99.171875 0+0+684.828125] [0+0+0 78 0+0+0] [BFC] children: not-inline
         Box <table#full-table> at [8,8] table-box [0+0+0 99.171875 0+0+0] [0+0+0 62 0+0+16] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <caption> at [8,70] [0+0+0 99.171875 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 5, length: 9, rect: [16.21875,70 82.734375x16] baseline: 12.796875
                 "A Caption"
@@ -14,53 +12,27 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <thead> at [10,10] table-header-group [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,10] table-row [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+0+1 93.171875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x16] baseline: 12.796875
                     "Head Cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tbody> at [10,30] table-row-group [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,30] table-row [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+0+1 93.171875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 9, rect: [11,31 70.234375x16] baseline: 12.796875
                     "Body Cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tfoot> at [10,50] table-footer-group [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,50] table-row [0+0+0 95.171875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,51] table-cell [0+0+1 93.171875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 11, rect: [11,51 93.171875x16] baseline: 12.796875
                     "Footer Cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,86] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/caption-constrained-to-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/caption-constrained-to-table-width.txt
@@ -20,8 +20,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             frag 3 from TextNode start: 34, length: 5, rect: [9,161 39.796875x16] baseline: 12.796875
                 "width"
             TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,178] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/caption-specified-width-with-float.txt
+++ b/Tests/LibWeb/Layout/expected/table/caption-specified-width-with-float.txt
@@ -11,8 +11,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,64] [0+0+0 200 0+0+584] [0+0+0 38 0+0+0] [BFC] children: not-inline
         Box <table> at [8,82] table-box [0+0+0 200 0+0+0] [0+0+0 2 0+0+18] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <caption> at [8,64] [0+0+0 200 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 9, length: 6, rect: [63.8125,64 41.296875x16] baseline: 12.796875
                 "inline"
@@ -21,8 +19,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               frag 0 from TextNode start: 13, length: 7, rect: [9,65 53.8125x16] baseline: 12.796875
                   "floated"
               TextNode <#text> (not painted)
-            TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,102] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -6,14 +6,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           TextNode <#text> (not painted)
         TableWrapper <(anonymous)> at [8,8] [0+0+0 80 0+0+0] [0+0+0 22 0+0+0] [BFC] children: not-inline
           Box <table#table> at [8,8] table-box [0+0+0 80 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tbody> at [10,10] table-row-group [0+0+0 76 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               Box <tr> at [10,10] table-row [0+0+0 76 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-                BlockContainer <(anonymous)> (not painted) children: inline
-                  TextNode <#text> (not painted)
                 BlockContainer <td> at [11,11] table-cell [0+0+1 17.828125 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                   frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x16] baseline: 12.796875
                       "A"
@@ -30,12 +24,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                   frag 0 from TextNode start: 0, length: 3, rect: [48.65625,11 29.453125x16] baseline: 12.796875
                       "C D"
                   TextNode <#text> (not painted)
-                BlockContainer <(anonymous)> (not painted) children: inline
-                  TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
         BlockContainer <(anonymous)> at [8,30] [0+0+0 80 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -3,14 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 42 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 784 0+0+0] [0+0+0 42 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,10] table-row-group [0+0+0 780 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [10,10] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <th> at [11,11] table-cell [0+0+1 300.640625 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [154.1875,11 14.265625x16] baseline: 12.796875
                     "A"
@@ -27,13 +21,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 3, rect: [623.953125,11 29.453125x16] baseline: 12.796875
                     "C D"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [10,30] table-row [0+0+0 780 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+0+1 300.640625 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [155.390625,31 11.859375x16] baseline: 12.796875
                     "E"
@@ -50,12 +40,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [632.0625,31 13.234375x16] baseline: 12.796875
                     "G"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 114 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 93.359375 0+0+690.640625] [0+0+0 114 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 93.359375 0+0+0] [0+0+0 114 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 93.359375 0+0+0] [0+0+0 114 0+0+0] children: not-inline
             Box <tr> at [8,8] table-row [0+0+0 93.359375 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [19,19] table-cell [0+1+10 8.453125 10+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [19,19 6.34375x16] baseline: 12.796875
                     "1"
@@ -25,14 +21,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [80.265625,19 9.09375x16] baseline: 12.796875
                     "3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <(anonymous)> at [101.359375,27] table-cell [0+1+0 0 0+0+0] [0+0+19 0 19+0+0] [BFC] children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,46] table-row [0+0+0 93.359375 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [19,57] table-cell [0+1+10 8.453125 10+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [19,57 7.75x16] baseline: 12.796875
                     "4"
@@ -43,21 +35,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 3, rect: [49.453125,76 24.046875x16] baseline: 12.796875
                     "6-9"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [8,84] table-row [0+0+0 93.359375 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [19,95] table-cell [0+1+10 8.453125 10+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [19,95 8.453125x16] baseline: 12.796875
                     "5"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x130]

--- a/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
@@ -3,25 +3,17 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 58 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 27.90625 0+0+756.09375] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 27.90625 0+0+0] [0+0+0 42 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,10] table-row-group [0+0+0 23.90625 0+0+0] [0+0+0 38 0+0+0] children: not-inline
             Box <tr> at [10,10] table-row [0+0+0 23.90625 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+0+1 6.8125 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x16] baseline: 12.796875
                     "1"
-                TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> at [20.8125,19] table-cell [0+0+0 0 0+0+0] [0+0+9 0 9+0+0] [BFC] children: not-inline
               BlockContainer <(anonymous)> at [22.8125,19] table-cell [0+0+0 11.09375 0+0+0] [0+0+9 0 9+0+0] [BFC] children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [10,30] table-row [0+0+0 23.90625 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+0+1 8.8125 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [11,31 8.8125x16] baseline: 12.796875
                     "2"
@@ -32,10 +24,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [23.8125,31 9.09375x16] baseline: 12.796875
                     "3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,50] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
         frag 0 from TextNode start: 1, length: 19, rect: [8,50 162.109375x16] baseline: 12.796875
             "PASS (didn't crash)"

--- a/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 42 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 420 0+0+364] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 418 0+1+0] [0+1+0 40 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 418 0+0+0] [0+0+0 40 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 418 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+1+1 79.59375 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [43.65625,11 14.265625x16] baseline: 12.796875
                     "A"
@@ -25,13 +21,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [335.296875,11 10.3125x16] baseline: 12.796875
                     "C"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 418 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 79.59375 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [45.21875,31 11.140625x16] baseline: 12.796875
                     "D"
@@ -42,10 +34,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [253.859375,31 11.859375x16] baseline: 12.796875
                     "E"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]

--- a/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 42 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 210 0+0+574] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 208 0+1+0] [0+1+0 40 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 208 0+0+0] [0+0+0 40 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 208 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+1+1 180 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [93.859375,11 14.265625x16] baseline: 12.796875
                     "A"
@@ -19,21 +15,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [200.328125,11 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 208 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 204 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [107.84375,31 10.3125x16] baseline: 12.796875
                     "C"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -7,12 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 39.3125 0+0+744.6875] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 37.3125 0+1+0] [0+1+0 40 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 37.3125 0+0+0] [0+0+0 40 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 37.3125 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+1+1 17.5625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [12.640625,11 14.265625x16] baseline: 12.796875
                     "A"
@@ -23,21 +19,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [33.765625,11 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 37.3125 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 33.3125 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 3, rect: [11,31 33.3125x16] baseline: 12.796875
                     "CDE"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,50] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
@@ -7,12 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 229.359375 0+0+554.640625] [0+0+0 82 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 227.359375 0+1+0] [0+1+0 80 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 227.359375 0+0+0] [0+0+0 80 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <th> at [11,11] table-cell [0+1+1 70.046875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x16] baseline: 12.796875
                     "Header 1"
@@ -29,35 +25,23 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x16] baseline: 12.796875
                     "Header 3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 223.359375 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [101.75,31 41.84375x16] baseline: 12.796875
                     "Cell 1"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,49] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,51] table-cell [0+1+1 223.359375 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [100.515625,51 44.3125x16] baseline: 12.796875
                     "Cell 2"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,69] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,71] table-cell [0+1+1 70.046875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [23.71875,71 44.59375x16] baseline: 12.796875
                     "Cell 3"
@@ -74,10 +58,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [175.984375,71 43.953125x16] baseline: 12.796875
                     "Cell 5"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,90] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -3,8 +3,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 104 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 104 0+0+0] [BFC] children: not-inline
         Box <table.ambox> at [9,9] table-box [0+1+0 782 0+1+0] [0+1+0 102 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [11,11] table-row-group [0+0+0 778 0+0+0] [0+0+0 98 0+0+0] children: not-inline
             Box <tr> at [11,11] table-row [0+0+0 778 0+0+0] [0+0+0 98 0+0+0] children: not-inline
               BlockContainer <td.mbox-image> at [12,35] table-cell [0+0+1 50 1+0+0] [0+0+24 50 24+0+0] [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 42 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 600 0+0+184] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 598 0+1+0] [0+1+0 40 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 598 0+0+0] [0+0+0 40 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 598 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+1+1 62.4375 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x16] baseline: 12.796875
                     "cell"
@@ -31,13 +27,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [276.765625,11 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 598 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 62.4375 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,31 26.078125x16] baseline: 12.796875
                     "cell"
@@ -60,10 +52,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [276.765625,31 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 42 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 600 0+0+184] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 598 0+1+0] [0+1+0 40 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 597.96875 0+0+0] [0+0+0 40 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 597.96875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+1+1 95.65625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x16] baseline: 12.796875
                     "cell"
@@ -31,13 +27,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 597.96875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 95.65625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,31 26.078125x16] baseline: 12.796875
                     "cell"
@@ -60,10 +52,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [309.96875,31 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 42 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 600 0+0+184] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 598 0+1+0] [0+1+0 40 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 598 0+0+0] [0+0+0 40 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 598 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+1+1 58.578125 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x16] baseline: 12.796875
                     "cell"
@@ -31,13 +27,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [256.6875,11 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 598 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 58.578125 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,31 26.078125x16] baseline: 12.796875
                     "cell"
@@ -60,10 +52,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [256.6875,31 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 74 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 600 0+0+184] [0+0+0 74 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 598 0+1+0] [0+1+0 72 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 598 0+0+0] [0+0+0 72 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 598 0+0+0] [0+0+0 36 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,19] table-cell [0+1+1 94 1+1+0] [0+1+9 16 9+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,19 26.078125x16] baseline: 12.796875
                     "cell"
@@ -33,13 +29,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [305,19 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,45] table-row [0+0+0 598 0+0+0] [0+0+0 36 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,55] table-cell [0+1+1 94 1+1+0] [0+1+9 16 9+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,55 26.078125x16] baseline: 12.796875
                     "cell"
@@ -64,10 +56,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [305,55 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x90]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 42 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 600 0+0+184] [0+0+0 42 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 598 0+1+0] [0+1+0 40 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 598 0+0+0] [0+0+0 40 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 598 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+1+1 145.5 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x16] baseline: 12.796875
                     "cell"
@@ -31,13 +27,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [459.5,11 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 598 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 145.5 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,31 26.078125x16] baseline: 12.796875
                     "cell"
@@ -60,10 +52,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [459.5,31 94.96875x16] baseline: 12.796875
                     "A table cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]

--- a/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
@@ -3,14 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 36 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 61 0+0+723] [0+0+0 36 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 61 0+0+0] [0+0+0 36 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 61 0+0+0] [0+0+0 36 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [8,8] table-row [0+0+0 61 0+0+0] [0+0+0 36 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [10,18] table-cell [0+1+1 14.296875 1+1+0] [0+1+9 16 9+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [10,18 14.265625x16] baseline: 12.796875
                     "A"
@@ -31,12 +25,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 5, length: 1, rect: [52.703125,18 11.140625x16] baseline: 12.796875
                     "D"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -5,8 +5,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 134 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 63.046875 0+0+720.953125] [0+0+0 134 0+0+0] [BFC] children: not-inline
         Box <table#full-table> at [10,40] table-box [0+2+0 59.046875 0+2+0] [0+2+0 68 0+2+32] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <caption> at [8,8] [0+0+0 63.046875 0+0+0] [0+0+0 32 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 5, length: 6, rect: [12.5,8 54.03125x16] baseline: 12.796875
                 "A long"
@@ -16,11 +14,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <thead> at [12,42] table-header-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [12,42] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [14,44] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 2, rect: [14,44 20.609375x16] baseline: 12.796875
                     "A1"
@@ -31,18 +25,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 2, rect: [41.25,44 23.078125x16] baseline: 12.796875
                     "A2"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tbody> at [12,64] table-row-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [12,64] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [14,66] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 2, rect: [14,66 15.6875x16] baseline: 12.796875
                     "B1"
@@ -53,18 +39,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 2, rect: [41.25,66 18.15625x16] baseline: 12.796875
                     "B2"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tfoot> at [12,86] table-footer-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [12,86] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [14,88] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 2, rect: [14,88 18.890625x16] baseline: 12.796875
                     "F1"
@@ -75,12 +53,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 2, rect: [41.25,88 21.359375x16] baseline: 12.796875
                     "F2"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,142] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -3,8 +3,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 64 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 81.4375 0+0+702.5625] [0+0+0 64 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 79.4375 0+1+71.4375] [0+1+0 62 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [11,11] table-row-group [0+0+0 75.4375 0+0+0] [0+0+0 58 0+0+0] children: not-inline
             Box <tr> at [11,11] table-row [0+0+0 75.4375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
               BlockContainer <td> at [13,13] table-cell [0+1+1 71.4375 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
@@ -20,8 +18,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 1 from TextNode start: 10, length: 8, rect: [13,51 63.5625x16] baseline: 12.796875
                     "***** **"
                 TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,72] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
@@ -7,14 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 115.828125 0+0+668.171875] [0+0+0 122 0+0+0] [BFC] children: not-inline
         Box <table> at [13,13] table-box [0+5+0 105.828125 0+5+0] [0+5+0 112 0+5+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [15,15] table-row-group [0+0+0 101.828125 0+0+0] [0+0+0 108 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [15,15] table-row [0+0+0 101.828125 0+0+0] [0+0+0 53 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [25,33.5] table-cell [0+5+5 11.5625 5+5+0] [0+5+13.5 16 13.5+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [25,33.5 11.5625x16] baseline: 12.796875
                     "X"
@@ -26,54 +20,28 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                   TextNode <#text> (not painted)
                 TableWrapper <(anonymous)> at [58.5625,25] [0+0+0 48.265625 0+0+0] [0+0+0 88 0+0+0] [BFC] children: not-inline
                   Box <table> at [63.5625,30] table-box [0+5+0 38.265625 0+5+0] [0+5+0 78 0+5+0] [TFC] children: not-inline
-                    BlockContainer <(anonymous)> (not painted) children: inline
-                      TextNode <#text> (not painted)
                     Box <tbody> at [65.5625,32] table-row-group [0+0+0 34.265625 0+0+0] [0+0+0 74 0+0+0] children: not-inline
-                      BlockContainer <(anonymous)> (not painted) children: inline
-                        TextNode <#text> (not painted)
                       Box <tr> at [65.5625,32] table-row [0+0+0 34.265625 0+0+0] [0+0+0 36 0+0+0] children: not-inline
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
                         BlockContainer <td> at [75.5625,42] table-cell [0+5+5 14.265625 5+5+0] [0+5+5 16 5+5+0] [BFC] children: inline
                           frag 0 from TextNode start: 0, length: 1, rect: [75.5625,42 14.265625x16] baseline: 12.796875
                               "A"
                           TextNode <#text> (not painted)
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text> (not painted)
                       Box <tr> at [65.5625,70] table-row [0+0+0 34.265625 0+0+0] [0+0+0 36 0+0+0] children: not-inline
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
                         BlockContainer <td> at [75.5625,80] table-cell [0+5+5 14.265625 5+5+0] [0+5+5 16 5+5+0] [BFC] children: inline
                           frag 0 from TextNode start: 0, length: 1, rect: [75.5625,80 9.34375x16] baseline: 12.796875
                               "B"
                           TextNode <#text> (not painted)
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
-                      BlockContainer <(anonymous)> (not painted) children: inline
-                        TextNode <#text> (not painted)
-                    BlockContainer <(anonymous)> (not painted) children: inline
-                      TextNode <#text> (not painted)
                 BlockContainer <(anonymous)> at [58.5625,113] [0+0+0 48.265625 0+0+0] [0+0+0 0 0+0+0] children: inline
                   TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [15,70] table-row [0+0+0 101.828125 0+0+0] [0+0+0 53 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [25,88.5] table-cell [0+5+5 11.5625 5+5+0] [0+5+13.5 16 13.5+5+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [25,88.5 11.09375x16] baseline: 12.796875
                     "Y"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,130] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -3,14 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 22 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 94 0+0+690] [0+0+0 22 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 92 0+1+0] [0+1+0 20 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 92 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [9,9] table-row [0+0+0 92 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+1+1 14.40625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [11.0625,11 14.265625x16] baseline: 12.796875
                     "A"
@@ -27,12 +21,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [86.640625,11 10.3125x16] baseline: 12.796875
                     "C"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x38]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 119 0+0+665] [0+0+0 20 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 119 0+0+0] [0+0+0 20 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 119 0+0+0] [0+0+0 20 0+0+0] children: not-inline
             Box <tr> at [8,8] table-row [0+0+0 119 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [10,10] table-cell [0+1+1 31.703125 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 3, rect: [10,10 31.609375x16] baseline: 12.796875
                     "A B"
@@ -25,10 +21,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [93.296875,10 11.140625x16] baseline: 12.796875
                     "D"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]

--- a/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
@@ -3,17 +3,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] positioned [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
         Box <table#t> at [8,8] table-box [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,10] table-row-group [0+0+0 2 0+0+0] [0+0+0 2 0+0+0] children: not-inline
             Box <tr> at [10,10] table-row [0+0+0 2 0+0+0] [0+0+0 2 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,11] table-cell [0+0+1 0 1+0+0] [0+0+1 0 1+0+0] [BFC] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]

--- a/Tests/LibWeb/Layout/expected/table/remove-irrelevant-whitespace-boxes.txt
+++ b/Tests/LibWeb/Layout/expected/table/remove-irrelevant-whitespace-boxes.txt
@@ -1,0 +1,39 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+      TableWrapper <(anonymous)> at [0,0] [0+0+0 20 0+0+780] [0+0+0 10 0+0+0] [BFC] children: not-inline
+        Box <div.table> at [0,0] table-box [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [TFC] children: not-inline
+          Box <div.row> at [0,0] table-row [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+            BlockContainer <div.cell> at [0,0] table-cell [0+0+0 20 0+0+0] [0+0+0 0 10+0+0] [BFC] children: not-inline
+      TableWrapper <(anonymous)> at [0,10] [0+0+0 20 0+0+780] [0+0+0 10 0+0+0] [BFC] children: not-inline
+        Box <div.table> at [0,10] table-box [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [TFC] children: not-inline
+          Box <div.group> at [0,10] table-row-group [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+            Box <div.row> at [0,10] table-row [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+              BlockContainer <div.cell> at [0,10] table-cell [0+0+0 20 0+0+0] [0+0+0 0 10+0+0] [BFC] children: not-inline
+      TableWrapper <(anonymous)> at [0,20] [0+0+0 20 0+0+780] [0+0+0 10 0+0+0] [BFC] children: not-inline
+        Box <div.table> at [0,20] table-box [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [TFC] children: not-inline
+          Box <div.row> at [0,20] table-row [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+            BlockContainer <div.cell> at [0,20] table-cell [0+0+0 20 0+0+0] [0+0+0 0 10+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,30] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x30]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x30]
+      PaintableWithLines (TableWrapper(anonymous)) [0,0 20x10]
+        Paintable (Box<DIV>.table) [0,0 20x10]
+          Paintable (Box<DIV>.row) [0,0 20x10]
+            PaintableWithLines (BlockContainer<DIV>.cell) [0,0 20x10]
+      PaintableWithLines (TableWrapper(anonymous)) [0,10 20x10]
+        Paintable (Box<DIV>.table) [0,10 20x10]
+          Paintable (Box<DIV>.group) [0,10 20x10]
+            Paintable (Box<DIV>.row) [0,10 20x10]
+              PaintableWithLines (BlockContainer<DIV>.cell) [0,10 20x10]
+      PaintableWithLines (TableWrapper(anonymous)) [0,20 20x10]
+        Paintable (Box<DIV>.table) [0,20 20x10]
+          Paintable (Box<DIV>.row) [0,20 20x10]
+            PaintableWithLines (BlockContainer<DIV>.cell) [0,20 20x10]
+      PaintableWithLines (BlockContainer(anonymous)) [0,30 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x30] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 24 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 49.21875 0+0+734.78125] [0+0+0 24 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 49.21875 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,10] table-row-group [0+0+0 45.21875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
             Box <tr> at [10,10] table-row [0+0+0 45.21875 0+0+0] [0+0+0 9 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,14.5] table-cell [0+0+1 0 1+0+0] [0+0+4.5 0 4.5+0+0] [BFC] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
@@ -19,18 +15,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       "Test"
                   TextNode <#text> (not painted)
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [10,21] table-row [0+0+0 45.21875 0+0+0] [0+0+0 9 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,25.5] table-cell [0+0+1 0 1+0+0] [0+0+4.5 0 4.5+0+0] [BFC] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -7,14 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 75.828125 0+0+708.171875] [0+0+0 112 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 73.828125 0+1+0] [0+1+0 110 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [11,11] table-row-group [0+0+0 69.828125 0+0+0] [0+0+0 106 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [11,11] table-row [0+0+0 69.828125 0+0+0] [0+0+0 52 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [17,29] table-cell [0+1+5 11.5625 5+1+0] [0+1+17 16 17+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [17,29 11.5625x16] baseline: 12.796875
                     "X"
@@ -26,65 +20,35 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                   TextNode <#text> (not painted)
                 TableWrapper <(anonymous)> at [42.5625,17] [0+0+0 32.265625 0+0+0] [0+0+0 94 0+0+0] [BFC] children: not-inline
                   Box <table> at [43.5625,18] table-box [0+1+0 30.265625 0+1+0] [0+1+0 92 0+1+0] [TFC] children: not-inline
-                    BlockContainer <(anonymous)> (not painted) children: inline
-                      TextNode <#text> (not painted)
                     Box <tbody> at [45.5625,20] table-row-group [0+0+0 26.265625 0+0+0] [0+0+0 88 0+0+0] children: not-inline
-                      BlockContainer <(anonymous)> (not painted) children: inline
-                        TextNode <#text> (not painted)
                       Box <tr> at [45.5625,20] table-row [0+0+0 26.265625 0+0+0] [0+0+0 28 0+0+0] children: not-inline
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
                         BlockContainer <td> at [51.5625,26] table-cell [0+1+5 14.265625 5+1+0] [0+1+5 16 5+1+0] [BFC] children: inline
                           frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x16] baseline: 12.796875
                               "A"
                           TextNode <#text> (not painted)
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text> (not painted)
                       Box <tr> at [45.5625,50] table-row [0+0+0 26.265625 0+0+0] [0+0+0 28 0+0+0] children: not-inline
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
                         BlockContainer <td> at [51.5625,56] table-cell [0+1+5 14.265625 5+1+0] [0+1+5 16 5+1+0] [BFC] children: inline
                           frag 0 from TextNode start: 0, length: 1, rect: [51.5625,56 9.34375x16] baseline: 12.796875
                               "B"
                           TextNode <#text> (not painted)
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text> (not painted)
                       Box <tr> at [45.5625,80] table-row [0+0+0 26.265625 0+0+0] [0+0+0 28 0+0+0] children: not-inline
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
                         BlockContainer <td> at [51.5625,86] table-cell [0+1+5 14.265625 5+1+0] [0+1+5 16 5+1+0] [BFC] children: inline
                           frag 0 from TextNode start: 0, length: 1, rect: [51.5625,86 10.3125x16] baseline: 12.796875
                               "C"
                           TextNode <#text> (not painted)
-                        BlockContainer <(anonymous)> (not painted) children: inline
-                          TextNode <#text> (not painted)
-                      BlockContainer <(anonymous)> (not painted) children: inline
-                        TextNode <#text> (not painted)
-                    BlockContainer <(anonymous)> (not painted) children: inline
-                      TextNode <#text> (not painted)
                 BlockContainer <(anonymous)> at [42.5625,111] [0+0+0 32.265625 0+0+0] [0+0+0 0 0+0+0] children: inline
                   TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [11,65] table-row [0+0+0 69.828125 0+0+0] [0+0+0 52 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [17,83] table-cell [0+1+5 11.5625 5+1+0] [0+1+17 16 17+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [17,83 11.09375x16] baseline: 12.796875
                     "Y"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,120] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
@@ -7,12 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 229.359375 0+0+554.640625] [0+0+0 122 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 227.359375 0+1+0] [0+1+0 120 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 227.359375 0+0+0] [0+0+0 120 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <th> at [11,11] table-cell [0+1+1 70.046875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x16] baseline: 12.796875
                     "Header 1"
@@ -29,13 +25,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x16] baseline: 12.796875
                     "Header 3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,29] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,31] table-cell [0+1+1 70.046875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [25.09375,31 41.84375x16] baseline: 12.796875
                     "Cell 1"
@@ -52,13 +44,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [175.65625,41 44.59375x16] baseline: 12.796875
                     "Cell 3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,49] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,51] table-cell [0+1+1 70.046875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [24.390625,51 43.25x16] baseline: 12.796875
                     "Cell 4"
@@ -69,13 +57,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [99.328125,51 43.953125x16] baseline: 12.796875
                     "Cell 5"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,69] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,71] table-cell [0+1+1 70.046875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [23.90625,71 44.234375x16] baseline: 12.796875
                     "Cell 6"
@@ -92,13 +76,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [175.46875,71 44.984375x16] baseline: 12.796875
                     "Cell 8"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,89] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,91] table-cell [0+1+1 70.046875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [23.859375,91 44.328125x16] baseline: 12.796875
                     "Cell 9"
@@ -115,13 +95,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 7, rect: [173.859375,101 48.1875x16] baseline: 12.796875
                     "Cell 11"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,109] table-row [0+0+0 227.359375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,111] table-cell [0+1+1 70.046875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 7, rect: [20.6875,111 50.65625x16] baseline: 12.796875
                     "Cell 12"
@@ -132,10 +108,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 7, rect: [95.828125,111 50.9375x16] baseline: 12.796875
                     "Cell 13"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,130] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -7,12 +7,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [8,8] [0+0+0 229.359375 0+0+554.640625] [0+0+0 82 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 229.359375 0+0+0] [0+0+0 82 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [10,10] table-row-group [0+0+0 225.359375 0+0+0] [0+0+0 78 0+0+0] children: not-inline
             Box <tr> at [10,10] table-row [0+0+0 225.359375 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <th> at [11,11] table-cell [0+0+1 70.046875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x16] baseline: 12.796875
                     "Header 1"
@@ -29,13 +25,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x16] baseline: 12.796875
                     "Header 3"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [10,30] table-row [0+0+0 225.359375 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,41] table-cell [0+0+1 70.046875 1+0+0] [0+0+11 16 11+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 5, rect: [11,41 49.609375x16] baseline: 12.796875
                     "Row 1"
@@ -52,13 +44,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [161.5625,31 44.3125x16] baseline: 12.796875
                     "Cell 2"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [10,50] table-row [0+0+0 225.359375 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [85.046875,51] table-cell [0+0+1 72.515625 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [85.046875,51 44.59375x16] baseline: 12.796875
                     "Cell 3"
@@ -69,13 +57,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [161.5625,51 43.25x16] baseline: 12.796875
                     "Cell 4"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [10,70] table-row [0+0+0 225.359375 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,71] table-cell [0+0+1 70.046875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 5, rect: [11,71 52.078125x16] baseline: 12.796875
                     "Row 2"
@@ -92,10 +76,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [161.5625,71 44.234375x16] baseline: 12.796875
                     "Cell 6"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,90] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 24 0+0+760] [0+0+0 100 0+0+0] [BFC] children: not-inline
         Box <table> at [19,19] table-box [0+1+10 2 10+1+0] [0+1+10 78 10+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [21,21] table-row-group [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
             Box <tr> at [21,21] table-row [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 26 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 102 0+0+682] [0+0+0 26 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 100 0+1+0] [0+1+0 24 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [11,11] table-row-group [0+0+0 95.984375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
             Box <tr> at [11,11] table-row [0+0+0 95.984375 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [13,13] table-cell [0+1+1 19 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x16] baseline: 12.796875
                     "A"
@@ -25,10 +21,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [85.984375,13 10.3125x16] baseline: 12.796875
                     "C"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]

--- a/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
@@ -9,8 +9,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 10, rect: [112,194 81.34375x16] baseline: 12.796875
                     "off-center"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x404]

--- a/Tests/LibWeb/Layout/expected/table/table-align-center.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center.txt
@@ -9,8 +9,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [374.1875,102 51.625x16] baseline: 12.796875
                     "center"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]

--- a/Tests/LibWeb/Layout/expected/table/table-caption-inline-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-caption-inline-width.txt
@@ -3,9 +3,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 61 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 208 0+0+576] [0+0+0 61 0+0+0] [BFC] children: not-inline
         Box <table> at [9,29] table-box [0+1+0 206 0+1+0] [0+1+0 17 0+1+22] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
-            TextNode <#text> (not painted)
           BlockContainer <caption> at [15,8] [0+1+6 194 6+1+0] [0+1+0 20 0+1+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 10, rect: [62,8 100x10] baseline: 8
                 "AAAAAAAAAA"
@@ -20,8 +17,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [12,31 10x10] baseline: 8
                     "x"
                 TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,69] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
@@ -17,8 +17,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [387.078125,133 56.109375x16] baseline: 12.796875
                     "bottom"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]

--- a/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 154 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 103.421875 0+0+680.578125] [0+0+0 154 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 101.421875 0+1+0] [0+1+0 152 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 101.421875 0+0+0] [0+0+0 152 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 101.421875 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [20,20] table-cell [0+1+10 9.59375 10+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [20,20 9.59375x16] baseline: 12.796875
                     "0"
@@ -25,24 +21,16 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [87.859375,58 11.5625x16] baseline: 12.796875
                     "X"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,47] table-row [0+0+0 101.421875 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [20,58] table-cell [0+1+10 9.59375 10+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [20,58 6.34375x16] baseline: 12.796875
                     "1"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,85] table-row [0+0+0 101.421875 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [20,96] table-cell [0+1+10 9.59375 10+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [20,96 8.8125x16] baseline: 12.796875
                     "2"
@@ -53,13 +41,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [51.59375,115 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text> (not painted)
             Box <tr> at [9,123] table-row [0+0+0 101.421875 0+0+0] [0+0+0 38 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [20,134] table-cell [0+1+10 9.59375 10+1+0] [0+1+10 16 10+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [20,134 9.09375x16] baseline: 12.796875
                     "3"
@@ -70,10 +54,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [87.859375,134 10.3125x16] baseline: 12.796875
                     "C"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,162] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/td-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/td-valign.txt
@@ -17,8 +17,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 6, rect: [92.078125,192 56.109375x16] baseline: 12.796875
                     "bottom"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -3,8 +3,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 84 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 80.46875 0+0+703.53125] [0+0+0 84 0+0+0] [BFC] children: not-inline
         Box <table> at [8,34] table-box [0+0+0 80.46875 0+0+0] [0+0+0 22 0+0+36] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <caption> at [18,8] [0+0+10 60.46875 10+0+0] [0+0+10 16 10+0+0] [BFC] children: inline
             frag 0 from TextNode start: 5, length: 7, rect: [18,8 60.46875x16] baseline: 12.796875
                 "Caption"
@@ -13,16 +11,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             TextNode <#text> (not painted)
           Box <tbody> at [10,36] table-row-group [0+0+0 76.46875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
             Box <tr> at [10,36] table-row [0+0+0 76.46875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [11,37] table-cell [0+0+1 74.46875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 4, rect: [11,37 27.5x16] baseline: 12.796875
                     "Cell"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-baseline.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-baseline.txt
@@ -3,8 +3,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 90 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 615.65625 0+0+168.34375] [0+0+0 90 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 613.65625 0+1+0] [0+1+0 88 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [9,9] table-row-group [0+0+0 613.65625 0+0+0] [0+0+0 88 0+0+0] children: not-inline
             Box <tr> at [9,9] table-row [0+0+0 613.65625 0+0+0] [0+0+0 44 0+0+0] children: not-inline
               BlockContainer <td> at [11,11] table-cell [0+1+1 349.90625 1+1+0] [0+1+1 40 1+1+0] [BFC] children: inline
@@ -26,8 +24,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 12, rect: [364.90625,55 255.75x40] baseline: 32
                     "Regular text"
                 TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,98] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
@@ -3,8 +3,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 26 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 420 0+0+364] [0+0+0 26 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 418 0+1+0] [0+1+0 24 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <colgroup> (not painted) table-column-group children: not-inline
             BlockContainer <col> (not painted) children: not-inline
             BlockContainer <col> (not painted) children: not-inline
@@ -12,8 +10,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             TextNode <#text> (not painted)
           Box <tbody> at [11,11] table-row-group [0+0+0 414 0+0+0] [0+0+0 20 0+0+0] children: not-inline
             Box <tr> at [11,11] table-row [0+0+0 414 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [13,13] table-cell [0+1+1 46 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x16] baseline: 12.796875
                     "A"
@@ -24,10 +20,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [65,13 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
@@ -3,8 +3,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 26 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 420 0+0+364] [0+0+0 26 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 418 0+1+0] [0+1+0 24 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           BlockContainer <colgroup> (not painted) table-column-group children: not-inline
             BlockContainer <col> (not painted) children: not-inline
             BlockContainer <col> (not painted) children: not-inline
@@ -12,8 +10,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             TextNode <#text> (not painted)
           Box <tbody> at [11,11] table-row-group [0+0+0 414 0+0+0] [0+0+0 20 0+0+0] children: not-inline
             Box <tr> at [11,11] table-row [0+0+0 414 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [13,13] table-cell [0+1+1 14.265625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x16] baseline: 12.796875
                     "A"
@@ -24,10 +20,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
@@ -3,12 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 26 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 420 0+0+364] [0+0+0 26 0+0+0] [BFC] children: not-inline
         Box <table> at [9,9] table-box [0+1+0 418 0+1+0] [0+1+0 24 0+1+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [11,11] table-row-group [0+0+0 414 0+0+0] [0+0+0 20 0+0+0] children: not-inline
             Box <tr> at [11,11] table-row [0+0+0 414 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [13,13] table-cell [0+1+1 14.265625 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x16] baseline: 12.796875
                     "A"
@@ -19,10 +15,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x16] baseline: 12.796875
                     "B"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
@@ -3,14 +3,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
         Box <table> at [8,8] table-box [0+0+0 784 0+0+0] [0+0+0 20 0+0+0] [TFC] children: not-inline
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
           Box <tbody> at [8,8] table-row-group [0+0+0 784 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
             Box <tr> at [8,8] table-row [0+0+0 784 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
               BlockContainer <td> at [10,10] table-cell [0+1+1 216.09375 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
                 frag 0 from TextNode start: 17, length: 1, rect: [10,10 14.265625x16] baseline: 12.796875
                     "A"
@@ -27,12 +21,6 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 17, length: 3, rect: [390.890625,10 29.453125x16] baseline: 12.796875
                     "C D"
                 TextNode <#text> (not painted)
-              BlockContainer <(anonymous)> (not painted) children: inline
-                TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> (not painted) children: inline
-              TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> (not painted) children: inline
-            TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]

--- a/Tests/LibWeb/Layout/input/table/remove-irrelevant-whitespace-boxes.html
+++ b/Tests/LibWeb/Layout/input/table/remove-irrelevant-whitespace-boxes.html
@@ -1,0 +1,30 @@
+<!doctype html><style>
+    body {
+        margin: 0;
+    }
+
+    .table {
+        display: table;
+        border-spacing: 0;
+    }
+
+    .group {
+        display: table-row-group;
+    }
+
+    .row {
+        display: table-row;
+    }
+
+    .cell {
+        display: table-cell;
+        width: 20px;
+        height: 10px;
+    }
+</style><body><div class="table">
+    <div class="row"><div class="cell"></div></div>
+</div><div class="table"><div class="group">
+    <div class="row"><div class="cell"></div></div>
+</div></div><div class="table"><div class="row">
+    <div class="cell"></div>
+</div></div>

--- a/Tests/LibWeb/Text/expected/github-diff-table-fixed-layout-row-height.txt
+++ b/Tests/LibWeb/Text/expected/github-diff-table-fixed-layout-row-height.txt
@@ -1,0 +1,3 @@
+fixed row height: 24
+auto row height: 24
+narrow fixed row height: 114

--- a/Tests/LibWeb/Text/expected/github-split-diff-fixed-table-width.txt
+++ b/Tests/LibWeb/Text/expected/github-split-diff-fixed-table-width.txt
@@ -1,0 +1,3 @@
+table width: 600
+cell widths: 150, 150, 150, 150
+cell width sum: 600

--- a/Tests/LibWeb/Text/input/github-diff-table-fixed-layout-row-height.html
+++ b/Tests/LibWeb/Text/input/github-diff-table-fixed-layout-row-height.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+table {
+    width: 600px;
+}
+
+.narrow {
+    width: 80px;
+}
+
+.fixed {
+    table-layout: fixed;
+}
+
+tr {
+    height: 24px;
+}
+</style>
+<table class="fixed">
+    <tr id="fixed">
+        <td>one two three four five six seven eight nine ten</td>
+    </tr>
+</table>
+<table>
+    <tr id="auto">
+        <td>one two three four five six seven eight nine ten</td>
+    </tr>
+</table>
+<table class="fixed narrow">
+    <tr id="narrow-fixed">
+        <td>one two three four five six seven eight nine ten</td>
+    </tr>
+</table>
+<script>
+test(() => {
+    const fixedRow = document.getElementById("fixed").getBoundingClientRect();
+    const autoRow = document.getElementById("auto").getBoundingClientRect();
+    const narrowFixedRow = document.getElementById("narrow-fixed").getBoundingClientRect();
+    println(`fixed row height: ${fixedRow.height}`);
+    println(`auto row height: ${autoRow.height}`);
+    println(`narrow fixed row height: ${narrowFixedRow.height}`);
+});
+</script>

--- a/Tests/LibWeb/Text/input/github-split-diff-fixed-table-width.html
+++ b/Tests/LibWeb/Text/input/github-split-diff-fixed-table-width.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+table {
+    border-spacing: 0;
+    table-layout: fixed;
+    width: 600px;
+}
+
+thead {
+    position: absolute;
+}
+</style>
+<table>
+    <thead></thead>
+    <tr>
+        <td>a</td>
+        <td>b</td>
+        <td>c</td>
+        <td>d</td>
+    </tr>
+</table>
+<script>
+test(() => {
+    const table = document.querySelector("table").getBoundingClientRect();
+    const cells = [...document.querySelectorAll("td")].map(td => td.getBoundingClientRect().width);
+    println(`table width: ${table.width}`);
+    println(`cell widths: ${cells.join(", ")}`);
+    println(`cell width sum: ${cells.reduce((a, b) => a + b, 0)}`);
+});
+</script>


### PR DESCRIPTION
Before:
<img width="1741" height="1210" alt="Screenshot_20260709_110325" src="https://github.com/user-attachments/assets/9da8fff8-c6d5-400b-abfa-0b1890f8534c" />

<img width="1585" height="1064" alt="Screenshot_20260709_155203" src="https://github.com/user-attachments/assets/6c221edc-f6d7-40f7-9437-9850c1e80b81" />

After:
<img width="1585" height="1064" alt="Screenshot_20260709_123407" src="https://github.com/user-attachments/assets/a02de6de-9a17-487c-96cb-f81d284042ed" />

<img width="1585" height="1064" alt="Screenshot_20260709_140843" src="https://github.com/user-attachments/assets/2308e571-88f2-40cd-a78c-50a8f329f689" />
