### PR TITLE
LibWeb+WebContent+LibWebView+UI: Resolve system-ui to the desktop font

### DIFF
--- a/Libraries/LibWeb/Platform/FontPlugin.cpp
+++ b/Libraries/LibWeb/Platform/FontPlugin.cpp
@@ -77,6 +77,14 @@ Vector<FlyString> FontPlugin::symbol_font_names()
     return m_symbol_font_names;
 }
 
+void FontPlugin::set_system_font_family(FlyString system_font_family)
+{
+    if (m_system_font_family == system_font_family)
+        return;
+    m_system_font_family = move(system_font_family);
+    m_generic_font_cache.clear();
+}
+
 void FontPlugin::update_generic_fonts()
 {
     // Store fallback font lists for each generic font category.
@@ -151,6 +159,15 @@ FlyString FontPlugin::compute_generic_font_name(GenericFont generic_font, int we
         break;
     default:
         VERIFY_NOT_REACHED();
+    }
+
+    if (generic_font == GenericFont::UiSansSerif && m_system_font_family.has_value()) {
+        auto system_font_family_is_available = false;
+        Gfx::FontDatabase::the().for_each_typeface_with_family_name(m_system_font_family.value(), [&](Gfx::Typeface const&) {
+            system_font_family_is_available = true;
+        });
+        if (system_font_family_is_available)
+            return m_system_font_family.value();
     }
 
     auto name = Gfx::TypefaceSkia::resolve_generic_family(generic_family_name, weight, slope);

--- a/Libraries/LibWeb/Platform/FontPlugin.h
+++ b/Libraries/LibWeb/Platform/FontPlugin.h
@@ -54,6 +54,8 @@ public:
 
     bool is_layout_test_mode() const { return m_is_layout_test_mode; }
 
+    void set_system_font_family(FlyString);
+
     void update_generic_fonts();
 
 private:
@@ -63,6 +65,7 @@ private:
     HashMap<GenericFontKey, FlyString> m_generic_font_cache;
     Vector<FlyString> m_symbol_font_names;
     RefPtr<Gfx::Font> m_default_fixed_width_font;
+    Optional<FlyString> m_system_font_family;
     bool m_is_layout_test_mode { false };
 };
 

--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -14,6 +14,8 @@ endpoint WebWorkerServer {
     connect_to_request_server(IPC::TransportHandle handle) =|
     connect_to_image_decoder(IPC::TransportHandle handle) =|
 
+    set_system_font_family(String family) =|
+
     start_worker(URL::URL url,
                  Web::Bindings::WorkerType type,
                  Web::Bindings::RequestCredentials credentials,

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -72,6 +72,8 @@ public:
     static RequestServerOptions const& request_server_options() { return the().m_request_server_options; }
     static WebContentOptions& web_content_options() { return the().m_web_content_options; }
 
+    virtual Optional<String> system_font_family() const { return {}; }
+
     static Requests::RequestClient& request_server_client(IsPrivate = IsPrivate::No);
     static ImageDecoderClient::Client& image_decoder_client() { return *the().m_image_decoder_client; }
 

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -142,7 +142,11 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsP
         arguments.append("--mach-server-name"sv);
         arguments.append(server.value());
     }
-    return launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), is_private, initial_page_id, root_navigable_id);
+
+    auto client = TRY(launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), is_private, initial_page_id, root_navigable_id));
+    if (auto system_font_family = WebView::Application::the().system_font_family(); system_font_family.has_value())
+        client->async_set_system_font_family(system_font_family.release_value());
+    return client;
 }
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process()

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -224,7 +224,10 @@ ErrorOr<NonnullRefPtr<WebWorkerClient>> launch_web_worker_process(Web::Bindings:
         arguments.append(server.value());
     }
 
-    return launch_server_process<WebWorkerClient>("WebWorker"sv, move(arguments), is_private, agent_id);
+    auto client = TRY(launch_server_process<WebWorkerClient>("WebWorker"sv, move(arguments), is_private, agent_id));
+    if (auto system_font_family = WebView::Application::the().system_font_family(); system_font_family.has_value())
+        client->async_set_system_font_family(system_font_family.release_value());
+    return client;
 }
 
 ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process()

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -78,6 +78,7 @@
 #include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
+#include <LibWeb/Platform/FontPlugin.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/DictionaryLookup.h>
@@ -2511,6 +2512,11 @@ void ConnectionFromClient::system_time_zone_changed()
 {
     JS::clear_system_time_zone_cache();
     Unicode::clear_system_time_zone_cache();
+}
+
+void ConnectionFromClient::set_system_font_family(String family)
+{
+    Web::Platform::FontPlugin::the().set_system_font_family(FlyString { family });
 }
 
 void ConnectionFromClient::set_document_cookie_version_buffer(u64 page_id, Core::AnonymousBuffer document_cookie_version_buffer)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -216,6 +216,7 @@ private:
     virtual void unmark_text_from_input_method(u64 page_id) override;
 
     virtual void system_time_zone_changed() override;
+    virtual void set_system_font_family(String family) override;
 
     virtual void set_document_cookie_version_buffer(u64 page_id, Core::AnonymousBuffer document_cookie_version_buffer) override;
     virtual void set_document_cookie_version_index(u64 page_id, i64 document_id, Core::SharedVersionIndex document_index) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -193,6 +193,7 @@ endpoint WebContentServer
     set_user_style(u64 page_id, String source) =|
 
     system_time_zone_changed() =|
+    set_system_font_family(String family) =|
 
     set_document_cookie_version_buffer(u64 page_id, Core::AnonymousBuffer document_cookie_version_buffer) =|
     set_document_cookie_version_index(u64 page_id, i64 document_id, Core::SharedVersionIndex document_index) =|

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/System.h>
 #include <LibWeb/HTML/BroadcastChannel.h>
 #include <LibWeb/HTML/WorkerAgentParent.h>
+#include <LibWeb/Platform/FontPlugin.h>
 #include <WebWorker/ConnectionFromClient.h>
 #include <WebWorker/PageHost.h>
 #include <WebWorker/WorkerHost.h>
@@ -33,6 +34,11 @@ void ConnectionFromClient::connect_to_image_decoder(IPC::TransportHandle handle)
 {
     if (on_image_decoder_connection)
         on_image_decoder_connection(handle);
+}
+
+void ConnectionFromClient::set_system_font_family(String family)
+{
+    Web::Platform::FontPlugin::the().set_system_font_family(FlyString { family });
 }
 
 void ConnectionFromClient::close_worker()

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -49,6 +49,7 @@ private:
 
     virtual void connect_to_request_server(IPC::TransportHandle handle) override;
     virtual void connect_to_image_decoder(IPC::TransportHandle handle) override;
+    virtual void set_system_font_family(String family) override;
     virtual void start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject, Web::Bindings::AgentType) override;
     virtual void connect_shared_worker(Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) override;

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -28,6 +28,7 @@
 #include <QDialogButtonBox>
 #include <QFileDialog>
 #include <QFileOpenEvent>
+#include <QFont>
 #include <QFormLayout>
 #include <QKeySequence>
 #include <QLineEdit>
@@ -364,6 +365,16 @@ void Application::create_platform_options(WebView::BrowserOptions&, WebView::Req
 {
     web_content_options.config_path = Settings::the()->directory();
 }
+
+#if !defined(AK_OS_MACOS)
+// On macOS, WebContent resolves system-ui with CoreText, so the system font family is not sent there.
+Optional<String> Application::system_font_family() const
+{
+    if (!m_application)
+        return {};
+    return ak_string_from_qstring(QGuiApplication::font().family());
+}
+#endif
 
 Core::EventLoop& Application::create_platform_event_loop()
 {

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -61,6 +61,9 @@ private:
 
     virtual void create_platform_options(WebView::BrowserOptions&, WebView::RequestServerOptions&, WebView::WebContentOptions&) override;
     virtual Core::EventLoop& create_platform_event_loop() override;
+#if !defined(AK_OS_MACOS)
+    virtual Optional<String> system_font_family() const override;
+#endif
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Vector<WebView::ViewImplementation&> active_window_web_views() const override;


### PR DESCRIPTION
Previously, on systems other than MacOS, the `system-ui` generic font family resolved to the generic `sans-serif` family, which typically differs from the font the desktop environment renders its interface with, so pages using `system-ui` rendered in a visibly different font than in other engines.

The interface font family is now queried from the UI toolkit when a WebContent process is spawned and sent over IPC before any page load. Font matching prefers that family for system-ui when it is installed.

---
An example from https://andrewkelley.me/post/my-thoughts-bun-rust-rewrite.html:

Before:

<img width="1183" height="357" alt="image" src="https://github.com/user-attachments/assets/c244389d-3be6-42e2-9c14-63609ac5a9c0" />

---

After:

<img width="1183" height="357" alt="image" src="https://github.com/user-attachments/assets/57d526b2-8963-46d0-9923-9856e1c411b6" />

---
Firefox for comparison:

<img width="1183" height="357" alt="image" src="https://github.com/user-attachments/assets/53078926-a429-44a9-abfe-12025e0c76b8" />

---

The font used now matches other engines, but the font still renders bolder than expected.

