### PR TITLE
LibWeb: Fix aspect-ratio sizing of flex items

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1331,12 +1331,23 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
     }
 
     if (item.box.has_preferred_aspect_ratio()) {
+        // AD-HOC: For a replaced box whose only sizing information is a natural aspect ratio (e.g an SVG with a
+        //         viewBox but no natural width or height) and an indefinite flex basis, we stretch-fit the cross size
+        //         to the flex container instead of transferring the used main size through the aspect ratio.
         auto auto_size = item.box.auto_content_box_size();
-        if (item.used_flex_basis_is_definite || (auto_size.has_width() && auto_size.has_height())) {
-            item.hypothetical_cross_size = css_clamp(calculate_cross_size_from_main_size_and_aspect_ratio(item.main_size.value(), item.box.preferred_aspect_ratio().value()), clamp_min, clamp_max);
+        bool is_replaced_box_with_only_natural_aspect_ratio = item.box.is_replaced_box() && !(auto_size.has_width() && auto_size.has_height());
+        if (is_replaced_box_with_only_natural_aspect_ratio && !item.used_flex_basis_is_definite) {
+            item.hypothetical_cross_size = css_clamp(inner_cross_size(m_flex_container_state), clamp_min, clamp_max);
             return;
         }
-        item.hypothetical_cross_size = css_clamp(inner_cross_size(m_flex_container_state), clamp_min, clamp_max);
+
+        // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
+        // When a box has a preferred aspect ratio, its automatic sizes are calculated the same as for a
+        // replaced element with a natural aspect ratio and no natural size in that axis, see e.g. CSS2 § 10
+        // and CSS Flexible Box Model Level 1 § 9.2. The axis in which the preferred size calculation depends
+        // on this aspect ratio is called the ratio-dependent axis, and the resulting size is definite if its
+        // input sizes are also definite.
+        item.hypothetical_cross_size = css_clamp(calculate_cross_size_from_main_size_and_aspect_ratio(item.main_size.value(), item.box.preferred_aspect_ratio().value()), clamp_min, clamp_max);
         return;
     }
 

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1348,6 +1348,7 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
         // on this aspect ratio is called the ratio-dependent axis, and the resulting size is definite if its
         // input sizes are also definite.
         item.hypothetical_cross_size = css_clamp(calculate_cross_size_from_main_size_and_aspect_ratio(item.main_size.value(), item.box.preferred_aspect_ratio().value()), clamp_min, clamp_max);
+        item.cross_size_was_resolved_from_aspect_ratio = has_definite_main_size(item);
         return;
     }
 
@@ -1440,6 +1441,14 @@ void FlexFormattingContext::determine_used_cross_size_of_each_flex_item()
             } else {
                 // Otherwise, the used cross size is the item’s hypothetical cross size.
                 item.cross_size = item.hypothetical_cross_size;
+
+                // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
+                // The axis in which the preferred size calculation depends on this aspect ratio is called the
+                // ratio-dependent axis, and the resulting size is definite if its input sizes are also definite.
+                if (item.cross_size_was_resolved_from_aspect_ratio) {
+                    set_cross_size(item, item.cross_size.value());
+                    set_has_definite_cross_size(item);
+                }
             }
         }
     }

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -60,6 +60,7 @@ private:
         Optional<CSS::FlexBasis> used_flex_basis {};
         bool used_flex_basis_is_definite { false };
         bool main_size_was_resolved_from_aspect_ratio { false };
+        bool cross_size_was_resolved_from_aspect_ratio { false };
         CSSPixels flex_base_size { 0 };
         CSSPixels hypothetical_main_size { 0 };
         CSSPixels hypothetical_cross_size { 0 };

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-aspect-ratio-with-percentage-size-svg-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-aspect-ratio-with-percentage-size-svg-child.txt
@@ -8,9 +8,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         Box <div.icon-wrapper> at [20,33] flex-container(row) flex-item [0+0+10 20 10+0+0] [0+0+10 20 10+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
-          SVGSVGBox <svg> at [20,33] flex-item [0+0+0 20 0+0+0] [0+0+0 32 0+0+0] [SVG] children: inline
+          SVGSVGBox <svg> at [20,33] flex-item [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [SVG] children: inline
             TextNode <#text> (not painted)
-            SVGGeometryBox <path> at [19.8125,34.796875] [0+0+0 16.390625 0+0+0] [0+0+0 28.40625 0+0+0] children: not-inline
+            SVGGeometryBox <path> at [23.625,34.125] [0+0+0 10.25 0+0+0] [0+0+0 17.75 0+0+0] children: not-inline
             TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
@@ -23,8 +23,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 500x300]
       Paintable (Box<DIV>.button) [10,8 40x70]
         Paintable (Box<DIV>.icon-wrapper) [10,23 40x40]
-          SVGSVGPaintable (SVGSVGBox<svg>) [20,33 20x32]
-            SVGPathPaintable (SVGGeometryBox<path>) [19.8125,34.796875 16.390625x28.40625]
+          SVGSVGPaintable (SVGSVGBox<svg>) [20,33 20x20]
+            SVGPathPaintable (SVGGeometryBox<path>) [23.625,34.125 10.25x17.75]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x316] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-aspect-ratio-with-percentage-size-svg-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-aspect-ratio-with-percentage-size-svg-child.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 316 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 500 0+0+292] [8+0+0 300 0+0+8] children: inline
+      TextNode <#text> (not painted)
+      Box <div.button> at [10,8] positioned flex-container(row) [0+0+0 40 0+0+0] [0+0+0 70 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.icon-wrapper> at [20,8] flex-container(row) flex-item [0+0+10 20 10+0+0] [0+0+10 70 10+0+0] [FFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          SVGSVGBox <svg> at [20,8] flex-item [0+0+0 20 0+0+0] [0+0+0 32 0+0+0] [SVG] children: inline
+            TextNode <#text> (not painted)
+            SVGGeometryBox <path> at [19.8125,9.796875] [0+0+0 16.390625 0+0+0] [0+0+0 28.40625 0+0+0] children: not-inline
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 500x300]
+      Paintable (Box<DIV>.button) [10,8 40x70]
+        Paintable (Box<DIV>.icon-wrapper) [10,-2 40x90]
+          SVGSVGPaintable (SVGSVGBox<svg>) [20,8 20x32]
+            SVGPathPaintable (SVGGeometryBox<path>) [19.8125,9.796875 16.390625x28.40625]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x316] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-aspect-ratio-with-percentage-size-svg-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-aspect-ratio-with-percentage-size-svg-child.txt
@@ -5,12 +5,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       Box <div.button> at [10,8] positioned flex-container(row) [0+0+0 40 0+0+0] [0+0+0 70 0+0+0] [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        Box <div.icon-wrapper> at [20,8] flex-container(row) flex-item [0+0+10 20 10+0+0] [0+0+10 70 10+0+0] [FFC] children: not-inline
+        Box <div.icon-wrapper> at [20,33] flex-container(row) flex-item [0+0+10 20 10+0+0] [0+0+10 20 10+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
-          SVGSVGBox <svg> at [20,8] flex-item [0+0+0 20 0+0+0] [0+0+0 32 0+0+0] [SVG] children: inline
+          SVGSVGBox <svg> at [20,33] flex-item [0+0+0 20 0+0+0] [0+0+0 32 0+0+0] [SVG] children: inline
             TextNode <#text> (not painted)
-            SVGGeometryBox <path> at [19.8125,9.796875] [0+0+0 16.390625 0+0+0] [0+0+0 28.40625 0+0+0] children: not-inline
+            SVGGeometryBox <path> at [19.8125,34.796875] [0+0+0 16.390625 0+0+0] [0+0+0 28.40625 0+0+0] children: not-inline
             TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
@@ -22,9 +22,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
     PaintableWithLines (BlockContainer<BODY>) [8,8 500x300]
       Paintable (Box<DIV>.button) [10,8 40x70]
-        Paintable (Box<DIV>.icon-wrapper) [10,-2 40x90]
-          SVGSVGPaintable (SVGSVGBox<svg>) [20,8 20x32]
-            SVGPathPaintable (SVGGeometryBox<path>) [19.8125,9.796875 16.390625x28.40625]
+        Paintable (Box<DIV>.icon-wrapper) [10,23 40x40]
+          SVGSVGPaintable (SVGSVGBox<svg>) [20,33 20x32]
+            SVGPathPaintable (SVGGeometryBox<path>) [19.8125,34.796875 16.390625x28.40625]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x316] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/flex-item-aspect-ratio-with-percentage-size-svg-child.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-item-aspect-ratio-with-percentage-size-svg-child.html
@@ -1,0 +1,33 @@
+<!doctype html><style>
+body {
+    width: 500px;
+    height: 300px;
+}
+.button {
+    position: absolute;
+    left: 10px;
+    width: 40px;
+    height: 70px;
+    display: flex;
+    align-items: center;
+}
+.icon-wrapper {
+    display: flex;
+    aspect-ratio: 1/1;
+    background-color: wheat;
+    padding: 10px;
+}
+svg {
+    width: 100%;
+    height: 100%;
+}
+</style>
+<body>
+    <div class="button">
+        <div class="icon-wrapper">
+            <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
+                <path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 246.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z"></path>
+            </svg>
+        </div>
+    </div>
+</body>


### PR DESCRIPTION
On the [Hungarian Embassy in Stockholm](https://stockholm.mfa.gov.hu/eng) website, the Swiper navigation buttons were distorted and overflowed their container. Their flex items use automatic sizes with an aspect-ratio, but we stretched their cross size instead of transferring the definite main size through the ratio.

Transfer the cross size through the preferred aspect ratio, while preserving the existing fallback for replaced boxes whose only sizing information is a natural aspect ratio. Treat the resulting cross size as definite when its input size is definite, allowing percentage-sized children such as SVG icons to resolve correctly.

Add a reduced layout test covering the affected flex item and its percentage-sized SVG child.

See the prev/next buttons in the screenshots below.

Before:

<img width="557" height="757" alt="Screenshot 2026-07-11 at 13 01 10" src="https://github.com/user-attachments/assets/bf044bc6-cbfc-4dce-8777-7d7ce8f7b2e8" />

After:

<img width="579" height="757" alt="Screenshot 2026-07-11 at 13 01 52" src="https://github.com/user-attachments/assets/b36c1f03-541c-4c75-bc58-f7cb6b40e726" />