### PR TITLE
LibWeb: Preserve pseudo-element styles during transitions

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6579,6 +6579,22 @@ void Document::update_animations_and_send_events(double timestamp)
     //    the previous step.
     for (auto const& event : events_to_dispatch)
         event.target->dispatch_event(event.event);
+
+    // AD-HOC: Nothing else re-requests a rendering update while time-driven animations are running, since
+    //         Document::set_needs_animated_style_update() only requests a frame when its flag flips from
+    //         false to true, and the flag is both set and cleared within the same rendering update.
+    //         Without this, animations only advance when unrelated tasks happen to schedule rendering
+    //         updates. Keep the frame pump going as long as some animation attached to a monotonically
+    //         increasing timeline is running.
+    for (auto const& animation : m_associated_animations) {
+        if (animation.play_state() != Bindings::AnimationPlayState::Running)
+            continue;
+        auto timeline = animation.timeline();
+        if (!timeline || !timeline->is_monotonically_increasing())
+            continue;
+        page().client().request_frame();
+        break;
+    }
 }
 
 // https://www.w3.org/TR/web-animations-1/#remove-replaced-animations

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1145,6 +1145,13 @@ void NodeWithStyle::propagate_style_to_anonymous_wrappers()
     // Propagate style to all anonymous children (except table wrappers!)
     for_each_child_of_type<NodeWithStyle>([&](NodeWithStyle& child) {
         if (child.is_anonymous() && !is<TableWrapper>(child)) {
+            // NB: The principal box of a pseudo-element (::before, ::after, ::marker, etc) is anonymous in the
+            //     sense that it has no DOM node, but it's not an anonymous wrapper: it has its own computed style,
+            //     which is applied to it separately. Don't clobber that style with inherited values from this node.
+            if (auto pseudo_element = child.generated_for_pseudo_element(); pseudo_element.has_value()
+                && child.pseudo_element_generator()->pseudo_element_unsafe_layout_node(*pseudo_element) == &child) {
+                return IterationDecision::Continue;
+            }
             auto& child_computed_values = static_cast<CSS::MutableComputedValues&>(static_cast<CSS::ComputedValues&>(const_cast<CSS::ImmutableComputedValues&>(child.computed_values())));
             child_computed_values.inherit_from(computed_values());
             propagate_non_inherit_values(child);

--- a/Tests/LibWeb/Text/expected/css/transition-on-element-keeps-pseudo-element-font.txt
+++ b/Tests/LibWeb/Text/expected/css/transition-on-element-keeps-pseudo-element-font.txt
@@ -1,0 +1,1 @@
+FAIL: ::after width was changed by the transition

--- a/Tests/LibWeb/Text/expected/css/transition-on-element-keeps-pseudo-element-font.txt
+++ b/Tests/LibWeb/Text/expected/css/transition-on-element-keeps-pseudo-element-font.txt
@@ -1,1 +1,1 @@
-FAIL: ::after width was changed by the transition
+PASS: ::after width is unchanged by the transition

--- a/Tests/LibWeb/Text/input/css/transition-on-element-keeps-pseudo-element-font.html
+++ b/Tests/LibWeb/Text/input/css/transition-on-element-keeps-pseudo-element-font.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: TestFont;
+    src: url(../../../Assets/HashSans.woff) format("woff");
+}
+#victim {
+    font-family: sans-serif;
+    font-size: 20px;
+    width: 200px;
+    transition: width 0.05s;
+}
+#victim::after {
+    content: "x";
+    font-family: TestFont;
+    font-size: 32px;
+}
+#victim.on {
+    width: 300px;
+}
+</style>
+<div id="victim">Some text</div>
+<script src="../include.js"></script>
+<script>
+    // Running a transition on an element must not corrupt the style of the layout nodes generated for its
+    // pseudo-elements. This used to clobber the ::after box's font with the element's font, because the pseudo
+    // box (having no DOM node) was mistaken for an anonymous wrapper when propagating style after each
+    // animation update.
+    asyncTest(async (done) => {
+        await document.fonts.load("32px TestFont");
+        await document.fonts.ready;
+        const victim = document.getElementById("victim");
+        const widthOf = () => getComputedStyle(victim, "::after").width;
+        const widthBefore = widthOf();
+        const transitionDone = new Promise((resolve) => {
+            victim.addEventListener("transitionend", resolve);
+        });
+        victim.classList.add("on");
+        await transitionDone;
+        await new Promise(requestAnimationFrame);
+        const widthAfter = widthOf();
+        if (widthBefore === widthAfter)
+            println("PASS: ::after width is unchanged by the transition");
+        else
+            println("FAIL: ::after width was changed by the transition");
+        done();
+    });
+</script>


### PR DESCRIPTION
This fixes a transition bug where layout boxes generated for pseudo-elements could be mistaken for anonymous wrappers and have their inherited style values
overwritten by the originating element.

On https://bookspry.com, this made the Subscribe button show a literal "5" instead of the ETmodules arrow icon while hovering.

The branch also keeps requesting rendering updates while time-driven animations are running, so quiet pages do not depend on unrelated timers or
input events to advance CSS transitions.

Before:

https://github.com/user-attachments/assets/ebb24fae-ab7e-4665-8a1f-81416911ace0

After:

https://github.com/user-attachments/assets/4fe7a484-8128-4243-9208-d7d5e06aa96d