### PR TITLE
LibWeb: Invalidate style and layout synchronously for cached images

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -711,6 +711,11 @@ void HTMLImageElement::update_the_image_data_impl(bool restart_animations, bool 
             //        That's why we value_or(1.0f) it.
             m_current_request->set_current_pixel_density(selected_pixel_density.value_or(1.0f));
 
+            // AD-HOC: Invalidate synchronously here. The image data is already available — so a paint taken before the
+            //         task below runs must still reflect it (otherwise, reftest screenshots can capture the old image).
+            set_needs_style_update(true);
+            set_needs_layout_update_or_repaint_after_image_data_change(*this, DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
+
             // 7. Queue an element task on the DOM manipulation task source given the img element and following steps:
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this, restart_animations, maybe_omit_events, url_string, previous_url] {
                 // AD-HOC: Bail out if the document became inactive (e.g. iframe removed or navigated)
@@ -726,9 +731,6 @@ void HTMLImageElement::update_the_image_data_impl(bool restart_animations, bool 
 
                 // 2. Set the current request's current URL to urlString.
                 m_current_request->set_current_url(document().realm(), Utf16String::from_utf8(*url_string));
-
-                set_needs_style_update(true);
-                set_needs_layout_update_or_repaint_after_image_data_change(*this, DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
 
                 // 3. If maybe omit events is not set or previousURL is not equal to urlString, then fire an event named load at the img element.
                 if (!maybe_omit_events || previous_url != Utf16String::from_utf8(*url_string))


### PR DESCRIPTION
**Problem:** In CI, `already-loaded-image-invalidates-style-and-layout.html` and other reftests that assign an `img` element’s `src` to an already-loaded image intermittently captured the previous image — with the whole image square painted the old color.

**Cause:** When an `img` adopts an image already in available-images list, the cached-image path in “update the image data” sets the current request’s image data synchronously — but defers the style and layout invalidation into a
queued element task. A rendering update that runs before that task — such as the one the `src` attribute change itself schedules — then paints the stale layout, because needs-layout hasn’t been set.

**Fix:** Do sync style and layout invalidation, alongside the sync image-data update. Only the observably-async steps (restart the animation, set the current URL, fire the `load` event) remain in the queued task.
