### PR TITLE
LibWeb: Lay out markers for inline list items

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -33,13 +33,6 @@
 
 namespace Web::Layout {
 
-static CSSPixels distance_between_marker_and_list_item(ListItemMarkerBox const& marker)
-{
-    if (marker.text().has_value())
-        return 0;
-    return CSSPixels::nearest_value_for(.5f * marker.first_available_font().pixel_size());
-}
-
 BlockFormattingContext::BlockFormattingContext(LayoutState& state, LayoutMode layout_mode, BlockContainer const& root, FormattingContext* parent)
     : FormattingContext(Type::Block, layout_mode, state, root, parent)
 {
@@ -1162,7 +1155,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     }
 
     if (is_list_item_box_without_css_content && list_item_box->marker()) {
-        ensure_sizes_correct_for_left_offset_calculation(*list_item_box);
+        dimension_list_item_marker(*list_item_box->marker());
 
         auto const& marker = *list_item_box->marker();
         if (marker.list_style_position() == CSS::ListStylePosition::Inside
@@ -1616,36 +1609,6 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
-}
-
-void BlockFormattingContext::ensure_sizes_correct_for_left_offset_calculation(ListItemBox const& list_item_box)
-{
-    if (!list_item_box.marker())
-        return;
-
-    auto& marker = *list_item_box.marker();
-    auto& marker_state = m_state.get_mutable(marker);
-
-    // If an image is used, the marker's dimensions are the same as the image.
-    if (auto const* list_style_image = marker.list_style_image()) {
-        marker_state.set_content_width(list_style_image->natural_width(marker.document()).value_or(0));
-        marker_state.set_content_height(list_style_image->natural_height(marker.document()).value_or(0));
-        return;
-    }
-
-    CSSPixels marker_size = marker.relative_size();
-    marker_state.set_content_height(marker_size);
-
-    // Text markers use text metrics to determine their width; other markers use square dimensions.
-    auto const& marker_font = marker.first_available_font();
-    auto marker_text = marker.text();
-    if (marker_text.has_value()) {
-        // FIXME: Use per-code-point fonts to measure text.
-        auto text_width = marker_font.width(Utf16String::from_utf8(marker_text.value()));
-        marker_state.set_content_width(CSSPixels::nearest_value_for(text_width));
-    } else {
-        marker_state.set_content_width(marker_size);
-    }
 }
 
 void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_item_box, SpaceUsedByFloats const& inline_space_used_before_list_item_elements_formatted)

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -128,7 +128,6 @@ private:
 
     [[nodiscard]] CSSPixels border_box_left_of_box_avoiding_floats(Box const&, LayoutState::UsedValues const&, SpaceUsedByFloats const&) const;
 
-    void ensure_sizes_correct_for_left_offset_calculation(ListItemBox const&);
     void layout_list_item_marker(ListItemBox const&, SpaceUsedByFloats const& inline_space_used_before_list_item_elements_formatted);
 
     void measure_scrollable_overflow(Box const&, CSSPixels& bottom_edge, CSSPixels& right_edge) const;

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/Layout/FormattingContext.h>
 #include <LibWeb/Layout/GridFormattingContext.h>
 #include <LibWeb/Layout/InlineNode.h>
+#include <LibWeb/Layout/ListItemMarkerBox.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Layout/ReplacedWithChildrenFormattingContext.h>
 #include <LibWeb/Layout/SVGFormattingContext.h>
@@ -217,6 +218,36 @@ FormattingContext::~FormattingContext() = default;
 void FormattingContext::place_child(Box const& child, CSSPixelPoint content_offset)
 {
     m_state.get_mutable(child).place(content_offset);
+}
+
+void FormattingContext::dimension_list_item_marker(ListItemMarkerBox const& marker)
+{
+    auto& marker_state = m_state.get_mutable(marker);
+
+    if (auto const* list_style_image = marker.list_style_image()) {
+        marker_state.set_content_width(list_style_image->natural_width(marker.document()).value_or(0));
+        marker_state.set_content_height(list_style_image->natural_height(marker.document()).value_or(0));
+        return;
+    }
+
+    auto marker_size = marker.relative_size();
+    marker_state.set_content_height(marker_size);
+
+    auto const& marker_font = marker.first_available_font();
+    if (auto marker_text = marker.text(); marker_text.has_value()) {
+        // FIXME: Use per-code-point fonts to measure text.
+        auto text_width = marker_font.width(Utf16String::from_utf8(marker_text.value()));
+        marker_state.set_content_width(CSSPixels::nearest_value_for(text_width));
+    } else {
+        marker_state.set_content_width(marker_size);
+    }
+}
+
+CSSPixels FormattingContext::distance_between_marker_and_list_item(ListItemMarkerBox const& marker)
+{
+    if (marker.text().has_value())
+        return 0;
+    return CSSPixels::nearest_value_for(.5f * marker.first_available_font().pixel_size());
 }
 
 bool FormattingContext::computed_height_establishes_definite_containing_block_height(CSS::Size const& computed_height)

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -192,6 +192,9 @@ public:
 protected:
     FormattingContext(Type, LayoutMode, LayoutState&, Box const&, FormattingContext* parent = nullptr);
 
+    void dimension_list_item_marker(ListItemMarkerBox const&);
+    [[nodiscard]] static CSSPixels distance_between_marker_and_list_item(ListItemMarkerBox const&);
+
     [[nodiscard]] static bool computed_height_establishes_definite_containing_block_height(CSS::Size const&);
     [[nodiscard]] Optional<CSSPixels> calculate_transferred_width_for_replaced_element(Layout::Box const&, ContainingBlockConstraints const&) const;
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -123,6 +123,16 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     box_state.border_bottom = computed_values.border_bottom().width;
     box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(width_of_containing_block);
 
+    if (auto const* marker = as_if<ListItemMarkerBox>(box)) {
+        dimension_list_item_marker(*marker);
+        auto marker_distance = distance_between_marker_and_list_item(*marker);
+        if (computed_values.direction() == CSS::Direction::Ltr)
+            box_state.margin_right += marker_distance;
+        else
+            box_state.margin_left += marker_distance;
+        return;
+    }
+
     auto const& box_constraints = m_layout_input->containing_block_constraints;
     if (box_is_sized_as_replaced_element(box, *m_available_space, box_constraints)) {
         box_state.set_content_width(compute_width_for_replaced_element(box, *m_available_space, box_constraints));

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -406,9 +406,17 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         };
     }
 
-    if (is<Layout::ListItemMarkerBox>(*m_current_node)) {
+    if (m_current_node->is_fragmented_inline()) {
         skip_to_next();
         return generate_next_item();
+    }
+
+    if (is<Layout::ListItemMarkerBox>(*m_current_node)) {
+        auto const* list_item = as_if<ListItemBox>(m_current_node->parent());
+        if (!list_item || !list_item->is_fragmented_inline()) {
+            skip_to_next();
+            return generate_next_item();
+        }
     }
 
     if (!is<Layout::Box>(*m_current_node)) {
@@ -426,7 +434,8 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
     }
 
     auto const& box_state = [&]() -> LayoutState::UsedValues const& {
-        if (!m_box_model_node_stack.is_empty() && m_box_model_node_stack.last() == &box)
+        if (is<ListItemMarkerBox>(box)
+            || (!m_box_model_node_stack.is_empty() && m_box_model_node_stack.last() == &box))
             return m_layout_state.get_mutable(box);
         return m_layout_state.create(box, m_layout_input.containing_block_constraints.percentage_basis_width, m_layout_input.containing_block_constraints.percentage_basis_height);
     }();

--- a/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -10,7 +10,6 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/InlineNode.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
 
 namespace Web::Layout {
 
@@ -20,18 +19,5 @@ InlineNode::InlineNode(DOM::Document& document, DOM::Element* element, CSS::Comp
 }
 
 InlineNode::~InlineNode() = default;
-
-NonnullRefPtr<Painting::PaintableWithLines> InlineNode::create_paintable_for_line_with_index(size_t line_index) const
-{
-    for (auto const& paintable : paintables()) {
-        if (is<Painting::PaintableWithLines>(*paintable)) {
-            auto const& paintable_with_lines = static_cast<Painting::PaintableWithLines const&>(*paintable);
-            if (paintable_with_lines.line_index() == line_index) {
-                return const_cast<Painting::PaintableWithLines&>(paintable_with_lines);
-            }
-        }
-    }
-    return Painting::PaintableWithLines::create(*this, line_index);
-}
 
 }

--- a/Libraries/LibWeb/Layout/InlineNode.h
+++ b/Libraries/LibWeb/Layout/InlineNode.h
@@ -17,8 +17,6 @@ public:
     InlineNode(DOM::Document&, DOM::Element*, CSS::ComputedProperties const&);
     virtual ~InlineNode() override;
 
-    NonnullRefPtr<Painting::PaintableWithLines> create_paintable_for_line_with_index(size_t line_index) const;
-
 private:
     virtual bool is_inline_node() const override { return true; }
 };

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -430,7 +430,7 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
 
 struct InlineAncestorChainRelativeOffset {
     CSSPixelPoint offset;
-    bool found_inline_node { false };
+    bool found_fragmented_inline_node { false };
 };
 
 // Accumulates relative position insets from a chain of inline-flow ancestors, starting at first_ancestor
@@ -443,7 +443,7 @@ static InlineAncestorChainRelativeOffset accumulated_relative_insets_from_inline
             break;
         if (!ancestor->display().is_inline_outside() || !ancestor->display().is_flow_inside())
             break;
-        result.found_inline_node |= is<Layout::InlineNode>(*ancestor);
+        result.found_fragmented_inline_node |= ancestor->is_fragmented_inline();
         if (ancestor->computed_values().position() == CSS::Positioning::Relative) {
             VERIFY(ancestor->first_paintable());
             auto const& ancestor_paintable_box = *ancestor->first_paintable();
@@ -465,7 +465,7 @@ void LayoutState::resolve_relative_positions()
 
         if (auto const* box = as_if<Box>(node); box && box->is_in_flow() && box->display().is_block_outside()) {
             auto accumulated = accumulated_relative_insets_from_inline_ancestor_chain(box->parent(), box->containing_block());
-            if (accumulated.found_inline_node) {
+            if (accumulated.found_fragmented_inline_node) {
                 for (auto& paintable : node.paintables()) {
                     auto& paintable_box = *paintable;
                     paintable_box.set_offset(paintable_box.offset().translated(accumulated.offset));
@@ -475,7 +475,7 @@ void LayoutState::resolve_relative_positions()
 
         for (auto& paintable : node.paintables()) {
             auto* inline_paintable = as_if<Painting::PaintableWithLines>(paintable.ptr());
-            if (!inline_paintable || !is<Layout::InlineNode>(inline_paintable->layout_node()))
+            if (!inline_paintable || !inline_paintable->layout_node().is_fragmented_inline())
                 continue;
 
             for (auto& fragment : inline_paintable->fragments()) {
@@ -489,7 +489,7 @@ void LayoutState::resolve_relative_positions()
 
 static Optional<size_t> line_index_for_paint_parent_matching(Painting::Paintable const& paintable)
 {
-    if (auto const* paintable_with_lines = as_if<Painting::PaintableWithLines>(paintable); paintable_with_lines && is<InlineNode>(paintable.layout_node()))
+    if (auto const* paintable_with_lines = as_if<Painting::PaintableWithLines>(paintable); paintable_with_lines && paintable.layout_node().is_fragmented_inline())
         return paintable_with_lines->line_index();
 
     if (paintable.containing_line_box_data().has_value())
@@ -498,7 +498,7 @@ static Optional<size_t> line_index_for_paint_parent_matching(Painting::Paintable
     return {};
 }
 
-// An InlineNode has one paintable per line it spans; a child paintable must be attached to the parent
+// A fragmented inline node has one paintable per line it spans; a child paintable must be attached to the parent
 // paintable for the line it belongs to, keyed by line index.
 static void build_paint_tree(Node& node, Painting::Paintable* fallback_parent_paintable = nullptr, HashMap<size_t, Painting::Paintable*> const* parent_paintable_by_line_index = nullptr)
 {
@@ -523,7 +523,8 @@ static void build_paint_tree(Node& node, Painting::Paintable* fallback_parent_pa
         return;
 
     HashMap<size_t, Painting::Paintable*> paintable_by_line_index;
-    if (is<InlineNode>(node)) {
+    bool const node_is_fragmented_inline = node.is_fragmented_inline();
+    if (node_is_fragmented_inline) {
         for (auto& paintable : node.paintables()) {
             if (auto* paintable_with_lines = as_if<Painting::PaintableWithLines>(paintable.ptr()))
                 paintable_by_line_index.set(paintable_with_lines->line_index(), paintable_with_lines);
@@ -534,8 +535,8 @@ static void build_paint_tree(Node& node, Painting::Paintable* fallback_parent_pa
         // out-of-flow boxes generates no line fragments) must not orphan its descendants' paintables;
         // pass the nearest ancestor paintable through. Other paintable-less nodes (e.g. non-rendered
         // SVG subtrees) keep their descendants disconnected on purpose.
-        auto* fallback_for_children = node.first_paintable() ? node.first_paintable().ptr() : (is<InlineNode>(node) ? fallback_parent_paintable : nullptr);
-        build_paint_tree(*child, fallback_for_children, is<InlineNode>(node) ? &paintable_by_line_index : nullptr);
+        auto* fallback_for_children = node.first_paintable() ? node.first_paintable().ptr() : (node_is_fragmented_inline ? fallback_parent_paintable : nullptr);
+        build_paint_tree(*child, fallback_for_children, node_is_fragmented_inline ? &paintable_by_line_index : nullptr);
     }
 }
 
@@ -554,11 +555,11 @@ void LayoutState::commit(Box& root)
     HashMap<Node const*, NonnullRefPtr<Painting::Paintable>> paintable_cache;
     root.for_each_in_inclusive_subtree([&](Node& node) {
         if (auto paintable = node.first_paintable(); auto* paintable_box = paintable.ptr()) {
-            // InlineNodes are excluded because they can span multiple lines, with a separate
+            // Fragmented inline nodes are excluded because they can span multiple lines, with a separate
             // InlinePaintable created for each line via create_paintable_for_line_with_index().
             // This 1:N relationship between layout node and paintables, combined with the
             // dynamic nature of fragment relocation, makes simple 1:1 caching inapplicable.
-            if (!is<InlineNode>(node))
+            if (!node.is_fragmented_inline())
                 paintable_cache.set(&node, *paintable_box);
         }
         return TraversalDecision::Continue;
@@ -573,13 +574,13 @@ void LayoutState::commit(Box& root)
 
     // After this point, we should have a clean slate to build the new paint tree.
 
-    HashTable<Layout::InlineNode*> inline_nodes;
+    HashTable<Layout::NodeWithStyleAndBoxModelMetrics*> fragmented_inline_nodes;
 
     root.for_each_in_inclusive_subtree([&](Node& node) {
         if (auto* dom_node = node.dom_node())
             dom_node->clear_paintable();
-        if (is<InlineNode>(node) && node.dom_node())
-            inline_nodes.set(static_cast<InlineNode*>(&node));
+        if (node.is_fragmented_inline() && node.dom_node())
+            fragmented_inline_nodes.set(&static_cast<NodeWithStyleAndBoxModelMetrics&>(node));
         return TraversalDecision::Continue;
     });
 
@@ -596,8 +597,8 @@ void LayoutState::commit(Box& root)
         for (auto const* parent = fragment.layout_node().parent(); parent; parent = parent->parent()) {
             if (!parent->display().is_inline_outside() || !parent->display().is_flow_inside())
                 break;
-            if (is<InlineNode>(*parent)) {
-                auto& inline_node = const_cast<InlineNode&>(static_cast<InlineNode const&>(*parent));
+            if (parent->is_fragmented_inline()) {
+                auto& inline_node = const_cast<NodeWithStyleAndBoxModelMetrics&>(static_cast<NodeWithStyleAndBoxModelMetrics const&>(*parent));
                 auto line_paintable = inline_node.create_paintable_for_line_with_index(line_box_data.index);
                 line_paintable->add_fragment(fragment, line_box_data);
                 line_paintable->set_fragmentation_state(fragmentation_state);
@@ -709,8 +710,8 @@ void LayoutState::commit(Box& root)
         }
     });
 
-    // Create paintables for inline nodes without fragments to make possible querying their geometry.
-    for (auto& inline_node : inline_nodes) {
+    // Create paintables for fragmented inline nodes without fragments to make possible querying their geometry.
+    for (auto& inline_node : fragmented_inline_nodes) {
         if (inline_node->first_paintable())
             continue;
 
@@ -726,9 +727,9 @@ void LayoutState::commit(Box& root)
     // it does not.
     for (auto const& paintable : inline_node_paintables.values()) {
         for (auto const* ancestor = paintable->layout_node().parent(); ancestor; ancestor = ancestor->parent()) {
-            if (!is<InlineNode>(*ancestor) || ancestor->dom_node())
+            if (!ancestor->is_fragmented_inline() || ancestor->dom_node())
                 break;
-            auto& inline_ancestor = const_cast<InlineNode&>(static_cast<InlineNode const&>(*ancestor));
+            auto& inline_ancestor = const_cast<NodeWithStyleAndBoxModelMetrics&>(static_cast<NodeWithStyleAndBoxModelMetrics const&>(*ancestor));
             if (inline_ancestor.first_paintable())
                 break;
             auto line_paintable = inline_ancestor.create_paintable_for_line_with_index(paintable->line_index());
@@ -745,7 +746,7 @@ void LayoutState::commit(Box& root)
     m_used_values_store.for_each([&](UsedValues& used_values) {
         auto& node = const_cast<NodeWithStyle&>(used_values.node());
 
-        if (!node.is_box())
+        if (!node.is_box() || node.is_fragmented_inline())
             return;
 
         auto paintable_ref = node.first_paintable();
@@ -794,7 +795,7 @@ void LayoutState::commit(Box& root)
         auto paintable_with_lines = weak_paintable_with_lines.strong_ref();
         if (!paintable_with_lines)
             continue;
-        if (!is<InlineNode>(paintable_with_lines->layout_node()))
+        if (!paintable_with_lines->layout_node().is_fragmented_inline())
             continue;
 
         if (paintable_with_lines->has_only_block_level_fragments()) {
@@ -809,7 +810,7 @@ void LayoutState::commit(Box& root)
         paintable_with_lines->for_each_in_inclusive_subtree_of_type<Painting::PaintableWithLines>([&](auto& paintable) {
             if (paintable.line_index() != line_index)
                 return TraversalDecision::Continue;
-            if (is<BlockContainer>(paintable.layout_node()))
+            if (is<BlockContainer>(paintable.layout_node()) && !paintable.layout_node().is_fragmented_inline())
                 return TraversalDecision::SkipChildrenAndContinue;
 
             auto const* used_values = try_get(paintable.layout_node_with_style_and_box_metrics());

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -483,7 +483,9 @@ void LineBuilder::update_last_line()
             : *fragment.layout_node().parent();
         auto const* containing_block = &m_context.containing_block();
         auto const* first_ancestor = &node == containing_block ? nullptr : node.parent();
-        for (auto const* ancestor = first_ancestor; !own_alignment_is_line_relative && ancestor && ancestor->is_inline_node() && ancestor != containing_block; ancestor = ancestor->parent()) {
+        for (auto const* ancestor = first_ancestor;
+            !own_alignment_is_line_relative && ancestor && ancestor->is_fragmented_inline() && ancestor != containing_block;
+            ancestor = ancestor->parent()) {
             auto const& ancestor_vertical_align = ancestor->computed_values().vertical_align();
             if (ancestor_vertical_align.has<CSS::VerticalAlign>()) {
                 auto keyword = ancestor_vertical_align.get<CSS::VerticalAlign>();

--- a/Libraries/LibWeb/Layout/ListItemBox.cpp
+++ b/Libraries/LibWeb/Layout/ListItemBox.cpp
@@ -22,4 +22,13 @@ void ListItemBox::set_marker(ListItemMarkerBox* marker)
     m_marker = marker;
 }
 
+RefPtr<Painting::Paintable> ListItemBox::create_paintable() const
+{
+    // A fragmented inline list item gets one paintable per line it spans, created via
+    // create_paintable_for_line_with_index(), instead of a node-level paintable.
+    if (is_fragmented_inline())
+        return nullptr;
+    return BlockContainer::create_paintable();
+}
+
 }

--- a/Libraries/LibWeb/Layout/ListItemBox.h
+++ b/Libraries/LibWeb/Layout/ListItemBox.h
@@ -24,6 +24,8 @@ public:
     ListItemMarkerBox const* marker() const { return m_marker; }
     void set_marker(ListItemMarkerBox*);
 
+    virtual RefPtr<Painting::Paintable> create_paintable() const override;
+
 private:
     virtual bool is_list_item_box() const override { return true; }
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -45,6 +45,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGFilterElement.h>
 #include <LibWeb/SVG/SVGForeignObjectElement.h>
@@ -273,7 +274,7 @@ bool Node::establishes_a_fixed_positioning_containing_block() const
 static Box* nearest_ancestor_capable_of_forming_a_containing_block(Node& node)
 {
     for (auto* ancestor = node.parent(); ancestor; ancestor = ancestor->parent()) {
-        if (ancestor->is_block_container()
+        if ((ancestor->is_block_container() && !ancestor->is_fragmented_inline())
             || ancestor->display().is_flex_inside()
             || ancestor->display().is_grid_inside()
             || ancestor->is_replaced_box_with_children()) {
@@ -622,6 +623,18 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullOw
 NodeWithStyleAndBoxModelMetrics::NodeWithStyleAndBoxModelMetrics(DOM::Document& document, DOM::Node* node, CSS::ComputedProperties const& style)
     : NodeWithStyle(document, node, style)
 {
+}
+
+NonnullRefPtr<Painting::PaintableWithLines> NodeWithStyleAndBoxModelMetrics::create_paintable_for_line_with_index(size_t line_index) const
+{
+    for (auto const& paintable : paintables()) {
+        if (is<Painting::PaintableWithLines>(*paintable)) {
+            auto const& paintable_with_lines = static_cast<Painting::PaintableWithLines const&>(*paintable);
+            if (paintable_with_lines.line_index() == line_index)
+                return const_cast<Painting::PaintableWithLines&>(paintable_with_lines);
+        }
+    }
+    return Painting::PaintableWithLines::create(*this, line_index);
 }
 
 NodeWithStyle::ImageObserver::ImageObserver(NodeWithStyle& owner, NonnullRefPtr<CSS::ImageStyleValue const> image)
@@ -1241,10 +1254,16 @@ bool Node::has_replaced_element_table_display_adjustment() const
 
 bool Node::is_atomic_inline() const
 {
-    if (is_replaced_element())
+    if (is_replaced_element() || is_list_item_marker_box())
         return true;
     auto display = this->display();
     return display.is_inline_outside() && !display.is_flow_inside();
+}
+
+bool Node::is_fragmented_inline() const
+{
+    return is_inline_node()
+        || (is_list_item_box() && display().is_inline_outside() && display().is_flow_inside());
 }
 
 // https://drafts.csswg.org/css-transforms-1/#transformable-element

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -129,6 +129,7 @@ public:
     bool is_replaced_element() const;
     bool has_replaced_element_table_display_adjustment() const;
     bool is_atomic_inline() const;
+    bool is_fragmented_inline() const;
     bool is_transformable() const;
 
     bool is_out_of_flow(FormattingContext const&) const;
@@ -381,6 +382,7 @@ class NodeWithStyleAndBoxModelMetrics : public NodeWithStyle {
 
 public:
     bool is_inline_flow_interrupting_block() const;
+    NonnullRefPtr<Painting::PaintableWithLines> create_paintable_for_line_with_index(size_t line_index) const;
 
 protected:
     NodeWithStyleAndBoxModelMetrics(DOM::Document&, DOM::Node*, CSS::ComputedProperties const&);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -465,7 +465,7 @@ static Optional<FirstLetterTarget> find_first_letter_in_block(BlockContainer& bl
                 result = find_first_letter_in_text(*text_node);
                 return result.has_value() ? TraversalDecision::Break : TraversalDecision::Continue;
             }
-            if (is<InlineNode>(node))
+            if (node.is_fragmented_inline())
                 return TraversalDecision::Continue;
 
             return TraversalDecision::Break;

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -1450,7 +1450,7 @@ bool Paintable::overflow_property_applies() const
     if (is<SVGPaintable>(*this))
         return false;
     auto const& display = computed_values().display();
-    if (layout_node().is_inline_node())
+    if (layout_node().is_fragmented_inline())
         return false;
     if (display.is_ruby_inside())
         return false;

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -14,7 +14,7 @@
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/Layout/BlockContainer.h>
-#include <LibWeb/Layout/InlineNode.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
@@ -42,7 +42,7 @@ NonnullRefPtr<PaintableWithLines> PaintableWithLines::create(Layout::BlockContai
     return adopt_ref(*new PaintableWithLines(block_container));
 }
 
-NonnullRefPtr<PaintableWithLines> PaintableWithLines::create(Layout::InlineNode const& inline_node, size_t line_index)
+NonnullRefPtr<PaintableWithLines> PaintableWithLines::create(Layout::NodeWithStyleAndBoxModelMetrics const& inline_node, size_t line_index)
 {
     return adopt_ref(*new PaintableWithLines(inline_node, line_index));
 }
@@ -52,7 +52,7 @@ PaintableWithLines::PaintableWithLines(Layout::BlockContainer const& layout_box)
 {
 }
 
-PaintableWithLines::PaintableWithLines(Layout::InlineNode const& inline_node, size_t line_index)
+PaintableWithLines::PaintableWithLines(Layout::NodeWithStyleAndBoxModelMetrics const& inline_node, size_t line_index)
     : Paintable(inline_node)
     , m_line_index(line_index)
 {
@@ -284,7 +284,7 @@ void PaintableWithLines::paint(DisplayListRecordingContext& context, PaintPhase 
 
     // An inline's per-line paintable that only hosts an interrupting block's phantom fragment generates no box
     // of its own; painting its background/border would draw a degenerate box at the block's corner.
-    if (is<Layout::InlineNode>(layout_node()) && has_only_block_level_fragments())
+    if (layout_node().is_fragmented_inline() && has_only_block_level_fragments())
         return;
 
     Paintable::paint(context, phase);

--- a/Libraries/LibWeb/Painting/PaintableWithLines.h
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.h
@@ -19,7 +19,7 @@ class HitTestDisplayList;
 class PaintableWithLines : public Paintable {
 public:
     static NonnullRefPtr<PaintableWithLines> create(Layout::BlockContainer const&);
-    static NonnullRefPtr<PaintableWithLines> create(Layout::InlineNode const&, size_t line_index);
+    static NonnullRefPtr<PaintableWithLines> create(Layout::NodeWithStyleAndBoxModelMetrics const&, size_t line_index);
     virtual ~PaintableWithLines() override;
     virtual StringView class_name() const override { return "PaintableWithLines"sv; }
 
@@ -51,7 +51,7 @@ public:
 
 protected:
     PaintableWithLines(Layout::BlockContainer const&);
-    PaintableWithLines(Layout::InlineNode const&, size_t line_index);
+    PaintableWithLines(Layout::NodeWithStyleAndBoxModelMetrics const&, size_t line_index);
 
 private:
     [[nodiscard]] virtual bool is_paintable_with_lines() const final { return true; }

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -11,7 +11,6 @@
 #include <AK/TemporaryChange.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/DOM/Document.h>
-#include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
@@ -126,10 +125,7 @@ static bool establishes_inline_level_painting_context(Paintable const& paintable
 
 static bool is_pure_inline_box(Paintable const& paintable)
 {
-    // NOTE: An InlineNode is never a replaced box and never establishes an inline-level painting
-    //       context (inline-block/inline-table produce a BlockContainer), so only the float and
-    //       positioned checks can vary here.
-    return is<Layout::InlineNode>(paintable.layout_node())
+    return paintable.layout_node().is_fragmented_inline()
         && !paintable.is_floating()
         && !paintable.is_positioned();
 }
@@ -139,11 +135,11 @@ static void paint_inline_level_non_positioned_descendant(DisplayListRecordingCon
     paint_node(paintable, context, PaintPhase::Background);
     paint_node(paintable, context, PaintPhase::Border);
     paint_node(paintable, context, PaintPhase::TableCollapsedBorder);
-    // A pure InlineNode paintable paints its own background/border in the inline-level phase. Its block descendants, if
+    // A pure inline paintable paints its own background/border in the inline-level phase. Its block descendants, if
     // any, are painted by the earlier BackgroundAndBorders descent through pure inline boxes. In today's layout trees,
     // this subtree sweep is a no-op for InlineNodes: it can only find inline children, floats, or positioned boxes,
     // all of which are skipped by the BackgroundAndBorders phase.
-    if (!is<Layout::InlineNode>(paintable.layout_node()))
+    if (!is_pure_inline_box(paintable))
         StackingContext::paint_descendants(context, paintable, StackingContext::StackingContextPaintPhase::BackgroundAndBorders);
 
     // https://drafts.csswg.org/css2/#elaborate-stacking-contexts

--- a/Tests/LibWeb/Ref/expected/inline-list-item-marker-ref.html
+++ b/Tests/LibWeb/Ref/expected/inline-list-item-marker-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        font: 20px/24px monospace;
+    }
+    .spacer {
+        color: transparent;
+    }
+    .box {
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        vertical-align: top;
+        background: green;
+    }
+</style>
+<span class="spacer">MMMM</span><span class="box"></span>

--- a/Tests/LibWeb/Ref/input/inline-list-item-marker.html
+++ b/Tests/LibWeb/Ref/input/inline-list-item-marker.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/inline-list-item-marker-ref.html">
+<style>
+    body {
+        margin: 0;
+        font: 20px/24px monospace;
+    }
+    .item {
+        display: inline list-item;
+        list-style-position: inside;
+        list-style-type: "MMMM";
+    }
+    .item::marker {
+        color: transparent;
+    }
+    .box {
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        vertical-align: top;
+        background: green;
+    }
+</style>
+<span class="item"><span class="box"></span></span>


### PR DESCRIPTION
Inline list item boxes were treated as atomic inline boxes even though their built-in marker children were skipped by the inline iterator. The list item therefore got a singular paintable and its marker occupied no space, so content started where the marker should have been.

Treat inline-flow ListItemBox nodes as fragmented inline containers, emit their built-in marker as an atomic inline item, and share marker sizing with block layout. Generalize per-line paintables to box-model nodes so inline list items participate in fragment painting, containing block selection, stacking, relative positioning, and vertical alignment like other inline-flow containers.