### PR TITLE
LibWeb+LibWebView+UI/Qt: Fix startup loading indicators

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3793,7 +3793,7 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
             if (!is_decoded_svg()) {
                 HTML::HTMLLinkElement::load_fallback_favicon_if_needed(*this);
             }
-            navigable->traversable_navigable()->page().client().page_did_finish_loading(url());
+            navigable->traversable_navigable()->page().client().page_did_finish_loading(m_navigation_id, url());
         } else {
             m_needs_to_call_page_did_load = true;
         }
@@ -5547,7 +5547,7 @@ void Document::make_active()
     HTML::relevant_settings_object(window).execution_ready = true;
 
     if (m_needs_to_call_page_did_load) {
-        navigable()->traversable_navigable()->page().client().page_did_finish_loading(url());
+        navigable()->traversable_navigable()->page().client().page_did_finish_loading(m_navigation_id, url());
         m_needs_to_call_page_did_load = false;
     }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -2600,7 +2600,7 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                 if (unload_prompt_canceled != LocalTraversableNavigable::CheckIfUnloadingIsCanceledResult::Continue) {
                     // FIXME: 1. Invoke WebDriver BiDi navigation failed with navigable and a new WebDriver BiDi navigation status whose id is navigationId, status is "canceled", and url is url.
                     if (is_top_level_traversable())
-                        active_browsing_context()->page().client().page_did_cancel_loading(url);
+                        active_browsing_context()->page().client().page_did_cancel_loading(navigation_id, url);
 
                     // 2. Abort these steps.
                     set_delaying_load_events(false);
@@ -2658,7 +2658,7 @@ void LocalNavigable::begin_navigation(NavigateParams params)
 
                 // AD-HOC: Tell the UI that we started loading.
                 if (is_top_level_traversable()) {
-                    active_browsing_context()->page().client().page_did_start_loading(url, document_resource, false, history_handling);
+                    active_browsing_context()->page().client().page_did_start_loading(navigation_id, url, document_resource, false, history_handling);
                 }
 
                 // AD-HOC: Subsequent steps will fail if the navigable doesn't have an active window.
@@ -2803,7 +2803,7 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                     source_snapshot_params, target_snapshot_params, user_involvement, navigation_id, navigation_params, csp_navigation_type, true, GC::create_function(heap(), [this, history_entry, history_handling, navigation_id, user_involvement](GC::Ptr<PopulateSessionHistoryEntryDocumentOutput> output) {
                         if (output && output->download_handled) {
                             if (is_top_level_traversable())
-                                active_browsing_context()->page().client().page_did_cancel_loading(history_entry->url());
+                                active_browsing_context()->page().client().page_did_cancel_loading(navigation_id, history_entry->url());
                             set_ongoing_navigation({});
                             set_delaying_load_events(false);
                             return;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1178,7 +1178,7 @@ void ApplyHistoryStepState::start()
                     || target_entry->document_state()->reload_pending());
             if (needs_population) {
                 if (target_entry->document_state()->reload_pending() && navigable->is_top_level_traversable())
-                    navigable->page().client().page_did_start_loading(target_entry->url(), Empty {}, false);
+                    navigable->page().client().page_did_start_loading({}, target_entry->url(), Empty {}, false);
 
                 // FIXME: 1. Let navTimingType be "back_forward" if targetEntry's document is null; otherwise "reload".
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -497,16 +497,16 @@ public:
     virtual void page_did_request_minimize_window() { }
     virtual void page_did_request_fullscreen_window() { }
     virtual void page_did_request_exit_fullscreen() { }
-    virtual void page_did_start_loading(URL::URL const&, Variant<Empty, String, HTML::POSTResource> document_resource, bool is_redirect, Bindings::NavigationHistoryBehavior history_handling = Bindings::NavigationHistoryBehavior::Auto)
+    virtual void page_did_start_loading(Optional<String> const&, URL::URL const&, Variant<Empty, String, HTML::POSTResource> document_resource, bool is_redirect, Bindings::NavigationHistoryBehavior history_handling = Bindings::NavigationHistoryBehavior::Auto)
     {
         (void)document_resource;
         (void)is_redirect;
         (void)history_handling;
     }
-    virtual void page_did_cancel_loading(URL::URL const&) { }
+    virtual void page_did_cancel_loading(Optional<String> const&, URL::URL const&) { }
     virtual void page_did_create_new_document(Web::DOM::Document&) { }
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) { }
-    virtual void page_did_finish_loading(URL::URL const&) { }
+    virtual void page_did_finish_loading(Optional<String> const&, URL::URL const&) { }
     virtual Optional<u64> page_did_start_download(URL::URL const&, ByteString const& suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data)
     {
         (void)suggested_filename;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -192,6 +192,9 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
 
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
+    set_loading_state(true);
+    m_is_waiting_for_navigation_start = true;
+    m_loading_navigation_id.clear();
     set_url(url);
     if (preparation.should_seed_web_content_before_load)
         seed_web_content_session_history_from_ui_process();
@@ -247,9 +250,12 @@ void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState 
 
 void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
+    set_loading_state(true);
     m_is_showing_crash_page = false;
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
+    m_is_waiting_for_navigation_start = true;
+    m_loading_navigation_id.clear();
     auto preparation = m_top_level_traversable.prepare_for_page_load(url, history_handling);
     if (preparation.should_update_navigation_action_state)
         update_navigation_action_state();
@@ -261,6 +267,9 @@ void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHist
 
 void ViewImplementation::load_html(StringView html)
 {
+    set_loading_state(true);
+    m_is_waiting_for_navigation_start = false;
+    m_loading_navigation_id.clear();
     m_is_showing_crash_page = false;
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
@@ -270,6 +279,9 @@ void ViewImplementation::load_html(StringView html)
 
 void ViewImplementation::load_crash_page_html(StringView html, URL::URL const& crashed_url)
 {
+    set_loading_state(true);
+    m_is_waiting_for_navigation_start = false;
+    m_loading_navigation_id.clear();
     m_is_showing_crash_page = true;
     m_should_suppress_history_for_current_load = true;
     m_should_suppress_history_for_next_load = true;
@@ -291,6 +303,9 @@ void ViewImplementation::load_navigation_error_page(StringView text)
 
 void ViewImplementation::reload()
 {
+    set_loading_state(true);
+    m_is_waiting_for_navigation_start = true;
+    m_loading_navigation_id.clear();
     if (m_is_showing_crash_page) {
         m_is_showing_crash_page = false;
         m_should_suppress_history_for_current_load = false;
@@ -1407,6 +1422,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
 
 void ViewImplementation::did_start_navigation(URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
+    set_loading_state(true);
     if (m_should_suppress_history_for_next_load || m_should_suppress_history_for_current_load)
         return;
 
@@ -1423,6 +1439,7 @@ void ViewImplementation::did_start_navigation(URL::URL const& url, Variant<Empty
 
 bool ViewImplementation::did_cancel_navigation(URL::URL const& url)
 {
+    set_loading_state(false);
     auto result = m_top_level_traversable.did_cancel_navigation(url, m_webdriver_pending_navigation_url.has_value());
     switch (result.status) {
     case NavigationCancelStatus::RestorePendingSessionHistoryNavigation:
@@ -1446,6 +1463,7 @@ bool ViewImplementation::did_cancel_navigation(URL::URL const& url)
 
 void ViewImplementation::did_finish_navigation(URL::URL const& url)
 {
+    set_loading_state(false);
     if (m_webdriver_pending_navigation_url.has_value() && *m_webdriver_pending_navigation_url == url && !m_webdriver_pending_navigation_completes_with_session_history_update)
         complete_webdriver_pending_navigation_if_url_matches(url);
 
@@ -1454,6 +1472,15 @@ void ViewImplementation::did_finish_navigation(URL::URL const& url)
         seed_web_content_session_history_from_ui_process(result.allow_current_entry_reconstruction ? AllowCurrentEntryReconstruction::Yes : AllowCurrentEntryReconstruction::No);
     else if (result.dump_reason.has_value())
         dump_session_history(*result.dump_reason);
+}
+
+void ViewImplementation::set_loading_state(bool is_loading)
+{
+    if (m_is_loading == is_loading)
+        return;
+    m_is_loading = is_loading;
+    if (on_loading_state_change)
+        on_loading_state_change(is_loading);
 }
 
 bool ViewImplementation::restore_pending_session_history_navigation(StringView reason)
@@ -1501,6 +1528,9 @@ static Optional<size_t> current_top_level_history_entry_index_for_step(Vector<We
 
 void ViewImplementation::did_start_webdriver_navigation(Badge<WebContentClient>, URL::URL const& url)
 {
+    set_loading_state(true);
+    m_is_waiting_for_navigation_start = true;
+    m_loading_navigation_id.clear();
     m_webdriver_pending_navigation_url = url;
     m_webdriver_pending_navigation_completes_with_session_history_update = false;
 }
@@ -1874,6 +1904,9 @@ void ViewImplementation::dump_session_history(StringView reason, SessionHistoryD
 
 void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_error_page)
 {
+    set_loading_state(false);
+    m_is_waiting_for_navigation_start = false;
+    m_loading_navigation_id.clear();
     auto const headless_mode = Application::browser_options().headless_mode.has_value();
 
     if (!headless_mode) {

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -102,6 +102,8 @@ public:
     void load_navigation_error_page(StringView);
 
     void reload();
+    bool is_loading() const { return m_is_loading; }
+
     struct SessionHistoryTraversalMenuItem {
         int delta { 0 };
         String title;
@@ -312,6 +314,7 @@ public:
     Function<void(URL::URL const&)> on_url_change;
     Function<void()> on_load_start;
     Function<void(URL::URL const&)> on_load_finish;
+    Function<void(bool)> on_loading_state_change;
     Function<void(ByteString const& path, i32)> on_request_file;
     Function<void(DictionaryLookup const&, Gfx::IntPoint)> on_request_dictionary_lookup;
     Function<void(Optional<Gfx::Bitmap const&>)> on_favicon_change;
@@ -413,6 +416,7 @@ protected:
     void did_start_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, bool is_redirect, Web::Bindings::NavigationHistoryBehavior);
     bool did_cancel_navigation(URL::URL const&);
     void did_finish_navigation(URL::URL const&);
+    void set_loading_state(bool);
     void complete_webdriver_navigation_completion(u64 request_id, Web::WebDriver::Response);
     void complete_webdriver_pending_navigation_if_url_matches(URL::URL const&);
     void update_navigation_action_state();
@@ -565,6 +569,10 @@ protected:
 
     bool m_should_suppress_history_for_current_load { false };
     bool m_should_suppress_history_for_next_load { false };
+    bool m_is_loading { false };
+    bool m_is_waiting_for_navigation_start { false };
+    Optional<String> m_loading_navigation_id;
+
     size_t m_crash_count = 0;
     RefPtr<Core::Timer> m_repeated_crash_timer;
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -584,7 +584,7 @@ void WebContentClient::maybe_record_history_visit_for_current_load(u64 page_id, 
     m_history_recorded_urls_for_current_load.set(page_id, normalized_url.release_value());
 }
 
-void WebContentClient::did_start_loading(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling)
+void WebContentClient::did_start_loading(u64 page_id, Optional<String> navigation_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
     if (auto process = WebView::Application::the().find_process(m_process_handle.pid); process.has_value())
         process->set_title(OptionalNone {});
@@ -592,6 +592,8 @@ void WebContentClient::did_start_loading(u64 page_id, URL::URL url, Variant<Empt
     m_history_recorded_urls_for_current_load.remove(page_id);
 
     if (auto view = view_for_page_id(page_id); view.has_value()) {
+        view->m_is_waiting_for_navigation_start = false;
+        view->m_loading_navigation_id = navigation_id;
         view->m_should_suppress_history_for_current_load = view->m_should_suppress_history_for_next_load;
         view->m_should_suppress_history_for_next_load = false;
         view->did_start_navigation(url, move(document_resource), is_redirect, history_handling);
@@ -610,11 +612,15 @@ void WebContentClient::did_start_loading(u64 page_id, URL::URL url, Variant<Empt
     }
 }
 
-void WebContentClient::did_cancel_loading(u64 page_id, URL::URL url)
+void WebContentClient::did_cancel_loading(u64 page_id, Optional<String> navigation_id, URL::URL url)
 {
     m_history_recorded_urls_for_current_load.remove(page_id);
 
     if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (!view->m_is_waiting_for_navigation_start && navigation_id != view->m_loading_navigation_id)
+            return;
+        view->m_is_waiting_for_navigation_start = false;
+        view->m_loading_navigation_id.clear();
         view->did_cancel_navigation(url);
 
         auto const& client_url = view->url();
@@ -694,7 +700,7 @@ void WebContentClient::did_fail_download(u64 page_id, u64 download_id, String er
     Application::the().file_downloader().fail_download(download_id, move(error));
 }
 
-void WebContentClient::did_finish_loading(u64 page_id, URL::URL url)
+void WebContentClient::did_finish_loading(u64 page_id, Optional<String> navigation_id, URL::URL url)
 {
     if (url.scheme() == "about"sv && url.paths().size() == 1) {
         if (auto web_ui = WebUI::create(*this, page_id, url.paths().first()); web_ui.is_error())
@@ -704,6 +710,10 @@ void WebContentClient::did_finish_loading(u64 page_id, URL::URL url)
     }
 
     if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->m_is_waiting_for_navigation_start || navigation_id != view->m_loading_navigation_id)
+            return;
+
+        view->m_loading_navigation_id.clear();
         auto client_url = url;
         // Browser-generated pages can finish with an internal document URL.
         // Keep exposing the URL accepted at load start for suppressed loads.

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -129,7 +129,7 @@ private:
     virtual void did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) override;
     virtual void did_start_webdriver_navigation(u64 page_id, URL::URL url) override;
-    virtual void did_finish_loading(u64 page_id, URL::URL) override;
+    virtual void did_finish_loading(u64 page_id, Optional<String>, URL::URL) override;
     virtual void did_request_refresh(u64 page_id) override;
     virtual void did_request_cursor_change(u64 page_id, Gfx::Cursor) override;
     virtual void did_change_title(u64 page_id, Utf16String) override;
@@ -142,8 +142,8 @@ private:
     virtual void did_unhover_link(u64 page_id) override;
     virtual void did_click_link(u64 page_id, URL::URL, ByteString, unsigned) override;
     virtual void did_middle_click_link(u64 page_id, URL::URL, ByteString, unsigned) override;
-    virtual void did_start_loading(u64 page_id, URL::URL, Variant<Empty, String, Web::HTML::POSTResource>, bool, Web::Bindings::NavigationHistoryBehavior) override;
-    virtual void did_cancel_loading(u64 page_id, URL::URL) override;
+    virtual void did_start_loading(u64 page_id, Optional<String>, URL::URL, Variant<Empty, String, Web::HTML::POSTResource>, bool, Web::Bindings::NavigationHistoryBehavior) override;
+    virtual void did_cancel_loading(u64 page_id, Optional<String>, URL::URL) override;
     virtual Messages::WebContentClient::DidStartDownloadWithoutRequestResponse did_start_download_without_request(u64 page_id, URL::URL, ByteString suggested_filename, Optional<u64> total_size) override;
     virtual Messages::WebContentClient::DidStartDownloadResponse did_start_download(u64 page_id, URL::URL, ByteString suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) override;
     virtual void did_receive_download_data(u64 page_id, u64 download_id, ByteBuffer data) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -539,20 +539,20 @@ void PageClient::page_did_middle_click_link(URL::URL const& url, ByteString cons
     client().async_did_middle_click_link(m_id, url, target, modifiers);
 }
 
-void PageClient::page_did_start_loading(URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling)
+void PageClient::page_did_start_loading(Optional<String> const& navigation_id, URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
     if (m_webdriver)
         m_webdriver->page_did_start_loading({}, url);
 
-    client().async_did_start_loading(m_id, url, move(document_resource), is_redirect, history_handling);
+    client().async_did_start_loading(m_id, navigation_id, url, move(document_resource), is_redirect, history_handling);
 }
 
-void PageClient::page_did_cancel_loading(URL::URL const& url)
+void PageClient::page_did_cancel_loading(Optional<String> const& navigation_id, URL::URL const& url)
 {
     if (m_webdriver)
         m_webdriver->page_did_cancel_loading({}, url);
 
-    client().async_did_cancel_loading(m_id, url);
+    client().async_did_cancel_loading(m_id, navigation_id, url);
 }
 
 void PageClient::page_did_create_new_document(Web::DOM::Document& document)
@@ -581,9 +581,9 @@ void PageClient::page_did_change_active_document_in_top_level_browsing_context(W
     }
 }
 
-void PageClient::page_did_finish_loading(URL::URL const& url)
+void PageClient::page_did_finish_loading(Optional<String> const& navigation_id, URL::URL const& url)
 {
-    client().async_did_finish_loading(m_id, url);
+    client().async_did_finish_loading(m_id, navigation_id, url);
 }
 
 Optional<u64> PageClient::page_did_start_download(URL::URL const& url, ByteString const& suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -190,11 +190,11 @@ private:
     virtual void page_did_request_link_context_menu(Web::CSSPixelPoint, URL::URL const&, ByteString const& target, unsigned modifiers) override;
     virtual void page_did_request_image_context_menu(Web::CSSPixelPoint, URL::URL const&, ByteString const& target, unsigned modifiers, Optional<Gfx::Bitmap const*>) override;
     virtual void page_did_request_media_context_menu(Web::CSSPixelPoint, ByteString const& target, unsigned modifiers, Web::Page::MediaContextMenu const&) override;
-    virtual void page_did_start_loading(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, bool, Web::Bindings::NavigationHistoryBehavior) override;
-    virtual void page_did_cancel_loading(URL::URL const&) override;
+    virtual void page_did_start_loading(Optional<String> const&, URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, bool, Web::Bindings::NavigationHistoryBehavior) override;
+    virtual void page_did_cancel_loading(Optional<String> const&, URL::URL const&) override;
     virtual void page_did_create_new_document(Web::DOM::Document&) override;
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) override;
-    virtual void page_did_finish_loading(URL::URL const&) override;
+    virtual void page_did_finish_loading(Optional<String> const&, URL::URL const&) override;
     virtual Optional<u64> page_did_start_download(URL::URL const&, ByteString const& suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) override;
     virtual Optional<u64> page_did_start_download(URL::URL const&, ByteString const& suggested_filename, Optional<u64> total_size) override;
     virtual void page_did_receive_download_data(u64 download_id, ByteBuffer data) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -56,9 +56,9 @@ endpoint WebContentClient
     did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
     did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) =|
     did_start_webdriver_navigation(u64 page_id, URL::URL url) =|
-    did_start_loading(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling) =|
-    did_cancel_loading(u64 page_id, URL::URL url) =|
-    did_finish_loading(u64 page_id, URL::URL url) =|
+    did_start_loading(u64 page_id, Optional<String> navigation_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling) =|
+    did_cancel_loading(u64 page_id, Optional<String> navigation_id, URL::URL url) =|
+    did_finish_loading(u64 page_id, Optional<String> navigation_id, URL::URL url) =|
     did_start_download_without_request(u64 page_id, URL::URL url, ByteString suggested_filename, Optional<u64> total_size) => (Optional<u64> download_id)
     did_start_download(u64 page_id, URL::URL url, ByteString suggested_filename, Optional<u64> total_size, int request_server_client_id, u64 request_server_request_id, ByteBuffer initial_data) => (Optional<u64> download_id)
     did_receive_download_data(u64 page_id, u64 download_id, ByteBuffer data) =|

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -401,20 +401,23 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         if (self == nil) {
             return;
         }
-        [self.observer onLoadStart];
-
         if (_status_label != nil) {
             [self.status_label setHidden:YES];
         }
     };
 
-    m_web_view_bridge->on_load_finish = [weak_self](auto const&) {
+    m_web_view_bridge->on_loading_state_change = [weak_self](bool is_loading) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
             return;
         }
-        [self.observer onLoadFinish];
+        if (is_loading)
+            [self.observer onLoadStart];
+        else
+            [self.observer onLoadFinish];
     };
+    if (m_web_view_bridge->is_loading())
+        m_web_view_bridge->on_loading_state_change(true);
 
     m_web_view_bridge->on_url_change = [weak_self](auto const& url) {
         LadybirdWebView* self = weak_self;

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -416,6 +416,13 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Win
 
     window->activateWindow();
     window->raise();
+
+    size_t initial_url_index = 0;
+    window->for_each_tab([&](Tab& tab) {
+        if (initial_url_index < initial_urls.size())
+            tab.navigate(initial_urls[initial_url_index++]);
+    });
+
     if (should_focus_location_editor) {
         QTimer::singleShot(0, window, [window] {
             if (auto* tab = window->current_tab())

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -482,9 +482,8 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     if (parent_tab) {
         new_child_tab(Web::HTML::ActivateTab::Yes, *parent_tab, AK::move(page_index));
     } else {
-        for (size_t i = 0; i < initial_urls.size(); ++i) {
-            new_tab_from_url(initial_urls[i], (i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No, TabLocation::end());
-        }
+        for (size_t i = 0; i < initial_urls.size(); ++i)
+            create_new_tab((i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No, TabLocation::end());
     }
 
     m_tabs_container->set_new_tab_action(m_new_tab_action);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -725,17 +725,10 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_hover_label->hide();
     };
 
-    view().on_load_start = [this]() {
-        set_loading(true);
+    view().on_loading_state_change = [this](bool is_loading) {
+        set_loading(is_loading);
     };
-
-    view().on_load_finish = [this](auto const&) {
-        set_loading(false);
-    };
-
-    view().on_web_content_crashed = [this] {
-        set_loading(false);
-    };
+    set_loading(view().is_loading());
 
     view().on_url_change = [this](auto const& url) {
         m_location_edit->set_url(url);


### PR DESCRIPTION
Show the loading spinner immediately when navigating startup tabs, and defer those navigations until the browser window is fully constructed and visible.

Track UI-requested loads so a fresh WebContent process finishing its initial about:blank document cannot prematurely clear the loading state for the requested URL.

Also propagate HTML parser end progress checks through ancestor documents. This prevents a parent document from remaining stuck when a descendant creates and later clears a load event delayer after its own load event has fired. Add a regression test covering this nested-document case.