### PR TITLE
LibWeb: Paint the caret in text controls inside shadow roots

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -487,10 +487,10 @@ void PaintableWithLines::paint_cursor(DisplayListRecordingContext& context) cons
     if (!dom_node)
         return;
 
-    auto active_element_is_editable = false;
-    if (auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(document().active_element()))
-        active_element_is_editable = text_control->text_control_to_html_element().is_mutable();
-    if (!active_element_is_editable && !dom_node->is_editable_or_editing_host())
+    auto focused_text_control_is_editable = false;
+    if (auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(document().focused_area().ptr()))
+        focused_text_control_is_editable = text_control->text_control_to_html_element().is_mutable();
+    if (!focused_text_control_is_editable && !dom_node->is_editable_or_editing_host())
         return;
 
     auto fragment = fragment_at_position(*cursor_position);

--- a/Tests/LibWeb/Ref/expected/caret-in-shadow-root-text-control-ref.html
+++ b/Tests/LibWeb/Ref/expected/caret-in-shadow-root-text-control-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+textarea {
+    font-size: 20px;
+    width: 200px;
+    outline: none;
+}
+</style>
+<div>
+    <textarea></textarea>
+</div>
+<script>
+document.querySelector("textarea").focus();
+</script>

--- a/Tests/LibWeb/Ref/input/caret-in-shadow-root-text-control.html
+++ b/Tests/LibWeb/Ref/input/caret-in-shadow-root-text-control.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/caret-in-shadow-root-text-control-ref.html">
+<div id="host"></div>
+<script>
+const shadowRoot = document.getElementById("host").attachShadow({ mode: "open" });
+shadowRoot.innerHTML = `
+    <style>
+    textarea {
+        font-size: 20px;
+        width: 200px;
+        outline: none;
+    }
+    </style>
+    <textarea></textarea>`;
+shadowRoot.querySelector("textarea").focus();
+</script>


### PR DESCRIPTION
paint_cursor() checked whether the focused text control is mutable by casting the document's active element, but activeElement retargets to the shadow host when focus is inside a shadow root, so the cast always failed and no caret was painted for such controls. Use the document's focused area instead, which is the actual control. This fixes the missing caret in the reddit.com search field, and comes with a ref test covering a focused textarea inside a shadow root.