### PR TITLE
UI/Qt: Don't select vertical tabs when right-clicking them

### DIFF
--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -908,7 +908,7 @@ void TabBar::mousePressEvent(QMouseEvent* event)
     }
 
     if (tab_layout() != TabLayout::Horizontal) {
-        if (pressed_tab >= 0) {
+        if (pressed_tab >= 0 && event->button() == Qt::LeftButton) {
             setCurrentIndex(pressed_tab);
         } else if (event->button() == Qt::LeftButton && start_window_move()) {
             event->accept();


### PR DESCRIPTION
To match the behaviour of horizontal tabs, only select a tab when left-clicking on it. For example, right-clicking should open the context menu without changing the currently-selected tab.