### PR TITLE
LibWeb: Fix CSS animation and top layer bugs that broke kronansapotek.se

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -917,15 +917,8 @@ AnimationUpdateContext::~AnimationUpdateContext()
 
         if (invalidation.needs_relayout())
             target->set_needs_layout_update(DOM::SetNeedsLayoutReason::KeyframeEffect);
-        if (invalidation.needs_layout_tree_rebuild()) {
-            // We mark layout tree for rebuild starting from parent element to correctly invalidate
-            // "display" property change to/from "contents" value.
-            if (auto parent_element = target->parent_element()) {
-                parent_element->set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::KeyframeEffect);
-            } else {
-                target->set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::KeyframeEffect);
-            }
-        }
+        if (invalidation.needs_layout_tree_rebuild())
+            target->set_needs_layout_tree_rebuild(DOM::SetNeedsLayoutTreeUpdateReason::KeyframeEffect);
         if (invalidation.accumulated_visual_contexts() == CSS::AccumulatedVisualContextInvalidation::Rebuild) {
             element.document().set_needs_accumulated_visual_contexts_update(true);
         } else if (invalidation.accumulated_visual_contexts() == CSS::AccumulatedVisualContextInvalidation::UpdateValues) {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1429,7 +1429,7 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
         if (auto const& existing_animation = element_animations->get(animation_properties.name); existing_animation.has_value()) {
             as<Animations::KeyframeEffect>(*existing_animation.value()->effect()).set_key_frame_set(resolve_keyframes());
             existing_animation.value()->apply_css_properties(animation_properties);
-            return;
+            continue;
         }
 
         if (is_in_display_none_subtree())

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1367,6 +1367,32 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
     if (!element_animations)
         return;
 
+    // https://drafts.csswg.org/css-animations-1/#animations
+    // Setting the 'display' property to 'none' will terminate any running animation applied to the element and its
+    // descendants. If an element has a 'display' of 'none', updating 'display' to a value other than 'none' will
+    // start all animations applied to the element by the 'animation-name' property, as well as all animations
+    // applied to descendants with 'display' other than 'none'.
+    // NB: We must not start animations on elements that are not rendered due to display:none. Once display becomes
+    //     something other than none, the resulting style recomputation re-enters this function and starts them.
+    //     Termination of running animations when display becomes none is handled by
+    //     Element::play_or_cancel_animations_after_display_property_change().
+    // OPTIMIZATION: This involves an ancestor walk, so it's computed lazily since it's only needed on the path that
+    //               starts a brand new animation, not for the common case of an element without animations.
+    Optional<bool> in_display_none_subtree;
+    auto is_in_display_none_subtree = [&] {
+        if (!in_display_none_subtree.has_value()) {
+            bool result = computed_properties.display().is_none();
+            if (!result) {
+                if (abstract_element.pseudo_element().has_value())
+                    result = abstract_element.element().has_inclusive_ancestor_with_display_none_ignoring_animations();
+                else if (auto* parent = abstract_element.element().parent_or_shadow_host())
+                    result = parent->has_inclusive_ancestor_with_display_none_ignoring_animations();
+            }
+            in_display_none_subtree = result;
+        }
+        return in_display_none_subtree.value();
+    };
+
     HashTable<Utf16FlyString> defined_animation_names;
 
     for (auto const& animation_properties : animation_definitions) {
@@ -1405,6 +1431,9 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
             existing_animation.value()->apply_css_properties(animation_properties);
             return;
         }
+
+        if (is_in_display_none_subtree())
+            continue;
 
         // An animation applies to an element if its name appears as one of the identifiers in the computed value of the
         // animation-name property and the animation uses a valid @keyframes rule

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -36,13 +36,8 @@ static void apply_element_style_invalidation_after_style_change(DOM::Element& el
 
     if (invalidation.needs_relayout())
         element.set_needs_layout_update(DOM::SetNeedsLayoutReason::StyleChange);
-    if (invalidation.needs_layout_tree_rebuild()) {
-        // Mark the parent to handle display changes to/from contents correctly.
-        if (auto parent_element = element.parent_element())
-            parent_element->set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::StyleChange);
-        else
-            element.set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::StyleChange);
-    }
+    if (invalidation.needs_layout_tree_rebuild())
+        element.set_needs_layout_tree_rebuild(DOM::SetNeedsLayoutTreeUpdateReason::StyleChange);
 
     element.set_needs_style_update(false);
 }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1072,6 +1072,22 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
     return invalidation;
 }
 
+void Element::set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason reason)
+{
+    // NB: We normally mark the parent element for the rebuild rather than this element itself, so that a "display"
+    //     change to or from "contents" is handled correctly: an element with display:contents generates no box of its
+    //     own, so its children's boxes have to be inserted into (or removed from) the parent's subtree.
+    //     Top layer elements (open modal dialogs, popovers, fullscreen elements) are the exception. They generate
+    //     boxes as siblings of the root, and a dedicated top layer pass in the layout tree builder recreates their
+    //     boxes based on the element's own needs-layout-tree-update flag; the DOM parent's subtree rebuild skips them
+    //     entirely. Mark the element itself in that case. This still propagates child-needs-layout-tree-update up to
+    //     the document, which is what makes the top layer pass run.
+    if (auto parent = parent_element(); parent && !rendered_in_top_layer())
+        parent->set_needs_layout_tree_update(true, reason);
+    else
+        set_needs_layout_tree_update(true, reason);
+}
+
 void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
 {
     if (invalidation.needs_layout_tree_rebuild() || !unsafe_layout_node())

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -209,6 +209,8 @@ public:
     CSS::RequiredInvalidationAfterStyleChange recompute_style(bool& did_change_custom_properties);
     CSS::RequiredInvalidationAfterStyleChange recompute_inherited_style(ScheduleAnimationUpdate = ScheduleAnimationUpdate::No);
 
+    void set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason);
+
     Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element() const { return m_associated_shadow_host_pseudo_element; }
     void set_associated_shadow_host_pseudo_element(CSS::PseudoElement pseudo_element);
 

--- a/Libraries/LibWeb/WebDriver/Actions.cpp
+++ b/Libraries/LibWeb/WebDriver/Actions.cpp
@@ -176,7 +176,7 @@ static CSSPixelPoint get_parent_offset(HTML::BrowsingContext const& browsing_con
 }
 
 // https://w3c.github.io/webdriver/#dfn-get-coordinates-relative-to-an-origin
-static ErrorOr<CSSPixelPoint, WebDriver::Error> get_coordinates_relative_to_origin(PointerInputSource const& source, HTML::BrowsingContext const& browsing_context, CSSPixelPoint offset, CSSPixelRect viewport, ActionObject::Origin const& origin, ActionsOptions const& actions_options)
+static ErrorOr<CSSPixelPoint, WebDriver::Error> get_coordinates_relative_to_origin(PointerInputSource const* source, HTML::BrowsingContext const& browsing_context, CSSPixelPoint offset, CSSPixelRect viewport, ActionObject::Origin const& origin, ActionsOptions const& actions_options)
 {
     // FIXME: Spec-issue: If the browsing context is that of a subframe, we need to get its offset relative to the top
     //        frame, rather than its own frame.
@@ -195,10 +195,13 @@ static ErrorOr<CSSPixelPoint, WebDriver::Error> get_coordinates_relative_to_orig
 
             // "pointer"
             case ActionObject::OriginType::Pointer:
+                // NB: Scroll actions reject a pointer origin at processing time, so source is always non-null here.
+                VERIFY(source);
+
                 // 1. Let start x be equal to the x property of source.
                 // 2. Let start y be equal to the y property of source.
                 // 3. Let x equal start x + x offset and y equal start y + y offset.
-                return source.position.translated(offset);
+                return source->position.translated(offset);
             }
 
             VERIFY_NOT_REACHED();
@@ -1259,7 +1262,7 @@ static ErrorOr<void, WebDriver::Error> dispatch_pointer_move_action(ActionObject
     // 3. Let origin be equal to the origin property of action object.
     // 4. Let (x, y) be the result of trying to get coordinates relative to an origin with source, x offset, y offset,
     //    origin, browsing context, and actions options.
-    auto coordinates = TRY(get_coordinates_relative_to_origin(source, browsing_context, action_object.position, viewport, action_object.origin, actions_options));
+    auto coordinates = TRY(get_coordinates_relative_to_origin(&source, browsing_context, action_object.position, viewport, action_object.origin, actions_options));
 
     // 5. If x is less than 0 or greater than the width of the viewport in CSS pixels, then return error with error code move target out of bounds.
     if (coordinates.x() < 0 || coordinates.x() > viewport.width())
@@ -1290,6 +1293,50 @@ static ErrorOr<void, WebDriver::Error> dispatch_pointer_move_action(ActionObject
     TRY(perform_pointer_move(action_object, source, global_key_state, browsing_context, duration, coordinates));
 
     // 19. Return success with data null.
+    return {};
+}
+
+// https://w3c.github.io/webdriver/#dfn-dispatch-a-scroll-action
+static ErrorOr<void, WebDriver::Error> dispatch_scroll_action(ActionObject::ScrollFields const& action_object, GlobalKeyState const& global_key_state, AK::Duration tick_duration, HTML::BrowsingContext& browsing_context, ActionsOptions const& actions_options)
+{
+    auto viewport = browsing_context.page().top_level_traversable()->viewport_rect();
+
+    // 1. Let x offset be equal to the x property of action object.
+    // 2. Let y offset be equal to the y property of action object.
+    CSSPixelPoint offset { action_object.x, action_object.y };
+
+    // 3. Let origin be equal to the origin property of action object.
+    // 4. Let (x, y) be the result of trying to get coordinates relative to an origin with source, x offset, y offset,
+    //    origin, browsing context, and actions options.
+    auto coordinates = TRY(get_coordinates_relative_to_origin(nullptr, browsing_context, offset, viewport, action_object.origin, actions_options));
+
+    // 5. If x is less than 0 or greater than the width of the viewport in CSS pixels, then return error with error
+    //    code move target out of bounds.
+    if (coordinates.x() < 0 || coordinates.x() > viewport.width())
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::MoveTargetOutOfBounds, MUST(String::formatted("Coordinates {} are out of bounds", coordinates)));
+
+    // 6. If y is less than 0 or greater than the height of the viewport in CSS pixels, then return error with error
+    //    code move target out of bounds.
+    if (coordinates.y() < 0 || coordinates.y() > viewport.height())
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::MoveTargetOutOfBounds, MUST(String::formatted("Coordinates {} are out of bounds", coordinates)));
+
+    // 7. Let delta x be equal to the deltaX property of action object.
+    // 8. Let delta y be equal to the deltaY property of action object.
+    // 9. Let duration be equal to action object's duration property if it is not undefined, or tick duration otherwise.
+    [[maybe_unused]] auto duration = action_object.duration.value_or(tick_duration);
+
+    // FIXME: 10. If duration is greater than 0 and inside any implementation-defined bounds, asynchronously wait for
+    //            an implementation defined amount of time to pass.
+
+    // 11. Perform implementation-specific action dispatch steps on browsing context equivalent to scrolling by delta x
+    //     and delta y at viewport x coordinate x, viewport y coordinate y. Set ctrlKey, shiftKey, altKey, and metaKey
+    //     equal to the corresponding items in global key state. The scroll may be performed as a series of increments,
+    //     but the total scroll applied at the end of duration milliseconds must be delta x and delta y, and after each
+    //     increment the sum of the applied deltas must not be greater than delta x and delta y.
+    auto position = browsing_context.page().css_to_device_point(coordinates);
+    browsing_context.page().handle_mousewheel(position, position, 0, 0, global_key_state.modifiers(), static_cast<double>(action_object.delta_x), static_cast<double>(action_object.delta_y));
+
+    // 12. Return success with data null.
     return {};
 }
 
@@ -1475,7 +1522,8 @@ ErrorOr<void, WebDriver::Error> dispatch_tick_actions(InputState& input_state, R
         case ActionObject::Subtype::PointerCancel:
             return WebDriver::Error::from_code(WebDriver::ErrorCode::UnsupportedOperation, "Pointer cancel events not implemented"sv);
         case ActionObject::Subtype::Scroll:
-            return WebDriver::Error::from_code(WebDriver::ErrorCode::UnsupportedOperation, "Scroll events not implemented"sv);
+            TRY(dispatch_scroll_action(action_object.scroll_fields(), global_key_state, tick_duration, browsing_context, actions_options));
+            break;
         }
 
         // 9. If subtype is "keyDown", append a copy of action object with the subtype property changed to "keyUp" to

--- a/Tests/LibWeb/Text/expected/css/animation-name-removal-cancels-animation.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-name-removal-cancels-animation.txt
@@ -1,0 +1,2 @@
+with both animations: a,b
+after removing 'b' from animation-name: a,b

--- a/Tests/LibWeb/Text/expected/css/animation-name-removal-cancels-animation.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-name-removal-cancels-animation.txt
@@ -1,2 +1,2 @@
 with both animations: a,b
-after removing 'b' from animation-name: a,b
+after removing 'b' from animation-name: a

--- a/Tests/LibWeb/Text/expected/css/animations-not-started-in-display-none-subtree.txt
+++ b/Tests/LibWeb/Text/expected/css/animations-not-started-in-display-none-subtree.txt
@@ -1,9 +1,9 @@
-box animations: 1
+box animations: 0
 child animations: 0
-drawer animations: 1
+drawer animations: 0
 drawer computed display: none
-drawer has transform: true
-box has transform: true
+drawer has transform: false
+box has transform: false
 after reveal, box animations: 1
 after reveal, child animations: 1
 after hiding again, box animations: 0

--- a/Tests/LibWeb/Text/expected/css/animations-not-started-in-display-none-subtree.txt
+++ b/Tests/LibWeb/Text/expected/css/animations-not-started-in-display-none-subtree.txt
@@ -1,0 +1,10 @@
+box animations: 1
+child animations: 0
+drawer animations: 1
+drawer computed display: none
+drawer has transform: true
+box has transform: true
+after reveal, box animations: 1
+after reveal, child animations: 1
+after hiding again, box animations: 0
+after hiding again, child animations: 0

--- a/Tests/LibWeb/Text/expected/css/modal-dialog-display-animation-lays-out.txt
+++ b/Tests/LibWeb/Text/expected/css/modal-dialog-display-animation-lays-out.txt
@@ -1,4 +1,4 @@
 modal: true
 computed display: block
-has box: false
-width: 0
+has box: true
+width: 698

--- a/Tests/LibWeb/Text/expected/css/modal-dialog-display-animation-lays-out.txt
+++ b/Tests/LibWeb/Text/expected/css/modal-dialog-display-animation-lays-out.txt
@@ -1,0 +1,4 @@
+modal: true
+computed display: block
+has box: false
+width: 0

--- a/Tests/LibWeb/Text/expected/css/modal-dialog-display-toggle-lays-out.txt
+++ b/Tests/LibWeb/Text/expected/css/modal-dialog-display-toggle-lays-out.txt
@@ -1,4 +1,4 @@
 modal: true
 computed display: block
-has box: false
-width: 0
+has box: true
+width: 698

--- a/Tests/LibWeb/Text/expected/css/modal-dialog-display-toggle-lays-out.txt
+++ b/Tests/LibWeb/Text/expected/css/modal-dialog-display-toggle-lays-out.txt
@@ -1,0 +1,4 @@
+modal: true
+computed display: block
+has box: false
+width: 0

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/event-dispatch.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/event-dispatch.tentative.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 32 tests
 
-24 Pass
-8 Fail
+26 Pass
+6 Fail
 Pass	Idle -> Active
 Fail	Idle -> After
 Pass	Before -> Active
@@ -33,6 +33,6 @@ Pass	Set timeline and play transition after clearing the timeline.
 Pass	Set null target effect after canceling the animation.
 Fail	Cancel the animation after clearing the target effect.
 Pass	Replacing a running animation should get animationcancel earlier than animationstart
-Fail	The cancel event should be fired before the new start event if both have the same position in the animation list
-Fail	The cancel event with an earlier position in animation list should be fired earlier
+Pass	The cancel event should be fired before the new start event if both have the same position in the animation list
+Pass	The cancel event with an earlier position in animation list should be fired earlier
 Fail	The order of the cancel events follows the relative positions in the animation list at the point when they were cancelled

--- a/Tests/LibWeb/Text/input/css/animation-name-removal-cancels-animation.html
+++ b/Tests/LibWeb/Text/input/css/animation-name-removal-cancels-animation.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<style>
+    @keyframes a {
+        from {
+            opacity: 0.1;
+        }
+        to {
+            opacity: 0.9;
+        }
+    }
+
+    @keyframes b {
+        from {
+            transform: translateX(100px);
+        }
+        to {
+            transform: translateX(0);
+        }
+    }
+
+    #box.two {
+        animation: a 100s linear, b 100s linear;
+    }
+
+    #box.one {
+        animation: a 100s linear;
+    }
+</style>
+<div id="box" class="two"></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const box = document.getElementById("box");
+        const names = () =>
+            box
+                .getAnimations()
+                .map(animation => animation.animationName)
+                .sort()
+                .join(",");
+
+        println("with both animations: " + names());
+
+        box.className = "one";
+        println("after removing 'b' from animation-name: " + names());
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animations-not-started-in-display-none-subtree.html
+++ b/Tests/LibWeb/Text/input/css/animations-not-started-in-display-none-subtree.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<style>
+    @keyframes slide {
+        from {
+            transform: translateX(100px);
+        }
+        to {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes appear {
+        from {
+            display: none;
+            transform: translateX(100px);
+        }
+        to {
+            display: block;
+            transform: translateX(0);
+        }
+    }
+
+    #box {
+        display: none;
+        animation: slide 100s linear;
+    }
+
+    #child {
+        animation: slide 100s linear;
+    }
+
+    /* Mimics an animate-in drawer that should stay hidden while closed. */
+    #drawer {
+        display: none;
+        animation: appear 100s linear;
+    }
+</style>
+<div id="box"><div id="child"></div></div>
+<div id="drawer"></div>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        // Give any (incorrectly started) animation time to advance past progress 0.
+        await animationFrame();
+        await animationFrame();
+
+        const box = document.getElementById("box");
+        const child = document.getElementById("child");
+        const drawer = document.getElementById("drawer");
+
+        println("box animations: " + box.getAnimations().length);
+        println("child animations: " + child.getAnimations().length);
+        println("drawer animations: " + drawer.getAnimations().length);
+
+        // Force a style recomputation so a running animation would be re-sampled mid-flight.
+        drawer.style.setProperty("--force", "1");
+        println("drawer computed display: " + getComputedStyle(drawer).display);
+        println("drawer has transform: " + (getComputedStyle(drawer).transform !== "none"));
+        println("box has transform: " + (getComputedStyle(box).transform !== "none"));
+
+        box.style.display = "block";
+        println("after reveal, box animations: " + box.getAnimations().length);
+        println("after reveal, child animations: " + child.getAnimations().length);
+
+        box.style.display = "none";
+        println("after hiding again, box animations: " + box.getAnimations().length);
+        println("after hiding again, child animations: " + child.getAnimations().length);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/modal-dialog-display-animation-lays-out.html
+++ b/Tests/LibWeb/Text/input/css/modal-dialog-display-animation-lays-out.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<style>
+    @keyframes slide-in-left {
+        0% {
+            display: none;
+            transform: translateX(-100%);
+        }
+        100% {
+            display: block;
+            transform: translateX(0);
+        }
+    }
+
+    dialog.drawer {
+        position: fixed;
+        inset: 0;
+        width: 660px;
+        height: 100%;
+        margin: 0;
+        animation: slide-in-left 100s linear;
+    }
+</style>
+<div style="display: flex; gap: 24px;">
+    <button>Produkter</button>
+    <dialog id="drawer" class="drawer">Drawer contents</dialog>
+</div>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const drawer = document.getElementById("drawer");
+        drawer.showModal();
+
+        // The animation samples display:none at its very first frame, so the dialog starts
+        // without a box. Once display animates to block, its box must be (re)generated even
+        // though top layer elements lay out as siblings of the root.
+        await animationFrame();
+        await animationFrame();
+
+        const rect = drawer.getBoundingClientRect();
+        println("modal: " + drawer.matches(":modal"));
+        println("computed display: " + getComputedStyle(drawer).display);
+        println("has box: " + (rect.width > 0 && rect.height > 0));
+        println("width: " + rect.width);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/modal-dialog-display-toggle-lays-out.html
+++ b/Tests/LibWeb/Text/input/css/modal-dialog-display-toggle-lays-out.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+    dialog#drawer {
+        position: fixed;
+        inset: 0;
+        width: 660px;
+        height: 100%;
+        margin: 0;
+    }
+</style>
+<dialog id="drawer">Drawer contents</dialog>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const drawer = document.getElementById("drawer");
+        drawer.showModal();
+
+        // Toggle display off and back on with a forced style/layout flush in between. When display
+        // comes back, the dialog's box must be regenerated even though top layer elements lay out
+        // as siblings of the root rather than under their DOM parent.
+        drawer.style.display = "none";
+        drawer.getBoundingClientRect();
+        drawer.style.display = "block";
+
+        const rect = drawer.getBoundingClientRect();
+        println("modal: " + drawer.matches(":modal"));
+        println("computed display: " + getComputedStyle(drawer).display);
+        println("has box: " + (rect.width > 0 && rect.height > 0));
+        println("width: " + rect.width);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Investigating https://kronansapotek.se turned up three engine bugs:

- CSS animations were started on `display:none` elements, leaving sampled keyframe values stuck in computed style. This left the site's closed cart drawer covering the viewport.
- The animation definition loop returned early on the first already-existing animation, so elements with multiple animations never got later definitions updated or removed ones canceled. Fixing this also progresses two WPT event-dispatch subtests.
- Display changes requiring a layout tree rebuild marked the DOM parent, whose subtree rebuild skips top layer elements, so a modal dialog animating from display:none never got its box back. The site's **Produkter** flyout stayed invisible while scroll-locking the page. Fixed for both animated and plain style changes via a shared `Element::set_needs_layout_tree_rebuild()` helper.

Also implements the WebDriver wheel scroll action (previously an unsupported operation error), which was needed to drive the investigation.

Each fix is preceded by a test commit capturing the wrong behavior, so the fix commits show the expectations flipping.