### PR TITLE
LibWeb: Skip style update of slotted elements with a styleless slot

### DIFF
--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/HTML/HTMLSlotElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/NavigableContainer.h>
 
@@ -218,6 +219,15 @@ static void enter_style_update_frame(StyleUpdateFrame& frame, StyleComputer& sty
 
 static bool should_update_style_for_child(StyleUpdateFrame const& frame, DOM::Node const& child, bool child_needs_inherited_style_update)
 {
+    // NB: Style inheritance follows the flat tree, so a slotted element inherits from its assigned slot. If that
+    //     slot has no computed style (because it sits in a display:none subtree that style update skips), the
+    //     slotted element's style cannot be computed either. Skip it; on-demand reads refresh it lazily via
+    //     update_style_for_element, and assigned slottables are invalidated when the slot eventually gets style.
+    if (auto const* element = as_if<DOM::Element>(child)) {
+        if (auto const slot = element->assigned_slot_internal(); slot && !slot->computed_properties())
+            return false;
+    }
+
     if (frame.traversal == StyleUpdateTraversal::TraverseDisplayNoneSubtrees) {
         if (auto const* element = as_if<DOM::Element>(child); element && !element->computed_properties())
             return true;

--- a/Tests/LibWeb/Crash/CSS/slotted-element-with-display-none-slot.html
+++ b/Tests/LibWeb/Crash/CSS/slotted-element-with-display-none-slot.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<div id="host"><span>slotted</span></div>
+<script>
+    const shadowRoot = host.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = "<div style='display: none'></div>";
+    // Force a style update so the display:none wrapper has computed style, but is no longer dirty.
+    document.body.offsetWidth;
+    // Insert the slot into the display:none subtree. The style update traversal will not descend into
+    // the wrapper, leaving the slot without computed style.
+    shadowRoot.firstChild.appendChild(document.createElement("slot"));
+    // Dirty the slotted element so the next style update recomputes it. Resolving the em length
+    // reads font metrics from the styleless slot it inherits from.
+    host.firstChild.style.fontSize = "2em";
+    getComputedStyle(document.body).getPropertyValue("width");
+</script>


### PR DESCRIPTION
Style inheritance follows the flat tree, so a slotted element inherits from its assigned slot. The style update traversal walks the DOM tree, though, so it could recompute a slotted element whose slot never got computed style because it sits in a `display:none` subtree that the traversal skips. Resolving font-relative lengths against the styleless slot then failed a `VERIFY` in `Length::ResolutionContext::for_element`.

Skip such elements during the traversal, like `display:none` descendants: on-demand reads already refresh them via update_style_for_element, and assigned slottables are invalidated when the slot eventually receives style. Add a crash test.

This fixes a crash when trying to create a post on https://reddit.com.