### PR TITLE
LibWeb: Avoid input type work for same-state re-sets

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1621,14 +1621,21 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
     }
 
     // AD-HOC: A change to any of these attributes can change whether the element satisfies its constraints, and
-    //         therefore which validity pseudo-classes match.
-    if (first_is_one_of(name, HTML::AttributeNames::type, HTML::AttributeNames::value, HTML::AttributeNames::required, HTML::AttributeNames::pattern, HTML::AttributeNames::min, HTML::AttributeNames::max, HTML::AttributeNames::step, HTML::AttributeNames::maxlength, HTML::AttributeNames::minlength, HTML::AttributeNames::multiple))
+    //         therefore which validity pseudo-classes match. Re-setting an attribute to its current value cannot
+    //         change validity, so skip the invalidation in that case.
+    if (old_value != value && first_is_one_of(name, HTML::AttributeNames::type, HTML::AttributeNames::value, HTML::AttributeNames::required, HTML::AttributeNames::pattern, HTML::AttributeNames::min, HTML::AttributeNames::max, HTML::AttributeNames::step, HTML::AttributeNames::maxlength, HTML::AttributeNames::minlength, HTML::AttributeNames::multiple))
         CSS::Invalidation::invalidate_style_after_validity_change(*this);
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#input-type-change
 void HTMLInputElement::type_attribute_changed(TypeAttributeState old_state, TypeAttributeState new_state)
 {
+    // NB: The steps below apply when the type attribute changes state. Re-setting the attribute to a value that
+    //     parses to the same state must not reset the element's internals; some sites re-set type="file" on a
+    //     hidden upload input on every keystroke, and rebuilding the internal shadow tree each time is wasteful.
+    if (old_state == new_state)
+        return;
+
     auto new_value_attribute_mode = value_attribute_mode_for_type_state(new_state);
     auto old_value_attribute_mode = value_attribute_mode_for_type_state(old_state);
 

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -35,7 +35,7 @@ static ErrorOr<Core::Process> launch_process(StringView application, ReadonlySpa
     return result;
 }
 
-static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint, bool headless, bool expose_experimental_interfaces, bool force_cpu_painting, bool disable_sandbox, Optional<StringView> debug_process, Optional<StringView> default_time_zone, Optional<StringView> resource_substitution_map_path)
+static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint, bool headless, bool expose_experimental_interfaces, bool expose_internals_object, bool force_cpu_painting, bool disable_sandbox, Optional<StringView> debug_process, Optional<StringView> default_time_zone, Optional<StringView> resource_substitution_map_path)
 {
     Vector<ByteString> arguments;
 #if defined(AK_OS_MACOS)
@@ -60,6 +60,8 @@ static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint,
     arguments.append("--disable-scrollbar-painting"sv);
     if (expose_experimental_interfaces)
         arguments.append("--expose-experimental-interfaces"sv);
+    if (expose_internals_object)
+        arguments.append("--expose-internals-object"sv);
     if (force_cpu_painting)
         arguments.append("--force-cpu-painting"sv);
     if (disable_sandbox)
@@ -95,6 +97,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto listen_address = "0.0.0.0"sv;
     int port = 8000;
     bool expose_experimental_interfaces = false;
+    bool expose_internals_object = false;
     bool force_cpu_painting = false;
     bool disable_sandbox = false;
     bool headless = false;
@@ -107,6 +110,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(port, "Port to listen on", "port", 'p', "port");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(expose_experimental_interfaces, "Expose experimental IDL interfaces", "expose-experimental-interfaces");
+    args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
     args_parser.add_option(force_cpu_painting, "Launch browser with GPU painting disabled", "force-cpu-painting");
     args_parser.add_option(disable_sandbox, "Launch browser with helper process sandboxing disabled", "disable-sandbox");
     args_parser.add_option(debug_process, "Wait for a debugger to attach to the given process name (WebContent, RequestServer, etc.)", "debug-process", 0, "process-name");
@@ -155,7 +159,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         }
 
         auto launch_browser_callback = [&](ByteString const& webdriver_endpoint, bool headless) {
-            auto arguments = create_arguments(webdriver_endpoint, headless, expose_experimental_interfaces, force_cpu_painting, disable_sandbox, debug_process, default_time_zone, resource_substitution_map_path);
+            auto arguments = create_arguments(webdriver_endpoint, headless, expose_experimental_interfaces, expose_internals_object, force_cpu_painting, disable_sandbox, debug_process, default_time_zone, resource_substitution_map_path);
             return launch_process("Ladybird"sv, arguments.span());
         };
 

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/input-type-same-state-no-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/input-type-same-state-no-invalidation.txt
@@ -1,1 +1,1 @@
-FAIL: same-state type set recomputed 504 elements
+PASS: same-state type set stayed targeted

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/input-type-same-state-no-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/input-type-same-state-no-invalidation.txt
@@ -1,0 +1,1 @@
+FAIL: same-state type set recomputed 504 elements

--- a/Tests/LibWeb/Text/input/css/style-invalidation/input-type-same-state-no-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/input-type-same-state-no-invalidation.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../include.js"></script>
+<style>
+    /* A never-matching :has() argument scans the whole wrapper subtree and
+       leaves every element in it inside the :has() scope, with #wrapper as an
+       anchor in non-subject position. */
+    #wrapper:has(.missing) span {
+        color: rgb(9, 9, 9);
+    }
+
+    /* A :has() selector with a featureless-sensitive argument makes child-list
+       mutations anywhere in the document take the conservative :has()
+       invalidation path. */
+    .hook:has(:not(.absent)) {
+        color: rgb(1, 1, 1);
+    }
+</style>
+<div id="wrapper">
+    <div id="big"></div>
+    <input id="file-input" type="file">
+</div>
+<script>
+    test(() => {
+        const big = document.getElementById("big");
+        for (let i = 0; i < 500; ++i) {
+            const leaf = document.createElement("span");
+            leaf.textContent = `leaf ${i}`;
+            big.appendChild(leaf);
+        }
+
+        const input = document.getElementById("file-input");
+        internals.updateStyle();
+        internals.resetStyleInvalidationCounters();
+
+        // Re-setting the type attribute to a value that parses to the same
+        // state must not rebuild the input's internal shadow tree. If it does,
+        // the internal child-list mutations take the conservative :has() path
+        // above and fan out into a restyle of the whole wrapper subtree.
+        input.setAttribute("type", "file");
+        internals.updateStyle();
+
+        const counters = internals.getStyleInvalidationCounters();
+        if (counters.elementStyleRecomputations < 10)
+            println("PASS: same-state type set stayed targeted");
+        else
+            println(`FAIL: same-state type set recomputed ${counters.elementStyleRecomputations} elements`);
+    });
+</script>


### PR DESCRIPTION
Re-setting an `input` element's `type` attribute to a value that parses to the same type state currently tears down and rebuilds the element's internal shadow tree. On pages with featureless-sensitive `:has()` selectors, those internal child-list mutations can trigger broad style invalidation and recompute style for far more of the document than needed.

Make same-state `type` attribute re-sets a no-op and skip validity style invalidation when an attribute is re-set to its existing value. This keeps repeated `type="file"` writes targeted instead of causing page-wide style work.

This dramatically improves typing responsiveness on https://chatgpt.com/

Bonus commit: Add `--expose-internals-object` to the `WebDriver` program.