### PR TITLE
Compositor: Make the frame pipeline damage-aware

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -885,6 +885,7 @@ set(SOURCES
     Painting/CheckBoxPaintable.cpp
     Painting/DisplayList.cpp
     Painting/DisplayListCommand.cpp
+    Painting/DisplayListDamage.cpp
     Painting/DisplayListPlayerSkia.cpp
     Painting/DisplayListRecorder.cpp
     Painting/DisplayListRecordingContext.cpp

--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -71,11 +71,6 @@ AsyncScrollEnqueueResult CompositorContextHandle::async_scroll_by(UniqueNodeID e
     return m_host.async_scroll_by(m_context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
 }
 
-bool CompositorContextHandle::should_defer_main_thread_present_for_async_scroll() const
-{
-    return m_host.should_defer_main_thread_present_for_async_scroll(m_context_id);
-}
-
 PendingAsyncScrollUpdates CompositorContextHandle::take_pending_async_scroll_updates()
 {
     return m_host.take_pending_async_scroll_updates(m_context_id);

--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -81,10 +81,10 @@ void CompositorContextHandle::viewport_size_updated(Gfx::IntSize viewport_size, 
     m_host.viewport_size_updated(m_context_id, viewport_size, window_resize_in_progress);
 }
 
-void CompositorContextHandle::present_frame(Gfx::IntRect viewport_rect)
+void CompositorContextHandle::present_frame(Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
 {
     m_host.flush_canvas_2d_stream();
-    m_host.present_frame(m_context_id, viewport_rect);
+    m_host.present_frame(m_context_id, viewport_rect, damage_rect);
 }
 
 void CompositorContextHandle::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -45,7 +45,7 @@ public:
         Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
     PendingAsyncScrollUpdates take_pending_async_scroll_updates();
     void viewport_size_updated(Gfx::IntSize, WindowResizingInProgress);
-    void present_frame(Gfx::IntRect);
+    void present_frame(Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
     void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
 private:
@@ -88,7 +88,7 @@ public:
         = 0;
     virtual PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId) = 0;
     virtual void viewport_size_updated(CompositorContextId, Gfx::IntSize, WindowResizingInProgress) = 0;
-    virtual void present_frame(CompositorContextId, Gfx::IntRect) = 0;
+    virtual void present_frame(CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) = 0;
     virtual void request_screenshot(CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback) = 0;
 
 protected:

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -43,7 +43,6 @@ public:
     void invalidate_wheel_event_listener_state(u64 generation);
     AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
         Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
-    bool should_defer_main_thread_present_for_async_scroll() const;
     PendingAsyncScrollUpdates take_pending_async_scroll_updates();
     void viewport_size_updated(Gfx::IntSize, WindowResizingInProgress);
     void present_frame(Gfx::IntRect);
@@ -87,7 +86,6 @@ public:
     virtual AsyncScrollEnqueueResult async_scroll_by(CompositorContextId, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
         Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking)
         = 0;
-    virtual bool should_defer_main_thread_present_for_async_scroll(CompositorContextId) const = 0;
     virtual PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId) = 0;
     virtual void viewport_size_updated(CompositorContextId, Gfx::IntSize, WindowResizingInProgress) = 0;
     virtual void present_frame(CompositorContextId, Gfx::IntRect) = 0;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -66,6 +66,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/DisplayListDamage.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
@@ -4257,6 +4258,9 @@ void LocalNavigable::repaint_after_compositor_process_reconnect()
         m_needs_repaint = true;
         m_needs_to_record_display_list = true;
         m_compositor_display_list_paint_config.clear();
+        m_compositor_display_list.clear();
+        m_compositor_visual_context_tree.clear();
+        m_compositor_scroll_state_snapshot.clear();
         m_compositor_display_list_resources = {};
     }
 
@@ -4288,7 +4292,7 @@ void LocalNavigable::set_should_show_caret_hit_test_debug_overlay(bool value)
         child_navigable->set_should_show_caret_hit_test_debug_overlay(value);
 }
 
-bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_config)
+bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_config, Gfx::IntRect* damage_rect)
 {
     if (!has_compositor_context())
         return false;
@@ -4328,7 +4332,32 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
     document_paintable->refresh_scroll_state();
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
+    auto viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
+    Gfx::IntRect surface_rect { {}, viewport_rect.size() };
+    if (damage_rect)
+        *damage_rect = surface_rect;
     if (should_record_display_list) {
+        if (damage_rect
+            && m_compositor_display_list
+            && m_compositor_visual_context_tree.has_value()
+            && m_compositor_scroll_state_snapshot.has_value()
+            && m_compositor_scroll_state_snapshot->device_offsets() == scroll_state_snapshot.device_offsets()
+            && m_compositor_display_list_paint_config == paint_config) {
+            auto computed_damage = Painting::compute_display_list_damage(
+                m_compositor_display_list->command_bytes(),
+                *m_compositor_visual_context_tree,
+                *m_compositor_scroll_state_snapshot,
+                display_list->command_bytes(),
+                *visual_context_tree,
+                scroll_state_snapshot,
+                surface_rect);
+            if (computed_damage.has_value())
+                *damage_rect = *computed_damage;
+        }
+
+        m_compositor_display_list = display_list;
+        m_compositor_visual_context_tree = *visual_context_tree;
+        m_compositor_scroll_state_snapshot = scroll_state_snapshot;
         m_compositor_display_list_visual_context_tree_version = display_list->compatible_visual_context_tree_version();
         compositor_context().update_display_list(*display_list, visual_context_tree.release_value(), move(resource_transaction), move(scroll_state_snapshot));
         document_paintable->did_update_visual_context_tree_in_compositor();
@@ -4369,10 +4398,11 @@ void LocalNavigable::paint_next_frame()
 
     m_needs_repaint = false;
 
-    if (!record_display_list_and_scroll_state(paint_config))
+    Gfx::IntRect damage_rect;
+    if (!record_display_list_and_scroll_state(paint_config, &damage_rect))
         return;
     viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
-    compositor_context().present_frame(viewport_rect);
+    compositor_context().present_frame(viewport_rect, damage_rect);
 }
 
 void LocalNavigable::render_screenshot(Gfx::PaintingSurface& painting_surface, PaintConfig paint_config, Function<void()>&& callback)

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4367,24 +4367,11 @@ void LocalNavigable::paint_next_frame()
             return;
     }
 
-    auto should_defer_main_thread_present_for_async_scroll = [&] {
-        return page().async_scrolling_enabled()
-            && compositor_context().should_defer_main_thread_present_for_async_scroll();
-    };
-    if (should_defer_main_thread_present_for_async_scroll())
-        return;
-
     m_needs_repaint = false;
 
     if (!record_display_list_and_scroll_state(paint_config))
         return;
-
     viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
-    if (should_defer_main_thread_present_for_async_scroll()) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred present while async scroll is pending");
-        return;
-    }
-
     compositor_context().present_frame(viewport_rect);
 }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -37,7 +37,9 @@
 #include <LibWeb/HTML/WindowType.h>
 #include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Page/EventHandler.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ScrollState.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/XHR/FormDataEntry.h>
 
@@ -256,7 +258,7 @@ public:
     bool has_pending_navigations() const { return !m_pending_navigations.is_empty(); }
     void clear_pending_navigations() { m_pending_navigations.clear(); }
 
-    bool record_display_list_and_scroll_state(PaintConfig);
+    bool record_display_list_and_scroll_state(PaintConfig, Gfx::IntRect* damage_rect = nullptr);
     void paint_next_frame();
     void render_screenshot(Gfx::PaintingSurface&, PaintConfig, Function<void()>&& callback);
     Painting::DisplayListResourceStorage& display_list_resource_storage() { return m_display_list_resource_storage; }
@@ -387,6 +389,9 @@ private:
     bool m_should_show_caret_hit_test_debug_overlay { false };
     Optional<PaintConfig> m_compositor_display_list_paint_config;
     u64 m_compositor_display_list_visual_context_tree_version { 0 };
+    RefPtr<Painting::DisplayList> m_compositor_display_list;
+    Optional<Painting::AccumulatedVisualContextTree> m_compositor_visual_context_tree;
+    Optional<Painting::ScrollStateSnapshot> m_compositor_scroll_state_snapshot;
     Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Painting::DisplayListResourceSet m_compositor_display_list_resources;
     OwnPtr<Compositor::CompositorContextHandle> m_compositor_context;

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Rect.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListDamage.h>
+#include <LibWeb/Painting/ScrollState.h>
+
+namespace Web::Painting {
+
+struct DisplayListCommandReference {
+    DisplayListCommandHeader header;
+    ReadonlyBytes payload;
+};
+
+static ReadonlyBytes display_list_data_span_bytes(ReadonlyBytes payload, DisplayListDataSpan span)
+{
+    VERIFY(span.offset <= payload.size());
+    VERIFY(span.size <= payload.size() - span.offset);
+    return payload.slice(span.offset, span.size);
+}
+
+static Vector<DisplayListCommandReference> collect_display_list_command_references(ReadonlyBytes command_bytes)
+{
+    Vector<DisplayListCommandReference> commands;
+    DisplayList::for_each_command_header(command_bytes, [&](auto const& header, auto payload) {
+        commands.append({ header, payload });
+    });
+    return commands;
+}
+
+static bool display_list_commands_are_equal(DisplayListCommandReference const& a, DisplayListCommandReference const& b)
+{
+    if (a.header.type != b.header.type
+        || a.header.has_bounding_rect != b.header.has_bounding_rect
+        || a.header.is_clip != b.header.is_clip
+        || a.header.bounding_rect != b.header.bounding_rect)
+        return false;
+
+    if (a.header.type == DisplayListCommandType::DrawScaledDecodedImageFrame) {
+        auto first = read_display_list_object<DrawScaledDecodedImageFrame>(a.payload);
+        auto second = read_display_list_object<DrawScaledDecodedImageFrame>(b.payload);
+        return first.dst_rect == second.dst_rect
+            && first.src_rect == second.src_rect
+            && first.frame_id == second.frame_id
+            && first.scaling_mode == second.scaling_mode
+            && first.compositing_and_blending_operator == second.compositing_and_blending_operator
+            && first.isolated_backdrop_color == second.isolated_backdrop_color;
+    }
+
+    if (a.header.type == DisplayListCommandType::DrawGlyphRun) {
+        auto first = read_display_list_object<DrawGlyphRun>(a.payload);
+        auto second = read_display_list_object<DrawGlyphRun>(b.payload);
+        return first.font_id == second.font_id
+            && first.glyphs.size == second.glyphs.size
+            && display_list_data_span_bytes(a.payload, first.glyphs) == display_list_data_span_bytes(b.payload, second.glyphs)
+            && first.rect == second.rect
+            && first.glyph_bounding_rect == second.glyph_bounding_rect
+            && first.translation == second.translation
+            && first.scale == second.scale
+            && first.color == second.color
+            && first.orientation == second.orientation;
+    }
+
+    if (a.header.type == DisplayListCommandType::PaintTextShadow) {
+        auto first = read_display_list_object<PaintTextShadow>(a.payload);
+        auto second = read_display_list_object<PaintTextShadow>(b.payload);
+        return first.font_id == second.font_id
+            && first.glyphs.size == second.glyphs.size
+            && display_list_data_span_bytes(a.payload, first.glyphs) == display_list_data_span_bytes(b.payload, second.glyphs)
+            && first.shadow_bounding_rect == second.shadow_bounding_rect
+            && first.text_rect == second.text_rect
+            && first.draw_location == second.draw_location
+            && first.scale == second.scale
+            && first.blur_radius == second.blur_radius
+            && first.color == second.color;
+    }
+
+    return a.header.payload_size == b.header.payload_size && a.payload == b.payload;
+}
+
+static bool corner_radii_are_equal(Gfx::CornerRadii const& a, Gfx::CornerRadii const& b)
+{
+    auto corner_radius_is_equal = [](auto const& first, auto const& second) {
+        return first.horizontal_radius == second.horizontal_radius
+            && first.vertical_radius == second.vertical_radius;
+    };
+    return corner_radius_is_equal(a.top_left, b.top_left)
+        && corner_radius_is_equal(a.top_right, b.top_right)
+        && corner_radius_is_equal(a.bottom_right, b.bottom_right)
+        && corner_radius_is_equal(a.bottom_left, b.bottom_left);
+}
+
+static bool matrices_are_equal(Gfx::FloatMatrix4x4 const& a, Gfx::FloatMatrix4x4 const& b)
+{
+    for (size_t row = 0; row < 4; ++row) {
+        for (size_t column = 0; column < 4; ++column) {
+            if (a[row, column] != b[row, column])
+                return false;
+        }
+    }
+    return true;
+}
+
+static bool visual_context_data_is_equal(VisualContextData const& a, VisualContextData const& b)
+{
+    return a.visit(
+        [&](ScrollData const& data) {
+            auto const* other = b.get_pointer<ScrollData>();
+            return other && data.scroll_frame_index == other->scroll_frame_index && data.is_sticky == other->is_sticky;
+        },
+        [&](ClipData const& data) {
+            auto const* other = b.get_pointer<ClipData>();
+            return other && data.rect == other->rect && corner_radii_are_equal(data.corner_radii, other->corner_radii);
+        },
+        [&](TransformData const& data) {
+            auto const* other = b.get_pointer<TransformData>();
+            return other && matrices_are_equal(data.matrix, other->matrix) && data.origin == other->origin;
+        },
+        [&](PerspectiveData const& data) {
+            auto const* other = b.get_pointer<PerspectiveData>();
+            return other && matrices_are_equal(data.matrix, other->matrix);
+        },
+        [&](ClipPathData const& data) {
+            auto const* other = b.get_pointer<ClipPathData>();
+            return other
+                && data.bounding_rect == other->bounding_rect
+                && data.fill_rule == other->fill_rule
+                && data.path.serialize_to_bytes() == other->path.serialize_to_bytes();
+        },
+        [&](EffectsData const& data) {
+            auto const* other = b.get_pointer<EffectsData>();
+            if (!other || data.gfx_filter.has_value() != other->gfx_filter.has_value())
+                return false;
+            if (data.gfx_filter.has_value()) {
+                Function<u64(Gfx::DecodedImageFrame const&)> encode_image = [](Gfx::DecodedImageFrame const& image) -> u64 {
+                    return reinterpret_cast<FlatPtr>(&image);
+                };
+                if (Gfx::serialize_filter(*data.gfx_filter, encode_image) != Gfx::serialize_filter(*other->gfx_filter, encode_image))
+                    return false;
+            }
+            return other
+                && data.opacity == other->opacity
+                && data.blend_mode == other->blend_mode;
+        },
+        [&](ScrollCompensation const& data) {
+            auto const* other = b.get_pointer<ScrollCompensation>();
+            return other && data.scroll_frame_index == other->scroll_frame_index;
+        },
+        [&](AnchorScrollShift const& data) {
+            auto const* other = b.get_pointer<AnchorScrollShift>();
+            return other
+                && data.scroll_frame_index == other->scroll_frame_index
+                && data.negate == other->negate
+                && data.compensate_x == other->compensate_x
+                && data.compensate_y == other->compensate_y;
+        });
+}
+
+static bool visual_context_chains_are_compatible(VisualContextIndex old_index, AccumulatedVisualContextTree const& old_tree, VisualContextIndex new_index, AccumulatedVisualContextTree const& new_tree)
+{
+    for (;;) {
+        auto const& old_node = old_tree.node_at(old_index);
+        auto const& new_node = new_tree.node_at(new_index);
+        if (old_node.depth != new_node.depth)
+            return false;
+        if (!old_node.data.visit([&](auto const& data) {
+                using DataType = RemoveCVReference<decltype(data)>;
+                return new_node.data.has<DataType>();
+            }))
+            return false;
+        if (old_index == VISUAL_VIEWPORT_NODE_INDEX)
+            return new_index == VISUAL_VIEWPORT_NODE_INDEX;
+        if (new_index == VISUAL_VIEWPORT_NODE_INDEX)
+            return false;
+        old_index = old_node.parent_index;
+        new_index = new_node.parent_index;
+    }
+}
+
+static bool visual_context_chains_are_equal(VisualContextIndex old_index, AccumulatedVisualContextTree const& old_tree, VisualContextIndex new_index, AccumulatedVisualContextTree const& new_tree)
+{
+    for (;;) {
+        auto const& old_node = old_tree.node_at(old_index);
+        auto const& new_node = new_tree.node_at(new_index);
+        if (old_node.has_empty_effective_clip != new_node.has_empty_effective_clip
+            || !visual_context_data_is_equal(old_node.data, new_node.data))
+            return false;
+        if (old_index == VISUAL_VIEWPORT_NODE_INDEX)
+            return true;
+        old_index = old_node.parent_index;
+        new_index = new_node.parent_index;
+    }
+}
+
+Optional<Gfx::IntRect> compute_display_list_damage(
+    ReadonlyBytes old_display_list_commands,
+    AccumulatedVisualContextTree const& old_visual_context_tree,
+    ScrollStateSnapshot const& old_scroll_state,
+    ReadonlyBytes new_display_list_commands,
+    AccumulatedVisualContextTree const& new_visual_context_tree,
+    ScrollStateSnapshot const& new_scroll_state,
+    Gfx::IntRect viewport_rect)
+{
+    auto old_commands = collect_display_list_command_references(old_display_list_commands);
+    auto new_commands = collect_display_list_command_references(new_display_list_commands);
+
+    auto commands_are_equal = [&](DisplayListCommandReference const& old_command, DisplayListCommandReference const& new_command) {
+        return display_list_commands_are_equal(old_command, new_command)
+            && visual_context_chains_are_compatible(old_command.header.context_index, old_visual_context_tree, new_command.header.context_index, new_visual_context_tree);
+    };
+    size_t common_prefix_length = 0;
+    auto common_length = min(old_commands.size(), new_commands.size());
+    while (common_prefix_length < common_length && commands_are_equal(old_commands[common_prefix_length], new_commands[common_prefix_length]))
+        ++common_prefix_length;
+
+    size_t common_suffix_length = 0;
+    while (common_suffix_length < common_length - common_prefix_length
+        && commands_are_equal(old_commands[old_commands.size() - common_suffix_length - 1], new_commands[new_commands.size() - common_suffix_length - 1]))
+        ++common_suffix_length;
+    Optional<Gfx::IntRect> damage_rect;
+    bool changed_unbounded_command = false;
+    auto add_command_damage = [&](DisplayListCommandReference const& command, auto const& visual_context_tree, auto const& scroll_state) {
+        if (!command.header.has_bounding_rect) {
+            if (display_list_command_is_compositor_metadata(command.header.type)
+                || command.header.type == DisplayListCommandType::Save
+                || command.header.type == DisplayListCommandType::SaveLayer
+                || command.header.type == DisplayListCommandType::Restore)
+                return;
+            changed_unbounded_command = true;
+            return;
+        }
+        auto transformed_rect = visual_context_tree.transform_rect_to_viewport(command.header.context_index, command.header.bounding_rect.to_type<float>(), scroll_state);
+        auto command_damage = Gfx::enclosing_int_rect(transformed_rect);
+        if (damage_rect.has_value())
+            damage_rect->unite(command_damage);
+        else
+            damage_rect = command_damage;
+    };
+
+    auto add_visual_context_damage = [&](DisplayListCommandReference const& old_command, DisplayListCommandReference const& new_command) {
+        if (visual_context_chains_are_equal(old_command.header.context_index, old_visual_context_tree, new_command.header.context_index, new_visual_context_tree))
+            return;
+        if (!old_command.header.has_bounding_rect || !new_command.header.has_bounding_rect) {
+            if (old_command.header.type == DisplayListCommandType::CompositorViewportScrollbar || old_command.header.type == DisplayListCommandType::PaintScrollBar)
+                changed_unbounded_command = true;
+            return;
+        }
+        add_command_damage(old_command, old_visual_context_tree, old_scroll_state);
+        add_command_damage(new_command, new_visual_context_tree, new_scroll_state);
+    };
+
+    for (size_t i = 0; i < common_prefix_length; ++i)
+        add_visual_context_damage(old_commands[i], new_commands[i]);
+
+    auto old_index = common_prefix_length;
+    auto new_index = common_prefix_length;
+    auto old_end = old_commands.size() - common_suffix_length;
+    auto new_end = new_commands.size() - common_suffix_length;
+    // Realign short inserted or removed sequences without making damage computation quadratic in the display list size.
+    static constexpr size_t maximum_realignment_distance = 8;
+    auto is_realignment_anchor = [&](size_t candidate_old_index, size_t candidate_new_index) {
+        if (!commands_are_equal(old_commands[candidate_old_index], new_commands[candidate_new_index]))
+            return false;
+        if (candidate_old_index + 1 == old_end || candidate_new_index + 1 == new_end)
+            return true;
+        return commands_are_equal(old_commands[candidate_old_index + 1], new_commands[candidate_new_index + 1]);
+    };
+    while (old_index < old_end && new_index < new_end) {
+        if (commands_are_equal(old_commands[old_index], new_commands[new_index])) {
+            add_visual_context_damage(old_commands[old_index], new_commands[new_index]);
+            ++old_index;
+            ++new_index;
+            continue;
+        }
+
+        Optional<size_t> skipped_old_commands;
+        Optional<size_t> skipped_new_commands;
+        for (size_t distance = 1; distance <= maximum_realignment_distance; ++distance) {
+            if (!skipped_old_commands.has_value() && old_index + distance < old_end && is_realignment_anchor(old_index + distance, new_index))
+                skipped_old_commands = distance;
+            if (!skipped_new_commands.has_value() && new_index + distance < new_end && is_realignment_anchor(old_index, new_index + distance))
+                skipped_new_commands = distance;
+        }
+
+        if (skipped_old_commands.has_value() && (!skipped_new_commands.has_value() || *skipped_old_commands <= *skipped_new_commands)) {
+            for (size_t i = 0; i < *skipped_old_commands; ++i)
+                add_command_damage(old_commands[old_index++], old_visual_context_tree, old_scroll_state);
+            continue;
+        }
+        if (skipped_new_commands.has_value()) {
+            for (size_t i = 0; i < *skipped_new_commands; ++i)
+                add_command_damage(new_commands[new_index++], new_visual_context_tree, new_scroll_state);
+            continue;
+        }
+
+        add_command_damage(old_commands[old_index++], old_visual_context_tree, old_scroll_state);
+        add_command_damage(new_commands[new_index++], new_visual_context_tree, new_scroll_state);
+    }
+    while (old_index < old_end)
+        add_command_damage(old_commands[old_index++], old_visual_context_tree, old_scroll_state);
+    while (new_index < new_end)
+        add_command_damage(new_commands[new_index++], new_visual_context_tree, new_scroll_state);
+
+    for (size_t i = 0; i < common_suffix_length; ++i)
+        add_visual_context_damage(old_commands[old_commands.size() - common_suffix_length + i], new_commands[new_commands.size() - common_suffix_length + i]);
+
+    if (changed_unbounded_command)
+        return {};
+    if (!damage_rect.has_value())
+        return Gfx::IntRect {};
+
+    damage_rect->inflate(1, 1, 1, 1);
+    damage_rect->intersect(viewport_rect);
+    return damage_rect;
+}
+
+}

--- a/Libraries/LibWeb/Painting/DisplayListDamage.h
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/Span.h>
+#include <LibGfx/Rect.h>
+#include <LibWeb/Export.h>
+
+namespace Web::Painting {
+
+class AccumulatedVisualContextTree;
+class ScrollStateSnapshot;
+
+WEB_API Optional<Gfx::IntRect> compute_display_list_damage(
+    ReadonlyBytes old_display_list_commands,
+    AccumulatedVisualContextTree const& old_visual_context_tree,
+    ScrollStateSnapshot const& old_scroll_state,
+    ReadonlyBytes new_display_list_commands,
+    AccumulatedVisualContextTree const& new_visual_context_tree,
+    ScrollStateSnapshot const& new_scroll_state,
+    Gfx::IntRect viewport_rect);
+
+}

--- a/Libraries/LibWebView/CompositorClient.cpp
+++ b/Libraries/LibWebView/CompositorClient.cpp
@@ -25,7 +25,7 @@ void CompositorClient::die()
     }
 }
 
-void CompositorClient::did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store)
+void CompositorClient::did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores)
 {
     auto web_content_client = WebContentClient::client_for_compositor_context_id(context_id);
     if (!web_content_client.has_value())
@@ -34,7 +34,7 @@ void CompositorClient::did_allocate_backing_stores(Web::Compositor::CompositorCo
     auto page_id = web_content_client->page_id_for_compositor_context_id(context_id);
     VERIFY(page_id.has_value());
 
-    web_content_client->did_present_backing_stores(*page_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
+    web_content_client->did_present_backing_stores(*page_id, move(bitmap_ids), move(backing_stores));
 }
 
 void CompositorClient::did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id)

--- a/Libraries/LibWebView/CompositorClient.cpp
+++ b/Libraries/LibWebView/CompositorClient.cpp
@@ -37,13 +37,13 @@ void CompositorClient::did_allocate_backing_stores(Web::Compositor::CompositorCo
     web_content_client->did_present_backing_stores(*page_id, move(bitmap_ids), move(backing_stores));
 }
 
-void CompositorClient::did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id)
+void CompositorClient::did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id)
 {
     auto web_content_client = WebContentClient::client_for_compositor_context_id(context_id);
     if (web_content_client.has_value()) {
         auto page_id = web_content_client->page_id_for_compositor_context_id(context_id);
         VERIFY(page_id.has_value());
-        web_content_client->did_present_bitmap(*page_id, content_rect, bitmap_id);
+        web_content_client->did_present_bitmap(*page_id, content_rect, damage_rect, bitmap_id);
         return;
     }
 

--- a/Libraries/LibWebView/CompositorClient.h
+++ b/Libraries/LibWebView/CompositorClient.h
@@ -32,7 +32,7 @@ public:
 private:
     virtual void die() override;
 
-    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store) override;
+    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores) override;
     virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) override;
 };
 

--- a/Libraries/LibWebView/CompositorClient.h
+++ b/Libraries/LibWebView/CompositorClient.h
@@ -33,7 +33,7 @@ private:
     virtual void die() override;
 
     virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores) override;
-    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) override;
+    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) override;
 };
 
 }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -207,21 +207,30 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
 void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size)
 {
     bool did_swap_bitmap = false;
-    if (m_client_state.back_bitmap.id == bitmap_id) {
+    auto previous_front_bitmap_id = m_client_state.front_bitmap.id;
+    auto bitmap_index = m_client_state.other_bitmaps.find_first_index_if([bitmap_id](auto const& bitmap) { return bitmap_id == bitmap.id; });
+    if (bitmap_index.has_value()) {
         m_client_state.has_usable_bitmap = true;
-        m_client_state.back_bitmap.last_painted_size = size.to_type<Web::DevicePixels>();
-        swap(m_client_state.back_bitmap, m_client_state.front_bitmap);
+        m_client_state.other_bitmaps[*bitmap_index].last_painted_size = size.to_type<Web::DevicePixels>();
+        swap(m_client_state.other_bitmaps[*bitmap_index], m_client_state.front_bitmap);
         m_backup_shared_image_buffer = nullptr;
         did_swap_bitmap = true;
     }
 
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI received presented bitmap {} for page {} size={}x{} did_swap={} front={} back={}",
-        bitmap_id, page_id(), size.width(), size.height(), did_swap_bitmap, m_client_state.front_bitmap.id, m_client_state.back_bitmap.id);
+    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI received presented bitmap {} for page {} size={}x{} did_swap={} front={}",
+        bitmap_id, page_id(), size.width(), size.height(), did_swap_bitmap, m_client_state.front_bitmap.id);
 
-    client().notify_presented_bitmap_ready_to_paint(page_id(), bitmap_id);
+    auto bitmap_to_release = did_swap_bitmap ? previous_front_bitmap_id : bitmap_id;
+    if (!defer_backing_store_release(bitmap_to_release))
+        release_backing_store(bitmap_to_release);
 
     if (did_swap_bitmap && on_ready_to_paint)
         on_ready_to_paint();
+}
+
+void ViewImplementation::release_backing_store(i32 bitmap_id)
+{
+    client().notify_presented_bitmap_ready_to_paint(page_id(), bitmap_id);
 }
 
 void ViewImplementation::set_window_position(Gfx::IntPoint position)
@@ -1325,20 +1334,29 @@ Gfx::Color ViewImplementation::preferred_canvas_background_color() const
     return m_system_canvas_background_color;
 }
 
-void ViewImplementation::did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store)
+void ViewImplementation::did_allocate_backing_stores(Badge<WebContentClient>, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores)
 {
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI installing backing stores for page {} front={} back={} had_usable_bitmap={}",
-        page_id(), front_bitmap_id, back_bitmap_id, m_client_state.has_usable_bitmap);
+    VERIFY(bitmap_ids.size() == backing_stores.size());
+    VERIFY(!bitmap_ids.is_empty());
+    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI installing {} backing stores for page {} had_usable_bitmap={}",
+        backing_stores.size(), page_id(), m_client_state.has_usable_bitmap);
     if (m_client_state.has_usable_bitmap) {
         // NOTE: We keep the outgoing front bitmap as a backup so we have something to paint until we get a new one.
         m_backup_shared_image_buffer = move(m_client_state.front_bitmap.shared_image_buffer);
         m_backup_bitmap_size = m_client_state.front_bitmap.last_painted_size;
     }
     m_client_state.has_usable_bitmap = false;
-    m_client_state.front_bitmap.id = front_bitmap_id;
-    m_client_state.back_bitmap.id = back_bitmap_id;
-    m_client_state.front_bitmap.shared_image_buffer = make<Gfx::SharedImageBuffer>(Gfx::SharedImageBuffer::import_from_shared_image(move(front_backing_store)));
-    m_client_state.back_bitmap.shared_image_buffer = make<Gfx::SharedImageBuffer>(Gfx::SharedImageBuffer::import_from_shared_image(move(back_backing_store)));
+    m_client_state.front_bitmap.id = bitmap_ids[0];
+    m_client_state.front_bitmap.shared_image_buffer = make<Gfx::SharedImageBuffer>(Gfx::SharedImageBuffer::import_from_shared_image(move(backing_stores[0])));
+    m_client_state.other_bitmaps.clear();
+    m_client_state.other_bitmaps.ensure_capacity(backing_stores.size() - 1);
+    for (size_t i = 1; i < backing_stores.size(); ++i) {
+        m_client_state.other_bitmaps.append({
+            .id = bitmap_ids[i],
+            .last_painted_size = {},
+            .shared_image_buffer = make<Gfx::SharedImageBuffer>(Gfx::SharedImageBuffer::import_from_shared_image(move(backing_stores[i]))),
+        });
+    }
 }
 
 void ViewImplementation::update_zoom()

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -204,7 +204,7 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
     dump_session_history("after-process-swap-load"sv);
 }
 
-void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size)
+void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size, Gfx::IntRect damage_rect)
 {
     bool did_swap_bitmap = false;
     auto previous_front_bitmap_id = m_client_state.front_bitmap.id;
@@ -224,6 +224,8 @@ void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id
     if (!defer_backing_store_release(bitmap_to_release))
         release_backing_store(bitmap_to_release);
 
+    if (did_swap_bitmap)
+        did_accept_presented_backing_store(bitmap_id, damage_rect);
     if (did_swap_bitmap && on_ready_to_paint)
         on_ready_to_paint();
 }

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -124,7 +124,6 @@ public:
     double device_pixel_ratio() const { return m_device_pixel_ratio; }
     Optional<u64> display_id() const { return m_display_id; }
     double maximum_frames_per_second() const { return m_maximum_frames_per_second; }
-
     void enqueue_input_event(Web::InputEvent);
     void did_finish_handling_input_event(Badge<WebContentClient>, Web::EventResult event_result);
 
@@ -276,7 +275,7 @@ public:
     void did_change_background_color(Badge<WebContentClient>, Gfx::Color);
     Gfx::Color page_background_color() const { return m_page_background_color; }
 
-    void did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store);
+    void did_allocate_backing_stores(Badge<WebContentClient>, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores);
 
     enum class ScreenshotType {
         Visible,
@@ -404,6 +403,9 @@ public:
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const = 0;
 
 protected:
+    virtual bool defer_backing_store_release(i32) { return false; }
+    void release_backing_store(i32 bitmap_id);
+
     static constexpr auto ZOOM_MIN_LEVEL = 0.3;
     static constexpr auto ZOOM_MAX_LEVEL = 5.0;
     static constexpr auto ZOOM_STEP = 0.1;
@@ -488,7 +490,7 @@ protected:
         RefPtr<WebContentClient> client;
         String client_handle;
         SharedBitmap front_bitmap;
-        SharedBitmap back_bitmap;
+        Vector<SharedBitmap> other_bitmaps;
         u64 page_index { 0 };
         bool has_usable_bitmap { false };
     } m_client_state;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -89,7 +89,7 @@ public:
 
     void create_new_process_for_cross_site_navigation(URL::URL const&, Variant<Empty, String, Web::HTML::POSTResource>, Web::Bindings::NavigationHistoryBehavior);
 
-    void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size);
+    void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size, Gfx::IntRect damage_rect);
 
     void set_window_position(Gfx::IntPoint);
     void set_window_size(Gfx::IntSize);
@@ -404,6 +404,7 @@ public:
 
 protected:
     virtual bool defer_backing_store_release(i32) { return false; }
+    virtual void did_accept_presented_backing_store(i32, Gfx::IntRect) { }
     void release_backing_store(i32 bitmap_id);
 
     static constexpr auto ZOOM_MIN_LEVEL = 0.3;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -458,12 +458,12 @@ void WebContentClient::notify_presented_bitmap_ready_to_paint(u64 page_id, i32 b
     Application::the().notify_compositor_presented_bitmap_ready_to_paint(context_id, bitmap_id);
 }
 
-void WebContentClient::did_present_bitmap(u64 page_id, Gfx::IntRect rect, i32 bitmap_id)
+void WebContentClient::did_present_bitmap(u64 page_id, Gfx::IntRect rect, Gfx::IntRect damage_rect, i32 bitmap_id)
 {
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC did_paint for page {} bitmap {} rect={}x{} at {},{}",
         page_id, bitmap_id, rect.width(), rect.height(), rect.x(), rect.y());
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        view->server_did_paint({}, bitmap_id, rect.size());
+        view->server_did_paint({}, bitmap_id, rect.size(), damage_rect);
     } else {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI dropping did_paint for page {} bitmap {}: no view",
             page_id, bitmap_id);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1831,15 +1831,13 @@ void WebContentClient::did_reset_session_history_for_testing(u64 page_id)
         view->did_reset_session_history_for_testing({});
 }
 
-void WebContentClient::did_present_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store)
+void WebContentClient::did_present_backing_stores(u64 page_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores)
 {
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI received backing stores for page {} front={} back={}",
-        page_id, front_bitmap_id, back_bitmap_id);
+    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI received {} backing stores for page {}", backing_stores.size(), page_id);
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        view->did_allocate_backing_stores({}, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
+        view->did_allocate_backing_stores({}, move(bitmap_ids), move(backing_stores));
     } else {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI dropping backing stores for page {} front={} back={}: no view",
-            page_id, front_bitmap_id, back_bitmap_id);
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI dropping {} backing stores for page {}: no view", backing_stores.size(), page_id);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -103,7 +103,7 @@ public:
     void dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const&);
     void notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
     void did_present_backing_stores(u64 page_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores);
-    void did_present_bitmap(u64 page_id, Gfx::IntRect, i32 bitmap_id);
+    void did_present_bitmap(u64 page_id, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id);
 
     pid_t pid() const { return m_process_handle.pid; }
     void set_pid(pid_t pid) { m_process_handle.pid = pid; }

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -102,7 +102,7 @@ public:
     bool handle_pinch_event_in_compositor(u64 page_id, Web::PinchEvent const&);
     void dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const&);
     void notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
-    void did_present_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store);
+    void did_present_backing_stores(u64 page_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores);
     void did_present_bitmap(u64 page_id, Gfx::IntRect, i32 bitmap_id);
 
     pid_t pid() const { return m_process_handle.pid; }

--- a/Services/Compositor/BackingStoreManager.cpp
+++ b/Services/Compositor/BackingStoreManager.cpp
@@ -129,6 +129,7 @@ Optional<BackingStoreManager::Publication> BackingStoreManager::allocate_backing
                 .surface = move(store.surface),
                 .bitmap_id = allocation.bitmap_ids[i],
                 .state = initial_buffer_state(i),
+                .accumulated_damage = { {}, allocation.size },
             });
             shared_images.append(move(store.shared_image));
         }
@@ -155,6 +156,7 @@ Optional<BackingStoreManager::Publication> BackingStoreManager::allocate_backing
             .surface = create_shareable_bitmap_backing_store(allocation.size, buffer, skia_backend_context),
             .bitmap_id = allocation.bitmap_ids[i],
             .state = initial_buffer_state(i),
+            .accumulated_damage = { {}, allocation.size },
         });
     }
 
@@ -177,9 +179,12 @@ bool BackingStoreManager::has_available_buffer() const
     return any_of(m_backing_stores, [](auto const& store) { return store.state == BufferState::Available; });
 }
 
-Optional<BackingStoreManager::RenderTarget> BackingStoreManager::acquire_render_target()
+Optional<BackingStoreManager::RenderTarget> BackingStoreManager::acquire_render_target(Gfx::IntRect frame_damage)
 {
     VERIFY(!m_rendering_store_index.has_value());
+    for (auto& store : m_backing_stores)
+        store.accumulated_damage.unite(frame_damage);
+
     for (size_t i = 0; i < m_backing_stores.size(); ++i) {
         auto& store = m_backing_stores[i];
         if (store.state != BufferState::Available)
@@ -187,7 +192,9 @@ Optional<BackingStoreManager::RenderTarget> BackingStoreManager::acquire_render_
 
         store.state = BufferState::Rendering;
         m_rendering_store_index = i;
-        return RenderTarget { *store.surface, store.bitmap_id };
+        auto damage_rect = store.accumulated_damage;
+        store.accumulated_damage = {};
+        return RenderTarget { *store.surface, store.bitmap_id, damage_rect };
     }
     return {};
 }

--- a/Services/Compositor/BackingStoreManager.cpp
+++ b/Services/Compositor/BackingStoreManager.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <Compositor/BackingStoreManager.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/SharedImageBuffer.h>
@@ -17,11 +18,6 @@
 
 namespace Compositor {
 
-struct BackingStorePair {
-    RefPtr<Gfx::PaintingSurface> front;
-    RefPtr<Gfx::PaintingSurface> back;
-};
-
 #if defined(USE_DIRECTX) || defined(USE_VULKAN)
 static NonnullRefPtr<Gfx::PaintingSurface> create_gpu_painting_surface_with_bitmap_flush(Gfx::IntSize size, Gfx::SharedImageBuffer& buffer, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
 {
@@ -34,56 +30,39 @@ static NonnullRefPtr<Gfx::PaintingSurface> create_gpu_painting_surface_with_bitm
 }
 #endif
 
-static BackingStorePair create_shareable_bitmap_backing_stores([[maybe_unused]] Gfx::IntSize size, Gfx::SharedImageBuffer& front_buffer, Gfx::SharedImageBuffer& back_buffer, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
+static NonnullRefPtr<Gfx::PaintingSurface> create_shareable_bitmap_backing_store([[maybe_unused]] Gfx::IntSize size, Gfx::SharedImageBuffer& buffer, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
 {
 #ifdef AK_OS_MACOS
-    if (skia_backend_context) {
-        return {
-            .front = Gfx::PaintingSurface::create_from_shared_image_buffer(front_buffer, *skia_backend_context),
-            .back = Gfx::PaintingSurface::create_from_shared_image_buffer(back_buffer, *skia_backend_context),
-        };
-    }
+    if (skia_backend_context)
+        return Gfx::PaintingSurface::create_from_shared_image_buffer(buffer, *skia_backend_context);
 #else
 #    if defined(USE_DIRECTX) || defined(USE_VULKAN)
-    if (skia_backend_context) {
-        return {
-            .front = create_gpu_painting_surface_with_bitmap_flush(size, front_buffer, skia_backend_context),
-            .back = create_gpu_painting_surface_with_bitmap_flush(size, back_buffer, skia_backend_context),
-        };
-    }
+    if (skia_backend_context)
+        return create_gpu_painting_surface_with_bitmap_flush(size, buffer, skia_backend_context);
 #    else
     (void)skia_backend_context;
 #    endif
 #endif
 
-    return {
-        .front = Gfx::PaintingSurface::wrap_bitmap(*front_buffer.bitmap()),
-        .back = Gfx::PaintingSurface::wrap_bitmap(*back_buffer.bitmap()),
-    };
+    return Gfx::PaintingSurface::wrap_bitmap(*buffer.bitmap());
 }
 
 #ifdef USE_VULKAN_DMABUF_IMAGES
-struct DMABufBackingStorePair {
-    RefPtr<Gfx::PaintingSurface> front;
-    RefPtr<Gfx::PaintingSurface> back;
-    Gfx::SharedImage front_shared_image;
-    Gfx::SharedImage back_shared_image;
+struct DMABufBackingStore {
+    RefPtr<Gfx::PaintingSurface> surface;
+    Gfx::SharedImage shared_image;
 };
 
-static ErrorOr<DMABufBackingStorePair> create_linear_dmabuf_backing_stores(Gfx::IntSize size, Gfx::SkiaBackendContext& skia_backend_context)
+static ErrorOr<DMABufBackingStore> create_linear_dmabuf_backing_store(Gfx::IntSize size, Gfx::SkiaBackendContext& skia_backend_context)
 {
     auto const& vulkan_context = skia_backend_context.vulkan_context();
-    static constexpr Array<uint64_t, 1> linear_modifiers = { DRM_FORMAT_MOD_LINEAR };
-    auto front_image = TRY(Gfx::create_shared_vulkan_image(vulkan_context, size.width(), size.height(), VK_FORMAT_B8G8R8A8_UNORM, linear_modifiers.span()));
-    auto back_image = TRY(Gfx::create_shared_vulkan_image(vulkan_context, size.width(), size.height(), VK_FORMAT_B8G8R8A8_UNORM, linear_modifiers.span()));
-    auto front_shared_image = Gfx::duplicate_shared_image(*front_image);
-    auto back_shared_image = Gfx::duplicate_shared_image(*back_image);
+    static constexpr Array<u64, 1> linear_modifiers = { DRM_FORMAT_MOD_LINEAR };
+    auto image = TRY(Gfx::create_shared_vulkan_image(vulkan_context, size.width(), size.height(), VK_FORMAT_B8G8R8A8_UNORM, linear_modifiers.span()));
+    auto shared_image = Gfx::duplicate_shared_image(*image);
 
-    return DMABufBackingStorePair {
-        .front = Gfx::PaintingSurface::create_from_vkimage(skia_backend_context, move(front_image), Gfx::PaintingSurface::Origin::TopLeft),
-        .back = Gfx::PaintingSurface::create_from_vkimage(skia_backend_context, move(back_image), Gfx::PaintingSurface::Origin::TopLeft),
-        .front_shared_image = move(front_shared_image),
-        .back_shared_image = move(back_shared_image),
+    return DMABufBackingStore {
+        .surface = Gfx::PaintingSurface::create_from_vkimage(skia_backend_context, move(image), Gfx::PaintingSurface::Origin::TopLeft),
+        .shared_image = move(shared_image),
     };
 }
 #endif
@@ -107,11 +86,11 @@ Optional<BackingStoreManager::Allocation> BackingStoreManager::resize_backing_st
 
     if (force_reallocate || m_allocated_size.is_empty() || !m_allocated_size.contains(minimum_needed_size)) {
         m_allocated_size = minimum_needed_size;
-        return Allocation {
-            .size = minimum_needed_size,
-            .front_bitmap_id = m_next_bitmap_id++,
-            .back_bitmap_id = m_next_bitmap_id++,
-        };
+        Vector<i32> bitmap_ids;
+        bitmap_ids.ensure_capacity(2);
+        for (size_t i = 0; i < 2; ++i)
+            bitmap_ids.append(m_next_bitmap_id++);
+        return Allocation { .size = minimum_needed_size, .bitmap_ids = move(bitmap_ids) };
     }
 
     return {};
@@ -119,77 +98,131 @@ Optional<BackingStoreManager::Allocation> BackingStoreManager::resize_backing_st
 
 Optional<BackingStoreManager::Publication> BackingStoreManager::allocate_backing_stores(Allocation const& allocation, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context, bool should_publish)
 {
+    m_backing_stores.clear();
+    m_rendering_store_index.clear();
+    m_latest_rendered_store_index.clear();
+
+    auto buffer_count = should_publish ? allocation.bitmap_ids.size() : 2;
+    VERIFY(buffer_count <= allocation.bitmap_ids.size());
+    m_backing_stores.ensure_capacity(buffer_count);
+
+    // The UI installs the first published buffer as its initial front buffer.
+    // Reserve it until the UI releases it after presenting another buffer.
+    auto initial_buffer_state = [should_publish](size_t index) {
+        return should_publish && index == 0 ? BufferState::Presented : BufferState::Available;
+    };
+
 #ifdef USE_VULKAN_DMABUF_IMAGES
     if (skia_backend_context && should_publish) {
-        auto backing_stores = create_linear_dmabuf_backing_stores(allocation.size, *skia_backend_context);
-        if (!backing_stores.is_error()) {
-            auto backing_store_pair = backing_stores.release_value();
-            m_backing_stores.front_store = move(backing_store_pair.front);
-            m_backing_stores.back_store = move(backing_store_pair.back);
-            m_backing_stores.front_bitmap_id = allocation.front_bitmap_id;
-            m_backing_stores.back_bitmap_id = allocation.back_bitmap_id;
+        Vector<Gfx::SharedImage> shared_images;
+        shared_images.ensure_capacity(buffer_count);
+        bool allocation_succeeded = true;
+        for (size_t i = 0; i < buffer_count; ++i) {
+            auto backing_store = create_linear_dmabuf_backing_store(allocation.size, *skia_backend_context);
+            if (backing_store.is_error()) {
+                allocation_succeeded = false;
+                break;
+            }
+
+            auto store = backing_store.release_value();
+            m_backing_stores.append({
+                .surface = move(store.surface),
+                .bitmap_id = allocation.bitmap_ids[i],
+                .state = initial_buffer_state(i),
+            });
+            shared_images.append(move(store.shared_image));
+        }
+
+        if (allocation_succeeded) {
             return Publication {
-                .front_bitmap_id = allocation.front_bitmap_id,
-                .front_shared_image = move(backing_store_pair.front_shared_image),
-                .back_bitmap_id = allocation.back_bitmap_id,
-                .back_shared_image = move(backing_store_pair.back_shared_image),
+                .bitmap_ids = allocation.bitmap_ids,
+                .shared_images = move(shared_images),
             };
         }
+
+        m_backing_stores.clear();
     }
 #endif
 
-    auto front_buffer = Gfx::SharedImageBuffer::create(allocation.size);
-    auto back_buffer = Gfx::SharedImageBuffer::create(allocation.size);
-    auto front_shared_image = front_buffer.export_shared_image();
-    auto back_shared_image = back_buffer.export_shared_image();
-    auto backing_store_pair = create_shareable_bitmap_backing_stores(allocation.size, front_buffer, back_buffer, skia_backend_context);
-    m_backing_stores.front_store = move(backing_store_pair.front);
-    m_backing_stores.back_store = move(backing_store_pair.back);
-    m_backing_stores.front_bitmap_id = allocation.front_bitmap_id;
-    m_backing_stores.back_bitmap_id = allocation.back_bitmap_id;
+    Vector<Gfx::SharedImage> shared_images;
+    if (should_publish)
+        shared_images.ensure_capacity(buffer_count);
+    for (size_t i = 0; i < buffer_count; ++i) {
+        auto buffer = Gfx::SharedImageBuffer::create(allocation.size);
+        if (should_publish)
+            shared_images.append(buffer.export_shared_image());
+        m_backing_stores.append({
+            .surface = create_shareable_bitmap_backing_store(allocation.size, buffer, skia_backend_context),
+            .bitmap_id = allocation.bitmap_ids[i],
+            .state = initial_buffer_state(i),
+        });
+    }
 
     if (!should_publish)
         return {};
 
     return Publication {
-        .front_bitmap_id = allocation.front_bitmap_id,
-        .front_shared_image = move(front_shared_image),
-        .back_bitmap_id = allocation.back_bitmap_id,
-        .back_shared_image = move(back_shared_image),
+        .bitmap_ids = allocation.bitmap_ids,
+        .shared_images = move(shared_images),
     };
 }
 
 bool BackingStoreManager::is_valid() const
 {
-    return m_backing_stores.is_valid();
+    return !m_backing_stores.is_empty();
 }
 
-RefPtr<Gfx::PaintingSurface> BackingStoreManager::front_store_if_present() const
+bool BackingStoreManager::has_available_buffer() const
 {
-    return m_backing_stores.front_store;
+    return any_of(m_backing_stores, [](auto const& store) { return store.state == BufferState::Available; });
 }
 
-Gfx::PaintingSurface& BackingStoreManager::front_store()
+Optional<BackingStoreManager::RenderTarget> BackingStoreManager::acquire_render_target()
 {
-    VERIFY(m_backing_stores.front_store);
-    return *m_backing_stores.front_store;
+    VERIFY(!m_rendering_store_index.has_value());
+    for (size_t i = 0; i < m_backing_stores.size(); ++i) {
+        auto& store = m_backing_stores[i];
+        if (store.state != BufferState::Available)
+            continue;
+
+        store.state = BufferState::Rendering;
+        m_rendering_store_index = i;
+        return RenderTarget { *store.surface, store.bitmap_id };
+    }
+    return {};
 }
 
-Gfx::PaintingSurface& BackingStoreManager::back_store()
+void BackingStoreManager::complete_rendering(i32 bitmap_id, bool wait_for_release)
 {
-    VERIFY(m_backing_stores.back_store);
-    return *m_backing_stores.back_store;
+    VERIFY(m_rendering_store_index.has_value());
+    auto& store = m_backing_stores[*m_rendering_store_index];
+    VERIFY(store.state == BufferState::Rendering);
+    VERIFY(store.bitmap_id == bitmap_id);
+
+    if (!wait_for_release && m_latest_rendered_store_index.has_value())
+        m_backing_stores[*m_latest_rendered_store_index].state = BufferState::Available;
+
+    store.state = BufferState::Presented;
+    m_latest_rendered_store_index = m_rendering_store_index;
+    m_rendering_store_index.clear();
 }
 
-i32 BackingStoreManager::back_bitmap_id() const
+bool BackingStoreManager::release_buffer(i32 bitmap_id)
 {
-    return m_backing_stores.back_bitmap_id;
+    for (auto& store : m_backing_stores) {
+        if (store.bitmap_id != bitmap_id || store.state != BufferState::Presented)
+            continue;
+        store.state = BufferState::Available;
+        return true;
+    }
+    return false;
 }
 
-void BackingStoreManager::swap()
+RefPtr<Gfx::PaintingSurface> BackingStoreManager::latest_rendered_surface() const
 {
-    AK::swap(m_backing_stores.front_store, m_backing_stores.back_store);
-    AK::swap(m_backing_stores.front_bitmap_id, m_backing_stores.back_bitmap_id);
+    if (!m_latest_rendered_store_index.has_value())
+        return nullptr;
+    return m_backing_stores[*m_latest_rendered_store_index].surface;
 }
 
 }

--- a/Services/Compositor/BackingStoreManager.h
+++ b/Services/Compositor/BackingStoreManager.h
@@ -10,6 +10,7 @@
 #include <AK/Optional.h>
 #include <AK/RefPtr.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/SharedImage.h>
 #include <LibGfx/Size.h>
@@ -24,14 +25,15 @@ class BackingStoreManager {
 public:
     struct Allocation {
         Gfx::IntSize size;
-        i32 front_bitmap_id { -1 };
-        i32 back_bitmap_id { -1 };
+        Vector<i32> bitmap_ids;
     };
     struct Publication {
-        i32 front_bitmap_id { -1 };
-        Gfx::SharedImage front_shared_image;
-        i32 back_bitmap_id { -1 };
-        Gfx::SharedImage back_shared_image;
+        Vector<i32> bitmap_ids;
+        Vector<Gfx::SharedImage> shared_images;
+    };
+    struct RenderTarget {
+        Gfx::PaintingSurface& surface;
+        i32 bitmap_id { -1 };
     };
 
     BackingStoreManager() = default;
@@ -41,27 +43,32 @@ public:
     Optional<Publication> allocate_backing_stores(Allocation const&, RefPtr<Gfx::SkiaBackendContext> const&, bool should_publish);
 
     bool is_valid() const;
-    RefPtr<Gfx::PaintingSurface> front_store_if_present() const;
-    Gfx::PaintingSurface& front_store();
-    Gfx::PaintingSurface& back_store();
-    i32 back_bitmap_id() const;
-    void swap();
+    bool has_available_buffer() const;
+    Optional<RenderTarget> acquire_render_target();
+    void complete_rendering(i32 bitmap_id, bool release_to_external);
+    bool release_buffer(i32 bitmap_id);
+    RefPtr<Gfx::PaintingSurface> latest_rendered_surface() const;
 
 private:
-    struct BackingStoreState {
-        RefPtr<Gfx::PaintingSurface> front_store;
-        RefPtr<Gfx::PaintingSurface> back_store;
-        i32 front_bitmap_id { -1 };
-        i32 back_bitmap_id { -1 };
+    enum class BufferState : u8 {
+        Available,
+        Rendering,
+        Presented,
+    };
 
-        bool is_valid() const { return front_store && back_store; }
+    struct BackingStore {
+        RefPtr<Gfx::PaintingSurface> surface;
+        i32 bitmap_id { -1 };
+        BufferState state { BufferState::Available };
     };
 
     int m_next_bitmap_id { 0 };
 
     // Used to track if backing stores need reallocation
     Gfx::IntSize m_allocated_size;
-    BackingStoreState m_backing_stores;
+    Vector<BackingStore> m_backing_stores;
+    Optional<size_t> m_rendering_store_index;
+    Optional<size_t> m_latest_rendered_store_index;
 };
 
 }

--- a/Services/Compositor/BackingStoreManager.h
+++ b/Services/Compositor/BackingStoreManager.h
@@ -34,6 +34,7 @@ public:
     struct RenderTarget {
         Gfx::PaintingSurface& surface;
         i32 bitmap_id { -1 };
+        Gfx::IntRect damage_rect;
     };
 
     BackingStoreManager() = default;
@@ -44,7 +45,7 @@ public:
 
     bool is_valid() const;
     bool has_available_buffer() const;
-    Optional<RenderTarget> acquire_render_target();
+    Optional<RenderTarget> acquire_render_target(Gfx::IntRect frame_damage);
     void complete_rendering(i32 bitmap_id, bool release_to_external);
     bool release_buffer(i32 bitmap_id);
     RefPtr<Gfx::PaintingSurface> latest_rendered_surface() const;
@@ -60,6 +61,7 @@ private:
         RefPtr<Gfx::PaintingSurface> surface;
         i32 bitmap_id { -1 };
         BufferState state { BufferState::Available };
+        Gfx::IntRect accumulated_damage;
     };
 
     int m_next_bitmap_id { 0 };

--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -48,7 +48,9 @@ target_include_directories(compositorservice PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
 target_include_directories(compositorservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Services/)
 
 target_link_libraries(Compositor PRIVATE compositorservice LibCore LibMain LibSandbox LibWebView)
-target_link_libraries(compositorservice PRIVATE LibCore LibGfx LibIPC LibMedia LibSync LibWeb ${ANGLE_TARGETS})
+# ANGLE must precede Skia so macOS GLES symbols bind to ANGLE rather than the
+# OpenGL framework pulled in by Skia.
+target_link_libraries(compositorservice PRIVATE LibCore LibGfx LibIPC LibMedia LibSync LibWeb ${ANGLE_TARGETS} skia)
 
 if (APPLE)
     target_link_libraries(Compositor PRIVATE "-framework CoreGraphics" "-framework CoreVideo")

--- a/Services/Compositor/CompositorControlClient.ipc
+++ b/Services/Compositor/CompositorControlClient.ipc
@@ -4,6 +4,6 @@
 
 endpoint CompositorControlClient
 {
-    did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store) =|
+    did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores) =|
     did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id) =|
 }

--- a/Services/Compositor/CompositorControlClient.ipc
+++ b/Services/Compositor/CompositorControlClient.ipc
@@ -5,5 +5,5 @@
 endpoint CompositorControlClient
 {
     did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores) =|
-    did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id) =|
+    did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) =|
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -239,14 +239,6 @@ bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId conte
     return apply_context_update_result(context_id, *context, context->async_scroll_by(position, delta));
 }
 
-bool CompositorState::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) const
-{
-    auto* context = context_if_present(context_id);
-    VERIFY(context);
-
-    return context->should_defer_main_thread_present_for_async_scroll();
-}
-
 Web::Compositor::PendingAsyncScrollUpdates CompositorState::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
 {
     auto* context = context_if_present(context_id);
@@ -285,6 +277,10 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
+    if (context->should_defer_main_thread_present_for_async_scroll()) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred present while async scroll is pending");
+        return;
+    }
     schedule_present_frame(context_id, *context, viewport_rect);
 }
 

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -292,7 +292,7 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
     if (!prepared_frame.has_value())
         return;
 
-    m_pending_async_presents.append(context_id, pending_frame.viewport_rect, prepared_frame->bitmap_id);
+    m_pending_async_presents.append(context_id, pending_frame.viewport_rect, pending_frame.damage_rect, prepared_frame->bitmap_id);
     auto* pending_present = &m_pending_async_presents.last();
 
     auto& event_loop = Core::EventLoop::current();
@@ -418,6 +418,7 @@ void CompositorState::did_finish_async_present(PendingAsyncPresent& pending_pres
 
     auto context_id = pending_present.context_id;
     auto viewport_rect = pending_present.viewport_rect;
+    auto damage_rect = pending_present.damage_rect;
     auto bitmap_id = pending_present.bitmap_id;
     auto was_cancelled = pending_present.was_cancelled;
     (void)m_pending_async_presents.remove(pending_present_iterator);
@@ -433,7 +434,7 @@ void CompositorState::did_finish_async_present(PendingAsyncPresent& pending_pres
     context->did_finish_gpu_present(bitmap_id);
     if (context->presents_to_client()) {
         VERIFY(m_client);
-        m_client->did_present_frame(context_id, viewport_rect, bitmap_id);
+        m_client->did_present_frame(context_id, viewport_rect, damage_rect, bitmap_id);
     }
     resize_backing_stores_if_needed(context_id, *context);
     if (auto parent_context_id = context->parent_context_id(); parent_context_id.has_value()) {

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -373,8 +373,11 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
             continue;
 
         auto pending_present_frame = context.take_pending_present_frame_if_unblocked();
-        if (!pending_present_frame.has_value())
+        if (!pending_present_frame.has_value()) {
+            if (context.has_pending_present_frame_scheduled_on(display_id))
+                vsync_scheduler_for_display(display_id).schedule(context.display_refresh_rate());
             continue;
+        }
         present_frame(context_id, context, *pending_present_frame);
     }
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -575,7 +575,7 @@ void CompositorState::publish_backing_stores(Web::Compositor::CompositorContextI
     VERIFY(m_client);
     VERIFY(context.presents_to_client());
 
-    m_client->did_allocate_backing_stores(context_id, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image));
+    m_client->did_allocate_backing_stores(context_id, move(publication.bitmap_ids), move(publication.shared_images));
 }
 
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -273,7 +273,7 @@ void CompositorState::set_display_metadata(Web::Compositor::CompositorContextId 
         schedule_pending_present_frame(context_id, *context);
 }
 
-void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
+void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
@@ -281,17 +281,18 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred present while async scroll is pending");
         return;
     }
-    schedule_present_frame(context_id, *context, viewport_rect);
+    damage_rect.intersect({ {}, viewport_rect.size() });
+    schedule_present_frame(context_id, *context, ContextState::PendingFrame { viewport_rect, damage_rect });
 }
 
-void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect viewport_rect)
+void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, ContextState::PendingFrame pending_frame)
 {
     auto composited_context_resolver = resolver_for(context_id);
-    auto prepared_frame = context.prepare_frame(*m_display_list_player, viewport_rect, &composited_context_resolver);
+    auto prepared_frame = context.prepare_frame(*m_display_list_player, pending_frame, &composited_context_resolver);
     if (!prepared_frame.has_value())
         return;
 
-    m_pending_async_presents.append(context_id, viewport_rect, prepared_frame->bitmap_id);
+    m_pending_async_presents.append(context_id, pending_frame.viewport_rect, prepared_frame->bitmap_id);
     auto* pending_present = &m_pending_async_presents.last();
 
     auto& event_loop = Core::EventLoop::current();
@@ -301,14 +302,22 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
             self->did_finish_async_present(*pending_present);
         });
     });
-    context.did_submit_prepared_frame(viewport_rect);
+    context.did_submit_prepared_frame(pending_frame.viewport_rect);
     schedule_gpu_completion_check();
+}
+
+void CompositorState::schedule_present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, ContextState::PendingFrame pending_frame)
+{
+    context.queue_present_frame(pending_frame);
+    schedule_pending_present_frame(context_id, context);
 }
 
 void CompositorState::schedule_present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect viewport_rect)
 {
-    context.queue_present_frame(viewport_rect);
-    schedule_pending_present_frame(context_id, context);
+    schedule_present_frame(context_id, context, ContextState::PendingFrame {
+                                                    .viewport_rect = viewport_rect,
+                                                    .damage_rect = { {}, viewport_rect.size() },
+                                                });
 }
 
 void CompositorState::schedule_pending_present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context)
@@ -423,6 +432,7 @@ void CompositorState::did_finish_async_present(PendingAsyncPresent& pending_pres
         VERIFY(m_client);
         m_client->did_present_frame(context_id, viewport_rect, bitmap_id);
     }
+    resize_backing_stores_if_needed(context_id, *context);
     if (auto parent_context_id = context->parent_context_id(); parent_context_id.has_value()) {
         auto* parent_context = context_if_present(*parent_context_id);
         VERIFY(parent_context);

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -92,7 +92,6 @@ public:
     bool handle_pinch_event(Web::Compositor::CompositorContextId, Web::PinchEvent const&);
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
     bool async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta);
-    bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) const;
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
     void set_display_metadata(Web::Compositor::CompositorContextId, Optional<u64> display_id, double refresh_rate);

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -95,7 +95,7 @@ public:
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
     void set_display_metadata(Web::Compositor::CompositorContextId, Optional<u64> display_id, double refresh_rate);
-    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect);
+    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
     bool request_screenshot(Web::Compositor::CompositorContextId, Gfx::ShareableBitmap&);
     void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
 
@@ -129,8 +129,9 @@ private:
         Web::Compositor::CompositorContextId,
         ContextState&,
         ContextState::ContextUpdateResult const&);
-    void present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect);
-    void schedule_present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect);
+    void present_frame(Web::Compositor::CompositorContextId, ContextState&, ContextState::PendingFrame);
+    void schedule_present_frame(Web::Compositor::CompositorContextId, ContextState&, ContextState::PendingFrame);
+    void schedule_present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect viewport_rect);
     void schedule_pending_present_frame(Web::Compositor::CompositorContextId, ContextState&);
     void schedule_pending_present_frame_on_vsync(Web::Compositor::CompositorContextId, ContextState&);
     void schedule_containing_context_present(ContextState&);

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -44,7 +44,7 @@ class CompositorStateClient {
 public:
     virtual ~CompositorStateClient() = default;
 
-    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, i32 front_bitmap_id, Gfx::SharedImage&& front_backing_store, i32 back_bitmap_id, Gfx::SharedImage&& back_backing_store) = 0;
+    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage>&& backing_stores) = 0;
     virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) = 0;
 };
 

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -45,7 +45,7 @@ public:
     virtual ~CompositorStateClient() = default;
 
     virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage>&& backing_stores) = 0;
-    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) = 0;
+    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) = 0;
 };
 
 class CompositorStateWebContentClient {
@@ -103,15 +103,17 @@ private:
     CompositorState(RefPtr<Gfx::SkiaBackendContext>, bool async_scrolling_enabled);
 
     struct PendingAsyncPresent {
-        PendingAsyncPresent(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, i32 bitmap_id)
+        PendingAsyncPresent(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect, i32 bitmap_id)
             : context_id(context_id)
             , viewport_rect(viewport_rect)
+            , damage_rect(damage_rect)
             , bitmap_id(bitmap_id)
         {
         }
 
         Web::Compositor::CompositorContextId context_id;
         Gfx::IntRect viewport_rect;
+        Gfx::IntRect damage_rect;
         i32 bitmap_id { 0 };
         bool was_cancelled { false };
     };

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -47,7 +47,6 @@ endpoint CompositorWebContentServer
 
     invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) =|
     async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) => (Web::Compositor::AsyncScrollEnqueueResult result)
-    should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) => (bool should_defer)
     take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) => (Web::Compositor::PendingAsyncScrollUpdates updates)
 
     viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -50,6 +50,6 @@ endpoint CompositorWebContentServer
     take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) => (Web::Compositor::PendingAsyncScrollUpdates updates)
 
     viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
-    present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) =|
+    present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) =|
     request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) =|
 }

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -34,9 +34,9 @@ void ConnectionFromClient::did_allocate_backing_stores(Web::Compositor::Composit
     async_did_allocate_backing_stores(context_id, move(bitmap_ids), move(backing_stores));
 }
 
-void ConnectionFromClient::did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id)
+void ConnectionFromClient::did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id)
 {
-    async_did_present_frame(context_id, content_rect, bitmap_id);
+    async_did_present_frame(context_id, content_rect, damage_rect, bitmap_id);
 }
 
 Messages::CompositorControlServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -29,9 +29,9 @@ void ConnectionFromClient::die()
     Core::Process::terminate_immediately(0);
 }
 
-void ConnectionFromClient::did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, i32 front_bitmap_id, Gfx::SharedImage&& front_backing_store, i32 back_bitmap_id, Gfx::SharedImage&& back_backing_store)
+void ConnectionFromClient::did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage>&& backing_stores)
 {
-    async_did_allocate_backing_stores(context_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
+    async_did_allocate_backing_stores(context_id, move(bitmap_ids), move(backing_stores));
 }
 
 void ConnectionFromClient::did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id)

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -32,7 +32,7 @@ private:
 
     virtual void die() override;
 
-    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, i32 front_bitmap_id, Gfx::SharedImage&& front_backing_store, i32 back_bitmap_id, Gfx::SharedImage&& back_backing_store) override;
+    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage>&& backing_stores) override;
     virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) override;
 
     virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -33,7 +33,7 @@ private:
     virtual void die() override;
 
     virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage>&& backing_stores) override;
-    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) override;
+    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) override;
 
     virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -203,12 +203,6 @@ Messages::CompositorWebContentServer::AsyncScrollByResponse ConnectionFromWebCon
     return result;
 }
 
-Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScrollResponse ConnectionFromWebContent::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id)
-{
-    verify_context_is_owned_by_this_connection(context_id);
-    return m_compositor_state->should_defer_main_thread_present_for_async_scroll(context_id);
-}
-
 Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse ConnectionFromWebContent::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
 {
     verify_context_is_owned_by_this_connection(context_id);

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -215,10 +215,10 @@ void ConnectionFromWebContent::viewport_size_updated(Web::Compositor::Compositor
     m_compositor_state->viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
-void ConnectionFromWebContent::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
+void ConnectionFromWebContent::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
 {
     verify_context_is_owned_by_this_connection(context_id);
-    m_compositor_state->present_frame(context_id, viewport_rect);
+    m_compositor_state->present_frame(context_id, viewport_rect, damage_rect);
 }
 
 void ConnectionFromWebContent::request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap)

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -61,7 +61,7 @@ private:
     virtual Messages::CompositorWebContentServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
     virtual Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress) override;
-    virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect) override;
+    virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) override;
     virtual void request_screenshot(Web::Compositor::CompositorContextId, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) override;
 
     virtual void dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const&) override;

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -59,7 +59,6 @@ private:
     virtual Messages::CompositorWebContentServer::WebglReadBufferSubDataResponse webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data) override;
     virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation) override;
     virtual Messages::CompositorWebContentServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
-    virtual Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScrollResponse should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) override;
     virtual Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress) override;
     virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect) override;

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -10,11 +10,10 @@
 #include <Compositor/ContextState.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/Color.h>
-#include <LibGfx/PainterSkia.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
+#include <core/SkCanvas.h>
 
 namespace Compositor {
 
@@ -501,6 +500,8 @@ void ContextState::finish_window_resize()
 
 Optional<BackingStoreManager::Publication> ContextState::resize_backing_stores_if_needed(RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
 {
+    if (m_gpu_present_bitmap_id_awaiting_completion.has_value())
+        return {};
     auto allocation = m_backing_store_manager.resize_backing_stores_if_needed(m_viewport_size, m_window_resize_in_progress);
     if (!allocation.has_value())
         return {};
@@ -514,9 +515,22 @@ bool ContextState::set_display_metadata(Optional<u64> display_id, double refresh
     return m_pending_present_frame_scheduled;
 }
 
-void ContextState::queue_present_frame(Gfx::IntRect viewport_rect)
+void ContextState::queue_present_frame(PendingFrame pending_frame)
 {
-    m_pending_present_frame = viewport_rect;
+    if (!m_pending_present_frame.has_value()) {
+        m_pending_present_frame = pending_frame;
+        return;
+    }
+
+    if (m_pending_present_frame->viewport_rect != pending_frame.viewport_rect) {
+        m_pending_present_frame = PendingFrame {
+            .viewport_rect = pending_frame.viewport_rect,
+            .damage_rect = { {}, pending_frame.viewport_rect.size() },
+        };
+        return;
+    }
+
+    m_pending_present_frame->damage_rect.unite(pending_frame.damage_rect);
 }
 
 void ContextState::mark_pending_present_frame_scheduled()
@@ -540,7 +554,7 @@ bool ContextState::can_schedule_pending_present_frame_if_unblocked() const
     return true;
 }
 
-Optional<Gfx::IntRect> ContextState::take_pending_present_frame_if_unblocked()
+Optional<ContextState::PendingFrame> ContextState::take_pending_present_frame_if_unblocked()
 {
     m_pending_present_frame_scheduled = false;
     if (is_present_blocked())
@@ -565,29 +579,25 @@ Optional<Gfx::IntRect> ContextState::current_frame_rect_to_present() const
     return m_presented_frame;
 }
 
-Optional<ContextState::PreparedFrame> ContextState::prepare_frame(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::IntRect viewport_rect, CompositedContextResolver const* composited_context_resolver)
+Optional<ContextState::PreparedFrame> ContextState::prepare_frame(Web::Painting::DisplayListPlayerSkia& display_list_player, PendingFrame pending_frame, CompositedContextResolver const* composited_context_resolver)
 {
     if (is_present_blocked()) {
-        m_pending_present_frame = viewport_rect;
+        queue_present_frame(pending_frame);
         return {};
     }
 
     if (!can_render_frame()) {
-        m_presented_frame = viewport_rect;
+        m_presented_frame = pending_frame.viewport_rect;
         return {};
     }
 
-    auto render_target = m_backing_store_manager.acquire_render_target();
+    auto render_target = m_backing_store_manager.acquire_render_target(pending_frame.damage_rect);
     if (!render_target.has_value()) {
-        m_pending_present_frame = viewport_rect;
+        queue_present_frame(pending_frame);
         return {};
     }
     auto& back_store = render_target->surface;
-    if (!presents_to_client()) {
-        Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
-        painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
-    }
-    paint_current_display_list(display_list_player, back_store, composited_context_resolver);
+    paint_current_display_list(display_list_player, back_store, composited_context_resolver, render_target->damage_rect);
 
     auto rendered_bitmap_id = render_target->bitmap_id;
     m_gpu_present_bitmap_id_awaiting_completion = rendered_bitmap_id;
@@ -610,25 +620,25 @@ bool ContextState::present_synchronously(Web::Painting::DisplayListPlayerSkia& d
     if (is_present_blocked())
         return false;
 
-    auto viewport_rect = m_pending_present_frame;
-    if (!viewport_rect.has_value())
-        viewport_rect = m_presented_frame;
-    if (!viewport_rect.has_value())
+    Optional<PendingFrame> pending_frame = m_pending_present_frame;
+    if (!pending_frame.has_value() && m_presented_frame.has_value()) {
+        pending_frame = PendingFrame {
+            .viewport_rect = *m_presented_frame,
+            .damage_rect = { {}, m_presented_frame->size() },
+        };
+    }
+    if (!pending_frame.has_value())
         return false;
 
-    auto render_target = m_backing_store_manager.acquire_render_target();
+    auto render_target = m_backing_store_manager.acquire_render_target(pending_frame->damage_rect);
     if (!render_target.has_value())
         return false;
     auto& back_store = render_target->surface;
-    if (!presents_to_client()) {
-        Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
-        painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
-    }
-    paint_current_display_list(display_list_player, back_store, composited_context_resolver);
+    paint_current_display_list(display_list_player, back_store, composited_context_resolver, render_target->damage_rect);
     display_list_player.flush(back_store);
     m_backing_store_manager.complete_rendering(render_target->bitmap_id, false);
     m_latest_rendered_surface = m_backing_store_manager.latest_rendered_surface();
-    m_presented_frame = viewport_rect;
+    m_presented_frame = pending_frame->viewport_rect;
     m_pending_present_frame.clear();
     m_pending_present_frame_scheduled = false;
     return true;
@@ -824,9 +834,16 @@ Web::Painting::AccumulatedVisualContextTree const& ContextState::visual_context_
     return *m_visual_context_tree_for_compositing;
 }
 
-void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::PaintingSurface& surface, CompositedContextResolver const* composited_context_resolver)
+void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::PaintingSurface& surface, CompositedContextResolver const* composited_context_resolver, Optional<Gfx::IntRect> damage_rect)
 {
     VERIFY(m_display_list);
+    auto& canvas = surface.canvas();
+    auto save_count = canvas.save();
+    if (damage_rect.has_value()) {
+        canvas.clipIRect(SkIRect::MakeXYWH(damage_rect->x(), damage_rect->y(), damage_rect->width(), damage_rect->height()));
+        if (!presents_to_client())
+            canvas.clear(SK_ColorTRANSPARENT);
+    }
     display_list_player.execute(
         *m_display_list,
         visual_context_tree_for_compositing(),
@@ -836,6 +853,7 @@ void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSk
         &m_canvas_surface_registry,
         composited_context_resolver);
     m_viewport_scrollbar_controller.paint(surface, display_list_player, m_scroll_state_snapshot);
+    canvas.restoreToCount(save_count);
 }
 
 }

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -557,9 +557,9 @@ bool ContextState::can_schedule_pending_present_frame_if_unblocked() const
 
 Optional<ContextState::PendingFrame> ContextState::take_pending_present_frame_if_unblocked()
 {
-    m_pending_present_frame_scheduled = false;
     if (is_present_blocked())
         return {};
+    m_pending_present_frame_scheduled = false;
     if (!m_pending_present_frame.has_value())
         return {};
     return m_pending_present_frame.release_value();

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -120,10 +120,8 @@ void ContextState::stop_presenting_to_client()
 
 void ContextState::did_stop_presenting_to_client_if_needed(bool was_presenting_to_client, bool will_present_to_client)
 {
-    if (was_presenting_to_client && !will_present_to_client
-        && m_gpu_present_bitmap_id_awaiting_completion.has_value()
-        && m_presented_bitmap_id_awaiting_ack == m_gpu_present_bitmap_id_awaiting_completion)
-        m_presented_bitmap_id_awaiting_ack.clear();
+    (void)was_presenting_to_client;
+    (void)will_present_to_client;
 }
 
 void ContextState::set_parent_context(Optional<Web::Compositor::CompositorContextId> parent_context_id)
@@ -464,8 +462,7 @@ bool ContextState::should_defer_main_thread_present_for_async_scroll() const
     if (m_pending_async_scroll_offsets.is_empty())
         return false;
     return m_pending_present_frame.has_value()
-        || m_gpu_present_bitmap_id_awaiting_completion.has_value()
-        || m_presented_bitmap_id_awaiting_ack.has_value();
+        || is_present_blocked();
 }
 
 Web::Compositor::PendingAsyncScrollUpdates ContextState::take_pending_async_scroll_updates()
@@ -580,17 +577,20 @@ Optional<ContextState::PreparedFrame> ContextState::prepare_frame(Web::Painting:
         return {};
     }
 
-    auto& back_store = m_backing_store_manager.back_store();
+    auto render_target = m_backing_store_manager.acquire_render_target();
+    if (!render_target.has_value()) {
+        m_pending_present_frame = viewport_rect;
+        return {};
+    }
+    auto& back_store = render_target->surface;
     if (!presents_to_client()) {
         Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
         painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
     }
     paint_current_display_list(display_list_player, back_store, composited_context_resolver);
 
-    auto rendered_bitmap_id = m_backing_store_manager.back_bitmap_id();
+    auto rendered_bitmap_id = render_target->bitmap_id;
     m_gpu_present_bitmap_id_awaiting_completion = rendered_bitmap_id;
-    if (presents_to_client())
-        m_presented_bitmap_id_awaiting_ack = rendered_bitmap_id;
     return PreparedFrame {
         .rendered_surface = &back_store,
         .bitmap_id = rendered_bitmap_id,
@@ -599,7 +599,6 @@ Optional<ContextState::PreparedFrame> ContextState::prepare_frame(Web::Painting:
 
 void ContextState::did_submit_prepared_frame(Gfx::IntRect viewport_rect)
 {
-    m_backing_store_manager.swap();
     m_presented_frame = viewport_rect;
 }
 
@@ -617,15 +616,18 @@ bool ContextState::present_synchronously(Web::Painting::DisplayListPlayerSkia& d
     if (!viewport_rect.has_value())
         return false;
 
-    auto& back_store = m_backing_store_manager.back_store();
+    auto render_target = m_backing_store_manager.acquire_render_target();
+    if (!render_target.has_value())
+        return false;
+    auto& back_store = render_target->surface;
     if (!presents_to_client()) {
         Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
         painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
     }
     paint_current_display_list(display_list_player, back_store, composited_context_resolver);
     display_list_player.flush(back_store);
-    m_backing_store_manager.swap();
-    m_latest_rendered_surface = m_backing_store_manager.front_store_if_present();
+    m_backing_store_manager.complete_rendering(render_target->bitmap_id, false);
+    m_latest_rendered_surface = m_backing_store_manager.latest_rendered_surface();
     m_presented_frame = viewport_rect;
     m_pending_present_frame.clear();
     m_pending_present_frame_scheduled = false;
@@ -648,18 +650,15 @@ void ContextState::paint_screenshot(Web::Painting::DisplayListPlayerSkia& displa
 
 bool ContextState::acknowledge_presented_bitmap(i32 bitmap_id)
 {
-    if (m_presented_bitmap_id_awaiting_ack != bitmap_id)
-        return false;
-
-    m_presented_bitmap_id_awaiting_ack.clear();
-    return true;
+    return m_backing_store_manager.release_buffer(bitmap_id);
 }
 
 void ContextState::did_finish_gpu_present(i32 bitmap_id)
 {
     VERIFY(m_gpu_present_bitmap_id_awaiting_completion == bitmap_id);
     m_gpu_present_bitmap_id_awaiting_completion.clear();
-    m_latest_rendered_surface = m_backing_store_manager.front_store_if_present();
+    m_backing_store_manager.complete_rendering(bitmap_id, presents_to_client());
+    m_latest_rendered_surface = m_backing_store_manager.latest_rendered_surface();
 }
 
 void ContextState::stop_backing_store_shrink_timer()
@@ -807,7 +806,7 @@ void ContextState::rebuild_wheel_hit_test_targets()
 bool ContextState::is_present_blocked() const
 {
     return m_gpu_present_bitmap_id_awaiting_completion.has_value()
-        || m_presented_bitmap_id_awaiting_ack.has_value();
+        || !m_backing_store_manager.has_available_buffer();
 }
 
 bool ContextState::can_render_frame() const

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <core/SkCanvas.h>
+#include <core/SkImage.h>
 
 namespace Compositor {
 
@@ -837,6 +838,44 @@ Web::Painting::AccumulatedVisualContextTree const& ContextState::visual_context_
 void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::PaintingSurface& surface, CompositedContextResolver const* composited_context_resolver, Optional<Gfx::IntRect> damage_rect)
 {
     VERIFY(m_display_list);
+    auto paint_display_list = [&](Gfx::PaintingSurface& target_surface) {
+        display_list_player.execute(
+            *m_display_list,
+            visual_context_tree_for_compositing(),
+            m_display_list_resource_storage,
+            m_scroll_state_snapshot,
+            target_surface,
+            &m_canvas_surface_registry,
+            composited_context_resolver);
+        m_viewport_scrollbar_controller.paint(target_surface, display_list_player, m_scroll_state_snapshot);
+    };
+
+    if (damage_rect.has_value() && !damage_rect->is_empty() && presents_to_client() && damage_rect->size() != surface.size() && surface.skia_backend_context()) {
+        if (!m_damage_surface || m_damage_surface->size() != damage_rect->size()) {
+            m_damage_surface = Gfx::PaintingSurface::create_with_size(
+                damage_rect->size(), Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, surface.skia_backend_context());
+        }
+
+        auto& damage_canvas = m_damage_surface->canvas();
+        damage_canvas.clear(SK_ColorTRANSPARENT);
+        damage_canvas.save();
+        damage_canvas.translate(-damage_rect->x(), -damage_rect->y());
+        paint_display_list(*m_damage_surface);
+        damage_canvas.restore();
+
+        auto image = m_damage_surface->sk_image_snapshot<sk_sp<SkImage>>();
+        SkPaint paint;
+        paint.setBlendMode(SkBlendMode::kSrc);
+        surface.canvas().drawImageRect(
+            image.get(),
+            SkRect::MakeWH(damage_rect->width(), damage_rect->height()),
+            SkRect::MakeXYWH(damage_rect->x(), damage_rect->y(), damage_rect->width(), damage_rect->height()),
+            SkSamplingOptions {},
+            &paint,
+            SkCanvas::kStrict_SrcRectConstraint);
+        return;
+    }
+
     auto& canvas = surface.canvas();
     auto save_count = canvas.save();
     if (damage_rect.has_value()) {
@@ -844,15 +883,7 @@ void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSk
         if (!presents_to_client())
             canvas.clear(SK_ColorTRANSPARENT);
     }
-    display_list_player.execute(
-        *m_display_list,
-        visual_context_tree_for_compositing(),
-        m_display_list_resource_storage,
-        m_scroll_state_snapshot,
-        surface,
-        &m_canvas_surface_registry,
-        composited_context_resolver);
-    m_viewport_scrollbar_controller.paint(surface, display_list_player, m_scroll_state_snapshot);
+    paint_display_list(surface);
     canvas.restoreToCount(save_count);
 }
 

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -198,7 +198,6 @@ private:
     bool m_pending_present_frame_scheduled { false };
     Optional<Gfx::IntRect> m_presented_frame;
     Optional<i32> m_gpu_present_bitmap_id_awaiting_completion;
-    Optional<i32> m_presented_bitmap_id_awaiting_ack;
 };
 
 }

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -74,6 +74,11 @@ public:
         i32 bitmap_id { 0 };
     };
 
+    struct PendingFrame {
+        Gfx::IntRect viewport_rect;
+        Gfx::IntRect damage_rect;
+    };
+
     ContextState(Optional<u64> page_id, CompositorStateWebContentClient&, Web::Painting::CanvasSurfaceRegistry const&, bool async_scrolling_enabled);
     ~ContextState();
 
@@ -123,14 +128,14 @@ public:
     Optional<u64> display_id() const { return m_display_id; }
     double display_refresh_rate() const { return m_display_refresh_rate; }
 
-    void queue_present_frame(Gfx::IntRect);
+    void queue_present_frame(PendingFrame);
     void mark_pending_present_frame_scheduled();
     bool has_pending_present_frame_scheduled_on(Optional<u64> display_id) const;
     bool can_schedule_pending_present_frame_if_unblocked() const;
-    Optional<Gfx::IntRect> take_pending_present_frame_if_unblocked();
+    Optional<PendingFrame> take_pending_present_frame_if_unblocked();
     bool needs_rasterization() const;
     Optional<Gfx::IntRect> current_frame_rect_to_present() const;
-    Optional<PreparedFrame> prepare_frame(Web::Painting::DisplayListPlayerSkia&, Gfx::IntRect, CompositedContextResolver const*);
+    Optional<PreparedFrame> prepare_frame(Web::Painting::DisplayListPlayerSkia&, PendingFrame, CompositedContextResolver const*);
     void did_submit_prepared_frame(Gfx::IntRect);
     bool present_synchronously(Web::Painting::DisplayListPlayerSkia&, CompositedContextResolver const*);
     bool can_paint_screenshot(Gfx::ShareableBitmap&) const;
@@ -156,7 +161,7 @@ private:
     bool is_present_blocked() const;
     bool can_render_frame() const;
     Web::Painting::AccumulatedVisualContextTree const& visual_context_tree_for_compositing() const;
-    void paint_current_display_list(Web::Painting::DisplayListPlayerSkia&, Gfx::PaintingSurface&, CompositedContextResolver const*);
+    void paint_current_display_list(Web::Painting::DisplayListPlayerSkia&, Gfx::PaintingSurface&, CompositedContextResolver const*, Optional<Gfx::IntRect> damage_rect = {});
 
     CompositorStateWebContentClient& m_web_content_client;
     Web::Painting::CanvasSurfaceRegistry const& m_canvas_surface_registry;
@@ -194,7 +199,7 @@ private:
     Optional<u64> m_display_id;
     double m_display_refresh_rate { 60.0 };
 
-    Optional<Gfx::IntRect> m_pending_present_frame;
+    Optional<PendingFrame> m_pending_present_frame;
     bool m_pending_present_frame_scheduled { false };
     Optional<Gfx::IntRect> m_presented_frame;
     Optional<i32> m_gpu_present_bitmap_id_awaiting_completion;

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -178,6 +178,7 @@ private:
     Web::Painting::ScrollStateSnapshot m_scroll_state_snapshot;
     BackingStoreManager m_backing_store_manager;
     RefPtr<Gfx::PaintingSurface> m_latest_rendered_surface;
+    RefPtr<Gfx::PaintingSurface> m_damage_surface;
 
     Web::Compositor::AsyncScrollTree m_async_scroll_tree;
     ViewportScrollbarController m_viewport_scrollbar_controller;

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -183,11 +183,11 @@ void CompositorConnection::viewport_size_updated(Web::Compositor::CompositorCont
     async_viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
-void CompositorConnection::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
+void CompositorConnection::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
 {
     if (!can_send_message_to_compositor())
         return;
-    async_present_frame(context_id, viewport_rect);
+    async_present_frame(context_id, viewport_rect, damage_rect);
 }
 
 Optional<Web::Painting::CanvasId> CompositorConnection::create_webgl_context(Web::WebGL::WebGLVersion webgl_version, Gfx::IntSize size, bool depth, bool stencil, bool antialias, Vector<String>& out_supported_extensions)

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -163,19 +163,6 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorConnection::async_scroll_by(
     return response->take_result();
 }
 
-bool CompositorConnection::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id)
-{
-    if (!can_send_message_to_compositor())
-        return false;
-
-    auto response = send_sync_but_allow_failure<Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScroll>(context_id);
-    if (!response) {
-        did_lose_compositor();
-        return false;
-    }
-    return response->should_defer();
-}
-
 Web::Compositor::PendingAsyncScrollUpdates CompositorConnection::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
 {
     if (!can_send_message_to_compositor())

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -52,7 +52,6 @@ public:
     Gfx::ShareableBitmap get_canvas_pixels(Web::Painting::CanvasId, Gfx::IntRect);
     void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation);
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
-    bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
     void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect);

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -54,7 +54,7 @@ public:
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
-    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect);
+    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
     void request_screenshot(Web::Compositor::CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&&);
 
     Optional<Web::Painting::CanvasId> create_webgl_context(Web::WebGL::WebGLVersion, Gfx::IntSize, bool depth, bool stencil, bool antialias, Vector<String>& out_supported_extensions);

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -111,8 +111,7 @@ PageClient::PageClient(PageHost& owner, u64 id, Optional<Web::HTML::NavigableId>
     m_page->set_async_scrolling_enabled(s_async_scrolling_enabled);
     setup_palette();
 
-    m_frame_timer = Core::Timer::create_single_shot(0, [this] {
-        m_last_frame_dispatch_time = Web::HighResolutionTime::unsafe_shared_current_time();
+    m_frame_timer = Core::Timer::create_single_shot(0, [] {
         Web::HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
     });
 }
@@ -429,10 +428,14 @@ void PageClient::request_frame()
         return;
 
     auto delay = 0.0;
-    if (m_last_frame_dispatch_time.has_value()) {
-        auto now = Web::HighResolutionTime::unsafe_shared_current_time();
+    auto now = Web::HighResolutionTime::unsafe_shared_current_time();
+    if (m_last_scheduled_frame_dispatch_time.has_value()) {
         auto minimum_frame_interval = 1000.0 / m_maximum_frames_per_second;
-        delay = max(0.0, *m_last_frame_dispatch_time + minimum_frame_interval - now);
+        auto next_frame_dispatch_time = *m_last_scheduled_frame_dispatch_time + minimum_frame_interval;
+        m_last_scheduled_frame_dispatch_time = max(now, next_frame_dispatch_time);
+        delay = *m_last_scheduled_frame_dispatch_time - now;
+    } else {
+        m_last_scheduled_frame_dispatch_time = now;
     }
 
     m_frame_timer->restart(static_cast<int>(AK::ceil(delay)));

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -311,7 +311,7 @@ private:
     GC::Ptr<WebContentConsoleClient> m_top_level_document_console_client;
 
     RefPtr<Core::Timer> m_frame_timer;
-    Optional<double> m_last_frame_dispatch_time;
+    Optional<double> m_last_scheduled_frame_dispatch_time;
     Queue<PendingDOMMutation> m_pending_dom_mutations;
     HashMap<Web::HTML::NavigableId, Web::Compositor::CompositorContextId> m_remote_child_frame_compositor_contexts;
     Optional<Web::HTML::NavigableId> m_pending_root_navigable_id;

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -259,10 +259,10 @@ private:
             connection->viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
     }
 
-    virtual void present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) override
+    virtual void present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) override
     {
         if (auto* connection = compositor_connection())
-            connection->present_frame(context_id, viewport_rect);
+            connection->present_frame(context_id, viewport_rect, damage_rect);
     }
 
     virtual void request_screenshot(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback) override

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -246,13 +246,6 @@ private:
         return {};
     }
 
-    virtual bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) const override
-    {
-        if (auto* connection = compositor_connection())
-            return connection->should_defer_main_thread_present_for_async_scroll(context_id);
-        return false;
-    }
-
     virtual Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) override
     {
         if (auto* connection = compositor_connection())

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     TestCSSSyntaxParser.cpp
     TestCSSTokenizer.cpp
     TestCSSTokenStream.cpp
+    TestDisplayListDamage.cpp
     TestFetchResponse.cpp
     TestFetchURL.cpp
     TestHTMLTokenizer.cpp
@@ -34,6 +35,7 @@ ladybird_utility(css-tokenizer SOURCES css-tokenizer.cpp LIBS LibFileSystem LibM
 
 target_link_libraries(TestContentBlocker PRIVATE LibURL)
 target_link_libraries(TestControlMessageQueue PRIVATE LibSync)
+target_link_libraries(TestDisplayListDamage PRIVATE LibGfx)
 target_link_libraries(TestFetchResponse PRIVATE LibGC LibHTTP LibJS)
 target_link_libraries(TestFetchURL PRIVATE LibURL)
 target_link_libraries(TestAccumulatedVisualContext PRIVATE LibGfx)

--- a/Tests/LibWeb/TestDisplayListDamage.cpp
+++ b/Tests/LibWeb/TestDisplayListDamage.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteBuffer.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/Painting/DisplayListCommand.h>
+#include <LibWeb/Painting/DisplayListDamage.h>
+
+using namespace Web::Painting;
+
+template<DisplayListCommand Command>
+static ByteBuffer command_bytes(Command const& command, Optional<Gfx::IntRect> bounding_rect = {}, VisualContextIndex context_index = VISUAL_VIEWPORT_NODE_INDEX)
+{
+    auto payload = display_list_object_bytes(command);
+    auto record_size = sizeof(DisplayListCommandHeader) + payload.size();
+    constexpr size_t command_alignment = 16;
+    auto payload_size = align_up_to(record_size, command_alignment) - sizeof(DisplayListCommandHeader);
+    DisplayListCommandHeader header {
+        .type = Command::command_type,
+        .payload_size = static_cast<u32>(payload_size),
+        .context_index = context_index,
+        .has_bounding_rect = bounding_rect.has_value(),
+        .bounding_rect = bounding_rect.value_or({}),
+    };
+    ByteBuffer bytes;
+    bytes.append(display_list_object_bytes(header));
+    bytes.append(payload);
+    bytes.resize(sizeof(header) + payload_size, ByteBuffer::ZeroFillNewElements::Yes);
+    return bytes;
+}
+
+static ByteBuffer fill_command_bytes(Gfx::IntRect rect, Gfx::Color color)
+{
+    return command_bytes(FillRect { rect, color }, rect);
+}
+
+static ByteBuffer glyph_run_command_bytes(size_t inline_padding)
+{
+    DisplayListGlyph glyph { .position = { 1, 2 }, .glyph_id = 3 };
+    DrawGlyphRun command {
+        .font_id = FontResourceId { 1 },
+        .glyphs = { static_cast<u32>(sizeof(DrawGlyphRun) + inline_padding), static_cast<u32>(sizeof(glyph)) },
+        .rect = { 10, 10, 20, 20 },
+        .glyph_bounding_rect = { 10, 10, 20, 20 },
+        .translation = { 10, 10 },
+        .scale = 1,
+        .color = Gfx::Color::Red,
+        .orientation = Gfx::Orientation::Horizontal,
+    };
+    auto payload_size = align_up_to(sizeof(DisplayListCommandHeader) + sizeof(command) + inline_padding + sizeof(glyph), 16) - sizeof(DisplayListCommandHeader);
+    DisplayListCommandHeader header {
+        .type = DrawGlyphRun::command_type,
+        .payload_size = static_cast<u32>(payload_size),
+        .context_index = VISUAL_VIEWPORT_NODE_INDEX,
+        .has_bounding_rect = true,
+        .bounding_rect = command.glyph_bounding_rect,
+    };
+    ByteBuffer bytes;
+    bytes.append(display_list_object_bytes(header));
+    bytes.append(display_list_object_bytes(command));
+    bytes.resize(bytes.size() + inline_padding, ByteBuffer::ZeroFillNewElements::Yes);
+    bytes.append(display_list_object_bytes(glyph));
+    bytes.resize(sizeof(header) + payload_size, ByteBuffer::ZeroFillNewElements::Yes);
+    return bytes;
+}
+
+TEST_CASE(identical_display_lists_have_no_damage)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto display_list = fill_command_bytes({ 10, 10, 20, 20 }, Gfx::Color::Red);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(display_list, visual_context_tree, scroll_state, display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT(damage->is_empty());
+}
+
+TEST_CASE(inactive_optional_storage_does_not_damage_scaled_images)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    DrawScaledDecodedImageFrame command {
+        .dst_rect = { 0, 0, 100, 100 },
+        .src_rect = {},
+        .frame_id = ImageFrameResourceId { 1 },
+        .scaling_mode = Gfx::ScalingMode::Bilinear,
+        .compositing_and_blending_operator = Gfx::CompositingAndBlendingOperator::Normal,
+        .isolated_backdrop_color = {},
+    };
+    auto old_display_list = command_bytes(command, command.dst_rect);
+    auto new_display_list = MUST(ByteBuffer::copy(old_display_list));
+
+    // Optional<T> leaves its inactive T storage unspecified. Alter that storage
+    // without changing the empty src_rect value represented by the command.
+    new_display_list[sizeof(DisplayListCommandHeader) + sizeof(Gfx::IntRect)] ^= 0xff;
+
+    ScrollStateSnapshot scroll_state;
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT(damage->is_empty());
+}
+
+TEST_CASE(inline_payload_alignment_does_not_damage_glyph_runs)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto old_display_list = glyph_run_command_bytes(0);
+    auto new_display_list = glyph_run_command_bytes(4);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT(damage->is_empty());
+}
+
+TEST_CASE(damage_contains_old_and_new_command_bounds)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto old_display_list = fill_command_bytes({ 10, 10, 20, 20 }, Gfx::Color::Red);
+    auto new_display_list = fill_command_bytes({ 40, 40, 20, 20 }, Gfx::Color::Blue);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT_EQ(*damage, (Gfx::IntRect { 9, 9, 52, 52 }));
+}
+
+TEST_CASE(changed_unbounded_commands_require_full_repaint)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto old_display_list = command_bytes(Translate { { 1, 1 } });
+    auto new_display_list = command_bytes(Translate { { 2, 2 } });
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(!damage.has_value());
+}
+
+TEST_CASE(changed_compositor_metadata_has_no_raster_damage)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto old_display_list = command_bytes(CompositorMainThreadWheelEventRegion { { 0, 0, 10, 10 } });
+    auto new_display_list = command_bytes(CompositorMainThreadWheelEventRegion { { 20, 20, 10, 10 } });
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT(damage->is_empty());
+}
+
+TEST_CASE(changed_visual_context_damages_affected_commands)
+{
+    auto old_visual_context_tree = AccumulatedVisualContextTree::create();
+    auto transform = Gfx::FloatMatrix4x4::identity();
+    transform[0, 3] = 10;
+    auto new_visual_context_tree = AccumulatedVisualContextTree::create({ transform, {} });
+    auto display_list = fill_command_bytes({ 10, 10, 20, 20 }, Gfx::Color::Red);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(display_list, old_visual_context_tree, scroll_state, display_list, new_visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT_EQ(*damage, (Gfx::IntRect { 9, 9, 32, 22 }));
+}
+
+TEST_CASE(unrelated_inserted_visual_context_does_not_damage_commands)
+{
+    auto old_visual_context_tree = AccumulatedVisualContextTree::create();
+    auto old_command_context = old_visual_context_tree.append(TransformData { Gfx::FloatMatrix4x4::identity(), {} }, VISUAL_VIEWPORT_NODE_INDEX);
+
+    auto new_visual_context_tree = AccumulatedVisualContextTree::create();
+    new_visual_context_tree.append(EffectsData { .opacity = 0.5f, .blend_mode = Gfx::CompositingAndBlendingOperator::Normal, .gfx_filter = {} }, VISUAL_VIEWPORT_NODE_INDEX);
+    auto new_command_context = new_visual_context_tree.append(TransformData { Gfx::FloatMatrix4x4::identity(), {} }, VISUAL_VIEWPORT_NODE_INDEX);
+
+    auto old_display_list = command_bytes(FillRect { { 10, 10, 20, 20 }, Gfx::Color::Red }, Gfx::IntRect { 10, 10, 20, 20 }, old_command_context);
+    auto new_display_list = command_bytes(FillRect { { 10, 10, 20, 20 }, Gfx::Color::Red }, Gfx::IntRect { 10, 10, 20, 20 }, new_command_context);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, old_visual_context_tree, scroll_state, new_display_list, new_visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT(damage->is_empty());
+}
+
+TEST_CASE(inserted_and_removed_commands_do_not_damage_shifted_commands)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto first = fill_command_bytes({ 10, 10, 10, 10 }, Gfx::Color::Red);
+    auto second = fill_command_bytes({ 30, 10, 10, 10 }, Gfx::Color::Green);
+    auto third = fill_command_bytes({ 50, 10, 10, 10 }, Gfx::Color::Blue);
+    auto removed = fill_command_bytes({ 70, 10, 10, 10 }, Gfx::Color::Yellow);
+    auto inserted = fill_command_bytes({ 20, 40, 10, 10 }, Gfx::Color::Cyan);
+    ByteBuffer old_display_list;
+    old_display_list.append(first);
+    old_display_list.append(second);
+    old_display_list.append(third);
+    old_display_list.append(removed);
+    ByteBuffer new_display_list;
+    new_display_list.append(first);
+    new_display_list.append(inserted);
+    new_display_list.append(second);
+    new_display_list.append(third);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT_EQ(*damage, (Gfx::IntRect { 19, 9, 62, 42 }));
+}


### PR DESCRIPTION
Refactor the frame pipeline around explicit backing store ownership and frame damage. This prepares native presentation paths to update only the changed part of a frame while preserving the existing two-buffer depth.

The compositor now tracks each backing store as `Available`, `Rendering`, or `Presented`. The UI publishes and releases stores explicitly instead of relying on fixed front/back roles. Damage accumulates independently for each store, ensuring that a reused buffer receives every update it missed while another buffer was being displayed.

Compute conservative damage by comparing display-list commands and their visual-context ancestry. Inserted and removed command sequences are realigned so that unchanged commands do not cause the remainder of the
display list to be invalidated. Raster is clipped to the resulting damage, and partial frames use damage-sized GPU surfaces so that temporary Skia layers and effects are not allocated at the full viewport size. Focused tests cover command changes, unbounded operations, visual-context changes, insertions, removals, and non-rendering payload differences.

The remaining frame-pipeline changes support that model and reduce latency:

- Preserve fractional frame deadlines instead of rounding every 60 Hz interval up to 17 ms.
- Move the final asynchronous-scroll race check into the compositor, removing two synchronous IPC round trips around display-list recording.
- Keep frames scheduled when rendering is temporarily blocked by GPU work or backing store ownership.
- Propagate the presented frame's damage rectangle through `LibWebView` so native frontends can use it for partial presentation.

These changes already reduce compositor raster work for small updates, particularly in large and high-DPI viewports. They also establish the ownership, scheduling, and damage information needed by later native GPU presentation work without introducing platform-specific behavior here.