### PR TITLE
Enforce layout constraint around placement in sizing

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -571,16 +571,32 @@ void BlockFormattingContext::rebuild_float_bands()
         add_float_to_bands(*floating_box, floating_box->containing_block_rect_in_root_coordinate_space);
 }
 
+void BlockFormattingContext::update_lowest_floating_descendant_bottom_margin_edge()
+{
+    Optional<CSSPixels> lowest;
+    for (auto const& floating_box : m_floats) {
+        auto bottom_margin_edge = floating_box->margin_box_rect_in_root_coordinate_space.bottom();
+        if (!lowest.has_value() || bottom_margin_edge > *lowest)
+            lowest = bottom_margin_edge;
+    }
+    m_state.get_mutable(root()).set_lowest_floating_descendant_bottom_margin_edge(lowest);
+}
+
 void BlockFormattingContext::translate_floats_in_subtree(Box const& ancestor, CSSPixelPoint delta)
 {
-    if (delta.is_zero())
+    if (delta.is_zero() || m_floats.is_empty())
         return;
+    bool any_float_moved = false;
     for (auto& floating_box : m_floats) {
         if (!ancestor.is_ancestor_of(floating_box->box))
             continue;
         floating_box->margin_box_rect_in_root_coordinate_space.translate_by(delta);
         floating_box->containing_block_rect_in_root_coordinate_space.translate_by(delta);
+        any_float_moved = true;
     }
+    if (!any_float_moved)
+        return;
+    update_lowest_floating_descendant_bottom_margin_edge();
     rebuild_float_bands();
 }
 
@@ -1592,7 +1608,11 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     floating_box.margin_box_rect_in_root_coordinate_space.set_x(margin_box_left_of_float_in_root(floating_box, containing_block_rect_in_root));
     add_float_to_bands(floating_box, containing_block_rect_in_root);
 
-    m_state.get_mutable(root()).add_floating_descendant(box);
+    auto& root_state = m_state.get_mutable(root());
+    auto bottom_margin_edge = m_floats.last()->margin_box_rect_in_root_coordinate_space.bottom();
+    auto lowest = root_state.lowest_floating_descendant_bottom_margin_edge();
+    if (!lowest.has_value() || bottom_margin_edge > *lowest)
+        root_state.set_lowest_floating_descendant_bottom_margin_edge(bottom_margin_edge);
 
     if (line_builder)
         line_builder->recalculate_available_space();

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -32,6 +32,13 @@
 
 namespace Web::Layout {
 
+static CSSPixels distance_between_marker_and_list_item(ListItemMarkerBox const& marker)
+{
+    if (marker.text().has_value())
+        return 0;
+    return CSSPixels::nearest_value_for(.5f * marker.first_available_font().pixel_size());
+}
+
 BlockFormattingContext::BlockFormattingContext(LayoutState& state, LayoutMode layout_mode, BlockContainer const& root, FormattingContext* parent)
     : FormattingContext(Type::Block, layout_mode, state, root, parent)
 {
@@ -188,7 +195,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
     layout_absolutely_positioned_children();
 }
 
-bool BlockFormattingContext::box_should_avoid_floats_because_it_establishes_fc(Box const& box)
+bool BlockFormattingContext::box_should_avoid_floats_because_it_establishes_fc(Box const& box) const
 {
     // https://drafts.csswg.org/css2/#floats
     // The border box of a table, a block-level replaced element, or an element in the normal flow that establishes
@@ -450,13 +457,6 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusions_for_band
     };
 }
 
-FormattingContext::SpaceUsedByFloats BlockFormattingContext::available_inline_space_in_box(LayoutState::UsedValues const& box_used_values, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
-{
-    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_used_values, root());
-    box_in_root_rect.translate_by(0, y_adjustment_from_pending_ancestor_top_margins(box_used_values.node()));
-    return intrusion_by_floats_into_rect(box_in_root_rect, block_start_in_box, block_end_in_box);
-}
-
 FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_rect(CSSPixelRect const& box_in_root_rect, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
 {
     auto intrusions = available_inline_space(box_in_root_rect.y() + block_start_in_box, box_in_root_rect.y() + block_end_in_box);
@@ -601,28 +601,24 @@ CSSPixels BlockFormattingContext::border_box_left_of_box_avoiding_floats(Box con
     return space_used_by_floats.left + box_state.margin_left;
 }
 
-void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+CSSPixels BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, CSSPixels content_y, CSSPixelRect const& containing_block_rect_in_root)
 {
     if (!available_space.width.is_definite())
-        return;
+        return content_y;
     if (!box_should_avoid_floats_because_it_establishes_fc(box))
-        return;
+        return content_y;
 
     // https://drafts.csswg.org/css2/#floats
     // If necessary, implementations should clear the said element by placing it below any preceding floats, but may
     // place it adjacent to such floats if there is sufficient space.
-    auto& box_state = m_state.get_mutable(box);
-    auto const pending_y_adjustment = y_adjustment_from_pending_ancestor_top_margins(box);
-    auto const* containing_block = box.containing_block();
-    VERIFY(containing_block);
-    auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(m_state.get(*containing_block), root());
+    auto const& box_state = m_state.get(box);
     while (true) {
-        auto border_box_y_in_root = content_box_rect_in_ancestor_coordinate_space(box_state, root()).y()
-            - box_state.border_box_top() + pending_y_adjustment;
-        containing_block_rect_in_root.set_y(border_box_y_in_root);
-        containing_block_rect_in_root.set_height(box_state.border_box_height());
+        auto border_box_y_in_root = containing_block_rect_in_root.y() + content_y - box_state.border_box_top();
+        auto band_containing_block_rect = containing_block_rect_in_root;
+        band_containing_block_rect.set_y(border_box_y_in_root);
+        band_containing_block_rect.set_height(box_state.border_box_height());
         auto const& band = band_at(border_box_y_in_root);
-        auto space_used_by_floats = intrusions_for_band_into_rect(band, containing_block_rect_in_root);
+        auto space_used_by_floats = intrusions_for_band_into_rect(band, band_containing_block_rect);
         bool const constrained_by_floats = space_used_by_floats.left > 0 || space_used_by_floats.right > 0;
         auto border_box_left_in_containing_block = border_box_left_of_box_avoiding_floats(box, box_state, space_used_by_floats);
 
@@ -631,7 +627,7 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
 
         if (!must_clear_below_current_band) {
             CSSPixelRect border_box_rect_in_root {
-                containing_block_rect_in_root.x() + border_box_left_in_containing_block,
+                band_containing_block_rect.x() + border_box_left_in_containing_block,
                 border_box_y_in_root,
                 box_state.border_box_width(),
                 box_state.border_box_height(),
@@ -649,12 +645,11 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
         if (!next_band_start.has_value())
             break;
 
-        box_state.set_content_y(box_state.offset.y() + next_band_start.value() - border_box_y_in_root);
-
-        auto content_position_in_root = content_box_rect_in_ancestor_coordinate_space(box_state, root()).location();
-        content_position_in_root.translate_by(0, pending_y_adjustment);
+        content_y += next_band_start.value() - border_box_y_in_root;
+        auto content_position_in_root = containing_block_rect_in_root.location().translated(0, content_y);
         compute_width(box, available_space, containing_block_constraints, content_position_in_root);
     }
+    return content_y;
 }
 
 void BlockFormattingContext::compute_width_for_floating_box(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
@@ -1128,13 +1123,50 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         margin_top = 0;
     }
 
-    place_block_level_element_in_normal_flow_vertically(box, y + margin_top);
+    auto box_opens_top_margin_group = !independent_formatting_context
+        && box_state.border_top == 0 && box_state.padding_top == 0
+        && !m_margin_state.has_open_top_margin_group();
 
-    compute_width(box, available_space, layout_input.containing_block_constraints,
-        containing_block_position_in_root.translated(box_state.offset.x(), box_state.offset.y() + y_adjustment_from_pending_ancestor_top_margins(box)));
-    avoid_float_intrusions(box, available_space, layout_input.containing_block_constraints);
+    auto const* fieldset_box = as_if<FieldSetBox>(block_container);
+    auto box_is_positioned_by_fieldset_layout = fieldset_box && fieldset_box->rendered_legend() == &box;
 
-    place_block_level_element_in_normal_flow_horizontally(box, available_space);
+    // Earlier sibling placement may have invalidated cached float bands.
+    rebuild_float_bands();
+
+    auto content_y = y + margin_top + box_state.border_box_top();
+
+    auto const containing_block_rect_in_root = CSSPixelRect { containing_block_position_in_root, block_container_state.content_size() };
+
+    auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, y_adjustment_from_pending_ancestor_top_margins(box));
+    auto content_position_in_root_now = [&](CSSPixels content_y) {
+        return containing_block_rect_in_root_now.location().translated(0, content_y);
+    };
+
+    compute_width(box, available_space, layout_input.containing_block_constraints, content_position_in_root_now(content_y));
+    content_y = avoid_float_intrusions(box, available_space, layout_input.containing_block_constraints, content_y, containing_block_rect_in_root_now);
+
+    auto content_x = compute_normal_flow_x(box, available_space, content_position_in_root_now(content_y));
+
+    // FIXME: We currently so not support ListItemBox-es generated by pseudo-elements. We will need to, eventually.
+    auto const* list_item_box = as_if<ListItemBox>(box);
+    auto is_list_item_box_without_css_content = list_item_box != nullptr;
+    if (auto const* dom_node = as_if<DOM::Element>(box.dom_node()); list_item_box && dom_node) {
+        if (auto const computed_properties = dom_node->computed_properties(CSS::PseudoElement::Marker))
+            is_list_item_box_without_css_content = !computed_properties->property(CSS::PropertyID::Content).is_content();
+    }
+
+    if (is_list_item_box_without_css_content && list_item_box->marker()) {
+        ensure_sizes_correct_for_left_offset_calculation(*list_item_box);
+
+        auto const& marker = *list_item_box->marker();
+        if (marker.list_style_position() == CSS::ListStylePosition::Inside
+            && box.computed_values().direction() == CSS::Direction::Ltr) {
+            content_x += m_state.get(marker).content_width() + distance_between_marker_and_list_item(marker);
+        }
+    }
+
+    if (box_is_positioned_by_fieldset_layout || !box_opens_top_margin_group)
+        box_state.set_content_offset({ content_x, content_y });
 
     AvailableSpace available_space_for_height_resolution = available_space;
     auto is_table_box = box.display().is_table_row() || box.display().is_table_row_group() || box.display().is_table_header_group() || box.display().is_table_footer_group() || box.display().is_table_cell() || box.display().is_table_caption();
@@ -1152,30 +1184,16 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         resolve_used_height_if_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints);
     }
 
-    // This monster basically means: "a ListItemBox that does not have specified content in the ::marker pseudo-element".
-    // This happens for ::marker with content 'normal'.
-    // FIXME: We currently so not support ListItemBox-es generated by pseudo-elements. We will need to, eventually.
-    auto const* li_box = as_if<ListItemBox>(box);
-    auto is_list_item_box_without_css_content = li_box != nullptr;
-    if (auto const* dom_node = as_if<DOM::Element>(box.dom_node()); li_box && dom_node) {
-        if (auto const computed_properties = dom_node->computed_properties(CSS::PseudoElement::Marker))
-            is_list_item_box_without_css_content = !computed_properties->property(CSS::PropertyID::Content).is_content();
-    }
-
     // Before we insert the children of a list item we need to know the location of the marker.
     // If we do not do this then left-floating elements inside the list item will push the marker to the right,
     // in some cases even causing it to overlap with the non-floating content of the list.
     SpaceUsedByFloats inline_space_used_before_children_formatted;
-    if (is_list_item_box_without_css_content && li_box->marker()) {
-        // We need to ensure that our height and width are final before we calculate our left offset.
-        // Otherwise, the y at which we calculate the intrusion by floats might be incorrect.
-        ensure_sizes_correct_for_left_offset_calculation(*li_box);
+    if (is_list_item_box_without_css_content && list_item_box->marker()) {
+        auto const& list_item_state = m_state.get(*list_item_box);
+        auto const& marker_state = m_state.get(*list_item_box->marker());
 
-        auto const& list_item_state = m_state.get(*li_box);
-        auto const& marker_state = m_state.get(*li_box->marker());
-
-        auto offset_y = max(CSSPixels(0), (li_box->marker()->computed_values().line_height() - marker_state.content_height()) / 2);
-        inline_space_used_before_children_formatted = intrusion_by_floats_into_box(list_item_state, offset_y);
+        auto offset_y = max(CSSPixels(0), (list_item_box->marker()->computed_values().line_height() - marker_state.content_height()) / 2);
+        inline_space_used_before_children_formatted = intrusion_by_floats_into_rect({ content_position_in_root_now(content_y).translated(content_x, 0), list_item_state.content_size() }, offset_y, offset_y);
     }
 
     if (independent_formatting_context) {
@@ -1209,30 +1227,31 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
-        auto opened_top_margin_group = false;
         if (box_state.border_top > 0 || box_state.padding_top > 0) {
             // margin-top of block container can't collapse with its children if it has non-zero border or padding.
             m_margin_state.reset();
-        } else if (!m_margin_state.has_open_top_margin_group()) {
+        } else if (box_opens_top_margin_group) {
             m_margin_state.open_top_margin_group(box, introduce_clearance == DidIntroduceClearance::Yes);
-            opened_top_margin_group = true;
         }
 
         auto inside_layout_input = layout_input.with_content_box_position_in_bfc_root(
-            containing_block_position_in_root.translated(box_state.offset.x(), box_state.offset.y()));
+            containing_block_position_in_root.translated(content_x, content_y));
 
         if (box.children_are_inline())
             layout_inline_children(as<BlockContainer>(box), inside_layout_input, space_available_for_children);
         else
             layout_block_level_children(as<BlockContainer>(box), inside_layout_input, space_available_for_children);
 
-        if (opened_top_margin_group) {
+        if (box_opens_top_margin_group) {
             auto resolved_margin_top = m_margin_state.take_pending_top_margin();
-            if (introduce_clearance == DidIntroduceClearance::No) {
-                auto const provisional_content_y = box_state.offset.y();
-                place_block_level_element_in_normal_flow_vertically(box, resolved_margin_top + y);
-                translate_floats_in_subtree(box, { 0, box_state.offset.y() - provisional_content_y });
-            }
+            auto final_content_y = introduce_clearance == DidIntroduceClearance::No
+                ? y + resolved_margin_top + box_state.border_box_top()
+                : content_y;
+            if (box_is_positioned_by_fieldset_layout)
+                box_state.set_content_y(final_content_y);
+            else
+                box_state.set_content_offset({ content_x, final_content_y });
+            translate_floats_in_subtree(box, { 0, final_content_y - content_y });
         }
     }
 
@@ -1245,7 +1264,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     // Now that our children are formatted we place the ListItemBox with the left space we remembered.
     if (is_list_item_box_without_css_content)
         // The marker pseudo-element will be created from a ListItemMarkerBox
-        layout_list_item_marker(*li_box, inline_space_used_before_children_formatted);
+        layout_list_item_marker(*list_item_box, inline_space_used_before_children_formatted);
     // Otherwise, it will be a dealt with as a generic pseudo-element with the content of the ::marker pseudo-element.
 
     if (independent_formatting_context || !margins_collapse_through(box, m_state)) {
@@ -1458,23 +1477,15 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
     return result;
 }
 
-void BlockFormattingContext::place_block_level_element_in_normal_flow_vertically(Box const& child_box, CSSPixels y)
+CSSPixels BlockFormattingContext::compute_normal_flow_x(Box const& child_box, AvailableSpace const& available_space, CSSPixelPoint content_position_in_root) const
 {
-    auto& box_state = m_state.get_mutable(child_box);
-    y += box_state.border_box_top();
-    box_state.set_content_y(y);
-    rebuild_float_bands();
-}
-
-void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const& available_space)
-{
-    auto& box_state = m_state.get_mutable(child_box);
+    auto const& box_state = m_state.get(child_box);
 
     CSSPixels x = 0;
     CSSPixels available_width_within_containing_block = available_space.width.to_px_or_zero();
 
     if (box_should_avoid_floats_because_it_establishes_fc(child_box)) {
-        auto space_used_by_floats = intrusion_by_floats_into_box(box_state, 0);
+        auto space_used_by_floats = intrusion_by_floats_into_rect({ content_position_in_root, box_state.content_size() }, 0, 0);
         available_width_within_containing_block -= space_used_by_floats.left + space_used_by_floats.right;
 
         // Subtracting the left margin here because it is applied again when the margin box offset is added below.
@@ -1490,7 +1501,7 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
         x += box_state.margin_box_left();
     }
 
-    box_state.set_content_x(x);
+    return x;
 }
 
 void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer const& block_container, LayoutInput const& layout_input, CSSPixels y, LineBuilder* line_builder)
@@ -1616,12 +1627,7 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
     auto& marker_state = m_state.get_mutable(marker);
     auto& list_item_state = m_state.get_mutable(list_item_box);
 
-    auto marker_text = marker.text();
-
-    // Text markers fit snug against the list item; non-text position themselves at 50% of the font size.
-    CSSPixels marker_distance = 0;
-    if (!marker_text.has_value())
-        marker_distance = CSSPixels::nearest_value_for(.5f * marker.first_available_font().pixel_size());
+    auto marker_distance = distance_between_marker_and_list_item(marker);
 
     auto marker_height = marker_state.content_height();
     auto marker_width = marker_state.content_width();
@@ -1633,11 +1639,8 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
     auto marker_offset_y = max(CSSPixels(0), (marker.computed_values().line_height() - marker_height) / 2);
 
     if (marker.list_style_position() == CSS::ListStylePosition::Inside) {
-        // FIXME: Just adjusting the content width and position for an inside marker is wrong, as it will still position
+        // FIXME: Just adjusting the content width for an inside marker is wrong, as it will still position
         //        the marker outside of the box, instead of treating it more like an inline child on the first line.
-        if (list_item_direction == CSS::Direction::Ltr) {
-            list_item_state.set_content_x(list_item_state.offset.x() + marker_width + marker_distance);
-        }
         list_item_state.set_content_width(list_item_state.content_width() - marker_width - marker_distance);
     }
 
@@ -1645,21 +1648,6 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
 
     if (marker.computed_values().line_height() > list_item_state.content_height())
         list_item_state.set_content_height(marker.computed_values().line_height());
-}
-
-FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_box(Box const& box, CSSPixels y_in_box) const
-{
-    return intrusion_by_floats_into_box(m_state.get(box), y_in_box);
-}
-
-FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_box(LayoutState::UsedValues const& box_used_values, CSSPixels y_in_box) const
-{
-    return intrusion_by_floats_into_box(box_used_values, y_in_box, y_in_box);
-}
-
-FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_box(LayoutState::UsedValues const& box_used_values, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
-{
-    return available_inline_space_in_box(box_used_values, block_start_in_box, block_end_in_box);
 }
 
 CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1187,12 +1187,14 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         ? static_cast<TableFormattingContext*>(independent_formatting_context.ptr())
         : nullptr;
 
+    Optional<CSSPixelPoint> pending_position;
+
     if (box_is_positioned_by_fieldset_layout) {
         m_pending_legend_flow_position = CSSPixelPoint { content_x, content_y };
     } else if (table_formatting_context) {
         table_formatting_context->set_pending_table_box_content_offset_in_wrapper({ content_x, content_y });
     } else if (!box_opens_top_margin_group) {
-        place_child(box, { content_x, content_y });
+        pending_position = CSSPixelPoint { content_x, content_y };
     }
 
     AvailableSpace available_space_for_height_resolution = available_space;
@@ -1246,7 +1248,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
         independent_formatting_context->run(layout_input.for_child_formatting_context(inner_available_space));
         if (table_formatting_context)
-            place_child(box, table_formatting_context->pending_table_box_content_offset_in_wrapper());
+            pending_position = table_formatting_context->pending_table_box_content_offset_in_wrapper();
         if (is<TableWrapper>(block_container) && box.display().is_table_inside()) {
             box_state.margin_left = max(box_state.margin_left, 0);
             box_state.margin_right = max(box_state.margin_right, 0);
@@ -1279,7 +1281,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             if (box_is_positioned_by_fieldset_layout) {
                 m_pending_legend_flow_position = CSSPixelPoint { content_x, final_content_y };
             } else {
-                place_child(box, { content_x, final_content_y });
+                pending_position = CSSPixelPoint { content_x, final_content_y };
             }
             translate_floats_in_subtree(box, { 0, final_content_y - content_y });
         }
@@ -1296,6 +1298,9 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         // The marker pseudo-element will be created from a ListItemMarkerBox
         layout_list_item_marker(*list_item_box, inline_space_used_before_children_formatted);
     // Otherwise, it will be a dealt with as a generic pseudo-element with the content of the ::marker pseudo-element.
+
+    if (pending_position.has_value())
+        place_child(box, *pending_position);
 
     if (independent_formatting_context || !margins_collapse_through(box, m_state)) {
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed()) {

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -222,6 +222,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     if (available_space.width.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
         auto available_width = available_space.width.to_px_or_zero();
         auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
+        box_in_root_rect.translate_by(0, y_adjustment_from_pending_ancestor_top_margins(box));
         box_in_root_rect.set_width(available_width);
         auto intrusion = intrusions_for_band_into_rect(band_at(box_in_root_rect.y()), box_in_root_rect);
         auto remaining_width = available_width - intrusion.left - intrusion.right;
@@ -451,6 +452,7 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusions_for_band
 FormattingContext::SpaceUsedByFloats BlockFormattingContext::available_inline_space_in_box(LayoutState::UsedValues const& box_used_values, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
 {
     auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_used_values, root());
+    box_in_root_rect.translate_by(0, y_adjustment_from_pending_ancestor_top_margins(box_used_values.node()));
     auto intrusions = available_inline_space(box_in_root_rect.y() + block_start_in_box, box_in_root_rect.y() + block_end_in_box);
     auto root_content_width = m_state.get(root()).content_width();
     return {
@@ -513,11 +515,14 @@ void BlockFormattingContext::ensure_band_boundary(CSSPixels block_start)
     m_bands.append(new_band);
 }
 
-void BlockFormattingContext::add_float_to_bands(FloatingBox const& floating_box, CSSPixelRect const& containing_block_rect_in_root)
+void BlockFormattingContext::add_float_to_bands(FloatingBox const& floating_box, CSSPixelRect containing_block_rect_in_root)
 {
+    auto const pending_y_adjustment = y_adjustment_from_pending_ancestor_top_margins(floating_box.box);
+    containing_block_rect_in_root.translate_by(0, pending_y_adjustment);
+
     auto const& box_state = floating_box.used_values;
     auto const root_content_width = m_state.get(root()).content_width();
-    auto const margin_box_rect_in_root = floating_box.margin_box_rect_in_root_coordinate_space;
+    auto const margin_box_rect_in_root = floating_box.margin_box_rect_in_root_coordinate_space.translated(0, pending_y_adjustment);
     auto const block_start = margin_box_rect_in_root.top();
     auto const block_end = margin_box_rect_in_root.bottom();
 
@@ -555,14 +560,21 @@ void BlockFormattingContext::rebuild_float_bands()
     m_lowest_left_margin_edge = 0;
     m_lowest_right_margin_edge = 0;
 
+    for (auto& floating_box : m_floats)
+        add_float_to_bands(*floating_box, floating_box->containing_block_rect_in_root_coordinate_space);
+}
+
+void BlockFormattingContext::translate_floats_in_subtree(Box const& ancestor, CSSPixelPoint delta)
+{
+    if (delta.is_zero())
+        return;
     for (auto& floating_box : m_floats) {
-        floating_box->margin_box_rect_in_root_coordinate_space = margin_box_rect_in_ancestor_coordinate_space(floating_box->used_values, root());
-        auto const* containing_block = floating_box->used_values.node().containing_block();
-        VERIFY(containing_block);
-        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(m_state.get(*containing_block), root());
-        floating_box->margin_box_rect_in_root_coordinate_space.set_x(margin_box_left_of_float_in_root(*floating_box, containing_block_rect_in_root));
-        add_float_to_bands(*floating_box, containing_block_rect_in_root);
+        if (!ancestor.is_ancestor_of(floating_box->box))
+            continue;
+        floating_box->margin_box_rect_in_root_coordinate_space.translate_by(delta);
+        floating_box->containing_block_rect_in_root_coordinate_space.translate_by(delta);
     }
+    rebuild_float_bands();
 }
 
 CSSPixels BlockFormattingContext::margin_box_left_of_float_in_root(FloatingBox const& floating_box, CSSPixelRect const& containing_block_rect_in_root) const
@@ -594,11 +606,13 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
     // If necessary, implementations should clear the said element by placing it below any preceding floats, but may
     // place it adjacent to such floats if there is sufficient space.
     auto& box_state = m_state.get_mutable(box);
+    auto const pending_y_adjustment = y_adjustment_from_pending_ancestor_top_margins(box);
     auto const* containing_block = box.containing_block();
     VERIFY(containing_block);
     auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(m_state.get(*containing_block), root());
     while (true) {
-        auto border_box_y_in_root = content_box_rect_in_ancestor_coordinate_space(box_state, root()).y() - box_state.border_box_top();
+        auto border_box_y_in_root = content_box_rect_in_ancestor_coordinate_space(box_state, root()).y()
+            - box_state.border_box_top() + pending_y_adjustment;
         containing_block_rect_in_root.set_y(border_box_y_in_root);
         containing_block_rect_in_root.set_height(box_state.border_box_height());
         auto const& band = band_at(border_box_y_in_root);
@@ -617,7 +631,9 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
                 box_state.border_box_height(),
             };
             must_clear_below_current_band = any_of(m_floats, [&](auto const& floating_box) {
-                return !floating_box->margin_box_rect_in_root_coordinate_space.intersected(border_box_rect_in_root).is_empty();
+                auto margin_box_rect_in_root = floating_box->margin_box_rect_in_root_coordinate_space.translated(
+                    0, y_adjustment_from_pending_ancestor_top_margins(floating_box->box));
+                return !margin_box_rect_in_root.intersected(border_box_rect_in_root).is_empty();
             });
         }
         if (!must_clear_below_current_band)
@@ -1001,13 +1017,13 @@ void BlockFormattingContext::layout_interrupting_block_inside_inline_context(Box
 
 CSSPixels BlockFormattingContext::commit_pending_margin_before_inline_content()
 {
-    auto margin_collapses_with_block_container = m_margin_state.has_block_container_waiting_for_final_y_position();
+    auto has_open_top_margin_group = m_margin_state.has_open_top_margin_group();
     auto collapsed_margin = m_margin_state.current_collapsed_margin();
 
-    m_margin_state.update_block_waiting_for_final_y_position();
+    m_margin_state.update_open_top_margin_group();
     m_margin_state.reset();
 
-    return margin_collapses_with_block_container ? CSSPixels(0) : collapsed_margin;
+    return has_open_top_margin_group ? CSSPixels(0) : collapsed_margin;
 }
 
 void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContainer const& block_container, CSSPixels& bottom_of_lowest_margin_box, LayoutInput const& layout_input)
@@ -1066,7 +1082,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     if (box.is_floating()) {
         auto const y = m_y_offset_of_current_block_container.value();
-        auto margin_top = !m_margin_state.has_block_container_waiting_for_final_y_position() ? m_margin_state.current_collapsed_margin() : 0;
+        auto margin_top = m_margin_state.has_open_top_margin_group() ? 0 : m_margin_state.current_collapsed_margin();
         layout_floating_box(box, block_container, layout_input, margin_top + y);
         bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
         return;
@@ -1076,7 +1092,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto introduce_clearance = clear_floating_boxes(box, {});
     if (introduce_clearance == DidIntroduceClearance::Yes)
         m_margin_state.reset();
-    m_margin_state.update_block_waiting_for_final_y_position();
+    m_margin_state.update_open_top_margin_group();
 
     auto const y = m_y_offset_of_current_block_container.value();
 
@@ -1098,7 +1114,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     CSSPixels margin_top = m_margin_state.current_collapsed_margin();
 
-    if (m_margin_state.has_block_container_waiting_for_final_y_position()) {
+    if (m_margin_state.has_open_top_margin_group()) {
         // If first child margin top will collapse with margin-top of containing block then margin-top of child is 0
         margin_top = 0;
     }
@@ -1183,18 +1199,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
-        auto registered_block_container_y_position_update_callback = false;
+        auto opened_top_margin_group = false;
         if (box_state.border_top > 0 || box_state.padding_top > 0) {
             // margin-top of block container can't collapse with its children if it has non-zero border or padding.
             m_margin_state.reset();
-        } else if (!m_margin_state.has_block_container_waiting_for_final_y_position()) {
-            // margin-top of block container can be updated during children layout hence its final y position is yet to be determined.
-            m_margin_state.register_block_container_y_position_update_callback([this, &box, y, introduce_clearance](CSSPixels margin_top) {
-                if (introduce_clearance == DidIntroduceClearance::No) {
-                    place_block_level_element_in_normal_flow_vertically(box, margin_top + y);
-                }
-            });
-            registered_block_container_y_position_update_callback = true;
+        } else if (!m_margin_state.has_open_top_margin_group()) {
+            m_margin_state.open_top_margin_group(box, introduce_clearance == DidIntroduceClearance::Yes);
+            opened_top_margin_group = true;
         }
 
         if (box.children_are_inline())
@@ -1202,8 +1213,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         else
             layout_block_level_children(as<BlockContainer>(box), layout_input, space_available_for_children);
 
-        if (registered_block_container_y_position_update_callback) {
-            m_margin_state.unregister_block_container_y_position_update_callback();
+        if (opened_top_margin_group) {
+            auto resolved_margin_top = m_margin_state.take_pending_top_margin();
+            if (introduce_clearance == DidIntroduceClearance::No) {
+                auto const provisional_content_y = box_state.offset.y();
+                place_block_level_element_in_normal_flow_vertically(box, resolved_margin_top + y);
+                translate_floats_in_subtree(box, { 0, box_state.offset.y() - provisional_content_y });
+            }
         }
     }
 
@@ -1228,7 +1244,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(false);
 
     m_margin_state.add_margin(box_state.margin_bottom);
-    m_margin_state.update_block_waiting_for_final_y_position();
+    m_margin_state.update_open_top_margin_group();
 
     compute_inset(box, content_box_rect(block_container_state).size());
 
@@ -1361,7 +1377,9 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     auto legend_border_box_centering_offset = (effective_border - legend_state.border_box_height()) / 2;
     auto fieldset_border_box_top_in_content = -(fieldset_state.border_top + fieldset_state.padding_top);
     auto legend_content_y = fieldset_border_box_top_in_content + legend_border_box_centering_offset + legend_state.border_box_top();
+    auto legend_y_delta = legend_content_y - legend_state.offset.y();
     legend_state.set_content_y(legend_content_y);
+    translate_floats_in_subtree(*legend, { 0, legend_y_delta });
 
     compute_and_store_baselines(fieldset_state);
 }
@@ -1409,6 +1427,7 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
         CSSPixels clearance_y_in_containing_block = clearance_y_in_root;
         for (auto containing_block = child_box.containing_block(); containing_block && containing_block != &root(); containing_block = containing_block->containing_block())
             clearance_y_in_containing_block -= m_state.get(*containing_block).offset.y();
+        clearance_y_in_containing_block -= y_adjustment_from_pending_ancestor_top_margins(child_box);
 
         if (inline_formatting_context.has_value()) {
             if (clearance_y_in_containing_block > inline_formatting_context->vertical_float_clearance()) {
@@ -1505,19 +1524,20 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         return;
 
     auto const containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(block_container_state, root());
+    auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container));
     auto margin_box_ceiling = line_builder ? line_builder->ceiling_for_float_to_be_inserted_here(box) : y;
     auto clearance = computed_values.clear();
     if (side.value() == FloatSide::Left && first_is_one_of(clearance, CSS::Clear::Left, CSS::Clear::Both, CSS::Clear::InlineStart))
-        margin_box_ceiling = max(margin_box_ceiling, m_lowest_left_margin_edge - containing_block_rect_in_root.y());
+        margin_box_ceiling = max(margin_box_ceiling, m_lowest_left_margin_edge - containing_block_rect_in_root_now.y());
     if (side.value() == FloatSide::Right && first_is_one_of(clearance, CSS::Clear::Right, CSS::Clear::Both, CSS::Clear::InlineEnd))
-        margin_box_ceiling = max(margin_box_ceiling, m_lowest_right_margin_edge - containing_block_rect_in_root.y());
+        margin_box_ceiling = max(margin_box_ceiling, m_lowest_right_margin_edge - containing_block_rect_in_root_now.y());
 
-    auto ceiling_in_root = containing_block_rect_in_root.y() + margin_box_ceiling;
+    auto ceiling_in_root = containing_block_rect_in_root_now.y() + margin_box_ceiling;
     if (!m_floats.is_empty())
-        ceiling_in_root = max(ceiling_in_root, m_floats.last()->margin_box_rect_in_root_coordinate_space.top());
+        ceiling_in_root = max(ceiling_in_root, m_floats.last()->margin_box_rect_in_root_coordinate_space.top() + y_adjustment_from_pending_ancestor_top_margins(m_floats.last()->box));
 
-    auto placement = place_float(side.value(), box_state, available_space, containing_block_rect_in_root, ceiling_in_root);
-    auto content_y = placement.block_start - containing_block_rect_in_root.y() + box_state.margin_box_top();
+    auto placement = place_float(side.value(), box_state, available_space, containing_block_rect_in_root_now, ceiling_in_root);
+    auto content_y = placement.block_start - containing_block_rect_in_root_now.y() + box_state.margin_box_top();
     box_state.set_content_y(content_y);
 
     auto margin_box_rect_in_root = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
@@ -1529,6 +1549,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         .top_margin_edge = content_y - box_state.margin_box_top(),
         .bottom_margin_edge = content_y + box_state.content_height() + box_state.margin_box_bottom(),
         .margin_box_rect_in_root_coordinate_space = margin_box_rect_in_root,
+        .containing_block_rect_in_root_coordinate_space = containing_block_rect_in_root,
         .percentage_basis_width = layout_input.containing_block_constraints.percentage_basis_width,
     }));
     auto& floating_box = *m_floats.last();
@@ -1637,6 +1658,7 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
     // but this one takes floats into account!
     CSSPixels max_width = 0;
     auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
+    box_in_root_rect.translate_by(0, y_adjustment_from_pending_ancestor_top_margins(box));
     for (auto const& band : m_bands) {
         auto intrusions = intrusions_for_band_into_rect(band, box_in_root_rect);
         max_width = max(max_width, intrusions.left + intrusions.right);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -128,14 +128,16 @@ void BlockFormattingContext::run(LayoutInput const& layout_input)
         (void)column_width;
     }
 
+    auto root_layout_input = layout_input.with_content_box_position_in_bfc_root(CSSPixelPoint {});
+
     if (auto const* fieldset_box = as_if<FieldSetBox>(root()); fieldset_box && fieldset_box->rendered_legend()) {
-        layout_fieldset_with_rendered_legend(*fieldset_box, layout_input);
+        layout_fieldset_with_rendered_legend(*fieldset_box, root_layout_input);
         return;
     }
     if (root().children_are_inline())
-        layout_inline_children(root(), layout_input, available_space);
+        layout_inline_children(root(), root_layout_input, available_space);
     else
-        layout_block_level_children(root(), layout_input, available_space);
+        layout_block_level_children(root(), root_layout_input, available_space);
 
     // Fieldsets without a rendered legend skip collapsed margin assignment.
     if (is<FieldSetBox>(root()))
@@ -214,15 +216,14 @@ bool BlockFormattingContext::box_should_avoid_floats_because_it_establishes_fc(B
         && first_is_one_of(formatting_context_type.value(), Type::Block, Type::Flex, Type::Grid);
 }
 
-void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root)
 {
     auto remaining_available_space = available_space;
 
     // Certain formatting contexts do not allow float intrusions, so reduce the available space for them.
     if (available_space.width.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
         auto available_width = available_space.width.to_px_or_zero();
-        auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
-        box_in_root_rect.translate_by(0, y_adjustment_from_pending_ancestor_top_margins(box));
+        auto box_in_root_rect = CSSPixelRect { content_position_in_root, m_state.get(box).content_size() };
         box_in_root_rect.set_width(available_width);
         auto intrusion = intrusions_for_band_into_rect(band_at(box_in_root_rect.y()), box_in_root_rect);
         auto remaining_width = available_width - intrusion.left - intrusion.right;
@@ -453,6 +454,11 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::available_inline_sp
 {
     auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_used_values, root());
     box_in_root_rect.translate_by(0, y_adjustment_from_pending_ancestor_top_margins(box_used_values.node()));
+    return intrusion_by_floats_into_rect(box_in_root_rect, block_start_in_box, block_end_in_box);
+}
+
+FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_rect(CSSPixelRect const& box_in_root_rect, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
+{
     auto intrusions = available_inline_space(box_in_root_rect.y() + block_start_in_box, box_in_root_rect.y() + block_end_in_box);
     auto root_content_width = m_state.get(root()).content_width();
     return {
@@ -645,7 +651,9 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
 
         box_state.set_content_y(box_state.offset.y() + next_band_start.value() - border_box_y_in_root);
 
-        compute_width(box, available_space, containing_block_constraints);
+        auto content_position_in_root = content_box_rect_in_ancestor_coordinate_space(box_state, root()).location();
+        content_position_in_root.translate_by(0, pending_y_adjustment);
+        compute_width(box, available_space, containing_block_constraints, content_position_in_root);
     }
 }
 
@@ -868,8 +876,6 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
 
 void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, LayoutInput const& layout_input, AvailableSpace const& available_space_for_children)
 {
-    // The layout input describes block_container itself; the inline formatting context gets
-    // the input for its children derived here.
     auto const& available_space = layout_input.available_space;
     VERIFY(block_container.children_are_inline());
 
@@ -1080,6 +1086,9 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     resolve_vertical_box_model_metrics(box, block_container_state.content_width());
 
+    VERIFY(box.containing_block() == &block_container);
+    auto containing_block_position_in_root = layout_input.content_box_position_in_bfc_root.value();
+
     if (box.is_floating()) {
         auto const y = m_y_offset_of_current_block_container.value();
         auto margin_top = m_margin_state.has_open_top_margin_group() ? 0 : m_margin_state.current_collapsed_margin();
@@ -1089,7 +1098,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     }
 
     m_margin_state.add_margin(box_state.margin_top);
-    auto introduce_clearance = clear_floating_boxes(box, {});
+    auto introduce_clearance = clear_floating_boxes(box, {}, containing_block_position_in_root);
     if (introduce_clearance == DidIntroduceClearance::Yes)
         m_margin_state.reset();
     m_margin_state.update_open_top_margin_group();
@@ -1121,7 +1130,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     place_block_level_element_in_normal_flow_vertically(box, y + margin_top);
 
-    compute_width(box, available_space, layout_input.containing_block_constraints);
+    compute_width(box, available_space, layout_input.containing_block_constraints,
+        containing_block_position_in_root.translated(box_state.offset.x(), box_state.offset.y() + y_adjustment_from_pending_ancestor_top_margins(box)));
     avoid_float_intrusions(box, available_space, layout_input.containing_block_constraints);
 
     place_block_level_element_in_normal_flow_horizontally(box, available_space);
@@ -1189,7 +1199,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
         make_button_content_box_definite(box, available_space, layout_input.containing_block_constraints, measured_content_height);
 
-        independent_formatting_context->run(layout_input.with_available_space(inner_available_space));
+        independent_formatting_context->run(layout_input.for_child_formatting_context(inner_available_space));
         if (is<TableWrapper>(block_container) && box.display().is_table_inside()) {
             box_state.margin_left = max(box_state.margin_left, 0);
             box_state.margin_right = max(box_state.margin_right, 0);
@@ -1208,10 +1218,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             opened_top_margin_group = true;
         }
 
+        auto inside_layout_input = layout_input.with_content_box_position_in_bfc_root(
+            containing_block_position_in_root.translated(box_state.offset.x(), box_state.offset.y()));
+
         if (box.children_are_inline())
-            layout_inline_children(as<BlockContainer>(box), layout_input, space_available_for_children);
+            layout_inline_children(as<BlockContainer>(box), inside_layout_input, space_available_for_children);
         else
-            layout_block_level_children(as<BlockContainer>(box), layout_input, space_available_for_children);
+            layout_block_level_children(as<BlockContainer>(box), inside_layout_input, space_available_for_children);
 
         if (opened_top_margin_group) {
             auto resolved_margin_top = m_margin_state.take_pending_top_margin();
@@ -1256,7 +1269,6 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
 void BlockFormattingContext::layout_block_level_children(BlockContainer const& block_container, LayoutInput const& layout_input, AvailableSpace const& available_space_for_children)
 {
-    // The layout input describes block_container itself; its children get the input derived here.
     VERIFY(!block_container.children_are_inline());
 
     auto const& available_space = available_space_for_children;
@@ -1265,7 +1277,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     // through to the table box unchanged.
     auto child_layout_input = [&]() -> LayoutInput {
         if (is<TableWrapper>(block_container))
-            return LayoutInput { available_space_for_children, layout_input.containing_block_constraints };
+            return LayoutInput { available_space_for_children, layout_input.containing_block_constraints, layout_input.content_box_position_in_bfc_root };
         else
             return layout_input_for_child_context(m_state.get(block_container), layout_input, available_space_for_children);
     }();
@@ -1281,7 +1293,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     if (m_layout_mode == LayoutMode::IntrinsicSizing) {
         auto& block_container_state = m_state.get_mutable(block_container);
         if (!block_container_state.has_definite_width()) {
-            auto width = greatest_child_width(block_container);
+            auto width = greatest_child_width_in_rect(block_container, { layout_input.content_box_position_in_bfc_root->translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container)), block_container_state.content_size() });
             auto const& computed_values = block_container.computed_values();
             // NOTE: Min and max constraints are not applied to a box that is being sized as intrinsic because
             //       according to css-sizing-3 spec:
@@ -1311,7 +1323,6 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
 // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
 void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox const& fieldset_box, LayoutInput const& layout_input)
 {
-    // The layout input describes the fieldset itself; its children get the input derived here.
     auto const& available_space = layout_input.available_space;
     auto child_layout_input = layout_input_for_child_context(m_state.get(fieldset_box), layout_input, available_space);
 
@@ -1410,7 +1421,7 @@ void BlockFormattingContext::resolve_horizontal_box_model_metrics(Box const& box
     box_state.padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
 }
 
-BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floating_boxes(Node const& child_box, Optional<InlineFormattingContext&> inline_formatting_context)
+BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floating_boxes(Node const& child_box, Optional<InlineFormattingContext&> inline_formatting_context, CSSPixelPoint containing_block_position_in_root)
 {
     auto const& computed_values = child_box.computed_values();
     auto result = DidIntroduceClearance::No;
@@ -1424,10 +1435,8 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
         //       This means that we have to first convert to a root-space Y coordinate before clearing,
         //       and then convert back to a local Y coordinate when assigning the cleared offset to
         //       the `child_box` layout state.
-        CSSPixels clearance_y_in_containing_block = clearance_y_in_root;
-        for (auto containing_block = child_box.containing_block(); containing_block && containing_block != &root(); containing_block = containing_block->containing_block())
-            clearance_y_in_containing_block -= m_state.get(*containing_block).offset.y();
-        clearance_y_in_containing_block -= y_adjustment_from_pending_ancestor_top_margins(child_box);
+        CSSPixels clearance_y_in_containing_block = clearance_y_in_root
+            - containing_block_position_in_root.y() - y_adjustment_from_pending_ancestor_top_margins(child_box);
 
         if (inline_formatting_context.has_value()) {
             if (clearance_y_in_containing_block > inline_formatting_context->vertical_float_clearance()) {
@@ -1495,7 +1504,10 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     auto const& block_container_state = m_state.get(block_container);
     resolve_vertical_box_model_metrics(box, block_container_state.content_width());
 
-    compute_width(box, available_space, layout_input.containing_block_constraints);
+    auto const containing_block_rect_in_root = CSSPixelRect { layout_input.content_box_position_in_bfc_root.value(), block_container_state.content_size() };
+    auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container));
+
+    compute_width(box, available_space, layout_input.containing_block_constraints, containing_block_rect_in_root_now.location());
 
     resolve_used_height_if_not_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
 
@@ -1504,7 +1516,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
     }
 
-    auto independent_formatting_context = layout_inside(box, m_layout_mode, layout_input.with_available_space(box_state.available_inner_space_or_constraints_from(available_space)));
+    auto independent_formatting_context = layout_inside(box, m_layout_mode, layout_input.for_child_formatting_context(box_state.available_inner_space_or_constraints_from(available_space)));
     // A floating table wrapper shrink-to-fits from cached intrinsic sizes, which may not match
     // the width table layout just produced; the wrapper is exactly as wide as the table grid box.
     if (is<TableWrapper>(box) && independent_formatting_context)
@@ -1523,8 +1535,6 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     if (!side.has_value())
         return;
 
-    auto const containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(block_container_state, root());
-    auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container));
     auto margin_box_ceiling = line_builder ? line_builder->ceiling_for_float_to_be_inserted_here(box) : y;
     auto clearance = computed_values.clear();
     if (side.value() == FloatSide::Left && first_is_one_of(clearance, CSS::Clear::Left, CSS::Clear::Both, CSS::Clear::InlineStart))
@@ -1540,7 +1550,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     auto content_y = placement.block_start - containing_block_rect_in_root_now.y() + box_state.margin_box_top();
     box_state.set_content_y(content_y);
 
-    auto margin_box_rect_in_root = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
+    auto margin_box_rect_in_root = margin_box_rect_in_ancestor_coordinate_space(box_state, block_container).translated(containing_block_rect_in_root.location());
     m_floats.append(adopt_own(*new FloatingBox {
         .box = box,
         .used_values = box_state,
@@ -1654,11 +1664,15 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats
 
 CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
 {
+    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
+    return greatest_child_width_in_rect(box, box_in_root_rect);
+}
+
+CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, CSSPixelRect const& box_in_root_rect) const
+{
     // Similar to FormattingContext::greatest_child_width()
     // but this one takes floats into account!
     CSSPixels max_width = 0;
-    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
-    box_in_root_rect.translate_by(0, y_adjustment_from_pending_ancestor_top_margins(box));
     for (auto const& band : m_bands) {
         auto intrusions = intrusions_for_band_into_rect(band, box_in_root_rect);
         max_width = max(max_width, intrusions.left + intrusions.right);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -176,7 +176,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
         auto content_y = floating_box->top_margin_edge + floating_box->used_values.margin_box_top();
         if (floating_box->side == FloatSide::Left) {
             // Left-side floats: offset_from_edge is from left edge (0) to left content edge of floating_box.
-            floating_box->used_values.set_content_offset({ floating_box->offset_from_edge, content_y });
+            place_child(floating_box->box, { floating_box->offset_from_edge, content_y });
         } else {
             // Right-side floats: offset_from_edge is from right edge (float_containing_block_width) to the left content edge of floating_box.
             auto float_containing_block_width = [&] {
@@ -190,7 +190,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
                 }
                 VERIFY_NOT_REACHED();
             }();
-            floating_box->used_values.set_content_offset({ float_containing_block_width - floating_box->offset_from_edge, content_y });
+            place_child(floating_box->box, { float_containing_block_width - floating_box->offset_from_edge, content_y });
         }
     }
 
@@ -1004,7 +1004,7 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
                 margin_bottom = 0;
             }
 
-            return max(CSSPixels(0), child_box_state.offset.y() + child_box_state.content_height() + child_box_state.border_box_bottom() + margin_bottom);
+            return max(CSSPixels(0), child_box_state.content_offset().y() + child_box_state.content_height() + child_box_state.border_box_bottom() + margin_bottom);
         }
 
         // If no in-flow children were found but there's a marker, use the marker's line-height.
@@ -1192,7 +1192,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     } else if (table_formatting_context) {
         table_formatting_context->set_pending_table_box_content_offset_in_wrapper({ content_x, content_y });
     } else if (!box_opens_top_margin_group) {
-        box_state.set_content_offset({ content_x, content_y });
+        place_child(box, { content_x, content_y });
     }
 
     AvailableSpace available_space_for_height_resolution = available_space;
@@ -1246,7 +1246,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
         independent_formatting_context->run(layout_input.for_child_formatting_context(inner_available_space));
         if (table_formatting_context)
-            box_state.set_content_offset(table_formatting_context->pending_table_box_content_offset_in_wrapper());
+            place_child(box, table_formatting_context->pending_table_box_content_offset_in_wrapper());
         if (is<TableWrapper>(block_container) && box.display().is_table_inside()) {
             box_state.margin_left = max(box_state.margin_left, 0);
             box_state.margin_right = max(box_state.margin_right, 0);
@@ -1279,7 +1279,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             if (box_is_positioned_by_fieldset_layout) {
                 m_pending_legend_flow_position = CSSPixelPoint { content_x, final_content_y };
             } else {
-                box_state.set_content_offset({ content_x, final_content_y });
+                place_child(box, { content_x, final_content_y });
             }
             translate_floats_in_subtree(box, { 0, final_content_y - content_y });
         }
@@ -1301,7 +1301,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed()) {
             m_margin_state.reset();
         }
-        m_y_offset_of_current_block_container = box_state.offset.y() + box_state.content_height() + box_state.border_box_bottom();
+        m_y_offset_of_current_block_container = box_state.content_offset().y() + box_state.content_height() + box_state.border_box_bottom();
     }
     m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(false);
 
@@ -1310,7 +1310,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     compute_inset(box, content_box_rect(block_container_state).size());
 
-    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
+    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.content_offset().y() + box_state.content_height() + box_state.margin_box_bottom());
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
@@ -1439,7 +1439,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     auto legend_content_y = fieldset_border_box_top_in_content + legend_border_box_centering_offset + legend_state.border_box_top();
     if (auto legend_flow_position = m_pending_legend_flow_position; legend_flow_position.has_value()) {
         m_pending_legend_flow_position = {};
-        legend_state.set_content_offset({ legend_flow_position->x(), legend_content_y });
+        place_child(*legend, { legend_flow_position->x(), legend_content_y });
         translate_floats_in_subtree(*legend, { 0, legend_content_y - legend_flow_position->y() });
     }
 
@@ -1683,7 +1683,7 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
 
     // Animations can make `float` or `position` apply to ::marker.
     if (!marker.is_floating() && !marker.is_absolutely_positioned())
-        marker_state.set_content_offset({ round(marker_offset_x), round(marker_offset_y) });
+        place_child(marker, { round(marker_offset_x), round(marker_offset_y) });
 
     if (marker.computed_values().line_height() > list_item_state.content_height())
         list_item_state.set_content_height(marker.computed_values().line_height());

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -27,6 +27,7 @@
 #include <LibWeb/Layout/ListItemMarkerBox.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Layout/SVGSVGBox.h>
+#include <LibWeb/Layout/TableFormattingContext.h>
 #include <LibWeb/Layout/TableWrapper.h>
 #include <LibWeb/Layout/Viewport.h>
 
@@ -1165,8 +1166,17 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         }
     }
 
-    if (box_is_positioned_by_fieldset_layout || !box_opens_top_margin_group)
+    auto* table_formatting_context = independent_formatting_context && independent_formatting_context->type() == Type::Table
+        ? static_cast<TableFormattingContext*>(independent_formatting_context.ptr())
+        : nullptr;
+
+    if (box_is_positioned_by_fieldset_layout) {
         box_state.set_content_offset({ content_x, content_y });
+    } else if (table_formatting_context) {
+        table_formatting_context->set_pending_table_box_content_offset_in_wrapper({ content_x, content_y });
+    } else if (!box_opens_top_margin_group) {
+        box_state.set_content_offset({ content_x, content_y });
+    }
 
     AvailableSpace available_space_for_height_resolution = available_space;
     auto is_table_box = box.display().is_table_row() || box.display().is_table_row_group() || box.display().is_table_header_group() || box.display().is_table_footer_group() || box.display().is_table_cell() || box.display().is_table_caption();
@@ -1218,6 +1228,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         make_button_content_box_definite(box, available_space, layout_input.containing_block_constraints, measured_content_height);
 
         independent_formatting_context->run(layout_input.for_child_formatting_context(inner_available_space));
+        if (table_formatting_context)
+            box_state.set_content_offset(table_formatting_context->pending_table_box_content_offset_in_wrapper());
         if (is<TableWrapper>(block_container) && box.display().is_table_inside()) {
             box_state.margin_left = max(box_state.margin_left, 0);
             box_state.margin_right = max(box_state.margin_right, 0);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1171,7 +1171,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         : nullptr;
 
     if (box_is_positioned_by_fieldset_layout) {
-        box_state.set_content_offset({ content_x, content_y });
+        m_pending_legend_flow_position = CSSPixelPoint { content_x, content_y };
     } else if (table_formatting_context) {
         table_formatting_context->set_pending_table_box_content_offset_in_wrapper({ content_x, content_y });
     } else if (!box_opens_top_margin_group) {
@@ -1259,10 +1259,11 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             auto final_content_y = introduce_clearance == DidIntroduceClearance::No
                 ? y + resolved_margin_top + box_state.border_box_top()
                 : content_y;
-            if (box_is_positioned_by_fieldset_layout)
-                box_state.set_content_y(final_content_y);
-            else
+            if (box_is_positioned_by_fieldset_layout) {
+                m_pending_legend_flow_position = CSSPixelPoint { content_x, final_content_y };
+            } else {
                 box_state.set_content_offset({ content_x, final_content_y });
+            }
             translate_floats_in_subtree(box, { 0, final_content_y - content_y });
         }
     }
@@ -1419,9 +1420,11 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     auto legend_border_box_centering_offset = (effective_border - legend_state.border_box_height()) / 2;
     auto fieldset_border_box_top_in_content = -(fieldset_state.border_top + fieldset_state.padding_top);
     auto legend_content_y = fieldset_border_box_top_in_content + legend_border_box_centering_offset + legend_state.border_box_top();
-    auto legend_y_delta = legend_content_y - legend_state.offset.y();
-    legend_state.set_content_y(legend_content_y);
-    translate_floats_in_subtree(*legend, { 0, legend_y_delta });
+    if (auto legend_flow_position = m_pending_legend_flow_position; legend_flow_position.has_value()) {
+        m_pending_legend_flow_position = {};
+        legend_state.set_content_offset({ legend_flow_position->x(), legend_content_y });
+        translate_floats_in_subtree(*legend, { 0, legend_content_y - legend_flow_position->y() });
+    }
 
     compute_and_store_baselines(fieldset_state);
 }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -173,9 +173,10 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
     m_was_notified_after_parent_dimensioned_my_root_box = true;
 
     for (auto& floating_box : m_floats) {
+        auto content_y = floating_box->top_margin_edge + floating_box->used_values.margin_box_top();
         if (floating_box->side == FloatSide::Left) {
             // Left-side floats: offset_from_edge is from left edge (0) to left content edge of floating_box.
-            floating_box->used_values.set_content_x(floating_box->offset_from_edge);
+            floating_box->used_values.set_content_offset({ floating_box->offset_from_edge, content_y });
         } else {
             // Right-side floats: offset_from_edge is from right edge (float_containing_block_width) to the left content edge of floating_box.
             auto float_containing_block_width = [&] {
@@ -189,7 +190,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
                 }
                 VERIFY_NOT_REACHED();
             }();
-            floating_box->used_values.set_content_x(float_containing_block_width - floating_box->offset_from_edge);
+            floating_box->used_values.set_content_offset({ float_containing_block_width - floating_box->offset_from_edge, content_y });
         }
     }
 
@@ -1105,7 +1106,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         auto const y = m_y_offset_of_current_block_container.value();
         auto margin_top = m_margin_state.has_open_top_margin_group() ? 0 : m_margin_state.current_collapsed_margin();
         layout_floating_box(box, block_container, layout_input, margin_top + y);
-        bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
+        bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, m_floats.last()->bottom_margin_edge);
         return;
     }
 
@@ -1590,9 +1591,10 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
     auto placement = place_float(side.value(), box_state, available_space, containing_block_rect_in_root_now, ceiling_in_root);
     auto content_y = placement.block_start - containing_block_rect_in_root_now.y() + box_state.margin_box_top();
-    box_state.set_content_y(content_y);
 
-    auto margin_box_rect_in_root = margin_box_rect_in_ancestor_coordinate_space(box_state, block_container).translated(containing_block_rect_in_root.location());
+    auto margin_box_rect_in_root = margin_box_rect(box_state)
+                                       .translated(0, content_y)
+                                       .translated(containing_block_rect_in_root.location());
     m_floats.append(adopt_own(*new FloatingBox {
         .box = box,
         .used_values = box_state,
@@ -1679,7 +1681,9 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
         list_item_state.set_content_width(list_item_state.content_width() - marker_width - marker_distance);
     }
 
-    marker_state.set_content_offset({ round(marker_offset_x), round(marker_offset_y) });
+    // Animations can make `float` or `position` apply to ::marker.
+    if (!marker.is_floating() && !marker.is_absolutely_positioned())
+        marker_state.set_content_offset({ round(marker_offset_x), round(marker_offset_y) });
 
     if (marker.computed_values().line_height() > list_item_state.content_height())
         list_item_state.set_content_height(marker.computed_values().line_height());

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -27,7 +27,7 @@ public:
     virtual CSSPixels automatic_content_height() const override;
 
     bool box_should_avoid_floats_because_it_establishes_fc(Box const&);
-    void compute_width(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints);
+    void compute_width(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root);
     void avoid_float_intrusions(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
     // https://www.w3.org/TR/css-display/#block-formatting-context-root
@@ -51,6 +51,7 @@ public:
     [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(Box const&, CSSPixels y_in_box) const;
     [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(LayoutState::UsedValues const&, CSSPixels y_in_box) const;
     [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(LayoutState::UsedValues const&, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
+    [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_rect(CSSPixelRect const& box_in_root_rect, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
     [[nodiscard]] Optional<CSSPixels> next_float_band_block_start_after(CSSPixels y_in_root) const;
 
     [[nodiscard]] CSSPixels y_adjustment_from_pending_ancestor_top_margins(Node const& box) const
@@ -82,7 +83,7 @@ public:
         No,
     };
 
-    [[nodiscard]] DidIntroduceClearance clear_floating_boxes(Node const& child_box, Optional<InlineFormattingContext&> inline_formatting_context);
+    [[nodiscard]] DidIntroduceClearance clear_floating_boxes(Node const& child_box, Optional<InlineFormattingContext&> inline_formatting_context, CSSPixelPoint containing_block_position_in_root);
 
     void reset_margin_state() { m_margin_state.reset(); }
 
@@ -158,6 +159,7 @@ private:
     [[nodiscard]] FloatBand const& band_at(CSSPixels y) const;
     [[nodiscard]] SpaceUsedByFloats intrusions_for_band_into_rect(FloatBand const&, CSSPixelRect const& rect_in_root) const;
     [[nodiscard]] SpaceUsedByFloats available_inline_space_in_box(LayoutState::UsedValues const&, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
+    [[nodiscard]] CSSPixels greatest_child_width_in_rect(Box const&, CSSPixelRect const& box_in_root_rect) const;
     [[nodiscard]] FloatPlacement place_float(FloatSide, LayoutState::UsedValues const&, AvailableSpace const&, CSSPixelRect const& containing_block_rect_in_root, CSSPixels ceiling_in_root) const;
     void ensure_band_boundary(CSSPixels);
     void add_float_to_bands(FloatingBox const&, CSSPixelRect containing_block_rect_in_root);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -236,6 +236,8 @@ private:
 
     Optional<CSSPixels> m_y_offset_of_current_block_container;
 
+    Optional<CSSPixelPoint> m_pending_legend_flow_position;
+
     BlockMarginState m_margin_state;
 
     Vector<NonnullOwnPtr<FloatingBox>> m_floats;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -26,9 +26,9 @@ public:
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
 
-    bool box_should_avoid_floats_because_it_establishes_fc(Box const&);
+    bool box_should_avoid_floats_because_it_establishes_fc(Box const&) const;
     void compute_width(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root);
-    void avoid_float_intrusions(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
+    [[nodiscard]] CSSPixels avoid_float_intrusions(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, CSSPixels content_y, CSSPixelRect const& containing_block_rect_in_root);
 
     // https://www.w3.org/TR/css-display/#block-formatting-context-root
     BlockContainer const& root() const { return static_cast<BlockContainer const&>(context_box()); }
@@ -48,9 +48,6 @@ public:
     }
 
     [[nodiscard]] SpaceUsedByFloats available_inline_space(CSSPixels block_start_in_root, CSSPixels block_end_in_root) const;
-    [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(Box const&, CSSPixels y_in_box) const;
-    [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(LayoutState::UsedValues const&, CSSPixels y_in_box) const;
-    [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(LayoutState::UsedValues const&, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
     [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_rect(CSSPixelRect const& box_in_root_rect, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
     [[nodiscard]] Optional<CSSPixels> next_float_band_block_start_after(CSSPixels y_in_root) const;
 
@@ -124,8 +121,7 @@ private:
     void layout_inline_children(BlockContainer const&, LayoutInput const&, AvailableSpace const& available_space_for_children);
     void layout_fieldset_with_rendered_legend(FieldSetBox const&, LayoutInput const&);
 
-    void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);
-    void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
+    [[nodiscard]] CSSPixels compute_normal_flow_x(Box const& child_box, AvailableSpace const&, CSSPixelPoint content_position_in_root) const;
     void translate_floats_in_subtree(Box const& ancestor, CSSPixelPoint delta);
 
     [[nodiscard]] CSSPixels border_box_left_of_box_avoiding_floats(Box const&, LayoutState::UsedValues const&, SpaceUsedByFloats const&) const;
@@ -158,7 +154,6 @@ private:
     [[nodiscard]] size_t band_index_at(CSSPixels y) const;
     [[nodiscard]] FloatBand const& band_at(CSSPixels y) const;
     [[nodiscard]] SpaceUsedByFloats intrusions_for_band_into_rect(FloatBand const&, CSSPixelRect const& rect_in_root) const;
-    [[nodiscard]] SpaceUsedByFloats available_inline_space_in_box(LayoutState::UsedValues const&, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
     [[nodiscard]] CSSPixels greatest_child_width_in_rect(Box const&, CSSPixelRect const& box_in_root_rect) const;
     [[nodiscard]] FloatPlacement place_float(FloatSide, LayoutState::UsedValues const&, AvailableSpace const&, CSSPixelRect const& containing_block_rect_in_root, CSSPixels ceiling_in_root) const;
     void ensure_band_boundary(CSSPixels);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -53,6 +53,18 @@ public:
     [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_box(LayoutState::UsedValues const&, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
     [[nodiscard]] Optional<CSSPixels> next_float_band_block_start_after(CSSPixels y_in_root) const;
 
+    [[nodiscard]] CSSPixels y_adjustment_from_pending_ancestor_top_margins(Node const& box) const
+    {
+        CSSPixels adjustment = 0;
+        for (auto const& group : m_margin_state.pending_top_margin_groups()) {
+            if (group.pinned_by_clearance)
+                continue;
+            if (group.box->is_inclusive_ancestor_of(box))
+                adjustment += group.collapsed_margin - group.collapsed_margin_at_open;
+        }
+        return adjustment;
+    }
+
     virtual CSSPixels greatest_child_width(Box const&) const override;
 
     void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutInput const&, CSSPixels y, LineBuilder* = nullptr);
@@ -96,6 +108,7 @@ public:
         CSSPixels bottom_margin_edge { 0 };
 
         CSSPixelRect margin_box_rect_in_root_coordinate_space;
+        CSSPixelRect containing_block_rect_in_root_coordinate_space;
         Optional<CSSPixels> percentage_basis_width;
     };
 
@@ -112,6 +125,7 @@ private:
 
     void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);
     void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
+    void translate_floats_in_subtree(Box const& ancestor, CSSPixelPoint delta);
 
     [[nodiscard]] CSSPixels border_box_left_of_box_avoiding_floats(Box const&, LayoutState::UsedValues const&, SpaceUsedByFloats const&) const;
 
@@ -146,7 +160,7 @@ private:
     [[nodiscard]] SpaceUsedByFloats available_inline_space_in_box(LayoutState::UsedValues const&, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
     [[nodiscard]] FloatPlacement place_float(FloatSide, LayoutState::UsedValues const&, AvailableSpace const&, CSSPixelRect const& containing_block_rect_in_root, CSSPixels ceiling_in_root) const;
     void ensure_band_boundary(CSSPixels);
-    void add_float_to_bands(FloatingBox const&, CSSPixelRect const& containing_block_rect_in_root);
+    void add_float_to_bands(FloatingBox const&, CSSPixelRect containing_block_rect_in_root);
     void rebuild_float_bands();
     [[nodiscard]] CSSPixels margin_box_left_of_float_in_root(FloatingBox const&, CSSPixelRect const& containing_block_rect_in_root) const;
 
@@ -161,37 +175,54 @@ private:
             }
         }
 
-        void register_block_container_y_position_update_callback(ESCAPING Function<void(CSSPixels)> callback)
-        {
-            m_block_container_y_position_update_callback = move(callback);
-        }
-
-        void unregister_block_container_y_position_update_callback()
-        {
-            m_block_container_y_position_update_callback = {};
-        }
-
         CSSPixels current_collapsed_margin() const
         {
             return m_current_positive_collapsible_margin + m_current_negative_collapsible_margin;
         }
 
-        bool has_block_container_waiting_for_final_y_position() const
+        // Several ancestor groups may await placement, but only the last can remain open
+        // and continue accumulating collapsed margins.
+        struct PendingTopMarginGroup {
+            Box const* box { nullptr };
+            CSSPixels collapsed_margin_at_open;
+            CSSPixels collapsed_margin;
+            bool open { false };
+            bool pinned_by_clearance { false };
+        };
+
+        void open_top_margin_group(Box const& box, bool pinned_by_clearance)
         {
-            return static_cast<bool>(m_block_container_y_position_update_callback);
+            m_pending_top_margin_groups.append({
+                .box = &box,
+                .collapsed_margin_at_open = current_collapsed_margin(),
+                .collapsed_margin = current_collapsed_margin(),
+                .open = true,
+                .pinned_by_clearance = pinned_by_clearance,
+            });
         }
 
-        void update_block_waiting_for_final_y_position() const
+        CSSPixels take_pending_top_margin()
         {
-            if (m_block_container_y_position_update_callback) {
-                CSSPixels collapsed_margin = current_collapsed_margin();
-                m_block_container_y_position_update_callback(collapsed_margin);
-            }
+            return m_pending_top_margin_groups.take_last().collapsed_margin;
         }
+
+        bool has_open_top_margin_group() const
+        {
+            return !m_pending_top_margin_groups.is_empty() && m_pending_top_margin_groups.last().open;
+        }
+
+        void update_open_top_margin_group()
+        {
+            if (has_open_top_margin_group())
+                m_pending_top_margin_groups.last().collapsed_margin = current_collapsed_margin();
+        }
+
+        Vector<PendingTopMarginGroup, 4> const& pending_top_margin_groups() const { return m_pending_top_margin_groups; }
 
         void reset()
         {
-            m_block_container_y_position_update_callback = {};
+            if (has_open_top_margin_group())
+                m_pending_top_margin_groups.last().open = false;
             m_current_negative_collapsible_margin = 0;
             m_current_positive_collapsible_margin = 0;
         }
@@ -202,7 +233,7 @@ private:
     private:
         CSSPixels m_current_positive_collapsible_margin;
         CSSPixels m_current_negative_collapsible_margin;
-        Function<void(CSSPixels)> m_block_container_y_position_update_callback;
+        Vector<PendingTopMarginGroup, 4> m_pending_top_margin_groups;
         bool m_box_last_in_flow_child_margin_bottom_collapsed { false };
     };
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -123,6 +123,7 @@ private:
 
     [[nodiscard]] CSSPixels compute_normal_flow_x(Box const& child_box, AvailableSpace const&, CSSPixelPoint content_position_in_root) const;
     void translate_floats_in_subtree(Box const& ancestor, CSSPixelPoint delta);
+    void update_lowest_floating_descendant_bottom_margin_edge();
 
     [[nodiscard]] CSSPixels border_box_left_of_box_avoiding_floats(Box const&, LayoutState::UsedValues const&, SpaceUsedByFloats const&) const;
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -64,6 +64,7 @@ public:
     }
 
     virtual CSSPixels greatest_child_width(Box const&) const override;
+    [[nodiscard]] CSSPixels greatest_child_width_in_rect(Box const&, CSSPixelRect const& box_in_root_rect) const;
 
     void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutInput const&, CSSPixels y, LineBuilder* = nullptr);
 
@@ -155,7 +156,6 @@ private:
     [[nodiscard]] size_t band_index_at(CSSPixels y) const;
     [[nodiscard]] FloatBand const& band_at(CSSPixels y) const;
     [[nodiscard]] SpaceUsedByFloats intrusions_for_band_into_rect(FloatBand const&, CSSPixelRect const& rect_in_root) const;
-    [[nodiscard]] CSSPixels greatest_child_width_in_rect(Box const&, CSSPixelRect const& box_in_root_rect) const;
     [[nodiscard]] FloatPlacement place_float(FloatSide, LayoutState::UsedValues const&, AvailableSpace const&, CSSPixelRect const& containing_block_rect_in_root, CSSPixels ceiling_in_root) const;
     void ensure_band_boundary(CSSPixels);
     void add_float_to_bands(FloatingBox const&, CSSPixelRect containing_block_rect_in_root);

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -262,9 +262,9 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
 
         for (auto& item : m_flex_items) {
             if (main_axis_is_horizontal())
-                item.used_values.set_content_offset({ item.main_offset, item.cross_offset });
+                place_child(item.box, { item.main_offset, item.cross_offset });
             else
-                item.used_values.set_content_offset({ item.cross_offset, item.main_offset });
+                place_child(item.box, { item.cross_offset, item.main_offset });
         }
 
         compute_and_store_baselines(m_flex_container_state);

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -260,6 +260,13 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
 
         resolve_baseline_aligned_items();
 
+        for (auto& item : m_flex_items) {
+            if (main_axis_is_horizontal())
+                item.used_values.set_content_offset({ item.main_offset, item.cross_offset });
+            else
+                item.used_values.set_content_offset({ item.cross_offset, item.main_offset });
+        }
+
         compute_and_store_baselines(m_flex_container_state);
     }
 
@@ -568,14 +575,6 @@ void FlexFormattingContext::set_cross_size(FlexItem& item, CSSPixels size)
         item.used_values.set_content_width(size);
     else
         item.used_values.set_content_height(size);
-}
-
-void FlexFormattingContext::set_offset(FlexItem& item, CSSPixels main_offset, CSSPixels cross_offset)
-{
-    if (main_axis_is_horizontal())
-        item.used_values.set_content_offset({ main_offset, cross_offset });
-    else
-        item.used_values.set_content_offset({ cross_offset, main_offset });
 }
 
 void FlexFormattingContext::set_main_axis_first_margin(FlexItem& item, CSSPixels margin)
@@ -1764,11 +1763,7 @@ void FlexFormattingContext::resolve_baseline_aligned_items()
             if (!participates_in_baseline_alignment(item))
                 continue;
 
-            auto adjustment = max_baseline - box_baseline(item.box, BaselineSet::First);
-            if (main_axis_is_horizontal())
-                item.used_values.set_content_y(item.used_values.offset.y() + adjustment);
-            else
-                item.used_values.set_content_x(item.used_values.offset.x() + adjustment);
+            item.cross_offset += max_baseline - box_baseline(item.box, BaselineSet::First);
         }
     }
 }
@@ -1944,7 +1939,6 @@ void FlexFormattingContext::copy_dimensions_from_flex_items_to_boxes()
 
         set_main_size(item, item.main_size.value());
         set_cross_size(item, item.cross_size.value());
-        set_offset(item, item.main_offset, item.cross_offset);
     }
 }
 

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -166,7 +166,6 @@ private:
     void set_cross_size(Box const&, CSSPixels size);
     void set_main_size(FlexItem&, CSSPixels size);
     void set_cross_size(FlexItem&, CSSPixels size);
-    void set_offset(FlexItem&, CSSPixels main_offset, CSSPixels cross_offset);
 
     void set_main_axis_first_margin(FlexItem&, CSSPixels margin);
     void set_main_axis_second_margin(FlexItem&, CSSPixels margin);

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -887,6 +887,7 @@ LayoutInput FormattingContext::layout_input_for_child_context(
     return LayoutInput {
         available_space,
         constraints_for_child_context(containing_block_used_values, containing_block_layout_input.containing_block_constraints),
+        containing_block_layout_input.content_box_position_in_bfc_root,
     };
 }
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -214,6 +214,11 @@ FormattingContext::FormattingContext(Type type, LayoutMode layout_mode, LayoutSt
 
 FormattingContext::~FormattingContext() = default;
 
+void FormattingContext::place_child(Box const& child, CSSPixelPoint content_offset)
+{
+    m_state.get_mutable(child).place(content_offset);
+}
+
 bool FormattingContext::computed_height_establishes_definite_containing_block_height(CSS::Size const& computed_height)
 {
     // A resolved used height is not always a definite containing block height.
@@ -634,7 +639,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
             if (!child_box_state)
                 return IterationDecision::Continue;
 
-            CSSPixels child_box_bottom = child_box_state->offset.y() + child_box_state->content_height() + child_box_state->margin_box_bottom();
+            CSSPixels child_box_bottom = child_box_state->content_offset().y() + child_box_state->content_height() + child_box_state->margin_box_bottom();
 
             if (!bottom.has_value() || child_box_bottom > bottom.value())
                 bottom = child_box_bottom;
@@ -1742,7 +1747,7 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
             if (child->is_absolutely_positioned() || child->is_floating())
                 continue;
             auto const* child_used_values = state.try_get(*child);
-            auto child_offset = child_used_values ? offset + child_used_values->offset : offset;
+            auto child_offset = child_used_values ? offset + child_used_values->content_offset() : offset;
             auto const* box_child = as_if<Box>(child.ptr());
             if (box_child && !box_child->is_anonymous()) {
                 auto const* dom = box_child->dom_node();
@@ -1770,7 +1775,7 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
     CSSPixelPoint outer_offset;
     for (Node const* ancestor = outer_block; ancestor && ancestor != &abspos_containing_block; ancestor = ancestor->parent()) {
         if (auto const* used_values = state.try_get(*ancestor))
-            outer_offset.translate_by(used_values->offset);
+            outer_offset.translate_by(used_values->content_offset());
     }
     walk(*outer_block, outer_offset);
 
@@ -2333,7 +2338,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
         auto offset_relative_to_merge_point = [&](Box const& descendant) {
             CSSPixelPoint offset;
             for (auto const* node = &descendant; node != merge_point; node = node->containing_block())
-                offset += m_state.get(*node).offset;
+                offset += m_state.get(*node).content_offset();
             return offset;
         };
         static_position += offset_relative_to_merge_point(*static_position_cb) - offset_relative_to_merge_point(*actual_containing_block);
@@ -2353,7 +2358,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
 
     used_offset.translate_by(box_state.margin_box_left(), box_state.margin_box_top());
 
-    box_state.set_content_offset(used_offset);
+    place_child(box, used_offset);
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
@@ -3022,7 +3027,7 @@ void FormattingContext::compute_and_store_baselines(LayoutState::UsedValues& use
             VERIFY(line_box.fragments().size() == 1);
             auto const& block_child = as<Box>(line_box.fragments().first().layout_node());
             auto const& block_child_state = m_state.get(block_child);
-            auto child_offset_from_margin_edge = block_child_state.offset.y() - block_child_state.margin_box_top();
+            auto child_offset_from_margin_edge = block_child_state.content_offset().y() - block_child_state.margin_box_top();
             return child_offset_from_margin_edge + box_baseline(block_child, baseline_set);
         };
 
@@ -3060,7 +3065,7 @@ void FormattingContext::compute_and_store_baselines(LayoutState::UsedValues& use
             auto const& child_baseline = deriving_first_baseline ? child_state->first_baseline : child_state->last_baseline;
             if (!child_baseline.has_value())
                 continue;
-            auto child_offset_from_margin_edge = child_state->offset.y() - child_state->margin_box_top();
+            auto child_offset_from_margin_edge = child_state->content_offset().y() - child_state->margin_box_top();
             return child_offset_from_margin_edge + box_baseline(*child_box, baseline_set);
         }
         return {};
@@ -3157,7 +3162,7 @@ CSSPixelRect FormattingContext::content_box_rect(Box const& box) const
 
 CSSPixelRect FormattingContext::content_box_rect(LayoutState::UsedValues const& used_values) const
 {
-    return CSSPixelRect { used_values.offset, used_values.content_size() };
+    return CSSPixelRect { used_values.content_offset(), used_values.content_size() };
 }
 
 CSSPixelRect FormattingContext::content_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const& used_values, Box const& ancestor_box) const
@@ -3166,7 +3171,7 @@ CSSPixelRect FormattingContext::content_box_rect_in_ancestor_coordinate_space(La
     for (auto const* current = &used_values; current;) {
         if (&current->node() == &ancestor_box)
             return rect;
-        rect.translate_by(current->offset);
+        rect.translate_by(current->content_offset());
         auto const* containing_block = current->node().containing_block();
         if (!containing_block)
             break;
@@ -3182,7 +3187,7 @@ CSSPixelRect FormattingContext::margin_box_rect_in_ancestor_coordinate_space(Lay
     for (auto const* current = &used_values; current;) {
         if (&current->node() == &ancestor_box)
             return rect;
-        rect.translate_by(current->offset);
+        rect.translate_by(current->content_offset());
         auto const* containing_block = current->node().containing_block();
         if (!containing_block)
             break;

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -626,8 +626,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
             if (child_box.is_absolutely_positioned())
                 return IterationDecision::Continue;
 
-            // FIXME: This doesn't look right.
-            if ((root.computed_values().overflow_y() == CSS::Overflow::Visible) && child_box.is_floating())
+            if (child_box.is_floating())
                 return IterationDecision::Continue;
 
             // Children that have not been laid out yet contribute nothing to the auto height.
@@ -647,13 +646,9 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
     // In addition, if the element has any floating descendants
     // whose bottom margin edge is below the element's bottom content edge,
     // then the height is increased to include those edges.
-    for (auto floating_box : m_state.get(root).floating_descendants()) {
-        // NOTE: Floating box coordinates are relative to their own containing block,
-        //       which may or may not be the BFC root.
-        auto margin_box = margin_box_rect_in_ancestor_coordinate_space(*floating_box, root);
-        CSSPixels floating_box_bottom_margin_edge = margin_box.bottom();
-        if (!bottom.has_value() || floating_box_bottom_margin_edge > bottom.value())
-            bottom = floating_box_bottom_margin_edge;
+    if (auto lowest_float_bottom_margin_edge = m_state.get(root).lowest_floating_descendant_bottom_margin_edge(); lowest_float_bottom_margin_edge.has_value()) {
+        if (!bottom.has_value() || *lowest_float_bottom_margin_edge > bottom.value())
+            bottom = lowest_float_bottom_margin_edge;
     }
 
     return max(CSSPixels(0.0f), bottom.value_or(0) - top.value_or(0));

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -3136,7 +3136,7 @@ CSSPixels FormattingContext::box_baseline(Box const& box, BaselineSet baseline_s
     return box_state.margin_box_height();
 }
 
-[[nodiscard]] static CSSPixelRect margin_box_rect(LayoutState::UsedValues const& used_values)
+CSSPixelRect FormattingContext::margin_box_rect(LayoutState::UsedValues const& used_values)
 {
     return {
         {

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -154,6 +154,8 @@ public:
 
     virtual void parent_context_did_dimension_child_root_box() { }
 
+    void place_child(Box const& child, CSSPixelPoint content_offset);
+
     CSSPixels calculate_min_content_width(Layout::Box const&, ContainingBlockConstraints const&) const;
     CSSPixels calculate_max_content_width(Layout::Box const&, ContainingBlockConstraints const&) const;
     CSSPixels calculate_min_content_height(Layout::Box const&, CSSPixels width, ContainingBlockConstraints const&) const;

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -167,6 +167,7 @@ public:
 
     virtual CSSPixels greatest_child_width(Box const&) const;
 
+    [[nodiscard]] static CSSPixelRect margin_box_rect(LayoutState::UsedValues const&);
     [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixelRect content_box_rect(Box const&) const;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2903,10 +2903,6 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
             grid_area_size.set_width(non_cyclic_containing_block_width_for_table_wrapper(grid_item, grid_area_size.width()));
             table_wrapper_grid_area_size = grid_area_size;
         }
-        CSSPixelPoint margin_offset = { grid_item.used_values.margin_box_left(), grid_item.used_values.margin_box_top() };
-        place_child(grid_item.box, grid_area_rect.top_left() + margin_offset);
-        compute_inset(grid_item.box, grid_area_rect.size());
-
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_width()), AvailableSize::make_definite(grid_item.used_values.content_height()));
         grid_item.used_values.set_has_definite_width(true);
         grid_item.used_values.set_has_definite_height(true);
@@ -2920,7 +2916,13 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
             }
             return constraints;
         }();
-        if (auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, LayoutInput { available_space_for_children, child_constraints }))
+        auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, LayoutInput { available_space_for_children, child_constraints });
+
+        CSSPixelPoint grid_item_content_offset = grid_area_rect.top_left() + CSSPixelPoint { grid_item.used_values.margin_box_left(), grid_item.used_values.margin_box_top() };
+        place_child(grid_item.box, grid_item_content_offset);
+        compute_inset(grid_item.box, grid_area_rect.size());
+
+        if (independent_formatting_context)
             independent_formatting_context->parent_context_did_dimension_child_root_box();
     }
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2904,7 +2904,7 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
             table_wrapper_grid_area_size = grid_area_size;
         }
         CSSPixelPoint margin_offset = { grid_item.used_values.margin_box_left(), grid_item.used_values.margin_box_top() };
-        grid_item.used_values.set_content_offset(grid_area_rect.top_left() + margin_offset);
+        place_child(grid_item.box, grid_area_rect.top_left() + margin_offset);
         compute_inset(grid_item.box, grid_area_rect.size());
 
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_width()), AvailableSize::make_definite(grid_item.used_values.content_height()));

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -41,9 +41,15 @@ BlockFormattingContext const& InlineFormattingContext::parent() const
     return static_cast<BlockFormattingContext const&>(*FormattingContext::parent());
 }
 
+FormattingContext::SpaceUsedByFloats InlineFormattingContext::intrusion_by_floats_into_containing_block(CSSPixels block_start, CSSPixels block_end) const
+{
+    auto containing_block_position_in_root_now = m_layout_input->content_box_position_in_bfc_root->translated(0, parent().y_adjustment_from_pending_ancestor_top_margins(containing_block()));
+    return parent().intrusion_by_floats_into_rect({ containing_block_position_in_root_now, m_containing_block_used_values.content_size() }, block_start, block_end);
+}
+
 CSSPixels InlineFormattingContext::leftmost_inline_offset_at(CSSPixels block_offset, CSSPixels line_height) const
 {
-    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, block_offset, block_offset + line_height);
+    auto intrusions = intrusion_by_floats_into_containing_block(block_offset, block_offset + line_height);
     return intrusions.left;
 }
 
@@ -52,7 +58,7 @@ AvailableSize InlineFormattingContext::available_space_for_line(CSSPixels block_
     if (!m_available_space->width.is_definite())
         return m_available_space->width;
 
-    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, block_offset, block_offset + line_height);
+    auto intrusions = intrusion_by_floats_into_containing_block(block_offset, block_offset + line_height);
     return AvailableSize::make_definite(m_available_space->width.to_px_or_zero() - intrusions.left - intrusions.right);
 }
 
@@ -118,7 +124,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     if (box_is_sized_as_replaced_element(box, *m_available_space, box_constraints)) {
         box_state.set_content_width(compute_width_for_replaced_element(box, *m_available_space, box_constraints));
         box_state.set_content_height(compute_height_for_replaced_element(box, *m_available_space, box_constraints));
-        auto child_layout_input = m_layout_input->with_available_space(box_state.available_inner_space_or_constraints_from(*m_available_space));
+        auto child_layout_input = m_layout_input->for_child_formatting_context(box_state.available_inner_space_or_constraints_from(*m_available_space));
         auto independent_formatting_context = layout_inside(box, layout_mode, child_layout_input);
         if (independent_formatting_context)
             independent_formatting_context->parent_context_did_dimension_child_root_box();
@@ -187,7 +193,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     make_button_content_box_definite(box, *m_available_space, box_constraints);
 
-    auto child_layout_input = m_layout_input->with_available_space(box_state.available_inner_space_or_constraints_from(*m_available_space));
+    auto child_layout_input = m_layout_input->for_child_formatting_context(box_state.available_inner_space_or_constraints_from(*m_available_space));
     auto independent_formatting_context = layout_inside(box, layout_mode, child_layout_input);
 
     if (should_treat_height_as_auto(box, *m_available_space, box_constraints)) {
@@ -402,7 +408,7 @@ void InlineFormattingContext::generate_line_boxes()
         case InlineLevelIterator::Item::Type::ForcedBreak: {
             line_builder.break_line(LineBuilder::ForcedBreak::Yes);
             if (item.node) {
-                auto introduce_clearance = parent().clear_floating_boxes(*item.node, *this);
+                auto introduce_clearance = parent().clear_floating_boxes(*item.node, *this, m_layout_input->content_box_position_in_bfc_root.value());
                 if (introduce_clearance == BlockFormattingContext::DidIntroduceClearance::Yes) {
                     line_builder.did_introduce_clearance(vertical_float_clearance());
                     parent().reset_margin_state();
@@ -454,7 +460,7 @@ void InlineFormattingContext::generate_line_boxes()
                 line_builder.commit_pending_margin_before_float();
                 if (!is<ListItemMarkerBox>(*box))
                     m_state.create(*box, m_layout_input->containing_block_constraints.percentage_basis_width, m_layout_input->containing_block_constraints.percentage_basis_height);
-                (void)parent().clear_floating_boxes(*item.node, *this);
+                (void)parent().clear_floating_boxes(*item.node, *this, m_layout_input->content_box_position_in_bfc_root.value());
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
                 line_builder.set_unbreakable_run_width_interrupted_by_float(iterator.next_non_whitespace_sequence_width());
@@ -577,7 +583,7 @@ void InlineFormattingContext::generate_line_boxes()
 bool InlineFormattingContext::any_floats_intrude_in_block_range(CSSPixels block_start, CSSPixels block_end) const
 {
     // FIXME: Respect inline direction.
-    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, block_start, block_end);
+    auto intrusions = intrusion_by_floats_into_containing_block(block_start, block_end);
     return intrusions.left > 0 || intrusions.right > 0;
 }
 
@@ -592,8 +598,7 @@ bool InlineFormattingContext::can_fit_new_line_at_block_offset(CSSPixels block_o
 
 Optional<CSSPixels> InlineFormattingContext::next_float_band_block_start_after(CSSPixels block_offset) const
 {
-    auto containing_block_y_in_root_now = content_box_rect_in_ancestor_coordinate_space(m_containing_block_used_values, parent().root()).y()
-        + parent().y_adjustment_from_pending_ancestor_top_margins(containing_block());
+    auto containing_block_y_in_root_now = m_layout_input->content_box_position_in_bfc_root->y() + parent().y_adjustment_from_pending_ancestor_top_margins(containing_block());
     auto next_band_start = parent().next_float_band_block_start_after(containing_block_y_in_root_now + block_offset);
     if (!next_band_start.has_value())
         return {};

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -92,7 +92,10 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
 
     // NOTE: We ask the parent BFC to calculate the automatic content width of this IFC.
     //       This ensures that any floated boxes are taken into account.
-    m_automatic_content_width = parent().greatest_child_width(containing_block());
+    auto provisional_containing_block_position_in_root = m_layout_input->content_box_position_in_bfc_root->translated(
+        0, parent().y_adjustment_from_pending_ancestor_top_margins(containing_block()));
+    m_automatic_content_width = parent().greatest_child_width_in_rect(
+        containing_block(), { provisional_containing_block_position_in_root, m_containing_block_used_values.content_size() });
     m_automatic_content_height = content_height;
 
     compute_and_store_baselines(m_containing_block_used_values);
@@ -537,8 +540,10 @@ void InlineFormattingContext::generate_line_boxes()
     // NB: This must happen after update_last_line() so that last-line alignment
     //     adjustments are reflected in the used values of atomic inlines.
     for (auto& line_box : line_boxes) {
+        if (line_box.has_block_level_box())
+            continue;
         for (auto& fragment : line_box.fragments()) {
-            if (fragment.layout_node().is_inline_block()) {
+            if (fragment.layout_node().is_atomic_inline()) {
                 auto& box = as<Box>(fragment.layout_node());
                 place_child(box, fragment.offset());
             }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -540,8 +540,7 @@ void InlineFormattingContext::generate_line_boxes()
         for (auto& fragment : line_box.fragments()) {
             if (fragment.layout_node().is_inline_block()) {
                 auto& box = as<Box>(fragment.layout_node());
-                auto& box_state = m_state.get_mutable(box);
-                box_state.set_content_offset(fragment.offset());
+                place_child(box, fragment.offset());
             }
         }
     }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -592,11 +592,12 @@ bool InlineFormattingContext::can_fit_new_line_at_block_offset(CSSPixels block_o
 
 Optional<CSSPixels> InlineFormattingContext::next_float_band_block_start_after(CSSPixels block_offset) const
 {
-    auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_containing_block_used_values, parent().root());
-    auto next_band_start = parent().next_float_band_block_start_after(box_in_root_rect.y() + block_offset);
+    auto containing_block_y_in_root_now = content_box_rect_in_ancestor_coordinate_space(m_containing_block_used_values, parent().root()).y()
+        + parent().y_adjustment_from_pending_ancestor_top_margins(containing_block());
+    auto next_band_start = parent().next_float_band_block_start_after(containing_block_y_in_root_now + block_offset);
     if (!next_band_start.has_value())
         return {};
-    return next_band_start.value() - box_in_root_rect.y();
+    return next_band_start.value() - containing_block_y_in_root_now;
 }
 
 CSSPixels InlineFormattingContext::vertical_float_clearance() const

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -44,6 +44,8 @@ private:
     void apply_text_overflow_ellipsis(Vector<LineBox>&);
     void apply_justification_to_fragments(CSS::TextJustify, LineBox&, bool is_last_line);
 
+    [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_containing_block(CSSPixels block_start, CSSPixels block_end) const;
+
     LayoutState::UsedValues& m_containing_block_used_values;
 
     Optional<AvailableSpace> m_available_space;

--- a/Libraries/LibWeb/Layout/LayoutInput.h
+++ b/Libraries/LibWeb/Layout/LayoutInput.h
@@ -19,19 +19,27 @@ struct ContainingBlockConstraints {
 };
 
 struct LayoutInput {
-    explicit LayoutInput(AvailableSpace new_available_space, ContainingBlockConstraints new_containing_block_constraints = {})
+    explicit LayoutInput(AvailableSpace new_available_space, ContainingBlockConstraints new_containing_block_constraints = {}, Optional<CSSPixelPoint> new_content_box_position_in_bfc_root = {})
         : available_space(move(new_available_space))
         , containing_block_constraints(move(new_containing_block_constraints))
+        , content_box_position_in_bfc_root(new_content_box_position_in_bfc_root)
     {
     }
 
-    [[nodiscard]] LayoutInput with_available_space(AvailableSpace new_available_space) const
+    [[nodiscard]] LayoutInput for_child_formatting_context(AvailableSpace new_available_space) const
     {
         return LayoutInput { move(new_available_space), containing_block_constraints };
     }
 
+    [[nodiscard]] LayoutInput with_content_box_position_in_bfc_root(Optional<CSSPixelPoint> position) const
+    {
+        return LayoutInput { available_space, containing_block_constraints, position };
+    }
+
     AvailableSpace const available_space;
     ContainingBlockConstraints const containing_block_constraints;
+
+    Optional<CSSPixelPoint> const content_box_position_in_bfc_root;
 };
 
 }

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -168,8 +168,8 @@ CSSPixelPoint LayoutState::cumulative_offset(UsedValues const& used_values) cons
     if (used_values.m_cumulative_offset.has_value())
         return *used_values.m_cumulative_offset;
     if (auto const* containing_block = used_values.node().containing_block())
-        return cumulative_offset(get(*containing_block)) + used_values.offset;
-    return used_values.offset;
+        return cumulative_offset(get(*containing_block)) + used_values.content_offset();
+    return used_values.content_offset();
 }
 
 // https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region
@@ -649,7 +649,7 @@ void LayoutState::commit(Box& root)
         if (auto* paintable_box = paintable.ptr()) {
             transfer_box_model_metrics(paintable_box->box_model(), used_values);
 
-            paintable_box->set_offset(used_values.offset);
+            paintable_box->set_offset(used_values.content_offset());
             paintable_box->set_content_size(used_values.content_width(), used_values.content_height());
             if (used_values.override_borders_data().has_value())
                 paintable_box->set_override_borders_data(used_values.override_borders_data().value());
@@ -779,13 +779,13 @@ void LayoutState::commit(Box& root)
                 if (containing_line_box_fragment.fragment_index < line_box.fragments().size())
                     offset = line_box.fragments()[containing_line_box_fragment.fragment_index].offset();
                 else
-                    offset = used_values.offset;
+                    offset = used_values.content_offset();
             } else {
-                offset = used_values.offset;
+                offset = used_values.content_offset();
             }
         } else {
             // Not an atomic inline, much simpler case.
-            offset = used_values.offset;
+            offset = used_values.content_offset();
         }
 
         // Apply relative position inset if appropriate.
@@ -925,7 +925,7 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
     if (this == &other)
         return *this;
 
-    offset = other.offset;
+    m_content_offset = other.m_content_offset;
     width_constraint = other.width_constraint;
     height_constraint = other.height_constraint;
     margin_left = other.margin_left;
@@ -955,7 +955,6 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
     m_content_height = other.m_content_height;
     m_has_definite_width = other.m_has_definite_width;
     m_has_definite_height = other.m_has_definite_height;
-
     if (other.m_rare)
         m_rare = make<RareData>(*other.m_rare);
     else
@@ -1095,7 +1094,7 @@ void LayoutState::UsedValues::materialize_from_paintable(Painting::Paintable con
     m_has_definite_width = true;
     m_has_definite_height = true;
 
-    set_content_offset(paintable.offset());
+    m_content_offset = paintable.offset();
     m_cumulative_offset = paintable.absolute_rect().location();
 
     margin_left = box_model.margin.left;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -1127,6 +1127,7 @@ void LayoutState::UsedValues::materialize_from_paintable(Painting::Paintable con
 
 void LayoutState::UsedValues::set_content_width(CSSPixels width)
 {
+    VERIFY(!is_placed());
     if (width < 0) {
         // Negative widths are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative width for {}: {}", m_node->debug_description(), width);
@@ -1140,6 +1141,7 @@ void LayoutState::UsedValues::set_content_width(CSSPixels width)
 
 void LayoutState::UsedValues::set_content_height(CSSPixels height)
 {
+    VERIFY(!is_placed());
     if (height < 0) {
         // Negative heights are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative height for {}: {}", m_node->debug_description(), height);

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/BumpAllocator.h>
-#include <AK/HashTable.h>
 #include <AK/OwnPtr.h>
 #include <AK/kmalloc.h>
 #include <LibGfx/Path.h>
@@ -244,11 +243,12 @@ struct LayoutState {
 
         Optional<LineBoxFragmentCoordinate> containing_line_box_fragment;
 
-        void add_floating_descendant(Box const& box) { ensure_rare_data().floating_descendants.set(&box); }
-        HashTable<Box const*> const& floating_descendants() const
+        void set_lowest_floating_descendant_bottom_margin_edge(Optional<CSSPixels> bottom_margin_edge) { ensure_rare_data().lowest_floating_descendant_bottom_margin_edge = bottom_margin_edge; }
+        Optional<CSSPixels> lowest_floating_descendant_bottom_margin_edge() const
         {
-            static auto const& empty = *new HashTable<Box const*>;
-            return m_rare ? m_rare->floating_descendants : empty;
+            if (!m_rare)
+                return {};
+            return m_rare->lowest_floating_descendant_bottom_margin_edge;
         }
 
         void set_override_borders_data(Painting::Paintable::BordersDataWithElementKind const& override_borders_data) { ensure_rare_data().override_borders_data = override_borders_data; }
@@ -344,7 +344,7 @@ struct LayoutState {
 
             RareData() = default;
             RareData(RareData const& other)
-                : floating_descendants(other.floating_descendants)
+                : lowest_floating_descendant_bottom_margin_edge(other.lowest_floating_descendant_bottom_margin_edge)
                 , table_cell_coordinates(other.table_cell_coordinates)
                 , computed_svg_path(other.computed_svg_path)
                 , grid_template_columns(other.grid_template_columns)
@@ -359,7 +359,7 @@ struct LayoutState {
                     flex_layout_data = make<FlexLayoutData>(*other.flex_layout_data);
             }
 
-            HashTable<Box const*> floating_descendants;
+            Optional<CSSPixels> lowest_floating_descendant_bottom_margin_edge;
             Optional<Painting::Paintable::TableCellCoordinates> table_cell_coordinates;
             Optional<Gfx::Path> computed_svg_path;
             OwnPtr<GridLayoutData> grid_layout_data;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -183,12 +183,7 @@ struct LayoutState {
 
         void materialize_from_paintable(Painting::Paintable const&);
 
-        void set_content_offset(CSSPixelPoint new_offset) { offset = new_offset; }
-        void set_content_x(CSSPixels x) { offset.set_x(x); }
-        void set_content_y(CSSPixels y) { offset.set_y(y); }
-
-        // offset from top-left corner of content area of box's containing block to top-left corner of box's content area
-        CSSPixelPoint offset;
+        CSSPixelPoint content_offset() const { return m_content_offset.value_or({}); }
 
         SizeConstraint width_constraint { SizeConstraint::None };
         SizeConstraint height_constraint { SizeConstraint::None };
@@ -328,6 +323,13 @@ struct LayoutState {
 
     private:
         friend struct LayoutState;
+        friend class FormattingContext;
+
+        void place(CSSPixelPoint content_offset)
+        {
+            VERIFY(!m_content_offset.has_value());
+            m_content_offset = content_offset;
+        }
 
         AvailableSize available_width_inside() const;
         AvailableSize available_height_inside() const;
@@ -386,6 +388,8 @@ struct LayoutState {
 
         bool m_has_definite_width { false };
         bool m_has_definite_height { false };
+
+        Optional<CSSPixelPoint> m_content_offset;
 
         OwnPtr<RareData> m_rare;
     };

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -185,6 +185,8 @@ struct LayoutState {
 
         CSSPixelPoint content_offset() const { return m_content_offset.value_or({}); }
 
+        bool is_placed() const { return m_content_offset.has_value(); }
+
         SizeConstraint width_constraint { SizeConstraint::None };
         SizeConstraint height_constraint { SizeConstraint::None };
 

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -186,8 +186,8 @@ void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom,
 
     // The fragment stores logical (inline/block) coordinates, while the box state carries physical ones.
     auto is_horizontal = m_writing_mode == CSS::WritingMode::HorizontalTb;
-    auto inline_offset = is_horizontal ? box_state.offset.x() : box_state.offset.y();
-    auto block_offset = is_horizontal ? box_state.offset.y() : box_state.offset.x();
+    auto inline_offset = is_horizontal ? box_state.content_offset().x() : box_state.content_offset().y();
+    auto block_offset = is_horizontal ? box_state.content_offset().y() : box_state.content_offset().x();
     auto inline_length = is_horizontal ? box_state.content_width() : box_state.content_height();
     auto block_length = is_horizontal ? box_state.content_height() : box_state.content_width();
 

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -47,7 +47,7 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
     auto wrapper_constraints = constraints_for_child_context(root_state, layout_input.containing_block_constraints);
     auto& wrapper_state = m_state.create(*wrapper, wrapper_constraints.percentage_basis_width, wrapper_constraints.percentage_basis_height);
     wrapper_state.set_content_width(content_width);
-    wrapper_state.set_content_offset({ 0, 0 });
+    place_child(*wrapper, { 0, 0 });
 
     auto bfc = make<BlockFormattingContext>(m_state, m_layout_mode, *wrapper, this);
     bfc->run(LayoutInput { child_available_space, wrapper_constraints });

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -47,7 +47,6 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
     auto wrapper_constraints = constraints_for_child_context(root_state, layout_input.containing_block_constraints);
     auto& wrapper_state = m_state.create(*wrapper, wrapper_constraints.percentage_basis_width, wrapper_constraints.percentage_basis_height);
     wrapper_state.set_content_width(content_width);
-    place_child(*wrapper, { 0, 0 });
 
     auto bfc = make<BlockFormattingContext>(m_state, m_layout_mode, *wrapper, this);
     bfc->run(LayoutInput { child_available_space, wrapper_constraints });
@@ -56,6 +55,8 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
     m_automatic_content_height = bfc->automatic_content_height();
 
     wrapper_state.set_content_height(m_automatic_content_height);
+
+    place_child(*wrapper, { 0, 0 });
 
     bfc->parent_context_did_dimension_child_root_box();
 }

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -203,7 +203,8 @@ void SVGFormattingContext::run(LayoutInput const& layout_input)
     auto& svg_box_state = m_state.get_mutable(context_box());
 
     auto const& document = context_box().document();
-    if (document.document_element() == context_box().dom_node() && !document.is_decoded_svg()) {
+    auto is_materialized_svg_root = svg_box_state.is_placed();
+    if (document.document_element() == context_box().dom_node() && !document.is_decoded_svg() && !is_materialized_svg_root) {
         // Overwrite the content width/height with the styled node width/height (from <svg width height ...>)
 
         // NOTE: If a height had not been provided by the svg element, it was set to the height of the container
@@ -333,12 +334,14 @@ void SVGFormattingContext::layout_svg_element(Box const& child, LayoutInput cons
         child_state.set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
         auto to_css_pixels_transform = Gfx::AffineTransform {}.multiply(m_current_viewbox_transform).multiply(svg_transform);
         auto transformed_rect = to_css_pixels_transform.map(rect.to_type<float>()).to_type<CSSPixels>();
-        place_child(child, transformed_rect.location());
         child_state.set_content_width(transformed_rect.width());
         child_state.set_content_height(transformed_rect.height());
 
         auto child_available_space = AvailableSpace(AvailableSize::make_definite(child_state.content_width()), AvailableSize::make_definite(child_state.content_height()));
         bfc.run(LayoutInput { child_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
+
+        // Masks and clips may use this offset for objectBoundingBox units.
+        place_child(child, transformed_rect.location());
 
         if (auto* mask_box = child.first_child_of_type<SVGMaskBox>())
             layout_mask_or_clip(*mask_box);
@@ -413,9 +416,9 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
             { nested_viewport_width.to_float(), nested_viewport_height.to_float() }
         };
         auto mapped_nested_viewport_rect = m_current_viewbox_transform.map(nested_viewport_rect_in_parent_user_space);
-        place_child(viewport, mapped_nested_viewport_rect.location().to_type<CSSPixels>());
         nested_viewport_state.set_content_width(CSSPixels(mapped_nested_viewport_rect.width()));
         nested_viewport_state.set_content_height(CSSPixels(mapped_nested_viewport_rect.height()));
+        place_child(viewport, mapped_nested_viewport_rect.location().to_type<CSSPixels>());
     }
 }
 
@@ -543,9 +546,9 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
     // Stroke increases the path's size by stroke_width/2 per side.
     CSSPixels stroke_width = CSSPixels::nearest_value_for(graphics_box.dom_node().visible_stroke_width() * m_current_viewbox_transform.x_scale());
     transformed_bounding_box.inflate(stroke_width, stroke_width);
-    place_child(graphics_box, transformed_bounding_box.top_left());
     graphics_box_state.set_content_width(transformed_bounding_box.width());
     graphics_box_state.set_content_height(transformed_bounding_box.height());
+    place_child(graphics_box, transformed_bounding_box.top_left());
     graphics_box_state.set_has_definite_width(true);
     graphics_box_state.set_has_definite_height(true);
     graphics_box_state.set_computed_svg_path(move(path));
@@ -592,9 +595,9 @@ void SVGFormattingContext::layout_image_element(SVGImageBox const& image_box)
                                        .multiply(box_state.computed_svg_transforms()->svg_transform());
     auto bounding_box = to_css_pixels_transform.map(image_box.dom_node().bounding_box(m_viewport_size)).to_type<CSSPixels>();
 
-    place_child(image_box, bounding_box.top_left());
     box_state.set_content_width(bounding_box.width());
     box_state.set_content_height(bounding_box.height());
+    place_child(image_box, bounding_box.top_left());
     box_state.set_has_definite_width(true);
     box_state.set_has_definite_height(true);
 }
@@ -646,9 +649,9 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
 
     Gfx::FloatRect box_rect_in_parent_user_space { {}, { float(layout_state.content_width()), float(layout_state.content_height()) } };
     auto mapped_box_rect = parent_viewbox_transform.map(box_rect_in_parent_user_space);
-    place_child(mask_or_clip, mapped_box_rect.location().to_type<CSSPixels>());
     layout_state.set_content_width(CSSPixels(mapped_box_rect.width()));
     layout_state.set_content_height(CSSPixels(mapped_box_rect.height()));
+    place_child(mask_or_clip, mapped_box_rect.location().to_type<CSSPixels>());
 }
 
 void SVGFormattingContext::layout_container_element(SVGBox const& container, LayoutInput const& layout_input, Gfx::AffineTransform const& container_svg_transform)
@@ -665,9 +668,9 @@ void SVGFormattingContext::layout_container_element(SVGBox const& container, Lay
         bounding_box.add_point(child_state.content_offset().translated(child_state.content_width(), child_state.content_height()));
         return IterationDecision::Continue;
     });
-    place_child(container, { bounding_box.x(), bounding_box.y() });
     box_state.set_content_width(bounding_box.width());
     box_state.set_content_height(bounding_box.height());
+    place_child(container, { bounding_box.x(), bounding_box.y() });
     box_state.set_has_definite_width(true);
     box_state.set_has_definite_height(true);
 }

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -333,7 +333,7 @@ void SVGFormattingContext::layout_svg_element(Box const& child, LayoutInput cons
         child_state.set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
         auto to_css_pixels_transform = Gfx::AffineTransform {}.multiply(m_current_viewbox_transform).multiply(svg_transform);
         auto transformed_rect = to_css_pixels_transform.map(rect.to_type<float>()).to_type<CSSPixels>();
-        child_state.set_content_offset(transformed_rect.location());
+        place_child(child, transformed_rect.location());
         child_state.set_content_width(transformed_rect.width());
         child_state.set_content_height(transformed_rect.height());
 
@@ -404,7 +404,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
     nested_viewport_state.set_has_definite_width(true);
     nested_viewport_state.set_has_definite_height(true);
     if (has_own_view_box)
-        nested_viewport_state.set_content_offset(content_offset);
+        place_child(viewport, content_offset);
     SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform, parent_svg_transform);
     nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
     if (!has_own_view_box) {
@@ -413,7 +413,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
             { nested_viewport_width.to_float(), nested_viewport_height.to_float() }
         };
         auto mapped_nested_viewport_rect = m_current_viewbox_transform.map(nested_viewport_rect_in_parent_user_space);
-        nested_viewport_state.set_content_offset(mapped_nested_viewport_rect.location().to_type<CSSPixels>());
+        place_child(viewport, mapped_nested_viewport_rect.location().to_type<CSSPixels>());
         nested_viewport_state.set_content_width(CSSPixels(mapped_nested_viewport_rect.width()));
         nested_viewport_state.set_content_height(CSSPixels(mapped_nested_viewport_rect.height()));
     }
@@ -543,7 +543,7 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
     // Stroke increases the path's size by stroke_width/2 per side.
     CSSPixels stroke_width = CSSPixels::nearest_value_for(graphics_box.dom_node().visible_stroke_width() * m_current_viewbox_transform.x_scale());
     transformed_bounding_box.inflate(stroke_width, stroke_width);
-    graphics_box_state.set_content_offset(transformed_bounding_box.top_left());
+    place_child(graphics_box, transformed_bounding_box.top_left());
     graphics_box_state.set_content_width(transformed_bounding_box.width());
     graphics_box_state.set_content_height(transformed_bounding_box.height());
     graphics_box_state.set_has_definite_width(true);
@@ -592,7 +592,7 @@ void SVGFormattingContext::layout_image_element(SVGImageBox const& image_box)
                                        .multiply(box_state.computed_svg_transforms()->svg_transform());
     auto bounding_box = to_css_pixels_transform.map(image_box.dom_node().bounding_box(m_viewport_size)).to_type<CSSPixels>();
 
-    box_state.set_content_offset(bounding_box.top_left());
+    place_child(image_box, bounding_box.top_left());
     box_state.set_content_width(bounding_box.width());
     box_state.set_content_height(bounding_box.height());
     box_state.set_has_definite_width(true);
@@ -624,14 +624,14 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
             auto& parent_node_state = m_state.get(*mask_or_clip.parent());
             layout_state.set_content_width(CSSPixels::nearest_value_for(pattern.pattern_width().value() * parent_node_state.content_width().to_double()));
             layout_state.set_content_height(CSSPixels::nearest_value_for(pattern.pattern_height().value() * parent_node_state.content_height().to_double()));
-            parent_viewbox_transform = Gfx::AffineTransform {}.translate(parent_node_state.offset.to_type<float>());
+            parent_viewbox_transform = Gfx::AffineTransform {}.translate(parent_node_state.content_offset().to_type<float>());
         }
     } else if (content_units == SVG::SVGUnits::ObjectBoundingBox) {
         auto& parent_node_state = m_state.get(*mask_or_clip.parent());
         layout_state.set_content_width(parent_node_state.content_width());
         layout_state.set_content_height(parent_node_state.content_height());
         // https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternContentUnitsAttribute
-        parent_viewbox_transform = Gfx::AffineTransform {}.translate(parent_node_state.offset.to_type<float>());
+        parent_viewbox_transform = Gfx::AffineTransform {}.translate(parent_node_state.content_offset().to_type<float>());
         if (pattern_box)
             parent_viewbox_transform.scale(parent_node_state.content_width().to_float(), parent_node_state.content_height().to_float());
     } else {
@@ -646,7 +646,7 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
 
     Gfx::FloatRect box_rect_in_parent_user_space { {}, { float(layout_state.content_width()), float(layout_state.content_height()) } };
     auto mapped_box_rect = parent_viewbox_transform.map(box_rect_in_parent_user_space);
-    layout_state.set_content_offset(mapped_box_rect.location().to_type<CSSPixels>());
+    place_child(mask_or_clip, mapped_box_rect.location().to_type<CSSPixels>());
     layout_state.set_content_width(CSSPixels(mapped_box_rect.width()));
     layout_state.set_content_height(CSSPixels(mapped_box_rect.height()));
 }
@@ -661,11 +661,11 @@ void SVGFormattingContext::layout_container_element(SVGBox const& container, Lay
             return IterationDecision::Continue;
         layout_svg_element(child, layout_input, container_svg_transform);
         auto& child_state = m_state.get(child);
-        bounding_box.add_point(child_state.offset);
-        bounding_box.add_point(child_state.offset.translated(child_state.content_width(), child_state.content_height()));
+        bounding_box.add_point(child_state.content_offset());
+        bounding_box.add_point(child_state.content_offset().translated(child_state.content_width(), child_state.content_height()));
         return IterationDecision::Continue;
     });
-    box_state.set_content_offset({ bounding_box.x(), bounding_box.y() });
+    place_child(container, { bounding_box.x(), bounding_box.y() });
     box_state.set_content_width(bounding_box.width());
     box_state.set_content_height(bounding_box.height());
     box_state.set_has_definite_width(true);

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -297,22 +297,7 @@ void SVGFormattingContext::run(LayoutInput const& layout_input)
 
     m_available_space = available_space;
     m_quirks_mode_percentage_basis_height = layout_input.containing_block_constraints.quirks_mode_percentage_basis_height;
-    m_svg_offset = svg_box_state.offset;
     m_viewport_size = { viewport_width, viewport_height };
-
-    if (svg_box_state.has_definite_width() && svg_box_state.has_definite_height()) {
-        // Scale the box of the viewport based on the parent's viewBox transform.
-        // The viewBox transform is always just a simple scale + offset.
-        // FIXME: Avoid converting SVG box to floats.
-        Gfx::FloatRect svg_rect = { svg_box_state.offset.to_type<float>(),
-            { float(svg_box_state.content_width()), float(svg_box_state.content_height()) } };
-        svg_rect = m_parent_viewbox_transform.map(svg_rect);
-        svg_box_state.set_content_offset(svg_rect.location().to_type<CSSPixels>());
-        svg_box_state.set_content_width(CSSPixels(svg_rect.width()));
-        svg_box_state.set_content_height(CSSPixels(svg_rect.height()));
-        svg_box_state.set_has_definite_width(true);
-        svg_box_state.set_has_definite_height(true);
-    }
 
     auto svg_transform_for_children = m_parent_svg_transform.value_or(Gfx::AffineTransform {});
     if (svg_box_state.computed_svg_transforms().has_value())
@@ -400,7 +385,8 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
     auto parent_viewbox_transform = m_current_viewbox_transform;
 
     auto* svg_element = as_if<SVG::SVGSVGElement>(*viewport.dom_node());
-    if (svg_element && svg_element->view_box().has_value()) {
+    bool has_own_view_box = svg_element && svg_element->view_box().has_value();
+    if (has_own_view_box) {
         // FIXME: Avoid converting SVG box to floats.
         Gfx::FloatRect nested_rect {
             { nested_viewport_x.to_float(), nested_viewport_y.to_float() },
@@ -413,13 +399,24 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
         parent_viewbox_transform = {};
     }
 
-    nested_viewport_state.set_content_offset(content_offset);
     nested_viewport_state.set_content_width(content_width);
     nested_viewport_state.set_content_height(content_height);
     nested_viewport_state.set_has_definite_width(true);
     nested_viewport_state.set_has_definite_height(true);
+    if (has_own_view_box)
+        nested_viewport_state.set_content_offset(content_offset);
     SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform, parent_svg_transform);
     nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
+    if (!has_own_view_box) {
+        Gfx::FloatRect nested_viewport_rect_in_parent_user_space {
+            { nested_viewport_x.to_float(), nested_viewport_y.to_float() },
+            { nested_viewport_width.to_float(), nested_viewport_height.to_float() }
+        };
+        auto mapped_nested_viewport_rect = m_current_viewbox_transform.map(nested_viewport_rect_in_parent_user_space);
+        nested_viewport_state.set_content_offset(mapped_nested_viewport_rect.location().to_type<CSSPixels>());
+        nested_viewport_state.set_content_width(CSSPixels(mapped_nested_viewport_rect.width()));
+        nested_viewport_state.set_content_height(CSSPixels(mapped_nested_viewport_rect.height()));
+    }
 }
 
 Gfx::Path SVGFormattingContext::compute_path_for_text(SVGTextBox const& text_box) const
@@ -595,8 +592,7 @@ void SVGFormattingContext::layout_image_element(SVGImageBox const& image_box)
                                        .multiply(box_state.computed_svg_transforms()->svg_transform());
     auto bounding_box = to_css_pixels_transform.map(image_box.dom_node().bounding_box(m_viewport_size)).to_type<CSSPixels>();
 
-    box_state.set_content_x(bounding_box.x());
-    box_state.set_content_y(bounding_box.y());
+    box_state.set_content_offset(bounding_box.top_left());
     box_state.set_content_width(bounding_box.width());
     box_state.set_content_height(bounding_box.height());
     box_state.set_has_definite_width(true);
@@ -647,6 +643,12 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
     layout_state.set_has_definite_width(true);
     layout_state.set_has_definite_height(true);
     nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
+
+    Gfx::FloatRect box_rect_in_parent_user_space { {}, { float(layout_state.content_width()), float(layout_state.content_height()) } };
+    auto mapped_box_rect = parent_viewbox_transform.map(box_rect_in_parent_user_space);
+    layout_state.set_content_offset(mapped_box_rect.location().to_type<CSSPixels>());
+    layout_state.set_content_width(CSSPixels(mapped_box_rect.width()));
+    layout_state.set_content_height(CSSPixels(mapped_box_rect.height()));
 }
 
 void SVGFormattingContext::layout_container_element(SVGBox const& container, LayoutInput const& layout_input, Gfx::AffineTransform const& container_svg_transform)
@@ -663,8 +665,7 @@ void SVGFormattingContext::layout_container_element(SVGBox const& container, Lay
         bounding_box.add_point(child_state.offset.translated(child_state.content_width(), child_state.content_height()));
         return IterationDecision::Continue;
     });
-    box_state.set_content_x(bounding_box.x());
-    box_state.set_content_y(bounding_box.y());
+    box_state.set_content_offset({ bounding_box.x(), bounding_box.y() });
     box_state.set_content_width(bounding_box.width());
     box_state.set_content_height(bounding_box.height());
     box_state.set_has_definite_width(true);

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -43,7 +43,6 @@ private:
     Optional<CSSPixels> m_quirks_mode_percentage_basis_height {};
     Gfx::AffineTransform m_current_viewbox_transform {};
     CSSPixelSize m_viewport_size {};
-    CSSPixelPoint m_svg_offset {};
     Gfx::FloatPoint m_current_text_position {};
 };
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -52,7 +52,8 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
             if (block_context) {
                 auto available_width = caption_available_space.width.to_px_or_zero();
                 block_context->resolve_vertical_box_model_metrics(child_box, available_width);
-                block_context->compute_width(child_box, caption_available_space, caption_constraints);
+                CSSPixelPoint caption_position_in_block_context {};
+                block_context->compute_width(child_box, caption_available_space, caption_constraints, caption_position_in_block_context);
                 inner_available_space = m_state.get(child_box).available_inner_space_or_constraints_from(caption_available_space);
             }
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -44,12 +44,13 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
         // Captions live inside the table wrapper, so their quirks percentage height basis derives
         // from the wrapper, not from anything the table box inherited.
         auto const& caption_constraints = m_participant_constraints;
-        bool caption_was_positioned_before_inside_layout = false;
+        bool caption_was_placed = false;
         // The caption boxes are principal block-level boxes that retain their own content, padding, margin, and border areas,
         // and are rendered as normal block boxes inside the table wrapper box, as described in https://www.w3.org/TR/CSS22/tables.html#model
         if (auto caption_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, child_box)) {
             auto inner_available_space = caption_available_space;
             auto* block_context = as_if<BlockFormattingContext>(caption_context.ptr());
+            CSSPixelPoint caption_offset;
             if (block_context) {
                 auto available_width = caption_available_space.width.to_px_or_zero();
                 block_context->resolve_vertical_box_model_metrics(child_box, available_width);
@@ -58,11 +59,9 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 inner_available_space = m_state.get(child_box).available_inner_space_or_constraints_from(caption_available_space);
 
                 auto const& caption_state = m_state.get(child_box);
-                CSSPixelPoint caption_offset { caption_state.border_box_left(), 0 };
+                caption_offset = { caption_state.border_box_left(), 0 };
                 if (phase == CSS::CaptionSide::Bottom)
                     caption_offset.set_y(m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top());
-                place_child(child_box, caption_offset);
-                caption_was_positioned_before_inside_layout = true;
             }
 
             caption_context->run(LayoutInput { inner_available_space, caption_constraints });
@@ -73,13 +72,15 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                     auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_height();
                     caption_state.set_content_height(height);
                 }
+                place_child(child_box, caption_offset);
+                caption_was_placed = true;
             }
         }
 
         auto const& caption_state = m_state.get(child_box);
         if (phase == CSS::CaptionSide::Top) {
             m_pending_table_box_content_offset_in_wrapper.set_y(caption_state.content_height() + caption_state.margin_box_bottom());
-        } else if (!caption_was_positioned_before_inside_layout) {
+        } else if (!caption_was_placed) {
             place_child(child_box, { caption_state.border_box_left(), m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top() });
         }
         caption_height += caption_state.margin_box_height();
@@ -1258,7 +1259,6 @@ void TableFormattingContext::position_row_boxes()
         CSSPixels row_group_width = 0;
 
         auto& row_group_box_state = m_state.get_mutable(row_group_box);
-        place_child(row_group_box, { row_group_left_offset, row_group_top_offset });
 
         int num_rows = 0;
         TableGrid::for_each_child_box_matching(row_group_box, TableGrid::is_table_row, [&](auto& row) {
@@ -1272,6 +1272,7 @@ void TableFormattingContext::position_row_boxes()
 
         row_group_box_state.set_content_height(row_group_height);
         row_group_box_state.set_content_width(row_group_width);
+        place_child(row_group_box, { row_group_left_offset, row_group_top_offset });
 
         row_group_top_offset += row_group_height + (num_rows > 0 ? border_spacing_vertical() : 0);
     });

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -44,6 +44,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
         // Captions live inside the table wrapper, so their quirks percentage height basis derives
         // from the wrapper, not from anything the table box inherited.
         auto const& caption_constraints = m_participant_constraints;
+        bool caption_was_positioned_before_inside_layout = false;
         // The caption boxes are principal block-level boxes that retain their own content, padding, margin, and border areas,
         // and are rendered as normal block boxes inside the table wrapper box, as described in https://www.w3.org/TR/CSS22/tables.html#model
         if (auto caption_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, child_box)) {
@@ -55,16 +56,19 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 CSSPixelPoint caption_position_in_block_context {};
                 block_context->compute_width(child_box, caption_available_space, caption_constraints, caption_position_in_block_context);
                 inner_available_space = m_state.get(child_box).available_inner_space_or_constraints_from(caption_available_space);
+
+                auto const& caption_state = m_state.get(child_box);
+                CSSPixelPoint caption_offset { caption_state.border_box_left(), 0 };
+                if (phase == CSS::CaptionSide::Bottom)
+                    caption_offset.set_y(m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top());
+                m_state.get_mutable(child_box).set_content_offset(caption_offset);
+                caption_was_positioned_before_inside_layout = true;
             }
 
             caption_context->run(LayoutInput { inner_available_space, caption_constraints });
 
             if (block_context) {
                 auto& caption_state = m_state.get_mutable(child_box);
-
-                // Adjust x offset so border-box aligns with the table wrapper.
-                caption_state.set_content_x(caption_state.offset.x() + caption_state.border_left + caption_state.padding_left);
-
                 if (should_treat_height_as_auto(child_box, caption_available_space, m_participant_constraints)) {
                     auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_height();
                     caption_state.set_content_height(height);
@@ -74,10 +78,9 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
 
         auto const& caption_state = m_state.get(child_box);
         if (phase == CSS::CaptionSide::Top) {
-            m_state.get_mutable(table_box()).set_content_y(caption_state.content_height() + caption_state.margin_box_bottom());
-        } else {
-            m_state.get_mutable(child_box).set_content_y(
-                m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top());
+            m_pending_table_box_content_offset_in_wrapper.set_y(caption_state.content_height() + caption_state.margin_box_bottom());
+        } else if (!caption_was_positioned_before_inside_layout) {
+            m_state.get_mutable(child_box).set_content_offset({ caption_state.offset.x(), m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top() });
         }
         caption_height += caption_state.margin_box_height();
     }
@@ -1229,7 +1232,7 @@ void TableFormattingContext::position_row_boxes()
 {
     auto const& table_state = m_state.get(table_box());
 
-    CSSPixels row_top_offset = table_state.offset.y() + border_spacing_vertical();
+    CSSPixels row_top_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
     CSSPixels row_left_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
     for (size_t y = 0; y < m_rows.size(); y++) {
         auto& row = m_rows[y];
@@ -1243,21 +1246,19 @@ void TableFormattingContext::position_row_boxes()
 
         row_state.set_content_height(row.final_height);
         row_state.set_content_width(row_width);
-        row_state.set_content_x(row_left_offset);
-        row_state.set_content_y(row_top_offset);
+        row_state.set_content_offset({ row_left_offset, row_top_offset });
         if (!row.is_collapsed)
             row_top_offset += row_state.content_height() + border_spacing_vertical();
     }
 
-    CSSPixels row_group_top_offset = table_state.offset.y() + border_spacing_vertical();
+    CSSPixels row_group_top_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
     CSSPixels row_group_left_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
     TableGrid::for_each_child_box_matching(table_box(), TableGrid::is_table_row_group, [&](auto& row_group_box) {
         CSSPixels row_group_height = 0;
         CSSPixels row_group_width = 0;
 
         auto& row_group_box_state = m_state.get_mutable(row_group_box);
-        row_group_box_state.set_content_x(row_group_left_offset);
-        row_group_box_state.set_content_y(row_group_top_offset);
+        row_group_box_state.set_content_offset({ row_group_left_offset, row_group_top_offset });
 
         int num_rows = 0;
         TableGrid::for_each_child_box_matching(row_group_box, TableGrid::is_table_row, [&](auto& row) {
@@ -1275,7 +1276,7 @@ void TableFormattingContext::position_row_boxes()
         row_group_top_offset += row_group_height + (num_rows > 0 ? border_spacing_vertical() : 0);
     });
 
-    auto total_content_height = max(row_top_offset, row_group_top_offset) - table_state.offset.y() - table_state.padding_top;
+    auto total_content_height = max(row_top_offset, row_group_top_offset) - m_pending_table_box_content_offset_in_wrapper.y() - table_state.padding_top;
     m_table_height = max(total_content_height, m_table_height);
 }
 
@@ -1351,9 +1352,10 @@ void TableFormattingContext::position_cell_boxes()
         // - for top: the height reserved for top captions (including margins), if any
         // - the padding-left/padding-top and border-left-width/border-top-width of the table
         // FIXME: Account for visibility.
-        cell_state.set_content_offset(row_state.offset.translated(
+        auto cell_offset = row_state.offset.translated(
             cell_state.border_box_left() + m_columns[cell.column_index].left_offset + cell.column_index * border_spacing_horizontal(),
-            cell_state.border_box_top()));
+            cell_state.border_box_top());
+        cell_state.set_content_offset(cell_offset);
     }
 }
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -61,7 +61,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 CSSPixelPoint caption_offset { caption_state.border_box_left(), 0 };
                 if (phase == CSS::CaptionSide::Bottom)
                     caption_offset.set_y(m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top());
-                m_state.get_mutable(child_box).set_content_offset(caption_offset);
+                place_child(child_box, caption_offset);
                 caption_was_positioned_before_inside_layout = true;
             }
 
@@ -80,7 +80,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
         if (phase == CSS::CaptionSide::Top) {
             m_pending_table_box_content_offset_in_wrapper.set_y(caption_state.content_height() + caption_state.margin_box_bottom());
         } else if (!caption_was_positioned_before_inside_layout) {
-            m_state.get_mutable(child_box).set_content_offset({ caption_state.offset.x(), m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top() });
+            place_child(child_box, { caption_state.border_box_left(), m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top() });
         }
         caption_height += caption_state.margin_box_height();
     }
@@ -1246,7 +1246,7 @@ void TableFormattingContext::position_row_boxes()
 
         row_state.set_content_height(row.final_height);
         row_state.set_content_width(row_width);
-        row_state.set_content_offset({ row_left_offset, row_top_offset });
+        place_child(row.box, { row_left_offset, row_top_offset });
         if (!row.is_collapsed)
             row_top_offset += row_state.content_height() + border_spacing_vertical();
     }
@@ -1258,7 +1258,7 @@ void TableFormattingContext::position_row_boxes()
         CSSPixels row_group_width = 0;
 
         auto& row_group_box_state = m_state.get_mutable(row_group_box);
-        row_group_box_state.set_content_offset({ row_group_left_offset, row_group_top_offset });
+        place_child(row_group_box, { row_group_left_offset, row_group_top_offset });
 
         int num_rows = 0;
         TableGrid::for_each_child_box_matching(row_group_box, TableGrid::is_table_row, [&](auto& row) {
@@ -1352,10 +1352,10 @@ void TableFormattingContext::position_cell_boxes()
         // - for top: the height reserved for top captions (including margins), if any
         // - the padding-left/padding-top and border-left-width/border-top-width of the table
         // FIXME: Account for visibility.
-        auto cell_offset = row_state.offset.translated(
+        auto cell_offset = row_state.content_offset().translated(
             cell_state.border_box_left() + m_columns[cell.column_index].left_offset + cell.column_index * border_spacing_horizontal(),
             cell_state.border_box_top());
-        cell_state.set_content_offset(cell_offset);
+        place_child(cell.box, cell_offset);
     }
 }
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -36,6 +36,9 @@ public:
 
     Box const& table_box() const { return context_box(); }
 
+    void set_pending_table_box_content_offset_in_wrapper(CSSPixelPoint offset) { m_pending_table_box_content_offset_in_wrapper = offset; }
+    CSSPixelPoint pending_table_box_content_offset_in_wrapper() const { return m_pending_table_box_content_offset_in_wrapper; }
+
     static bool border_is_less_specific(CSS::BorderData const& a, CSS::BorderData const& b);
 
     virtual void parent_context_did_dimension_child_root_box() override;
@@ -86,6 +89,7 @@ private:
 
     CSSPixels m_table_height { 0 };
     CSSPixels m_automatic_content_height { 0 };
+    CSSPixelPoint m_pending_table_box_content_offset_in_wrapper {};
 
     Optional<AvailableSpace> m_available_space;
     bool m_needs_fixed_mode_row_measurement { false };


### PR DESCRIPTION
With changes in this PR we no longer allow to store provisional box's offset in UsedValue, instead LayoutState API is restructured such that each box is only allowed to be placed once at its final position. By doing that we open opportunity to start catching bugs when layout code reads unassigned offset which was previously not possible to enforce. The moment layout box is "placed" is also considered a point when it got it's final geometry, so any future reassignments of width/height would VERIFY().