### PR TITLE
LibWeb: Suppress autoscroll when middle-clicking pseudo-element links

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1772,7 +1772,16 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
         if (!hit.has_value())
             return;
 
-        for (GC::Ptr<DOM::Node const> node = hit->paintable->dom_node(); node; node = node->parent_or_shadow_host_node()) {
+        // NB: Generated pseudo-elements don't have a DOM node, so we first have to walk up to find one.
+        GC::Ptr<DOM::Node const> start_node = nullptr;
+        for (RefPtr<Painting::Paintable> paintable = hit->paintable; paintable; paintable = paintable->parent()) {
+            if (paintable->dom_node()) {
+                start_node = paintable->dom_node();
+                break;
+            }
+        }
+
+        for (GC::Ptr<DOM::Node const> node = start_node; node; node = node->parent_or_shadow_host_node()) {
             if (node->is_editable_or_editing_host() || is<HTML::FormAssociatedTextControlElement>(*node))
                 return;
             if (auto const* anchor = as_if<HTML::HTMLAnchorElement>(*node); anchor && anchor->has_attribute(HTML::AttributeNames::href))

--- a/Tests/LibWeb/Text/expected/UIEvents/middle-click-generated-content-link-autoscroll.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/middle-click-generated-content-link-autoscroll.txt
@@ -1,0 +1,2 @@
+plain link scrollY: 0
+generated-content link scrollY: 0

--- a/Tests/LibWeb/Text/input/UIEvents/middle-click-generated-content-link-autoscroll.html
+++ b/Tests/LibWeb/Text/input/UIEvents/middle-click-generated-content-link-autoscroll.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        height: 2000px;
+    }
+
+    a {
+        display: inline-block;
+        margin: 20px;
+        padding: 8px;
+    }
+
+    #generated::after {
+        content: "Generated link";
+    }
+</style>
+<a id="plain" href="about:blank">Plain link</a>
+<a id="generated" href="about:blank"></a>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        async function middleDragFrom(element) {
+            const rect = element.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+
+            internals.mouseDown(x, y, 1, internals.BUTTON_MIDDLE);
+            internals.mouseMove(x, y + 100);
+            await animationFrame();
+            await animationFrame();
+            internals.mouseUp(x, y + 100, internals.BUTTON_MIDDLE);
+        }
+
+        await middleDragFrom(plain);
+        println(`plain link scrollY: ${scrollY}`);
+
+        scrollTo(0, 0);
+
+        await middleDragFrom(generated);
+        println(`generated-content link scrollY: ${scrollY}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
We suppressed middle-click autoscroll when the clicked DOM node is editable or a link, but generated pseudo-elements (such as ::before) do not have a DOM node. This meant that middle-clicking a pseudo-element that is part of a link, would both open the link in a new tab, and start autoscrolling.

To solve it, we now find the nearest ancestor DOM node before starting to look for suppressing elements.

This showed up when middle-clicking some of the header links on https://itch.io