### PR TITLE
Stop page loading with Esc key :^)

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -110,6 +110,8 @@
 #include <LibWeb/DOM/Utils.h>
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/Fetch/Infrastructure/FetchController.h>
+#include <LibWeb/Fetch/Infrastructure/FetchRecord.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/FileAPI/BlobURLStore.h>
 #include <LibWeb/HTML/AttributeNames.h>
@@ -332,7 +334,7 @@ static GC::Ref<HTML::BrowsingContext> obtain_a_browsing_context_to_use_for_a_nav
     return new_browsing_context;
 }
 
-// https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object
+// https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object
 WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type, String content_type, HTML::NavigationParams const& navigation_params)
 {
     // 1. Let browsingContext be the result of obtaining a browsing context to use for a navigation response given navigationParams.
@@ -501,7 +503,20 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
         }
     }
 
-    // FIXME: 15: If navigationParams's fetch controller is not null, then:
+    // AD-HOC: Retain the navigation fetch controller so aborting the document can cancel the main resource after
+    //         response commitment. Navigation fetches are not included in the document's subresource fetch group.
+    if (navigation_params.fetch_controller)
+        document->m_ongoing_navigation_fetch_controller = navigation_params.fetch_controller;
+
+    // FIXME: 15. If navigationParams's fetch controller is not null:
+    //            1. Let fullTimingInfo be the result of extracting the full timing info from navigationParams's fetch controller.
+    //            2. Let redirectCount be 0.
+    //            3. If navigationParams's response's has cross-origin redirects is false, or all of the following are true:
+    //                - navigationParams's request's client is null, or navigationParams's request's referrer is not "no-referrer", and
+    //                - navigation TAO check given navigationParams's response and navigationParams's origin returns success,
+    //               then set redirectCount to navigationParams's request's redirect count.
+    //            4. Create the navigation timing entry for document, given fullTimingInfo, redirectCount, navigationTimingType,
+    //               navigationParams's response's service worker timing info, and navigationParams's response's body info.
 
     // FIXME: 16. Create the navigation timing entry for document, with navigationParams's response's timing info,
     //        redirectCount, navigationParams's navigation timing type, and navigationParams's response's service
@@ -711,6 +726,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_pending_parsing_blocking_svg_script);
     visitor.visit(m_history);
     visitor.visit(m_html_parser_end_state);
+    visitor.visit(m_ongoing_navigation_fetch_controller);
     visitor.visit(m_style_computer);
     visitor.visit(m_font_computer);
     visitor.visit(m_browsing_context);
@@ -5158,22 +5174,38 @@ void Document::destroy_a_document_and_its_descendants(GC::Ptr<GC::Function<void(
     // NB: This is handled by destruction_state.
 }
 
-// https://html.spec.whatwg.org/multipage/browsing-the-web.html#abort-a-document
+// https://html.spec.whatwg.org/multipage/document-lifecycle.html#abort-a-document
 void Document::abort()
 {
     // 1. Assert: this is running as part of a task queued on document's relevant agent's event loop.
 
-    // FIXME: 2. Cancel any instances of the fetch algorithm in the context of document,
-    //           discarding any tasks queued for them, and discarding any further data received from the network for them.
-    //           If this resulted in any instances of the fetch algorithm being canceled
-    //           or any queued tasks or any network data getting discarded,
-    //           then make document unsalvageable given document and "fetch".
+    // 2. Cancel any instances of the fetch algorithm in the context of document,
+    //    discarding any tasks queued for them, and discarding any further data received from the network for them.
+    //    If this resulted in any instances of the fetch algorithm being canceled
+    //    or any queued tasks or any network data getting discarded,
+    //    then make document unsalvageable given document and "fetch".
+    bool canceled_fetch = false;
+    if (m_ongoing_navigation_fetch_controller && m_ongoing_navigation_fetch_controller->state() == Fetch::Infrastructure::FetchController::State::Ongoing) {
+        m_ongoing_navigation_fetch_controller->stop_fetch();
+        canceled_fetch = true;
+    }
+
+    for (auto& fetch_record : relevant_settings_object().fetch_group()) {
+        auto controller = fetch_record.fetch_controller();
+        if (!controller || controller->state() != Fetch::Infrastructure::FetchController::State::Ongoing)
+            continue;
+        controller->stop_fetch();
+        canceled_fetch = true;
+    }
+
+    if (canceled_fetch)
+        make_unsalvageable("fetch"_string);
 
     // 3. If document's during-loading navigation ID for WebDriver BiDi is non-null, then:
     if (m_navigation_id.has_value()) {
-        // 1. FIXME: Invoke WebDriver BiDi navigation aborted with document's node navigable,
-        //           and new WebDriver BiDi navigation status whose whose id is document's navigation id,
-        //           status is "canceled", and url is document's URL.
+        // FIXME: 1. Invoke WebDriver BiDi navigation aborted with document's node navigable and a new WebDriver BiDi
+        //           navigation status whose id is document's during-loading navigation ID for WebDriver BiDi, status
+        //           is "canceled", and url is document's URL.
 
         // 2. Set document's during-loading navigation ID for WebDriver BiDi to null.
         m_navigation_id = {};

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -758,7 +758,7 @@ public:
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document-and-its-descendants
     void destroy_a_document_and_its_descendants(GC::Ptr<GC::Function<void()>> after_all_destruction = {});
 
-    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#abort-a-document
+    // https://html.spec.whatwg.org/multipage/document-lifecycle.html#abort-a-document
     void abort();
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#abort-a-document-and-its-descendants
     void abort_a_document_and_its_descendants();
@@ -1472,6 +1472,10 @@ private:
 
     // https://html.spec.whatwg.org/multipage/dom.html#concept-document-navigation-id
     Optional<String> m_navigation_id;
+
+    // AD-HOC: The main resource fetch is not part of the document's subresource fetch group, so retain its controller
+    //         separately while the navigation fetch is ongoing.
+    GC::Ptr<Fetch::Infrastructure::FetchController> m_ongoing_navigation_fetch_controller;
 
     // https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set
     HTML::SandboxingFlagSet m_active_sandboxing_flag_set;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4208,11 +4208,16 @@ void LocalNavigable::unregister_navigation_observer(Badge<NavigationObserver>, N
     m_navigation_observers.remove(navigation_observer);
 }
 
-// https://html.spec.whatwg.org/multipage/document-lifecycle.html#nav-stop
+// https://html.spec.whatwg.org/multipage/document-lifecycle.html#stop-document-loading
 void LocalNavigable::stop_loading()
 {
     // 1. Let document be navigable's active document.
     auto document = active_document();
+
+    // AD-HOC: The HTML Standard does not cancel planned navigations here, but Chromium, WebKit, and Gecko do so when
+    //         handling window.stop(). Prevent navigations deferred behind an ongoing traversal from starting once it
+    //         completes. See https://github.com/whatwg/html/issues/12609.
+    clear_pending_navigations();
 
     // 2. If document's unload counter is 0, and navigable's ongoing navigation is a navigation ID, then set the ongoing navigation for navigable to null.
     if (document->unload_counter() == 0 && ongoing_navigation().has<String>())

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -195,6 +195,8 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
     set_loading_state(true);
     m_is_waiting_for_navigation_start = true;
     m_loading_navigation_id.clear();
+    m_loading_url = url;
+    m_last_stopped_load_url.clear();
     set_url(url);
     if (preparation.should_seed_web_content_before_load)
         seed_web_content_session_history_from_ui_process();
@@ -256,6 +258,8 @@ void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHist
     m_should_suppress_history_for_next_load = false;
     m_is_waiting_for_navigation_start = true;
     m_loading_navigation_id.clear();
+    m_loading_url = url;
+    m_last_stopped_load_url.clear();
     auto preparation = m_top_level_traversable.prepare_for_page_load(url, history_handling);
     if (preparation.should_update_navigation_action_state)
         update_navigation_action_state();
@@ -270,6 +274,8 @@ void ViewImplementation::load_html(StringView html)
     set_loading_state(true);
     m_is_waiting_for_navigation_start = false;
     m_loading_navigation_id.clear();
+    m_loading_url.clear();
+    m_last_stopped_load_url.clear();
     m_is_showing_crash_page = false;
     m_should_suppress_history_for_current_load = false;
     m_should_suppress_history_for_next_load = false;
@@ -282,6 +288,8 @@ void ViewImplementation::load_crash_page_html(StringView html, URL::URL const& c
     set_loading_state(true);
     m_is_waiting_for_navigation_start = false;
     m_loading_navigation_id.clear();
+    m_loading_url.clear();
+    m_last_stopped_load_url.clear();
     m_is_showing_crash_page = true;
     m_should_suppress_history_for_current_load = true;
     m_should_suppress_history_for_next_load = true;
@@ -303,6 +311,14 @@ void ViewImplementation::load_navigation_error_page(StringView text)
 
 void ViewImplementation::reload()
 {
+    if (m_last_stopped_load_url.has_value()) {
+        // AD-HOC: If a UI-requested navigation was stopped before its document committed, WebContent still considers
+        //         the previous document active. Reissue the stopped URL instead of reloading that previous document.
+        auto url = m_last_stopped_load_url.release_value();
+        load(url, Web::Bindings::NavigationHistoryBehavior::Replace);
+        return;
+    }
+
     set_loading_state(true);
     m_is_waiting_for_navigation_start = true;
     m_loading_navigation_id.clear();
@@ -322,6 +338,17 @@ void ViewImplementation::reload()
     update_navigation_action_state();
     dump_session_history("reload-mark-current-entry-reload-pending"sv);
     client().async_reload(page_id());
+}
+
+void ViewImplementation::stop_loading()
+{
+    if (!m_is_loading)
+        return;
+    m_last_stopped_load_url = m_loading_url;
+    set_loading_state(false);
+    m_is_waiting_for_navigation_start = false;
+    m_loading_navigation_id.clear();
+    client().async_stop_loading(page_id());
 }
 
 HistoryTraversalOutcome ViewImplementation::traverse_the_history_by_delta(

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -102,6 +102,7 @@ public:
     void load_navigation_error_page(StringView);
 
     void reload();
+    void stop_loading();
     bool is_loading() const { return m_is_loading; }
 
     struct SessionHistoryTraversalMenuItem {
@@ -572,6 +573,8 @@ protected:
     bool m_is_loading { false };
     bool m_is_waiting_for_navigation_start { false };
     Optional<String> m_loading_navigation_id;
+    Optional<URL::URL> m_loading_url;
+    Optional<URL::URL> m_last_stopped_load_url;
 
     size_t m_crash_count = 0;
     RefPtr<Core::Timer> m_repeated_crash_timer;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -594,6 +594,7 @@ void WebContentClient::did_start_loading(u64 page_id, Optional<String> navigatio
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         view->m_is_waiting_for_navigation_start = false;
         view->m_loading_navigation_id = navigation_id;
+        view->m_loading_url = url;
         view->m_should_suppress_history_for_current_load = view->m_should_suppress_history_for_next_load;
         view->m_should_suppress_history_for_next_load = false;
         view->did_start_navigation(url, move(document_resource), is_redirect, history_handling);
@@ -621,6 +622,7 @@ void WebContentClient::did_cancel_loading(u64 page_id, Optional<String> navigati
             return;
         view->m_is_waiting_for_navigation_start = false;
         view->m_loading_navigation_id.clear();
+        view->m_loading_url.clear();
         view->did_cancel_navigation(url);
 
         auto const& client_url = view->url();
@@ -714,6 +716,7 @@ void WebContentClient::did_finish_loading(u64 page_id, Optional<String> navigati
             return;
 
         view->m_loading_navigation_id.clear();
+        view->m_loading_url.clear();
         auto client_url = url;
         // Browser-generated pages can finish with an internal document URL.
         // Keep exposing the URL accepted at load start for suppressed loads.

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -315,6 +315,12 @@ void ConnectionFromClient::reload(u64 page_id)
         page->page().reload();
 }
 
+void ConnectionFromClient::stop_loading(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().top_level_traversable()->stop_loading();
+}
+
 void ConnectionFromClient::cancel_download(u64 page_id, u64 download_id)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -91,6 +91,7 @@ private:
     virtual void load_html(u64 page_id, ByteString) override;
     virtual void load_html_with_url(u64 page_id, ByteString, URL::URL) override;
     virtual void reload(u64 page_id) override;
+    virtual void stop_loading(u64 page_id) override;
     virtual void cancel_download(u64 page_id, u64 download_id) override;
     virtual void run_iframe_load_event_steps(u64 page_id, Web::HTML::NavigableId frame_id) override;
     virtual void set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId>) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -62,6 +62,7 @@ endpoint WebContentServer
     load_html(u64 page_id, ByteString html) =|
     load_html_with_url(u64 page_id, ByteString html, URL::URL url) =|
     reload(u64 page_id) =|
+    stop_loading(u64 page_id) =|
     cancel_download(u64 page_id, u64 download_id) =|
     run_iframe_load_event_steps(u64 page_id, Web::HTML::NavigableId frame_id) =|
     set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id) =|

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -1399,6 +1399,12 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         return;
     }
 
+    auto key_event = Ladybird::ns_event_to_key_event(Web::KeyEvent::Type::KeyDown, event);
+    if (key_event.key == Web::UIEvents::KeyCode::Key_Escape && key_event.modifiers == Web::UIEvents::KeyModifier::Mod_None && m_web_view_bridge->is_loading()) {
+        m_web_view_bridge->stop_loading();
+        return;
+    }
+
     self.current_key_down_event = event;
     [self interpretKeyEvents:@[ event ]];
 }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -516,6 +516,12 @@ void WebContentView::keyPressEvent(QKeyEvent* event)
         return;
     }
 
+    if (event->key() == Qt::Key_Escape && event->modifiers() == Qt::NoModifier && is_loading()) {
+        stop_loading();
+        event->accept();
+        return;
+    }
+
     enqueue_native_event(Web::KeyEvent::Type::KeyDown, *event);
 }
 


### PR DESCRIPTION
Add the conventional <kbd>Esc</kbd> stop action to both browser frontends. Stopping a load now immediately updates the UI loading state and asks WebContent to abort the active top-level navigation.

Retain the main-resource fetch controller on its resulting document so stopping can cancel it after response commitment. Abort also cancels active subresource fetches associated with the document.

Cancel planned navigations consistently with Chromium, WebKit, and Gecko. Remember stopped navigations that have not committed yet so reloading retries the requested URL instead of reloading the previous about:blank document.