### PR TITLE
Tests: Add fuzziness to non-square checkbox/radio-button tests

### DIFF
--- a/Tests/LibWeb/Screenshot/input/non-square-checkboxes.html
+++ b/Tests/LibWeb/Screenshot/input/non-square-checkboxes.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-914" />
 <style>
     input.a {
         width: 10px;

--- a/Tests/LibWeb/Screenshot/input/non-square-radio-buttons.html
+++ b/Tests/LibWeb/Screenshot/input/non-square-radio-buttons.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1817" />
 <style>
     input.a {
         width: 10px;


### PR DESCRIPTION
On macOS, at least for me, these render a bit differently around the edges. The PR #10587 was already merged before I remembered that might be a thing and tested it locally. 😅