### PR TITLE
UI/AppKit: Apply a bit of extra spacing between bookmark icons and text

### DIFF
--- a/UI/AppKit/Interface/BookmarksBar.mm
+++ b/UI/AppKit/Interface/BookmarksBar.mm
@@ -26,6 +26,52 @@ static constexpr CGFloat const BOOKMARK_ITEM_SPACING = 2;
 static constexpr CGFloat const BOOKMARK_LEADING_INSET = 8;
 static constexpr CGFloat const OVERFLOW_TRAILING_INSET = 4;
 
+@interface BookmarkBarButtonCell : NSButtonCell
+@end
+
+@implementation BookmarkBarButtonCell
+
+- (NSRect)drawTitle:(NSAttributedString*)title
+          withFrame:(NSRect)frame
+             inView:(NSView*)controlView
+{
+    if ([self shouldApplyIconTitleSpacing]) {
+        frame.origin.x += BOOKMARK_ITEM_SPACING;
+    }
+
+    return [super drawTitle:title withFrame:frame inView:controlView];
+}
+
+- (NSSize)cellSize
+{
+    auto size = [super cellSize];
+
+    if ([self shouldApplyIconTitleSpacing]) {
+        size.width += BOOKMARK_ITEM_SPACING;
+    }
+
+    return size;
+}
+
+- (BOOL)shouldApplyIconTitleSpacing
+{
+    return [self image] != nil && [[self title] length] > 0;
+}
+
+@end
+
+@interface BookmarkBarButton : NSButton
+@end
+
+@implementation BookmarkBarButton
+
++ (Class)cellClass
+{
+    return [BookmarkBarButtonCell class];
+}
+
+@end
+
 static Optional<WebView::Menu&> find_bookmark_folder_by_id(WebView::Menu& menu, StringView id)
 {
     for (auto& item : menu.items()) {
@@ -149,15 +195,16 @@ static Optional<WebView::Menu&> find_bookmark_folder_by_id(WebView::Menu& menu, 
                 if (bookmark->id() != WebView::ActionID::BookmarkItem)
                     return nil;
 
-                auto* button = Ladybird::create_application_button(bookmark);
+                auto* button = Ladybird::create_application_button(bookmark, [BookmarkBarButton class]);
                 set_button_properties(button, bookmark->text());
 
                 return button;
             },
             [&](NonnullRefPtr<WebView::Menu> const& folder) -> NSButton* {
-                auto* button = [NSButton buttonWithImage:[NSImage imageWithSystemSymbolName:@"folder" accessibilityDescription:@""]
-                                                  target:self
-                                                  action:@selector(openFolder:)];
+                auto* button = [[BookmarkBarButton alloc] init];
+                [button setImage:[NSImage imageWithSystemSymbolName:@"folder" accessibilityDescription:@""]];
+                [button setTarget:self];
+                [button setAction:@selector(openFolder:)];
                 set_button_properties(button, folder->title());
 
                 Ladybird::add_control_properties(button, *folder);


### PR DESCRIPTION
By default, these were squished a bit too close together. To add spacing we unfortunately need to draw a custom cell.

Before:
<img width="1045" height="535" alt="Screenshot 2026-07-09 at 2 26 57 PM" src="https://github.com/user-attachments/assets/e53184af-4a0b-4487-8004-1990a4e43c96" />

After:
<img width="1045" height="535" alt="Screenshot 2026-07-09 at 2 27 47 PM" src="https://github.com/user-attachments/assets/b1fc0f18-bc01-4cd0-8c74-aa363c60ee25" />

