### PR TITLE
LibWeb/DOM: Let replaceChildren() replace a document's children 

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -27,7 +27,9 @@
 #include <LibWeb/DOM/AccessibilityTreeNode.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/CDATASection.h>
+#include <LibWeb/DOM/CharacterData.h>
 #include <LibWeb/DOM/Comment.h>
+#include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ElementFactory.h>
@@ -526,7 +528,7 @@ bool Node::is_browsing_context_connected() const
 }
 
 // https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
-WebIDL::ExceptionOr<void> Node::ensure_pre_insertion_validity(JS::Realm& realm, GC::Ref<Node> node, GC::Ptr<Node> child) const
+WebIDL::ExceptionOr<void> Node::ensure_pre_insert_validity(JS::Realm& realm, GC::Ref<Node> node, GC::Ptr<Node> child, ChildrenToExclude children_to_exclude) const
 {
     // 1. If parent is not a Document, DocumentFragment, or Element node, then throw a "HierarchyRequestError" DOMException.
     if (!is<Document>(this) && !is<DocumentFragment>(this) && !is<Element>(this))
@@ -542,35 +544,104 @@ WebIDL::ExceptionOr<void> Node::ensure_pre_insertion_validity(JS::Realm& realm, 
 
     // FIXME: All the following "Invalid node type for insertion" messages could be more descriptive.
     // 4. If node is not a DocumentFragment, DocumentType, Element, or CharacterData node, then throw a "HierarchyRequestError" DOMException.
-    if (!is<DocumentFragment>(*node) && !is<DocumentType>(*node) && !is<Element>(*node) && !is<Text>(*node) && !is<Comment>(*node) && !is<ProcessingInstruction>(*node) && !is<CDATASection>(*node))
+    if (!is<DocumentFragment>(*node) && !is<DocumentType>(*node) && !is<Element>(*node) && !is<CharacterData>(*node))
         return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
 
-    // 5. If either node is a Text node and parent is a document, or node is a doctype and parent is not a document, then throw a "HierarchyRequestError" DOMException.
-    if ((is<Text>(*node) && is<Document>(this)) || (is<DocumentType>(*node) && !is<Document>(this)))
-        return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
-
-    // 6. If parent is a document, and any of the statements below, switched on the interface node implements, are true, then throw a "HierarchyRequestError" DOMException.
-    if (is<Document>(this)) {
-        // DocumentFragment
-        if (is<DocumentFragment>(*node)) {
-            // If node has more than one element child or has a Text node child.
-            // Otherwise, if node has one element child and either parent has an element child, child is a doctype, or child is non-null and a doctype is following child.
-            auto node_element_child_count = as<DocumentFragment>(*node).child_element_count();
-            if ((node_element_child_count > 1 || node->has_child_of_type<Text>())
-                || (node_element_child_count == 1 && (has_child_of_type<Element>() || is<DocumentType>(child.ptr()) || (child && child->has_following_node_of_type_in_tree_order<DocumentType>())))) {
-                return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
-            }
-        } else if (is<Element>(*node)) {
-            // Element
-            // If parent has an element child, child is a doctype, or child is non-null and a doctype is following child.
-            if (has_child_of_type<Element>() || is<DocumentType>(child.ptr()) || (child && child->has_following_node_of_type_in_tree_order<DocumentType>()))
-                return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
-        } else if (is<DocumentType>(*node)) {
-            // DocumentType
-            // parent has a doctype child, child is non-null and an element is preceding child, or child is null and parent has an element child.
-            if (has_child_of_type<DocumentType>() || (child && child->has_preceding_node_of_type_in_tree_order<Element>()) || (!child && has_child_of_type<Element>()))
-                return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
+    auto children_to_exclude_contains = [&](Node const& candidate) {
+        switch (children_to_exclude) {
+        case ChildrenToExclude::None:
+            return false;
+        case ChildrenToExclude::Child:
+            return child.ptr() == &candidate;
+        case ChildrenToExclude::AllChildren:
+            return candidate.parent() == this;
         }
+        VERIFY_NOT_REACHED();
+    };
+
+    auto has_element_child_not_excluded = [&] {
+        bool has_element_child = false;
+        for_each_child([&](auto const& child) {
+            if (is<Element>(child) && !children_to_exclude_contains(child)) {
+                has_element_child = true;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+        return has_element_child;
+    };
+
+    auto has_doctype_child_not_excluded = [&] {
+        bool has_doctype_child = false;
+        for_each_child([&](auto const& child) {
+            if (is<DocumentType>(child) && !children_to_exclude_contains(child)) {
+                has_doctype_child = true;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+        return has_doctype_child;
+    };
+
+    // 5. If parent is not a document:
+    if (!is<Document>(*this)) {
+        // 1. If node is a doctype, then throw a "HierarchyRequestError" DOMException.
+        if (is<DocumentType>(*node))
+            return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
+
+        // 2. Return.
+        return {};
+    }
+
+    // 6. If node is a Text node, then throw a "HierarchyRequestError" DOMException.
+    if (is<Text>(*node))
+        return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
+
+    // 7. If node is a CharacterData node, then return.
+    if (is<CharacterData>(*node))
+        return {};
+
+    // 8. If node is a DocumentFragment node:
+    if (auto const* document_fragment = as_if<DocumentFragment>(*node)) {
+        // 1. If node has more than one element child or has a Text node child, then throw a "HierarchyRequestError" DOMException.
+        auto node_element_child_count = document_fragment->child_element_count();
+        if (node_element_child_count > 1 || node->has_child_of_type<Text>())
+            return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
+
+        // 2. If node has no element child, then return.
+        if (node_element_child_count == 0)
+            return {};
+    }
+
+    // 9. If node is a DocumentFragment or Element node:
+    if (is<DocumentFragment>(*node) || is<Element>(*node)) {
+        // 1. If any of the following are true:
+        //   * parent has an element child that childrenToExclude does not contain;
+        //   * child is non-null and a doctype is following child; or
+        //   * child is a doctype that childrenToExclude does not contain,
+        // then throw a "HierarchyRequestError" DOMException.
+        if (has_element_child_not_excluded()
+            || (child && child->has_following_node_of_type_in_tree_order<DocumentType>())
+            || (is<DocumentType>(child.ptr()) && !children_to_exclude_contains(*child))) {
+            return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
+        }
+
+        // 2. Return.
+        return {};
+    }
+
+    // 10. Assert: node is a doctype.
+    VERIFY(is<DocumentType>(*node));
+
+    // 11. If any of the following are true:
+    //   * parent has a doctype child that childrenToExclude does not contain;
+    //   * child is non-null and an element is preceding child; or
+    //   * child is null and parent has an element child that childrenToExclude does not contain,
+    // then throw a "HierarchyRequestError" DOMException.
+    if (has_doctype_child_not_excluded()
+        || (child && child->has_preceding_node_of_type_in_tree_order<Element>())
+        || (!child && has_element_child_not_excluded())) {
+        return WebIDL::HierarchyRequestError::create(realm, "Invalid node type for insertion"_utf16);
     }
 
     return {};
@@ -771,8 +842,8 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
 // https://dom.spec.whatwg.org/#concept-node-pre-insert
 WebIDL::ExceptionOr<GC::Ref<Node>> Node::pre_insert(GC::Ref<Node> node, GC::Ptr<Node> child)
 {
-    // 1. Ensure pre-insertion validity of node into parent before child.
-    TRY(ensure_pre_insertion_validity(realm(), node, child));
+    // 1. Ensure pre-insert validity given node, parent, child, and « ».
+    TRY(ensure_pre_insert_validity(realm(), node, child, ChildrenToExclude::None));
 
     // 2. Let referenceChild be child.
     auto reference_child = child;
@@ -998,52 +1069,8 @@ void Node::remove(bool suppress_observers)
 // https://dom.spec.whatwg.org/#concept-node-replace
 WebIDL::ExceptionOr<GC::Ref<Node>> Node::replace_child(GC::Ref<Node> node, GC::Ref<Node> child)
 {
-    // 1. If parent is not a Document, DocumentFragment, or Element node, then throw a "HierarchyRequestError"
-    //    DOMException.
-    if (!is<Document>(this) && !is<DocumentFragment>(this) && !is<Element>(this))
-        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element"_utf16);
-
-    // 2. If node is a host-including inclusive ancestor of parent, then throw a "HierarchyRequestError" DOMException.
-    if (node->is_host_including_inclusive_ancestor_of(*this))
-        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node"_utf16);
-
-    // 3. If child’s parent is not parent, then throw a "NotFoundError" DOMException.
-    if (child->parent() != this)
-        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child"_utf16);
-
-    // FIXME: All the following "Invalid node type for insertion" messages could be more descriptive.
-
-    // 4. If node is not a DocumentFragment, DocumentType, Element, or CharacterData node, then throw a "HierarchyRequestError" DOMException.
-    if (!is<DocumentFragment>(*node) && !is<DocumentType>(*node) && !is<Element>(*node) && !is<Text>(*node) && !is<Comment>(*node) && !is<ProcessingInstruction>(*node))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_utf16);
-
-    // 5. If either node is a Text node and parent is a document, or node is a doctype and parent is not a document, then throw a "HierarchyRequestError" DOMException.
-    if ((is<Text>(*node) && is<Document>(this)) || (is<DocumentType>(*node) && !is<Document>(this)))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_utf16);
-
-    // If parent is a document, and any of the statements below, switched on the interface node implements, are true, then throw a "HierarchyRequestError" DOMException.
-    if (is<Document>(this)) {
-        // DocumentFragment
-        if (is<DocumentFragment>(*node)) {
-            // If node has more than one element child or has a Text node child.
-            // Otherwise, if node has one element child and either parent has an element child that is not child or a doctype is following child.
-            auto node_element_child_count = as<DocumentFragment>(*node).child_element_count();
-            if ((node_element_child_count > 1 || node->has_child_of_type<Text>())
-                || (node_element_child_count == 1 && (first_child_of_type<Element>() != child || child->has_following_node_of_type_in_tree_order<DocumentType>()))) {
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_utf16);
-            }
-        } else if (is<Element>(*node)) {
-            // Element
-            // parent has an element child that is not child or a doctype is following child.
-            if (first_child_of_type<Element>() != child || child->has_following_node_of_type_in_tree_order<DocumentType>())
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_utf16);
-        } else if (is<DocumentType>(*node)) {
-            // DocumentType
-            // parent has a doctype child that is not child, or an element is preceding child.
-            if (first_child_of_type<DocumentType>() != child || child->has_preceding_node_of_type_in_tree_order<Element>())
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_utf16);
-        }
-    }
+    // 1. Ensure pre-insert validity given node, parent, child, and « child ».
+    TRY(ensure_pre_insert_validity(realm(), node, child, ChildrenToExclude::Child));
 
     // 7. Let referenceChild be child’s next sibling.
     GC::Ptr<Node> reference_child = child->next_sibling();

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -399,7 +399,12 @@ public:
     template<typename T>
     T const* fast_as() const = delete;
 
-    WebIDL::ExceptionOr<void> ensure_pre_insertion_validity(JS::Realm&, GC::Ref<Node> node, GC::Ptr<Node> child) const;
+    enum class ChildrenToExclude : u8 {
+        None,
+        Child,
+        AllChildren,
+    };
+    WebIDL::ExceptionOr<void> ensure_pre_insert_validity(JS::Realm&, GC::Ref<Node> node, GC::Ptr<Node> child, ChildrenToExclude children_to_exclude) const;
 
     bool is_host_including_inclusive_ancestor_of(Node const&) const;
 

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -172,6 +172,7 @@ WebIDL::ExceptionOr<void> ParentNode::prepend(ReadonlySpan<Variant<GC::Ref<Node>
     return {};
 }
 
+// https://dom.spec.whatwg.org/#dom-parentnode-append
 WebIDL::ExceptionOr<void> ParentNode::append(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
@@ -183,13 +184,14 @@ WebIDL::ExceptionOr<void> ParentNode::append(ReadonlySpan<Variant<GC::Ref<Node>,
     return {};
 }
 
+// https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
 WebIDL::ExceptionOr<void> ParentNode::replace_children(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));
 
-    // 2. Ensure pre-insertion validity of node into this before null.
-    TRY(ensure_pre_insertion_validity(realm(), node, nullptr));
+    // 2. Ensure pre-insert validity given node, this, null, and this’s children.
+    TRY(ensure_pre_insert_validity(realm(), node, nullptr, ChildrenToExclude::AllChildren));
 
     // 3. Replace all with node within this.
     replace_all(*node);

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -858,8 +858,8 @@ WebIDL::ExceptionOr<void> Range::insert(GC::Ref<Node> node)
     else
         parent = reference_node->parent();
 
-    // 6. Ensure pre-insertion validity of node into parent before referenceNode.
-    TRY(parent->ensure_pre_insertion_validity(node->realm(), node, reference_node));
+    // 6. Ensure pre-insert validity given node, parent, referenceNode, and « ».
+    TRY(parent->ensure_pre_insert_validity(node->realm(), node, reference_node, Node::ChildrenToExclude::None));
 
     // 7. If range’s start node is a Text node, set referenceNode to the result of splitting it with offset range’s start offset.
     if (is<Text>(*m_start_container))

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/ParentNode-replaceChildren.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/ParentNode-replaceChildren.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 31 tests
 
-28 Pass
-3 Fail
+31 Pass
 Pass	If node is a host-including inclusive ancestor of parent, then throw a HierarchyRequestError DOMException.
 Pass	If node is not a DocumentFragment, DocumentType, Element, Text, ProcessingInstruction, or Comment node, then throw a HierarchyRequestError DOMException.
 Pass	If node is a Text node and parent is a document, then throw a HierarchyRequestError DOMException.
@@ -27,9 +26,9 @@ Pass	DocumentFragment.replaceChildren() without any argument, on a parent having
 Pass	DocumentFragment.replaceChildren() with null as an argument, on a parent having a child.
 Pass	DocumentFragment.replaceChildren() with one element and text as argument, on a parent having a child.
 Pass	DocumentFragment.replaceChildren() should move nodes in the right order
-Fail	Document.replaceChildren() with an element, replacing an existing doctype and element.
-Fail	Document.replaceChildren() with a DocumentFragment containing a single element, replacing an existing doctype and element.
-Fail	Document.replaceChildren() with a doctype, replacing an existing doctype and element.
+Pass	Document.replaceChildren() with an element, replacing an existing doctype and element.
+Pass	Document.replaceChildren() with a DocumentFragment containing a single element, replacing an existing doctype and element.
+Pass	Document.replaceChildren() with a doctype, replacing an existing doctype and element.
 Pass	Document.replaceChildren() without any argument, removing an existing doctype and element.
 Pass	Document.replaceChildren() with two elements throws a HierarchyRequestError.
 Pass	Document.replaceChildren() with text throws a HierarchyRequestError.

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/ParentNode-replaceChildren.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/ParentNode-replaceChildren.txt
@@ -1,0 +1,37 @@
+Harness status: OK
+
+Found 31 tests
+
+28 Pass
+3 Fail
+Pass	If node is a host-including inclusive ancestor of parent, then throw a HierarchyRequestError DOMException.
+Pass	If node is not a DocumentFragment, DocumentType, Element, Text, ProcessingInstruction, or Comment node, then throw a HierarchyRequestError DOMException.
+Pass	If node is a Text node and parent is a document, then throw a HierarchyRequestError DOMException.
+Pass	If node is a doctype and parent is not a document, then throw a HierarchyRequestError DOMException.
+Pass	If node is a DocumentFragment with multiple elements and parent is a document, then throw a HierarchyRequestError DOMException.
+Pass	Element.replaceChildren() without any argument, on a parent having no child.
+Pass	Element.replaceChildren() with null as an argument, on a parent having no child.
+Pass	Element.replaceChildren() with undefined as an argument, on a parent having no child.
+Pass	Element.replaceChildren() with only text as an argument, on a parent having no child.
+Pass	Element.replaceChildren() with only one element as an argument, on a parent having no child.
+Pass	Element.replaceChildren() without any argument, on a parent having a child.
+Pass	Element.replaceChildren() with null as an argument, on a parent having a child.
+Pass	Element.replaceChildren() with one element and text as argument, on a parent having a child.
+Pass	Element.replaceChildren() should move nodes in the right order
+Pass	DocumentFragment.replaceChildren() without any argument, on a parent having no child.
+Pass	DocumentFragment.replaceChildren() with null as an argument, on a parent having no child.
+Pass	DocumentFragment.replaceChildren() with undefined as an argument, on a parent having no child.
+Pass	DocumentFragment.replaceChildren() with only text as an argument, on a parent having no child.
+Pass	DocumentFragment.replaceChildren() with only one element as an argument, on a parent having no child.
+Pass	DocumentFragment.replaceChildren() without any argument, on a parent having a child.
+Pass	DocumentFragment.replaceChildren() with null as an argument, on a parent having a child.
+Pass	DocumentFragment.replaceChildren() with one element and text as argument, on a parent having a child.
+Pass	DocumentFragment.replaceChildren() should move nodes in the right order
+Fail	Document.replaceChildren() with an element, replacing an existing doctype and element.
+Fail	Document.replaceChildren() with a DocumentFragment containing a single element, replacing an existing doctype and element.
+Fail	Document.replaceChildren() with a doctype, replacing an existing doctype and element.
+Pass	Document.replaceChildren() without any argument, removing an existing doctype and element.
+Pass	Document.replaceChildren() with two elements throws a HierarchyRequestError.
+Pass	Document.replaceChildren() with text throws a HierarchyRequestError.
+Pass	There should be a MutationRecord for the node removed from another parent node.
+Pass	There should be MutationRecords for the nodes removed from another parent node.

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/ParentNode-replaceChildren.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/ParentNode-replaceChildren.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>ParentNode.replaceChildren</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-parentnode-replacechildren">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="pre-insertion-validation-hierarchy.js"></script>
+<script>
+  preInsertionValidateHierarchy("replaceChildren");
+
+  function test_replacechildren(node, nodeName) {
+    test(() => {
+      const parent = node.cloneNode();
+      parent.replaceChildren();
+      assert_array_equals(parent.childNodes, []);
+    }, `${nodeName}.replaceChildren() without any argument, on a parent having no child.`);
+
+    test(() => {
+      const parent = node.cloneNode();
+      parent.replaceChildren(null);
+      assert_equals(parent.childNodes[0].textContent, 'null');
+    }, `${nodeName}.replaceChildren() with null as an argument, on a parent having no child.`);
+
+    test(() => {
+      const parent = node.cloneNode();
+      parent.replaceChildren(undefined);
+      assert_equals(parent.childNodes[0].textContent, 'undefined');
+    }, `${nodeName}.replaceChildren() with undefined as an argument, on a parent having no child.`);
+
+    test(() => {
+      const parent = node.cloneNode();
+      parent.replaceChildren('text');
+      assert_equals(parent.childNodes[0].textContent, 'text');
+    }, `${nodeName}.replaceChildren() with only text as an argument, on a parent having no child.`);
+
+    test(() => {
+      const parent = node.cloneNode();
+      const x = document.createElement('x');
+      parent.replaceChildren(x);
+      assert_array_equals(parent.childNodes, [x]);
+    }, `${nodeName}.replaceChildren() with only one element as an argument, on a parent having no child.`);
+
+    test(() => {
+      const parent = node.cloneNode();
+      const child = document.createElement('test');
+      parent.appendChild(child);
+      parent.replaceChildren();
+      assert_array_equals(parent.childNodes, []);
+    }, `${nodeName}.replaceChildren() without any argument, on a parent having a child.`);
+
+    test(() => {
+      const parent = node.cloneNode();
+      const child = document.createElement('test');
+      parent.appendChild(child);
+      parent.replaceChildren(null);
+      assert_equals(parent.childNodes.length, 1);
+      assert_equals(parent.childNodes[0].textContent, 'null');
+    }, `${nodeName}.replaceChildren() with null as an argument, on a parent having a child.`);
+
+    test(() => {
+      const parent = node.cloneNode();
+      const x = document.createElement('x');
+      const child = document.createElement('test');
+      parent.appendChild(child);
+      parent.replaceChildren(x, 'text');
+      assert_equals(parent.childNodes.length, 2);
+      assert_equals(parent.childNodes[0], x);
+      assert_equals(parent.childNodes[1].textContent, 'text');
+    }, `${nodeName}.replaceChildren() with one element and text as argument, on a parent having a child.`);
+
+    async_test(t => {
+      let phase = 0;
+
+      const previousParent = node.cloneNode();
+      const insertions = [
+        document.createElement("test1"),
+        document.createElement("test2")
+      ];
+      previousParent.append(...insertions);
+
+      const parent = node.cloneNode();
+      const children = [
+        document.createElement("test3"),
+        document.createElement("test4")
+      ];
+      parent.append(...children);
+
+      const previousObserver = new MutationObserver(mutations => {
+        t.step(() => {
+          assert_equals(phase, 0);
+          assert_equals(mutations.length, 2);
+          for (const [i, mutation] of Object.entries(mutations)) {
+            assert_equals(mutation.type, "childList");
+            assert_equals(mutation.addedNodes.length, 0);
+            assert_equals(mutation.removedNodes.length, 1);
+            assert_equals(mutation.removedNodes[0], insertions[i]);
+          }
+          phase = 1;
+        });
+      });
+      previousObserver.observe(previousParent, { childList: true });
+
+      const observer = new MutationObserver(mutations => {
+        t.step(() => {
+          assert_equals(phase, 1, "phase");
+          assert_equals(mutations.length, 1, "mutations.length");
+          const mutation = mutations[0];
+          assert_equals(mutation.type, "childList", "mutation.type");
+          assert_equals(mutation.addedNodes.length, 2, "added nodes length");
+          assert_array_equals([...mutation.addedNodes], insertions, "added nodes");
+          assert_equals(mutation.removedNodes.length, 2, "removed nodes length");
+          assert_array_equals([...mutation.removedNodes], children, "removed nodes");
+        });
+        t.done();
+      });
+      observer.observe(parent, { childList: true });
+
+      parent.replaceChildren(...previousParent.children);
+    }, `${nodeName}.replaceChildren() should move nodes in the right order`);
+  }
+
+  test_replacechildren(document.createElement('div'), 'Element');
+  test_replacechildren(document.createDocumentFragment(), 'DocumentFragment');
+
+  // Document is special: replaceChildren removes the existing children (a
+  // doctype and a document element) before inserting, so the pre-insert
+  // validity checks must ignore them. See
+  // https://github.com/whatwg/dom/issues/1045.
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const el = doc.createElement("a");
+    doc.replaceChildren(el);
+    assert_array_equals(doc.childNodes, [el]);
+  }, "Document.replaceChildren() with an element, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const df = doc.createDocumentFragment();
+    const el = doc.createElement("a");
+    df.appendChild(el);
+    doc.replaceChildren(df);
+    assert_array_equals(doc.childNodes, [el]);
+  }, "Document.replaceChildren() with a DocumentFragment containing a single element, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    const doctype = doc.doctype.cloneNode();
+    doc.replaceChildren(doctype);
+    assert_array_equals(doc.childNodes, [doctype]);
+  }, "Document.replaceChildren() with a doctype, replacing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    doc.replaceChildren();
+    assert_array_equals(doc.childNodes, []);
+  }, "Document.replaceChildren() without any argument, removing an existing doctype and element.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    assert_throws_dom("HierarchyRequestError",
+      () => doc.replaceChildren(doc.createElement("a"), doc.createElement("b")));
+  }, "Document.replaceChildren() with two elements throws a HierarchyRequestError.");
+
+  test(() => {
+    const doc = document.implementation.createHTMLDocument("title");
+    assert_throws_dom("HierarchyRequestError", () => doc.replaceChildren("text"));
+  }, "Document.replaceChildren() with text throws a HierarchyRequestError.");
+
+  async_test(t => {
+    let root = document.createElement("div");
+    root.innerHTML = "<div id='a'>text<div id='b'>text2</div></div>";
+    const a = root.firstChild;
+    const b = a.lastChild;
+    const txt = b.previousSibling;
+    const txt2 = b.firstChild;
+
+    const observer = new MutationObserver((mutations) => {
+
+      assert_equals(mutations.length, 2, "mutations.length");
+
+      assert_equals(mutations[0].target.id, "a", "Target of the removal");
+      assert_equals(mutations[0].addedNodes.length, 0, "Should not have added nodes");
+      assert_equals(mutations[0].removedNodes.length, 1, "Should have 1 removed node");
+      assert_equals(mutations[0].removedNodes[0], txt, "Should have removed txt node");
+
+      assert_equals(mutations[1].target.id, "b", "Target of the replaceChildren");
+      assert_equals(mutations[1].removedNodes.length, 1, "Should have removed 1 node");
+      assert_equals(mutations[1].removedNodes[0], txt2, "Should have removed txt2 node");
+      assert_equals(mutations[1].addedNodes.length, 1, "Should have added a node");
+      assert_equals(mutations[1].addedNodes[0], txt, "Should have added txt node");
+
+      observer.disconnect();
+      t.done();
+    });
+
+    observer.observe(a,  {
+      subtree: true,
+      childList: true
+    });
+
+    b.replaceChildren(txt);
+  }, "There should be a MutationRecord for the node removed from another parent node.");
+
+  async_test(t => {
+    // This is almost the same test as above, but passes two nodes to replaceChildren.
+
+    let root = document.createElement("div");
+    root.innerHTML = "<div id='a'><div id='c'></div>text<div id='b'>text2</div></div>";
+    const a = root.firstChild;
+    const b = a.lastChild;
+    const c = a.firstChild;
+    const txt = b.previousSibling;
+    const txt2 = b.firstChild;
+
+    const observer = new MutationObserver((mutations) => {
+
+      assert_equals(mutations.length, 3, "mutations.length");
+
+      assert_equals(mutations[0].target.id, "a", "Target of the removal");
+      assert_equals(mutations[0].addedNodes.length, 0, "Should not have added nodes");
+      assert_equals(mutations[0].removedNodes.length, 1, "Should have 1 removed node");
+      assert_equals(mutations[0].removedNodes[0], c, "Should have removed c node");
+
+      assert_equals(mutations[1].target.id, "a", "Target of the removal");
+      assert_equals(mutations[1].addedNodes.length, 0, "Should not have added nodes");
+      assert_equals(mutations[1].removedNodes.length, 1, "Should have 1 removed node");
+      assert_equals(mutations[1].removedNodes[0], txt, "Should have removed txt node");
+
+      assert_equals(mutations[2].target.id, "b", "Target of the replaceChildren");
+      assert_equals(mutations[2].removedNodes.length, 1, "Should have removed 1 node");
+      assert_equals(mutations[2].removedNodes[0], txt2, "Should have removed txt2 node");
+      assert_equals(mutations[2].addedNodes.length, 2, "Should have added a node");
+      assert_equals(mutations[2].addedNodes[0], c, "Should have added c node");
+      assert_equals(mutations[2].addedNodes[1], txt, "Should have added txt node");
+
+      observer.disconnect();
+      t.done();
+    });
+
+    observer.observe(a,  {
+      subtree: true,
+      childList: true
+    });
+
+    b.replaceChildren(c, txt);
+  }, "There should be MutationRecords for the nodes removed from another parent node.");
+</script>
+
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/pre-insertion-validation-hierarchy.js
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/pre-insertion-validation-hierarchy.js
@@ -51,31 +51,41 @@ function preInsertionValidateHierarchy(methodName) {
   }, "If node is a DocumentFragment with multiple elements and parent is a document, then throw a HierarchyRequestError DOMException.");
 
   // Step 6, in case of DocumentFragment has multiple elements when document already has an element
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const df = doc.createDocumentFragment();
-    df.appendChild(doc.createElement("a"));
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, df));
-  }, "If node is a DocumentFragment with an element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const df = doc.createDocumentFragment();
+      df.appendChild(doc.createElement("a"));
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, df));
+    }, "If node is a DocumentFragment with an element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of an element
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const el = doc.createElement("a");
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, el));
-  }, "If node is an Element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const el = doc.createElement("a");
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, el));
+    }, "If node is an Element and parent is a document with another element, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of a doctype when document already has another doctype
-  test(() => {
-    const doc = document.implementation.createHTMLDocument("title");
-    const doctype = doc.childNodes[0].cloneNode();
-    doc.documentElement.remove();
-    assert_throws_dom("HierarchyRequestError", () => insert(doc, doctype));
-  }, "If node is a doctype and parent is a document with another doctype, then throw a HierarchyRequestError DOMException.");
+  if (methodName !== "replaceChildren") {
+    // Skip `.replaceChildren` as it removes the document's existing children first
+    test(() => {
+      const doc = document.implementation.createHTMLDocument("title");
+      const doctype = doc.childNodes[0].cloneNode();
+      doc.documentElement.remove();
+      assert_throws_dom("HierarchyRequestError", () => insert(doc, doctype));
+    }, "If node is a doctype and parent is a document with another doctype, then throw a HierarchyRequestError DOMException.");
+  }
 
   // Step 6, in case of a doctype when document has an element
-  if (methodName !== "prepend") {
+  if (methodName !== "prepend" && methodName !== "replaceChildren") {
     // Skip `.prepend` as this doesn't throw if `child` is an element
+    // Skip `.replaceChildren` as it removes the document's existing children first
     test(() => {
       const doc = document.implementation.createHTMLDocument("title");
       const doctype = doc.childNodes[0].cloneNode();


### PR DESCRIPTION
Corresponds to https://github.com/whatwg/dom/commit/ea2a74edc
alongside some other editorial changes.