### PR TITLE
LibWeb: Clear formatting context roots below floats they overlap

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -549,8 +549,16 @@ void BlockFormattingContext::rebuild_float_bands()
         auto const* containing_block = floating_box->used_values.node().containing_block();
         VERIFY(containing_block);
         auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(m_state.get(*containing_block), root());
+        floating_box->margin_box_rect_in_root_coordinate_space.set_x(margin_box_left_of_float_in_root(*floating_box, containing_block_rect_in_root));
         add_float_to_bands(*floating_box, containing_block_rect_in_root);
     }
+}
+
+CSSPixels BlockFormattingContext::margin_box_left_of_float_in_root(FloatingBox const& floating_box, CSSPixelRect const& containing_block_rect_in_root) const
+{
+    if (floating_box.side == FloatSide::Left)
+        return containing_block_rect_in_root.x() + floating_box.offset_from_edge - floating_box.used_values.margin_box_left();
+    return containing_block_rect_in_root.right() - floating_box.offset_from_edge - floating_box.used_values.margin_box_left();
 }
 
 void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space)
@@ -1490,7 +1498,9 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         .margin_box_rect_in_root_coordinate_space = margin_box_rect_in_root,
         .percentage_basis_width = layout_input.containing_block_constraints.percentage_basis_width,
     }));
-    add_float_to_bands(*m_floats.last(), containing_block_rect_in_root);
+    auto& floating_box = *m_floats.last();
+    floating_box.margin_box_rect_in_root_coordinate_space.set_x(margin_box_left_of_float_in_root(floating_box, containing_block_rect_in_root));
+    add_float_to_bands(floating_box, containing_block_rect_in_root);
 
     m_state.get_mutable(root()).add_floating_descendant(box);
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <AK/TemporaryChange.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Length.h>
@@ -219,10 +220,20 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     // Certain formatting contexts do not allow float intrusions, so reduce the available space for them.
     if (available_space.width.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
+        auto available_width = available_space.width.to_px_or_zero();
         auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
-        box_in_root_rect.set_width(available_space.width.to_px_or_zero());
+        box_in_root_rect.set_width(available_width);
         auto intrusion = intrusions_for_band_into_rect(band_at(box_in_root_rect.y()), box_in_root_rect);
-        auto remaining_width = available_space.width.to_px_or_zero() - intrusion.left - intrusion.right;
+        auto remaining_width = available_width - intrusion.left - intrusion.right;
+        if (intrusion.left > 0 || intrusion.right > 0) {
+            // Negative margins do not create additional space next to a float. Reduce the space available for
+            // resolving an automatic width by any negative margins, so that the resulting border box is no wider
+            // than the space next to the float.
+            auto margin_left = box.computed_values().margin().left().resolved_or_auto(available_width).to_px_or_zero();
+            auto margin_right = box.computed_values().margin().right().resolved_or_auto(available_width).to_px_or_zero();
+            auto negative_margin_sum = min(margin_left, CSSPixels(0)) + min(margin_right, CSSPixels(0));
+            remaining_width = max(remaining_width + negative_margin_sum, CSSPixels(0));
+        }
         remaining_available_space.width = AvailableSize::make_definite(remaining_width);
     }
 
@@ -561,10 +572,19 @@ CSSPixels BlockFormattingContext::margin_box_left_of_float_in_root(FloatingBox c
     return containing_block_rect_in_root.right() - floating_box.offset_from_edge - floating_box.used_values.margin_box_left();
 }
 
-void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space)
+CSSPixels BlockFormattingContext::border_box_left_of_box_avoiding_floats(Box const& box, LayoutState::UsedValues const& box_state, SpaceUsedByFloats const& space_used_by_floats) const
 {
-    if (box.computed_values().width().is_auto())
-        return;
+    if (box.computed_values().margin().left().is_auto())
+        return space_used_by_floats.left + box_state.margin_left;
+    if (box_state.margin_left >= 0)
+        return max(space_used_by_floats.left, box_state.margin_left);
+    if (space_used_by_floats.left > 0 || space_used_by_floats.right > 0)
+        return space_used_by_floats.left;
+    return space_used_by_floats.left + box_state.margin_left;
+}
+
+void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+{
     if (!available_space.width.is_definite())
         return;
     if (!box_should_avoid_floats_because_it_establishes_fc(box))
@@ -574,25 +594,42 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
     // If necessary, implementations should clear the said element by placing it below any preceding floats, but may
     // place it adjacent to such floats if there is sufficient space.
     auto& box_state = m_state.get_mutable(box);
+    auto const* containing_block = box.containing_block();
+    VERIFY(containing_block);
+    auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(m_state.get(*containing_block), root());
     while (true) {
-        auto border_box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_state, root());
-        border_box_in_root_rect.translate_by(-box_state.border_box_left(), -box_state.border_box_top());
-        auto const* containing_block = box.containing_block();
-        VERIFY(containing_block);
-        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(m_state.get(*containing_block), root());
-        containing_block_rect_in_root.set_y(border_box_in_root_rect.y());
+        auto border_box_y_in_root = content_box_rect_in_ancestor_coordinate_space(box_state, root()).y() - box_state.border_box_top();
+        containing_block_rect_in_root.set_y(border_box_y_in_root);
         containing_block_rect_in_root.set_height(box_state.border_box_height());
-        auto const& band = band_at(border_box_in_root_rect.y());
+        auto const& band = band_at(border_box_y_in_root);
         auto space_used_by_floats = intrusions_for_band_into_rect(band, containing_block_rect_in_root);
-        auto remaining_space = available_space.width.to_px_or_zero() - space_used_by_floats.left - space_used_by_floats.right;
-        if (box_state.border_box_width() <= remaining_space)
+        bool const constrained_by_floats = space_used_by_floats.left > 0 || space_used_by_floats.right > 0;
+        auto border_box_left_in_containing_block = border_box_left_of_box_avoiding_floats(box, box_state, space_used_by_floats);
+
+        bool must_clear_below_current_band = constrained_by_floats
+            && border_box_left_in_containing_block + box_state.border_box_width() > available_space.width.to_px_or_zero() - space_used_by_floats.right;
+
+        if (!must_clear_below_current_band) {
+            CSSPixelRect border_box_rect_in_root {
+                containing_block_rect_in_root.x() + border_box_left_in_containing_block,
+                border_box_y_in_root,
+                box_state.border_box_width(),
+                box_state.border_box_height(),
+            };
+            must_clear_below_current_band = any_of(m_floats, [&](auto const& floating_box) {
+                return !floating_box->margin_box_rect_in_root_coordinate_space.intersected(border_box_rect_in_root).is_empty();
+            });
+        }
+        if (!must_clear_below_current_band)
             break;
 
-        auto next_band_start = next_float_band_block_start_after(border_box_in_root_rect.y());
+        auto next_band_start = next_float_band_block_start_after(border_box_y_in_root);
         if (!next_band_start.has_value())
             break;
 
-        box_state.set_content_y(box_state.offset.y() + next_band_start.value() - border_box_in_root_rect.y());
+        box_state.set_content_y(box_state.offset.y() + next_band_start.value() - border_box_y_in_root);
+
+        compute_width(box, available_space, containing_block_constraints);
     }
 }
 
@@ -1069,7 +1106,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     place_block_level_element_in_normal_flow_vertically(box, y + margin_top);
 
     compute_width(box, available_space, layout_input.containing_block_constraints);
-    avoid_float_intrusions(box, available_space);
+    avoid_float_intrusions(box, available_space, layout_input.containing_block_constraints);
 
     place_block_level_element_in_normal_flow_horizontally(box, available_space);
 
@@ -1412,12 +1449,8 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
         auto space_used_by_floats = intrusion_by_floats_into_box(box_state, 0);
         available_width_within_containing_block -= space_used_by_floats.left + space_used_by_floats.right;
 
-        // Since this box has a FC, it should avoid floats which means we cannot have its border box overlap with any
-        // float's margin box. We start off at the right-most border of the floats, and if this box' margin-left is not
-        // auto, we must overlap that margin with the floats as far as possible.
-        x = space_used_by_floats.left;
-        if (!child_box.computed_values().margin().left().is_auto())
-            x = max(x - max(box_state.margin_left, 0), 0);
+        // Subtracting the left margin here because it is applied again when the margin box offset is added below.
+        x = border_box_left_of_box_avoiding_floats(child_box, box_state, space_used_by_floats) - box_state.margin_left;
     }
 
     if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebCenter) {

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -28,7 +28,7 @@ public:
 
     bool box_should_avoid_floats_because_it_establishes_fc(Box const&);
     void compute_width(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints);
-    void avoid_float_intrusions(Box const&, AvailableSpace const&);
+    void avoid_float_intrusions(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
     // https://www.w3.org/TR/css-display/#block-formatting-context-root
     BlockContainer const& root() const { return static_cast<BlockContainer const&>(context_box()); }
@@ -112,6 +112,8 @@ private:
 
     void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);
     void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
+
+    [[nodiscard]] CSSPixels border_box_left_of_box_avoiding_floats(Box const&, LayoutState::UsedValues const&, SpaceUsedByFloats const&) const;
 
     void ensure_sizes_correct_for_left_offset_calculation(ListItemBox const&);
     void layout_list_item_marker(ListItemBox const&, SpaceUsedByFloats const& inline_space_used_before_list_item_elements_formatted);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -146,6 +146,7 @@ private:
     void ensure_band_boundary(CSSPixels);
     void add_float_to_bands(FloatingBox const&, CSSPixelRect const& containing_block_rect_in_root);
     void rebuild_float_bands();
+    [[nodiscard]] CSSPixels margin_box_left_of_float_in_root(FloatingBox const&, CSSPixelRect const& containing_block_rect_in_root) const;
 
     class BlockMarginState {
     public:

--- a/Tests/LibWeb/Layout/expected/flex/flex-container-with-auto-width-avoids-float-intrusions.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-with-auto-width-avoids-float-intrusions.txt
@@ -1,0 +1,52 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 552 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 400 0+0+392] [8+0+0 536 0+0+8] children: not-inline
+      BlockContainer <div.full-width-float> at [8,8] floating [0+0+0 400 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+      Box <div.small-negative-margin> at [3,108] flex-container(row) [-5+0+0 405 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> at [3,108] flex-item [0+0+0 303.78125 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 39, rect: [3,108 303.78125x16] baseline: 12.796875
+              "This should clear the full-width float."
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,208] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <hr> at [9,217] [0+1+0 398 0+1+0] [8+1+0 0 0+1+8] [BFC] children: not-inline
+      BlockContainer <div.partial-width-float> at [8,226] floating [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+      Box <div.small-negative-margin> at [108,226] flex-container(row) [-5+0+0 300 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> at [108,226] flex-item [0+0+0 300 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 33, rect: [108,226 267.703125x16] baseline: 12.796875
+              "This should sit flush against the"
+          frag 1 from TextNode start: 34, length: 6, rect: [108,242 41.578125x16] baseline: 12.796875
+              "float."
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,326] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <hr> at [9,335] [0+1+0 398 0+1+0] [8+1+0 0 0+1+8] [BFC] children: not-inline
+      BlockContainer <div.partial-width-float> at [8,344] floating [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+      Box <div.large-negative-margin> at [-342,444] flex-container(row) [-350+0+0 750 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> at [-342,444] flex-item [0+0+0 224.828125 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 28, rect: [-342,444 224.828125x16] baseline: 12.796875
+              "This should clear the float."
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,544] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x552]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 400x536]
+      PaintableWithLines (BlockContainer<DIV>.full-width-float) [8,8 400x100]
+      Paintable (Box<DIV>.small-negative-margin) [3,108 405x100]
+        PaintableWithLines (BlockContainer(anonymous)) [3,108 303.78125x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 400x0]
+      PaintableWithLines (BlockContainer<HR>) [8,216 400x2]
+      PaintableWithLines (BlockContainer<DIV>.partial-width-float) [8,226 100x100]
+      Paintable (Box<DIV>.small-negative-margin) [108,226 300x100]
+        PaintableWithLines (BlockContainer(anonymous)) [108,226 300x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,326 400x0]
+      PaintableWithLines (BlockContainer<HR>) [8,334 400x2]
+      PaintableWithLines (BlockContainer<DIV>.partial-width-float) [8,344 100x100]
+      Paintable (Box<DIV>.large-negative-margin) [-342,444 750x100]
+        PaintableWithLines (BlockContainer(anonymous)) [-342,444 224.828125x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,544 400x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x552] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/flex-container-with-definite-width-avoids-float-intrusions.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-with-definite-width-avoids-float-intrusions.txt
@@ -4,7 +4,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <(anonymous)> at [8,8] [0+0+0 400 0+0+0] [0+0+0 16 0+0+0] children: inline
         BreakNode <br> (not painted)
         BlockContainer <div.a> at [8,24] floating [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
-      Box <div.c> at [8,124] flex-container(row) [0+0+0 400 0+0+-100] [0+0+0 100 0+0+0] [FFC] children: not-inline
+      Box <div.c> at [8,124] flex-container(row) [0+0+0 400 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
         BlockContainer <(anonymous)> at [8,124] flex-item [0+0+0 257.3125 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 31, rect: [8,124 257.3125x16] baseline: 12.796875
               "This should clear the blue box."
@@ -14,7 +14,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <hr> at [9,233] [0+1+0 398 0+1+0] [8+1+0 0 0+1+8] [BFC] children: not-inline
       BlockContainer <div.a> at [8,242] floating [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
       BlockContainer <div.b> at [358,242] floating [0+0+0 50 0+0+0] [0+0+0 200 0+0+0] [BFC] children: not-inline
-      Box <div.c> at [8,442] flex-container(row) [0+0+0 400 0+0+-150] [0+0+0 100 0+0+0] [FFC] children: not-inline
+      Box <div.c> at [8,442] flex-container(row) [0+0+0 400 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
         BlockContainer <(anonymous)> at [8,442] flex-item [0+0+0 268.5625 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 32, rect: [8,442 268.5625x16] baseline: 12.796875
               "This should clear the green box."
@@ -24,7 +24,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <hr> at [9,551] [0+1+0 398 0+1+0] [8+1+0 0 0+1+8] [BFC] children: not-inline
       BlockContainer <div.a> at [8,560] floating [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
       BlockContainer <div.b> at [358,560] floating [0+0+0 50 0+0+0] [0+0+0 200 0+0+0] [BFC] children: not-inline
-      Box <div.d> at [58,660] flex-container(row) [50+0+0 300 0+0+-100] [0+0+0 100 0+0+0] [FFC] children: not-inline
+      Box <div.d> at [58,660] flex-container(row) [50+0+0 300 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
         BlockContainer <(anonymous)> at [58,660] flex-item [0+0+0 300 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 34, rect: [58,660 287.78125x16] baseline: 12.796875
               "This should clear the blue box and"

--- a/Tests/LibWeb/Layout/input/flex/flex-container-with-auto-width-avoids-float-intrusions.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-container-with-auto-width-avoids-float-intrusions.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+body {
+    width: 400px;
+}
+.full-width-float {
+    background: blue;
+    float: left;
+    height: 100px;
+    width: 100%;
+}
+.partial-width-float {
+    background: blue;
+    float: left;
+    height: 100px;
+    width: 100px;
+}
+.small-negative-margin {
+    background: green;
+    display: flex;
+    height: 100px;
+    margin-left: -5px;
+}
+.large-negative-margin {
+    background: green;
+    display: flex;
+    height: 100px;
+    margin-left: -350px;
+}
+</style>
+<div class="full-width-float"></div><div class="small-negative-margin">This should clear the full-width float.</div>
+<hr><div class="partial-width-float"></div><div class="small-negative-margin">This should sit flush against the float.</div>
+<hr><div class="partial-width-float"></div><div class="large-negative-margin">This should clear the float.</div>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -352,16 +352,11 @@ Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-001.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-001a.tentative.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-002.tentative.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-003.tentative.html
-Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-004.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-005.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-006.tentative.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-010.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-001l.xht
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-001r.xht
-Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-002l.xht
-Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-002r.xht
-Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-003l.xht
-Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-003r.xht
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-inline-002l.xht
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-inline-002r.xht
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-inline-003l.xht


### PR DESCRIPTION
The border box of a box that establishes a formatting context must not overlap the margin box of any float. Previously, boxes with an automatic width were never cleared below floats, and a negative margin could both widen a box beyond the space next to a float and pull its border box into an adjacent float.

Fixes #10436