### PR TITLE
LibWebView+UI: Set the web view url, title, and favicon explictly and consistently on nav start

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -2817,7 +2817,7 @@ void Application::listen_for_navigation_events(DevTools::TabDescription const& d
         return;
 
     ViewImplementation::NavigationListener listener;
-    listener.on_load_start = [on_started = move(on_started)](URL::URL const& url, bool) {
+    listener.on_load_start = [on_started = move(on_started)](URL::URL const& url) {
         on_started(url.to_string());
     };
     listener.on_load_finish = [view_id = view->view_id(), on_finished = move(on_finished)](URL::URL const& url) {

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -125,20 +125,22 @@ void ViewImplementation::set_url(URL::URL url)
         apply_zoom_for_current_host();
 }
 
-void ViewImplementation::set_favicon(Badge<WebContentClient>, Gfx::Bitmap const& favicon)
+void ViewImplementation::set_favicon(Badge<WebContentClient>, Optional<Gfx::Bitmap const&> favicon)
 {
     m_favicon_base64_png.clear();
 
-    if (auto favicon_png = Gfx::PNGWriter::encode(favicon); !favicon_png.is_error()) {
-        if (auto favicon_base64_png = encode_base64(favicon_png.value().bytes()); !favicon_base64_png.is_error())
-            m_favicon_base64_png = favicon_base64_png.release_value();
-    }
+    if (favicon.has_value()) {
+        if (auto favicon_png = Gfx::PNGWriter::encode(*favicon); !favicon_png.is_error()) {
+            if (auto favicon_base64_png = encode_base64(favicon_png.value().bytes()); !favicon_base64_png.is_error())
+                m_favicon_base64_png = favicon_base64_png.release_value();
+        }
 
-    if (m_favicon_base64_png.has_value()) {
-        if (m_is_private == IsPrivate::No)
-            Application::bookmark_store().update_favicon(m_url, *m_favicon_base64_png);
-        if (!m_should_suppress_history_for_current_load)
-            Application::history_store(m_is_private).update_favicon(m_url, *m_favicon_base64_png);
+        if (m_favicon_base64_png.has_value()) {
+            if (m_is_private == IsPrivate::No)
+                Application::bookmark_store().update_favicon(m_url, *m_favicon_base64_png);
+            if (!m_should_suppress_history_for_current_load)
+                Application::history_store(m_is_private).update_favicon(m_url, *m_favicon_base64_png);
+        }
     }
 
     if (on_favicon_change)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -125,6 +125,17 @@ void ViewImplementation::set_url(URL::URL url)
         apply_zoom_for_current_host();
 }
 
+void ViewImplementation::set_title(Badge<WebContentClient>, Utf16String title)
+{
+    if (m_title == title)
+        return;
+
+    m_title = move(title);
+
+    if (on_title_change)
+        on_title_change(m_title);
+}
+
 void ViewImplementation::set_favicon(Badge<WebContentClient>, Optional<Gfx::Bitmap const&> favicon)
 {
     m_favicon_base64_png.clear();

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -123,6 +123,9 @@ void ViewImplementation::set_url(URL::URL url)
 
     if (current_host() != previous_host)
         apply_zoom_for_current_host();
+
+    if (on_url_change)
+        on_url_change(m_url);
 }
 
 void ViewImplementation::set_title(Badge<WebContentClient>, Utf16String title)
@@ -1229,10 +1232,8 @@ void ViewImplementation::apply_web_content_session_history_update(WebContentSess
 {
     if (update.current_url.has_value()) {
         auto current_url = *update.current_url;
-        auto const url_changed = m_url != current_url;
         set_url(current_url);
-        if (url_changed && on_url_change)
-            on_url_change(m_url);
+
         if (m_webdriver_pending_navigation_url.has_value() && *m_webdriver_pending_navigation_url != current_url)
             m_webdriver_pending_navigation_url = current_url;
         if (m_webdriver_pending_navigation_completes_with_session_history_update)
@@ -1463,10 +1464,7 @@ bool ViewImplementation::restore_pending_session_history_navigation(StringView r
 
     if (result.current_url.has_value()) {
         auto current_url = *result.current_url;
-        auto const url_changed = m_url != current_url;
         set_url(current_url);
-        if (url_changed && on_url_change)
-            on_url_change(m_url);
 
         if (result.web_content_restore_mode == PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess) {
             m_top_level_traversable.prepare_to_seed_web_content_session_history_from_ui_process();
@@ -1758,10 +1756,8 @@ void ViewImplementation::did_traverse_the_history_to_step(Badge<WebContentClient
         m_webdriver_pending_navigation_completes_with_session_history_update = false;
     if (step_result.current_url.has_value()) {
         auto current_url = *step_result.current_url;
-        auto const url_changed = m_url != current_url;
         set_url(current_url);
-        if (url_changed && on_url_change)
-            on_url_change(m_url);
+
         if (m_webdriver_pending_navigation_url.has_value() && *m_webdriver_pending_navigation_url != current_url)
             m_webdriver_pending_navigation_url = current_url;
     }

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -79,7 +79,7 @@ public:
     void set_url(Badge<WebContentClient>, URL::URL url) { set_url(move(url)); }
     URL::URL const& url() const { return m_url; }
 
-    void set_title(Badge<WebContentClient>, Utf16String title) { m_title = move(title); }
+    void set_title(Badge<WebContentClient>, Utf16String title);
     Utf16String const& title() const { return m_title; }
 
     void set_favicon(Badge<WebContentClient>, Optional<Gfx::Bitmap const&>);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -82,7 +82,7 @@ public:
     void set_title(Badge<WebContentClient>, Utf16String title) { m_title = move(title); }
     Utf16String const& title() const { return m_title; }
 
-    void set_favicon(Badge<WebContentClient>, Gfx::Bitmap const&);
+    void set_favicon(Badge<WebContentClient>, Optional<Gfx::Bitmap const&>);
     Optional<String> const& favicon_base64_png() const { return m_favicon_base64_png; }
 
     String const& handle() const { return m_client_state.client_handle; }
@@ -315,7 +315,7 @@ public:
 
     Function<void(ByteString const& path, i32)> on_request_file;
     Function<void(DictionaryLookup const&, Gfx::IntPoint)> on_request_dictionary_lookup;
-    Function<void(Gfx::Bitmap const&)> on_favicon_change;
+    Function<void(Optional<Gfx::Bitmap const&>)> on_favicon_change;
     Function<void(Gfx::Cursor const&)> on_cursor_change;
     Function<void(Gfx::IntPoint, ByteString const&)> on_request_tooltip_override;
     Function<void()> on_stop_tooltip_override;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -295,6 +295,13 @@ public:
     Function<void()> prepare_for_immediate_close();
     bool needs_beforeunload_check() const { return m_needs_beforeunload_check; }
 
+    struct NavigationListener {
+        Function<void(URL::URL const&)> on_load_start;
+        Function<void(URL::URL const&)> on_load_finish;
+    };
+    u64 add_navigation_listener(NavigationListener);
+    void remove_navigation_listener(u64 listener_id);
+
     Function<void()> on_ready_to_paint;
     Function<String(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Optional<u64>)> on_new_web_view;
     Function<void()> on_activate_tab;
@@ -303,16 +310,8 @@ public:
     Function<void()> on_link_unhover;
     Function<void(Utf16String const&)> on_title_change;
     Function<void(URL::URL const&)> on_url_change;
-    Function<void(URL::URL const&, bool)> on_load_start;
+    Function<void()> on_load_start;
     Function<void(URL::URL const&)> on_load_finish;
-
-    struct NavigationListener {
-        Function<void(URL::URL const&, bool)> on_load_start;
-        Function<void(URL::URL const&)> on_load_finish;
-    };
-    u64 add_navigation_listener(NavigationListener);
-    void remove_navigation_listener(u64 listener_id);
-
     Function<void(ByteString const& path, i32)> on_request_file;
     Function<void(DictionaryLookup const&, Gfx::IntPoint)> on_request_dictionary_lookup;
     Function<void(Optional<Gfx::Bitmap const&>)> on_favicon_change;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -597,6 +597,7 @@ void WebContentClient::did_start_loading(u64 page_id, URL::URL url, Variant<Empt
         view->did_start_navigation(url, move(document_resource), is_redirect, history_handling);
 
         view->set_url({}, url);
+        view->set_title({}, Utf16String::from_utf8(url.serialize()));
         view->set_favicon({}, {});
 
         if (view->on_load_start)
@@ -812,9 +813,6 @@ void WebContentClient::did_change_title(u64 page_id, Utf16String title)
             title = Utf16String::from_utf8(view->url().serialize());
 
         view->set_title({}, title);
-
-        if (view->on_title_change)
-            view->on_title_change(title);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -597,6 +597,7 @@ void WebContentClient::did_start_loading(u64 page_id, URL::URL url, Variant<Empt
         view->did_start_navigation(url, move(document_resource), is_redirect, history_handling);
 
         view->set_url({}, url);
+        view->set_favicon({}, {});
 
         if (view->on_load_start)
             view->on_load_start(url, is_redirect);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -601,11 +601,11 @@ void WebContentClient::did_start_loading(u64 page_id, URL::URL url, Variant<Empt
         view->set_favicon({}, {});
 
         if (view->on_load_start)
-            view->on_load_start(url, is_redirect);
+            view->on_load_start();
 
         for (auto const& [id, listener] : view->m_navigation_listeners) {
             if (listener.on_load_start)
-                listener.on_load_start(url, is_redirect);
+                listener.on_load_start(url);
         }
     }
 }
@@ -818,20 +818,10 @@ void WebContentClient::did_change_title(u64 page_id, Utf16String title)
 
 void WebContentClient::did_change_url(u64 page_id, URL::URL url)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        // Some navigations report the same URL more than once. Keep those
-        // duplicate updates inside LibWebView so frontends do not reset
-        // location bar state or steal focus for a no-op change.
-        if (view->url() == url)
-            return;
-
+    if (auto view = view_for_page_id(page_id); view.has_value())
         view->set_url({}, url);
-
-        if (view->on_url_change)
-            view->on_url_change(url);
-    } else if (auto* child_frame = embedded_page_host(page_id)) {
+    else if (auto* child_frame = embedded_page_host(page_id))
         child_frame->reporting_client().async_run_iframe_load_event_steps(child_frame->reporting_page_id(), child_frame->id());
-    }
 }
 
 void WebContentClient::did_request_tooltip_override(u64 page_id, Gfx::IntPoint position, ByteString title)

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -27,8 +27,8 @@
                       activateTab:(Web::HTML::ActivateTab)activate_tab
                         pageIndex:(u64)page_index;
 
-- (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)is_redirect;
-- (void)onLoadFinish:(URL::URL const&)url;
+- (void)onLoadStart;
+- (void)onLoadFinish;
 
 - (void)onURLChange:(URL::URL const&)url;
 - (void)onTitleChange:(Utf16String const&)title;

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -32,7 +32,7 @@
 
 - (void)onURLChange:(URL::URL const&)url;
 - (void)onTitleChange:(Utf16String const&)title;
-- (void)onFaviconChange:(Gfx::Bitmap const&)bitmap;
+- (void)onFaviconChange:(Optional<Gfx::Bitmap const&>)bitmap;
 - (void)onAudioPlayStateChange:(Web::HTML::AudioPlayState)play_state;
 
 - (void)onEnterFullscreenWindow;

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -396,24 +396,24 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         [[self window] close];
     };
 
-    m_web_view_bridge->on_load_start = [weak_self](auto const& url, bool is_redirect) {
+    m_web_view_bridge->on_load_start = [weak_self]() {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
             return;
         }
-        [self.observer onLoadStart:url isRedirect:is_redirect];
+        [self.observer onLoadStart];
 
         if (_status_label != nil) {
             [self.status_label setHidden:YES];
         }
     };
 
-    m_web_view_bridge->on_load_finish = [weak_self](auto const& url) {
+    m_web_view_bridge->on_load_finish = [weak_self](auto const&) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
             return;
         }
-        [self.observer onLoadFinish:url];
+        [self.observer onLoadFinish];
     };
 
     m_web_view_bridge->on_url_change = [weak_self](auto const& url) {

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -406,16 +406,16 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
     return [[tab web_view] handle];
 }
 
-- (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)is_redirect
+- (void)onLoadStart
 {
     [self setTabLoading:YES];
-    [[self tabController] onLoadStart:url isRedirect:is_redirect];
+    [[self tabController] onLoadStart];
 }
 
-- (void)onLoadFinish:(URL::URL const&)url
+- (void)onLoadFinish
 {
     [self setTabLoading:NO];
-    [[self tabController] onLoadFinish:url];
+    [[self tabController] onLoadFinish];
 }
 
 - (void)onURLChange:(URL::URL const&)url

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -409,11 +409,9 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)is_redirect
 {
     [self setPageTitle:Ladybird::string_to_ns_string(url.serialize())];
-    self.favicon = [Tab defaultFavicon];
     [self setTabLoading:YES];
     [self updateTabTitleAndFavicon];
 
-    [[self tabController] onFaviconChange:nil];
     [[self tabController] onLoadStart:url isRedirect:is_redirect];
 }
 
@@ -434,11 +432,18 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
     [self updateTabTitleAndFavicon];
 }
 
-- (void)onFaviconChange:(Gfx::Bitmap const&)bitmap
+- (void)onFaviconChange:(Optional<Gfx::Bitmap const&>)bitmap
 {
-    auto* favicon = Ladybird::gfx_bitmap_to_ns_image(bitmap);
-    [favicon setResizingMode:NSImageResizingModeStretch];
-    self.favicon = favicon;
+    NSImage* favicon = nil;
+
+    if (bitmap.has_value()) {
+        favicon = Ladybird::gfx_bitmap_to_ns_image(*bitmap);
+        [favicon setResizingMode:NSImageResizingModeStretch];
+        self.favicon = favicon;
+    } else {
+        self.favicon = [Tab defaultFavicon];
+    }
+
     [self updateTabTitleAndFavicon];
     [[self tabController] onFaviconChange:favicon];
 }

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -408,10 +408,7 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
 
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)is_redirect
 {
-    [self setPageTitle:Ladybird::string_to_ns_string(url.serialize())];
     [self setTabLoading:YES];
-    [self updateTabTitleAndFavicon];
-
     [[self tabController] onLoadStart:url isRedirect:is_redirect];
 }
 

--- a/UI/AppKit/Interface/TabController.h
+++ b/UI/AppKit/Interface/TabController.h
@@ -24,8 +24,8 @@
 
 - (void)loadURL:(URL::URL const&)url;
 
-- (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)isRedirect;
-- (void)onLoadFinish:(URL::URL const&)url;
+- (void)onLoadStart;
+- (void)onLoadFinish;
 - (void)onFaviconChange:(NSImage*)favicon;
 
 - (void)onURLChange:(URL::URL const&)url;

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -818,15 +818,13 @@ private:
     [[self tab].web_view loadURL:url];
 }
 
-- (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)isRedirect
+- (void)onLoadStart
 {
-    [self setLocationFieldText:url.serialize()];
     [[self locationSearchField] setLoading:YES];
 }
 
-- (void)onLoadFinish:(URL::URL const&)url
+- (void)onLoadFinish
 {
-    (void)url;
     [[self locationSearchField] setLoading:NO];
 }
 

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -821,7 +821,6 @@ private:
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)isRedirect
 {
     [self setLocationFieldText:url.serialize()];
-    [[self locationSearchField] setFavicon:nil];
     [[self locationSearchField] setLoading:YES];
 }
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -731,7 +731,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_title = url_serialized;
         update_tab_title();
 
-        m_favicon = {};
         set_loading(true);
 
         m_location_edit->set_url(url);
@@ -760,7 +759,13 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     view().on_favicon_change = [this](auto const& bitmap) {
-        auto qimage = QImage(bitmap.scanline_u8(0), bitmap.width(), bitmap.height(), QImage::Format_ARGB32);
+        if (!bitmap.has_value()) {
+            m_favicon = {};
+            update_tab_icon();
+            return;
+        }
+
+        auto qimage = QImage(bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), QImage::Format_ARGB32);
         if (qimage.isNull())
             return;
         auto qpixmap = QPixmap::fromImage(qimage);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -725,9 +725,8 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_hover_label->hide();
     };
 
-    view().on_load_start = [this](URL::URL const& url, bool) {
+    view().on_load_start = [this]() {
         set_loading(true);
-        m_location_edit->set_url(url);
     };
 
     view().on_load_finish = [this](auto const&) {

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -726,13 +726,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     view().on_load_start = [this](URL::URL const& url, bool) {
-        auto url_serialized = qstring_from_ak_string(url.serialize());
-
-        m_title = url_serialized;
-        update_tab_title();
-
         set_loading(true);
-
         m_location_edit->set_url(url);
     };
 


### PR DESCRIPTION
The first commit fixes a bug where we would not clear the WebView's stored PNG-encoded favicon on navigation start. For pages that did not have a favicon (e.g. example.com), this resulted in the previous page's favicon being used for bookmarks and history.

The next commits make us explicitly and consistently set the UI URL and title to match the previous favicon fix. The result is that the `on_load_start` callback no longer carries implicit knowledge of what needs to be done in the UI; the state changes are carried out by LibWebView.