### PR TITLE
LibWeb: Clear stale navigation IDs left by non-continued navigations

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -2573,8 +2573,19 @@ void LocalNavigable::begin_navigation(NavigateParams params)
         auto continue_ = navigation->fire_a_push_replace_reload_navigate_event(navigation_type, url, false, user_involvement, source_element, entry_list_for_firing, navigation_api_state_for_firing);
 
         // 5. If continue is false, then return.
-        if (!continue_)
+        if (!continue_) {
+            // AD-HOC: This navigation is over: the navigate event either canceled it, or intercepted it and already
+            //         committed it as a same-document navigation. In the spec, an intercepted navigation's queued
+            //         same-document finalize sets the navigable's ongoing navigation to null moments later; our
+            //         synchronous same-document commit replaces that queued step but deliberately preserves foreign
+            //         navigation IDs, so clear our own ID here. Leaving it stamped makes later same-document
+            //         traversals treat themselves as superseded and lets WebDriver wait forever for this navigation
+            //         to finish. Preserve the Navigation API state: an intercepted navigate event stays ongoing
+            //         until its handlers settle.
+            if (ongoing_navigation() == navigation_id)
+                set_ongoing_navigation(Empty {}, NavigationAPIAbortBehavior::Preserve);
             return;
+        }
     }
 
     // FIXME: 22. If sourceDocument is navigable's container document, then reserve deferred fetch quota for navigable's container given url's origin.

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -799,6 +799,10 @@ void Navigation::abort_a_navigate_event(GC::Ref<NavigateEvent> event, GC::Ref<We
     // 1. Let navigation be event's relevant global object's navigation API.
     // NB: Navigation is `this`.
 
+    // AD-HOC: Aborting can be triggered from session history traversal tasks with no JavaScript on the stack, and
+    //         both the abort signal and the promise rejections below run script.
+    TemporaryExecutionContext execution_context { relevant_realm(*this), TemporaryExecutionContext::CallbacksEnabled::Yes };
+
     // 2. Signal abort on event's abort controller given reason.
     event->abort_controller()->abort(reason);
 

--- a/Tests/LibWeb/Text/expected/navigation/canceled-push-then-intercepted-traverse.txt
+++ b/Tests/LibWeb/Text/expected/navigation/canceled-push-then-intercepted-traverse.txt
@@ -1,0 +1,4 @@
+navigate push destination=?canceled cancelable=true
+navigate traverse destination=?start
+traverse handler
+final location=?start index=0

--- a/Tests/LibWeb/Text/expected/navigation/intercepted-push-then-intercepted-traverse.txt
+++ b/Tests/LibWeb/Text/expected/navigation/intercepted-push-then-intercepted-traverse.txt
@@ -1,0 +1,9 @@
+navigate push destination=?pushed canIntercept=true
+currententrychange push to=?pushed
+push handler
+navigatesuccess at ?pushed
+navigate traverse destination=?start canIntercept=true
+currententrychange traverse to=?start
+traverse handler
+navigatesuccess at ?start
+final location=?start index=0

--- a/Tests/LibWeb/Text/expected/navigation/traverse-aborts-pending-intercepted-push.txt
+++ b/Tests/LibWeb/Text/expected/navigation/traverse-aborts-pending-intercepted-push.txt
@@ -1,0 +1,6 @@
+navigate push destination=?pushed
+push handler started
+navigateerror at ?pushed
+navigate traverse destination=?start
+traverse handler
+final location=?start index=0

--- a/Tests/LibWeb/Text/input/navigation/canceled-push-then-intercepted-traverse.html
+++ b/Tests/LibWeb/Text/input/navigation/canceled-push-then-intercepted-traverse.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Regression test: a real navigation canceled by the navigate event (preventDefault) used to leave
+    // its navigation ID stamped as the navigable's ongoing navigation forever, which made later
+    // same-document traversals treat themselves as superseded and never commit.
+    asyncTest(done => {
+        const events = [];
+        let finished = false;
+
+        function queryFromURL(url) {
+            return new URL(url).search || "(none)";
+        }
+
+        function maybeDone() {
+            if (finished)
+                return;
+            if (!events.includes("traverse handler"))
+                return;
+            if (queryFromURL(location.href) !== "?start" || navigation.currentEntry.index !== 0)
+                return;
+
+            finished = true;
+            for (const event of events)
+                println(event);
+            println(`final location=${queryFromURL(location.href)} index=${navigation.currentEntry.index}`);
+            done();
+        }
+
+        navigation.addEventListener("navigate", event => {
+            if (event.navigationType === "push" && !event.destination.sameDocument) {
+                events.push(`navigate push destination=${queryFromURL(event.destination.url)} cancelable=${event.cancelable}`);
+                event.preventDefault();
+                return;
+            }
+
+            if (event.navigationType === "traverse") {
+                events.push(`navigate traverse destination=${queryFromURL(event.destination.url)}`);
+                event.intercept({
+                    handler() {
+                        events.push("traverse handler");
+                    },
+                });
+            }
+        });
+
+        navigation.addEventListener("navigatesuccess", () => {
+            maybeDone();
+        });
+
+        const nextTask = () => new Promise(resolve => setTimeout(resolve, 0));
+
+        // NB: Wait until the document is completely loaded so that the location.href navigation gets
+        //     push (not replace) semantics. The task hops let each navigation settle before the next
+        //     one starts.
+        window.addEventListener("load", async () => {
+            await nextTask();
+            history.replaceState({}, "", "?start");
+            history.pushState({}, "", "?pushed");
+            await nextTask();
+
+            // A real navigation that stamps the navigable's ongoing navigation; the navigate
+            // listener cancels it.
+            location.href = "?canceled";
+            await nextTask();
+
+            // The canceled navigation must not block this same-document traversal.
+            history.back();
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/canceled-push-then-intercepted-traverse.html.headers
+++ b/Tests/LibWeb/Text/input/navigation/canceled-push-then-intercepted-traverse.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/Tests/LibWeb/Text/input/navigation/intercepted-push-then-intercepted-traverse.html
+++ b/Tests/LibWeb/Text/input/navigation/intercepted-push-then-intercepted-traverse.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Regression test: an entry created by an intercepted push (via a real navigation, not pushState)
+    // must still be traversable. The intercepted push used to leave its navigation ID stamped as the
+    // navigable's ongoing navigation forever, which made the later intercepted traverse treat itself
+    // as superseded: history.back() moved the session history step without ever committing, so the
+    // URL, navigation.currentEntry, and the intercept handler never updated or ran.
+    asyncTest(done => {
+        const events = [];
+        let finished = false;
+
+        function queryFromURL(url) {
+            return new URL(url).search || "(none)";
+        }
+
+        function finish() {
+            if (finished)
+                return;
+
+            finished = true;
+            for (const event of events)
+                println(event);
+            println(`final location=${queryFromURL(location.href)} index=${navigation.currentEntry.index}`);
+            done();
+        }
+
+        navigation.addEventListener("navigate", event => {
+            if (event.navigationType !== "push" && event.navigationType !== "traverse")
+                return;
+
+            events.push(`navigate ${event.navigationType} destination=${queryFromURL(event.destination.url)} canIntercept=${event.canIntercept}`);
+            if (!event.canIntercept) {
+                events.push("FAIL: cannot intercept");
+                finish();
+                return;
+            }
+
+            event.intercept({
+                handler() {
+                    events.push(`${event.navigationType} handler`);
+                },
+            });
+        });
+
+        navigation.addEventListener("currententrychange", event => {
+            if (event.navigationType !== "push" && event.navigationType !== "traverse")
+                return;
+            events.push(`currententrychange ${event.navigationType} to=${queryFromURL(navigation.currentEntry.url)}`);
+        });
+
+        navigation.addEventListener("navigatesuccess", () => {
+            events.push(`navigatesuccess at ${queryFromURL(location.href)}`);
+
+            if (queryFromURL(location.href) === "?pushed") {
+                // The intercepted push has fully finished; now traverse back to the original entry.
+                history.back();
+                return;
+            }
+
+            finish();
+        });
+
+        // NB: Wait until the document is completely loaded so that the location.href navigation gets
+        //     push (not replace) semantics.
+        window.addEventListener("load", () => {
+            setTimeout(() => {
+                history.replaceState({}, "", "?start");
+
+                // A real navigation (unlike pushState) stamps the navigable's ongoing navigation before
+                // firing the navigate event.
+                location.href = "?pushed";
+            }, 0);
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/intercepted-push-then-intercepted-traverse.html.headers
+++ b/Tests/LibWeb/Text/input/navigation/intercepted-push-then-intercepted-traverse.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/Tests/LibWeb/Text/input/navigation/traverse-aborts-pending-intercepted-push.html
+++ b/Tests/LibWeb/Text/input/navigation/traverse-aborts-pending-intercepted-push.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Regression test: a traversal that starts while an intercepted navigation's handler is still
+    // pending aborts that navigation from a session history traversal task, with no JavaScript on
+    // the stack. This used to crash WebContent inside abort_a_navigate_event because rejecting the
+    // pending promises ran script without an execution context.
+    asyncTest(done => {
+        const events = [];
+        let finished = false;
+
+        function queryFromURL(url) {
+            return new URL(url).search || "(none)";
+        }
+
+        function maybeDone() {
+            if (finished)
+                return;
+            if (!events.includes("traverse handler") || !events.includes("navigateerror at ?pushed"))
+                return;
+            if (queryFromURL(location.href) !== "?start" || navigation.currentEntry.index !== 0)
+                return;
+
+            finished = true;
+            for (const event of events)
+                println(event);
+            println(`final location=${queryFromURL(location.href)} index=${navigation.currentEntry.index}`);
+            done();
+        }
+
+        navigation.addEventListener("navigate", event => {
+            if (event.navigationType !== "push" && event.navigationType !== "traverse")
+                return;
+
+            events.push(`navigate ${event.navigationType} destination=${queryFromURL(event.destination.url)}`);
+
+            if (event.navigationType === "push") {
+                // A handler that never settles keeps the navigate event ongoing.
+                event.intercept({
+                    handler() {
+                        events.push("push handler started");
+                        return new Promise(() => {});
+                    },
+                });
+                return;
+            }
+
+            event.intercept({
+                handler() {
+                    events.push("traverse handler");
+                },
+            });
+        });
+
+        navigation.addEventListener("navigateerror", () => {
+            events.push(`navigateerror at ${queryFromURL(location.href)}`);
+        });
+
+        navigation.addEventListener("navigatesuccess", () => {
+            maybeDone();
+        });
+
+        const nextTask = () => new Promise(resolve => setTimeout(resolve, 0));
+
+        // NB: Wait until the document is completely loaded so that the location.href navigation gets
+        //     push (not replace) semantics. The task hops let each navigation settle before the next
+        //     one starts.
+        window.addEventListener("load", async () => {
+            await nextTask();
+            history.replaceState({}, "", "?start");
+            await nextTask();
+
+            // The intercepted push commits immediately, but its handler never settles.
+            location.href = "?pushed";
+            await nextTask();
+
+            // Traversing back aborts the pending intercepted push, then commits normally.
+            history.back();
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/traverse-aborts-pending-intercepted-push.html.headers
+++ b/Tests/LibWeb/Text/input/navigation/traverse-aborts-pending-intercepted-push.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html


### PR DESCRIPTION
When the navigate event canceled a navigation or intercepted it into a same-document navigation, navigate() returned with the navigation ID still stamped as the navigable ongoing navigation, and nothing ever cleared it. The spec clears it in the queued same-document finalize, but our synchronous same-document commit path deliberately preserves navigation IDs it does not own, so the dead ID lingered forever.

Later same-document traversals then hit the stale-traversal guard in apply the history step and treated themselves as superseded: on reddit, going back from an SPA-navigated page moved the session history step without committing anything, leaving the page, URL, and Navigation API state stuck, and WebDriver waited forever for the dead navigation when clicking links. Firing another traverse navigate event from that state aborted the never-finished intercepted event from a traversal task with no JavaScript on the stack and crashed WebContent, so give abort_a_navigate_event an execution context as well.

The three new tests cover the intercepted push, canceled push, and pending-handler abort cases; the first two used to time out and the third crashed WebContent. Chromium and Firefox agree on the fixed behavior end to end.