### PR TITLE
LibWeb: Make foreignObject a fixed positioning containing block

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1686,11 +1686,6 @@ static void relayout_svg_root(Layout::SVGSVGBox& svg_root)
     if (auto paintable = svg_root.paintable_box())
         layout_state.populate_from_paintable(svg_root, *paintable);
 
-    // Pre-populate the viewport for position:fixed elements inside <foreignObject>.
-    auto& viewport = svg_root.root();
-    if (auto paintable = viewport.paintable_box())
-        layout_state.populate_from_paintable(viewport, *paintable);
-
     auto const& svg_state = layout_state.get(svg_root);
     auto content_width = svg_state.content_width();
     auto content_height = svg_state.content_height();

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -207,6 +207,11 @@ bool Node::establishes_a_fixed_positioning_containing_block() const
     if (!is<Box>(*this))
         return false;
 
+    // https://github.com/w3c/fxtf-drafts/issues/307#issuecomment-499612420
+    // foreignObject establishes a containing block for absolutely and fixed positioned elements.
+    if (is_svg_foreign_object_box())
+        return true;
+
     auto const& computed_values = this->computed_values();
 
     // https://drafts.csswg.org/css-will-change/#will-change

--- a/Tests/LibWeb/Ref/expected/svg-relayout-preserves-fixed-foreignobject-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-relayout-preserves-fixed-foreignobject-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        background: green;
+    }
+</style>

--- a/Tests/LibWeb/Ref/input/svg-relayout-preserves-fixed-foreignobject.html
+++ b/Tests/LibWeb/Ref/input/svg-relayout-preserves-fixed-foreignobject.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-relayout-preserves-fixed-foreignobject-ref.html">
+<style>
+    body {
+        margin: 0;
+        background: red;
+    }
+    .fixed {
+        position: fixed;
+        top: 30px;
+        left: 50px;
+        width: 40px;
+        height: 40px;
+        background: green;
+    }
+</style>
+<svg width="100" height="100">
+    <path id="path" d="M 10 10 L 20 20" fill="none" />
+    <foreignObject x="0" y="0" width="100" height="100">
+        <div xmlns="http://www.w3.org/1999/xhtml" id="fixed" class="fixed"></div>
+    </foreignObject>
+</svg>
+<script>
+    document.body.offsetHeight;
+    document.getElementById("path").setAttribute("d", "M 10 10 L 30 30");
+    document.body.offsetHeight;
+    const rect = document.getElementById("fixed").getBoundingClientRect();
+    document.body.style.background = rect.x === 50 && rect.y === 30 && rect.width === 40 && rect.height === 40
+        ? "green"
+        : "red";
+    document.querySelector("svg").style.visibility = "hidden";
+</script>


### PR DESCRIPTION
Previously, a position:fixed element inside <foreignObject> used the viewport as its containing block. During partial SVG relayout, the viewport is outside the relayed-out subtree, so the fixed element was registered as an abspos child of the viewport but never laid out. LayoutState::commit() then cleared its paintable without rebuilding it, making getBoundingClientRect() return an empty rect until the next full layout.

With foreignObject establishing the fixed positioning containing block, such elements are laid out by the foreignObject's formatting context, which runs inside the partial SVG relayout pass. This also makes the viewport pre-population in relayout_svg_root() (added in 9231b54d49 to fix a crash in this same scenario) unnecessary, so remove it.