### PR TITLE
CI: Use Blacksmith macOS M4 machines for build jobs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -87,7 +87,7 @@ runs:
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 26.2
+        xcode-version: '26.5'
 
     - name: 'Install Dependencies'
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -117,7 +117,23 @@ runs:
     - name: 'Warm up the Rust toolchain'
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
       shell: bash
-      run: rustup toolchain install
+      run: |
+        if rustup toolchain install ; then
+          exit 0
+        fi
+
+        # Some Blacksmith runner images boot with a partially installed toolchain whose files rustup does not know
+        # about. It cannot repair that on its own and fails with a "detected conflict" error, so wipe the toolchain and
+        # retry.
+        CHANNEL=$(sed -n 's/^channel *= *"\(.*\)"/\1/p' "${{ github.workspace }}/rust-toolchain.toml")
+        if [ -z "${CHANNEL}" ]; then
+          echo "Could not determine the pinned Rust channel" >&2
+          exit 1
+        fi
+
+        echo "Reinstalling Rust toolchain ${CHANNEL} from scratch"
+        rustup toolchain uninstall "${CHANNEL}" || rm -rf "$(rustup show home)/toolchains/${CHANNEL}"-*
+        rustup toolchain install
 
     - name: 'Resolve wasm-tools release'
       id: 'wasm-tools'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             build_preset: 'Sanitizer'
             toolchain: 'Clang'
             clang_plugins: false
-            runner_labels: '["macos-26", "self-hosted"]'
+            runner_labels: '["blacksmith-12vcpu-macos-26"]'
             container: 'null'
 
           - os_name: 'Linux'

--- a/.github/workflows/js-and-wasm-artifacts.yml
+++ b/.github/workflows/js-and-wasm-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
             arch: 'arm64'
             toolchain: 'Clang'
             package_type: 'macOS-arm64'
-            runner_labels: '["macos-26", "self-hosted"]'
+            runner_labels: '["blacksmith-6vcpu-macos-26"]'
             container: 'null'
 
           - os_name: 'Linux'

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -40,7 +40,7 @@ jobs:
             build_preset: 'Distribution'
             toolchain: 'Clang'
             clang_plugins: false
-            runner_labels: '["macos-26", "self-hosted"]'
+            runner_labels: '["blacksmith-6vcpu-macos-26"]'
             container: 'null'
 
           - os_name: 'Linux'

--- a/Services/Compositor/SandboxMacOS.cpp
+++ b/Services/Compositor/SandboxMacOS.cpp
@@ -48,9 +48,11 @@ ErrorOr<void> apply_sandbox(StringView cache_path)
         }
     }
 
-    // ANGLE's Metal backend opens this while creating WebGL contexts.
+    // ANGLE's Metal backend opens one of these while creating WebGL contexts, depending on whether the GPU is real
+    // hardware or the paravirtualized device of a virtual machine.
     static constexpr Array metal_iokit_user_client_classes {
         "AGXDeviceUserClient"sv,
+        "AppleParavirtDeviceUserClient"sv,
     };
 
     return Sandbox::apply_macos_sandbox(paths.span(), Sandbox::NetworkAccess::Denied, {}, metal_iokit_user_client_classes);


### PR DESCRIPTION
This should alleviate the macOS job pressure by making use of Blacksmith's fleet of macOS runners. We still use our self-hosted benchmarking machine whenever we need more reproducible results.