### PR TITLE
LibWeb: Lay out each box at most once per layout state

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1680,7 +1680,7 @@ void Document::set_needs_container_query_evaluation_after_layout(Element const& 
 
 static void relayout_svg_root(Layout::SVGSVGBox& svg_root)
 {
-    Layout::LayoutState layout_state(svg_root);
+    Layout::LayoutState layout_state(svg_root, Layout::LayoutState::Purpose::Commit);
 
     // Pre-populate the svg_root itself.
     if (auto paintable = svg_root.paintable_box())

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -691,7 +691,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
 
 CSSPixels FormattingContext::measure_automatic_content_height(Box const& box, AvailableSpace const& inner_available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
-    LayoutState throwaway_state(box);
+    LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
     throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
     auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
     measuring_context->run(LayoutInput { inner_available_space, containing_block_constraints });
@@ -775,7 +775,7 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     });
     VERIFY(table_box.has_value());
 
-    LayoutState throwaway_state(box);
+    LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     // The table wrapper is invisible to percentage resolution, so the table box gets the
     // wrapper's constraints unchanged. Callers measuring a table wrapper for grid alignment
@@ -820,7 +820,7 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
     // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
     auto available_height = height_of_containing_block - margin_top - margin_bottom;
 
-    LayoutState throwaway_state(box);
+    LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
     throwaway_state.create(box, table_wrapper_constraints.percentage_basis_width, table_wrapper_constraints.percentage_basis_height);
 
     auto context = create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
@@ -2198,6 +2198,8 @@ void FormattingContext::layout_absolutely_positioned_children(Box const& box)
 {
     if (m_layout_mode != LayoutMode::Normal)
         return;
+    if (m_state.is_for_measurement())
+        return;
     // Laying out one child can register further children onto this box (a fixed position
     // box inside an absolutely positioned one shares its viewport containing block), so
     // take one at a time instead of iterating a snapshot.
@@ -2594,7 +2596,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box,
     if (cache.has_value())
         return cache.value();
 
-    LayoutState throwaway_state(box);
+    LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
     box_state.width_constraint = SizeConstraint::MinContent;
@@ -2682,7 +2684,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
     if (cache.has_value())
         return cache.value();
 
-    LayoutState throwaway_state(box);
+    LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     auto const& actual_box_state = m_state.get(box);
 
@@ -2732,7 +2734,7 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     if (cache.has_value())
         return cache.value();
 
-    LayoutState throwaway_state(box);
+    LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
     box_state.height_constraint = SizeConstraint::MinContent;
@@ -2767,7 +2769,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
     if (cache_slot.has_value())
         return cache_slot.value();
 
-    LayoutState throwaway_state(box);
+    LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
     box_state.height_constraint = SizeConstraint::MaxContent;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -113,15 +113,6 @@ LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node, Optional
     return used_values;
 }
 
-void LayoutState::discard_used_values_for_descendants(Box const& root)
-{
-    root.for_each_in_subtree([&](auto const& descendant) {
-        if (auto const* node_with_style = as_if<NodeWithStyle>(descendant))
-            m_used_values_store.remove(node_with_style->layout_index());
-        return TraversalDecision::Continue;
-    });
-}
-
 LayoutState::UsedValues& LayoutState::populate_from_paintable(NodeWithStyle const& node, Painting::Paintable const& paintable)
 {
     VERIFY(m_subtree_root);
@@ -1191,10 +1182,9 @@ void LayoutState::UsedValues::set_indefinite_content_height()
 void LayoutState::register_contained_abspos_child(Box const& target, Box const& child, StaticPositionRect const& static_position_rect)
 {
     auto& children = m_contained_abspos_children.ensure(&target);
-    // The same box can be encountered again when a subtree is intentionally laid out
-    // twice (percentage-height table cells); the fresh static position replaces the
-    // stale one instead of duplicating the entry. New entries are inserted in layout
-    // index order so consumption follows document order.
+    // If the same box is registered again, the fresh static position replaces the stale
+    // one instead of duplicating the entry. New entries are inserted in layout index
+    // order so consumption follows document order.
     size_t insertion_index = children.size();
     for (size_t i = 0; i < children.size(); ++i) {
         if (children[i].box == &child) {

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -1182,15 +1182,11 @@ void LayoutState::UsedValues::set_indefinite_content_height()
 void LayoutState::register_contained_abspos_child(Box const& target, Box const& child, StaticPositionRect const& static_position_rect)
 {
     auto& children = m_contained_abspos_children.ensure(&target);
-    // If the same box is registered again, the fresh static position replaces the stale
-    // one instead of duplicating the entry. New entries are inserted in layout index
-    // order so consumption follows document order.
+    // Entries are inserted in layout index order so consumption follows document order.
     size_t insertion_index = children.size();
     for (size_t i = 0; i < children.size(); ++i) {
-        if (children[i].box == &child) {
-            children[i].static_position_rect = static_position_rect;
-            return;
-        }
+        // Every box is laid out at most once per state, so it can only be registered once.
+        VERIFY(children[i].box != &child);
         if (insertion_index == children.size() && child.layout_index() < children[i].box->layout_index())
             insertion_index = i;
     }

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -27,8 +27,9 @@
 
 namespace Web::Layout {
 
-LayoutState::LayoutState(NodeWithStyle const& subtree_root)
+LayoutState::LayoutState(NodeWithStyle const& subtree_root, Purpose purpose)
     : m_subtree_root(&subtree_root)
+    , m_purpose(purpose)
 {
 }
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -98,18 +98,6 @@ public:
         return page->entries[index & PageMask];
     }
 
-    void remove(u32 index)
-    {
-        auto page_index = index >> PageBits;
-        if (page_index >= m_pages.size())
-            return;
-        auto& page = m_pages[page_index];
-        if (!page)
-            return;
-        // NB: The entry is only unlinked here; its destructor runs when the allocator is destroyed.
-        page->entries[index & PageMask] = nullptr;
-    }
-
     T& allocate(u32 index)
     {
         auto page_index = index >> PageBits;
@@ -119,10 +107,7 @@ public:
         if (!page)
             page = make<Page>();
         auto& entry = page->entries[index & PageMask];
-        if (entry) {
-            *entry = T {};
-            return *entry;
-        }
+        VERIFY(!entry);
         entry = m_allocator.allocate();
         VERIFY(entry);
         return *entry;
@@ -410,10 +395,6 @@ struct LayoutState {
     UsedValues const& get(NodeWithStyle const&) const;
 
     UsedValues& create(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height);
-
-    // Discards used values created for the descendants of `root` by an earlier layout pass, so an
-    // intentional second layout of the subtree can create them anew.
-    void discard_used_values_for_descendants(Box const& root);
 
     UsedValues& populate_from_paintable(NodeWithStyle const&, Painting::Paintable const&);
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -387,9 +387,16 @@ struct LayoutState {
         OwnPtr<RareData> m_rare;
     };
 
+    enum class Purpose : u8 {
+        Commit,      // Results will be committed (full layout, or a partial relayout of a subtree).
+        Measurement, // Throwaway state; only scalar measurements are read back, nothing is committed.
+    };
+
     LayoutState() = default;
-    explicit LayoutState(NodeWithStyle const& subtree_root);
+    LayoutState(NodeWithStyle const& subtree_root, Purpose);
     ~LayoutState();
+
+    bool is_for_measurement() const { return m_purpose == Purpose::Measurement; }
 
     // Commits the used values produced by layout and builds a paintable tree.
     void commit(Box& root);
@@ -432,6 +439,7 @@ private:
 
     PagedStore<UsedValues> m_used_values_store;
     Layout::NodeWithStyle const* m_subtree_root { nullptr };
+    Purpose m_purpose { Purpose::Commit };
     bool m_should_collect_devtools_layout_data { false };
     HashMap<Box const*, Vector<ContainedAbsposChild>> m_contained_abspos_children;
 };

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -978,6 +978,41 @@ bool TableFormattingContext::can_skip_row_intrinsic_measurement() const
     return true;
 }
 
+static bool cell_height_depends_on_table_height(Box const& cell_box)
+{
+    return cell_box.computed_values().height().is_percentage();
+}
+
+Optional<TableFormattingContext::MeasuredCellContent> TableFormattingContext::measure_cell_content(Box const& cell_box, LayoutState::UsedValues const& cell_used_values, AvailableSpace const& inner_available_space)
+{
+    if (m_layout_mode == LayoutMode::IntrinsicSizing
+        && !cell_box.is_inline()
+        && cell_used_values.width_constraint == SizeConstraint::None
+        && cell_used_values.height_constraint == SizeConstraint::None
+        && cell_used_values.has_definite_width()
+        && cell_used_values.has_definite_height()) {
+        return {};
+    }
+    if (!cell_box.can_have_children())
+        return {};
+
+    LayoutState throwaway_state(cell_box, LayoutState::Purpose::Measurement);
+    auto& throwaway_cell_used_values = throwaway_state.create(cell_box, {}, {});
+    throwaway_cell_used_values = cell_used_values;
+
+    auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, cell_box);
+    if (!measuring_context)
+        return {};
+    measuring_context->run(LayoutInput { inner_available_space });
+
+    auto content_height = measuring_context->automatic_content_height();
+    throwaway_cell_used_values.set_content_height(content_height);
+    return MeasuredCellContent {
+        .content_height = content_height,
+        .first_baseline = measuring_context->box_baseline(cell_box, BaselineSet::First),
+    };
+}
+
 void TableFormattingContext::compute_table_height()
 {
     // First pass of row height calculation:
@@ -1034,7 +1069,15 @@ void TableFormattingContext::compute_table_height()
         // - the horizontal/vertical border-spacing times the amount of spanned visible columns/rows minus one
         // FIXME: Account for visibility.
         cell_state.set_content_width(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
-        if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
+        Optional<CSSPixels> measured_baseline;
+        if (cell_height_depends_on_table_height(cell.box)) {
+            // This cell's final inside layout happens in the second pass below; measure its
+            // content in a throwaway state instead of laying out the committing state twice.
+            if (auto measured = measure_cell_content(cell.box, cell_state, cell_state.available_inner_space_or_constraints_from(*m_available_space)); measured.has_value()) {
+                cell_state.set_content_height(measured->content_height);
+                measured_baseline = measured->first_baseline;
+            }
+        } else if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
             cell_state.set_content_height(independent_formatting_context->automatic_content_height());
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         }
@@ -1050,7 +1093,7 @@ void TableFormattingContext::compute_table_height()
         // https://drafts.csswg.org/css2/#height-layout
         // The baseline of a cell is the baseline of the first in-flow line box in the cell, or the first in-flow
         // table-row in the cell, whichever comes first.
-        cell.baseline = box_baseline(cell.box, BaselineSet::First);
+        cell.baseline = measured_baseline.value_or_lazy_evaluated([&] { return box_baseline(cell.box, BaselineSet::First); });
 
         // Implements https://www.w3.org/TR/css-tables-3/#computing-the-table-height
 
@@ -1136,21 +1179,18 @@ void TableFormattingContext::compute_table_height()
         for (size_t i = 0; i < cell.column_span; ++i)
             span_width += m_columns[cell.column_index + i].used_width;
 
-        auto cell_computed_height = cell.box.computed_values().height();
-        if (cell_computed_height.is_percentage()) {
-            auto cell_used_height = cell_computed_height.to_px(m_table_height);
-            cell_state.set_content_height(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
-
-            if (!row.is_collapsed)
-                row.reference_height = max(row.reference_height, cell_used_height);
-        } else {
+        if (!cell_height_depends_on_table_height(cell.box))
             continue;
-        }
+
+        auto cell_used_height = cell.box.computed_values().height().to_px(m_table_height);
+        cell_state.set_content_height(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
+
+        if (!row.is_collapsed)
+            row.reference_height = max(row.reference_height, cell_used_height);
 
         cell_state.set_content_width(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
-        // This is the second inside layout of this cell in the same layout state: its descendants
-        // already have used values from the first pass, so discard them before creating them anew.
-        m_state.discard_used_values_for_descendants(cell.box);
+        // The first pass only measured this cell in a throwaway state; this is its one and
+        // only inside layout in the committing state.
         if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         }

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -43,6 +43,12 @@ public:
     virtual void parent_context_did_dimension_child_root_box() override;
 
 private:
+    struct MeasuredCellContent {
+        CSSPixels content_height;
+        CSSPixels first_baseline;
+    };
+    Optional<MeasuredCellContent> measure_cell_content(Box const&, LayoutState::UsedValues const&, AvailableSpace const& inner_available_space);
+
     CSSPixels run_caption_layout(CSS::CaptionSide, AvailableSpace const&);
     CSSPixels compute_capmin();
     void compute_constrainedness();

--- a/Tests/LibWeb/Crash/Layout/anchor-position-inside-height-measurement.html
+++ b/Tests/LibWeb/Crash/Layout/anchor-position-inside-height-measurement.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<!-- The outer box has auto height and a min-height, so laying it out first measures its
+     automatic content height in a throwaway LayoutState. Abspos children used to be laid
+     out inside that measurement, and resolving the anchor() inset walked the containing
+     block chain past the measurement root, reading state for boxes that don't exist in
+     the throwaway state. -->
+<div style="overflow: hidden; min-height: 10px; position: relative;">
+    <div style="anchor-name: --a; width: 20px; height: 20px;"></div>
+    <div style="position: absolute; left: anchor(--a right); top: 0;">abs</div>
+</div>
+<script>
+    document.body.offsetHeight;
+</script>


### PR DESCRIPTION
- Skip abspos layout in measurement states — out-of-flow boxes can't affect
  measured metrics
- Run the first (measuring) layout of percentage-height table cells in a throwaway
  state, making the second pass the only one in the committing state. This removes
  the discard_used_values_for_descendants() API and PagedStore::remove().
- Turn the now-dead double-registration tolerance for abspos children into a VERIFY.