### PR TITLE
Compute inline containing block rect without cumulative_offset

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1703,45 +1703,32 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
             return CSSPixelRect { { inline_start, block_start }, { inline_size, block_size } };
         return CSSPixelRect { { block_start, inline_start }, { block_size, inline_size } };
     };
-    auto add_atomic_inline_fragment_rect = [&](Box const& box_child, LayoutState::UsedValues const& child_used_values) {
-        if (!child_used_values.containing_line_box_fragment.has_value())
+    // The fragment belongs to the line boxes of the box we're currently walking, so `offset`
+    // (that box's running offset from abspos_containing_block) is the fragment's coordinate
+    // space origin; no walk up the containing block chain is needed.
+    auto add_atomic_inline_fragment_rect = [&](LineBoxFragment const& fragment, CSSPixelPoint offset) {
+        auto const* child_used_values = state.try_get(fragment.layout_node());
+        if (!child_used_values)
             return;
 
-        auto const* containing_block = box_child.containing_block();
-        auto const* containing_block_used_values = containing_block ? state.try_get(*containing_block) : nullptr;
-        auto const* abspos_containing_block_used_values = state.try_get(abspos_containing_block);
-        if (!containing_block_used_values || !abspos_containing_block_used_values)
-            return;
-
-        auto const& containing_line_box_fragment = child_used_values.containing_line_box_fragment.value();
-        if (containing_line_box_fragment.line_box_index >= containing_block_used_values->line_boxes.size())
-            return;
-
-        auto const& line_box = containing_block_used_values->line_boxes[containing_line_box_fragment.line_box_index];
-        if (containing_line_box_fragment.fragment_index >= line_box.fragments().size())
-            return;
-
-        auto const& fragment = line_box.fragments()[containing_line_box_fragment.fragment_index];
-        auto const containing_block_offset = state.cumulative_offset(*containing_block_used_values)
-            - state.cumulative_offset(*abspos_containing_block_used_values);
         auto const writing_mode = fragment.writing_mode();
         auto const is_horizontal = writing_mode == CSS::WritingMode::HorizontalTb;
-        auto const inline_axis_border_box_start = fragment.inline_offset() - (is_horizontal ? child_used_values.border_box_left() : child_used_values.border_box_top());
+        auto const inline_axis_border_box_start = fragment.inline_offset() - (is_horizontal ? child_used_values->border_box_left() : child_used_values->border_box_top());
         auto const inline_axis_border_box_extent = is_horizontal
-            ? child_used_values.border_box_width()
-            : child_used_values.border_box_height();
+            ? child_used_values->border_box_width()
+            : child_used_values->border_box_height();
         auto const block_axis_line_height = inline_node.computed_values().line_height();
         auto const block_axis_start = [&] {
-            if (box_child.computed_values().block_axis_is_reverse())
-                return fragment.block_offset() + child_used_values.border_box_right() - block_axis_line_height;
-            return fragment.block_offset() - (is_horizontal ? child_used_values.border_box_top() : child_used_values.border_box_left());
+            if (fragment.layout_node().computed_values().block_axis_is_reverse())
+                return fragment.block_offset() + child_used_values->border_box_right() - block_axis_line_height;
+            return fragment.block_offset() - (is_horizontal ? child_used_values->border_box_top() : child_used_values->border_box_left());
         }();
         add_fragment_rect(make_physical_rect(writing_mode,
             inline_axis_border_box_start,
             block_axis_start,
             inline_axis_border_box_extent,
             block_axis_line_height)
-                .translated(containing_block_offset));
+                .translated(offset));
     };
 
     // Walk outer_block's subtree in pre-order, threading the running offset from
@@ -1754,11 +1741,14 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
         if (used_values && !used_values->line_boxes.is_empty()) {
             for (auto const& line_box : used_values->line_boxes) {
                 for (auto const& fragment : line_box.fragments()) {
-                    if (fragment.is_atomic_inline())
+                    auto const* dom = fragment.layout_node().dom_node();
+                    if (!dom || !inline_dom_node->is_inclusive_ancestor_of(*dom))
                         continue;
-                    if (auto const* dom = fragment.layout_node().dom_node(); dom && inline_dom_node->is_inclusive_ancestor_of(*dom)) {
-                        add_fragment_rect({ fragment.offset() + offset, fragment.size() });
+                    if (fragment.is_atomic_inline()) {
+                        add_atomic_inline_fragment_rect(fragment, offset);
+                        continue;
                     }
+                    add_fragment_rect({ fragment.offset() + offset, fragment.size() });
                 }
             }
         }
@@ -1773,11 +1763,10 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
                 auto const* dom = box_child->dom_node();
                 if (!dom || !inline_dom_node->is_inclusive_ancestor_of(*dom))
                     continue;
-                if (box_child->is_atomic_inline()) {
-                    if (child_used_values)
-                        add_atomic_inline_fragment_rect(*box_child, *child_used_values);
+                // Atomic inlines contribute their fragment rect via their containing block's
+                // line boxes above; don't descend into their independent subtree.
+                if (box_child->is_atomic_inline())
                     continue;
-                }
                 // child_offset addresses the box's content area; the border-box origin sits
                 // (border-left + padding-left, border-top + padding-top) before that.
                 if (child_used_values) {

--- a/Tests/LibWeb/Crash/Layout/abspos-inline-containing-block-inside-height-measurement.html
+++ b/Tests/LibWeb/Crash/Layout/abspos-inline-containing-block-inside-height-measurement.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!-- The outer box has auto height and a min-height, so laying it out first measures its
+     automatic content height in a throwaway LayoutState. The measuring BFC lays out the
+     abspos child against its inline containing block (the position:relative span), and
+     computing the inline's rect for the atomic inline sibling used to walk the containing
+     block chain past the measurement root, reading state for boxes that don't exist in
+     the throwaway state. -->
+<div style="overflow: hidden; min-height: 10px; position: relative;">
+    <span style="position: relative;">
+        <div style="display: inline-block; width: 10px; height: 10px;"></div>
+        <div style="position: absolute; left: 0; top: 0;">abs</div>
+    </span>
+</div>
+<script>
+    document.body.offsetHeight;
+</script>


### PR DESCRIPTION
compute_inline_containing_block_rect() positioned atomic inline fragments by subtracting two LayoutState::cumulative_offset() calls, each of which recursively reads used values up the containing block chain to the root. Since measurement layout states stopped copying ancestor state, that up-walk reads past the measurement root when a box establishing an independent formatting context with auto height and a min-height contains an absolutely positioned element whose containing block is an inline: the measuring BFC lays out the abspos child inside the throwaway state, and resolving the inline containing block rect crashed on the "no used values" VERIFY in LayoutState.

Only the difference between the two cumulative offsets ever mattered, and it equals the running offset the fragment walk already threads down: an atomic inline's fragment lives in the line boxes of its containing block, which is exactly the node being walked when the fragment is encountered. Handle atomic inline fragments directly in the line box fragment loop with that offset, instead of reaching them through the child walk and re-deriving their coordinate space from the containing_line_box_fragment back-pointer. This removes the last up-the-tree state reads from this function and makes it purely top-down.

Adds a crash test that lays out an abspos element against an inline containing block inside an automatic content height measurement.