### PR TITLE
LibWeb: Avoid loading unused CSS image resources

### DIFF
--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -253,12 +253,6 @@ void CSSImportRule::set_style_sheet(GC::Ref<CSSStyleSheet> style_sheet)
             m_style_sheet->add_owning_document_or_shadow_root(*owning_document_or_shadow_root);
     }
 
-    auto document = m_style_sheet->owning_document();
-    if (!document && m_parent_style_sheet)
-        document = m_parent_style_sheet->owning_document();
-    if (document)
-        m_style_sheet->load_pending_image_resources(*document);
-
     m_style_sheet->invalidate_owners(DOM::StyleInvalidationReason::CSSImportRule);
 }
 

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -156,7 +156,6 @@ size_t CSSStyleSheet::external_memory_size() const
     size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_import_rules));
     size = JS::saturating_add_external_memory_size(size, JS::hash_table_external_memory_size(m_owning_documents_or_shadow_roots));
     size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_critical_subresources));
-    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_pending_image_values));
     return size;
 }
 
@@ -420,7 +419,6 @@ void CSSStyleSheet::set_disabled(bool disabled)
         if (document) {
             evaluate_media_queries(*document);
             document->font_computer().load_fonts_from_sheet(*this);
-            load_pending_image_resources(*document);
         }
     } else if (document) {
         document->font_computer().unload_fonts_from_sheet(*this);
@@ -528,20 +526,6 @@ GC::Ptr<DOM::Document> CSSStyleSheet::owning_document() const
         return element->document();
 
     return nullptr;
-}
-
-void CSSStyleSheet::load_pending_image_resources(DOM::Document& document)
-{
-    if (disabled())
-        return;
-
-    auto pending = move(m_pending_image_values);
-    for (auto const& weak_image_value : pending) {
-        if (auto* image_value = weak_image_value.ptr()) {
-            image_value->update_style_sheet_resource_context(*this);
-            image_value->load_any_resources(document);
-        }
-    }
 }
 
 bool CSSStyleSheet::evaluate_media_queries(DOM::Document const& document)

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -19,7 +19,6 @@
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/SelectorInsights.h>
 #include <LibWeb/CSS/StyleSheet.h>
-#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/StyleInvalidationReason.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/WebIDL/Types.h>
@@ -113,9 +112,6 @@ public:
     Optional<::URL::URL> base_url() const { return m_base_url; }
     void set_base_url(Optional<::URL::URL> base_url) { m_base_url = move(base_url); }
 
-    void register_pending_image_value(ImageStyleValue& value) { m_pending_image_values.append(value); }
-    void load_pending_image_resources(DOM::Document&);
-
     bool constructed() const { return m_constructed; }
 
     GC::Ptr<DOM::Document const> constructor_document() const { return m_constructor_document; }
@@ -165,8 +161,6 @@ private:
     RefPtr<StyleCache> m_shared_single_constructed_sheet_style_cache;
 
     Vector<Subresource&> m_critical_subresources;
-
-    Vector<WeakPtr<ImageStyleValue>> m_pending_image_values;
 };
 
 }

--- a/Libraries/LibWeb/CSS/Invalidation/AdoptedStyleSheetInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/AdoptedStyleSheetInvalidator.cpp
@@ -16,7 +16,6 @@ namespace Web::CSS::Invalidation {
 void invalidate_style_after_adopting_style_sheet(DOM::Node& document_or_shadow_root, CSSStyleSheet& style_sheet)
 {
     style_sheet.add_owning_document_or_shadow_root(document_or_shadow_root);
-    style_sheet.load_pending_image_resources(document_or_shadow_root.document());
 
     // Evaluate the sheet's media queries before the next style update so the cascade can see its rules. Otherwise the
     // rule cache may be rebuilt (e.g. via a :has() invalidation pass) before Document::evaluate_media_rules has a

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -58,6 +58,7 @@
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
@@ -68,6 +69,7 @@
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
@@ -3134,6 +3136,22 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
     return CSS::LengthStyleValue::create(CSS::Length::make_px(current_size_in_px));
 }
 
+static void load_computed_content_image_resources_if_needed(CSS::ComputedProperties const& computed_style, DOM::AbstractElement abstract_element)
+{
+    if (computed_style.display().is_none())
+        return;
+
+    auto const& content_value = computed_style.property(PropertyID::Content);
+    if (!content_value.is_content())
+        return;
+
+    for (auto const& item : content_value.as_content().content().values()) {
+        if (!item->is_image())
+            continue;
+        const_cast<ImageStyleValue&>(item->as_image()).load_any_resources(abstract_element.document());
+    }
+}
+
 NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties, u64 matching_pseudo_element_styles) const
 {
     VERIFY(computation_context_cache_is_empty());
@@ -3167,6 +3185,21 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         if (computation_context.depends_on_viewport_metrics())
             depends_on_viewport_metrics = true;
         return computed_value;
+    };
+
+    auto set_style_resource_context_for_value = [](StyleValue const& value, GC::Ptr<CSSStyleDeclaration const> source) {
+        if (!source)
+            return;
+
+        auto parent_rule = source->parent_rule();
+        if (!parent_rule)
+            return;
+
+        auto* parent_style_sheet = parent_rule->parent_style_sheet();
+        if (!parent_style_sheet)
+            return;
+
+        const_cast<StyleValue&>(value).set_style_sheet(parent_style_sheet);
     };
 
     Optional<LogicalAliasMappingContext> logical_alias_mapping_context;
@@ -3211,6 +3244,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
             if (cascaded_style_property->important == Important::Yes)
                 builder.set_property_important(property_id, Important::Yes);
             value = cascaded_style_property->value;
+            set_style_resource_context_for_value(*value, cascaded_properties.property_source(cascaded_property_id));
             requires_computation = property_requires_computation_with_cascaded_value(property_id);
 
             // Store the raw winning cascaded font-size. This is needed to implement the time-traveling inheritance for
@@ -3355,6 +3389,8 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
 
     if (parent_style_in_display_none_subtree || builder.display().is_none())
         builder.set_in_display_none_subtree();
+
+    load_computed_content_image_resources_if_needed(computed_style, abstract_element);
 
     return CSS::ComputedProperties::create(move(builder));
 }

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -110,8 +110,6 @@ void StyleSheetList::add_sheet(CSSStyleSheet& sheet)
 {
     sheet.add_owning_document_or_shadow_root(document_or_shadow_root());
 
-    sheet.load_pending_image_resources(document());
-
     if (m_sheets.is_empty()) {
         // This is the first sheet, append it to the list.
         m_sheets.append(sheet);

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -181,9 +181,8 @@ void ImageSetStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
 {
     Base::set_style_sheet(style_sheet);
 
-    // Propagate the style sheet to candidate images whose type() filter does not exclude them. This ensures the
-    // candidate images register themselves as pending image resources on the style sheet, so their fetches start when
-    // the style sheet is associated with the document, properly delaying the document's load event.
+    // Propagate the style sheet to candidate images whose type() filter does not exclude them. This ensures relative
+    // URLs resolve against the owning style sheet when the selected image is loaded.
     for (auto const& option : m_options) {
         if (option.type.has_value() && !HTML::is_supported_image_type(*option.type))
             continue;

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -230,10 +230,8 @@ void ImageStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
     m_parent_style_sheet_origin_clean.clear();
     m_should_absolutize_url_for_computed_value = false;
 
-    if (style_sheet) {
+    if (style_sheet)
         update_style_sheet_resource_context(*style_sheet);
-        style_sheet->register_pending_image_value(*this);
-    }
 }
 
 void ImageStyleValue::update_style_sheet_resource_context(CSSStyleSheet const& style_sheet)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4547,6 +4547,24 @@ bool Document::anything_is_delaying_the_load_event() const
     return false;
 }
 
+bool Document::ready_to_fire_load_event()
+{
+    if (anything_is_delaying_the_load_event())
+        return false;
+
+    if (!m_did_update_layout_for_load_event_delay) {
+        // AD-HOC: Used CSS image resources are fetched lazily during layout. Force layout once
+        //         before firing the load event so newly discovered resources can delay it.
+        update_layout(UpdateLayoutReason::ParserLoadEventDelay);
+        m_did_update_layout_for_load_event_delay = true;
+
+        if (anything_is_delaying_the_load_event())
+            return false;
+    }
+
+    return true;
+}
+
 void Document::set_page_showing(bool page_showing)
 {
     if (m_page_showing == page_showing)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -146,6 +146,7 @@ enum class InvalidateLayoutTreeReason {
     X(NavigableSelectedText)                 \
     X(NavigableViewportScroll)               \
     X(NodeNameOrDescription)                 \
+    X(ParserLoadEventDelay)                  \
     X(RangeGetClientRects)                   \
     X(ResolvedCSSStyleDeclarationProperty)   \
     X(SVGDecodedImageDataRender)             \

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -622,6 +622,7 @@ public:
     [[nodiscard]] GC::Ptr<HTML::Location> location();
 
     bool anything_is_delaying_the_load_event() const;
+    [[nodiscard]] bool ready_to_fire_load_event();
     void increment_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>);
     void decrement_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>);
 
@@ -1385,6 +1386,7 @@ private:
     GC::Ptr<HTML::History> m_history;
 
     size_t m_number_of_things_delaying_the_load_event { 0 };
+    bool m_did_update_layout_for_load_event_delay { false };
     GC::Ptr<HTML::HTMLParserEndState> m_html_parser_end_state;
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#concept-document-salvageable

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -106,11 +106,12 @@ void Range::visit_edges(Cell::Visitor& visitor)
 
 void Range::set_associated_selection(Badge<Selection::Selection>, GC::Ptr<Selection::Selection> selection)
 {
+    auto should_reset_selection_states = m_associated_selection && !selection;
     m_associated_selection = selection;
-    update_associated_selection();
+    update_associated_selection(should_reset_selection_states);
 }
 
-void Range::update_associated_selection()
+void Range::update_associated_selection(bool should_reset_selection_states)
 {
     auto& document = m_start_container->document();
 
@@ -118,7 +119,7 @@ void Range::update_associated_selection()
     if (auto viewport = document.unsafe_paintable()) {
         if (m_associated_selection)
             viewport->recompute_selection_states(*this);
-        else
+        else if (should_reset_selection_states)
             viewport->reset_selection_states();
         viewport->set_needs_repaint();
     }

--- a/Libraries/LibWeb/DOM/Range.h
+++ b/Libraries/LibWeb/DOM/Range.h
@@ -133,7 +133,7 @@ private:
 
     GC::Ref<Node> root() const;
 
-    void update_associated_selection();
+    void update_associated_selection(bool should_reset_selection_states = false);
 
     enum class StartOrEnd {
         Start,

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -563,6 +563,14 @@ void HTMLParserEndState::check_progress()
         if (m_document->anything_is_delaying_the_load_event())
             return;
 
+        if (!m_did_update_layout_for_load_event_delay) {
+            m_document->update_layout(DOM::UpdateLayoutReason::ParserLoadEventDelay);
+            m_did_update_layout_for_load_event_delay = true;
+
+            if (m_document->anything_is_delaying_the_load_event())
+                return;
+        }
+
         m_phase = Phase::Completed;
         [[fallthrough]];
 

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -560,16 +560,8 @@ void HTMLParserEndState::check_progress()
 
     case Phase::WaitingForLoadEventDelay:
         // 8. Spin the event loop until there is nothing that delays the load event in the Document.
-        if (m_document->anything_is_delaying_the_load_event())
+        if (!m_document->ready_to_fire_load_event())
             return;
-
-        if (!m_did_update_layout_for_load_event_delay) {
-            m_document->update_layout(DOM::UpdateLayoutReason::ParserLoadEventDelay);
-            m_did_update_layout_for_load_event_delay = true;
-
-            if (m_document->anything_is_delaying_the_load_event())
-                return;
-        }
 
         m_phase = Phase::Completed;
         [[fallthrough]];

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -171,6 +171,7 @@ private:
 
     Phase m_phase { Phase::WaitingForDeferredScripts };
     bool m_check_pending { false };
+    bool m_did_update_layout_for_load_event_delay { false };
 
     GC::Ref<DOM::Document> m_document;
     GC::Ptr<HTMLParser> m_parser;

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -171,7 +171,6 @@ private:
 
     Phase m_phase { Phase::WaitingForDeferredScripts };
     bool m_check_pending { false };
-    bool m_did_update_layout_for_load_event_delay { false };
 
     GC::Ref<DOM::Document> m_document;
     GC::Ptr<HTMLParser> m_parser;

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -356,7 +356,7 @@ void XMLDocumentBuilder::document_end()
 
     // Spin the event loop until there is nothing that delays the load event in the Document.
     HTML::main_thread_event_loop().spin_until(GC::create_function(heap, [&] {
-        return !m_document->anything_is_delaying_the_load_event();
+        return m_document->ready_to_fire_load_event();
     }));
 
     // Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following steps:

--- a/Tests/LibWeb/Text/expected/XHTML/load-event-delayed-by-css-background-image.txt
+++ b/Tests/LibWeb/Text/expected/XHTML/load-event-delayed-by-css-background-image.txt
@@ -1,0 +1,3 @@
+Load event delayed by at least 400ms: true
+Image resource entry exists: true
+Image loaded before load event: true

--- a/Tests/LibWeb/Text/expected/css/overridden-css-image-resource-not-fetched.txt
+++ b/Tests/LibWeb/Text/expected/css/overridden-css-image-resource-not-fetched.txt
@@ -1,0 +1,1 @@
+Overridden CSS image request was not sent: true

--- a/Tests/LibWeb/Text/expected/css/unused-css-image-resource-not-fetched.txt
+++ b/Tests/LibWeb/Text/expected/css/unused-css-image-resource-not-fetched.txt
@@ -1,0 +1,1 @@
+Unused CSS image request was not sent: true

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/urls/resolve-relative-to-base.sub.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/urls/resolve-relative-to-base.sub.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
+2 Pass
 Pass	base-relative URL: relative-image-url
-Fail	base-relative URL: relative-image-variable-url
+Pass	base-relative URL: relative-image-variable-url

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/urls/resolve-relative-to-stylesheet.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/urls/resolve-relative-to-stylesheet.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-1 Pass
-2 Fail
+3 Pass
 Pass	stylesheet-relative URL: stylesheet-relative-image
-Fail	stylesheet-relative URL: stylesheet-relative-variable-image
-Fail	stylesheet-relative URL: stylesheet-relative-document-variable-image
+Pass	stylesheet-relative URL: stylesheet-relative-variable-image
+Pass	stylesheet-relative URL: stylesheet-relative-document-variable-image

--- a/Tests/LibWeb/Text/input/XHTML/load-event-delayed-by-css-background-image.xhtml
+++ b/Tests/LibWeb/Text/input/XHTML/load-event-delayed-by-css-background-image.xhtml
@@ -1,0 +1,54 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<script src="../include.js"></script>
+<script><![CDATA[
+const imagePath = "/echo/delayed-green-xhtml.png";
+const imageUrl = `${httpTestServer().baseURL}${imagePath}`;
+
+var xhr = new XMLHttpRequest();
+xhr.open("POST", `${httpTestServer().baseURL}/echo`, false);
+xhr.setRequestHeader("Content-Type", "application/json");
+xhr.send(JSON.stringify({
+    method: "GET",
+    path: imagePath,
+    status: 200,
+    headers: {
+        "Content-Type": "image/png",
+        "Cache-Control": "no-store",
+        "Timing-Allow-Origin": "*"
+    },
+    body: "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAD0lEQVR4nGNgaGAAIQgFAA4OAgFhGn2EAAAAAElFTkSuQmCC",
+    body_encoding: "base64",
+    delay_ms: 500
+}));
+
+document.documentElement.style.setProperty("--delayed-image-url", `url("${imageUrl}")`);
+]]></script>
+<style><![CDATA[
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+    background-image: var(--delayed-image-url);
+    background-size: cover;
+}
+]]></style>
+</head>
+<body>
+<div id="target"></div>
+<script><![CDATA[
+asyncTest((done) => {
+    window.addEventListener("load", () => {
+        let loadTime = performance.now();
+        println(`Load event delayed by at least 400ms: ${loadTime >= 400}`);
+
+        let entries = performance.getEntriesByType("resource");
+        let imageEntry = entries.find(e => e.name.includes("delayed-green-xhtml"));
+        println(`Image resource entry exists: ${imageEntry !== undefined}`);
+        println(`Image loaded before load event: ${imageEntry !== undefined && imageEntry.responseEnd <= loadTime}`);
+        done();
+    });
+});
+]]></script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/css/overridden-css-image-resource-not-fetched.html
+++ b/Tests/LibWeb/Text/input/css/overridden-css-image-resource-not-fetched.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+const imagePath = `/echo/overridden-css-image-resource-${crypto.randomUUID()}.png`;
+const transparentPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+const xhr = new XMLHttpRequest();
+xhr.open("POST", "/echo", false);
+xhr.setRequestHeader("Content-Type", "application/json");
+xhr.send(JSON.stringify({
+    method: "GET",
+    path: imagePath,
+    status: 200,
+    headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "image/png",
+    },
+    body_encoding: "base64",
+    body: transparentPng,
+}));
+document.write(`<style>#target { background-image: url("${imagePath}"); } #target { background-image: none; }</style>`);
+
+asyncTest(done => {
+    window.addEventListener("load", async () => {
+        const response = await fetch(`/recorded-request-headers${imagePath}`);
+        println(`Overridden CSS image request was not sent: ${response.status === 404}`);
+        done();
+    });
+});
+</script>
+<div id="target"></div>

--- a/Tests/LibWeb/Text/input/css/overridden-css-image-resource-not-fetched.html.headers
+++ b/Tests/LibWeb/Text/input/css/overridden-css-image-resource-not-fetched.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/Tests/LibWeb/Text/input/css/unused-css-image-resource-not-fetched.html
+++ b/Tests/LibWeb/Text/input/css/unused-css-image-resource-not-fetched.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+const imagePath = `/echo/unused-css-image-resource-${crypto.randomUUID()}.png`;
+const transparentPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+const xhr = new XMLHttpRequest();
+xhr.open("POST", "/echo", false);
+xhr.setRequestHeader("Content-Type", "application/json");
+xhr.send(JSON.stringify({
+    method: "GET",
+    path: imagePath,
+    status: 200,
+    headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "image/png",
+    },
+    body_encoding: "base64",
+    body: transparentPng,
+}));
+
+document.write(`<style>.unused { background-image: url("${imagePath}"); }</style>`);
+
+asyncTest(done => {
+    window.addEventListener("load", async () => {
+        const response = await fetch(`/recorded-request-headers${imagePath}`);
+        println(`Unused CSS image request was not sent: ${response.status === 404}`);
+        done();
+    });
+});
+</script>
+<div></div>

--- a/Tests/LibWeb/Text/input/css/unused-css-image-resource-not-fetched.html.headers
+++ b/Tests/LibWeb/Text/input/css/unused-css-image-resource-not-fetched.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html


### PR DESCRIPTION
Stop treating every CSS image reference in a stylesheet as immediately used. Instead, load image resources from computed style once style/layout has identified that the resource is actually used by the document.

This avoids fetching overridden or otherwise unused CSS image resources while still delaying the document load event for used CSS images. The load-event readiness check now performs the parser-independent layout step needed to discover those used resources before `load`.

Added coverage for unused and overridden CSS image resources, plus XHTML coverage for the `load`-event delay path.

This fixes an issue where https://www.bookspry.com/for-readers/ was taking a very long time to load due to unused images referenced by non-matching CSS rules.