### PR TITLE
LibGfx+LibWeb: Follow fontconfig hinting when rasterizing glyphs

### DIFF
--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -15,6 +15,10 @@
 #include <LibGfx/Font/TypefaceSkia.h>
 #include <LibGfx/TextLayout.h>
 
+#if defined(USE_FONTCONFIG)
+#    include <LibGfx/Font/GlobalFontConfig.h>
+#endif
+
 #include <core/SkFont.h>
 #include <core/SkFontMetrics.h>
 #include <core/SkFontTypes.h>
@@ -130,11 +134,57 @@ hb_font_t* Font::harfbuzz_font() const
     return m_harfbuzz_font;
 }
 
+#if defined(USE_FONTCONFIG)
+static Optional<FontHintingStyle> s_hinting_override_for_testing;
+
+static SkFontHinting to_skia_hinting(FontHintingStyle style)
+{
+    switch (style) {
+    case FontHintingStyle::None:
+        return SkFontHinting::kNone;
+    case FontHintingStyle::Slight:
+        return SkFontHinting::kSlight;
+    case FontHintingStyle::Normal:
+        return SkFontHinting::kNormal;
+    case FontHintingStyle::Full:
+        return SkFontHinting::kFull;
+    }
+    VERIFY_NOT_REACHED();
+}
+#endif
+
+void force_hinting_for_testing([[maybe_unused]] Optional<FontHintingStyle> style)
+{
+#if defined(USE_FONTCONFIG)
+    s_hinting_override_for_testing = style;
+#endif
+}
+
+#if defined(USE_FONTCONFIG)
+FontHintingOptions Font::hinting_options(float scale) const
+{
+    if (!m_hinting_options.has_value() || m_hinting_options->scale != scale)
+        m_hinting_options = ScaledFontHintingOptions { scale, GlobalFontConfig::the().hinting_for_font(family(), pixel_size() * scale, weight(), slope()) };
+    return m_hinting_options->options;
+}
+#endif
+
 SkFont Font::skia_font(float scale) const
 {
     auto const& sk_typeface = as<TypefaceSkia>(*m_typeface).sk_typeface();
     auto sk_font = SkFont { sk_ref_sp(sk_typeface), pixel_size() * scale };
     sk_font.setSubpixel(true);
+
+#if defined(USE_FONTCONFIG)
+    if (s_hinting_override_for_testing.has_value()) {
+        sk_font.setHinting(to_skia_hinting(*s_hinting_override_for_testing));
+    } else {
+        auto options = hinting_options(scale);
+        sk_font.setHinting(to_skia_hinting(options.style));
+        sk_font.setForceAutoHinting(options.force_autohinting);
+    }
+#endif
+
     return sk_font;
 }
 

--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -12,6 +12,7 @@
 #include <AK/AtomicRefCounted.h>
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
+#include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/Utf16String.h>
@@ -61,6 +62,20 @@ enum FontWidth {
 
 constexpr float text_shaping_resolution = 64;
 
+enum class FontHintingStyle {
+    None,
+    Slight,
+    Normal,
+    Full,
+};
+
+struct FontHintingOptions {
+    FontHintingStyle style { FontHintingStyle::Normal };
+    bool force_autohinting { false };
+};
+
+void force_hinting_for_testing(Optional<FontHintingStyle>);
+
 class Font : public AtomicRefCounted<Font> {
 public:
     Font(NonnullRefPtr<Typeface const>, float point_width, float point_height, FontVariationSettings const variations, ShapeFeatures const& features);
@@ -103,6 +118,16 @@ public:
 
 private:
     u64 m_id { 0 };
+
+#if defined(USE_FONTCONFIG)
+    FontHintingOptions hinting_options(float scale) const;
+
+    struct ScaledFontHintingOptions {
+        float scale;
+        FontHintingOptions options;
+    };
+    mutable Optional<ScaledFontHintingOptions> m_hinting_options;
+#endif
 
     mutable RefPtr<Font const> m_bold_variant;
     mutable hb_font_t* m_harfbuzz_font { nullptr };

--- a/Libraries/LibGfx/Font/GlobalFontConfig.cpp
+++ b/Libraries/LibGfx/Font/GlobalFontConfig.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/ByteString.h>
 #include <AK/NeverDestroyed.h>
 #include <LibGfx/Font/GlobalFontConfig.h>
 #include <fontconfig/fontconfig.h>
@@ -18,6 +19,62 @@ GlobalFontConfig::GlobalFontConfig()
 
     m_config = FcConfigGetCurrent();
     FcConfigReference(m_config);
+}
+
+FontHintingOptions GlobalFontConfig::hinting_for_font(FlyString const& family, float pixel_size, u16 weight, u8 slope)
+{
+    FontHintingOptions options;
+
+    FcPattern* pattern = FcPatternCreate();
+    if (!pattern)
+        return options;
+
+    auto family_name = family.bytes_as_string_view().to_byte_string();
+    FcPatternAddString(pattern, FC_FAMILY, reinterpret_cast<FcChar8 const*>(family_name.characters()));
+    FcPatternAddDouble(pattern, FC_PIXEL_SIZE, pixel_size);
+    FcPatternAddInteger(pattern, FC_WEIGHT, FcWeightFromOpenType(weight));
+
+    int slant = FC_SLANT_ROMAN;
+    if (slope == 1)
+        slant = FC_SLANT_ITALIC;
+    else if (slope == 2)
+        slant = FC_SLANT_OBLIQUE;
+    FcPatternAddInteger(pattern, FC_SLANT, slant);
+
+    FcConfigSubstitute(m_config, pattern, FcMatchPattern);
+    FcDefaultSubstitute(pattern);
+
+    // Substitute a duplicate of the query pattern in place of a matched font, so that font-target
+    // rules testing family or size apply without matching against the font set.
+    FcPattern* font_pattern = FcPatternDuplicate(pattern);
+    if (!font_pattern) {
+        FcPatternDestroy(pattern);
+        return options;
+    }
+    FcConfigSubstituteWithPat(m_config, font_pattern, pattern, FcMatchFont);
+
+    FcBool hinting_enabled = FcTrue;
+    FcPatternGetBool(font_pattern, FC_HINTING, 0, &hinting_enabled);
+
+    int hint_style = FC_HINT_FULL;
+    FcPatternGetInteger(font_pattern, FC_HINT_STYLE, 0, &hint_style);
+
+    if (!hinting_enabled || hint_style == FC_HINT_NONE)
+        options.style = FontHintingStyle::None;
+    else if (hint_style == FC_HINT_SLIGHT)
+        options.style = FontHintingStyle::Slight;
+    else if (hint_style == FC_HINT_MEDIUM)
+        options.style = FontHintingStyle::Normal;
+    else
+        options.style = FontHintingStyle::Full;
+
+    FcBool autohint = FcFalse;
+    FcPatternGetBool(font_pattern, FC_AUTOHINT, 0, &autohint);
+    options.force_autohinting = autohint;
+
+    FcPatternDestroy(font_pattern);
+    FcPatternDestroy(pattern);
+    return options;
 }
 
 GlobalFontConfig::~GlobalFontConfig()

--- a/Libraries/LibGfx/Font/GlobalFontConfig.h
+++ b/Libraries/LibGfx/Font/GlobalFontConfig.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Font/Font.h>
 #include <fontconfig/fontconfig.h>
 
 namespace AK {
@@ -21,6 +22,8 @@ class GlobalFontConfig {
 public:
     static GlobalFontConfig& the();
     FcConfig* get();
+
+    FontHintingOptions hinting_for_font(FlyString const& family, float pixel_size, u16 weight, u8 slope);
 
 private:
     friend class AK::NeverDestroyed<GlobalFontConfig>;

--- a/Libraries/LibWeb/Platform/FontPlugin.cpp
+++ b/Libraries/LibWeb/Platform/FontPlugin.cpp
@@ -37,6 +37,9 @@ void FontPlugin::install(FontPlugin& plugin)
 FontPlugin::FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* font_provider)
     : m_is_layout_test_mode(is_layout_test_mode)
 {
+    if (is_layout_test_mode)
+        Gfx::force_hinting_for_testing(Gfx::FontHintingStyle::Normal);
+
     if (!font_provider)
         font_provider = &static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
     if (is<Gfx::PathFontProvider>(*font_provider)) {

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -168,6 +168,8 @@ ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process()
     Vector<ByteString> arguments;
     if (browser_options.disable_sandbox == DisableSandbox::Yes)
         arguments.append("--disable-sandbox"sv);
+    if (web_content_options.is_test_mode == WebView::IsTestMode::Yes)
+        arguments.append("--test-mode"sv);
     if (web_content_options.force_cpu_painting == WebView::ForceCPUPainting::Yes)
         arguments.append("--force-cpu-painting"sv);
     if (web_content_options.force_fontconfig == WebView::ForceFontconfig::Yes)

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -9,6 +9,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Process.h>
+#include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
 #include <LibGfx/SkiaBackendContext.h>
@@ -22,6 +23,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     StringView mach_server_name;
     bool wait_for_debugger = false;
+    bool enable_test_mode = false;
     bool force_cpu_painting = false;
     bool force_fontconfig = false;
     bool disable_async_scrolling = false;
@@ -30,6 +32,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::ArgsParser args_parser;
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
+    args_parser.add_option(enable_test_mode, "Enable test mode", "test-mode");
     args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(disable_async_scrolling, "Disable async scrolling", "disable-async-scrolling");
@@ -38,6 +41,9 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     if (wait_for_debugger)
         Core::Process::wait_for_debugger_and_break();
+
+    if (enable_test_mode)
+        Gfx::force_hinting_for_testing(Gfx::FontHintingStyle::Normal);
 
     WebView::platform_init();
     auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));


### PR DESCRIPTION
Glyph positions and advances are produced by HarfBuzz from un-hinted font metrics, but glyphs were rasterized with Skia's default normal hinting. For fonts without a TrueType hinting program, this makes FreeType's autohinter grid-fit glyph outlines horizontally, so the rasterized glyphs no longer line up with the un-hinted advances. The result is visibly uneven spacing, most noticeably a spurious gap before narrow glyphs such as "t".

Resolve the hinting configuration from fontconfig per font family and size, honoring family and size-specific configuration rules such as the common rules that disable hinting for DejaVu fonts at small sizes. The query runs the configuration's substitution edits over a pattern describing the font, standing in for a matched font. Results are cached per font. The configuration itself is loaded before the renderer sandbox is installed, and the queries perform no filesystem
access, so resolution at rasterization time is sandbox-safe.

Test mode pins the hinting style to normal, matching Skia's previous default, so that rendering is deterministic across machines rather than depending on the host's fontconfig configuration.

Tested by visually comparing[ this test page](https://gist.github.com/tcl3/448cd548fcd1a7e8f7efbf950aa9fa38):

Before:

<img width="213" height="28" alt="image" src="https://github.com/user-attachments/assets/4a94e1dc-d02e-4ca3-8d99-fbacef4db4bb" />

After:

<img width="213" height="28" alt="image" src="https://github.com/user-attachments/assets/2d0c871b-292e-4722-b788-dce3d01de9cc" />

Fixes #10344

NB: This will conflict with #10547, which removes the direct fontconfig dependency and goes through Skia. Unfortunately, skia doesn't have the necessary APIs for this, so the direct  fontconfig dependency would need to be kept :disappointed: 