### PR TITLE
LibWeb: Collect abspos containing-block children during layout

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1871,28 +1871,6 @@ void Document::update_layout(UpdateLayoutReason reason)
 
             layout_node.recompute_containing_block({});
 
-            auto* box = as_if<Layout::Box>(layout_node);
-            if (!box)
-                return TraversalDecision::Continue;
-
-            box->clear_contained_abspos_children();
-
-            if (!box->is_absolutely_positioned())
-                return TraversalDecision::Continue;
-
-            if (auto containing_block = box->containing_block()) {
-                auto closest_box_that_establishes_formatting_context = containing_block;
-                while (closest_box_that_establishes_formatting_context) {
-                    if (closest_box_that_establishes_formatting_context == m_layout_root)
-                        break;
-                    if (Layout::FormattingContext::formatting_context_type_created_by_box(*closest_box_that_establishes_formatting_context).has_value())
-                        break;
-                    closest_box_that_establishes_formatting_context = closest_box_that_establishes_formatting_context->containing_block();
-                }
-                VERIFY(closest_box_that_establishes_formatting_context);
-                closest_box_that_establishes_formatting_context->add_contained_abspos_child(*box);
-            }
-
             return TraversalDecision::Continue;
         });
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1051,24 +1051,12 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     if (box.is_absolutely_positioned()) {
         if (m_layout_mode == LayoutMode::Normal) {
-            // Absolutely positioned boxes enter layout here, in the context that contains them.
-            // Two kinds of boxes already have used values: list item markers, whose used values
-            // were created together with the ListItemBox that places them, and the document
-            // element, which was created by the layout entry point (and can end up absolutely
-            // positioned, e.g. as a popover).
-            auto box_is_document_element = box.dom_node() && box.dom_node() == box.document().document_element();
-            // The percentage basis of an absolutely positioned box is the padding box of its
-            // absolute positioning containing block; layout_absolutely_positioned_element() pins
-            // it once that rectangle is known.
-            auto& box_state = is<ListItemMarkerBox>(box) || box_is_document_element
-                ? m_state.get_mutable(box)
-                : m_state.create(box, {}, {});
             // NB: An originally-inline absolutely positioned box never reaches this path; the tree
             //     builder keeps out-of-flow boxes in inline context, where static position markers
             //     pin them at their exact flow position.
             StaticPositionRect static_position;
             static_position.rect = { { 0, m_y_offset_of_current_block_container.value() }, { 0, 0 } };
-            box_state.set_static_position_rect(static_position);
+            register_contained_abspos_child(box, static_position);
         }
         return;
     }

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -55,10 +55,6 @@ public:
 
     virtual RefPtr<Painting::Paintable> create_paintable() const override;
 
-    void add_contained_abspos_child(Node& child) { m_contained_abspos_children.append(child.make_weak_ptr()); }
-    void clear_contained_abspos_children() { m_contained_abspos_children.clear(); }
-    Vector<WeakPtr<Node>> const& contained_abspos_children() const { return m_contained_abspos_children; }
-
     void set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_scroll_in_x, bool compensates_for_scroll_in_y)
     {
         m_default_scroll_shift_anchor = move(anchor);
@@ -85,8 +81,6 @@ protected:
 
 private:
     virtual bool is_box() const final { return true; }
-
-    Vector<WeakPtr<Node>> m_contained_abspos_children;
 
     WeakPtr<Node> m_default_scroll_shift_anchor;
     bool m_compensates_for_scroll_in_x { false };

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -280,9 +280,8 @@ void FlexFormattingContext::parent_context_did_dimension_child_root_box()
         return;
 
     flex_container().for_each_child_of_type<Box>([&](Layout::Box& box) {
-        if (box.is_absolutely_positioned()) {
-            m_state.create(box, {}, {}).set_static_position_rect(calculate_static_position_rect(box));
-        }
+        if (box.is_absolutely_positioned())
+            register_contained_abspos_child(box, calculate_static_position_rect(box));
         return IterationDecision::Continue;
     });
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -384,6 +384,27 @@ Optional<FormattingContext::Type> FormattingContext::formatting_context_type_cre
     return {};
 }
 
+Box const& FormattingContext::box_establishing_containing_formatting_context(Box const& child)
+{
+    auto const* box = child.containing_block();
+    VERIFY(box);
+    while (box->containing_block() && !formatting_context_type_created_by_box(*box).has_value())
+        box = box->containing_block();
+    return *box;
+}
+
+void FormattingContext::register_contained_abspos_child(Box const& child, StaticPositionRect const& static_position_rect)
+{
+    if (!child.containing_block())
+        return;
+    m_state.register_contained_abspos_child(box_establishing_containing_formatting_context(child), child, static_position_rect);
+}
+
+CSSPixelPoint FormattingContext::aligned_static_position(StaticPositionRect const& static_position_rect, LayoutState::UsedValues const& box_state)
+{
+    return static_position_rect.aligned_position_for_box_with_size({ box_state.margin_box_width(), box_state.margin_box_height() });
+}
+
 // FIXME: This is a hack. Get rid of it.
 struct ReplacedFormattingContext : public FormattingContext {
     ReplacedFormattingContext(LayoutState& state, LayoutMode layout_mode, Box const& box)
@@ -955,20 +976,20 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     return used_width;
 }
 
-void FormattingContext::compute_width_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+void FormattingContext::compute_width_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
 {
     if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints))
-        compute_width_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints);
+        compute_width_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints, static_position_rect);
     else
-        compute_width_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints);
+        compute_width_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, static_position_rect);
 }
 
-void FormattingContext::compute_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints))
-        compute_height_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
+        compute_height_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints, static_position_rect, before_or_after_inside_layout);
     else
-        compute_height_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
+        compute_height_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, static_position_rect, before_or_after_inside_layout);
 }
 
 CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
@@ -1086,7 +1107,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
     return used_height;
 }
 
-void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
 {
     auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto const& computed_values = box.computed_values();
@@ -1149,7 +1170,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             width = CSS::Length::make_px(content_width);
             m_state.get_mutable(box).set_content_width(content_width);
 
-            auto static_position = m_state.get(box).static_position();
+            auto static_position = aligned_static_position(static_position_rect, box_state);
 
             left = static_position.x();
             right = solve_for_right();
@@ -1205,7 +1226,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         //    Then solve for 'left' (if 'direction is 'rtl') or 'right' (if 'direction' is 'ltr').
         else if (computed_left.is_auto() && computed_right.is_auto() && !width.is_auto()) {
             // FIXME: Check direction
-            auto static_position = m_state.get(box).static_position();
+            auto static_position = aligned_static_position(static_position_rect, box_state);
             left = static_position.x();
             right = solve_for_right();
         }
@@ -1270,7 +1291,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 }
 
 // https://drafts.csswg.org/css2/#abs-replaced-width
-void FormattingContext::compute_width_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+void FormattingContext::compute_width_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
 {
     // 10.3.8 Absolutely positioned, replaced elements
     // In this case, section 10.3.7 applies up through and including the constraint equation,
@@ -1291,7 +1312,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
     auto margin_left = computed_values.margin().left();
     auto right = computed_values.inset().right();
     auto margin_right = computed_values.margin().right();
-    auto static_position = m_state.get(box).static_position();
+    auto static_position = aligned_static_position(static_position_rect, box_state);
 
     auto to_px = [&](CSS::LengthPercentageOrAuto const& l) {
         return l.to_px_or_zero(width_of_containing_block);
@@ -1354,7 +1375,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
 }
 
 // https://drafts.csswg.org/css-position-3/#abs-non-replaced-height
-void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     // 5.3. The Height Of Absolutely Positioned, Non-Replaced Elements
 
@@ -1468,7 +1489,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             auto constrained_height = apply_min_max_height_constraints(height);
             m_state.get_mutable(box).set_content_height(constrained_height.to_px_or_zero());
 
-            auto static_position = m_state.get(box).static_position();
+            auto static_position = aligned_static_position(static_position_rect, state);
             top = CSS::Length::make_px(static_position.y());
 
             solve_for_bottom();
@@ -1523,7 +1544,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             // 2. If top and bottom are auto and height is not auto,
             else if (top.is_auto() && bottom.is_auto() && !height.is_auto()) {
                 // then set top to the static position,
-                top = CSS::Length::make_px(m_state.get(box).static_position().y());
+                top = CSS::Length::make_px(aligned_static_position(static_position_rect, state).y());
 
                 // then solve for bottom.
                 solve_for_bottom();
@@ -2189,19 +2210,24 @@ void FormattingContext::layout_absolutely_positioned_children(Box const& box)
 {
     if (m_layout_mode != LayoutMode::Normal)
         return;
-    for (auto& child : box.contained_abspos_children()) {
-        if (!child)
-            continue;
-        layout_absolutely_positioned_element(as<Box>(*child));
+    // Laying out one child can register further children onto this box (a fixed position
+    // box inside an absolutely positioned one shares its viewport containing block), so
+    // take one at a time instead of iterating a snapshot.
+    while (true) {
+        auto child = m_state.take_next_contained_abspos_child(box);
+        if (!child.has_value())
+            break;
+        layout_absolutely_positioned_element(const_cast<Box&>(*child->box), child->static_position_rect);
     }
 }
 
-void FormattingContext::layout_absolutely_positioned_element(Box& box)
+void FormattingContext::layout_absolutely_positioned_element(Box& box, StaticPositionRect const& static_position_rect)
 {
     // SVG elements cannot be absolutely positioned.
     VERIFY(!box.is_svg_box());
 
-    auto& box_state = m_state.get_mutable(box);
+    auto* existing_box_state = m_state.try_get_mutable(box);
+    auto& box_state = existing_box_state ? *existing_box_state : m_state.create(box, {}, {});
 
     resolve_anchor_insets(box);
 
@@ -2237,12 +2263,12 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     box_state.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
     box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
 
-    compute_width_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints);
+    compute_width_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect);
 
     // NOTE: We compute height before *and* after doing inside layout.
     //       This is done so that inside layout can resolve percentage heights.
     //       In some situations, e.g with non-auto top & bottom values, the height can be determined early.
-    compute_height_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, BeforeOrAfterInsideLayout::Before);
+    compute_height_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect, BeforeOrAfterInsideLayout::Before);
 
     // If the box width and/or height is fixed and/or or resolved from inset properties,
     // mark the size as being definite (since layout was not required to resolve it, per CSS-SIZING-3).
@@ -2275,7 +2301,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, LayoutInput { box_state.available_inner_space_or_constraints_from(available_space), absolutely_positioned_constraints });
 
     if (computed_values.height().is_auto()) {
-        compute_height_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, BeforeOrAfterInsideLayout::After);
+        compute_height_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect, BeforeOrAfterInsideLayout::After);
     }
 
     // Apply grid alignment for auto inset axes
@@ -2324,7 +2350,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
 
     CSSPixelPoint used_offset;
 
-    auto static_position = m_state.get(box).static_position();
+    auto static_position = aligned_static_position(static_position_rect, box_state);
     auto const* static_position_cb = box.static_position_containing_block();
     auto actual_containing_block = box.containing_block();
     if (static_position_cb && static_position_cb != actual_containing_block) {
@@ -2364,7 +2390,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
 }
 
-void FormattingContext::compute_height_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_height_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     // 10.6.5 Absolutely positioned, replaced elements
     // This situation is similar to 10.6.4, except that the element has an intrinsic height.
@@ -2384,7 +2410,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     auto margin_top = computed_values.margin().top();
     auto bottom = computed_values.inset().bottom();
     auto margin_bottom = computed_values.margin().bottom();
-    auto static_position = m_state.get(box).static_position();
+    auto static_position = aligned_static_position(static_position_rect, box_state);
 
     auto to_px = [&](CSS::LengthPercentageOrAuto const& l) {
         return l.to_px_or_zero(height_of_containing_block);

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -129,6 +129,10 @@ public:
 
     [[nodiscard]] static Optional<Type> formatting_context_type_created_by_box(Box const&);
 
+    // The box whose formatting context lays out `child` if `child` is absolutely
+    // positioned: the closest formatting context root at or above its containing block.
+    [[nodiscard]] static Box const& box_establishing_containing_formatting_context(Box const& child);
+
     static bool creates_block_formatting_context(Box const&);
 
     CSSPixels compute_table_box_width_inside_table_wrapper(Box const&, AvailableSpace const&,
@@ -237,25 +241,27 @@ protected:
 
     ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&, ContainingBlockConstraints const&);
 
-    void layout_absolutely_positioned_element(Box&);
+    void layout_absolutely_positioned_element(Box&, StaticPositionRect const&);
 
     CSSPixels gap_to_px(Variant<CSS::LengthPercentage, CSS::NormalGap> const& gap, CSSPixels reference_value) const;
 
+    void register_contained_abspos_child(Box const& child, StaticPositionRect const&);
+    [[nodiscard]] static CSSPixelPoint aligned_static_position(StaticPositionRect const&, LayoutState::UsedValues const&);
     void layout_absolutely_positioned_children();
     void layout_absolutely_positioned_children(Box const&);
     virtual AbsposContainingBlockInfo resolve_abspos_containing_block_info(Box const&);
     void resolve_anchor_insets(Box&) const;
-    void compute_width_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
-    void compute_width_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
-    void compute_width_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
+    void compute_width_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
+    void compute_width_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
+    void compute_width_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
 
     enum class BeforeOrAfterInsideLayout {
         Before,
         After,
     };
-    void compute_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout);
-    void compute_height_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout);
-    void compute_height_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout);
+    void compute_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
+    void compute_height_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
+    void compute_height_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
 
     [[nodiscard]] Optional<CSSPixels> compute_auto_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout) const;
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -3102,7 +3102,10 @@ void GridFormattingContext::parent_context_did_dimension_child_root_box()
 
     grid_container().for_each_child_of_type<Box>([&](Layout::Box& box) {
         if (box.is_absolutely_positioned()) {
-            m_state.create(box, {}, {}).set_static_position_rect(calculate_static_position_rect(box));
+            // A zero static position rect suffices: it is only consulted when the containing
+            // block is not the grid container; when it is, the static position is the grid
+            // area rect, which GFC's abspos containing block resolution supplies instead.
+            register_contained_abspos_child(box, {});
         }
         return IterationDecision::Continue;
     });
@@ -3993,17 +3996,6 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
     }
 
     return calculate_min_content_contribution(item, dimension);
-}
-
-StaticPositionRect GridFormattingContext::calculate_static_position_rect(Box const& box) const
-{
-    // Result of this function is only used when containing block is not a grid container.
-    // If the containing block is a grid container then static position is a grid area rect and
-    // layout_absolutely_positioned_element() defined for GFC knows how to handle this case.
-    StaticPositionRect static_position;
-    auto const& box_state = m_state.get(box);
-    static_position.rect = { { 0, 0 }, { box_state.content_width(), box_state.content_height() } };
-    return static_position;
 }
 
 }

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -173,7 +173,6 @@ public:
     virtual void run(LayoutInput const&) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
-    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     Box const& grid_container() const { return context_box(); }
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -574,10 +574,7 @@ void InlineFormattingContext::generate_line_boxes()
                 if (found_static_position_marker)
                     break;
             }
-            auto& box_state = is<ListItemMarkerBox>(*box)
-                ? m_state.get_mutable(*box)
-                : m_state.create(*box, {}, {});
-            box_state.set_static_position_rect(static_position_rect);
+            register_contained_abspos_child(*box, static_position_rect);
         }
     }
 

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -1194,4 +1194,34 @@ void LayoutState::UsedValues::set_indefinite_content_height()
     m_has_definite_height = false;
 }
 
+void LayoutState::register_contained_abspos_child(Box const& target, Box const& child, StaticPositionRect const& static_position_rect)
+{
+    auto& children = m_contained_abspos_children.ensure(&target);
+    // The same box can be encountered again when a subtree is intentionally laid out
+    // twice (percentage-height table cells); the fresh static position replaces the
+    // stale one instead of duplicating the entry. New entries are inserted in layout
+    // index order so consumption follows document order.
+    size_t insertion_index = children.size();
+    for (size_t i = 0; i < children.size(); ++i) {
+        if (children[i].box == &child) {
+            children[i].static_position_rect = static_position_rect;
+            return;
+        }
+        if (insertion_index == children.size() && child.layout_index() < children[i].box->layout_index())
+            insertion_index = i;
+    }
+    children.insert(insertion_index, { &child, static_position_rect });
+}
+
+Optional<LayoutState::ContainedAbsposChild> LayoutState::take_next_contained_abspos_child(Box const& target)
+{
+    auto it = m_contained_abspos_children.find(&target);
+    if (it == m_contained_abspos_children.end())
+        return {};
+    auto child = it->value.take_first();
+    if (it->value.is_empty())
+        m_contained_abspos_children.remove(it);
+    return child;
+}
+
 }

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/BumpAllocator.h>
+#include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 #include <AK/kmalloc.h>
 #include <LibGfx/Path.h>
@@ -315,14 +316,6 @@ struct LayoutState {
             return move(m_rare->flex_layout_data);
         }
 
-        void set_static_position_rect(StaticPositionRect const& static_position_rect) { ensure_rare_data().static_position_rect = static_position_rect; }
-        CSSPixelPoint static_position() const
-        {
-            if (!m_rare || !m_rare->static_position_rect.has_value())
-                return {};
-            return m_rare->static_position_rect->aligned_position_for_box_with_size({ margin_box_width(), margin_box_height() });
-        }
-
     private:
         friend struct LayoutState;
         friend class FormattingContext;
@@ -355,7 +348,6 @@ struct LayoutState {
                 , grid_template_rows(other.grid_template_rows)
                 , override_borders_data(other.override_borders_data)
                 , computed_svg_transforms(other.computed_svg_transforms)
-                , static_position_rect(other.static_position_rect)
             {
                 if (other.grid_layout_data)
                     grid_layout_data = make<GridLayoutData>(*other.grid_layout_data);
@@ -372,7 +364,6 @@ struct LayoutState {
             RefPtr<CSS::GridTrackSizeListStyleValue const> grid_template_rows;
             Optional<Painting::Paintable::BordersDataWithElementKind> override_borders_data;
             Optional<Painting::SVGGraphicsPaintable::ComputedTransforms> computed_svg_transforms;
-            Optional<StaticPositionRect> static_position_rect;
         };
 
         RareData& ensure_rare_data()
@@ -430,12 +421,20 @@ struct LayoutState {
 
     bool has_subtree_root() const { return m_subtree_root != nullptr; }
 
+    struct ContainedAbsposChild {
+        Box const* box { nullptr };
+        StaticPositionRect static_position_rect;
+    };
+    void register_contained_abspos_child(Box const& target, Box const& child, StaticPositionRect const&);
+    [[nodiscard]] Optional<ContainedAbsposChild> take_next_contained_abspos_child(Box const& target);
+
 private:
     void resolve_relative_positions();
 
     PagedStore<UsedValues> m_used_values_store;
     Layout::NodeWithStyle const* m_subtree_root { nullptr };
     bool m_should_collect_devtools_layout_data { false };
+    HashMap<Box const*, Vector<ContainedAbsposChild>> m_contained_abspos_children;
 };
 
 inline CSSPixels clamp_to_max_dimension_value(CSSPixels value)

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1815,16 +1815,8 @@ void TableFormattingContext::seed_table_participant_used_values(ContainingBlockC
         if (!child_box)
             continue;
 
-        if (child_box->display().is_table_caption()) {
+        if (child_box->display().is_table_caption())
             m_state.create(*child_box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
-            continue;
-        }
-
-        if (!child_box->is_absolutely_positioned() || m_state.try_get_mutable(*child_box))
-            continue;
-
-        auto& child_box_state = m_state.create(*child_box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
-        child_box_state.set_static_position_rect(calculate_static_position_rect(*child_box));
     }
 }
 
@@ -1893,11 +1885,10 @@ void TableFormattingContext::parent_context_did_dimension_child_root_box()
         return;
 
     context_box().for_each_in_subtree_of_type<Box const>([&](Layout::Box const& box) {
-        if (box.is_absolutely_positioned() && !m_state.try_get(box)) {
-            // FIXME: calculate_static_position_rect() is not aware of how to correctly calculate static position for
-            //        a box nested inside a table, but we need to set some value, so layout_absolutely_positioned_element()
-            //        won't crash trying to access it.
-            m_state.create(box, {}, {}).set_static_position_rect(calculate_static_position_rect(box));
+        if (box.is_absolutely_positioned()) {
+            // FIXME: Calculate the real static position for a box nested inside a table
+            //        instead of registering a zero rect.
+            register_contained_abspos_child(box, {});
         }
 
         if (formatting_context_type_created_by_box(box).has_value()) {
@@ -2144,14 +2135,6 @@ CSSPixels TableFormattingContext::border_spacing_vertical() const
     if (computed_values.border_collapse() == CSS::BorderCollapse::Collapse)
         return 0;
     return computed_values.border_spacing_vertical();
-}
-
-StaticPositionRect TableFormattingContext::calculate_static_position_rect(Box const&) const
-{
-    // FIXME: Implement static position calculation for table descendants instead of always returning a rectangle with zero position and size.
-    StaticPositionRect static_position;
-    static_position.rect = { { 0, 0 }, { 0, 0 } };
-    return static_position;
 }
 
 template<>

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -32,7 +32,6 @@ public:
     virtual void run(LayoutInput const&) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
-    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     Box const& table_box() const { return context_box(); }
 


### PR DESCRIPTION
Every layout pass rebuilt a persistent per-box registry of contained absolutely positioned boxes with a whole-tree walk in update_layout(). Persistent derived state like this goes stale whenever the layout tree changes without that walk running. This change restructures code such that we no longer need this registery, which is going to simplify future partial relayout support.