### PR TITLE
ImageDecoder: Do event-loop init before sandbox install

### DIFF
--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -51,10 +51,11 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         Gfx::SkiaBackendContext::initialize_gpu_backend();
     auto skia_backend_context = Gfx::SkiaBackendContext::the_main_thread_context();
 
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
+
     if (!disable_sandbox)
         TRY(Compositor::apply_sandbox());
 
-    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<Compositor::ConnectionFromClient>(
         mach_server_name, move(skia_backend_context), !disable_async_scrolling));
 

--- a/Services/ImageDecoder/main.cpp
+++ b/Services/ImageDecoder/main.cpp
@@ -31,10 +31,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     if (wait_for_debugger)
         Core::Process::wait_for_debugger_and_break();
 
+    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
+
     if (!disable_sandbox)
         TRY(ImageDecoder::apply_sandbox());
-
-    auto& event_loop = Core::EventLoop::initialize_for_current_thread();
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<ImageDecoder::ConnectionFromClient>(mach_server_name));
 


### PR DESCRIPTION
**Problem:** Crash with a sandbox violation for `newfstatat` or `access`.

**Cause:** ImageDecoder did seccomp-sandbox install before event-loop init. And unlike WebContent, WebWorker, RequestServer, and Compositor, it by design doesn’t allow filesystem metadata queries. So any `newfstatat`/`access` the event-loop init performs hits the default-deny.

**Fix:** Do ImageDecoder event-loop init before sandbox install — matching what we already do for WebContent, WebWorker, and RequestServer. And do the same for Compositor, too — not to prevent any crash (Compositor hadn’t/wouldn’t hit the same crash, because it allows filesystem metadata queries), but instead just for consistency.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/10155
