### PR TITLE
LibWebView: Use CrossProcessId for session history document state

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -637,7 +637,7 @@ set(SOURCES
     HTML/MimeType.cpp
     HTML/MimeTypeArray.cpp
     HTML/Navigable.cpp
-    HTML/NavigableId.cpp
+    HTML/CrossProcessId.cpp
     HTML/NavigableContainer.cpp
     HTML/NavigateEvent.cpp
     HTML/Navigation.cpp

--- a/Libraries/LibWeb/HTML/CrossProcessId.cpp
+++ b/Libraries/LibWeb/HTML/CrossProcessId.cpp
@@ -6,12 +6,12 @@
 
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 
 namespace IPC {
 
 template<>
-ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigableId const& id)
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::CrossProcessId const& id)
 {
     TRY(encoder.encode(id.namespace_id));
     TRY(encoder.encode(id.local_id));
@@ -19,16 +19,16 @@ ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigableId const& id)
 }
 
 template<>
-ErrorOr<Web::HTML::NavigableId> decode(Decoder& decoder)
+ErrorOr<Web::HTML::CrossProcessId> decode(Decoder& decoder)
 {
-    return Web::HTML::NavigableId {
+    return Web::HTML::CrossProcessId {
         .namespace_id = TRY(decoder.decode<u64>()),
         .local_id = TRY(decoder.decode<u64>()),
     };
 }
 
 template<>
-ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigableIdAllocator const& allocator)
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::CrossProcessIdAllocator const& allocator)
 {
     TRY(encoder.encode(allocator.namespace_id));
     TRY(encoder.encode(allocator.next_local_id));
@@ -36,9 +36,9 @@ ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigableIdAllocator const& al
 }
 
 template<>
-ErrorOr<Web::HTML::NavigableIdAllocator> decode(Decoder& decoder)
+ErrorOr<Web::HTML::CrossProcessIdAllocator> decode(Decoder& decoder)
 {
-    return Web::HTML::NavigableIdAllocator {
+    return Web::HTML::CrossProcessIdAllocator {
         .namespace_id = TRY(decoder.decode<u64>()),
         .next_local_id = TRY(decoder.decode<u64>()),
     };

--- a/Libraries/LibWeb/HTML/CrossProcessId.h
+++ b/Libraries/LibWeb/HTML/CrossProcessId.h
@@ -9,7 +9,6 @@
 #include <AK/Assertions.h>
 #include <AK/Format.h>
 #include <AK/HashFunctions.h>
-#include <AK/Optional.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
 #include <LibIPC/Forward.h>
@@ -17,22 +16,24 @@
 
 namespace Web::HTML {
 
-struct NavigableId {
+class CrossProcessId {
+public:
     u64 namespace_id { 0 };
     u64 local_id { 0 };
 
-    bool operator==(NavigableId const&) const = default;
+    bool operator==(CrossProcessId const&) const = default;
 };
 
-struct NavigableIdAllocator {
+class CrossProcessIdAllocator {
+public:
     u64 namespace_id { 0 };
     u64 next_local_id { 1 };
 
-    NavigableId allocate()
+    CrossProcessId allocate()
     {
         VERIFY(namespace_id > 0);
         VERIFY(next_local_id > 0);
-        return NavigableId {
+        return CrossProcessId {
             .namespace_id = namespace_id,
             .local_id = next_local_id++,
         };
@@ -42,8 +43,8 @@ struct NavigableIdAllocator {
 }
 
 template<>
-struct AK::Traits<Web::HTML::NavigableId> : public DefaultTraits<Web::HTML::NavigableId> {
-    static unsigned hash(Web::HTML::NavigableId const& id)
+struct AK::Traits<Web::HTML::CrossProcessId> : public DefaultTraits<Web::HTML::CrossProcessId> {
+    static unsigned hash(Web::HTML::CrossProcessId const& id)
     {
         return pair_int_hash(Traits<u64>::hash(id.namespace_id), Traits<u64>::hash(id.local_id));
     }
@@ -52,20 +53,20 @@ struct AK::Traits<Web::HTML::NavigableId> : public DefaultTraits<Web::HTML::Navi
 namespace IPC {
 
 template<>
-WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::NavigableId const&);
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::CrossProcessId const&);
 template<>
-WEB_API ErrorOr<Web::HTML::NavigableId> decode(Decoder&);
+WEB_API ErrorOr<Web::HTML::CrossProcessId> decode(Decoder&);
 
 template<>
-WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::NavigableIdAllocator const&);
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::CrossProcessIdAllocator const&);
 template<>
-WEB_API ErrorOr<Web::HTML::NavigableIdAllocator> decode(Decoder&);
+WEB_API ErrorOr<Web::HTML::CrossProcessIdAllocator> decode(Decoder&);
 
 }
 
 template<>
-struct AK::Formatter<Web::HTML::NavigableId> : Formatter<FormatString> {
-    ErrorOr<void> format(FormatBuilder& builder, Web::HTML::NavigableId const& id)
+struct AK::Formatter<Web::HTML::CrossProcessId> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::HTML::CrossProcessId const& id)
     {
         return Formatter<FormatString>::format(builder, "{}:{}"sv, id.namespace_id, id.local_id);
     }

--- a/Libraries/LibWeb/HTML/DocumentState.h
+++ b/Libraries/LibWeb/HTML/DocumentState.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/RefCounted.h>
 #include <AK/Utf16String.h>
 #include <LibURL/Origin.h>
@@ -38,6 +39,9 @@ public:
 
     [[nodiscard]] Optional<UniqueNodeID> document_id() const { return m_document_id; }
     void set_document_id(Optional<UniqueNodeID> document_id) { m_document_id = document_id; }
+
+    [[nodiscard]] Optional<CrossProcessId> cross_process_id() const { return m_cross_process_id; }
+    void set_cross_process_id(Optional<CrossProcessId> id) { m_cross_process_id = id; }
 
     [[nodiscard]] Variant<SerializedPolicyContainer, Client> const& history_policy_container() const { return m_history_policy_container; }
     void set_history_policy_container(Variant<SerializedPolicyContainer, Client> history_policy_container) { m_history_policy_container = move(history_policy_container); }
@@ -79,6 +83,10 @@ private:
     // NOTE: We store the document's unique ID rather than a pointer to the document, because DocumentState is
     //       decoupled from the document's lifetime (LocalNavigable owns the document directly).
     Optional<UniqueNodeID> m_document_id;
+
+    // AD-HOC: Stable identity used by the UI-process session history mirror to preserve shared document states
+    //         across IPC and WebContent process swaps.
+    Optional<CrossProcessId> m_cross_process_id;
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#document-state-history-policy-container
     Variant<SerializedPolicyContainer, Client> m_history_policy_container { Client::Tag };

--- a/Libraries/LibWeb/HTML/DocumentState.h
+++ b/Libraries/LibWeb/HTML/DocumentState.h
@@ -14,7 +14,7 @@
 #include <LibWeb/Export.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/SerializedPolicyContainer.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
@@ -28,7 +28,7 @@ public:
     ~DocumentState();
 
     struct NestedHistory {
-        NavigableId id;
+        CrossProcessId id;
         Vector<NonnullRefPtr<SessionHistoryEntry>> entries;
     };
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -2634,7 +2634,7 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                 auto& page_client = active_browsing_context()->page().client();
                 auto is_top_level_navigation = is_top_level_traversable();
                 auto target = is_top_level_navigation ? NavigationTarget::TopLevel : NavigationTarget::IFrame;
-                auto frame_id = is_top_level_navigation ? Optional<NavigableId> {} : Optional<NavigableId> { id() };
+                auto frame_id = is_top_level_navigation ? Optional<CrossProcessId> {} : Optional<CrossProcessId> { id() };
                 auto process_decision = page_client.decide_navigation_process(this->active_document()->url(), url, target, move(frame_id));
                 if (process_decision == NavigationProcessDecision::Remote && is_top_level_navigation) {
                     page_client.request_new_process_for_navigation(url, document_resource, history_handling);

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -76,7 +76,7 @@ public:
     using NavigationParamsVariant = Variant<NullOrError, GC::Ref<NavigationParams>, GC::Ref<NonFetchSchemeNavigationParams>>;
 
     void initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document);
-    void set_id_for_session_history_reconstruction(NavigableId id) { set_id(id); }
+    void set_id_for_session_history_reconstruction(CrossProcessId id) { set_id(id); }
 
     void register_navigation_observer(Badge<NavigationObserver>, NavigationObserver&);
     void unregister_navigation_observer(Badge<NavigationObserver>, NavigationObserver&);

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1227,10 +1227,9 @@ void ApplyHistoryStepState::start()
                         ContentSecurityPolicy::Directives::Directive::NavigationType::Other, allow_POST,
                         GC::create_function(this->heap(), [this, after_document_populated, navigable](GC::Ptr<PopulateSessionHistoryEntryDocumentOutput> output) {
                             VERIFY(m_traversable->active_window());
-                            // AD-HOC: Queue with navigable's active Document instead of using queue_global_task(active_window).
-                            //         During initial about:blank Window reuse, active_window()->associated_document() can already be
-                            //         the pending Document. This continuation must stay runnable against the current active Document.
-                            queue_a_task(Task::Source::NavigationAndTraversal, nullptr, navigable->active_document(), GC::create_function(heap(), [after_document_populated, output]() {
+                            // AD-HOC: Queue through the apply-history helper so child completion tasks survive frame
+                            //         removal/deactivation. The continuation revalidates the navigable before applying.
+                            queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [after_document_populated, output]() {
                                 after_document_populated->function()(output);
                             }));
                         }));

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -243,7 +243,7 @@ static void populate_nested_histories_from_ui_process(DocumentState& document_st
         // FIXME: This is temporary glue for the current load-then-seed ordering.
         //        A replacement WebContent process can create live child navigables
         //        before the UI process sends its canonical session-history tree.
-        //        Now that nested history ids are canonical NavigableIds, the UI id
+        //        Now that nested history ids are canonical CrossProcessIds, the UI id
         //        must win; retarget the already-created child to match it. The
         //        longer-term model should avoid creating a distinct temporary id
         //        for a child the UI process already knows about.

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -218,7 +218,7 @@ static bool session_history_entry_descriptors_are_valid(Vector<SessionHistoryEnt
 }
 
 struct SessionHistoryEntryReconstructionState {
-    HashMap<u64, RefPtr<DocumentState>> document_states;
+    HashMap<CrossProcessId, RefPtr<DocumentState>> document_states;
 };
 
 static NonnullRefPtr<SessionHistoryEntry> create_session_history_entry_from_ui_process(SessionHistoryEntryDescriptor, SessionHistoryEntryReconstructionState&);
@@ -289,6 +289,7 @@ static void apply_session_history_entry_descriptor_from_ui_process(SessionHistor
 
 static void apply_session_history_document_state_descriptor_from_ui_process(DocumentState& document_state, SessionHistoryDocumentStateDescriptor const& document_state_descriptor)
 {
+    document_state.set_cross_process_id(document_state_descriptor.id);
     document_state.set_history_policy_container(document_state_descriptor.history_policy_container);
     document_state.set_request_referrer(document_state_descriptor.request_referrer);
     document_state.set_request_referrer_policy(document_state_descriptor.request_referrer_policy);
@@ -297,25 +298,21 @@ static void apply_session_history_document_state_descriptor_from_ui_process(Docu
     document_state.set_about_base_url(document_state_descriptor.about_base_url);
     document_state.set_resource(document_state_descriptor.resource);
     document_state.set_reload_pending(document_state_descriptor.reload_pending);
-    // AD-HOC: Descriptor ID 0 marks a provisional UI-created document state whose entry has not yet been populated
-    //         by WebContent. Treat it as already populated when reseeding the active entry, since a replacement
-    //         WebContent process already has the active document for that entry.
-    document_state.set_ever_populated(document_state_descriptor.id == 0 ? true : document_state_descriptor.ever_populated);
+    // AD-HOC: A UI-created document state can still be provisional when reseeded into WebContent. Do not let that
+    //         stale mirror state make an already-populated live document state appear unpopulated again.
+    document_state.set_ever_populated(document_state.ever_populated() || document_state_descriptor.ever_populated);
     document_state.set_navigable_target_name(document_state_descriptor.navigable_target_name);
 }
 
 static RefPtr<DocumentState> get_or_create_document_state_from_ui_process(SessionHistoryDocumentStateDescriptor const& document_state_descriptor, SessionHistoryEntryReconstructionState& reconstruction_state)
 {
     RefPtr<DocumentState> document_state;
-    if (document_state_descriptor.id != 0) {
-        if (auto existing_document_state = reconstruction_state.document_states.get(document_state_descriptor.id); existing_document_state.has_value())
-            document_state = *existing_document_state;
-    }
+    if (auto existing_document_state = reconstruction_state.document_states.get(document_state_descriptor.id); existing_document_state.has_value())
+        document_state = *existing_document_state;
 
     if (!document_state) {
         document_state = DocumentState::create();
-        if (document_state_descriptor.id != 0)
-            reconstruction_state.document_states.set(document_state_descriptor.id, document_state);
+        reconstruction_state.document_states.set(document_state_descriptor.id, document_state);
     }
 
     apply_session_history_document_state_descriptor_from_ui_process(*document_state, document_state_descriptor);
@@ -378,12 +375,12 @@ bool LocalTraversableNavigable::replace_top_level_session_history_entries_from_u
         //     incomplete or stale snapshot. Same-document history updates are committed synchronously in WebContent,
         //     while the UI-process mirror is necessarily fed by async IPC. If that mirror sends back an older current
         //     entry, accepting it would clobber the active document's live latest entry and make a queued traversal
-        //     target unreachable. Rejecting the seed lets the UI process converge from WebContent's current snapshot
-        //     instead. Descriptor ID 0 means the UI process only has a provisional document state; do not apply that
-        //     to a live non-initial document. Process-swap/preload seeds still go through the initial about:blank path
-        //     above.
+        //     target unreachable. A provisional descriptor is UI-owned state, not an authoritative description of an
+        //     already-live current document. The broader model should move toward a narrower seed-ack contract or
+        //     targeted UI-process mutations instead of sending a full async mirror back as authoritative state.
+        //     Process-swap/preload seeds still go through the initial about:blank path above.
         auto const& current_entry_from_ui_process = entries_from_ui_process[current_top_level_entry_index];
-        if (current_entry_from_ui_process.document_state.id == 0)
+        if (current_entry_from_ui_process.document_state.is_provisional)
             return false;
         // NB: Nested histories can be UI-owned state that is intentionally restored after the current top-level
         //     document has loaded. The live latest entry must still match the UI seed's top-level state, but requiring
@@ -437,11 +434,9 @@ bool LocalTraversableNavigable::replace_top_level_session_history_entries_from_u
     }
 
     SessionHistoryEntryReconstructionState reconstruction_state;
-    if (entries_from_ui_process[current_top_level_entry_index].document_state.id != 0) {
-        auto active_document_state = active_entry->document_state();
-        VERIFY(active_document_state);
-        reconstruction_state.document_states.set(entries_from_ui_process[current_top_level_entry_index].document_state.id, active_document_state);
-    }
+    auto active_document_state = active_entry->document_state();
+    VERIFY(active_document_state);
+    reconstruction_state.document_states.set(entries_from_ui_process[current_top_level_entry_index].document_state.id, active_document_state);
 
     Vector<NonnullRefPtr<SessionHistoryEntry>> entries;
     entries.ensure_capacity(entries_from_ui_process.size());
@@ -1494,7 +1489,9 @@ LocalTraversableNavigable::SessionHistorySnapshot LocalTraversableNavigable::cre
 
     Vector<SessionHistoryEntryDescriptor> top_level_session_history_entries;
     top_level_session_history_entries.ensure_capacity(session_history_entries().size());
-    SessionHistoryEntryDescriptorCreationState creation_state;
+    SessionHistoryEntryDescriptorCreationState creation_state { [this] {
+        return page().client().allocate_cross_process_id();
+    } };
     for (auto const& entry : session_history_entries())
         top_level_session_history_entries.unchecked_append(create_session_history_entry_descriptor(entry, creation_state));
 

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -13,7 +13,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 
 namespace Web::HTML {
 
@@ -25,7 +25,7 @@ public:
     virtual ~Navigable() override;
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-id
-    NavigableId id() const { return m_id; }
+    CrossProcessId id() const { return m_id; }
 
     GC::Ptr<Navigable> parent() const { return m_parent; }
 
@@ -39,13 +39,13 @@ public:
 
 protected:
     Navigable() = default;
-    void set_id(NavigableId id) { m_id = id; }
+    void set_id(CrossProcessId id) { m_id = id; }
     void set_parent(GC::Ptr<Navigable> parent) { m_parent = parent; }
 
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    NavigableId m_id;
+    CrossProcessId m_id;
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-parent
     GC::Ptr<Navigable> m_parent;

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
@@ -463,7 +463,7 @@ ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SessionHistoryNestedHisto
 template<>
 ErrorOr<Web::HTML::SessionHistoryNestedHistoryDescriptor> IPC::decode(Decoder& decoder)
 {
-    auto id = TRY(decoder.decode<Web::HTML::NavigableId>());
+    auto id = TRY(decoder.decode<Web::HTML::CrossProcessId>());
     auto entries = TRY(decoder.decode<Vector<Web::HTML::SessionHistoryEntryDescriptor>>());
 
     return Web::HTML::SessionHistoryNestedHistoryDescriptor { id, move(entries) };

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
@@ -32,18 +32,18 @@ SessionHistoryEntry::SessionHistoryEntry()
 {
 }
 
-static u64 document_state_id_for_descriptor(DocumentState const& document_state, SessionHistoryEntryDescriptorCreationState& creation_state)
+static CrossProcessId document_state_id_for_descriptor(DocumentState& document_state, SessionHistoryEntryDescriptorCreationState& creation_state)
 {
-    if (auto id = creation_state.document_state_ids.get(&document_state); id.has_value())
+    if (auto id = document_state.cross_process_id(); id.has_value())
         return *id;
 
-    auto id = creation_state.next_document_state_id++;
-    VERIFY(id != 0);
-    creation_state.document_state_ids.set(&document_state, id);
+    auto id = creation_state.allocate_cross_process_id();
+    VERIFY(id.local_id != 0);
+    document_state.set_cross_process_id(id);
     return id;
 }
 
-static SessionHistoryDocumentStateDescriptor create_session_history_document_state_descriptor(DocumentState const& document_state, SessionHistoryEntryDescriptorCreationState& creation_state)
+static SessionHistoryDocumentStateDescriptor create_session_history_document_state_descriptor(DocumentState& document_state, SessionHistoryEntryDescriptorCreationState& creation_state)
 {
     Vector<SessionHistoryNestedHistoryDescriptor> nested_history_descriptors;
     nested_history_descriptors.ensure_capacity(document_state.nested_histories().size());
@@ -171,30 +171,9 @@ static bool session_history_document_state_descriptors_match(SessionHistoryDocum
         && a.resource == b.resource
         && a.reload_pending == b.reload_pending
         && a.ever_populated == b.ever_populated
+        && a.is_provisional == b.is_provisional
         && a.navigable_target_name == b.navigable_target_name
         && session_history_nested_history_descriptors_match(a.nested_histories, b.nested_histories);
-}
-
-static bool session_history_nested_history_descriptors_match_ignoring_document_state_ids(Vector<SessionHistoryNestedHistoryDescriptor> const&, Vector<SessionHistoryNestedHistoryDescriptor> const&);
-
-static bool session_history_document_state_descriptors_match_ignoring_id(SessionHistoryDocumentStateDescriptor const& a, SessionHistoryDocumentStateDescriptor const& b, MatchNestedHistories match_nested_histories)
-{
-    if (!(history_policy_containers_match(a.history_policy_container, b.history_policy_container)
-            && a.request_referrer == b.request_referrer
-            && a.request_referrer_policy == b.request_referrer_policy
-            && a.initiator_origin == b.initiator_origin
-            && a.origin == b.origin
-            && a.about_base_url == b.about_base_url
-            && a.resource == b.resource
-            && a.reload_pending == b.reload_pending
-            && a.ever_populated == b.ever_populated
-            && a.navigable_target_name == b.navigable_target_name))
-        return false;
-
-    if (match_nested_histories == MatchNestedHistories::No)
-        return true;
-
-    return session_history_nested_history_descriptors_match_ignoring_document_state_ids(a.nested_histories, b.nested_histories);
 }
 
 bool session_history_entry_descriptors_match(SessionHistoryEntryDescriptor const& a, SessionHistoryEntryDescriptor const& b)
@@ -210,25 +189,6 @@ bool session_history_entry_descriptors_match(SessionHistoryEntryDescriptor const
         && a.scroll_position_data == b.scroll_position_data;
 }
 
-bool session_history_entry_descriptors_match_ignoring_document_state_id(SessionHistoryEntryDescriptor const& a, SessionHistoryEntryDescriptor const& b, MatchNestedHistories match_nested_histories)
-{
-    if (a.step != b.step)
-        return false;
-    if (a.url != b.url)
-        return false;
-    if (a.document_state.id != 0 && !session_history_document_state_descriptors_match_ignoring_id(a.document_state, b.document_state, match_nested_histories))
-        return false;
-    if (a.classic_history_api_state != b.classic_history_api_state)
-        return false;
-    if (a.navigation_api_state != b.navigation_api_state || a.navigation_api_key != b.navigation_api_key || a.navigation_api_id != b.navigation_api_id)
-        return false;
-    if (a.scroll_restoration_mode != b.scroll_restoration_mode)
-        return false;
-    if (a.document_state.id != 0 && a.scroll_position_data != b.scroll_position_data)
-        return false;
-    return true;
-}
-
 static bool session_history_entry_descriptors_match(Vector<SessionHistoryEntryDescriptor> const& a, Vector<SessionHistoryEntryDescriptor> const& b)
 {
     if (a.size() != b.size())
@@ -242,19 +202,6 @@ static bool session_history_entry_descriptors_match(Vector<SessionHistoryEntryDe
     return true;
 }
 
-static bool session_history_entry_descriptors_match_ignoring_document_state_ids(Vector<SessionHistoryEntryDescriptor> const& a, Vector<SessionHistoryEntryDescriptor> const& b)
-{
-    if (a.size() != b.size())
-        return false;
-
-    for (size_t i = 0; i < a.size(); ++i) {
-        if (session_history_entry_descriptors_match_ignoring_document_state_id(a[i], b[i]))
-            continue;
-        return false;
-    }
-    return true;
-}
-
 static bool session_history_nested_history_descriptors_match(Vector<SessionHistoryNestedHistoryDescriptor> const& a, Vector<SessionHistoryNestedHistoryDescriptor> const& b)
 {
     if (a.size() != b.size())
@@ -262,19 +209,6 @@ static bool session_history_nested_history_descriptors_match(Vector<SessionHisto
 
     for (size_t i = 0; i < a.size(); ++i) {
         if (a[i].id == b[i].id && session_history_entry_descriptors_match(a[i].entries, b[i].entries))
-            continue;
-        return false;
-    }
-    return true;
-}
-
-static bool session_history_nested_history_descriptors_match_ignoring_document_state_ids(Vector<SessionHistoryNestedHistoryDescriptor> const& a, Vector<SessionHistoryNestedHistoryDescriptor> const& b)
-{
-    if (a.size() != b.size())
-        return false;
-
-    for (size_t i = 0; i < a.size(); ++i) {
-        if (a[i].id == b[i].id && session_history_entry_descriptors_match_ignoring_document_state_ids(a[i].entries, b[i].entries))
             continue;
         return false;
     }
@@ -327,18 +261,16 @@ bool session_history_entry_matches_descriptor_ignoring_document_state_id(Session
         return false;
     if (entry.url() != descriptor.url)
         return false;
-    if (descriptor.document_state.id != 0) {
-        auto document_state = entry.document_state();
-        if (!document_state || !session_history_document_state_descriptor_matches_document_state_ignoring_id(descriptor.document_state, *document_state, match_nested_histories))
-            return false;
-    }
+    auto document_state = entry.document_state();
+    if (!document_state || !session_history_document_state_descriptor_matches_document_state_ignoring_id(descriptor.document_state, *document_state, match_nested_histories))
+        return false;
     if (entry.classic_history_api_state() != descriptor.classic_history_api_state)
         return false;
     if (entry.navigation_api_state() != descriptor.navigation_api_state || entry.navigation_api_key() != descriptor.navigation_api_key || entry.navigation_api_id() != descriptor.navigation_api_id)
         return false;
     if (entry.scroll_restoration_mode() != descriptor.scroll_restoration_mode)
         return false;
-    if (descriptor.document_state.id != 0 && entry.scroll_position_data() != descriptor.scroll_position_data)
+    if (entry.scroll_position_data() != descriptor.scroll_position_data)
         return false;
     return true;
 }
@@ -415,6 +347,7 @@ ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SessionHistoryDocumentSta
     TRY(encoder.encode(document_state.resource));
     TRY(encoder.encode(document_state.reload_pending));
     TRY(encoder.encode(document_state.ever_populated));
+    TRY(encoder.encode(document_state.is_provisional));
     TRY(encoder.encode(document_state.navigable_target_name));
     TRY(encoder.encode(document_state.nested_histories));
     return {};
@@ -423,7 +356,7 @@ ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SessionHistoryDocumentSta
 template<>
 ErrorOr<Web::HTML::SessionHistoryDocumentStateDescriptor> IPC::decode(Decoder& decoder)
 {
-    auto id = TRY(decoder.decode<u64>());
+    auto id = TRY(decoder.decode<Web::HTML::CrossProcessId>());
     auto history_policy_container = TRY(decoder.decode<Variant<Web::HTML::SerializedPolicyContainer, Web::HTML::DocumentState::Client>>());
     auto request_referrer = TRY(decoder.decode<Web::Fetch::Infrastructure::Request::ReferrerType>());
     auto request_referrer_policy = TRY(decoder.decode<Web::ReferrerPolicy::ReferrerPolicy>());
@@ -433,6 +366,7 @@ ErrorOr<Web::HTML::SessionHistoryDocumentStateDescriptor> IPC::decode(Decoder& d
     auto resource = TRY(decoder.decode<Variant<Empty, String, Web::HTML::POSTResource>>());
     auto reload_pending = TRY(decoder.decode<bool>());
     auto ever_populated = TRY(decoder.decode<bool>());
+    auto is_provisional = TRY(decoder.decode<bool>());
     auto navigable_target_name = TRY(decoder.decode<Utf16String>());
     auto nested_histories = TRY(decoder.decode<Vector<Web::HTML::SessionHistoryNestedHistoryDescriptor>>());
 
@@ -447,6 +381,7 @@ ErrorOr<Web::HTML::SessionHistoryDocumentStateDescriptor> IPC::decode(Decoder& d
         .resource = move(resource),
         .reload_pending = reload_pending,
         .ever_populated = ever_populated,
+        .is_provisional = is_provisional,
         .navigable_target_name = move(navigable_target_name),
         .nested_histories = move(nested_histories),
     };

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.h
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/RefCounted.h>
@@ -18,8 +19,8 @@
 #include <LibWeb/Export.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/DocumentState.h>
 #include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/DocumentState.h>
 #include <LibWeb/HTML/StructuredSerializeTypes.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
@@ -47,7 +48,7 @@ struct SessionHistoryNestedHistoryDescriptor;
 struct SessionHistoryDocumentStateDescriptor {
     // AD-HOC: The spec models shared document state by object identity. The UI-process mirror uses a stable
     //         descriptor ID so entries that share a document state can be reconstructed after IPC.
-    u64 id { 0 };
+    CrossProcessId id;
     Variant<SerializedPolicyContainer, DocumentState::Client> history_policy_container { DocumentState::Client::Tag };
     Fetch::Infrastructure::Request::ReferrerType request_referrer { Fetch::Infrastructure::Request::Referrer::Client };
     ReferrerPolicy::ReferrerPolicy request_referrer_policy { ReferrerPolicy::DEFAULT_REFERRER_POLICY };
@@ -57,6 +58,7 @@ struct SessionHistoryDocumentStateDescriptor {
     Variant<Empty, String, POSTResource> resource;
     bool reload_pending { false };
     bool ever_populated { false };
+    bool is_provisional { false };
     Utf16String navigable_target_name;
     Vector<SessionHistoryNestedHistoryDescriptor> nested_histories;
 };
@@ -175,8 +177,12 @@ private:
 };
 
 struct SessionHistoryEntryDescriptorCreationState {
-    HashMap<DocumentState const*, u64> document_state_ids;
-    u64 next_document_state_id { 1 };
+    explicit SessionHistoryEntryDescriptorCreationState(Function<CrossProcessId()> allocate_cross_process_id)
+        : allocate_cross_process_id(move(allocate_cross_process_id))
+    {
+    }
+
+    Function<CrossProcessId()> allocate_cross_process_id;
 };
 
 WEB_API SessionHistoryEntryDescriptor create_session_history_entry_descriptor(SessionHistoryEntry const&, SessionHistoryEntryDescriptorCreationState&);
@@ -185,7 +191,6 @@ enum class MatchNestedHistories {
     Yes,
     No,
 };
-WEB_API bool session_history_entry_descriptors_match_ignoring_document_state_id(SessionHistoryEntryDescriptor const&, SessionHistoryEntryDescriptor const&, MatchNestedHistories = MatchNestedHistories::Yes);
 WEB_API bool session_history_entry_matches_descriptor_ignoring_document_state_id(SessionHistoryEntry const&, SessionHistoryEntryDescriptor const&, MatchNestedHistories = MatchNestedHistories::Yes);
 
 }

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.h
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.h
@@ -19,7 +19,7 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/DocumentState.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/StructuredSerializeTypes.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
@@ -84,7 +84,7 @@ struct SessionHistoryEntryDescriptor {
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#nested-history
 struct SessionHistoryNestedHistoryDescriptor {
-    NavigableId id;
+    CrossProcessId id;
     Vector<SessionHistoryEntryDescriptor> entries;
 };
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -44,8 +44,8 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
-#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
@@ -482,10 +482,11 @@ public:
             return Compositor::compositor_context_id_for_page(id());
         VERIFY_NOT_REACHED();
     }
-    virtual HTML::CrossProcessId allocate_navigable_id()
+    virtual HTML::CrossProcessId allocate_cross_process_id()
     {
         VERIFY_NOT_REACHED();
     }
+    virtual HTML::CrossProcessId allocate_navigable_id() { return allocate_cross_process_id(); }
     virtual void request_frame() = 0;
     virtual void page_did_change_title(Utf16String const&) { }
     virtual void page_did_change_url(URL::URL const&) { }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -45,7 +45,7 @@
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/FileFilter.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
@@ -452,17 +452,17 @@ public:
         [[maybe_unused]] URL::URL const& current_url,
         [[maybe_unused]] URL::URL const& target_url,
         [[maybe_unused]] NavigationTarget target = NavigationTarget::TopLevel,
-        [[maybe_unused]] Optional<HTML::NavigableId> frame_id = {}) const
+        [[maybe_unused]] Optional<HTML::CrossProcessId> frame_id = {}) const
     {
         return NavigationProcessDecision::Local;
     }
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
-    virtual void request_new_process_for_child_frame_navigation(HTML::NavigableId, URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
-    virtual void page_did_create_child_frame(HTML::NavigableId, HTML::NavigableId, HTML::ReplicatedNavigableState const&) { }
-    virtual void page_did_update_child_frame_viewport(HTML::NavigableId, CSSPixelRect) { }
-    virtual void page_did_commit_child_frame_navigation(HTML::NavigableId, HTML::ReplicatedNavigableState const&) { }
-    virtual void page_did_destroy_child_frame(HTML::NavigableId) { }
-    virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(HTML::NavigableId) const { return {}; }
+    virtual void request_new_process_for_child_frame_navigation(HTML::CrossProcessId, URL::URL const&, Variant<Empty, String, HTML::POSTResource>, Bindings::NavigationHistoryBehavior) { }
+    virtual void page_did_create_child_frame(HTML::CrossProcessId, HTML::CrossProcessId, HTML::ReplicatedNavigableState const&) { }
+    virtual void page_did_update_child_frame_viewport(HTML::CrossProcessId, CSSPixelRect) { }
+    virtual void page_did_commit_child_frame_navigation(HTML::CrossProcessId, HTML::ReplicatedNavigableState const&) { }
+    virtual void page_did_destroy_child_frame(HTML::CrossProcessId) { }
+    virtual Optional<Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(HTML::CrossProcessId) const { return {}; }
     virtual String dump_site_isolation_process_tree_for_testing() { return {}; }
     virtual Gfx::Palette palette() const = 0;
     virtual DevicePixelRect screen_rect() const = 0;
@@ -482,7 +482,7 @@ public:
             return Compositor::compositor_context_id_for_page(id());
         VERIFY_NOT_REACHED();
     }
-    virtual HTML::NavigableId allocate_navigable_id()
+    virtual HTML::CrossProcessId allocate_navigable_id()
     {
         VERIFY_NOT_REACHED();
     }

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -90,7 +90,7 @@ public:
     GC::Ptr<Page> m_svg_page;
 
     virtual u64 id() const override { VERIFY_NOT_REACHED(); }
-    virtual HTML::NavigableId allocate_navigable_id() override { return m_host_page->client().allocate_navigable_id(); }
+    virtual HTML::CrossProcessId allocate_navigable_id() override { return m_host_page->client().allocate_navigable_id(); }
     virtual Page& page() override { return *m_svg_page; }
     virtual Page const& page() const override { return *m_svg_page; }
     virtual bool is_connection_open() const override { return false; }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -117,6 +117,7 @@ Application::Application(Optional<ByteString> ladybird_binary_path)
 {
     VERIFY(!s_the);
     s_the = this;
+    m_ui_process_cross_process_id_allocator = allocate_cross_process_id_allocator();
 
     platform_init(move(ladybird_binary_path));
 }
@@ -650,6 +651,11 @@ Web::HTML::CrossProcessIdAllocator Application::allocate_cross_process_id_alloca
 {
     VERIFY(m_next_cross_process_id_namespace > 0);
     return Web::HTML::CrossProcessIdAllocator { .namespace_id = m_next_cross_process_id_namespace++ };
+}
+
+Web::HTML::CrossProcessId Application::allocate_ui_process_cross_process_id()
+{
+    return m_ui_process_cross_process_id_allocator.allocate();
 }
 
 PrivateBrowsingSession& Application::ensure_private_browsing_session()

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -620,16 +620,16 @@ void Application::open_bookmark_in_new_window(String const& bookmark_id, IsPriva
         open_url_in_new_window(bookmark->bookmark().url, is_private);
 }
 
-ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id, Optional<Web::HTML::NavigableId> root_navigable_id)
+ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(Optional<ViewImplementation&> view, IsPrivate is_private, u64 initial_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id)
 {
     auto request_server_handle = TRY(connect_new_request_server_client(is_private));
     auto image_decoder_handle = TRY(connect_new_image_decoder_client());
 
-    auto navigable_id_allocator = allocate_navigable_id_allocator();
-    auto root_id = root_navigable_id.value_or(navigable_id_allocator.allocate());
+    auto cross_process_id_allocator = allocate_cross_process_id_allocator();
+    auto root_id = root_navigable_id.value_or(cross_process_id_allocator.allocate());
 
     auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id, root_id));
-    client->async_initialize(initial_page_id, root_id, navigable_id_allocator);
+    client->async_initialize(initial_page_id, root_id, cross_process_id_allocator);
     if (view.has_value())
         client->assign_view({}, *view);
 
@@ -646,10 +646,10 @@ u64 Application::allocate_page_id()
     return m_next_page_or_compositor_context_id++;
 }
 
-Web::HTML::NavigableIdAllocator Application::allocate_navigable_id_allocator()
+Web::HTML::CrossProcessIdAllocator Application::allocate_cross_process_id_allocator()
 {
-    VERIFY(m_next_navigable_id_namespace > 0);
-    return Web::HTML::NavigableIdAllocator { .namespace_id = m_next_navigable_id_namespace++ };
+    VERIFY(m_next_cross_process_id_namespace > 0);
+    return Web::HTML::CrossProcessIdAllocator { .namespace_id = m_next_cross_process_id_namespace++ };
 }
 
 PrivateBrowsingSession& Application::ensure_private_browsing_session()
@@ -861,7 +861,7 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process
     return create_web_content_client(view, IsPrivate::No, allocate_page_id());
 }
 
-ErrorOr<Application::ChildFrameWebContentProcess> Application::launch_child_frame_web_content_process(IsPrivate is_private, Web::HTML::NavigableId root_navigable_id)
+ErrorOr<Application::ChildFrameWebContentProcess> Application::launch_child_frame_web_content_process(IsPrivate is_private, Web::HTML::CrossProcessId root_navigable_id)
 {
     auto page_id = allocate_page_id();
     auto client = TRY(create_web_content_client({}, is_private, page_id, root_navigable_id));

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -29,7 +29,7 @@
 #include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/HTML/ActivateTab.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWebView/BookmarkStore.h>
 #include <LibWebView/FileDownloader.h>
 #include <LibWebView/Forward.h>
@@ -124,9 +124,9 @@ public:
         NonnullRefPtr<WebContentClient> client;
         u64 page_id { 0 };
     };
-    ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process(IsPrivate, Web::HTML::NavigableId root_navigable_id);
+    ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process(IsPrivate, Web::HTML::CrossProcessId root_navigable_id);
     u64 allocate_page_id();
-    Web::HTML::NavigableIdAllocator allocate_navigable_id_allocator();
+    Web::HTML::CrossProcessIdAllocator allocate_cross_process_id_allocator();
 
     void maybe_close_private_browsing_session();
     void reset_private_browsing_session();
@@ -277,7 +277,7 @@ protected:
     Main::Arguments& arguments() { return m_arguments; }
 
 private:
-    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, IsPrivate, u64 initial_page_id, Optional<Web::HTML::NavigableId> root_navigable_id = {});
+    ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&>, IsPrivate, u64 initial_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id = {});
     PrivateBrowsingSession& ensure_private_browsing_session();
     ErrorOr<void> launch_services();
     void launch_spare_web_content_process();
@@ -405,7 +405,7 @@ private:
     RefPtr<WebContentClient> m_spare_web_content_process;
     bool m_has_queued_task_to_launch_spare_web_content_process { false };
     u64 m_next_page_or_compositor_context_id { 1 };
-    u64 m_next_navigable_id_namespace { 1 };
+    u64 m_next_cross_process_id_namespace { 1 };
 
     RefPtr<Database::Database> m_database;
     RefPtr<Database::Database> m_history_database;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -127,6 +127,7 @@ public:
     ErrorOr<ChildFrameWebContentProcess> launch_child_frame_web_content_process(IsPrivate, Web::HTML::CrossProcessId root_navigable_id);
     u64 allocate_page_id();
     Web::HTML::CrossProcessIdAllocator allocate_cross_process_id_allocator();
+    Web::HTML::CrossProcessId allocate_ui_process_cross_process_id();
 
     void maybe_close_private_browsing_session();
     void reset_private_browsing_session();
@@ -406,6 +407,7 @@ private:
     bool m_has_queued_task_to_launch_spare_web_content_process { false };
     u64 m_next_page_or_compositor_context_id { 1 };
     u64 m_next_cross_process_id_namespace { 1 };
+    Web::HTML::CrossProcessIdAllocator m_ui_process_cross_process_id_allocator;
 
     RefPtr<Database::Database> m_database;
     RefPtr<Database::Database> m_history_database;

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -12,7 +12,7 @@
 
 namespace WebView {
 
-CanonicalNavigable::CanonicalNavigable(Web::HTML::NavigableId id, Optional<Web::HTML::NavigableId> parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id)
+CanonicalNavigable::CanonicalNavigable(Web::HTML::CrossProcessId id, Optional<Web::HTML::CrossProcessId> parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id)
     : m_id(id)
     , m_parent_id(parent_id)
     , m_reporting_client(move(reporting_client))

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -17,7 +17,7 @@
 #include <AK/Vector.h>
 #include <AK/Weakable.h>
 #include <LibURL/URL.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/Export.h>
@@ -39,14 +39,14 @@ public:
         Optional<u64> remote_page_id;
     };
 
-    CanonicalNavigable(Web::HTML::NavigableId id, Optional<Web::HTML::NavigableId> parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id);
+    CanonicalNavigable(Web::HTML::CrossProcessId id, Optional<Web::HTML::CrossProcessId> parent_id, RefPtr<WebContentClient> reporting_client, u64 reporting_page_id);
     virtual ~CanonicalNavigable();
 
     virtual bool is_top_level_traversable() const { return false; }
 
-    Web::HTML::NavigableId id() const { return m_id; }
-    Optional<Web::HTML::NavigableId> parent_id() const { return m_parent_id; }
-    void set_id(Web::HTML::NavigableId id) { m_id = id; }
+    Web::HTML::CrossProcessId id() const { return m_id; }
+    Optional<Web::HTML::CrossProcessId> parent_id() const { return m_parent_id; }
+    void set_id(Web::HTML::CrossProcessId id) { m_id = id; }
 
     // The WebContent process and page whose document tree contains this frame. When the
     // frame is local, this process also hosts the frame's active document.
@@ -88,8 +88,8 @@ public:
     bool has_matching_pending_navigation(URL::URL const&, HostLocality) const;
 
 private:
-    Web::HTML::NavigableId m_id;
-    Optional<Web::HTML::NavigableId> m_parent_id;
+    Web::HTML::CrossProcessId m_id;
+    Optional<Web::HTML::CrossProcessId> m_parent_id;
     RefPtr<WebContentClient> m_reporting_client;
     u64 m_reporting_page_id { 0 };
     CanonicalNavigable* m_parent { nullptr };

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -15,7 +15,7 @@ CanonicalTraversable::CanonicalTraversable()
 {
 }
 
-CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, CanonicalNavigable& fallback_parent)
+CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, CanonicalNavigable& fallback_parent)
 {
     if (auto existing_navigable = find(frame_id); existing_navigable.has_value())
         remove(*existing_navigable);
@@ -34,7 +34,7 @@ CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_cli
     return navigable_ref;
 }
 
-Optional<CanonicalNavigable&> CanonicalTraversable::find(Web::HTML::NavigableId frame_id)
+Optional<CanonicalNavigable&> CanonicalTraversable::find(Web::HTML::CrossProcessId frame_id)
 {
     auto navigable = m_navigable_index.get(frame_id);
     if (!navigable.has_value() || !navigable.value())
@@ -43,7 +43,7 @@ Optional<CanonicalNavigable&> CanonicalTraversable::find(Web::HTML::NavigableId 
     return *navigable.value();
 }
 
-Optional<CanonicalNavigable const&> CanonicalTraversable::find(Web::HTML::NavigableId frame_id) const
+Optional<CanonicalNavigable const&> CanonicalTraversable::find(Web::HTML::CrossProcessId frame_id) const
 {
     auto navigable = m_navigable_index.get(frame_id);
     if (!navigable.has_value() || !navigable.value())

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWebView/Application.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/WebContentClient.h>
@@ -13,6 +14,11 @@ namespace WebView {
 CanonicalTraversable::CanonicalTraversable()
     : CanonicalNavigable({}, {}, nullptr, 0)
 {
+}
+
+static Web::HTML::CrossProcessId allocate_ui_process_document_state_id()
+{
+    return Application::the().allocate_ui_process_cross_process_id();
 }
 
 CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, CanonicalNavigable& fallback_parent)
@@ -146,9 +152,9 @@ ProcessSwapNavigationPreparation CanonicalTraversable::prepare_for_process_swap_
         }
 
         if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
-            m_session_history.replace_current_entry(url, move(document_resource));
+            m_session_history.replace_current_entry(url, allocate_ui_process_document_state_id(), move(document_resource));
         else
-            m_session_history.navigate(url, move(document_resource));
+            m_session_history.navigate(url, allocate_ui_process_document_state_id(), move(document_resource));
         m_current_web_content_session_history_matches_mirror = false;
         result.should_update_navigation_action_state = true;
     }
@@ -193,9 +199,9 @@ PageLoadPreparation CanonicalTraversable::prepare_for_page_load(URL::URL const& 
     }
 
     if (ui_process_history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
-        m_session_history.replace_current_entry(url, Empty {});
+        m_session_history.replace_current_entry(url, allocate_ui_process_document_state_id(), Empty {});
     else
-        m_session_history.navigate(url);
+        m_session_history.navigate(url, allocate_ui_process_document_state_id());
     m_current_web_content_session_history_matches_mirror = false;
     result.should_update_navigation_action_state = true;
     return result;
@@ -403,7 +409,7 @@ NavigationStartResult CanonicalTraversable::did_start_navigation(URL::URL const&
     }
 
     if (is_redirect) {
-        m_session_history.replace_current_entry_url(url);
+        m_session_history.replace_current_entry_url(url, allocate_ui_process_document_state_id());
         if (m_pending_session_history_navigation.has_value())
             m_pending_session_history_navigation->url = url;
         m_current_web_content_session_history_matches_mirror = false;
@@ -420,12 +426,12 @@ NavigationStartResult CanonicalTraversable::did_start_navigation(URL::URL const&
             m_pending_session_history_navigation.clear();
 
         if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace) {
-            m_session_history.replace_current_entry(url, move(document_resource));
+            m_session_history.replace_current_entry(url, allocate_ui_process_document_state_id(), move(document_resource));
             m_current_web_content_session_history_matches_mirror = false;
             return { .dump_reason = "did-start-navigation-replace-current-url"sv, .should_update_navigation_action_state = true, .did_clear_crash_page = is_showing_crash_page };
         }
         if (history_handling == Web::Bindings::NavigationHistoryBehavior::Push) {
-            m_session_history.navigate(url, move(document_resource));
+            m_session_history.navigate(url, allocate_ui_process_document_state_id(), move(document_resource));
             m_current_web_content_session_history_matches_mirror = false;
             return { .dump_reason = "did-start-navigation-push-current-url"sv, .should_update_navigation_action_state = true, .did_clear_crash_page = is_showing_crash_page };
         }
@@ -437,9 +443,9 @@ NavigationStartResult CanonicalTraversable::did_start_navigation(URL::URL const&
     else
         m_pending_session_history_navigation.clear();
     if (history_handling == Web::Bindings::NavigationHistoryBehavior::Replace)
-        m_session_history.replace_current_entry(url, move(document_resource));
+        m_session_history.replace_current_entry(url, allocate_ui_process_document_state_id(), move(document_resource));
     else
-        m_session_history.navigate(url, move(document_resource));
+        m_session_history.navigate(url, allocate_ui_process_document_state_id(), move(document_resource));
     m_current_web_content_session_history_matches_mirror = false;
     return { .dump_reason = "did-start-navigation"sv, .should_update_navigation_action_state = true, .did_clear_crash_page = is_showing_crash_page };
 }
@@ -540,8 +546,7 @@ HistoryTraversalDecision CanonicalTraversable::traverse_the_history_by_delta(int
         m_pending_session_history_traversal = move(pending_traversal);
         auto webdriver_pending_navigation_completes_with_session_history_update = false;
         if (auto const* current_entry = m_session_history.current_entry()) {
-            webdriver_pending_navigation_completes_with_session_history_update = current_entry->document_state.id != 0
-                && current_entry->document_state.id == target->target_top_level_entry->document_state.id;
+            webdriver_pending_navigation_completes_with_session_history_update = current_entry->document_state.id == target->target_top_level_entry->document_state.id;
         }
         return {
             .outcome = { .status = HistoryTraversalStatus::Started, .will_replace_web_content_process = will_replace_web_content_process, .will_change_top_level_entry = target->changes_top_level_entry },

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -209,9 +209,9 @@ public:
 
     virtual bool is_top_level_traversable() const override { return true; }
 
-    CanonicalNavigable& insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, CanonicalNavigable& fallback_parent);
-    Optional<CanonicalNavigable&> find(Web::HTML::NavigableId frame_id);
-    Optional<CanonicalNavigable const&> find(Web::HTML::NavigableId frame_id) const;
+    CanonicalNavigable& insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, CanonicalNavigable& fallback_parent);
+    Optional<CanonicalNavigable&> find(Web::HTML::CrossProcessId frame_id);
+    Optional<CanonicalNavigable const&> find(Web::HTML::CrossProcessId frame_id) const;
     void remove(CanonicalNavigable&);
 
     TraversableSessionHistory const& session_history() const { return m_session_history; }
@@ -260,7 +260,7 @@ private:
     WebContentSessionHistoryUpdateResult update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot, URL::URL const& current_url);
     WebContentSessionHistoryUpdateResult adopt_web_content_session_history_after_rejected_seed(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
 
-    HashMap<Web::HTML::NavigableId, WeakPtr<CanonicalNavigable>> m_navigable_index;
+    HashMap<Web::HTML::CrossProcessId, WeakPtr<CanonicalNavigable>> m_navigable_index;
     TraversableSessionHistory m_session_history;
     Web::HTML::VisibilityState m_system_visibility_state { Web::HTML::VisibilityState::Hidden };
     bool m_current_web_content_session_history_matches_mirror { false };

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -82,7 +82,7 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate is_private, u64 initial_page_id, Web::HTML::NavigableId root_navigable_id)
+ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate is_private, u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id)
 {
     auto const& browser_options = WebView::Application::browser_options();
     auto const& web_content_options = WebView::Application::web_content_options();

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -12,7 +12,7 @@
 #include <LibImageDecoderClient/Client.h>
 #include <LibRequests/RequestClient.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/WebContentClient.h>
@@ -20,7 +20,7 @@
 
 namespace WebView {
 
-WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate, u64 initial_page_id, Web::HTML::NavigableId root_navigable_id);
+WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsPrivate, u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id);
 
 WEBVIEW_API ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process();
 WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process();

--- a/Libraries/LibWebView/HistoryDebug.cpp
+++ b/Libraries/LibWebView/HistoryDebug.cpp
@@ -53,8 +53,7 @@ static void append_history_log_entry(StringBuilder& builder, Web::HTML::SessionH
 {
     builder.appendff("{}:{}", entry.step, entry.url);
     auto resource_type = document_state_resource_type(entry.document_state.resource);
-    if (entry.document_state.id != 0
-        || entry.document_state.reload_pending
+    if (entry.document_state.reload_pending
         || !entry.document_state.navigable_target_name.is_empty()
         || resource_type != "none"sv) {
         builder.appendff(" document_state={{id={}", entry.document_state.id);
@@ -120,7 +119,7 @@ JsonObject history_json_entry(Web::HTML::SessionHistoryEntryDescriptor const& en
     JsonObject serialized;
     serialized.set("step"sv, entry.step);
     serialized.set("url"sv, entry.url.serialize());
-    serialized.set("documentStateId"sv, entry.document_state.id);
+    serialized.set("documentStateId"sv, MUST(String::formatted("{}", entry.document_state.id)));
     serialized.set("resource"sv, document_state_resource_type(entry.document_state.resource));
     serialized.set("reloadPending"sv, entry.document_state.reload_pending);
     serialized.set("targetName"sv, entry.document_state.navigable_target_name.to_utf8());

--- a/Libraries/LibWebView/SessionHistory.cpp
+++ b/Libraries/LibWebView/SessionHistory.cpp
@@ -22,16 +22,6 @@ enum class StepTranslationMode {
     Nested,
 };
 
-struct DocumentStateIdTranslationState {
-    HashMap<u64, u64> translated_document_state_ids;
-    u64 next_document_state_id { 1 };
-};
-
-struct DocumentStateIdCanonicalizationState {
-    HashMap<u64, u64> canonical_document_state_ids;
-    u64 next_document_state_id { 1 };
-};
-
 static bool steps_are_valid(Vector<i32> const& steps)
 {
     Optional<i32> previous_step;
@@ -81,6 +71,8 @@ static bool current_unknown_entry_seed_ack_matches(TraversableSessionHistory::En
 {
     if (a.step != b.step || a.url != b.url)
         return false;
+    if (a.document_state.id != b.document_state.id)
+        return false;
     if (!a.classic_history_api_state.is_empty() && a.classic_history_api_state != b.classic_history_api_state)
         return false;
     if (!a.navigation_api_state.is_empty() && a.navigation_api_state != b.navigation_api_state)
@@ -104,7 +96,7 @@ static bool seed_ack_entries_match(Vector<TraversableSessionHistory::Entry> cons
     for (size_t i = 0; i < a.size(); ++i) {
         if (current_unknown_entry_index.has_value() && i == *current_unknown_entry_index && current_unknown_entry_seed_ack_matches(a[i], b[i]))
             continue;
-        if (Web::HTML::session_history_entry_descriptors_match_ignoring_document_state_id(a[i], b[i]))
+        if (Web::HTML::session_history_entry_descriptors_match(a[i], b[i]))
             continue;
         return false;
     }
@@ -156,11 +148,6 @@ static bool entry_steps_match(TraversableSessionHistory::Entry const& a, Travers
     }
 
     return true;
-}
-
-static bool entries_have_matching_nonzero_document_state_id(TraversableSessionHistory::Entry const& a, TraversableSessionHistory::Entry const& b)
-{
-    return a.document_state.id != 0 && a.document_state.id == b.document_state.id;
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-all-used-history-steps
@@ -260,56 +247,6 @@ static bool nested_histories_need_restore_after_loading_entry(TraversableSession
     return false;
 }
 
-static void update_next_document_state_id(Vector<TraversableSessionHistory::Entry> const& entries, u64& next_document_state_id)
-{
-    for (auto const& entry : entries) {
-        if (entry.document_state.id >= next_document_state_id)
-            next_document_state_id = entry.document_state.id + 1;
-        for (auto const& nested_history : entry.document_state.nested_histories)
-            update_next_document_state_id(nested_history.entries, next_document_state_id);
-    }
-}
-
-static u64 translate_incoming_document_state_id(u64 incoming_document_state_id, DocumentStateIdTranslationState& translation_state)
-{
-    if (incoming_document_state_id == 0)
-        return 0;
-
-    if (auto translated_document_state_id = translation_state.translated_document_state_ids.get(incoming_document_state_id); translated_document_state_id.has_value())
-        return *translated_document_state_id;
-
-    auto translated_document_state_id = translation_state.next_document_state_id++;
-    VERIFY(translated_document_state_id != 0);
-    translation_state.translated_document_state_ids.set(incoming_document_state_id, translated_document_state_id);
-    return translated_document_state_id;
-}
-
-static void canonicalize_document_state_ids(Vector<TraversableSessionHistory::Entry>& entries, DocumentStateIdCanonicalizationState& canonicalization_state)
-{
-    for (auto& entry : entries) {
-        if (entry.document_state.id != 0) {
-            auto canonical_document_state_id = canonicalization_state.canonical_document_state_ids.get(entry.document_state.id);
-            if (canonical_document_state_id.has_value()) {
-                entry.document_state.id = *canonical_document_state_id;
-            } else {
-                auto new_document_state_id = canonicalization_state.next_document_state_id++;
-                VERIFY(new_document_state_id != 0);
-                canonicalization_state.canonical_document_state_ids.set(entry.document_state.id, new_document_state_id);
-                entry.document_state.id = new_document_state_id;
-            }
-        }
-
-        for (auto& nested_history : entry.document_state.nested_histories)
-            canonicalize_document_state_ids(nested_history.entries, canonicalization_state);
-    }
-}
-
-static void canonicalize_document_state_ids(Vector<TraversableSessionHistory::Entry>& entries)
-{
-    DocumentStateIdCanonicalizationState canonicalization_state;
-    canonicalize_document_state_ids(entries, canonicalization_state);
-}
-
 static Optional<i32> translate_incoming_step(i32 incoming_step, i32 incoming_anchor_step, i32 local_anchor_step, StepTranslationMode mode = StepTranslationMode::TopLevel, Optional<i32> nested_history_step_floor = {})
 {
     // AD-HOC: WebContent snapshots can describe only the history slice known to the current process. When merging
@@ -330,16 +267,14 @@ static Optional<i32> translate_incoming_step(i32 incoming_step, i32 incoming_anc
     return local_anchor_step + static_cast<i32>(step_delta);
 }
 
-static Optional<Web::HTML::SessionHistoryNestedHistoryDescriptor> translate_incoming_nested_history(Web::HTML::SessionHistoryNestedHistoryDescriptor const&, i32 incoming_anchor_step, i32 local_anchor_step, DocumentStateIdTranslationState&, Optional<i32> nested_history_step_floor);
+static Optional<Web::HTML::SessionHistoryNestedHistoryDescriptor> translate_incoming_nested_history(Web::HTML::SessionHistoryNestedHistoryDescriptor const&, i32 incoming_anchor_step, i32 local_anchor_step, Optional<i32> nested_history_step_floor);
 
-static Optional<Web::HTML::SessionHistoryDocumentStateDescriptor> translate_incoming_document_state_descriptor(Web::HTML::SessionHistoryDocumentStateDescriptor document_state, i32 incoming_anchor_step, i32 local_anchor_step, DocumentStateIdTranslationState& document_state_id_translation_state, Optional<i32> nested_history_step_floor)
+static Optional<Web::HTML::SessionHistoryDocumentStateDescriptor> translate_incoming_document_state_descriptor(Web::HTML::SessionHistoryDocumentStateDescriptor document_state, i32 incoming_anchor_step, i32 local_anchor_step, Optional<i32> nested_history_step_floor)
 {
-    document_state.id = translate_incoming_document_state_id(document_state.id, document_state_id_translation_state);
-
     Vector<Web::HTML::SessionHistoryNestedHistoryDescriptor> nested_histories;
     nested_histories.ensure_capacity(document_state.nested_histories.size());
     for (auto const& nested_history : document_state.nested_histories) {
-        auto translated_nested_history = translate_incoming_nested_history(nested_history, incoming_anchor_step, local_anchor_step, document_state_id_translation_state, nested_history_step_floor);
+        auto translated_nested_history = translate_incoming_nested_history(nested_history, incoming_anchor_step, local_anchor_step, nested_history_step_floor);
         if (!translated_nested_history.has_value())
             return {};
         nested_histories.unchecked_append(translated_nested_history.release_value());
@@ -349,12 +284,12 @@ static Optional<Web::HTML::SessionHistoryDocumentStateDescriptor> translate_inco
     return document_state;
 }
 
-static Optional<TraversableSessionHistory::Entry> translate_incoming_entry(TraversableSessionHistory::Entry const& entry, i32 incoming_anchor_step, i32 local_anchor_step, DocumentStateIdTranslationState& document_state_id_translation_state, StepTranslationMode mode = StepTranslationMode::TopLevel, Optional<i32> nested_history_step_floor = {})
+static Optional<TraversableSessionHistory::Entry> translate_incoming_entry(TraversableSessionHistory::Entry const& entry, i32 incoming_anchor_step, i32 local_anchor_step, StepTranslationMode mode = StepTranslationMode::TopLevel, Optional<i32> nested_history_step_floor = {})
 {
     auto translated_step = translate_incoming_step(entry.step, incoming_anchor_step, local_anchor_step, mode, nested_history_step_floor);
     if (!translated_step.has_value())
         return {};
-    auto translated_document_state = translate_incoming_document_state_descriptor(entry.document_state, incoming_anchor_step, local_anchor_step, document_state_id_translation_state, nested_history_step_floor);
+    auto translated_document_state = translate_incoming_document_state_descriptor(entry.document_state, incoming_anchor_step, local_anchor_step, nested_history_step_floor);
     if (!translated_document_state.has_value())
         return {};
 
@@ -371,13 +306,13 @@ static Optional<TraversableSessionHistory::Entry> translate_incoming_entry(Trave
     };
 }
 
-static Optional<Web::HTML::SessionHistoryNestedHistoryDescriptor> translate_incoming_nested_history(Web::HTML::SessionHistoryNestedHistoryDescriptor const& nested_history, i32 incoming_anchor_step, i32 local_anchor_step, DocumentStateIdTranslationState& document_state_id_translation_state, Optional<i32> nested_history_step_floor)
+static Optional<Web::HTML::SessionHistoryNestedHistoryDescriptor> translate_incoming_nested_history(Web::HTML::SessionHistoryNestedHistoryDescriptor const& nested_history, i32 incoming_anchor_step, i32 local_anchor_step, Optional<i32> nested_history_step_floor)
 {
     Vector<TraversableSessionHistory::Entry> entries;
     entries.ensure_capacity(nested_history.entries.size());
     Optional<i32> previous_step;
     for (auto const& entry : nested_history.entries) {
-        auto translated_entry = translate_incoming_entry(entry, incoming_anchor_step, local_anchor_step, document_state_id_translation_state, StepTranslationMode::Nested, nested_history_step_floor);
+        auto translated_entry = translate_incoming_entry(entry, incoming_anchor_step, local_anchor_step, StepTranslationMode::Nested, nested_history_step_floor);
         if (!translated_entry.has_value())
             return {};
         if (previous_step.has_value() && translated_entry->step <= *previous_step)
@@ -425,13 +360,14 @@ static void clear_forward_session_history_entries(Vector<TraversableSessionHisto
 static TraversableSessionHistory::Entry create_ui_process_session_history_entry(
     i32 step,
     URL::URL url,
+    Web::HTML::CrossProcessId document_state_id,
     Variant<Empty, String, Web::HTML::POSTResource> document_resource)
 {
     return {
         .step = step,
         .url = move(url),
         .document_state = {
-            .id = 0,
+            .id = document_state_id,
             .history_policy_container = Web::HTML::DocumentState::Client::Tag,
             .request_referrer = Web::Fetch::Infrastructure::Request::Referrer::Client,
             .request_referrer_policy = Web::ReferrerPolicy::DEFAULT_REFERRER_POLICY,
@@ -441,6 +377,7 @@ static TraversableSessionHistory::Entry create_ui_process_session_history_entry(
             .resource = move(document_resource),
             .reload_pending = false,
             .ever_populated = false,
+            .is_provisional = true,
             .navigable_target_name = {},
             .nested_histories = {},
         },
@@ -453,19 +390,19 @@ static TraversableSessionHistory::Entry create_ui_process_session_history_entry(
     };
 }
 
-void TraversableSessionHistory::navigate(URL::URL url)
+void TraversableSessionHistory::navigate(URL::URL url, Web::HTML::CrossProcessId document_state_id)
 {
-    navigate(move(url), Empty {});
+    navigate(move(url), document_state_id, Empty {});
 }
 
-void TraversableSessionHistory::navigate(URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource)
+void TraversableSessionHistory::navigate(URL::URL url, Web::HTML::CrossProcessId document_state_id, Variant<Empty, String, Web::HTML::POSTResource> document_resource)
 {
     forget_web_content_state();
 
     if (!m_current_used_step_index.has_value()) {
         m_entries.clear();
         m_used_steps.clear();
-        m_entries.append(create_ui_process_session_history_entry(0, move(url), move(document_resource)));
+        m_entries.append(create_ui_process_session_history_entry(0, move(url), document_state_id, move(document_resource)));
         m_used_steps.append(0);
         m_current_used_step_index = 0;
         return;
@@ -478,7 +415,7 @@ void TraversableSessionHistory::navigate(URL::URL url, Variant<Empty, String, We
     m_used_steps.remove_all_matching([current_step](auto const& used_step) {
         return used_step > current_step;
     });
-    m_entries.append(create_ui_process_session_history_entry(step, move(url), move(document_resource)));
+    m_entries.append(create_ui_process_session_history_entry(step, move(url), document_state_id, move(document_resource)));
     m_used_steps.append(step);
     m_current_used_step_index = m_used_steps.size() - 1;
 }
@@ -491,12 +428,12 @@ void TraversableSessionHistory::clear()
     forget_web_content_state();
 }
 
-void TraversableSessionHistory::replace_current_entry_url(URL::URL url)
+void TraversableSessionHistory::replace_current_entry_url(URL::URL url, Web::HTML::CrossProcessId document_state_id)
 {
     forget_web_content_state();
 
     if (!m_current_used_step_index.has_value()) {
-        navigate(move(url));
+        navigate(move(url), document_state_id);
         return;
     }
 
@@ -505,12 +442,12 @@ void TraversableSessionHistory::replace_current_entry_url(URL::URL url)
     m_entries[*current_top_level_entry_index].url = move(url);
 }
 
-void TraversableSessionHistory::replace_current_entry(URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource)
+void TraversableSessionHistory::replace_current_entry(URL::URL url, Web::HTML::CrossProcessId document_state_id, Variant<Empty, String, Web::HTML::POSTResource> document_resource)
 {
     forget_web_content_state();
 
     if (!m_current_used_step_index.has_value()) {
-        navigate(move(url), move(document_resource));
+        navigate(move(url), document_state_id, move(document_resource));
         return;
     }
 
@@ -519,7 +456,7 @@ void TraversableSessionHistory::replace_current_entry(URL::URL url, Variant<Empt
 
     auto current_step = m_used_steps[*m_current_used_step_index];
     m_entries[*current_top_level_entry_index] = create_ui_process_session_history_entry(
-        current_step, move(url), move(document_resource));
+        current_step, move(url), document_state_id, move(document_resource));
     recompute_used_steps(m_entries, m_used_steps, m_current_used_step_index, current_step);
     VERIFY(m_current_used_step_index.has_value());
 }
@@ -569,7 +506,6 @@ TraversableSessionHistory::UpdateResult TraversableSessionHistory::update_from_w
         return invalid_snapshot();
 
     if (m_entries.is_empty()) {
-        canonicalize_document_state_ids(entries);
         m_entries.clear_with_capacity();
         m_entries.ensure_capacity(entries.size());
         for (auto& entry : entries)
@@ -609,7 +545,6 @@ TraversableSessionHistory::UpdateResult TraversableSessionHistory::update_from_w
         && *incoming_current_top_level_entry_index > 0
         && m_entries[*local_current_top_level_entry_index - 1].step == used_steps[current_used_step_index]
         && m_entries[*local_current_top_level_entry_index].url == entries[*incoming_current_top_level_entry_index].url) {
-        canonicalize_document_state_ids(entries);
         m_entries = move(entries);
         m_used_steps = move(used_steps);
         m_current_used_step_index = current_used_step_index;
@@ -689,7 +624,7 @@ TraversableSessionHistory::UpdateResult TraversableSessionHistory::update_from_w
         };
 
         merge_anchor = find_url_merge_anchor([](Entry const& local_entry, Entry const& incoming_entry) {
-            return entries_have_matching_nonzero_document_state_id(local_entry, incoming_entry);
+            return local_entry.document_state.id == incoming_entry.document_state.id;
         });
         if (!merge_anchor.has_value()) {
             merge_anchor = find_url_merge_anchor([](Entry const&, Entry const&) {
@@ -718,18 +653,13 @@ TraversableSessionHistory::UpdateResult TraversableSessionHistory::update_from_w
     auto local_anchor_step = m_entries[merge_anchor->local_index].step;
     auto incoming_anchor_step = entries[merge_anchor->incoming_index].step;
     Optional<i32> nested_history_step_floor;
-    if (auto incoming_anchor_document_state_id = entries[merge_anchor->incoming_index].document_state.id; incoming_anchor_document_state_id != 0) {
-        for (size_t i = 0; i < merge_anchor->incoming_index; ++i) {
-            if (entries[i].document_state.id != incoming_anchor_document_state_id)
-                continue;
-            nested_history_step_floor = entries[i].step;
-            break;
-        }
+    auto incoming_anchor_document_state_id = entries[merge_anchor->incoming_index].document_state.id;
+    for (size_t i = 0; i < merge_anchor->incoming_index; ++i) {
+        if (entries[i].document_state.id != incoming_anchor_document_state_id)
+            continue;
+        nested_history_step_floor = entries[i].step;
+        break;
     }
-    DocumentStateIdTranslationState document_state_id_translation_state;
-    update_next_document_state_id(m_entries, document_state_id_translation_state.next_document_state_id);
-    if (entries[merge_anchor->incoming_index].document_state.id != 0 && m_entries[merge_anchor->local_index].document_state.id != 0)
-        document_state_id_translation_state.translated_document_state_ids.set(entries[merge_anchor->incoming_index].document_state.id, m_entries[merge_anchor->local_index].document_state.id);
 
     auto incoming_has_used_steps_after_anchor = false;
     for (auto const& used_step : used_steps) {
@@ -750,7 +680,7 @@ TraversableSessionHistory::UpdateResult TraversableSessionHistory::update_from_w
         merged_entries.unchecked_append(m_entries[i]);
 
     for (size_t i = merge_anchor->incoming_index; i < entries.size(); ++i) {
-        auto translated_entry = translate_incoming_entry(entries[i], incoming_anchor_step, local_anchor_step, document_state_id_translation_state, StepTranslationMode::TopLevel, nested_history_step_floor);
+        auto translated_entry = translate_incoming_entry(entries[i], incoming_anchor_step, local_anchor_step, StepTranslationMode::TopLevel, nested_history_step_floor);
         if (!translated_entry.has_value())
             return invalid_snapshot();
         if (!entry_steps_match(entries[i], *translated_entry))
@@ -825,7 +755,6 @@ TraversableSessionHistory::UpdateResult TraversableSessionHistory::update_from_w
         return invalid_snapshot();
     if (!entries_and_used_steps_are_consistent(merged_entries, merged_used_steps))
         return invalid_snapshot();
-    canonicalize_document_state_ids(merged_entries);
 
     Vector<Entry> translated_web_content_entries;
     auto web_content_known_entries_start_index = merge_anchor->local_index;
@@ -838,9 +767,7 @@ TraversableSessionHistory::UpdateResult TraversableSessionHistory::update_from_w
     for (size_t i = web_content_known_entries_start_index; i < merge_anchor->local_index + incoming_suffix_size; ++i)
         translated_web_content_entries.unchecked_append(merged_entries[i]);
 
-    auto entries_in_ui_document_state_id_order = entries;
-    canonicalize_document_state_ids(entries_in_ui_document_state_id_order);
-    auto web_content_matches_mirror = entries_match(merged_entries, entries_in_ui_document_state_id_order) && steps_match(merged_used_steps, used_steps);
+    auto web_content_matches_mirror = entries_match(merged_entries, entries) && steps_match(merged_used_steps, used_steps);
 
     m_entries = move(merged_entries);
     m_used_steps = move(merged_used_steps);
@@ -883,22 +810,15 @@ bool TraversableSessionHistory::did_seed_web_content_from_ui_process(Vector<Entr
     if (used_steps[current_used_step_index] != m_entries[*current_top_level_entry_index].step)
         return false;
 
-    auto entries_from_web_content = entries;
-    auto expected_entries = m_entries;
-    canonicalize_document_state_ids(expected_entries);
-    canonicalize_document_state_ids(entries);
-
     if (!steps_match(m_used_steps, used_steps))
         return false;
 
-    if (!entries_match(expected_entries, entries)) {
-        Optional<size_t> current_unknown_entry_index;
-        if (m_entries[*current_top_level_entry_index].document_state.id == 0)
-            current_unknown_entry_index = *current_top_level_entry_index;
-        if (!seed_ack_entries_match(m_entries, entries_from_web_content, current_unknown_entry_index))
-            return false;
-        m_entries = move(entries_from_web_content);
-    }
+    Optional<size_t> current_unknown_entry_index;
+    if (!m_entries[*current_top_level_entry_index].document_state.ever_populated)
+        current_unknown_entry_index = *current_top_level_entry_index;
+
+    if (!seed_ack_entries_match(m_entries, entries, current_unknown_entry_index))
+        return false;
 
     m_web_content_known_entries = m_entries;
     m_web_content_known_used_steps = m_used_steps;

--- a/Libraries/LibWebView/SessionHistory.h
+++ b/Libraries/LibWebView/SessionHistory.h
@@ -53,10 +53,10 @@ public:
     Optional<size_t> current_top_level_entry_index() const;
 
     void clear();
-    void navigate(URL::URL);
-    void navigate(URL::URL, Variant<Empty, String, Web::HTML::POSTResource>);
-    void replace_current_entry_url(URL::URL);
-    void replace_current_entry(URL::URL, Variant<Empty, String, Web::HTML::POSTResource>);
+    void navigate(URL::URL, Web::HTML::CrossProcessId document_state_id);
+    void navigate(URL::URL, Web::HTML::CrossProcessId document_state_id, Variant<Empty, String, Web::HTML::POSTResource>);
+    void replace_current_entry_url(URL::URL, Web::HTML::CrossProcessId document_state_id);
+    void replace_current_entry(URL::URL, Web::HTML::CrossProcessId document_state_id, Variant<Empty, String, Web::HTML::POSTResource>);
     void mark_current_entry_reload_pending();
     void clear_current_entry_reload_pending();
     UpdateResult update_from_web_content(Vector<Entry> entries, Vector<i32> used_steps, size_t current_used_step_index);

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -64,7 +64,7 @@ bool SiteIsolationManager::child_frame_navigation_requires_process_swap(Canonica
     return navigation_requires_process_swap(current_url, target_url, Web::NavigationTarget::IFrame);
 }
 
-Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(WebContentClient& parent_client, u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
+Web::NavigationProcessDecision SiteIsolationManager::decide_navigation_process(WebContentClient& parent_client, u64 page_id, Optional<Web::HTML::CrossProcessId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
 {
     Optional<CanonicalNavigable&> child_frame;
     if (target == Web::NavigationTarget::IFrame && frame_id.has_value())
@@ -198,7 +198,7 @@ HashMap<pid_t, pid_t> SiteIsolationManager::remote_frame_process_embedders() con
     return embedders;
 }
 
-void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::NavigableId frame_id, NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)
+void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::CrossProcessId frame_id, NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)
 {
     auto child_frame = parent_client.child_frame(page_id, frame_id);
     if (!child_frame.has_value())

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -29,11 +29,11 @@ public:
         Web::DevicePixelRect viewport_rect;
     };
 
-    Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
+    Web::NavigationProcessDecision decide_navigation_process(WebContentClient&, u64 page_id, Optional<Web::HTML::CrossProcessId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget);
     [[nodiscard]] bool navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget = Web::NavigationTarget::TopLevel) const;
     [[nodiscard]] bool child_frame_navigation_requires_process_swap(CanonicalNavigable const& child_frame, URL::URL const& current_url, URL::URL const& target_url) const;
 
-    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::NavigableId frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
+    void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::CrossProcessId frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
     void transition_child_frame_to_local(CanonicalNavigable&);
 
     void remove_child_frame_subtree(CanonicalNavigable&);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -73,7 +73,7 @@ static bool is_download_in_progress(FileDownloader const& file_downloader, u64 d
     return download.has_value() && download->status == FileDownloader::DownloadStatus::InProgress;
 }
 
-WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, IsPrivate is_private, u64 initial_page_id, Web::HTML::NavigableId root_navigable_id)
+WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, IsPrivate is_private, u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
     , m_is_private(is_private)
     , m_initial_page_id(initial_page_id)
@@ -276,7 +276,7 @@ CanonicalNavigable* WebContentClient::navigable_for_page(u64 page_id)
     return nullptr;
 }
 
-Optional<CanonicalNavigable&> WebContentClient::child_frame(u64 page_id, Web::HTML::NavigableId frame_id)
+Optional<CanonicalNavigable&> WebContentClient::child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id)
 {
     auto* host = navigable_for_page(page_id);
     if (!host)
@@ -477,12 +477,12 @@ void WebContentClient::did_request_new_process_for_navigation(u64 page_id, URL::
         view->create_new_process_for_cross_site_navigation(url, move(document_resource), history_handling);
 }
 
-Messages::WebContentClient::DecideNavigationProcessResponse WebContentClient::decide_navigation_process(u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
+Messages::WebContentClient::DecideNavigationProcessResponse WebContentClient::decide_navigation_process(u64 page_id, Optional<Web::HTML::CrossProcessId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
 {
     return SiteIsolationManager::the().decide_navigation_process(*this, page_id, move(frame_id), move(current_url), move(target_url), target);
 }
 
-void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
@@ -516,7 +516,7 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
     SiteIsolationManager::the().transition_child_frame_to_remote(*this, page_id, frame_id, move(remote_client), remote_page_id);
 }
 
-void WebContentClient::did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state)
+void WebContentClient::did_create_child_frame(u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state)
 {
     auto* host = navigable_for_page(page_id);
     if (!host)
@@ -526,13 +526,13 @@ void WebContentClient::did_create_child_frame(u64 page_id, Web::HTML::NavigableI
     child_frame.set_replicated_state(move(replicated_state));
 }
 
-void WebContentClient::did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
+void WebContentClient::did_update_child_frame_viewport(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)
 {
     if (auto child_frame = this->child_frame(page_id, frame_id); child_frame.has_value())
         child_frame->set_viewport(viewport_rect, device_pixel_ratio);
 }
 
-void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state)
+void WebContentClient::did_commit_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
@@ -553,7 +553,7 @@ void WebContentClient::did_change_top_level_active_document(u64 page_id, Web::HT
     navigable->did_commit_navigation(move(replicated_state));
 }
 
-void WebContentClient::did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id)
+void WebContentClient::did_destroy_child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id)
 {
     if (auto child_frame = this->child_frame(page_id, frame_id); child_frame.has_value())
         SiteIsolationManager::the().remove_child_frame_subtree(*child_frame);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -28,8 +28,8 @@
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
-#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -29,7 +29,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/FileFilter.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
@@ -64,7 +64,7 @@ public:
     static size_t client_count() { return clients().size(); }
     static Optional<WebContentClient&> client_for_compositor_context_id(Web::Compositor::CompositorContextId);
 
-    WebContentClient(NonnullOwnPtr<IPC::Transport>, IsPrivate, u64 initial_page_id, Web::HTML::NavigableId root_navigable_id);
+    WebContentClient(NonnullOwnPtr<IPC::Transport>, IsPrivate, u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id);
     ~WebContentClient();
 
     IsPrivate is_private() const { return m_is_private; }
@@ -86,7 +86,7 @@ public:
     CanonicalNavigable* embedded_page_host(u64 page_id);
     CanonicalNavigable* navigable_for_page(u64 page_id);
 
-    Optional<CanonicalNavigable&> child_frame(u64 page_id, Web::HTML::NavigableId frame_id);
+    Optional<CanonicalNavigable&> child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id);
 
     bool has_views() const { return !m_views.is_empty(); }
 
@@ -120,14 +120,14 @@ private:
 
     virtual Messages::WebContentClient::AllocateCompositorContextIdResponse allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration) override;
     virtual void did_destroy_compositor_context(Web::Compositor::CompositorContextId) override;
-    virtual Messages::WebContentClient::DecideNavigationProcessResponse decide_navigation_process(u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget) override;
+    virtual Messages::WebContentClient::DecideNavigationProcessResponse decide_navigation_process(u64 page_id, Optional<Web::HTML::CrossProcessId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget) override;
     virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
-    virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
-    virtual void did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
-    virtual void did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
-    virtual void did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
+    virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
+    virtual void did_create_child_frame(u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
+    virtual void did_update_child_frame_viewport(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
+    virtual void did_commit_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
-    virtual void did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) override;
+    virtual void did_destroy_child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id) override;
     virtual void did_start_webdriver_navigation(u64 page_id, URL::URL url) override;
     virtual void did_finish_loading(u64 page_id, URL::URL) override;
     virtual void did_request_refresh(u64 page_id) override;
@@ -275,7 +275,7 @@ private:
     HashMap<u64, String> m_history_recorded_urls_for_current_load;
     Optional<i32> m_compositor_connection_id;
     u64 m_initial_page_id { 0 };
-    Web::HTML::NavigableId m_root_navigable_id;
+    Web::HTML::CrossProcessId m_root_navigable_id;
 
     ProcessHandle m_process_handle;
     RefPtr<Core::Timer> m_detached_page_close_timer;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -126,9 +126,9 @@ Messages::WebContentServer::InitTransportResponse ConnectionFromClient::init_tra
     VERIFY_NOT_REACHED();
 }
 
-void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator navigable_id_allocator)
+void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator)
 {
-    m_page_host->initialize(initial_page_id, root_navigable_id, navigable_id_allocator);
+    m_page_host->initialize(initial_page_id, root_navigable_id, cross_process_id_allocator);
 }
 
 void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id)
@@ -143,13 +143,13 @@ void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Co
     compositor_context.set_parent_context(parent_context_id);
 }
 
-void ConnectionFromClient::set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::NavigableId frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
+void ConnectionFromClient::set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::CrossProcessId frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->set_remote_child_frame_compositor_context(frame_id, context_id);
 }
 
-void ConnectionFromClient::run_iframe_load_event_steps(u64 page_id, Web::HTML::NavigableId frame_id)
+void ConnectionFromClient::run_iframe_load_event_steps(u64 page_id, Web::HTML::CrossProcessId frame_id)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->run_iframe_load_event_steps(frame_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -71,7 +71,7 @@ private:
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;
 
     virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
-    virtual void initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator navigable_id_allocator) override;
+    virtual void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
     virtual void set_window_handle(u64 page_id, String handle) override;
@@ -92,9 +92,9 @@ private:
     virtual void load_html_with_url(u64 page_id, ByteString, URL::URL) override;
     virtual void reload(u64 page_id) override;
     virtual void cancel_download(u64 page_id, u64 download_id) override;
-    virtual void run_iframe_load_event_steps(u64 page_id, Web::HTML::NavigableId frame_id) override;
+    virtual void run_iframe_load_event_steps(u64 page_id, Web::HTML::CrossProcessId frame_id) override;
     virtual void set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId>) override;
-    virtual void set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::NavigableId frame_id, Optional<Web::Compositor::CompositorContextId>) override;
+    virtual void set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::CrossProcessId frame_id, Optional<Web::Compositor::CompositorContextId>) override;
     virtual void traverse_the_history_to_step(u64 page_id, i32 step) override;
     virtual void check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) override;
     virtual void set_top_level_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, size_t current_top_level_entry_index, bool allow_reconstructing_current_entry) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -97,12 +97,12 @@ void PageClient::set_should_report_session_history_updates_in_test_mode(bool sho
     s_should_report_session_history_updates_in_test_mode = should_report;
 }
 
-GC::Ref<PageClient> PageClient::create(JS::VM& vm, PageHost& page_host, u64 id, Optional<Web::HTML::NavigableId> pending_root_navigable_id)
+GC::Ref<PageClient> PageClient::create(JS::VM& vm, PageHost& page_host, u64 id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id)
 {
     return vm.heap().allocate<PageClient>(page_host, id, pending_root_navigable_id);
 }
 
-PageClient::PageClient(PageHost& owner, u64 id, Optional<Web::HTML::NavigableId> pending_root_navigable_id)
+PageClient::PageClient(PageHost& owner, u64 id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id)
     : m_owner(owner)
     , m_page(Web::Page::create(Web::Bindings::main_thread_vm(), *this))
     , m_id(id)
@@ -200,7 +200,7 @@ bool PageClient::is_connection_open() const
     return client().is_open();
 }
 
-Web::HTML::NavigableId PageClient::allocate_navigable_id()
+Web::HTML::CrossProcessId PageClient::allocate_navigable_id()
 {
     if (m_pending_root_navigable_id.has_value()) {
         auto id = *m_pending_root_navigable_id;
@@ -211,7 +211,7 @@ Web::HTML::NavigableId PageClient::allocate_navigable_id()
     return m_owner.allocate_navigable_id();
 }
 
-Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target, Optional<Web::HTML::NavigableId> frame_id) const
+Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target, Optional<Web::HTML::CrossProcessId> frame_id) const
 {
     return client().decide_navigation_process(m_id, move(frame_id), current_url, target_url, target);
 }
@@ -224,33 +224,33 @@ void PageClient::request_new_process_for_navigation(URL::URL const& url, Variant
     client().async_did_request_new_process_for_navigation(m_id, url, move(document_resource), history_handling);
 }
 
-void PageClient::request_new_process_for_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void PageClient::request_new_process_for_child_frame_navigation(Web::HTML::CrossProcessId frame_id, URL::URL const& url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
     client().async_did_request_new_process_for_child_frame_navigation(m_id, frame_id, url, move(document_resource), history_handling);
 }
 
-void PageClient::page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const& replicated_state)
+void PageClient::page_did_create_child_frame(Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState const& replicated_state)
 {
     client().async_did_create_child_frame(m_id, parent_frame_id, frame_id, replicated_state);
 }
 
-void PageClient::page_did_update_child_frame_viewport(Web::HTML::NavigableId frame_id, Web::CSSPixelRect viewport_rect)
+void PageClient::page_did_update_child_frame_viewport(Web::HTML::CrossProcessId frame_id, Web::CSSPixelRect viewport_rect)
 {
     client().async_did_update_child_frame_viewport(m_id, frame_id, page().css_to_device_rect(viewport_rect), page().client().device_pixel_ratio());
 }
 
-void PageClient::page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const& replicated_state)
+void PageClient::page_did_commit_child_frame_navigation(Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState const& replicated_state)
 {
     client().async_did_commit_child_frame_navigation(m_id, frame_id, replicated_state);
 }
 
-void PageClient::page_did_destroy_child_frame(Web::HTML::NavigableId frame_id)
+void PageClient::page_did_destroy_child_frame(Web::HTML::CrossProcessId frame_id)
 {
     m_remote_child_frame_compositor_contexts.remove(frame_id);
     client().async_did_destroy_child_frame(m_id, frame_id);
 }
 
-void PageClient::set_remote_child_frame_compositor_context(Web::HTML::NavigableId frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
+void PageClient::set_remote_child_frame_compositor_context(Web::HTML::CrossProcessId frame_id, Optional<Web::Compositor::CompositorContextId> context_id)
 {
     if (context_id.has_value())
         m_remote_child_frame_compositor_contexts.set(frame_id, *context_id);
@@ -259,12 +259,12 @@ void PageClient::set_remote_child_frame_compositor_context(Web::HTML::NavigableI
     request_frame();
 }
 
-Optional<Web::Compositor::CompositorContextId> PageClient::compositor_context_id_for_remote_child_frame(Web::HTML::NavigableId frame_id) const
+Optional<Web::Compositor::CompositorContextId> PageClient::compositor_context_id_for_remote_child_frame(Web::HTML::CrossProcessId frame_id) const
 {
     return m_remote_child_frame_compositor_contexts.get(frame_id);
 }
 
-void PageClient::run_iframe_load_event_steps(Web::HTML::NavigableId frame_id)
+void PageClient::run_iframe_load_event_steps(Web::HTML::CrossProcessId frame_id)
 {
     auto active_document = page().top_level_traversable()->active_document();
     if (!active_document)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -200,6 +200,11 @@ bool PageClient::is_connection_open() const
     return client().is_open();
 }
 
+Web::HTML::CrossProcessId PageClient::allocate_cross_process_id()
+{
+    return m_owner.allocate_cross_process_id();
+}
+
 Web::HTML::CrossProcessId PageClient::allocate_navigable_id()
 {
     if (m_pending_root_navigable_id.has_value()) {
@@ -208,7 +213,7 @@ Web::HTML::CrossProcessId PageClient::allocate_navigable_id()
         return id;
     }
 
-    return m_owner.allocate_navigable_id();
+    return allocate_cross_process_id();
 }
 
 Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target, Optional<Web::HTML::CrossProcessId> frame_id) const

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -14,8 +14,8 @@
 #include <LibGfx/Rect.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/AudioPlayState.h>
-#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -58,6 +58,7 @@ public:
     virtual void did_handle_input_event(u64 page_id, Web::InputEvent const&) override;
     virtual void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled) override;
     virtual Web::Compositor::CompositorContextId allocate_compositor_context_id(Web::Compositor::PagePresentationRegistration) override;
+    virtual Web::HTML::CrossProcessId allocate_cross_process_id() override;
     virtual Web::HTML::CrossProcessId allocate_navigable_id() override;
 
     void set_palette_impl(Gfx::PaletteImpl&);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -15,7 +15,7 @@
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -35,7 +35,7 @@ class PageClient final : public Web::PageClient {
     GC_DECLARE_ALLOCATOR(PageClient);
 
 public:
-    static GC::Ref<PageClient> create(JS::VM& vm, PageHost& page_host, u64 id, Optional<Web::HTML::NavigableId> pending_root_navigable_id = {});
+    static GC::Ref<PageClient> create(JS::VM& vm, PageHost& page_host, u64 id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id = {});
 
     virtual ~PageClient() override;
 
@@ -58,7 +58,7 @@ public:
     virtual void did_handle_input_event(u64 page_id, Web::InputEvent const&) override;
     virtual void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled) override;
     virtual Web::Compositor::CompositorContextId allocate_compositor_context_id(Web::Compositor::PagePresentationRegistration) override;
-    virtual Web::HTML::NavigableId allocate_navigable_id() override;
+    virtual Web::HTML::CrossProcessId allocate_navigable_id() override;
 
     void set_palette_impl(Gfx::PaletteImpl&);
     void set_viewport(Web::DevicePixelSize const&, double device_pixel_ratio);
@@ -133,8 +133,8 @@ public:
     void send_current_needs_beforeunload_check();
     void wait_for_webdriver_navigation_completion(Optional<u64> page_load_timeout, Function<void(Web::WebDriver::Response)>);
     void did_complete_webdriver_navigation_completion(u64 request_id, Web::WebDriver::Response);
-    void run_iframe_load_event_steps(Web::HTML::NavigableId);
-    void set_remote_child_frame_compositor_context(Web::HTML::NavigableId, Optional<Web::Compositor::CompositorContextId>);
+    void run_iframe_load_event_steps(Web::HTML::CrossProcessId);
+    void set_remote_child_frame_compositor_context(Web::HTML::CrossProcessId, Optional<Web::Compositor::CompositorContextId>);
     void cancel_download(u64 download_id);
     void clear_pending_dom_mutations();
     void did_delete_all_cookies(u64 request_id);
@@ -145,20 +145,20 @@ private:
         WebView::Mutation mutation;
     };
 
-    PageClient(PageHost&, u64 id, Optional<Web::HTML::NavigableId>);
+    PageClient(PageHost&, u64 id, Optional<Web::HTML::CrossProcessId>);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
     // ^PageClient
     virtual bool is_connection_open() const override;
-    virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget, Optional<Web::HTML::NavigableId> frame_id) const override;
+    virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget, Optional<Web::HTML::CrossProcessId> frame_id) const override;
     virtual void request_new_process_for_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
-    virtual void request_new_process_for_child_frame_navigation(Web::HTML::NavigableId frame_id, URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
-    virtual void page_did_create_child_frame(Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
-    virtual void page_did_update_child_frame_viewport(Web::HTML::NavigableId frame_id, Web::CSSPixelRect) override;
-    virtual void page_did_commit_child_frame_navigation(Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
-    virtual void page_did_destroy_child_frame(Web::HTML::NavigableId frame_id) override;
-    virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(Web::HTML::NavigableId) const override;
+    virtual void request_new_process_for_child_frame_navigation(Web::HTML::CrossProcessId frame_id, URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior) override;
+    virtual void page_did_create_child_frame(Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
+    virtual void page_did_update_child_frame_viewport(Web::HTML::CrossProcessId frame_id, Web::CSSPixelRect) override;
+    virtual void page_did_commit_child_frame_navigation(Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
+    virtual void page_did_destroy_child_frame(Web::HTML::CrossProcessId frame_id) override;
+    virtual Optional<Web::Compositor::CompositorContextId> compositor_context_id_for_remote_child_frame(Web::HTML::CrossProcessId) const override;
     virtual String dump_site_isolation_process_tree_for_testing() override;
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_all_screen_rects[m_main_screen_index]; }
@@ -313,8 +313,8 @@ private:
     RefPtr<Core::Timer> m_frame_timer;
     Optional<double> m_last_frame_dispatch_time;
     Queue<PendingDOMMutation> m_pending_dom_mutations;
-    HashMap<Web::HTML::NavigableId, Web::Compositor::CompositorContextId> m_remote_child_frame_compositor_contexts;
-    Optional<Web::HTML::NavigableId> m_pending_root_navigable_id;
+    HashMap<Web::HTML::CrossProcessId, Web::Compositor::CompositorContextId> m_remote_child_frame_compositor_contexts;
+    Optional<Web::HTML::CrossProcessId> m_pending_root_navigable_id;
 
     u64 m_devtools_client_count { 0 };
 };

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -23,15 +23,15 @@ PageHost::PageHost(ConnectionFromClient& client)
 {
 }
 
-void PageHost::initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator navigable_id_allocator)
+void PageHost::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator)
 {
     VERIFY(m_pages.is_empty());
-    m_navigable_id_allocator = navigable_id_allocator;
+    m_cross_process_id_allocator = cross_process_id_allocator;
     auto& first_page = create_page(initial_page_id, root_navigable_id);
     Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank());
 }
 
-PageClient& PageHost::create_page(u64 page_id, Optional<Web::HTML::NavigableId> pending_root_navigable_id)
+PageClient& PageHost::create_page(u64 page_id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id)
 {
     VERIFY(page_id > 0);
     VERIFY(!m_pages.contains(page_id));
@@ -39,10 +39,10 @@ PageClient& PageHost::create_page(u64 page_id, Optional<Web::HTML::NavigableId> 
     return *m_pages.get(page_id).value();
 }
 
-Web::HTML::NavigableId PageHost::allocate_navigable_id()
+Web::HTML::CrossProcessId PageHost::allocate_navigable_id()
 {
-    VERIFY(m_navigable_id_allocator.has_value());
-    return m_navigable_id_allocator->allocate();
+    VERIFY(m_cross_process_id_allocator.has_value());
+    return m_cross_process_id_allocator->allocate();
 }
 
 void PageHost::remove_page(Badge<PageClient>, u64 page_id)

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -39,10 +39,15 @@ PageClient& PageHost::create_page(u64 page_id, Optional<Web::HTML::CrossProcessI
     return *m_pages.get(page_id).value();
 }
 
-Web::HTML::CrossProcessId PageHost::allocate_navigable_id()
+Web::HTML::CrossProcessId PageHost::allocate_cross_process_id()
 {
     VERIFY(m_cross_process_id_allocator.has_value());
     return m_cross_process_id_allocator->allocate();
+}
+
+Web::HTML::CrossProcessId PageHost::allocate_navigable_id()
+{
+    return allocate_cross_process_id();
 }
 
 void PageHost::remove_page(Badge<PageClient>, u64 page_id)

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -40,6 +40,7 @@ public:
     Optional<PageClient&> page(u64 page_id);
     PageClient& create_page(u64 page_id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id = {});
     void remove_page(Badge<PageClient>, u64 page_id);
+    Web::HTML::CrossProcessId allocate_cross_process_id();
     Web::HTML::CrossProcessId allocate_navigable_id();
 
     ConnectionFromClient& client() const { return m_client; }

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -13,7 +13,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <LibGC/Root.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <WebContent/Forward.h>
 
 namespace Web {
@@ -36,11 +36,11 @@ public:
     static NonnullOwnPtr<PageHost> create(ConnectionFromClient& client) { return adopt_own(*new PageHost(client)); }
     virtual ~PageHost();
 
-    void initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator);
+    void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator);
     Optional<PageClient&> page(u64 page_id);
-    PageClient& create_page(u64 page_id, Optional<Web::HTML::NavigableId> pending_root_navigable_id = {});
+    PageClient& create_page(u64 page_id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id = {});
     void remove_page(Badge<PageClient>, u64 page_id);
-    Web::HTML::NavigableId allocate_navigable_id();
+    Web::HTML::CrossProcessId allocate_navigable_id();
 
     ConnectionFromClient& client() const { return m_client; }
     void ensure_compositor_host();
@@ -55,7 +55,7 @@ private:
     ConnectionFromClient& m_client;
     OwnPtr<Web::Compositor::CompositorHost> m_compositor_host;
     HashMap<u64, GC::Root<PageClient>> m_pages;
-    Optional<Web::HTML::NavigableIdAllocator> m_navigable_id_allocator;
+    Optional<Web::HTML::CrossProcessIdAllocator> m_cross_process_id_allocator;
 };
 
 }

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -21,7 +21,7 @@
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/LocalNavigable.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SelectItem.h>
@@ -47,14 +47,14 @@ endpoint WebContentClient
     allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
     did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
 
-    decide_navigation_process(u64 page_id, Optional<Web::HTML::NavigableId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target) => (Web::NavigationProcessDecision decision)
+    decide_navigation_process(u64 page_id, Optional<Web::HTML::CrossProcessId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target) => (Web::NavigationProcessDecision decision)
     did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
-    did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
-    did_create_child_frame(u64 page_id, Web::HTML::NavigableId parent_frame_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
-    did_update_child_frame_viewport(u64 page_id, Web::HTML::NavigableId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
-    did_commit_child_frame_navigation(u64 page_id, Web::HTML::NavigableId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
+    did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
+    did_create_child_frame(u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
+    did_update_child_frame_viewport(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
+    did_commit_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
     did_change_top_level_active_document(u64 page_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
-    did_destroy_child_frame(u64 page_id, Web::HTML::NavigableId frame_id) =|
+    did_destroy_child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id) =|
     did_start_webdriver_navigation(u64 page_id, URL::URL url) =|
     did_start_loading(u64 page_id, URL::URL url, Variant<Empty, String, Web::HTML::POSTResource> document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     did_cancel_loading(u64 page_id, URL::URL url) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -16,7 +16,7 @@
 #include <LibWeb/HTML/AutoplayPolicy.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/VisibilityState.h>
@@ -37,7 +37,7 @@
 endpoint WebContentServer
 {
     init_transport(int peer_pid) => (int peer_pid)
-    initialize(u64 initial_page_id, Web::HTML::NavigableId root_navigable_id, Web::HTML::NavigableIdAllocator navigable_id_allocator) =|
+    initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator) =|
     close_server() =|
 
     get_window_handle(u64 page_id) => (String handle)
@@ -63,9 +63,9 @@ endpoint WebContentServer
     load_html_with_url(u64 page_id, ByteString html, URL::URL url) =|
     reload(u64 page_id) =|
     cancel_download(u64 page_id, u64 download_id) =|
-    run_iframe_load_event_steps(u64 page_id, Web::HTML::NavigableId frame_id) =|
+    run_iframe_load_event_steps(u64 page_id, Web::HTML::CrossProcessId frame_id) =|
     set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id) =|
-    set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::NavigableId frame_id, Optional<Web::Compositor::CompositorContextId> context_id) =|
+    set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::CrossProcessId frame_id, Optional<Web::Compositor::CompositorContextId> context_id) =|
     traverse_the_history_to_step(u64 page_id, i32 step) =|
     check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) =|
     set_top_level_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries,

--- a/Tests/LibWeb/TestSessionHistoryEntry.cpp
+++ b/Tests/LibWeb/TestSessionHistoryEntry.cpp
@@ -7,10 +7,10 @@
 #include <LibJS/Runtime/VM.h>
 #include <LibTest/TestCase.h>
 #include <LibURL/Parser.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 
-static Web::HTML::NavigableId frame_1_id()
+static Web::HTML::CrossProcessId frame_1_id()
 {
     return { 1, 1 };
 }

--- a/Tests/LibWeb/TestSessionHistoryEntry.cpp
+++ b/Tests/LibWeb/TestSessionHistoryEntry.cpp
@@ -24,14 +24,22 @@ static URL::URL parse_url(StringView url)
 
 TEST_CASE(post_load_seed_match_allows_ui_owned_nested_histories)
 {
-    Web::HTML::SessionHistoryEntryDescriptor live_descriptor;
-    live_descriptor.step = 0;
-    live_descriptor.url = parse_url("https://a.example/"sv);
-    live_descriptor.document_state.id = 1;
-    live_descriptor.document_state.ever_populated = true;
-    live_descriptor.document_state.navigable_target_name = Utf16String::from_utf8("main"sv);
+    auto vm = JS::VM::create();
 
-    auto seed_descriptor = live_descriptor;
+    auto live_document_state = Web::HTML::DocumentState::create();
+    live_document_state->set_ever_populated(true);
+    live_document_state->set_navigable_target_name(Utf16String::from_utf8("main"sv));
+
+    auto live_entry = Web::HTML::SessionHistoryEntry::create();
+    live_entry->set_step(0);
+    live_entry->set_url(parse_url("https://a.example/"sv));
+    live_entry->set_document_state(live_document_state);
+
+    Web::HTML::CrossProcessIdAllocator cross_process_id_allocator { .namespace_id = 3 };
+    Web::HTML::SessionHistoryEntryDescriptorCreationState creation_state { [&] {
+        return cross_process_id_allocator.allocate();
+    } };
+    auto seed_descriptor = Web::HTML::create_session_history_entry_descriptor(*live_entry, creation_state);
 
     Web::HTML::SessionHistoryEntryDescriptor nested_entry;
     nested_entry.step = 1;
@@ -41,8 +49,8 @@ TEST_CASE(post_load_seed_match_allows_ui_owned_nested_histories)
         .entries = { move(nested_entry) },
     });
 
-    EXPECT(!Web::HTML::session_history_entry_descriptors_match_ignoring_document_state_id(live_descriptor, seed_descriptor));
-    EXPECT(Web::HTML::session_history_entry_descriptors_match_ignoring_document_state_id(live_descriptor, seed_descriptor, Web::HTML::MatchNestedHistories::No));
+    EXPECT(!Web::HTML::session_history_entry_matches_descriptor_ignoring_document_state_id(*live_entry, seed_descriptor));
+    EXPECT(Web::HTML::session_history_entry_matches_descriptor_ignoring_document_state_id(*live_entry, seed_descriptor, Web::HTML::MatchNestedHistories::No));
 }
 
 TEST_CASE(descriptor_creation_preserves_nested_history_with_only_pending_entries)
@@ -65,7 +73,10 @@ TEST_CASE(descriptor_creation_preserves_nested_history_with_only_pending_entries
     top_level_entry->set_url(parse_url("https://a.example/"sv));
     top_level_entry->set_document_state(top_level_document_state);
 
-    Web::HTML::SessionHistoryEntryDescriptorCreationState creation_state;
+    Web::HTML::CrossProcessIdAllocator cross_process_id_allocator { .namespace_id = 3 };
+    Web::HTML::SessionHistoryEntryDescriptorCreationState creation_state { [&] {
+        return cross_process_id_allocator.allocate();
+    } };
     auto descriptor = Web::HTML::create_session_history_entry_descriptor(top_level_entry, creation_state);
 
     EXPECT_EQ(descriptor.document_state.nested_histories.size(), 1u);

--- a/Tests/LibWebView/TestSessionHistory.cpp
+++ b/Tests/LibWebView/TestSessionHistory.cpp
@@ -6,11 +6,11 @@
 
 #include <LibTest/TestCase.h>
 #include <LibURL/Parser.h>
-#include <LibWeb/HTML/NavigableId.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWebView/HistoryDebug.h>
 #include <LibWebView/SessionHistory.h>
 
-static Web::HTML::NavigableId navigable_id(StringView id)
+static Web::HTML::CrossProcessId navigable_id(StringView id)
 {
     if (id == "frame-1"sv)
         return { 1, 1 };

--- a/Tests/LibWebView/TestSessionHistory.cpp
+++ b/Tests/LibWebView/TestSessionHistory.cpp
@@ -21,6 +21,18 @@ static Web::HTML::CrossProcessId navigable_id(StringView id)
     VERIFY_NOT_REACHED();
 }
 
+static Web::HTML::CrossProcessId test_document_state_id(u64 local_id)
+{
+    VERIFY(local_id > 0);
+    return { 3, local_id };
+}
+
+static Web::HTML::CrossProcessId allocate_test_ui_process_document_state_id()
+{
+    static Web::HTML::CrossProcessIdAllocator allocator { .namespace_id = 4 };
+    return allocator.allocate();
+}
+
 static Web::HTML::SessionHistoryNestedHistoryDescriptor nested_history(StringView id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries)
 {
     return {
@@ -49,7 +61,7 @@ static Web::HTML::SessionHistoryEntryDescriptor create_test_entry(i32 step, URL:
         .step = step,
         .url = move(url),
         .document_state = {
-            .id = 0,
+            .id = test_document_state_id(1000 + static_cast<u64>(step)),
             .history_policy_container = Web::HTML::DocumentState::Client::Tag,
             .request_referrer = Web::Fetch::Infrastructure::Request::Referrer::Client,
             .request_referrer_policy = Web::ReferrerPolicy::DEFAULT_REFERRER_POLICY,
@@ -97,7 +109,7 @@ static Web::HTML::SessionHistoryEntryDescriptor entry_with_scroll_position(i32 s
 static Web::HTML::SessionHistoryEntryDescriptor entry(i32 step, StringView url, u64 document_state_id, StringView navigable_target_name)
 {
     auto entry = create_test_entry(step, parse_url(url));
-    entry.document_state.id = document_state_id;
+    entry.document_state.id = test_document_state_id(document_state_id);
     entry.document_state.ever_populated = true;
     entry.document_state.navigable_target_name = Utf16String::from_utf8(navigable_target_name);
     return entry;
@@ -106,7 +118,7 @@ static Web::HTML::SessionHistoryEntryDescriptor entry(i32 step, StringView url, 
 static Web::HTML::SessionHistoryEntryDescriptor entry_with_reload_pending(i32 step, StringView url, u64 document_state_id, StringView navigable_target_name, Vector<Web::HTML::SessionHistoryNestedHistoryDescriptor> nested_histories)
 {
     auto entry = create_test_entry(step, parse_url(url));
-    entry.document_state.id = document_state_id;
+    entry.document_state.id = test_document_state_id(document_state_id);
     entry.document_state.reload_pending = true;
     entry.document_state.ever_populated = true;
     entry.document_state.navigable_target_name = Utf16String::from_utf8(navigable_target_name);
@@ -134,7 +146,7 @@ static Web::HTML::SessionHistoryEntryDescriptor entry(i32 step, StringView url, 
 static Web::HTML::SessionHistoryEntryDescriptor entry(i32 step, StringView url, u64 document_state_id, StringView navigable_target_name, Vector<Web::HTML::SessionHistoryNestedHistoryDescriptor> nested_histories)
 {
     auto entry = create_test_entry(step, parse_url(url));
-    entry.document_state.id = document_state_id;
+    entry.document_state.id = test_document_state_id(document_state_id);
     entry.document_state.ever_populated = true;
     entry.document_state.navigable_target_name = Utf16String::from_utf8(navigable_target_name);
     entry.document_state.nested_histories = move(nested_histories);
@@ -173,7 +185,7 @@ static void expect_entry_state(Web::HTML::SessionHistoryEntryDescriptor const& e
 
 static void expect_entry_document_state(Web::HTML::SessionHistoryEntryDescriptor const& entry, u64 expected_document_state_id, StringView expected_navigable_target_name)
 {
-    EXPECT_EQ(entry.document_state.id, expected_document_state_id);
+    EXPECT_EQ(entry.document_state.id, test_document_state_id(expected_document_state_id));
     EXPECT_EQ(entry.document_state.navigable_target_name, Utf16String::from_utf8(expected_navigable_target_name));
 }
 
@@ -247,8 +259,8 @@ TEST_CASE(complete_web_content_update_replaces_mirror)
 TEST_CASE(fresh_process_snapshot_does_not_drop_previous_entries)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
 
     auto update_result = history.update_from_web_content({
                                                              entry(0, URL::about_blank()),
@@ -275,7 +287,7 @@ TEST_CASE(replace_navigation_snapshot_drops_speculative_entry)
         { 0, 1 }, 1);
     EXPECT_EQ(initial_update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
 
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
 
     auto update_result = history.update_from_web_content({
                                                              entry(0, "https://a.example/"sv),
@@ -301,7 +313,7 @@ TEST_CASE(replace_navigation_snapshot_drops_speculative_first_entry)
         { 0 }, 0);
     EXPECT_EQ(initial_update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
 
-    history.replace_current_entry_url(parse_url("https://b.example/"sv));
+    history.replace_current_entry_url(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
 
     auto update_result = history.update_from_web_content({
                                                              entry(0, "https://b.example/"sv),
@@ -319,8 +331,8 @@ TEST_CASE(replace_navigation_snapshot_drops_speculative_first_entry)
 TEST_CASE(fresh_single_entry_snapshot_does_not_drop_previous_entries)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
 
     auto update_result = history.update_from_web_content({
                                                              entry(0, "https://b.example/"sv),
@@ -346,16 +358,11 @@ TEST_CASE(fresh_single_entry_snapshot_does_not_drop_previous_entries)
 TEST_CASE(complete_matching_snapshot_updates_current_index)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
 
-    auto update_result = history.update_from_web_content({
-                                                             entry(0, "https://a.example/"sv),
-                                                             entry(1, "https://b.example/"sv),
-                                                             entry(2, "https://c.example/"sv),
-                                                         },
-        { 0, 1, 2 }, 1);
+    auto update_result = history.update_from_web_content(history.entries(), history.used_steps(), 1);
 
     EXPECT_EQ(update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
     EXPECT_EQ(history.size(), 3uz);
@@ -442,9 +449,9 @@ TEST_CASE(matching_snapshot_updates_document_state)
 TEST_CASE(partial_snapshot_preserves_forward_history_after_fallback_traversal)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(1);
 
     auto update_result = history.update_from_web_content({
@@ -465,9 +472,9 @@ TEST_CASE(partial_snapshot_preserves_forward_history_after_fallback_traversal)
 TEST_CASE(partial_snapshot_preserves_entries_outside_web_content_known_history)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(1);
 
     auto update_result = history.update_from_web_content({
@@ -494,7 +501,7 @@ TEST_CASE(partial_snapshot_preserves_entries_outside_web_content_known_history)
     EXPECT(!history.web_content_can_traverse_to(*target_c));
 }
 
-TEST_CASE(complete_snapshot_accepts_reassigned_document_state_ids)
+TEST_CASE(complete_snapshot_preserves_document_state_ids)
 {
     WebView::TraversableSessionHistory history;
 
@@ -512,14 +519,14 @@ TEST_CASE(complete_snapshot_accepts_reassigned_document_state_ids)
     EXPECT_EQ(initial_update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
 
     auto update_result = history.update_from_web_content({
-                                                             entry(0, "https://a.example/"sv, 10, "top-a"sv),
-                                                             entry(1, "https://nested.example/"sv, 20, "top-nested"sv, {
-                                                                                                                           nested_history("frame-1"sv, {
-                                                                                                                                                           entry(1, "https://frame.example/a"sv, 30, "frame"sv),
-                                                                                                                                                           entry(2, "https://frame.example/b"sv, 40, "frame"sv),
-                                                                                                                                                       }),
-                                                                                                                       }),
-                                                             entry(3, "https://c.example/"sv, 50, "top-c"sv),
+                                                             entry(0, "https://a.example/"sv, 1, "top-a"sv),
+                                                             entry(1, "https://nested.example/"sv, 2, "top-nested"sv, {
+                                                                                                                          nested_history("frame-1"sv, {
+                                                                                                                                                          entry(1, "https://frame.example/a"sv, 3, "frame"sv),
+                                                                                                                                                          entry(2, "https://frame.example/b"sv, 4, "frame"sv),
+                                                                                                                                                      }),
+                                                                                                                      }),
+                                                             entry(3, "https://c.example/"sv, 5, "top-c"sv),
                                                          },
         { 0, 1, 2, 3 }, 2);
 
@@ -544,9 +551,9 @@ TEST_CASE(complete_snapshot_accepts_reassigned_document_state_ids)
 TEST_CASE(partial_snapshot_updates_nested_history_and_preserves_forward_history)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(1);
 
     auto update_result = history.update_from_web_content({
@@ -578,9 +585,9 @@ TEST_CASE(partial_snapshot_updates_nested_history_and_preserves_forward_history)
 TEST_CASE(fresh_process_snapshot_preserves_forward_history_at_first_entry)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(URL::about_blank());
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
+    history.navigate(URL::about_blank(), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(0);
 
     auto update_result = history.update_from_web_content({
@@ -600,8 +607,8 @@ TEST_CASE(fresh_process_snapshot_preserves_forward_history_at_first_entry)
 TEST_CASE(partial_snapshot_extends_history_without_dropping_prefix)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
 
     auto update_result = history.update_from_web_content({
                                                              entry(0, URL::about_blank()),
@@ -660,8 +667,8 @@ TEST_CASE(partial_snapshot_accepts_same_document_update_at_current_step)
 TEST_CASE(partial_snapshot_allows_web_content_traversal_within_known_suffix)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
 
     auto update_result = history.update_from_web_content({
                                                              entry(0, URL::about_blank()),
@@ -746,9 +753,9 @@ TEST_CASE(reseeded_partial_snapshot_preserves_ui_only_history)
 TEST_CASE(partial_snapshot_replaces_forward_history_after_new_navigation)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(1);
 
     auto update_result = history.update_from_web_content({
@@ -770,10 +777,10 @@ TEST_CASE(partial_snapshot_replaces_forward_history_after_new_navigation)
 TEST_CASE(partial_snapshot_anchors_to_current_duplicate_url_entry)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(2);
 
     auto update_result = history.update_from_web_content({
@@ -915,9 +922,9 @@ TEST_CASE(used_steps_include_nested_history_steps)
 TEST_CASE(traversal_target_for_top_level_step)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(1);
 
     EXPECT(history.current_step_is_top_level_entry());
@@ -1234,7 +1241,7 @@ TEST_CASE(applied_web_content_traversal_rejects_unknown_web_content_state)
     EXPECT(!history.web_content_current_step().has_value());
 }
 
-TEST_CASE(same_document_reseed_snapshot_accepts_reassigned_document_state_ids)
+TEST_CASE(same_document_reseed_snapshot_preserves_document_state_ids)
 {
     WebView::TraversableSessionHistory history;
 
@@ -1267,17 +1274,17 @@ TEST_CASE(same_document_reseed_snapshot_accepts_reassigned_document_state_ids)
                                                              entry(0, "https://a.example/"sv),
                                                              entry(1, "https://b.example/"sv),
                                                              entry(2, "https://c.example/"sv),
-                                                             entry(3, "https://nested.example/"sv, 8, "main"sv, {
-                                                                                                                    nested_history("1"sv, {
-                                                                                                                                              entry(3, "https://frame.example/a"sv, 6, ""sv),
-                                                                                                                                              entry(4, "https://frame.example/b"sv, 7, ""sv),
-                                                                                                                                          }),
+                                                             entry(3, "https://nested.example/"sv, 6, "main"sv, {
+                                                                                                                    nested_history("frame-1"sv, {
+                                                                                                                                                    entry(3, "https://frame.example/a"sv, 7, ""sv),
+                                                                                                                                                    entry(4, "https://frame.example/b"sv, 8, ""sv),
+                                                                                                                                                }),
                                                                                                                 }),
-                                                             entry(5, "https://nested.example/same-document"sv, 8, "main"sv, {
-                                                                                                                                 nested_history("1"sv, {
-                                                                                                                                                           entry(3, "https://frame.example/a"sv, 6, ""sv),
-                                                                                                                                                           entry(4, "https://frame.example/b"sv, 7, ""sv),
-                                                                                                                                                       }),
+                                                             entry(5, "https://nested.example/same-document"sv, 6, "main"sv, {
+                                                                                                                                 nested_history("frame-1"sv, {
+                                                                                                                                                                 entry(3, "https://frame.example/a"sv, 7, ""sv),
+                                                                                                                                                                 entry(4, "https://frame.example/b"sv, 8, ""sv),
+                                                                                                                                                             }),
                                                                                                                              }),
                                                          },
         { 0, 1, 2, 3, 4, 5 }, 5);
@@ -1288,7 +1295,7 @@ TEST_CASE(same_document_reseed_snapshot_accepts_reassigned_document_state_ids)
     EXPECT(history.web_content_can_traverse_to(*history.traversal_target_for_delta(-1)));
 }
 
-TEST_CASE(seed_ack_accepts_reconstructed_document_state_for_unknown_current_entry)
+TEST_CASE(seed_ack_accepts_preserved_document_state_ids)
 {
     WebView::TraversableSessionHistory history;
     auto update_result = history.update_from_web_content({
@@ -1302,9 +1309,9 @@ TEST_CASE(seed_ack_accepts_reconstructed_document_state_for_unknown_current_entr
     history.forget_web_content_state();
 
     EXPECT(history.did_seed_web_content_from_ui_process({
-                                                            entry(0, "https://a.example/"sv, 1, "main"sv),
-                                                            entry(1, "https://a.example/replaced"sv, 2, "main"sv),
-                                                            entry(2, "https://a.example/pushed"sv, 2, "main"sv),
+                                                            entry(0, "https://a.example/"sv),
+                                                            entry(1, "https://a.example/replaced"sv, 1, "main"sv),
+                                                            entry(2, "https://a.example/pushed"sv, 1, "main"sv),
                                                         },
         { 0, 1, 2 }, 0));
     EXPECT(history.web_content_history_matches_mirror());
@@ -1336,7 +1343,7 @@ TEST_CASE(seed_ack_rejects_reconstructed_history_with_mismatched_state)
 TEST_CASE(traversal_target_for_delta_outside_used_steps)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
 
     EXPECT(!history.traversal_target_for_delta(-1).has_value());
     EXPECT(!history.traversal_target_for_delta(0).has_value());
@@ -1392,7 +1399,7 @@ TEST_CASE(navigate_clears_forward_nested_history_entries)
         { 0, 1, 2, 3 }, 1);
     EXPECT_EQ(update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
 
-    history.navigate(parse_url("https://b.example/"sv));
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
 
     EXPECT_EQ(history.size(), 2uz);
     EXPECT_EQ(history.used_step_count(), 3uz);
@@ -1414,9 +1421,9 @@ TEST_CASE(navigate_clears_forward_nested_history_entries)
 TEST_CASE(partial_snapshot_missing_nested_history_descriptor_is_invalid)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(1);
 
     auto update_result = history.update_from_web_content({
@@ -1610,9 +1617,9 @@ TEST_CASE(partial_snapshot_missing_preserved_nested_history_descriptor_is_invali
 TEST_CASE(matching_snapshot_missing_nested_history_descriptor_is_invalid)
 {
     WebView::TraversableSessionHistory history;
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv));
-    history.navigate(parse_url("https://c.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://c.example/"sv), allocate_test_ui_process_document_state_id());
     history.traverse_to(1);
 
     auto update_result = history.update_from_web_content({
@@ -1650,8 +1657,8 @@ TEST_CASE(history_log_entries_marks_current_entries_steps_and_reload_pending)
     EXPECT_EQ(update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
 
     EXPECT_EQ(history_log_entries(history), ByteString { "entries=[0:0:https://a.example/, *1:1:https://b.example/ "
-                                                         "document_state={id=0, resource=post}, 2:2:https://c.example/ "
-                                                         "document_state={id=1, reload_pending=true, target_name=main} "
+                                                         "document_state={id=3:1001, resource=post}, 2:2:https://c.example/ "
+                                                         "document_state={id=3:7, reload_pending=true, target_name=main} "
                                                          "nested={1:2=[3:https://frame.example/]}] "
                                                          "used_steps=[0:0, *1:1, 2:2, 3:3]"sv });
 
@@ -1683,7 +1690,7 @@ TEST_CASE(history_log_entries_marks_nested_histories)
     EXPECT_EQ(update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
 
     EXPECT_EQ(history_log_entries(history), ByteString { "entries=[0:0:https://a.example/, *1:1:https://b.example/ "
-                                                         "document_state={id=1, target_name=main} "
+                                                         "document_state={id=3:7, target_name=main} "
                                                          "nested={1:2=[2:https://frame.example/]}] "
                                                          "used_steps=[0:0, 1:1, *2:2]"sv });
 }
@@ -1760,11 +1767,11 @@ TEST_CASE(navigate_preserves_document_resource)
 {
     WebView::TraversableSessionHistory history;
 
-    history.navigate(parse_url("https://a.example/"sv));
-    history.navigate(parse_url("https://b.example/"sv), Web::HTML::POSTResource {
-                                                            .request_body = MUST(ByteBuffer::copy("name=ladybird"sv.bytes())),
-                                                            .request_content_type = Web::HTML::POSTResource::RequestContentType::ApplicationXWWWFormUrlencoded,
-                                                        });
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.navigate(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id(), Web::HTML::POSTResource {
+                                                                                                          .request_body = MUST(ByteBuffer::copy("name=ladybird"sv.bytes())),
+                                                                                                          .request_content_type = Web::HTML::POSTResource::RequestContentType::ApplicationXWWWFormUrlencoded,
+                                                                                                      });
 
     auto current_entry = history.current_entry();
     VERIFY(current_entry);
@@ -1775,11 +1782,11 @@ TEST_CASE(replace_current_entry_preserves_document_resource)
 {
     WebView::TraversableSessionHistory history;
 
-    history.navigate(parse_url("https://a.example/"sv));
-    history.replace_current_entry(parse_url("https://b.example/"sv), Web::HTML::POSTResource {
-                                                                         .request_body = MUST(ByteBuffer::copy("name=ladybird"sv.bytes())),
-                                                                         .request_content_type = Web::HTML::POSTResource::RequestContentType::ApplicationXWWWFormUrlencoded,
-                                                                     });
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id());
+    history.replace_current_entry(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id(), Web::HTML::POSTResource {
+                                                                                                                       .request_body = MUST(ByteBuffer::copy("name=ladybird"sv.bytes())),
+                                                                                                                       .request_content_type = Web::HTML::POSTResource::RequestContentType::ApplicationXWWWFormUrlencoded,
+                                                                                                                   });
 
     auto current_entry = history.current_entry();
     VERIFY(current_entry);
@@ -1803,10 +1810,10 @@ TEST_CASE(replace_current_entry_discards_replaced_document_state)
         { 0, 1, 2 }, 0);
     EXPECT_EQ(update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
 
-    history.replace_current_entry(parse_url("https://b.example/"sv), Web::HTML::POSTResource {
-                                                                         .request_body = MUST(ByteBuffer::copy("name=ladybird"sv.bytes())),
-                                                                         .request_content_type = Web::HTML::POSTResource::RequestContentType::ApplicationXWWWFormUrlencoded,
-                                                                     });
+    history.replace_current_entry(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id(), Web::HTML::POSTResource {
+                                                                                                                       .request_body = MUST(ByteBuffer::copy("name=ladybird"sv.bytes())),
+                                                                                                                       .request_content_type = Web::HTML::POSTResource::RequestContentType::ApplicationXWWWFormUrlencoded,
+                                                                                                                   });
 
     EXPECT_EQ(history.size(), 2uz);
     EXPECT_EQ(history.used_step_count(), 2uz);
@@ -1819,7 +1826,8 @@ TEST_CASE(replace_current_entry_discards_replaced_document_state)
 
     auto* current_entry = history.current_entry();
     VERIFY(current_entry);
-    EXPECT_EQ(current_entry->document_state.id, 0u);
+    EXPECT(current_entry->document_state.id.namespace_id > 0);
+    EXPECT(current_entry->document_state.id.local_id > 0);
     EXPECT(current_entry->document_state.navigable_target_name.is_empty());
     EXPECT(current_entry->document_state.nested_histories.is_empty());
     expect_entry_resource(*current_entry, "post"sv);
@@ -1841,7 +1849,7 @@ TEST_CASE(replace_current_entry_at_nested_step_keeps_current_step_valid)
         { 0, 1, 2 }, 1);
     EXPECT_EQ(update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
 
-    history.replace_current_entry(parse_url("https://b.example/"sv), Empty {});
+    history.replace_current_entry(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id(), Empty {});
 
     EXPECT_EQ(history.size(), 2uz);
     EXPECT_EQ(history.used_step_count(), 2uz);
@@ -1863,11 +1871,11 @@ TEST_CASE(replace_current_entry_url_keeps_document_resource)
 {
     WebView::TraversableSessionHistory history;
 
-    history.navigate(parse_url("https://a.example/"sv), Web::HTML::POSTResource {
-                                                            .request_body = MUST(ByteBuffer::copy("name=ladybird"sv.bytes())),
-                                                            .request_content_type = Web::HTML::POSTResource::RequestContentType::ApplicationXWWWFormUrlencoded,
-                                                        });
-    history.replace_current_entry_url(parse_url("https://b.example/"sv));
+    history.navigate(parse_url("https://a.example/"sv), allocate_test_ui_process_document_state_id(), Web::HTML::POSTResource {
+                                                                                                          .request_body = MUST(ByteBuffer::copy("name=ladybird"sv.bytes())),
+                                                                                                          .request_content_type = Web::HTML::POSTResource::RequestContentType::ApplicationXWWWFormUrlencoded,
+                                                                                                      });
+    history.replace_current_entry_url(parse_url("https://b.example/"sv), allocate_test_ui_process_document_state_id());
 
     auto current_entry = history.current_entry();
     VERIFY(current_entry);


### PR DESCRIPTION
Give session history document states stable CrossProcessId identities
instead of UI-local u64 descriptor IDs. Store the ID on DocumentState so
shared document state can be recognized directly across IPC and
WebContent process swaps.

This removes the need for ID remapping/canonicalization and gives
UI-created history entries real document-state IDs too. With identity no
longer inferred from descriptor contents, follow-up work can simplify
session-history matching, seeding, and crash/process-swap recovery
paths.