### PR TITLE
LibWeb/CSS: Load fonts from grouped rules

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -374,10 +374,12 @@ void CSSStyleSheet::add_owning_document_or_shadow_root(DOM::Node& document_or_sh
     m_owning_documents_or_shadow_roots.set(document_or_shadow_root);
 
     // CSSOM's "add a CSS style sheet" steps bail out once the disabled flag is set, so ownership alone should not
-    // make a disabled sheet observable in the destination document. Delay CSS-connected font activation until the
-    // sheet actually becomes enabled.
-    if (!disabled() && this->owning_documents_or_shadow_roots().size() == 1)
+    // make a disabled sheet observable in the destination document. Delay its media-query evaluation and
+    // CSS-connected font activation until the sheet actually becomes enabled.
+    if (!disabled() && this->owning_documents_or_shadow_roots().size() == 1) {
+        evaluate_media_queries(document_or_shadow_root.document());
         document_or_shadow_root.document().font_computer().load_fonts_from_sheet(*this);
+    }
 
     for (auto const& import_rule : m_import_rules) {
         if (import_rule->loaded_style_sheet())

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -10,11 +10,13 @@
 
 #include "FontComputer.h"
 #include <AK/Platform.h>
+#include <LibGC/RootHashTable.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/TypefaceSkia.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSFontFeatureValuesRule.h>
+#include <LibWeb/CSS/CSSGroupingRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Fetch.h>
@@ -481,15 +483,14 @@ HashMap<FontFeatureValueKey, Vector<u32>> const& FontComputer::font_feature_valu
 
         // FIXME: We only account for Author stylesheets here, we should also account for UserAgent and User
         m_document->style_scope().for_each_active_css_style_sheet([&](CSS::CSSStyleSheet const& sheet) {
-            // FIXME: Account for @font-feature-values within grouping (i.e. @media, @supports) rules as well.
-            for (auto const& rule : sheet.rules()) {
-                if (auto const* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule)) {
+            sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](auto const& rule) {
+                if (auto const* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule)) {
                     if (!font_feature_values_rule->font_families().contains_slow(family_name))
-                        continue;
+                        return;
 
                     font_feature_values.update(font_feature_values_rule->to_hash_map());
                 }
-            }
+            });
         });
 
         return font_feature_values;
@@ -856,13 +857,43 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
     return loader;
 }
 
+static bool is_font_rule(CSSRule const& rule)
+{
+    return is<CSSFontFaceRule>(rule) || is<CSSFontFeatureValuesRule>(rule);
+}
+
+static void for_each_nested_font_rule(CSSRuleList& rules, Function<void(CSSRule&)> const& callback)
+{
+    for (auto& rule : rules) {
+        if (is_font_rule(*rule))
+            callback(*rule);
+
+        if (auto* grouping_rule = as_if<CSSGroupingRule>(*rule))
+            for_each_nested_font_rule(grouping_rule->css_rules(), callback);
+    }
+}
+
+static void for_each_effective_font_rule(CSSStyleSheet& sheet, Function<void(CSSRule&)> const& callback)
+{
+    GC::RootHashTable<CSSRule const*> effective_font_rules;
+    sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& rule) {
+        // Imported sheets are attached and load their fonts separately.
+        if (rule.parent_style_sheet() == &sheet && is_font_rule(rule))
+            effective_font_rules.set(&rule);
+    });
+
+    for_each_nested_font_rule(sheet.rules(), [&](CSSRule& rule) {
+        if (effective_font_rules.contains(&rule))
+            callback(rule);
+    });
+}
+
 void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 {
-    // FIXME: Handle @font-face and @font-feature-values within grouping rules (@media, @supports, etc)
-    for (auto const& rule : sheet.rules()) {
-        if (auto* font_face_rule = as_if<CSSFontFaceRule>(*rule)) {
+    for_each_effective_font_rule(sheet, [&](auto& rule) {
+        if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
             if (!font_face_rule->is_valid())
-                continue;
+                return;
 
             auto font_face = FontFace::create_css_connected(document().realm(), *font_face_rule);
             document().fonts()->add_css_connected_font(font_face);
@@ -881,26 +912,25 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
             }
         }
 
-        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule))
+        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule))
             font_feature_values_rule->clear_caches();
-    }
+    });
 }
 
 void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
 {
-    // FIXME: Handle @font-face and @font-feature-values within grouping rules (@media, @supports, etc)
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
     // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
-    for (auto const& rule : sheet.rules()) {
-        if (auto* font_face_rule = as_if<CSSFontFaceRule>(*rule)) {
+    for_each_nested_font_rule(sheet.rules(), [&](auto& rule) {
+        if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
             if (auto font_face = font_face_rule->css_connected_font_face())
                 unregister_font_face(*font_face);
             font_face_rule->disconnect_font_face();
         }
 
-        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule))
+        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule))
             font_feature_values_rule->clear_caches();
-    }
+    });
 }
 
 }

--- a/Tests/LibWeb/Ref/expected/font-feature-values-within-grouping-rules-ref.html
+++ b/Tests/LibWeb/Ref/expected/font-feature-values-within-grouping-rules-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+    @font-face {
+        font-family: FeatureFont;
+        src: url("../input/wpt-import/css/css-fonts/support/fonts/FontWithFancyFeatures.otf");
+    }
+
+    p {
+        font-family: FeatureFont;
+        font-size: 2em;
+        font-feature-settings: "salt" 1;
+    }
+</style>
+<p>Xnophijklmqrstuvwxyz</p>

--- a/Tests/LibWeb/Ref/input/font-feature-values-within-grouping-rules.html
+++ b/Tests/LibWeb/Ref/input/font-feature-values-within-grouping-rules.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/font-feature-values-within-grouping-rules-ref.html">
+<style>
+    @font-face {
+        font-family: FeatureFont;
+        src: url("wpt-import/css/css-fonts/support/fonts/FontWithFancyFeatures.otf");
+    }
+
+    @supports (display: block) {
+        @media screen {
+            @layer nested {
+                @font-feature-values FeatureFont {
+                    @stylistic {
+                        fancy: 1;
+                    }
+                }
+            }
+        }
+    }
+
+    @media not all {
+        @font-feature-values FeatureFont {
+            @stylistic {
+                fancy: 2;
+            }
+        }
+    }
+
+    p {
+        font-family: FeatureFont;
+        font-size: 2em;
+        font-variant-alternates: stylistic(fancy);
+    }
+</style>
+<p>Xnophijklmqrstuvwxyz</p>

--- a/Tests/LibWeb/Text/expected/css/font-rules-within-grouping-rules.txt
+++ b/Tests/LibWeb/Text/expected/css/font-rules-within-grouping-rules.txt
@@ -1,0 +1,4 @@
+Nested face count: 2
+NestedMatchingMediaFont: unloaded
+NestedSupportsFont: unloaded
+Nested face count after removal: 0

--- a/Tests/LibWeb/Text/input/css/font-rules-within-grouping-rules.html
+++ b/Tests/LibWeb/Text/input/css/font-rules-within-grouping-rules.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<style id="font-rules">
+    @media not all {
+        @font-face {
+            font-family: NestedNonMatchingMediaFont;
+            src: url("does-not-exist-non-matching-media.woff");
+            unicode-range: U+FFFF;
+        }
+
+        @font-feature-values NestedNonMatchingMediaFont {
+            @styleset {
+                fancy: 1;
+            }
+        }
+    }
+
+    @media screen {
+        @font-face {
+            font-family: NestedMatchingMediaFont;
+            src: url("does-not-exist-matching-media.woff");
+            unicode-range: U+FFFF;
+        }
+    }
+
+    @supports (display: block) {
+        @layer nested {
+            @font-face {
+                font-family: NestedSupportsFont;
+                src: url("does-not-exist-supports.woff");
+                unicode-range: U+FFFF;
+            }
+
+            @font-feature-values NestedSupportsFont {
+                @styleset {
+                    fancy: 1;
+                }
+            }
+        }
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const nestedFaces = [...document.fonts]
+            .filter(face => face.family.startsWith("Nested"))
+            .sort((a, b) => a.family.localeCompare(b.family));
+
+        println(`Nested face count: ${nestedFaces.length}`);
+        for (const face of nestedFaces)
+            println(`${face.family}: ${face.status}`);
+
+        document.getElementById("font-rules").remove();
+        println(`Nested face count after removal: ${[...document.fonts].filter(face => face.family.startsWith("Nested")).length}`);
+    });
+</script>


### PR DESCRIPTION
Makes deltarune.wiki and undertale.wiki load the correct fonts, where (almost) all of them are declared under a `@media screen` rule.

Before:
<img width="1624" height="1002" alt="Screenshot 2026-07-09 at 20 40 00" src="https://github.com/user-attachments/assets/bab361b7-35df-4d6f-a5a7-06a993a1fba0" />

After:
<img width="1624" height="1002" alt="Screenshot 2026-07-09 at 20 40 56" src="https://github.com/user-attachments/assets/9c3ef1bc-835a-41a8-a747-f1ccb71bf79c" />
