### PR TITLE
UI/Qt: Use a non-activating popup label for link previews

### DIFF
--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -1268,10 +1268,12 @@ void Tab::update_hover_label()
     if (m_find_in_page->isVisible())
         hover_label_height -= m_find_in_page->height();
 
-    if (m_hover_label->underMouse() && m_hover_label->x() == 0)
-        m_hover_label->move(width() / 2 + (width() / 2 - m_hover_label->width()), hover_label_height);
+    auto left_position = mapToGlobal(QPoint { 0, hover_label_height });
+
+    if (m_hover_label->underMouse() && m_hover_label->pos() == left_position)
+        m_hover_label->move(mapToGlobal(QPoint { width() - m_hover_label->width(), hover_label_height }));
     else
-        m_hover_label->move(0, hover_label_height);
+        m_hover_label->move(left_position);
 
     m_hover_label->raise();
 }

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -40,8 +40,9 @@ class HyperlinkLabel final : public QLabel {
 
 public:
     explicit HyperlinkLabel(QWidget* parent = nullptr)
-        : QLabel(parent)
+        : QLabel(parent, Qt::ToolTip | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint)
     {
+        setAttribute(Qt::WA_ShowWithoutActivating);
         setMouseTracking(true);
     }
 


### PR DESCRIPTION
Similar to commit c3c9a75970c87e7509f31c96de2d5a9ebb5807cb, the Vulkan window stacked above the `QLabel` for link previews. In this case, we can use a non-activating popup label to display the preview, as popups do stack above the Vulkan window.

Fixes #10557

<img width="1219" height="788" alt="Screenshot_20260709_152044" src="https://github.com/user-attachments/assets/9dc934b2-a52b-468d-8842-d26ac0d9658f" />
