### PR TITLE
LibWeb: Fix load event stalls and event ordering around frames, media, and images

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4530,6 +4530,17 @@ void Document::schedule_html_parser_end_check()
         m_html_parser_end_state->schedule_progress_check();
     if (m_parser)
         m_parser->schedule_resume_check();
+
+    // NB: Whatever unblocked this document's load event may also have been the last thing delaying the load event of
+    //     an ancestor document, since NavigableContainer::currently_delays_the_load_event() considers everything that
+    //     delays the load event of a container's active document. Wake ancestor parser end states so they notice.
+    //     This implements the re-evaluation implied by "the end" step 8, which spins the event loop until there is
+    //     nothing that delays the load event in the ancestor's document. Repeated wake-ups within one event loop
+    //     turn coalesce into a single deferred progress check via HTMLParserEndState::m_check_pending.
+    if (auto navigable = this->navigable()) {
+        if (auto container = navigable->container())
+            container->document().schedule_html_parser_end_check();
+    }
 }
 
 void Document::set_ready_for_post_load_tasks(bool ready)

--- a/Libraries/LibWeb/DOM/DocumentLoadEventDelayer.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoadEventDelayer.cpp
@@ -23,6 +23,12 @@ DocumentLoadEventDelayer::DocumentLoadEventDelayer(DocumentLoadEventDelayer&& de
 
 DocumentLoadEventDelayer& DocumentLoadEventDelayer::operator=(DocumentLoadEventDelayer&& delayer)
 {
+    if (this == &delayer)
+        return *this;
+
+    if (m_document)
+        m_document->decrement_number_of_things_delaying_the_load_event({});
+
     m_document = move(delayer.m_document);
     delayer.m_document = nullptr;
 

--- a/Libraries/LibWeb/DOM/DocumentObserver.cpp
+++ b/Libraries/LibWeb/DOM/DocumentObserver.cpp
@@ -45,6 +45,26 @@ void DocumentObserver::set_document(GC::Ref<Document> document)
     document->register_document_observer({}, *this);
 }
 
+void DocumentObserver::retarget_for_adoption(GC::Ref<Document> new_document)
+{
+    bool was_fully_active = m_document->is_fully_active();
+    set_document(new_document);
+    bool is_fully_active = new_document->is_fully_active();
+
+    // NB: If the observed element moved between a fully active document and a document that is not fully active,
+    //     synthesize the matching activity transition, so that observers see the same sequence of transitions as if
+    //     the element had stayed put and its document had changed activity.
+    if (was_fully_active == is_fully_active)
+        return;
+    if (is_fully_active) {
+        if (m_document_became_active)
+            m_document_became_active->function()();
+    } else {
+        if (m_document_became_inactive)
+            m_document_became_inactive->function()();
+    }
+}
+
 void DocumentObserver::set_document_became_active(Function<void()> callback)
 {
     if (callback)

--- a/Libraries/LibWeb/DOM/DocumentObserver.h
+++ b/Libraries/LibWeb/DOM/DocumentObserver.h
@@ -44,6 +44,10 @@ public:
     GC::Ref<Document> document() { return m_document; }
     void set_document(GC::Ref<Document>);
 
+    // Retargets this observer to the observed element's new document and synthesizes a became-active or
+    // became-inactive callback if the old and new documents differ in fully-active state.
+    void retarget_for_adoption(GC::Ref<Document>);
+
 private:
     explicit DocumentObserver(JS::Realm&, Document&);
 

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -182,11 +182,7 @@ void HTMLImageElement::adopted_from(DOM::Document& old_document)
     old_document.unregister_viewport_client(*this);
     document().register_viewport_client(*this);
 
-    m_document_observer->set_document(document());
-    if (!old_document.is_fully_active() && document().is_fully_active()) {
-        if (auto callback = m_document_observer->document_became_active())
-            callback->function()();
-    }
+    m_document_observer->retarget_for_adoption(document());
 
     if (m_load_event_delayer.has_value())
         m_load_event_delayer.emplace(document());

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -712,7 +712,17 @@ void HTMLImageElement::update_the_image_data_impl(bool restart_animations, bool 
             m_current_request->set_current_pixel_density(selected_pixel_density.value_or(1.0f));
 
             // 7. Queue an element task on the DOM manipulation task source given the img element and following steps:
-            queue_an_element_task(HTML::Task::Source::DOMManipulation, [this, restart_animations, maybe_omit_events, url_string, previous_url] {
+            queue_an_element_task(HTML::Task::Source::DOMManipulation, [this, restart_animations, maybe_omit_events, url_string, previous_url, update_the_image_data_count] {
+                // AD-HOC: If another instance of this algorithm was started after this one, let that newer instance
+                //         fire the load event instead of firing one per instance. The spec only has this guard in the
+                //         microtask continuation below (step 9: "Only the last instance takes effect, to avoid
+                //         multiple requests when, for example, the src, srcset, and crossorigin attributes are all
+                //         set in succession."), but relevant mutations (e.g. setting src and then inserting into a
+                //         picture) can also invoke this algorithm several times in the same script block, and the
+                //         major engines coalesce those updates into a single load event.
+                if (update_the_image_data_count != m_update_the_image_data_count)
+                    return;
+
                 // AD-HOC: Bail out if the document became inactive (e.g. iframe removed or navigated)
                 //         between when this task was queued and when it runs.
                 if (!document().is_fully_active()) {
@@ -762,6 +772,16 @@ after_step_7:
             selected_source = result.value().source;
             pixel_density = result.value().pixel_density;
         }
+
+        // AD-HOC: Record the selected source for elements that use srcset or picture. The spec only sets
+        //         https://html.spec.whatwg.org/multipage/images.html#last-selected-source in step 6, leaving it null
+        //         for such elements, which would make every environment change reselect and refetch the same URL and
+        //         fire a spurious load event, since "react to environment changes" only returns early when the newly
+        //         selected source matches the last selected source. Blink likewise records the selected candidate URL
+        //         at selection time and deliberately skips same-candidate updates on environment changes to avoid
+        //         spurious downloads. Spec issue: https://github.com/whatwg/html/issues/4646
+        if (selected_source.has_value())
+            m_last_selected_source = selected_source->url;
 
         // 11. If selected source is null, then:
         if (!selected_source.has_value()) {

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -274,8 +274,35 @@ void HTMLMediaElement::adopted_from(DOM::Document& old_document)
 {
     Base::adopted_from(old_document);
 
-    if (m_delaying_the_load_event.has_value())
+    // NB: The became-inactive transition synthesized when moving into a document that is not fully active stops any
+    //     in-flight fetch, and the became-active transition synthesized when moving back into a fully active document
+    //     resumes it. Without the former, the latter would find a fetch controller that is still live and start a
+    //     second fetch on top of it.
+    m_document_observer->retarget_for_adoption(document());
+
+    // https://html.spec.whatwg.org/multipage/media.html#delaying-the-load-event-flag
+    // While the delaying-the-load-event flag is true, the element must delay the load event of its document.
+    // NB: The flag delays the load event of the element's current node document, so it follows the element when it is
+    //     adopted into another document.
+    if (m_delaying_the_load_event.has_value()) {
         m_delaying_the_load_event.emplace(document());
+
+        // AD-HOC: If the resource selection algorithm was invoked while the element's node document was not fully
+        //         active, its queued media element tasks are associated with the old document and will never run.
+        //         That would leave this element delaying the load event of the document that adopted it forever.
+        //         Drop those stale tasks and re-invoke the resource selection algorithm so that it can proceed with
+        //         tasks associated with the new document. This matches the major engines, where a pending media load
+        //         continues after adoption and delays the new document's load event until it completes. Once a fetch
+        //         is in flight the pending work lives in the fetch machinery rather than in queued media element
+        //         tasks, and the synthesized activity transitions above take care of stopping and resuming it, so
+        //         only restart resource selection when no fetch has begun.
+        if (!old_document.is_fully_active() && !m_remote_fetch_data) {
+            main_thread_event_loop().task_queue().remove_tasks_matching([&](auto const& task) {
+                return task.source() == media_element_event_task_source();
+            });
+            select_resource();
+        }
+    }
 
     if (m_screen_wake_lock.has_value()) {
         m_screen_wake_lock.clear();

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3316,6 +3316,17 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
     // NOTE: pending_document corresponds to historyEntry's document — it is the document produced by
     //       populate_session_history_entry_document, threaded here explicitly instead of being stored on the entry.
     if (!pending_document) {
+        // AD-HOC: Notify the UI that this navigation will never produce a document (e.g. an unhandled non-fetch
+        //         scheme like mailto:), so that it does not consider the page to be loading forever.
+        if (navigable->is_top_level_traversable())
+            navigable->active_browsing_context()->page().client().page_did_cancel_loading(expected_ongoing_navigation_id, history_entry->url());
+
+        // AD-HOC: Clear the ongoing navigation, like the "navigation must be a replace" and download cases do.
+        //         No history step will be applied for this navigation, so nothing else clears it, and a stale
+        //         ongoing navigation ID makes later same-document traversals consider themselves superseded.
+        if (expected_ongoing_navigation_id.has_value() && navigable->ongoing_navigation() == expected_ongoing_navigation_id)
+            navigable->set_ongoing_navigation({});
+
         on_complete->function()(HistoryStepResult::Applied);
         return;
     }

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -553,8 +553,12 @@ void HTMLParserEndState::check_progress()
             (void)m_document->scripts_to_execute_when_parsing_has_finished().take_first();
         }
 
-        advance_to_asap_scripts_phase();
-        [[fallthrough]];
+        advance_to_dom_content_loaded_phase();
+        return;
+
+    case Phase::WaitingForDOMContentLoaded:
+        // NB: The task queued by advance_to_dom_content_loaded_phase() advances the state machine once it has run.
+        return;
 
     case Phase::WaitingForASAPScripts:
         // 7. Spin the event loop until the set of scripts that will execute as soon as possible and the list of scripts
@@ -580,7 +584,7 @@ void HTMLParserEndState::check_progress()
     }
 }
 
-void HTMLParserEndState::advance_to_asap_scripts_phase()
+void HTMLParserEndState::advance_to_dom_content_loaded_phase()
 {
     // AD-HOC: We need to scroll to the fragment on page load somewhere.
     // But a script that ran in step 5 above may have scrolled the page already,
@@ -591,8 +595,10 @@ void HTMLParserEndState::advance_to_asap_scripts_phase()
         m_document->scroll_to_the_fragment();
     }
 
+    m_phase = Phase::WaitingForDOMContentLoaded;
+
     // 6. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
-    queue_global_task(HTML::Task::Source::DOMManipulation, *m_document, GC::create_function(m_document->heap(), [document = m_document] {
+    queue_global_task(HTML::Task::Source::DOMManipulation, *m_document, GC::create_function(m_document->heap(), [state = GC::Ref(*this), document = m_document] {
         // 1. Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::current_high_resolution_time(relevant_global_object(*document));
 
@@ -607,9 +613,16 @@ void HTMLParserEndState::advance_to_asap_scripts_phase()
         // FIXME: 4. Enable the client message queue of the ServiceWorkerContainer object whose associated service worker client is the Document object's relevant settings object.
 
         // FIXME: 5. Invoke WebDriver BiDi DOM content loaded with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "pending", and url is the Document object's URL.
-    }));
 
-    m_phase = Phase::WaitingForASAPScripts;
+        // NB: Only advance the state machine after this task has run, so that anything the DOMContentLoaded event
+        //     handlers did (e.g. starting loads that delay the load event) is visible to the remaining phases. This
+        //     matches steps 7 and 8, whose "spin the event loop" continuations resume in a new task queued after the
+        //     DOMContentLoaded task, per https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop.
+        if (state->m_phase == Phase::WaitingForDOMContentLoaded) {
+            state->m_phase = Phase::WaitingForASAPScripts;
+            state->schedule_progress_check();
+        }
+    }));
 }
 
 void HTMLParserEndState::complete()

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -633,6 +633,15 @@ void HTMLParserEndState::complete()
 
     // 9. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following steps:
     queue_global_task(HTML::Task::Source::DOMManipulation, *m_document, GC::create_function(m_document->heap(), [document = m_document, parser = m_parser] {
+        // 11. The Document is now ready for post-load tasks.
+        // NB: The spec sets this synchronously after queueing this task, and relies on "spin the event loop"
+        //     continuations being queued tasks to keep an ancestor document's load event behind this document's own
+        //     load event and its container's load event. Our parser end state machine checks its progress from
+        //     deferred invocations, which run ahead of queued tasks, so flip readiness inside this task instead;
+        //     an ancestor then cannot complete until this task (and everything it queues) is already in the queue.
+        //     WebKit and Blink time their equivalent flag the same way.
+        document->set_ready_for_post_load_tasks(true);
+
         // 1. Update the current document readiness to "complete".
         document->update_readiness(HTML::DocumentReadyState::Complete);
 
@@ -679,8 +688,7 @@ void HTMLParserEndState::complete()
 
     // FIXME: 10. If the Document's print when loaded flag is set, then run the printing steps.
 
-    // 11. The Document is now ready for post-load tasks.
-    m_document->set_ready_for_post_load_tasks(true);
+    // NB: Step 11 (the Document is now ready for post-load tasks) runs inside the task queued above; see there.
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#create-an-element-for-the-token

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -171,6 +171,7 @@ public:
 private:
     enum class Phase {
         WaitingForDeferredScripts,
+        WaitingForDOMContentLoaded,
         WaitingForASAPScripts,
         WaitingForLoadEventDelay,
         Completed,
@@ -181,7 +182,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     void check_progress();
-    void advance_to_asap_scripts_phase();
+    void advance_to_dom_content_loaded_phase();
     void complete();
 
     Phase m_phase { Phase::WaitingForDeferredScripts };

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -74,7 +74,7 @@ void SVGUseElement::adopted_from(DOM::Document& old_document)
     if (m_load_event_delayer.has_value())
         m_load_event_delayer.emplace(document());
 
-    m_document_observer->set_document(document());
+    m_document_observer->retarget_for_adoption(document());
 
     auto href = href_value();
     if (!href.has_value())

--- a/Libraries/LibWeb/WebAudio/BaseAudioContext.h
+++ b/Libraries/LibWeb/WebAudio/BaseAudioContext.h
@@ -43,11 +43,11 @@ public:
     // Other browsers appear to only allow 32 channels - so let's limit ourselves to that too.
     static constexpr WebIDL::UnsignedLong MAX_NUMBER_OF_CHANNELS { 32 };
 
-    // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer-samplerate
-    // > An implementation MUST support sample rates in at least the range 8000 to 96000.
-    // This doesn't seem consistent between browsers. We use what firefox accepts from testing BaseAudioContext.createAudioBuffer.
-    static constexpr float MIN_SAMPLE_RATE { 8000 };
-    static constexpr float MAX_SAMPLE_RATE { 192000 };
+    // https://webaudio.github.io/web-audio-api/#sample-rates
+    // Implementations MUST support sample rates between 3000 Hz and 768000 Hz, inclusive. A NotSupportedError MUST
+    // be thrown if a sample rate outside this range is specified.
+    static constexpr float MIN_SAMPLE_RATE { 3000 };
+    static constexpr float MAX_SAMPLE_RATE { 768000 };
 
     static WebIDL::UnsignedLong render_quantum_size() { return s_render_quantum_size; }
 

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-adopted-from-inactive-document.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-adopted-from-inactive-document.txt
@@ -1,0 +1,3 @@
+video loadstart event (networkState=2, error=null)
+video error event (networkState=3, error=4)
+window load event

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-adoption-round-trip-during-fetch.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-adoption-round-trip-during-fetch.txt
@@ -1,0 +1,2 @@
+video survived adoption round-trip during fetch
+video error event (error=4)

--- a/Tests/LibWeb/Text/expected/HTML/HTMLObjectElement-adoption-does-not-leak-load-delayer.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLObjectElement-adoption-does-not-leak-load-delayer.txt
@@ -1,0 +1,2 @@
+iframe load event
+window load event

--- a/Tests/LibWeb/Text/expected/HTML/iframe-load-event-fires-before-window-load-event.txt
+++ b/Tests/LibWeb/Text/expected/HTML/iframe-load-event-fires-before-window-load-event.txt
@@ -1,0 +1,2 @@
+iframe load event
+window load event

--- a/Tests/LibWeb/Text/expected/HTML/img-in-picture-fires-single-load-event.txt
+++ b/Tests/LibWeb/Text/expected/HTML/img-in-picture-fires-single-load-event.txt
@@ -1,0 +1,2 @@
+img load #1
+sentinel load

--- a/Tests/LibWeb/Text/expected/HTML/load-event-waits-for-img-added-in-DOMContentLoaded.txt
+++ b/Tests/LibWeb/Text/expected/HTML/load-event-waits-for-img-added-in-DOMContentLoaded.txt
@@ -1,0 +1,2 @@
+img error event
+window load event

--- a/Tests/LibWeb/Text/expected/HTML/load-event-wakes-up-after-subframe-delayer-clears.txt
+++ b/Tests/LibWeb/Text/expected/HTML/load-event-wakes-up-after-subframe-delayer-clears.txt
@@ -1,0 +1,1 @@
+frame load event

--- a/Tests/LibWeb/Text/expected/navigation/traversal-works-after-fizzled-navigation.txt
+++ b/Tests/LibWeb/Text/expected/navigation/traversal-works-after-fizzled-navigation.txt
@@ -1,0 +1,1 @@
+popstate after fizzled navigation

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/the-img-element/img.complete.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/the-img-element/img.complete.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 19 tests
 
-16 Pass
-3 Fail
+18 Pass
+1 Fail
 Pass	img src and srcset omitted
 Pass	img src and srcset omitted on newly-created image
 Pass	img src and srcset omitted on newly-created-and-inserted image
@@ -14,11 +14,11 @@ Pass	img src empty and srcset omitted on newly-created-and-inserted image
 Pass	img src empty and srcset omitted on newly-created-via-innerHTML image
 Pass	img src and srcset omitted on image after it started a load
 Pass	async src complete test
-Fail	async srcset complete test
+Pass	async srcset complete test
 Pass	IDL attribute complete cannot "randomly" change during a task
 Pass	async src broken test
 Pass	async src removal test
-Fail	async srcset removal test
+Pass	async srcset removal test
 Pass	async src available image lookup test
 Fail	async pending request test
 Pass	not loadable

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 41 tests
 
-35 Pass
-6 Fail
+41 Pass
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "test-audiocontextoptions-latencyHint-basic"
 Pass	Executing "test-audiocontextoptions-latencyHint-double"
@@ -37,11 +36,11 @@ Pass	  context = new AudioContext({sampleRate: -1}) threw NotSupportedError: "Sa
 Pass	  context = new AudioContext({sampleRate: 0}) threw NotSupportedError: "Sample rate is outside of allowed range".
 Pass	  context = new AudioContext({sampleRate: 2999}) threw NotSupportedError: "Sample rate is outside of allowed range".
 Pass	  context = new AudioContext({sampleRate: 768001}) threw NotSupportedError: "Sample rate is outside of allowed range".
-Fail	X context = new AudioContext({sampleRate: 3000}) incorrectly threw NotSupportedError: "Sample rate is outside of allowed range".
-Fail	X sampleRate inrange is not equal to 3000. Got 44100.
-Fail	X context = new AudioContext({sampleRate: 768000}) incorrectly threw NotSupportedError: "Sample rate is outside of allowed range".
-Fail	X sampleRate inrange is not equal to 768000. Got 44100.
+Pass	  context = new AudioContext({sampleRate: 3000}) did not throw an exception.
+Pass	  sampleRate inrange is equal to 3000.
+Pass	  context = new AudioContext({sampleRate: 768000}) did not throw an exception.
+Pass	  sampleRate inrange is equal to 768000.
 Pass	  context = new AudioContext({sampleRate: 24000}) did not throw an exception.
 Pass	  sampleRate inrange is equal to 24000.
-Fail	< [test-audiocontextoptions-sampleRate] 4 out of 10 assertions were failed.
-Fail	# AUDIT TASK RUNNER FINISHED: 1 out of 3 tasks were failed.
+Pass	< [test-audiocontextoptions-sampleRate] All assertions passed. (total 10 assertions)
+Pass	# AUDIT TASK RUNNER FINISHED: 3 tasks ran successfully.

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-adopted-from-inactive-document.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-adopted-from-inactive-document.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // A media element whose load algorithm was invoked while its node document was not fully
+    // active must not delay the load event of a document it is later adopted into forever.
+    // Instead, the pending resource selection continues after adoption, and the adopting
+    // document's load event waits for it, matching Chrome, Firefox and Safari.
+    const events = [];
+
+    const parsedDocument = new DOMParser().parseFromString(
+        `<video src="file:///nonexistent-media-file.webm"></video>`,
+        "text/html"
+    );
+    const video = parsedDocument.querySelector("video");
+    for (const eventName of ["loadstart", "emptied", "abort", "error"]) {
+        video.addEventListener(eventName, () => {
+            events.push(`video ${eventName} event (networkState=${video.networkState}, error=${video.error ? video.error.code : null})`);
+        });
+    }
+    document.body.appendChild(video);
+
+    asyncTest(done => {
+        window.addEventListener("load", () => {
+            events.push("window load event");
+            for (const event of events)
+                println(event);
+            done();
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-adoption-round-trip-during-fetch.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-adoption-round-trip-during-fetch.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // Adopting a media element with an in-flight fetch into a document that is not fully active
+    // must stop the fetch, so that adopting it back into a fully active document can resume it.
+    // Without that, the resume path would find a live fetch controller and crash.
+    asyncTest(async done => {
+        internals.setTestTimeout(15000);
+        const httpServer = httpTestServer();
+
+        const token = "media-adoption-round-trip";
+        const mediaURL = await httpServer.createEcho("GET", "/media-adoption-round-trip", {
+            status: 200,
+            headers: { "Content-Type": "video/webm", "Cache-Control": "no-store" },
+            body: "",
+            wait_for_unblock: token,
+        });
+
+        const video = document.createElement("video");
+        video.preload = "auto";
+        video.src = mediaURL;
+        document.body.appendChild(video);
+        await new Promise(resolve => video.addEventListener("loadstart", resolve, { once: true }));
+
+        // Give the resource fetch algorithm a few event loop turns to actually start the fetch.
+        for (let i = 0; i < 10; ++i)
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+        const inactiveDocument = new DOMParser().parseFromString("<body></body>", "text/html");
+        inactiveDocument.adoptNode(video);
+        document.body.appendChild(video);
+        println("video survived adoption round-trip during fetch");
+
+        video.addEventListener("error", () => {
+            println(`video error event (error=${video.error.code})`);
+            done();
+        });
+        await fetch(new URL(`/unblock/${token}`, mediaURL));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLObjectElement-adoption-does-not-leak-load-delayer.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLObjectElement-adoption-does-not-leak-load-delayer.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // Moving an <object> element whose load event delayers are engaged to another document
+    // must release the delayers on the old document. If one leaks, the old document's load
+    // event (and therefore this page's load event) never fires.
+    window.grabObject = iframeDocument => {
+        document.body.appendChild(document.adoptNode(iframeDocument.querySelector("object")));
+    };
+
+    const iframe = document.createElement("iframe");
+    iframe.srcdoc = `<object data="file:///nonexistent-object-data"></object><script>parent.grabObject(document)<\/script>`;
+    iframe.addEventListener("load", () => println("iframe load event"));
+    document.body.appendChild(iframe);
+
+    asyncTest(done => {
+        window.addEventListener("load", () => {
+            println("window load event");
+            done();
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/iframe-load-event-fires-before-window-load-event.html
+++ b/Tests/LibWeb/Text/input/HTML/iframe-load-event-fires-before-window-load-event.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // An iframe's load event fires before its document's window load event, matching Chrome,
+    // Firefox and Safari, where a frame delays the load event until it has completely finished
+    // loading, including firing its own load event.
+    const events = [];
+
+    const iframe = document.createElement("iframe");
+    iframe.srcdoc = "<body>hello</body>";
+    iframe.addEventListener("load", () => events.push("iframe load event"));
+    document.body.appendChild(iframe);
+
+    asyncTest(done => {
+        window.addEventListener("load", () => {
+            events.push("window load event");
+            for (const event of events)
+                println(event);
+            done();
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/img-in-picture-fires-single-load-event.html
+++ b/Tests/LibWeb/Text/input/HTML/img-in-picture-fires-single-load-event.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // An img element inside a picture element fires exactly one load event, even when its src
+    // was set before insertion (multiple invocations of "update the image data" coalesce), and
+    // removing the picture afterwards is not a relevant mutation, so it must not fire another
+    // load event. Chrome, Firefox and Safari all fire exactly one load event here.
+    //
+    // The spurious load events this guards against were dispatched via the image loading
+    // batching dispatcher. The sentinel image below is a fresh (uncached) URL whose successful
+    // load also flows through the batching dispatcher, so by the time the sentinel's load event
+    // fires, any spurious load event queued before it has already been dispatched.
+    const events = [];
+
+    // Load the image once up front so the scenario below hits the list of available images.
+    const plainImage = document.createElement("img");
+    plainImage.src = "../../../Assets/120.png";
+    plainImage.onload = () => {
+        const picture = document.createElement("picture");
+        const source = document.createElement("source");
+        source.media = "(min-width: 1px)";
+        source.srcset = "../../../Assets/120.png";
+        const img = document.createElement("img");
+        img.src = "../../../Assets/120.png";
+        let loads = 0;
+        img.onload = () => {
+            loads++;
+            events.push(`img load #${loads}`);
+            if (loads > 1)
+                return;
+            picture.remove();
+
+            const sentinel = document.createElement("img");
+            sentinel.src =
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNgYGBgAAAABQABh6FO1AAAAABJRU5ErkJggg==";
+            sentinel.onload = () => {
+                events.push("sentinel load");
+                for (const event of events)
+                    println(event);
+                window.__done();
+            };
+            document.body.appendChild(sentinel);
+        };
+        picture.appendChild(source);
+        picture.appendChild(img);
+        document.body.appendChild(picture);
+    };
+
+    asyncTest(done => {
+        window.__done = done;
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/load-event-waits-for-img-added-in-DOMContentLoaded.html
+++ b/Tests/LibWeb/Text/input/HTML/load-event-waits-for-img-added-in-DOMContentLoaded.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // An image whose load is started by a DOMContentLoaded event handler delays the load
+    // event: the img error event must fire before the window load event, matching Chrome,
+    // Firefox and Safari.
+    const events = [];
+
+    document.addEventListener("DOMContentLoaded", () => {
+        const img = document.createElement("img");
+        img.src = "file:///nonexistent-image.png";
+        img.addEventListener("error", () => events.push("img error event"));
+        document.body.appendChild(img);
+    });
+
+    asyncTest(done => {
+        window.addEventListener("load", () => {
+            events.push("window load event");
+            for (const event of events)
+                println(event);
+            done();
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/load-event-wakes-up-after-subframe-delayer-clears.html
+++ b/Tests/LibWeb/Text/input/HTML/load-event-wakes-up-after-subframe-delayer-clears.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // A document's load event can be gated on something that delays the load event inside a
+    // subframe's document (e.g. an image load started after the subframe itself finished
+    // loading). When that inner load settles, the outer document's load event must fire.
+    //
+    // Frame A is gated by its own image (blocked on the "gate" token) while its subframe B
+    // finishes loading and starts an image load of its own (blocked on the "inner" token).
+    // Once both images are in flight, the gate token is released; when A's own image settles,
+    // the only thing delaying A's load event is the image inside B. Then the inner token is
+    // released; if clearing that inner delayer fails to wake A's parser end state machine,
+    // A's load event never fires and this test times out.
+    asyncTest(async done => {
+        internals.setTestTimeout(15000);
+        const httpServer = httpTestServer();
+
+        const gateToken = "subframe-delayer-gate";
+        const innerToken = "subframe-delayer-inner";
+        const frameGateURL = await httpServer.createEcho("GET", "/subframe-delayer-frame-gate", {
+            status: 404,
+            headers: { "Cache-Control": "no-store" },
+            body: "",
+            wait_for_unblock: gateToken,
+        });
+        const innerImageURL = await httpServer.createEcho("GET", "/subframe-delayer-inner-image", {
+            status: 404,
+            headers: { "Cache-Control": "no-store" },
+            body: "",
+            wait_for_unblock: innerToken,
+        });
+        const unblock = token => fetch(new URL(`/unblock/${token}`, frameGateURL));
+
+        window.addEventListener("message", async event => {
+            if (event.data === "inner image inserted") {
+                // The subframe's image insertion (and thus its load event delayer) is ordered
+                // before this message task, so the inner delayer is engaged; release the gate.
+                await unblock(gateToken);
+                // A's own image now settles, leaving the inner image as the only thing delaying
+                // A's load event; release it too.
+                await unblock(innerToken);
+                return;
+            }
+            println(event.data);
+            done();
+        });
+
+        const frame = document.createElement("iframe");
+        frame.srcdoc = `
+            <img src="${frameGateURL}">
+            <script>
+                const subframe = document.createElement("iframe");
+                subframe.srcdoc = "<body></body>";
+                subframe.addEventListener("load", () => {
+                    const innerImage = subframe.contentDocument.createElement("img");
+                    innerImage.src = "${innerImageURL}";
+                    subframe.contentDocument.body.appendChild(innerImage);
+                    parent.postMessage("inner image inserted", "*");
+                });
+                document.body.appendChild(subframe);
+                window.addEventListener("load", () => parent.postMessage("frame load event", "*"));
+            <\/script>
+        `;
+        document.body.appendChild(frame);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/WebAudio/AudioBuffer.html
+++ b/Tests/LibWeb/Text/input/WebAudio/AudioBuffer.html
@@ -7,8 +7,8 @@
             { numberOfChannels: 0, length: 17, sampleRate: 10_002 }, // 0 channels (below min)
             { numberOfChannels: 33, length: 17, sampleRate: 10_002 }, // 33 channels (above max)
             { numberOfChannels: 3, length: 0, sampleRate: 10_002 }, // 0 length
-            { numberOfChannels: 3, length: 17, sampleRate: 7999 }, // 7999 sample rate (below min)
-            { numberOfChannels: 3, length: 17, sampleRate: 192001 }, // 192001 sample rate (above max)
+            { numberOfChannels: 3, length: 17, sampleRate: 2999 }, // 2999 sample rate (below min)
+            { numberOfChannels: 3, length: 17, sampleRate: 768001 }, // 768001 sample rate (above max)
         ];
 
         for (let invalidOption of invalidOptions) {

--- a/Tests/LibWeb/Text/input/navigation/traversal-works-after-fizzled-navigation.html
+++ b/Tests/LibWeb/Text/input/navigation/traversal-works-after-fizzled-navigation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<a href="mailto:contact@ladybird.org">mailto link</a>
+<script>
+    // A navigation that fizzles without producing a document (e.g. an unhandled non-fetch scheme
+    // like mailto:) must not leave a stale ongoing navigation ID behind, or later same-document
+    // traversals consider themselves superseded and never complete.
+    asyncTest(async done => {
+        history.pushState("pushed", "", "#pushed");
+
+        window.addEventListener("popstate", () => {
+            println("popstate after fizzled navigation");
+            done();
+        });
+
+        document.querySelector("a").click();
+
+        // Give the fizzled navigation's event loop turns to run to completion; it performs no
+        // fetches, so a fixed number of turns suffices regardless of machine speed.
+        for (let i = 0; i < 32; ++i)
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+        history.back();
+    });
+</script>


### PR DESCRIPTION
Loading https://thebodyshop.se/ never fired the window `load` event, so the tab spinner spun forever. The root cause was the site's Instagram widget, which builds its `<video>` elements inside a `DOMParser` document and then adopts them into the main document. The media element load algorithm had queued its resource selection tasks against the never-fully-active `DOMParser` document, where they can never run, while the engaged delaying-the-load-event flag transferred to the adopting document on adoption and stayed set forever.

Media elements now continue a pending load after adoption: stale tasks tied to the old document are dropped and resource selection re-runs in the new document, and a new `DocumentObserver::retarget_for_adoption()` helper synthesizes became-inactive/became-active transitions when an element crosses documents of differing activity, so an in-flight fetch is stopped on the way out and resumed on the way back instead of crashing on a live fetch controller. Chrome, Firefox and Safari all behave this way (verified in all three: `loadstart`, then `error`, then the window `load` event, which waits for the adopted video).

Pulling on that thread surfaced a series of adjacent bugs, each cross-checked against the spec and the major engines:

- `DocumentLoadEventDelayer`'s move-assignment overwrote its document without decrementing the old document's delayer count. This is reachable by adopting an `<object>` out of a loading document, which then never fires its `load` event.
- Picture-wrapped `img` elements fired spurious extra `load` events through two paths: environment changes reselecting the same candidate (the spec only records the last selected source for non-`srcset` elements; Blink records it at selection time and deliberately skips same-candidate refetches, see whatwg/html#4646), and multiple update-the-image-data instances in one script block each firing a `load` event where engines coalesce them into one.
- Navigations that fizzle without producing a document (e.g. an unhandled scheme like mailto:) sent the UI a start notification but no completion, leaving the tab in a loading state forever, and leaked a stale ongoing navigation ID that made later same-document traversals consider themselves superseded.
- Our nominal audio sample rate range of 8000 to 192000 was narrower than every engine. It now matches Blink and Gecko at 3000 to 768000 (WebKit allows 3000 to 384000), taking the audiocontextoptions WPT test from 35/41 to 41/41 passes.
- Loads started by `DOMContentLoaded` event handlers now delay the `load` event. The parser end state machine previously evaluated all of its phases in one synchronous pass at parse end, before the queued `DOMContentLoaded` task ran, which diverges from the spec's spin-the-event-loop semantics and from engine behavior.
- Clearing a `load` event delayer inside a subframe document now wakes ancestor documents' parser end state machines. Previously the last thing delaying an ancestor's load event could clear without anyone re-checking the ancestor, stalling its `load` event forever; this also hit https://thebodyshop.se at larger window sizes via an image inside one of its tracking-pixel iframes.
- A container's `load` event now always fires before the ancestor document's `load` event, as in every major engine. The ancestor previously stopped waiting once the content document was ready for post-load tasks, which is set before the container's `load` event task is queued, so the two could race.

Every behavior change comes with a regression test. The tests order asynchronous work with echo server unblock tokens and task-ordering anchors rather than wall-clock delays.