### PR TITLE
LibMedia: Estimate MP4 frame durations when they are omitted by libavformat

### DIFF
--- a/Libraries/LibMedia/CodedVideoFrameData.h
+++ b/Libraries/LibMedia/CodedVideoFrameData.h
@@ -6,15 +6,22 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+#include <AK/Time.h>
+
 namespace Media {
 
 class CodedVideoFrameData {
 public:
-    CodedVideoFrameData()
+    explicit CodedVideoFrameData(Optional<AK::Duration> decode_timestamp = {})
+        : m_decode_timestamp(decode_timestamp)
     {
     }
 
+    Optional<AK::Duration> decode_timestamp() const { return m_decode_timestamp; }
+
 private:
+    Optional<AK::Duration> m_decode_timestamp;
 };
 
 }

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -199,6 +199,13 @@ static inline AK::Duration time_units_to_duration(i64 time_units, AVRational con
     return AK::Duration::from_time_units(time_units, time_base.num, time_base.den);
 }
 
+static AK::Duration frame_duration_from_frame_rate(AVRational const& frame_rate)
+{
+    if (frame_rate.num <= 0 || frame_rate.den <= 0)
+        return AK::Duration::zero();
+    return AK::Duration::from_time_units(frame_rate.den, 1, frame_rate.num);
+}
+
 static inline i64 duration_to_time_units(AK::Duration duration, AVRational const& time_base)
 {
     VERIFY(time_base.num > 0);
@@ -520,9 +527,15 @@ DecoderErrorOr<CodedFrame> FFmpegDemuxer::get_next_sample_for_track(Track const&
             track_context.timestamp_offset = track_context.pending_timestamp_offset.release_value();
 
         auto flags = (packet.flags & AV_PKT_FLAG_KEY) != 0 ? FrameFlags::Keyframe : FrameFlags::None;
+        auto duration = time_units_to_duration(packet.duration, stream.time_base);
+        // FIXME: This is a hack to work around a bug in libavformat where the stts box of an MP4 track is ignored if
+        //        it also contains a ctts box. This should not be necessary when we move to our own MP4 demuxer.
+        if (duration.is_zero() && track.type() == TrackType::Video)
+            duration = frame_duration_from_frame_rate(av_guess_frame_rate(&format_context, &stream, nullptr));
+
         auto sample = CodedFrame(
             track_context.timestamp_offset + time_units_to_duration(packet.pts, stream.time_base),
-            time_units_to_duration(packet.duration, stream.time_base),
+            duration,
             flags,
             move(packet_data),
             auxiliary_data);

--- a/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
@@ -106,19 +106,24 @@ FFmpegVideoDecoder::~FFmpegVideoDecoder()
     avcodec_free_context(&m_codec_context);
 }
 
-DecoderErrorOr<void> FFmpegVideoDecoder::receive_coded_data(AK::Duration timestamp, AK::Duration duration, ReadonlyBytes coded_data)
+DecoderErrorOr<void> FFmpegVideoDecoder::receive_coded_data(AK::Duration timestamp, AK::Duration duration, ReadonlyBytes coded_data, Optional<AK::Duration> decode_timestamp)
 {
     VERIFY(coded_data.size() < NumericLimits<int>::max());
 
     m_packet->data = const_cast<u8*>(coded_data.data());
     m_packet->size = static_cast<int>(coded_data.size());
     m_packet->pts = timestamp.to_microseconds();
-    m_packet->dts = m_packet->pts;
+    m_packet->dts = decode_timestamp.value_or(timestamp).to_microseconds();
     m_packet->duration = duration.to_microseconds();
+    auto packet_pts = m_packet->pts;
 
     auto result = avcodec_send_packet(m_codec_context, m_packet);
     switch (result) {
     case 0:
+        // Some FFmpeg decoders do not propagate packet duration to decoded frames, so
+        // remember the accepted packet duration by PTS and consume it on output.
+        if (!duration.is_zero())
+            m_frame_durations.set(packet_pts, duration);
         return {};
     case AVERROR(EAGAIN):
         return DecoderError::with_description(DecoderErrorCategory::NeedsMoreInput, "FFmpeg decoder cannot decode any more data until frames have been retrieved"sv);
@@ -215,6 +220,12 @@ DecoderErrorOr<NonnullRefPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame(
 
         auto timestamp = AK::Duration::from_microseconds(m_frame->pts);
         auto duration = AK::Duration::from_microseconds(m_frame->duration);
+        if (duration.is_zero()) {
+            if (auto packet_duration = m_frame_durations.take(m_frame->pts); packet_duration.has_value())
+                duration = *packet_duration;
+        } else {
+            m_frame_durations.remove(m_frame->pts);
+        }
 
         auto yuv_data = DECODER_TRY_ALLOC(Gfx::YUVData::create(gfx_size, bit_depth, subsampling, cicp));
 
@@ -264,6 +275,7 @@ DecoderErrorOr<NonnullRefPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame(
 
 void FFmpegVideoDecoder::flush()
 {
+    m_frame_durations.clear();
     avcodec_flush_buffers(m_codec_context);
 }
 

--- a/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <LibMedia/CodecID.h>
 #include <LibMedia/Export.h>
 #include <LibMedia/VideoDecoder.h>
@@ -20,7 +21,7 @@ public:
     FFmpegVideoDecoder(AVCodecContext* codec_context, AVPacket* packet, AVFrame* frame);
     virtual ~FFmpegVideoDecoder() override;
 
-    virtual DecoderErrorOr<void> receive_coded_data(AK::Duration timestamp, AK::Duration duration, ReadonlyBytes coded_data) override;
+    virtual DecoderErrorOr<void> receive_coded_data(AK::Duration timestamp, AK::Duration duration, ReadonlyBytes coded_data, Optional<AK::Duration> decode_timestamp = {}) override;
     virtual void signal_end_of_stream() override;
     virtual DecoderErrorOr<NonnullRefPtr<VideoFrame>> get_decoded_frame(CodingIndependentCodePoints const& container_cicp) override;
 
@@ -30,6 +31,7 @@ private:
     AVCodecContext* m_codec_context;
     AVPacket* m_packet;
     AVFrame* m_frame;
+    HashMap<i64, AK::Duration> m_frame_durations;
 };
 
 }

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/EventLoop.h>
+#include <LibMedia/CodedVideoFrameData.h>
 #include <LibMedia/Demuxer.h>
 #include <LibMedia/FFmpeg/FFmpegVideoDecoder.h>
 #include <LibMedia/Sinks/VideoSink.h>
@@ -460,7 +461,8 @@ bool DecodedVideoProducer::ThreadData::handle_seek()
                 auto coded_frame = coded_frame_result.release_value();
                 dispatch_frame_end_time(coded_frame);
 
-                auto decode_result = m_decoder->receive_coded_data(coded_frame.timestamp(), coded_frame.duration(), coded_frame.data());
+                auto const& video_frame_data = coded_frame.auxiliary_data().get<CodedVideoFrameData>();
+                auto decode_result = m_decoder->receive_coded_data(coded_frame.timestamp(), coded_frame.duration(), coded_frame.data(), video_frame_data.decode_timestamp());
                 if (decode_result.is_error()) {
                     handle_error(decode_result.release_error());
                     return true;
@@ -545,7 +547,8 @@ void DecodedVideoProducer::ThreadData::push_data_and_decode_some_frames()
         auto coded_frame = sample_result.release_value();
         dispatch_frame_end_time(coded_frame);
 
-        auto decode_result = m_decoder->receive_coded_data(coded_frame.timestamp(), coded_frame.duration(), coded_frame.data());
+        auto const& video_frame_data = coded_frame.auxiliary_data().get<CodedVideoFrameData>();
+        auto decode_result = m_decoder->receive_coded_data(coded_frame.timestamp(), coded_frame.duration(), coded_frame.data(), video_frame_data.decode_timestamp());
         if (decode_result.is_error()) {
             set_halting_status_and_wait_for_seek(PipelineStatus::Error, decode_result.release_error());
             return;

--- a/Libraries/LibMedia/VideoDecoder.h
+++ b/Libraries/LibMedia/VideoDecoder.h
@@ -9,6 +9,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
 #include <AK/Time.h>
 #include <LibMedia/Color/CodingIndependentCodePoints.h>
 
@@ -20,8 +21,8 @@ class VideoDecoder {
 public:
     virtual ~VideoDecoder() { }
 
-    virtual DecoderErrorOr<void> receive_coded_data(AK::Duration timestamp, AK::Duration duration, ReadonlyBytes coded_data) = 0;
-    DecoderErrorOr<void> receive_coded_data(AK::Duration timestamp, AK::Duration duration, ByteBuffer const& coded_data) { return receive_coded_data(timestamp, duration, coded_data.span()); }
+    virtual DecoderErrorOr<void> receive_coded_data(AK::Duration timestamp, AK::Duration duration, ReadonlyBytes coded_data, Optional<AK::Duration> decode_timestamp = {}) = 0;
+    DecoderErrorOr<void> receive_coded_data(AK::Duration timestamp, AK::Duration duration, ByteBuffer const& coded_data, Optional<AK::Duration> decode_timestamp = {}) { return receive_coded_data(timestamp, duration, coded_data.span(), decode_timestamp); }
     virtual void signal_end_of_stream() = 0;
     virtual DecoderErrorOr<NonnullRefPtr<VideoFrame>> get_decoded_frame(CodingIndependentCodePoints const& container_cicp) = 0;
 

--- a/Tests/LibMedia/TestH264Decode.cpp
+++ b/Tests/LibMedia/TestH264Decode.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibMedia/FFmpeg/FFmpegDemuxer.h>
 #include <LibMedia/FFmpeg/FFmpegVideoDecoder.h>
+#include <LibMedia/IncrementallyPopulatedStream.h>
 
 #include "TestMediaCommon.h"
 
@@ -16,4 +18,70 @@ static NonnullOwnPtr<Media::VideoDecoder> make_decoder(Media::Matroska::TrackEnt
 TEST_CASE(avc_in_matroska)
 {
     decode_video("./avc_in_matroska.mkv"sv, 50, make_decoder);
+}
+
+TEST_CASE(avc_in_mp4_with_reordered_frames)
+{
+    auto file = MUST(Core::File::open("./avc.mp4"sv, Core::File::OpenMode::Read));
+    auto stream = Media::IncrementallyPopulatedStream::create_from_buffer(MUST(file->read_until_eof()));
+    auto demuxer = MUST(Media::FFmpeg::FFmpegDemuxer::from_stream(stream));
+    auto optional_track = MUST(demuxer->get_preferred_track_for_type(Media::TrackType::Video));
+    VERIFY(optional_track.has_value());
+    auto track = optional_track.release_value();
+    MUST(demuxer->create_context_for_track(track));
+
+    auto codec_id = MUST(demuxer->get_codec_id_for_track(track));
+    auto codec_initialization_data = MUST(demuxer->get_codec_initialization_data_for_track(track));
+    auto decoder = MUST(Media::FFmpeg::FFmpegVideoDecoder::try_create(codec_id, codec_initialization_data));
+
+    size_t frame_count = 0;
+    auto last_timestamp = AK::Duration::min();
+
+    auto process_decoded_frames = [&] {
+        while (true) {
+            auto frame_result = decoder->get_decoded_frame(track.video_data().cicp);
+            if (frame_result.is_error()) {
+                if (frame_result.error().category() == Media::DecoderErrorCategory::NeedsMoreInput)
+                    return;
+                VERIFY_NOT_REACHED();
+            }
+
+            auto frame = frame_result.release_value();
+            EXPECT(last_timestamp <= frame->timestamp());
+            EXPECT(!frame->duration().is_zero());
+            last_timestamp = frame->timestamp();
+            ++frame_count;
+        }
+    };
+
+    while (true) {
+        auto sample_result = demuxer->get_next_sample_for_track(track);
+        if (sample_result.is_error()) {
+            EXPECT_EQ(sample_result.error().category(), Media::DecoderErrorCategory::EndOfStream);
+            break;
+        }
+
+        auto sample = sample_result.release_value();
+        EXPECT(!sample.duration().is_zero());
+
+        MUST(decoder->receive_coded_data(sample.timestamp(), sample.duration(), sample.data()));
+        process_decoded_frames();
+    }
+
+    decoder->signal_end_of_stream();
+    while (true) {
+        auto frame_result = decoder->get_decoded_frame(track.video_data().cicp);
+        if (frame_result.is_error()) {
+            EXPECT_EQ(frame_result.error().category(), Media::DecoderErrorCategory::EndOfStream);
+            break;
+        }
+
+        auto frame = frame_result.release_value();
+        EXPECT(last_timestamp <= frame->timestamp());
+        EXPECT(!frame->duration().is_zero());
+        last_timestamp = frame->timestamp();
+        ++frame_count;
+    }
+
+    EXPECT_EQ(frame_count, 50u);
 }


### PR DESCRIPTION
Carry decode timestamps from FFmpegDemuxer into the video decoder so reordered H.264 packets keep their DTS instead of mirroring PTS.

Some MP4 streams, including videos served by x.com, leave decoded H.264 frames with a zero duration. Infer a frame duration from the container frame rate when packets omit one, and preserve accepted packet durations for decoded frames whose AVFrame duration is still zero.

Add MP4 H.264 coverage for reordered samples and non-zero decoded frame durations.

This fixes an issue where some videos on https://x.com/ would play with a very poor visual framerate.

Before:

https://github.com/user-attachments/assets/9314fdce-ba50-4d62-ad81-85a8f3957994

After:

https://github.com/user-attachments/assets/1505c49d-16a6-4849-aed7-fb07b4d6dbad

