### PR TITLE
LibWeb: Avoid feedback when blending opaque image backgrounds

### DIFF
--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -101,6 +101,15 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
     auto paint_into_isolated_group = any_of(resolved_background.layers, [](auto const& layer) {
         return layer.blend_mode != CSS::MixBlendMode::Normal;
     });
+    // OPTIMIZATION: An opaque color covering the border box already isolates a single background layer from the
+    //               element's backdrop.
+    Optional<Color> isolated_backdrop_color;
+    if (paint_into_isolated_group && resolved_background.layers.size() == 1
+        && resolved_background.color.alpha() == 255
+        && resolved_background.color_box.rect == resolved_background.background_rect) {
+        paint_into_isolated_group = false;
+        isolated_backdrop_color = resolved_background.color;
+    }
 
     bool is_root_element = paintable_box.layout_node().is_root_element();
     bool needs_text_clip = resolved_background.needs_text_clip && !is_root_element;
@@ -303,9 +312,13 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
         };
 
         Gfx::CompositingAndBlendingOperator compositing_and_blending_operator = mix_blend_mode_to_compositing_and_blending_operator(layer.blend_mode);
-        if (compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal) {
+        bool applied_blend_layer = false;
+        auto apply_blend_layer = [&] {
+            if (compositing_and_blending_operator == Gfx::CompositingAndBlendingOperator::Normal)
+                return;
             display_list_recorder.apply_effects(1.0f, compositing_and_blending_operator);
-        }
+            applied_blend_layer = true;
+        };
 
         // Past this (super-large) tile count, the non-image branch below covers the area with a single repeating
         // pattern whose command count is independent of the tile count. Otherwise, recording one painting command per
@@ -317,6 +330,7 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
 
         auto const& document = paintable_box.layout_node().document();
         if (auto color = image.color_if_single_pixel_bitmap(document); color.has_value()) {
+            apply_blend_layer();
             // OPTIMIZATION: If the image is a single pixel, we can just fill the whole area with it.
             //               However, we must first figure out the real coverage area, taking repeat etc into account.
 
@@ -326,7 +340,9 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
                 fill_rect.unite(image_device_rect);
             });
             display_list_recorder.fill_rect(fill_rect.to_type<int>(), color.value());
-        } else if (is<CSS::ImageStyleValue>(image) && (repeat_x || repeat_y) && !repeat_x_has_gap && !repeat_y_has_gap) {
+        } else if (is<CSS::ImageStyleValue>(image)
+            && ((repeat_x || repeat_y) || compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal)
+            && !repeat_x_has_gap && !repeat_y_has_gap) {
             // Use a dedicated painting command for repeated images instead of recording a separate command for each instance
             // of a repeated background, so the painter has the opportunity to optimize the painting of repeated images.
             auto dest_rect = context.rounded_device_rect(image_rect);
@@ -339,6 +355,7 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
 
             auto const& image_style_value = static_cast<CSS::ImageStyleValue const&>(image);
             if (auto display_list = image_style_value.record_display_list(context, document, dest_rect); display_list.has_value()) {
+                apply_blend_layer();
                 auto dest_int_rect = dest_rect.to_type<int>();
                 auto scaling_mode = to_gfx_scaling_mode(image_rendering, dest_int_rect.size(), dest_int_rect.size());
                 context.display_list_recorder().draw_repeated_display_list(dest_int_rect, clip_rect.to_type<int>(), *display_list, scaling_mode, repeat_x, repeat_y);
@@ -352,13 +369,14 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
                 if (tile_count == 1) {
                     auto source_rect = source_rect_for_visible_image_part(visible_rect, tile_device_rect, frame->size());
                     auto scaling_mode = to_gfx_scaling_mode(image_rendering, source_rect.size().to_rounded<int>(), visible_rect.size());
-                    context.display_list_recorder().draw_scaled_decoded_image_frame(visible_rect, source_rect, *frame, scaling_mode);
+                    context.display_list_recorder().draw_scaled_decoded_image_frame(visible_rect, source_rect, *frame, scaling_mode, compositing_and_blending_operator, isolated_backdrop_color);
                 } else if (tile_count > 1) {
                     auto scaling_mode = to_gfx_scaling_mode(image_rendering, frame->size(), tile_device_rect.size());
-                    context.display_list_recorder().draw_repeated_decoded_image_frame(tile_device_rect, clip_device_rect, *frame, scaling_mode, repeat_x, repeat_y);
+                    context.display_list_recorder().draw_repeated_decoded_image_frame(tile_device_rect, clip_device_rect, *frame, scaling_mode, repeat_x, repeat_y, compositing_and_blending_operator, isolated_backdrop_color);
                 }
             }
         } else if ((repeat_x || repeat_y) && !repeat_x_has_gap && !repeat_y_has_gap && tile_count > max_tiles_before_pattern_fallback) {
+            apply_blend_layer();
             // A not-decoded-image repeating background otherwise records a separate painting command for every tile —
             // which for very-large tile counts can lead to enough commands that we crash. So, instead record a single
             // tile into a nested display list, and fill the area with a repeating pattern. The painter does the tiling.
@@ -400,12 +418,13 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
                 .winding_rule = Gfx::WindingRule::Nonzero,
             });
         } else {
+            apply_blend_layer();
             for_each_image_device_rect([&](auto const& image_device_rect) {
                 image.paint(context, document, image_device_rect, image_rendering);
             });
         }
 
-        if (compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal) {
+        if (applied_blend_layer) {
             display_list_recorder.restore();
         }
     }

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -50,11 +50,19 @@ void DrawScaledDecodedImageFrame::dump(StringBuilder& builder) const
     builder.appendff(" dst_rect={}", dst_rect);
     if (src_rect.has_value())
         builder.appendff(" src_rect={}", src_rect.value());
+    if (compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal)
+        builder.appendff(" blend_mode={}", static_cast<int>(compositing_and_blending_operator));
+    if (isolated_backdrop_color.has_value())
+        builder.appendff(" isolated_backdrop_color={}", isolated_backdrop_color.value());
 }
 
 void DrawRepeatedDecodedImageFrame::dump(StringBuilder& builder) const
 {
     builder.appendff(" dst_rect={} clip_rect={}", dst_rect, clip_rect);
+    if (compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal)
+        builder.appendff(" blend_mode={}", static_cast<int>(compositing_and_blending_operator));
+    if (isolated_backdrop_color.has_value())
+        builder.appendff(" isolated_backdrop_color={}", isolated_backdrop_color.value());
 }
 
 void DrawRepeatedDisplayList::dump(StringBuilder& builder) const

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -168,6 +168,8 @@ struct DrawScaledDecodedImageFrame {
     Optional<Gfx::FloatRect> src_rect;
     ImageFrameResourceId frame_id;
     Gfx::ScalingMode scaling_mode;
+    Gfx::CompositingAndBlendingOperator compositing_and_blending_operator { Gfx::CompositingAndBlendingOperator::Normal };
+    Optional<Color> isolated_backdrop_color;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return dst_rect; }
     void dump(StringBuilder&) const;
@@ -187,6 +189,8 @@ struct DrawRepeatedDecodedImageFrame {
     ImageFrameResourceId frame_id;
     Gfx::ScalingMode scaling_mode;
     Repeat repeat;
+    Gfx::CompositingAndBlendingOperator compositing_and_blending_operator { Gfx::CompositingAndBlendingOperator::Normal };
+    Optional<Color> isolated_backdrop_color;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return clip_rect; }
     void dump(StringBuilder&) const;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -321,9 +321,22 @@ void DisplayListPlayerSkia::play_command(DrawScaledDecodedImageFrame const& comm
     auto& canvas = surface().canvas();
     SkPaint paint;
     paint.setAntiAlias(true);
+    if (command.isolated_backdrop_color.has_value()) {
+        auto src_rect = command.src_rect.value_or(Gfx::FloatRect { 0, 0, static_cast<float>(image->width()), static_cast<float>(image->height()) });
+        SkMatrix matrix;
+        matrix.setScale(dst_rect.width() / src_rect.width(), dst_rect.height() / src_rect.height());
+        matrix.postTranslate(dst_rect.x() - src_rect.x() * dst_rect.width() / src_rect.width(), dst_rect.y() - src_rect.y() * dst_rect.height() / src_rect.height());
+        auto image_shader = image->makeShader(SkTileMode::kDecal, SkTileMode::kDecal, to_skia_sampling_options(command.scaling_mode), matrix);
+        auto backdrop_shader = SkShaders::Color(to_skia_color(command.isolated_backdrop_color.value()));
+        paint.setShader(SkShaders::Blend(Gfx::to_skia_blender(command.compositing_and_blending_operator), move(backdrop_shader), move(image_shader)));
+    } else if (command.compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal) {
+        paint.setBlender(Gfx::to_skia_blender(command.compositing_and_blending_operator));
+    }
     canvas.save();
     canvas.clipRect(dst_rect, true);
-    if (command.src_rect.has_value()) {
+    if (command.isolated_backdrop_color.has_value()) {
+        canvas.drawRect(dst_rect, paint);
+    } else if (command.src_rect.has_value()) {
         auto src_rect = to_skia_rect(command.src_rect.value());
         canvas.drawImageRect(image.get(), src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
     } else {
@@ -352,7 +365,14 @@ void DisplayListPlayerSkia::play_command(DrawRepeatedDecodedImageFrame const& co
 
     SkPaint paint;
     paint.setAntiAlias(true);
-    paint.setShader(shader);
+    if (command.isolated_backdrop_color.has_value()) {
+        auto backdrop_shader = SkShaders::Color(to_skia_color(command.isolated_backdrop_color.value()));
+        paint.setShader(SkShaders::Blend(Gfx::to_skia_blender(command.compositing_and_blending_operator), move(backdrop_shader), move(shader)));
+    } else {
+        paint.setShader(shader);
+    }
+    if (!command.isolated_backdrop_color.has_value() && command.compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal)
+        paint.setBlender(Gfx::to_skia_blender(command.compositing_and_blending_operator));
     auto& canvas = surface().canvas();
     canvas.drawPaint(paint);
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -545,7 +545,7 @@ void DisplayListRecorder::draw_video_frame(Gfx::IntRect const& dst_rect, VideoFr
     });
 }
 
-void DisplayListRecorder::draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode)
+void DisplayListRecorder::draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Optional<Color> isolated_backdrop_color)
 {
     if (dst_rect.is_empty())
         return;
@@ -554,10 +554,12 @@ void DisplayListRecorder::draw_scaled_decoded_image_frame(Gfx::IntRect const& ds
         .src_rect = {},
         .frame_id = resource_storage().add_image_frame(frame),
         .scaling_mode = scaling_mode,
+        .compositing_and_blending_operator = compositing_and_blending_operator,
+        .isolated_backdrop_color = isolated_backdrop_color,
     });
 }
 
-void DisplayListRecorder::draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::FloatRect const& src_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode)
+void DisplayListRecorder::draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::FloatRect const& src_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Optional<Color> isolated_backdrop_color)
 {
     if (dst_rect.is_empty())
         return;
@@ -568,10 +570,12 @@ void DisplayListRecorder::draw_scaled_decoded_image_frame(Gfx::IntRect const& ds
         .src_rect = src_rect,
         .frame_id = resource_storage().add_image_frame(frame),
         .scaling_mode = scaling_mode,
+        .compositing_and_blending_operator = compositing_and_blending_operator,
+        .isolated_backdrop_color = isolated_backdrop_color,
     });
 }
 
-void DisplayListRecorder::draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y)
+void DisplayListRecorder::draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Optional<Color> isolated_backdrop_color)
 {
     if (dst_rect.is_empty() || clip_rect.is_empty())
         return;
@@ -581,6 +585,8 @@ void DisplayListRecorder::draw_repeated_decoded_image_frame(Gfx::IntRect dst_rec
         .frame_id = resource_storage().add_image_frame(frame),
         .scaling_mode = scaling_mode,
         .repeat = { repeat_x, repeat_y },
+        .compositing_and_blending_operator = compositing_and_blending_operator,
+        .isolated_backdrop_color = isolated_backdrop_color,
     });
 }
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -72,13 +72,13 @@ public:
 
     void draw_rect(Gfx::IntRect const& rect, Color color, bool rough = false);
 
-    void draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
-    void draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::FloatRect const& src_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode);
+    void draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Color> isolated_backdrop_color = {});
+    void draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::FloatRect const& src_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Color> isolated_backdrop_color = {});
     void draw_composited_context(Gfx::IntRect const& dst_rect, Web::Compositor::CompositorContextId, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
     void draw_canvas(Gfx::IntRect const& dst_rect, CanvasId, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
     void draw_video_frame(Gfx::IntRect const& dst_rect, VideoFrameResourceId, RefPtr<Media::VideoFrame const>, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
 
-    void draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y);
+    void draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Color> isolated_backdrop_color = {});
     void draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, DisplayListResource const&, Gfx::ScalingMode, bool repeat_x, bool repeat_y);
     struct DrawTiledDecodedImageFrameParams {
         Gfx::FloatRect tile_rect;

--- a/Tests/LibWeb/Text/expected/display_list/opaque-background-image-blend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/opaque-background-image-blend.txt
@@ -1,0 +1,16 @@
+AccumulatedVisualContext Tree:
+  [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
+    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x53]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x40]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 40x40]
+  FillRect@1 rect=[0,0 40x40] color=rgb(45, 22, 0)
+  Save@1
+    AddClipRect@1 rect=[0,0 40x40]
+    DrawScaledDecodedImageFrame@1 dst_rect=[0,0 40x40] src_rect=[0,0 40x40] blend_mode=2 isolated_backdrop_color=rgb(45, 22, 0)
+  Restore@1
+Restore@0

--- a/Tests/LibWeb/Text/input/display_list/opaque-background-image-blend.html
+++ b/Tests/LibWeb/Text/input/display_list/opaque-background-image-blend.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #target {
+        width: 40px;
+        height: 40px;
+        background-color: rgb(45, 22, 0);
+        background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAGQAQMAAADRPL3zAAAABlBMVEUwMDCAgIDHGf6uAAAAQ0lEQVRo3u3YMREAQAgDQRzg3+U7gDbl9+y1i4AMNdGrjBBCCCGEXJas84wQQgghhJwWW5kQQgghhPgnEkIIIYSQT1nvD3WWWfRskgAAAABJRU5ErkJggg==");
+        background-blend-mode: multiply;
+        background-repeat: no-repeat;
+    }
+</style>
+<div id="target"></div>
+<script>
+    asyncTest(done => {
+        window.addEventListener("load", () => {
+            println(internals.dumpDisplayList());
+            done();
+        });
+    });
+</script>


### PR DESCRIPTION
Blend a single decoded background image with its opaque background color in the source shader. Avoid offscreen and destination-read feedback that can produce diagonal artifacts on accelerated Vulkan rendering.

Keep isolated layers for backgrounds whose color or layer structure does not make the source-only composition equivalent. Cover the optimized no-repeat path with a display-list regression test.

Fixes glitchy artifacts on https://bookspry.com/ on Intel GPUs

<img width="2092" height="970" alt="Screenshot at 2026-07-10 01-58-56" src="https://github.com/user-attachments/assets/d4940344-188c-49a0-98e6-d7a3531d057b" />
