### PR TITLE
LibWeb: Fix CSS Grid auto-placement and auto-fill/auto-fit repeat bugs

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -593,16 +593,18 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimensi
     // enough times for the name list to match the subgrid’s specified grid span (falling back to 0 if
     // the span is already fulfilled).
 
-    // Otherwise on a standalone axis, when auto-fill is given as the repetition number
-    // If the grid container has a definite size or max size in the relevant axis, then the number of
+    // Otherwise on a standalone axis, when auto-fill is given as the repetition number, if the grid
+    // container has a definite preferred size or maximum size in the relevant axis, then the number of
     // repetitions is the largest possible positive integer that does not cause the grid to overflow the
-    // content box of its grid container
+    // content box of its grid container taking gap into account; if any number of repetitions would
+    // overflow, then 1 repetition.
 
     auto const& grid_computed_values = grid_container().computed_values();
     CSSPixels size_of_repeated_tracks = 0;
-    // (treating each track as its max track sizing function if that is definite or its minimum track sizing
-    // function otherwise, flooring the max track sizing function by the min track sizing function if both
-    // are definite, and taking gap into account)
+    // For this purpose, each track is treated as its max track sizing function if that is definite or
+    // else its min track sizing function if that is definite. If both are definite, floor the max track
+    // sizing function by the min track sizing function. If neither are definite, the number of
+    // repetitions is one.
     auto const& repeat_track_list = repeated_track.repeat().grid_track_size_list().track_list();
     for (auto const& explicit_grid_track : repeat_track_list) {
         auto const& track_sizing_function = explicit_grid_track;
@@ -613,11 +615,11 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimensi
             if (max_size.is_definite()) {
                 track_size = resolve_definite_track_size(max_size, *m_available_space);
                 if (min_size.is_definite())
-                    track_size = min(track_size, resolve_definite_track_size(min_size, *m_available_space));
+                    track_size = max(track_size, resolve_definite_track_size(min_size, *m_available_space));
             } else if (min_size.is_definite()) {
                 track_size = resolve_definite_track_size(min_size, *m_available_space);
             } else {
-                VERIFY_NOT_REACHED();
+                return 1;
             }
         } else {
             track_size = resolve_definite_track_size(track_sizing_function.grid_size(), *m_available_space);
@@ -632,8 +634,6 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimensi
     auto const& gap = dimension == GridDimension::Column ? grid_computed_values.column_gap() : grid_computed_values.row_gap();
     auto gap_px = gap_to_px(gap, available_size.to_px_or_zero());
     auto size_of_repeated_tracks_with_gap = size_of_repeated_tracks + repeat_track_list.size() * gap_px;
-    // Otherwise, if the grid container has a definite min size in the relevant axis, the number of repetitions is the
-    // smallest possible positive integer that fulfills that minimum requirement
     if (available_size.is_definite()) {
         // NOTE: Gap size is added to free space to compensate for the fact that the last track does not have a gap
         auto free_space = available_size.to_px_or_zero();
@@ -641,6 +641,10 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimensi
         // If any number of repetitions would overflow, then 1 repetition.
         return max(1, number_of_repetitions);
     }
+
+    // FIXME: Otherwise, if the grid container has a definite minimum size in the relevant axis, the number of
+    //        repetitions is the smallest possible positive integer that fulfills that minimum requirement.
+
     // Otherwise, the specified track list repeats only once.
     return 1;
 }

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -873,7 +873,7 @@ void GridFormattingContext::place_item_with_no_declared_position(Box const& chil
     // area does not overlap any occupied grid cells, or the cursor's column position, plus the item's
     // column span, overflow the number of columns in the implicit grid, as determined earlier in this
     // algorithm.
-    auto found_unoccupied_area = find_unoccupied_grid_area(dimension, auto_placement_cursor_column, auto_placement_cursor_row, column_span, row_span);
+    find_unoccupied_grid_area(dimension, auto_placement_cursor_column, auto_placement_cursor_row, column_span, row_span);
 
     // 4.1.2.2. If a non-overlapping position was found in the previous step, set the item's row-start
     // and column-start lines to the cursor's position. Otherwise, increment the auto-placement cursor's
@@ -882,18 +882,13 @@ void GridFormattingContext::place_item_with_no_declared_position(Box const& chil
     column_start = auto_placement_cursor_column;
     row_start = auto_placement_cursor_row;
 
-    auto_placement_cursor_column += column_span - 1;
-    auto_placement_cursor_row += row_span - 1;
-
-    if (found_unoccupied_area == FoundUnoccupiedPlace::Yes) {
-        if (dimension == GridDimension::Column) {
-            auto_placement_cursor_column++;
-            auto_placement_cursor_row = m_occupation_grid.min_row_index();
-        } else {
-            auto_placement_cursor_row++;
-            auto_placement_cursor_column = m_occupation_grid.min_column_index();
-        }
-    }
+    // NB: The cursor's major-axis position must stay at the item's start line, so that subsequent items
+    //     keep packing into the same row (or column, for column flow) before moving on. Only advance the
+    //     minor-axis position past the item.
+    if (dimension == GridDimension::Column)
+        auto_placement_cursor_column += column_span;
+    else
+        auto_placement_cursor_row += row_span;
 
     record_grid_placement(GridItem {
         .box = child_box,
@@ -966,7 +961,7 @@ bool GridFormattingContext::grid_area_is_occupied(int column_start, int row_star
     return m_occupation_grid.is_area_occupied(column_start, row_start, static_cast<int>(column_span), static_cast<int>(row_span));
 }
 
-FoundUnoccupiedPlace GridFormattingContext::find_unoccupied_grid_area(GridDimension dimension, int& column_index, int& row_index, size_t column_span, size_t row_span) const
+void GridFormattingContext::find_unoccupied_grid_area(GridDimension dimension, int& column_index, int& row_index, size_t column_span, size_t row_span) const
 {
     if (dimension == GridDimension::Column) {
         // Row-flow: columns are the inner (minor) axis, rows are the outer (major) axis.
@@ -981,7 +976,7 @@ FoundUnoccupiedPlace GridFormattingContext::find_unoccupied_grid_area(GridDimens
 
                 auto minor_axis_fits = candidate_column_index + static_cast<int>(candidate_column_span) - 1 <= m_occupation_grid.max_column_index();
                 if (minor_axis_fits && !m_occupation_grid.is_area_occupied(candidate_column_index, candidate_row_index, static_cast<int>(candidate_column_span), static_cast<int>(candidate_row_span)))
-                    return FoundUnoccupiedPlace::Yes;
+                    return;
                 column_index++;
             }
             row_index++;
@@ -1000,15 +995,13 @@ FoundUnoccupiedPlace GridFormattingContext::find_unoccupied_grid_area(GridDimens
 
                 auto minor_axis_fits = candidate_row_index + static_cast<int>(candidate_row_span) - 1 <= m_occupation_grid.max_row_index();
                 if (minor_axis_fits && !m_occupation_grid.is_area_occupied(candidate_column_index, candidate_row_index, static_cast<int>(candidate_column_span), static_cast<int>(candidate_row_span)))
-                    return FoundUnoccupiedPlace::Yes;
+                    return;
                 row_index++;
             }
             column_index++;
             row_index = m_occupation_grid.min_row_index();
         }
     }
-
-    return FoundUnoccupiedPlace::No;
 }
 
 void GridFormattingContext::record_grid_placement(GridItem grid_item)

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -622,11 +622,11 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimensi
         } else {
             track_size = resolve_definite_track_size(track_sizing_function.grid_size(), *m_available_space);
         }
-        size_of_repeated_tracks += track_size;
+        // For the purpose of finding the number of auto-repeated tracks in a standalone axis, the UA must
+        // floor the track size to a UA-specified value to avoid division by zero. It is suggested that this
+        // floor be 1px.
+        size_of_repeated_tracks += max(track_size, CSSPixels(1));
     }
-
-    if (size_of_repeated_tracks == 0)
-        return 0;
 
     auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
     auto const& gap = dimension == GridDimension::Column ? grid_computed_values.column_gap() : grid_computed_values.row_gap();
@@ -643,10 +643,6 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimensi
     }
     // Otherwise, the specified track list repeats only once.
     return 1;
-
-    // For the purpose of finding the number of auto-repeated tracks in a standalone axis, the UA must
-    // floor the track size to a UA-specified value to avoid division by zero. It is suggested that this
-    // floor be 1px.
 }
 
 GridFormattingContext::PlacementPosition GridFormattingContext::resolve_grid_position(Box const& child_box, GridDimension dimension)
@@ -1176,11 +1172,20 @@ void GridFormattingContext::initialize_gap_tracks(GridDimension dimension, Avail
 
     gap_tracks.ensure_capacity(grid_tracks.size() - 1);
 
+    // When a collapsed track's gutters collapse, they coincide exactly--the two gutters overlap so that their start
+    // and end edges coincide. If one side of a collapsed track does not have a gutter (e.g. if it is the first or
+    // last track of the implicit grid), then collapsing its gutters results in no gutter on either "side" of the
+    // collapsed track.
+    // NB: We model this by keeping the gutter that directly precedes each non-collapsed track (except the first such
+    //     track) and giving all other gutters a zero size.
+    bool seen_non_collapsed_track = false;
     for (size_t track_index = 0; track_index < grid_tracks.size(); track_index++) {
+        seen_non_collapsed_track |= !grid_tracks[track_index].is_collapsed;
         tracks_and_gaps.append(grid_tracks[track_index]);
 
         if (track_index != grid_tracks.size() - 1) {
-            gap_tracks.unchecked_append(GridTrack::create_gap(gap_size));
+            bool gutter_collapses = grid_tracks[track_index + 1].is_collapsed || !seen_non_collapsed_track;
+            gap_tracks.unchecked_append(GridTrack::create_gap(gutter_collapses ? CSSPixels(0) : gap_size));
             tracks_and_gaps.append(gap_tracks.last());
         }
     }
@@ -2672,9 +2677,12 @@ void GridFormattingContext::collapse_auto_fit_tracks_if_needed(GridDimension dim
         if (m_occupation_grid.is_occupied(dimension == GridDimension::Column ? track_index : 0, dimension == GridDimension::Row ? track_index : 0))
             continue;
 
-        // NOTE: A collapsed track is treated as having a fixed track sizing function of 0px
+        // A collapsed grid track is treated as having a fixed track sizing function of 0px, and the gutters on
+        // either side of it--including any space allotted through distributed alignment--collapse.
+        // NB: The gutter collapsing is handled by initialize_gap_tracks(), which runs after this.
         tracks[track_index].min_track_sizing_function = CSS::GridSize(CSS::LengthStyleValue::create(CSS::Length::make_px(0)));
         tracks[track_index].max_track_sizing_function = CSS::GridSize(CSS::LengthStyleValue::create(CSS::Length::make_px(0)));
+        tracks[track_index].is_collapsed = true;
     }
 }
 
@@ -2835,10 +2843,12 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
 
     initialize_grid_tracks_for_columns_and_rows();
 
-    initialize_gap_tracks(available_space);
-
     collapse_auto_fit_tracks_if_needed(GridDimension::Column);
     collapse_auto_fit_tracks_if_needed(GridDimension::Row);
+
+    // NB: Gap tracks must be initialized after collapsing auto-fit tracks, since gutters next to collapsed tracks
+    //     collapse as well.
+    initialize_gap_tracks(available_space);
 
     // Do the first pass of resolving grid items box metrics to compute values that are independent of a track width
     resolve_items_box_metrics(GridDimension::Column);

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -200,6 +200,7 @@ private:
         bool is_gap { false };
         bool is_auto_fit { false };
         bool is_auto_repeat { false };
+        bool is_collapsed { false };
 
         static GridTrack create_from_definition(CSS::ExplicitGridTrack const& definition, bool is_auto_fit = false, bool is_auto_repeat = false);
         static GridTrack create_auto();

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -118,11 +118,6 @@ struct GridItem {
     }
 };
 
-enum class FoundUnoccupiedPlace {
-    No,
-    Yes
-};
-
 class OccupationGrid {
 public:
     OccupationGrid(size_t columns_count, size_t rows_count)
@@ -353,7 +348,7 @@ private:
     void clamp_grid_area_to_subgrid(GridDimension, int&, size_t&) const;
     void clamp_grid_area_to_subgrid(GridItem&) const;
     bool grid_area_is_occupied(int column_start, int row_start, size_t column_span, size_t row_span) const;
-    FoundUnoccupiedPlace find_unoccupied_grid_area(GridDimension, int& column_index, int& row_index, size_t column_span, size_t row_span) const;
+    void find_unoccupied_grid_area(GridDimension, int& column_index, int& row_index, size_t column_span, size_t row_span) const;
     void record_grid_placement(GridItem);
 
     void initialize_grid_tracks_from_definition(GridDimension);

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill-repeat-count-floors-max-track-size-by-min.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill-repeat-count-floors-max-track-size-by-min.txt
@@ -4,13 +4,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       Box <div.grid.a> at [8,8] [0+0+0 450 0+0+334] [0+0+0 40 0+0+0] [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [8,8] [0+0+0 112.5 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <div.item> at [8,8] [0+0+0 150 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [120.5,8] [0+0+0 112.5 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <div.item> at [158,8] [0+0+0 150 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [233,8] [0+0+0 112.5 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <div.item> at [308,8] [0+0+0 150 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,48] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
@@ -31,9 +31,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x96]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x80]
       Paintable (Box<DIV>.grid.a) [8,8 450x40]
-        PaintableWithLines (BlockContainer<DIV>.item) [8,8 112.5x40]
-        PaintableWithLines (BlockContainer<DIV>.item) [120.5,8 112.5x40]
-        PaintableWithLines (BlockContainer<DIV>.item) [233,8 112.5x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 150x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [158,8 150x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [308,8 150x40]
       PaintableWithLines (BlockContainer(anonymous)) [8,48 784x0]
       Paintable (Box<DIV>.grid.b) [8,48 450x40]
         PaintableWithLines (BlockContainer<DIV>.item) [8,48 200x40]

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill-repeat-count-floors-max-track-size-by-min.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill-repeat-count-floors-max-track-size-by-min.txt
@@ -1,0 +1,44 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 96 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
+      Box <div.grid.a> at [8,8] [0+0+0 450 0+0+334] [0+0+0 40 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,8] [0+0+0 112.5 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [120.5,8] [0+0+0 112.5 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [233,8] [0+0+0 112.5 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,48] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.grid.b> at [8,48] [0+0+0 450 0+0+334] [0+0+0 40 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,48] [0+0+0 200 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [208,48] [0+0+0 200 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,88] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x96]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x80]
+      Paintable (Box<DIV>.grid.a) [8,8 450x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 112.5x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [120.5,8 112.5x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [233,8 112.5x40]
+      PaintableWithLines (BlockContainer(anonymous)) [8,48 784x0]
+      Paintable (Box<DIV>.grid.b) [8,48 450x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,48 200x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [208,48 200x40]
+      PaintableWithLines (BlockContainer(anonymous)) [8,88 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x96] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit-and-auto-fill-with-zero-min-track-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit-and-auto-fill-with-zero-min-track-size.txt
@@ -1,57 +1,57 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 296 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 280 0+0+8] children: not-inline
-      Box <div.grid.fit> at [8,8] [0+0+0 530 0+0+254] [0+0+0 140 0+0+0] [GFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 96 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
+      Box <div.grid.fit> at [8,8] [0+0+0 530 0+0+254] [0+0+0 40 0+0+0] [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [8,8] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
+        BlockContainer <div.item> at [8,8] [0+0+0 170 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x16] baseline: 12.796875
               "a"
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [8,58] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 1, rect: [8,58 9.46875x16] baseline: 12.796875
+        BlockContainer <div.item> at [188,8] [0+0+0 170 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [188,8 9.46875x16] baseline: 12.796875
               "b"
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [8,108] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 1, rect: [8,108 8.890625x16] baseline: 12.796875
+        BlockContainer <div.item> at [368,8] [0+0+0 170 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [368,8 8.890625x16] baseline: 12.796875
               "c"
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,148] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,48] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      Box <div.grid.fill> at [8,148] [0+0+0 530 0+0+254] [0+0+0 140 0+0+0] [GFC] children: not-inline
+      Box <div.grid.fill> at [8,48] [0+0+0 530 0+0+254] [0+0+0 40 0+0+0] [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [8,148] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <div.item> at [8,48] [0+0+0 1.015625 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [8,198] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <div.item> at [19.015625,48] [0+0+0 1.015625 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [8,248] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <div.item> at [30.03125,48] [0+0+0 1.015625 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,288] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,88] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x296]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x280]
-      Paintable (Box<DIV>.grid.fit) [8,8 530x140]
-        PaintableWithLines (BlockContainer<DIV>.item) [8,8 530x40]
-        PaintableWithLines (BlockContainer<DIV>.item) [8,58 530x40]
-        PaintableWithLines (BlockContainer<DIV>.item) [8,108 530x40]
-      PaintableWithLines (BlockContainer(anonymous)) [8,148 784x0]
-      Paintable (Box<DIV>.grid.fill) [8,148 530x140]
-        PaintableWithLines (BlockContainer<DIV>.item) [8,148 530x40]
-        PaintableWithLines (BlockContainer<DIV>.item) [8,198 530x40]
-        PaintableWithLines (BlockContainer<DIV>.item) [8,248 530x40]
-      PaintableWithLines (BlockContainer(anonymous)) [8,288 784x0]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x96]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x80]
+      Paintable (Box<DIV>.grid.fit) [8,8 530x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 170x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [188,8 170x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [368,8 170x40]
+      PaintableWithLines (BlockContainer(anonymous)) [8,48 784x0]
+      Paintable (Box<DIV>.grid.fill) [8,48 530x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,48 1.015625x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [19.015625,48 1.015625x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [30.03125,48 1.015625x40]
+      PaintableWithLines (BlockContainer(anonymous)) [8,88 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x296] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x96] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit-and-auto-fill-with-zero-min-track-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit-and-auto-fill-with-zero-min-track-size.txt
@@ -1,0 +1,57 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 296 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 280 0+0+8] children: not-inline
+      Box <div.grid.fit> at [8,8] [0+0+0 530 0+0+254] [0+0+0 140 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,8] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x16] baseline: 12.796875
+              "a"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,58] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,58 9.46875x16] baseline: 12.796875
+              "b"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,108] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,108 8.890625x16] baseline: 12.796875
+              "c"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,148] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.grid.fill> at [8,148] [0+0+0 530 0+0+254] [0+0+0 140 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,148] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,198] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,248] [0+0+0 530 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,288] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x296]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x280]
+      Paintable (Box<DIV>.grid.fit) [8,8 530x140]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 530x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,58 530x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,108 530x40]
+      PaintableWithLines (BlockContainer(anonymous)) [8,148 784x0]
+      Paintable (Box<DIV>.grid.fill) [8,148 530x140]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,148 530x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,198 530x40]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,248 530x40]
+      PaintableWithLines (BlockContainer(anonymous)) [8,288 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x296] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/auto-placement-cursor-after-spanning-item-overflows-implicit-rows.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-placement-cursor-after-spanning-item-overflows-implicit-rows.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 141 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 125 0+0+8] children: not-inline
-      Box <div.grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 125 0+0+0] [GFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
         BlockContainer <div.item> at [8,8] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
@@ -22,24 +22,24 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [108,83] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 4, rect: [108,83 35.390625x16] baseline: 12.796875
+        BlockContainer <div.item> at [108,58] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [108,58 35.390625x16] baseline: 12.796875
               "four"
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,133] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,108] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x141]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x125]
-      Paintable (Box<DIV>.grid) [8,8 784x125]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      Paintable (Box<DIV>.grid) [8,8 784x100]
         PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x50]
         PaintableWithLines (BlockContainer<DIV>.item) [108,8 100x50]
         PaintableWithLines (BlockContainer<DIV>.item) [8,58 100x50]
-        PaintableWithLines (BlockContainer<DIV>.item) [108,83 100x50]
-      PaintableWithLines (BlockContainer(anonymous)) [8,133 784x0]
+        PaintableWithLines (BlockContainer<DIV>.item) [108,58 100x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x141] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/auto-placement-cursor-after-spanning-item-overflows-implicit-rows.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-placement-cursor-after-spanning-item-overflows-implicit-rows.txt
@@ -1,0 +1,45 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 141 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 125 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 125 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,8] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 28.6875x16] baseline: 12.796875
+              "one"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [108,8] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [108,8 28.4375x16] baseline: 12.796875
+              "two"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,58] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [8,58 42.421875x16] baseline: 12.796875
+              "three"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [108,83] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [108,83 35.390625x16] baseline: 12.796875
+              "four"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,133] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x141]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x125]
+      Paintable (Box<DIV>.grid) [8,8 784x125]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x50]
+        PaintableWithLines (BlockContainer<DIV>.item) [108,8 100x50]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,58 100x50]
+        PaintableWithLines (BlockContainer<DIV>.item) [108,83 100x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,133 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x141] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/subgrid-auto-placement-of-row-spanning-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/subgrid-auto-placement-of-row-spanning-items.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 144 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 128 0+0+8] children: not-inline
-      Box <div.grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 128 0+0+0] [GFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 112 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 96 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 96 0+0+0] [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
         Box <div.item> at [8,8] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
@@ -64,17 +64,17 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        Box <div.item> at [108,88] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
-          BlockContainer <div> at [108,88] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 2, rect: [108,88 15.0625x16] baseline: 12.796875
+        Box <div.item> at [108,56] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
+          BlockContainer <div> at [108,56] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,56 15.0625x16] baseline: 12.796875
                 "e1"
             TextNode <#text> (not painted)
-          BlockContainer <div> at [108,104] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 2, rect: [108,104 17.53125x16] baseline: 12.796875
+          BlockContainer <div> at [108,72] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,72 17.53125x16] baseline: 12.796875
                 "e2"
             TextNode <#text> (not painted)
-          BlockContainer <div> at [108,120] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 2, rect: [108,120 17.8125x16] baseline: 12.796875
+          BlockContainer <div> at [108,88] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,88 17.8125x16] baseline: 12.796875
                 "e3"
             TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -94,13 +94,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,136] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,104] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x144]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x128]
-      Paintable (Box<DIV>.grid) [8,8 784x128]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x112]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x96]
+      Paintable (Box<DIV>.grid) [8,8 784x96]
         Paintable (Box<DIV>.item) [8,8 100x48]
           PaintableWithLines (BlockContainer<DIV>) [8,8 100x16]
           PaintableWithLines (BlockContainer<DIV>) [8,24 100x16]
@@ -117,15 +117,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableWithLines (BlockContainer<DIV>) [8,56 100x16]
           PaintableWithLines (BlockContainer<DIV>) [8,72 100x16]
           PaintableWithLines (BlockContainer<DIV>) [8,88 100x16]
-        Paintable (Box<DIV>.item) [108,88 100x48]
+        Paintable (Box<DIV>.item) [108,56 100x48]
+          PaintableWithLines (BlockContainer<DIV>) [108,56 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [108,72 100x16]
           PaintableWithLines (BlockContainer<DIV>) [108,88 100x16]
-          PaintableWithLines (BlockContainer<DIV>) [108,104 100x16]
-          PaintableWithLines (BlockContainer<DIV>) [108,120 100x16]
         Paintable (Box<DIV>.item) [208,56 100x48]
           PaintableWithLines (BlockContainer<DIV>) [208,56 100x16]
           PaintableWithLines (BlockContainer<DIV>) [208,72 100x16]
           PaintableWithLines (BlockContainer<DIV>) [208,88 100x16]
-      PaintableWithLines (BlockContainer(anonymous)) [8,136 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,104 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x144] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x112] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/subgrid-auto-placement-of-row-spanning-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/subgrid-auto-placement-of-row-spanning-items.txt
@@ -1,0 +1,131 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 144 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 128 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 128 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.item> at [8,8] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
+          BlockContainer <div> at [8,8] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [8,8 15.6875x16] baseline: 12.796875
+                "a1"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [8,24] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [8,24 18.15625x16] baseline: 12.796875
+                "a2"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [8,40] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [8,40 18.4375x16] baseline: 12.796875
+                "a3"
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.item> at [108,8] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
+          BlockContainer <div> at [108,8] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,8 15.8125x16] baseline: 12.796875
+                "b1"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [108,24] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,24 18.28125x16] baseline: 12.796875
+                "b2"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [108,40] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,40 18.5625x16] baseline: 12.796875
+                "b3"
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.item> at [208,8] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
+          BlockContainer <div> at [208,8] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [208,8 15.234375x16] baseline: 12.796875
+                "c1"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [208,24] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [208,24 17.703125x16] baseline: 12.796875
+                "c2"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [208,40] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [208,40 17.984375x16] baseline: 12.796875
+                "c3"
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.item> at [8,56] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
+          BlockContainer <div> at [8,56] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [8,56 14.203125x16] baseline: 12.796875
+                "d1"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [8,72] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [8,72 16.671875x16] baseline: 12.796875
+                "d2"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [8,88] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [8,88 16.953125x16] baseline: 12.796875
+                "d3"
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.item> at [108,88] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
+          BlockContainer <div> at [108,88] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,88 15.0625x16] baseline: 12.796875
+                "e1"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [108,104] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,104 17.53125x16] baseline: 12.796875
+                "e2"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [108,120] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [108,120 17.8125x16] baseline: 12.796875
+                "e3"
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.item> at [208,56] [0+0+0 100 0+0+0] [0+0+0 48 0+0+0] [GFC] children: not-inline
+          BlockContainer <div> at [208,56] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [208,56 12.78125x16] baseline: 12.796875
+                "f1"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [208,72] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [208,72 15.25x16] baseline: 12.796875
+                "f2"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [208,88] [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 2, rect: [208,88 15.53125x16] baseline: 12.796875
+                "f3"
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,136] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x144]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x128]
+      Paintable (Box<DIV>.grid) [8,8 784x128]
+        Paintable (Box<DIV>.item) [8,8 100x48]
+          PaintableWithLines (BlockContainer<DIV>) [8,8 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [8,24 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [8,40 100x16]
+        Paintable (Box<DIV>.item) [108,8 100x48]
+          PaintableWithLines (BlockContainer<DIV>) [108,8 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [108,24 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [108,40 100x16]
+        Paintable (Box<DIV>.item) [208,8 100x48]
+          PaintableWithLines (BlockContainer<DIV>) [208,8 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [208,24 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [208,40 100x16]
+        Paintable (Box<DIV>.item) [8,56 100x48]
+          PaintableWithLines (BlockContainer<DIV>) [8,56 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [8,72 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [8,88 100x16]
+        Paintable (Box<DIV>.item) [108,88 100x48]
+          PaintableWithLines (BlockContainer<DIV>) [108,88 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [108,104 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [108,120 100x16]
+        Paintable (Box<DIV>.item) [208,56 100x48]
+          PaintableWithLines (BlockContainer<DIV>) [208,56 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [208,72 100x16]
+          PaintableWithLines (BlockContainer<DIV>) [208,88 100x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,136 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x144] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/auto-fill-repeat-count-floors-max-track-size-by-min.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fill-repeat-count-floors-max-track-size-by-min.html
@@ -1,0 +1,18 @@
+<!doctype html><style>
+.grid {
+    display: grid;
+    width: 450px;
+}
+.a { grid-template-columns: repeat(auto-fill, minmax(100px, 150px)); }
+.b { grid-template-columns: repeat(auto-fill, minmax(200px, 50px)); }
+.item { height: 40px; }
+</style>
+<div class="grid a">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+</div>
+<div class="grid b">
+    <div class="item"></div>
+    <div class="item"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/auto-fit-and-auto-fill-with-zero-min-track-size.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fit-and-auto-fill-with-zero-min-track-size.html
@@ -1,0 +1,20 @@
+<!doctype html><style>
+.grid {
+    display: grid;
+    gap: 10px;
+    width: 530px;
+}
+.fit { grid-template-columns: repeat(auto-fit, minmax(0, 1fr)); }
+.fill { grid-template-columns: repeat(auto-fill, minmax(0, 1fr)); }
+.item { height: 40px; }
+</style>
+<div class="grid fit">
+    <div class="item">a</div>
+    <div class="item">b</div>
+    <div class="item">c</div>
+</div>
+<div class="grid fill">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/auto-placement-cursor-after-spanning-item-overflows-implicit-rows.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-placement-cursor-after-spanning-item-overflows-implicit-rows.html
@@ -1,0 +1,15 @@
+<!doctype html><style>
+.grid {
+    display: grid;
+    grid-template-columns: repeat(2, 100px);
+}
+.item {
+    grid-row: span 2;
+    height: 50px;
+}
+</style><div class="grid">
+<div class="item">one</div>
+<div class="item">two</div>
+<div class="item">three</div>
+<div class="item">four</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/subgrid-auto-placement-of-row-spanning-items.html
+++ b/Tests/LibWeb/Layout/input/grid/subgrid-auto-placement-of-row-spanning-items.html
@@ -1,0 +1,18 @@
+<!doctype html><style>
+.grid {
+    display: grid;
+    grid-template-columns: repeat(3, 100px);
+}
+.item {
+    display: grid;
+    grid-template-rows: subgrid;
+    grid-row: span 3;
+}
+</style><div class="grid">
+<div class="item"><div>a1</div><div>a2</div><div>a3</div></div>
+<div class="item"><div>b1</div><div>b2</div><div>b3</div></div>
+<div class="item"><div>c1</div><div>c2</div><div>c3</div></div>
+<div class="item"><div>d1</div><div>d2</div><div>d3</div></div>
+<div class="item"><div>e1</div><div>e2</div><div>e3</div></div>
+<div class="item"><div>f1</div><div>f2</div><div>f3</div></div>
+</div>


### PR DESCRIPTION
Reducing two mangled layouts on https://alensa.se (a product card pushed a full row group down, and footer columns stacked vertically) exposed three independent grid bugs, each fixed with a regression test committed beforehand.

First, after auto-placing a row-spanning item, the placement cursor advanced by the item's span in both axes instead of staying on the item's row, so the next item started searching too far down and left a hole in the grid.

Second, `repeat(auto-fit, minmax(0, 1fr))` resolved to zero repetitions, stacking every item into one implicit column. The spec requires flooring the track size at 1px when counting auto-repeated tracks. The gutters around collapsed auto-fit tracks now collapse too, as the leftover gaps were eating the free space.

Third, with both `minmax()` sizes definite the repeat count must treat each track as `max(min, max)`, but we took the smaller of the two, producing too many repetitions.