### PR TITLE
LibWeb: Normalize table displays on replaced elements

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -352,6 +352,15 @@ Optional<FormattingContext::Type> FormattingContext::formatting_context_type_cre
 
     auto display = box.display();
 
+    // Native controls can use a generic box to host their shadow tree. When a table-specific
+    // display was adjusted to inline or block, keep that box atomic and give its contents an
+    // independent context without changing the formatting of ordinary controls.
+    if (box.has_replaced_element_table_display_adjustment()) {
+        if (is<BlockContainer>(box))
+            return Type::Block;
+        return Type::InternalReplaced;
+    }
+
     if (display.is_flex_inside())
         return Type::Flex;
 
@@ -3230,6 +3239,9 @@ CSSPixelRect FormattingContext::margin_box_rect_in_ancestor_coordinate_space(Box
 
 bool FormattingContext::box_is_sized_as_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
+    if (box.has_replaced_element_table_display_adjustment())
+        return true;
+
     // When a box has a preferred aspect ratio, its automatic sizes are calculated the same as for a
     // replaced element with a natural aspect ratio and no natural size in that axis, see e.g. CSS2 §10
     // and CSS Flexible Box Model Level 1 §9.2.

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -119,7 +119,7 @@ Layout::Node const* InlineLevelIterator::next_inline_node_in_pre_order(Layout::N
             || current.first_child()->is_out_of_flow(m_inline_formatting_context))
         && current.display().is_flow_inside()
         && !is_inline_flow_interrupting_block(current)
-        && !current.is_replaced_box()) {
+        && !current.is_atomic_inline()) {
         if (!current.is_box() || !static_cast<Box const&>(current).is_out_of_flow(m_inline_formatting_context))
             return current.first_child();
     }
@@ -168,7 +168,7 @@ void InlineLevelIterator::skip_to_next()
         && m_next_node->is_inline()
         && m_next_node->display().is_flow_inside()
         && !m_next_node->is_out_of_flow(m_inline_formatting_context)
-        && !m_next_node->is_replaced_box())
+        && !m_next_node->is_atomic_inline())
         enter_node_with_box_model_metrics(static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(*m_next_node));
 
     m_current_node = m_next_node;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -32,6 +32,7 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/FormattingContext.h>
@@ -1223,9 +1224,24 @@ bool Node::is_inline_table() const
     return display.is_inline_outside() && display.is_table_inside();
 }
 
+bool Node::is_replaced_element() const
+{
+    // Some native controls use a generic box so they can host their internal shadow tree, but
+    // remain replaced elements for CSS box generation and inline layout.
+    return is_replaced_box() || is<HTML::HTMLInputElement>(dom_node());
+}
+
+bool Node::has_replaced_element_table_display_adjustment() const
+{
+    if (!is_replaced_element())
+        return false;
+    auto display = display_before_box_type_transformation();
+    return display.is_table_inside() || display.is_internal_table() || display.is_table_caption();
+}
+
 bool Node::is_atomic_inline() const
 {
-    if (is_replaced_box())
+    if (is_replaced_element())
         return true;
     auto display = this->display();
     return display.is_inline_outside() && !display.is_flow_inside();

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -126,6 +126,8 @@ public:
     bool is_inline_block() const;
     bool is_inline_table() const;
 
+    bool is_replaced_element() const;
+    bool has_replaced_element_table_display_adjustment() const;
     bool is_atomic_inline() const;
     bool is_transformable() const;
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -80,7 +80,23 @@ static bool is_out_of_flow_table_internal_child_of_table_root(Layout::NodeWithSt
     return parent.display().is_table_inside()
         && !child.is_anonymous()
         && child.is_out_of_flow()
+        && !child.has_replaced_element_table_display_adjustment()
         && child.display_before_box_type_transformation().is_internal_table();
+}
+
+static Optional<CSS::Display> adjusted_table_display_for_replaced_element(CSS::Display display)
+{
+    // https://drafts.csswg.org/css-tables-3/#table-structure
+    // Replaced elements with a table-root display behave as block or inline depending on their
+    // outer display type. Replaced elements with a table-internal display behave as inline.
+    if (display.is_table_inside()) {
+        if (display.is_block_outside())
+            return CSS::Display::from_short(CSS::Display::Short::Block);
+        return CSS::Display::from_short(CSS::Display::Short::Inline);
+    }
+    if (display.is_internal_table() || display.is_table_caption())
+        return CSS::Display::from_short(CSS::Display::Short::Inline);
+    return {};
 }
 
 // The insertion_parent_for_*() functions maintain the invariant that the in-flow children of
@@ -882,6 +898,14 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
     if (!layout_node)
         return;
 
+    if (layout_node->is_replaced_element()) {
+        if (auto adjusted_display = adjusted_table_display_for_replaced_element(display); adjusted_display.has_value()) {
+            display = *adjusted_display;
+            auto& computed_values = as<NodeWithStyle>(*layout_node).mutable_computed_values();
+            computed_values.set_display(display);
+        }
+    }
+
     // Decide whether to replace an existing node (partial tree update) or insert a new one appropriately.
     bool const may_replace_existing_layout_node = must_create_subtree == MustCreateSubtree::No
         && old_layout_node
@@ -1464,6 +1488,8 @@ static CSS::Display display_for_table_fixup(Node const& node)
     //
     // AD-HOC: Table-internal boxes can be blockified before fixup. Use the pre-transformation display for authored
     // boxes so an out-of-flow table-header-group is still recognized as a proper table child during fixup.
+    if (node.has_replaced_element_table_display_adjustment())
+        return node.display();
     if (!node.is_anonymous())
         return node.display_before_box_type_transformation();
     return node.display();

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-tables/table-model-fixup-2.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-tables/table-model-fixup-2.txt
@@ -2,19 +2,18 @@ Harness status: OK
 
 Found 40 tests
 
-26 Pass
-14 Fail
-Fail	Replaced elements inside a table cannot be table-row and are considered inline -- input elements (width)
-Fail	Replaced elements inside a table cannot be table-row and are considered inline -- input elements (top)
-Fail	Replaced elements inside a table cannot be table-row and are considered inline -- img elements (width)
-Fail	Replaced elements inside a table cannot be table-row and are considered inline -- img elements (top)
-Fail	Replaced elements inside a table cannot be table-column and are considered inline -- input elements (width)
+40 Pass
+Pass	Replaced elements inside a table cannot be table-row and are considered inline -- input elements (width)
+Pass	Replaced elements inside a table cannot be table-row and are considered inline -- input elements (top)
+Pass	Replaced elements inside a table cannot be table-row and are considered inline -- img elements (width)
+Pass	Replaced elements inside a table cannot be table-row and are considered inline -- img elements (top)
+Pass	Replaced elements inside a table cannot be table-column and are considered inline -- input elements (width)
 Pass	Replaced elements inside a table cannot be table-column and are considered inline -- input elements (top)
-Fail	Replaced elements inside a table cannot be table-column and are considered inline -- img elements (width)
+Pass	Replaced elements inside a table cannot be table-column and are considered inline -- img elements (width)
 Pass	Replaced elements inside a table cannot be table-column and are considered inline -- img elements (top)
-Fail	Replaced elements inside a table cannot be table-cell and are considered inline -- input elements (width)
+Pass	Replaced elements inside a table cannot be table-cell and are considered inline -- input elements (width)
 Pass	Replaced elements inside a table cannot be table-cell and are considered inline -- input elements (top)
-Fail	Replaced elements inside a table cannot be table-cell and are considered inline -- img elements (width)
+Pass	Replaced elements inside a table cannot be table-cell and are considered inline -- img elements (width)
 Pass	Replaced elements inside a table cannot be table-cell and are considered inline -- img elements (top)
 Pass	Replaced elements outside a table cannot be inline-table and are considered inline -- input=text elements
 Pass	Replaced elements outside a table cannot be inline-table and are considered inline -- input=button elements
@@ -24,13 +23,13 @@ Pass	Replaced elements outside a table cannot be table and are considered block 
 Pass	Replaced elements outside a table cannot be table and are considered block -- input=button elements
 Pass	Replaced elements outside a table cannot be table and are considered block -- input=file elements
 Pass	Replaced elements outside a table cannot be table and are considered block -- img elements
-Fail	Replaced elements outside a table cannot be table-row and are considered inline -- input=text elements
-Fail	Replaced elements outside a table cannot be table-row and are considered inline -- input=button elements
-Fail	Replaced elements outside a table cannot be table-row and are considered inline -- input=file elements
+Pass	Replaced elements outside a table cannot be table-row and are considered inline -- input=text elements
+Pass	Replaced elements outside a table cannot be table-row and are considered inline -- input=button elements
+Pass	Replaced elements outside a table cannot be table-row and are considered inline -- input=file elements
 Pass	Replaced elements outside a table cannot be table-row and are considered inline -- img elements
-Fail	Replaced elements outside a table cannot be table-row-group and are considered inline -- input=text elements
-Fail	Replaced elements outside a table cannot be table-row-group and are considered inline -- input=button elements
-Fail	Replaced elements outside a table cannot be table-row-group and are considered inline -- input=file elements
+Pass	Replaced elements outside a table cannot be table-row-group and are considered inline -- input=text elements
+Pass	Replaced elements outside a table cannot be table-row-group and are considered inline -- input=button elements
+Pass	Replaced elements outside a table cannot be table-row-group and are considered inline -- input=file elements
 Pass	Replaced elements outside a table cannot be table-row-group and are considered inline -- img elements
 Pass	Replaced elements outside a table cannot be table-column and are considered inline inline -- input=text elements
 Pass	Replaced elements outside a table cannot be table-column and are considered inline -- input=button elements


### PR DESCRIPTION
Table fixup treated replaced images and input controls with table-root or table-internal display values as actual table participants. Some were wrapped as rows or cells and never received normal inline placement; others used generic inline-container traversal for native controls. This produced incorrect geometry and, with strict placement, unplaced boxes and duplicate UsedValues failures.

Apply the CSS Tables rule before inserting replaced layout nodes: table roots become block or inline based on their outer display. Internal table values and captions become inline. Preserve the authored display for computed-style bookkeeping but make table fixup use the adjusted value.

Recognize native input boxes as replaced atomic inlines even when their implementation uses a generic box for shadow content. Give only controls affected by table display normalization an independent internal context and replaced sizing, leaving ordinary control layout unchanged.