### PR TITLE
LibWeb: Don't scroll a navigable container into view when focused

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3179,7 +3179,11 @@ void Document::set_focused_area(GC::Ptr<Node> node)
     set_needs_repaint();
 
     // Scroll the viewport if necessary to make the newly focused element visible.
-    if (new_focused_element) {
+    // NB: Not if the focused element is a navigable container: focus moving into a frame lands on its container
+    //     element in this document, and other engines do not scroll embedded content into view on focus. Ad
+    //     scripts commonly pull focus into an offscreen iframe during page load, and scrolling to it would
+    //     hijack the viewport.
+    if (new_focused_element && !is<HTML::NavigableContainer>(*new_focused_element)) {
         new_focused_element->queue_an_element_task(HTML::Task::Source::UserInteraction, [new_focused_element] {
             if (new_focused_element->document().focused_area().ptr() != new_focused_element)
                 return;

--- a/Tests/LibWeb/Text/expected/focus-on-frame-does-not-scroll.txt
+++ b/Tests/LibWeb/Text/expected/focus-on-frame-does-not-scroll.txt
@@ -1,0 +1,3 @@
+scrollY after focusing iframe element: 2512
+scrollY after iframe content calls window.focus(): 2660
+scrollY after focusing a regular element is nonzero: true

--- a/Tests/LibWeb/Text/expected/focus-on-frame-does-not-scroll.txt
+++ b/Tests/LibWeb/Text/expected/focus-on-frame-does-not-scroll.txt
@@ -1,3 +1,3 @@
-scrollY after focusing iframe element: 2512
-scrollY after iframe content calls window.focus(): 2660
+scrollY after focusing iframe element: 0
+scrollY after iframe content calls window.focus(): 0
 scrollY after focusing a regular element is nonzero: true

--- a/Tests/LibWeb/Text/input/focus-on-frame-does-not-scroll.html
+++ b/Tests/LibWeb/Text/input/focus-on-frame-does-not-scroll.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div style="height: 3000px"></div>
+<iframe id="frame1" style="height: 100px"></iframe>
+<button id="button">bottom button</button>
+<script>
+    // Programmatically focusing a frame must not scroll it into view. Ad scripts
+    // commonly steal focus into an offscreen iframe on load; other engines only
+    // scroll on focus when the focused element is not embedded content.
+    asyncTest(async done => {
+        const settle = async () => {
+            for (let i = 0; i < 3; i++) {
+                await new Promise(resolve => requestAnimationFrame(resolve));
+                await new Promise(resolve => setTimeout(resolve, 0));
+            }
+        };
+
+        scrollTo(0, 0);
+        document.getElementById("frame1").focus();
+        await settle();
+        println(`scrollY after focusing iframe element: ${window.scrollY}`);
+
+        scrollTo(0, 0);
+        const frame2 = document.createElement("iframe");
+        frame2.style.height = "100px";
+        frame2.srcdoc = "<script>window.focus();<\/script>";
+        await new Promise(resolve => {
+            frame2.addEventListener("load", resolve, { once: true });
+            document.body.appendChild(frame2);
+        });
+        await settle();
+        println(`scrollY after iframe content calls window.focus(): ${window.scrollY}`);
+
+        scrollTo(0, 0);
+        document.getElementById("button").focus();
+        await settle();
+        println(`scrollY after focusing a regular element is nonzero: ${window.scrollY > 0}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Whenever the focused area of a document changed, we scrolled the newly
focused element into view unconditionally. When focus moves into a
frame, the frame's container element becomes the focused area of its
document, so an iframe pulling focus during page load scrolled the
viewport down to wherever the iframe happened to be. Ad scripts do this
on real pages: on fragrantica.com forum pages, an ad iframe at the
bottom steals focus while the page loads and the viewport jumped to it.

Match Blink, which only scrolls on focus when the focused element is
not embedded content, by skipping the scroll when the focused element
is a navigable container. Focusing a regular element still scrolls it
into view.