### PR TITLE
LibWeb: Fix keyboard input event dispatch for controlled editors

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -782,12 +782,7 @@ public:
     void set_previous_document_unload_timing(DocumentUnloadTimingInfo const& previous_document_unload_timing) { m_previous_document_unload_timing = previous_document_unload_timing; }
 
     // https://w3c.github.io/editing/docs/execCommand/
-    enum class DispatchInputEvent {
-        No,
-        Yes,
-    };
     WebIDL::ExceptionOr<bool> exec_command(FlyString const& command, bool show_ui, Utf16String const& value);
-    WebIDL::ExceptionOr<bool> exec_command_internal(FlyString const& command, bool show_ui, Utf16String const& value, DispatchInputEvent);
     WebIDL::ExceptionOr<bool> query_command_enabled(FlyString const& command);
     WebIDL::ExceptionOr<bool> query_command_indeterm(FlyString const& command);
     WebIDL::ExceptionOr<bool> query_command_state(FlyString const& command);

--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -174,7 +174,7 @@ void EditingHostManager::decrement_cursor_position_to_previous_line(CollapseSele
         selection->move_offset_to_previous_line(collapse == CollapseSelection::Yes);
 }
 
-void EditingHostManager::handle_delete(FlyString const& input_type, DispatchInputEvent dispatch_input_event)
+void EditingHostManager::handle_delete(FlyString const& input_type)
 {
     // https://w3c.github.io/editing/docs/execCommand/#additional-requirements
     // When the user instructs the user agent to delete the previous character inside an editing host, such as by
@@ -184,7 +184,7 @@ void EditingHostManager::handle_delete(FlyString const& input_type, DispatchInpu
     // the Delete key while the cursor is in an editable node, the user agent must call execCommand("forwarddelete") on
     // the relevant document.
     auto command = input_type == UIEvents::InputTypes::deleteContentBackward ? Editing::CommandNames::delete_ : Editing::CommandNames::forwardDelete;
-    auto editing_result = m_document->exec_command_internal(command, false, {}, dispatch_input_event == DispatchInputEvent::Yes ? DOM::Document::DispatchInputEvent::Yes : DOM::Document::DispatchInputEvent::No);
+    auto editing_result = m_document->exec_command(command, false, {});
     if (editing_result.is_exception())
         dbgln("handle_delete(): editing resulted in exception: {}", editing_result.exception());
 }

--- a/Libraries/LibWeb/DOM/EditingHostManager.h
+++ b/Libraries/LibWeb/DOM/EditingHostManager.h
@@ -23,7 +23,7 @@ public:
     [[nodiscard]] static GC::Ref<EditingHostManager> create(JS::Realm&, GC::Ref<Document>);
 
     virtual void handle_insert(FlyString const& input_type, Utf16String const&) override;
-    virtual void handle_delete(FlyString const& input_type, DispatchInputEvent = DispatchInputEvent::Yes) override;
+    virtual void handle_delete(FlyString const& input_type) override;
     virtual EventResult handle_return_key(FlyString const& ui_input_type) override;
     virtual GC::Ptr<DOM::Node> mouse_selection_scope() override { return m_active_contenteditable_element; }
     virtual void select_all() override;

--- a/Libraries/LibWeb/DOM/InputEventsTarget.h
+++ b/Libraries/LibWeb/DOM/InputEventsTarget.h
@@ -22,11 +22,7 @@ public:
 
     virtual void handle_insert(FlyString const& input_type, Utf16String const&) = 0;
     virtual EventResult handle_return_key(FlyString const& input_type) = 0;
-    enum class DispatchInputEvent {
-        No,
-        Yes,
-    };
-    virtual void handle_delete(FlyString const& input_type, DispatchInputEvent = DispatchInputEvent::Yes) = 0;
+    virtual void handle_delete(FlyString const& input_type) = 0;
 
     // The node that mouse-driven selection through this target is constrained to (e.g. the text node inside a text
     // control, or the active editing host). Dragging outside it snaps the selection focus to its closest position.

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -20,11 +20,6 @@ namespace Web::DOM {
 // https://w3c.github.io/editing/docs/execCommand/#execcommand()
 WebIDL::ExceptionOr<bool> Document::exec_command(FlyString const& command, [[maybe_unused]] bool show_ui, Utf16String const& value)
 {
-    return exec_command_internal(command, show_ui, value, DispatchInputEvent::Yes);
-}
-
-WebIDL::ExceptionOr<bool> Document::exec_command_internal(FlyString const& command, [[maybe_unused]] bool show_ui, Utf16String const& value, DispatchInputEvent dispatch_input_event)
-{
     // AD-HOC: This is not directly mentioned in the spec, but all major browsers limit editing API calls to HTML documents
     if (!is_html_document())
         return WebIDL::InvalidStateError::create(realm(), "execCommand is only supported on HTML documents"_utf16);
@@ -124,7 +119,7 @@ WebIDL::ExceptionOr<bool> Document::exec_command_internal(FlyString const& comma
     //    value of command, and its data attribute initialized to null.
     bool tree_was_modified = dom_tree_version() != old_dom_tree_version
         || character_data_version() != old_character_data_version;
-    if (tree_was_modified && affected_editing_host && dispatch_input_event == DispatchInputEvent::Yes) {
+    if (tree_was_modified && affected_editing_host) {
         Bindings::InputEventInit event_init {};
         event_init.bubbles = true;
         event_init.input_type = command_definition.mapped_value.to_string();

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -1071,7 +1071,7 @@ void FormAssociatedTextControlElement::handle_insert(FlyString const& input_type
     scroll_cursor_into_view();
 }
 
-void FormAssociatedTextControlElement::handle_delete(FlyString const& input_type, DispatchInputEvent dispatch_input_event)
+void FormAssociatedTextControlElement::handle_delete(FlyString const& input_type)
 {
     auto text_node = form_associated_element_to_text_node();
     if (!text_node || !static_cast<FormAssociatedElement&>(text_control_to_html_element()).is_mutable())
@@ -1093,8 +1093,7 @@ void FormAssociatedTextControlElement::handle_delete(FlyString const& input_type
     MUST(set_range_text({}, selection_start, selection_end, Bindings::SelectionMode::End));
 
     text_node->invalidate_style(DOM::StyleInvalidationReason::EditingDeletion);
-    if (dispatch_input_event == DispatchInputEvent::Yes)
-        did_edit_text_node(input_type, {});
+    did_edit_text_node(input_type, {});
     scroll_cursor_into_view();
 }
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -257,7 +257,7 @@ public:
     virtual GC::Ptr<DOM::Element> text_control_scroll_container() = 0;
 
     virtual void handle_insert(FlyString const& input_type, Utf16String const&) override;
-    virtual void handle_delete(FlyString const& input_type, DispatchInputEvent = DispatchInputEvent::Yes) override;
+    virtual void handle_delete(FlyString const& input_type) override;
     virtual GC::Ptr<DOM::Node> mouse_selection_scope() override;
     virtual void select_all() override;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset, TextAffinity = TextAffinity::Downstream) override;

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -2046,17 +2046,33 @@ void HTMLElement::did_receive_focus()
             return;
     }
 
-    DOM::Text* text = nullptr;
+    // AD-HOC: Place the cursor at the first valid caret position inside the editing host, matching other browsers:
+    //         the start of the first non-whitespace text node, or before the first <br> when there is no text. This
+    //         matters for editor frameworks (e.g. Draft.js) that only reconcile DOM mutations occurring inside their
+    //         rendered leaf elements.
+    DOM::Text* first_text = nullptr;
     for_each_in_inclusive_subtree_of_type<DOM::Text>([&](auto& node) {
-        text = &node;
-        return TraversalDecision::Continue;
+        if (node.data().is_ascii_whitespace())
+            return TraversalDecision::Continue;
+        first_text = &node;
+        return TraversalDecision::Break;
     });
-
-    if (!text) {
-        editing_host->set_selection_anchor(*this, 0);
+    if (first_text) {
+        editing_host->set_selection_anchor(*first_text, 0);
         return;
     }
-    editing_host->set_selection_anchor(*text, text->length());
+
+    HTMLBRElement* first_br = nullptr;
+    for_each_in_inclusive_subtree_of_type<HTMLBRElement>([&](auto& node) {
+        first_br = &node;
+        return TraversalDecision::Break;
+    });
+    if (first_br && first_br->parent()) {
+        editing_host->set_selection_anchor(*first_br->parent(), first_br->index());
+        return;
+    }
+
+    editing_host->set_selection_anchor(*this, 0);
 }
 
 void HTMLElement::did_lose_focus()

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1043,7 +1043,7 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     if (should_ignore_device_input_event() && m_mousedown_target_is_drag_candidate && key == UIEvents::KeyCode::Key_Escape)
         return cancel_drag_and_drop_event(m_last_known_mouse_visual_viewport_position.value_or({}), m_last_known_mouse_screen_position, UIEvents::MouseButton::Primary, m_last_known_mouse_buttons, modifiers);
 
-    auto handle_delete_key = [&](InputEventsTarget& target, InputEventsTarget::DispatchInputEvent dispatch_input_event) -> Optional<EventResult> {
+    auto handle_delete_key = [&](InputEventsTarget& target) -> Optional<EventResult> {
         auto input_type = input_type_for_delete_key(key);
         if (!input_type.has_value())
             return {};
@@ -1052,20 +1052,13 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         if (beforeinput_result == EventResult::Cancelled)
             return beforeinput_result;
 
-        target.handle_delete(input_type.value(), dispatch_input_event);
+        target.handle_delete(input_type.value());
         return EventResult::Handled;
     };
 
     auto dispatch_result = fire_keyboard_event(UIEvents::EventNames::keydown, m_navigable, key, modifiers, code_point, repeat);
-    if (dispatch_result == EventResult::Cancelled) {
-        if (auto document = m_navigable->active_document(); document && document->is_fully_active()) {
-            if (auto* target = document->active_input_events_target()) {
-                if (auto delete_result = handle_delete_key(*target, InputEventsTarget::DispatchInputEvent::No); delete_result.has_value())
-                    return delete_result.value();
-            }
-        }
+    if (dispatch_result != EventResult::Accepted)
         return dispatch_result;
-    }
 
     // https://w3c.github.io/uievents/#event-type-keypress
     // If supported by a user agent, this event MUST be dispatched when a key is pressed down, if and only if that key
@@ -1116,7 +1109,7 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     }
 
     if (auto* target = document->active_input_events_target()) {
-        if (auto delete_result = handle_delete_key(*target, InputEventsTarget::DispatchInputEvent::Yes); delete_result.has_value())
+        if (auto delete_result = handle_delete_key(*target); delete_result.has_value())
             return delete_result.value();
 
 #if defined(AK_OS_MACOS)

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -59,6 +59,7 @@
 #include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 #include <LibWeb/UIEvents/PointerEvent.h>
+#include <LibWeb/UIEvents/TextEvent.h>
 #include <LibWeb/UIEvents/WheelEvent.h>
 
 #include <SDL3/SDL_events.h>
@@ -1199,6 +1200,7 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
             }
 
             FIRE(input_event(UIEvents::EventNames::beforeinput, input_type, m_navigable, code_point));
+            FIRE(fire_text_input_event(m_navigable, "\n"_string));
             if (target->handle_return_key(input_type) != EventResult::Handled)
                 target->handle_insert(input_type, Utf16String::from_code_point(code_point));
 
@@ -1208,6 +1210,7 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         // FIXME: Text editing shortcut keys (copy/paste etc.) should be handled here.
         if (!should_ignore_keydown_event(code_point, modifiers, should_insert_text)) {
             FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::insertText, m_navigable, code_point));
+            FIRE(fire_text_input_event(m_navigable, String::from_code_point(code_point)));
             target->handle_insert(UIEvents::InputTypes::insertText, Utf16String::from_code_point(code_point));
             return EventResult::Handled;
         }
@@ -1538,6 +1541,35 @@ EventResult EventHandler::fire_keyboard_event(FlyString const& event_name, HTML:
 
     GC::Ptr target = document->body() ?: &document->root();
     return target->dispatch_event(event) ? EventResult::Accepted : EventResult::Cancelled;
+}
+
+// https://w3c.github.io/uievents/#event-type-textInput
+// AD-HOC: The legacy textInput event is deprecated, but all major browsers still fire it between beforeinput and the
+//         actual text insertion, and cancelling it prevents the insertion. React sources its onBeforeInput synthetic
+//         event from textInput whenever the TextEvent interface is exposed, so controlled editors depend on it.
+EventResult EventHandler::fire_text_input_event(HTML::LocalNavigable& navigable, String const& data)
+{
+    auto document = navigable.active_document();
+    if (!document)
+        return EventResult::Dropped;
+    if (!document->is_fully_active())
+        return EventResult::Dropped;
+
+    if (auto focused_area = document->focused_area()) {
+        if (is<HTML::NavigableContainer>(*focused_area)) {
+            auto& navigable_container = as<HTML::NavigableContainer>(*focused_area);
+            if (navigable_container.content_navigable())
+                return fire_text_input_event(as<HTML::LocalNavigable>(*navigable_container.content_navigable()), data);
+        }
+
+        auto event = UIEvents::TextEvent::create(document->realm(), UIEvents::EventNames::textInput);
+        event->init_text_event(UIEvents::EventNames::textInput.to_string(), true, true, navigable.active_window_proxy(), data);
+        event->set_composed(true);
+        event->set_is_trusted(true);
+        return focused_area->dispatch_event(event) ? EventResult::Accepted : EventResult::Cancelled;
+    }
+
+    return EventResult::Accepted;
 }
 
 EventResult EventHandler::input_event(FlyString const& event_name, FlyString const& input_type, HTML::LocalNavigable& navigable, Variant<u32, Utf16String> code_point_or_string)

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -85,6 +85,7 @@ private:
     bool should_ignore_device_input_event() const;
 
     EventResult fire_keyboard_event(FlyString const& event_name, HTML::LocalNavigable&, UIEvents::KeyCode, unsigned modifiers, u32 code_point, bool repeat);
+    [[nodiscard]] EventResult fire_text_input_event(HTML::LocalNavigable&, String const& data);
     [[nodiscard]] EventResult input_event(FlyString const& event_name, FlyString const& input_type, HTML::LocalNavigable&, Variant<u32, Utf16String> code_point_or_string);
 
     EventResult focus_next_element();

--- a/Libraries/LibWeb/UIEvents/EventNames.h
+++ b/Libraries/LibWeb/UIEvents/EventNames.h
@@ -42,6 +42,7 @@ namespace Web::UIEvents::EventNames {
     __ENUMERATE_UI_EVENT(pointerrawupdate)   \
     __ENUMERATE_UI_EVENT(pointerup)          \
     __ENUMERATE_UI_EVENT(resize)             \
+    __ENUMERATE_UI_EVENT(textInput)          \
     __ENUMERATE_UI_EVENT(wheel)
 
 #define __ENUMERATE_UI_EVENT(name) extern WEB_API FlyString const& name;

--- a/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -705,6 +705,13 @@ GC::Ref<KeyboardEvent> KeyboardEvent::create_from_platform_event(JS::Realm& real
     auto key_code = determine_key_code(platform_key, code_point);
     auto char_code = determine_char_code(event_name, code_point);
 
+    // https://w3c.github.io/uievents/#determine-keypress-keycode
+    // For keypress events that produce a character, all major browsers set keyCode (and therefore which) to the
+    // character code rather than the virtual key code. React synthesizes its onBeforeInput text from
+    // String.fromCharCode(event.which) on keypress, so controlled editors break without this.
+    if (event_name == UIEvents::EventNames::keypress && char_code != 0)
+        key_code = char_code;
+
     Bindings::KeyboardEventInit event_init {};
     event_init.key = move(event_key);
     event_init.code = move(event_code);

--- a/Tests/LibWeb/Text/expected/Editing/backspace-cancelled-keydown.txt
+++ b/Tests/LibWeb/Text/expected/Editing/backspace-cancelled-keydown.txt
@@ -1,2 +1,2 @@
-editor text: a
-events: keydown:Backspace, beforeinput:deleteContentBackward
+editor text: ab
+events: keydown:Backspace

--- a/Tests/LibWeb/Text/expected/Editing/backspace-cancelled-keydown.txt
+++ b/Tests/LibWeb/Text/expected/Editing/backspace-cancelled-keydown.txt
@@ -1,0 +1,2 @@
+editor text: a
+events: keydown:Backspace, beforeinput:deleteContentBackward

--- a/Tests/LibWeb/Text/expected/Editing/click-empty-editable-after-focus-layout-change.txt
+++ b/Tests/LibWeb/Text/expected/Editing/click-empty-editable-after-focus-layout-change.txt
@@ -1,10 +1,10 @@
 beforeinput composed: true
 input composed: true
 activeElement: editor
-editor text: a
-block text: a
+editor text: abcd
+block text: abcd
 selection anchor: #text
-selection anchor offset: 1
-beforeinput target ranges: 0-0, 1-1, 2-2, 3-3, 3-4, 2-3, 1-2
+selection anchor offset: 4
+beforeinput target ranges: 0-0, 1-1, 2-2, 3-3
 input types: insertText, insertText, insertText, insertText
 input selection offsets: 1, 2, 3, 4

--- a/Tests/LibWeb/Text/expected/Editing/contenteditable-focus-caret-position.txt
+++ b/Tests/LibWeb/Text/expected/Editing/contenteditable-focus-caret-position.txt
@@ -1,0 +1,4 @@
+a: anchor=#text("abc") offset=0
+b: anchor=#text("abc") offset=0
+c: anchor=span#c-span offset=0
+d: anchor=#text("one") offset=0

--- a/Tests/LibWeb/Text/expected/UIEvents/keypress-legacy-key-attributes.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/keypress-legacy-key-attributes.txt
@@ -1,0 +1,6 @@
+keydown key=h keyCode=72 charCode=0 which=72
+keypress key=h keyCode=72 charCode=104 which=72
+keydown key=H keyCode=72 charCode=0 which=72
+keypress key=H keyCode=72 charCode=72 which=72
+keydown key=1 keyCode=49 charCode=0 which=49
+keypress key=1 keyCode=49 charCode=49 which=49

--- a/Tests/LibWeb/Text/expected/UIEvents/keypress-legacy-key-attributes.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/keypress-legacy-key-attributes.txt
@@ -1,5 +1,5 @@
 keydown key=h keyCode=72 charCode=0 which=72
-keypress key=h keyCode=72 charCode=104 which=72
+keypress key=h keyCode=104 charCode=104 which=104
 keydown key=H keyCode=72 charCode=0 which=72
 keypress key=H keyCode=72 charCode=72 which=72
 keydown key=1 keyCode=49 charCode=0 which=49

--- a/Tests/LibWeb/Text/expected/UIEvents/textinput-event.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/textinput-event.txt
@@ -1,0 +1,8 @@
+editor text: "a"
+field value: "bz"
+beforeinput(InputEvent data="a" inputType=insertText cancelable=true bubbles=true composed=true)
+input(InputEvent data="a" inputType=insertText cancelable=false bubbles=true composed=true)
+beforeinput(InputEvent data=null inputType=insertParagraph cancelable=true bubbles=true composed=true)
+input(InputEvent data=null inputType=insertParagraph cancelable=false bubbles=true composed=true)
+beforeinput(InputEvent data="b" inputType=insertText cancelable=true bubbles=true composed=true)
+beforeinput(InputEvent data="z" inputType=insertText cancelable=true bubbles=true composed=true)

--- a/Tests/LibWeb/Text/expected/UIEvents/textinput-event.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/textinput-event.txt
@@ -1,8 +1,12 @@
 editor text: "a"
-field value: "bz"
+field value: "b"
 beforeinput(InputEvent data="a" inputType=insertText cancelable=true bubbles=true composed=true)
+textInput(TextEvent data="a" inputType=- cancelable=true bubbles=true composed=true)
 input(InputEvent data="a" inputType=insertText cancelable=false bubbles=true composed=true)
 beforeinput(InputEvent data=null inputType=insertParagraph cancelable=true bubbles=true composed=true)
+textInput(TextEvent data="\n" inputType=- cancelable=true bubbles=true composed=true)
 input(InputEvent data=null inputType=insertParagraph cancelable=false bubbles=true composed=true)
 beforeinput(InputEvent data="b" inputType=insertText cancelable=true bubbles=true composed=true)
+textInput(TextEvent data="b" inputType=- cancelable=true bubbles=true composed=true)
 beforeinput(InputEvent data="z" inputType=insertText cancelable=true bubbles=true composed=true)
+textInput(TextEvent data="z" inputType=- cancelable=true bubbles=true composed=true)

--- a/Tests/LibWeb/Text/expected/contenteditable-should-insert-into-nested-node.txt
+++ b/Tests/LibWeb/Text/expected/contenteditable-should-insert-into-nested-node.txt
@@ -1,1 +1,1 @@
-hello!!!
+!!!hello

--- a/Tests/LibWeb/Text/input/Editing/backspace-cancelled-keydown.html
+++ b/Tests/LibWeb/Text/input/Editing/backspace-cancelled-keydown.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="editor" contenteditable="true">abc</div>
+<script>
+    test(() => {
+        const editor = document.getElementById("editor");
+        const events = [];
+
+        // Like Lexical-based editors (e.g. Reddit's comment composer), handle Backspace on keydown by
+        // deleting a character ourselves and cancelling the event. Cancelling the keydown must suppress
+        // the entire editing action, including the beforeinput event, so only one character is deleted.
+        editor.addEventListener("keydown", event => {
+            events.push(`keydown:${event.key}`);
+            if (event.key === "Backspace") {
+                const text = editor.firstChild;
+                text.data = text.data.slice(0, -1);
+                event.preventDefault();
+            }
+        });
+        editor.addEventListener("beforeinput", event => {
+            events.push(`beforeinput:${event.inputType}`);
+            if (event.inputType === "deleteContentBackward") {
+                const text = editor.firstChild;
+                text.data = text.data.slice(0, -1);
+                event.preventDefault();
+            }
+        });
+        editor.addEventListener("input", event => {
+            events.push(`input:${event.inputType}`);
+        });
+
+        editor.focus();
+        const text = editor.firstChild;
+        getSelection().setBaseAndExtent(text, 3, text, 3);
+
+        internals.sendKey(editor, "Backspace");
+
+        println(`editor text: ${editor.textContent}`);
+        println(`events: ${events.join(", ")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Editing/contenteditable-focus-caret-position.html
+++ b/Tests/LibWeb/Text/input/Editing/contenteditable-focus-caret-position.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="a" contenteditable="true">abc</div>
+<div id="b" contenteditable="true"><div><span id="b-span">abc</span></div></div>
+<div id="c" contenteditable="true"><div><div><span id="c-span"><br></span></div></div></div>
+<div id="d" contenteditable="true"><p>one</p><p>two</p></div>
+<script>
+    test(() => {
+        const describe = n => !n
+            ? "null"
+            : (n.nodeType === Node.TEXT_NODE ? `#text("${n.data}")` : n.nodeName.toLowerCase() + (n.id ? "#" + n.id : ""));
+        for (const id of ["a", "b", "c", "d"]) {
+            const editor = document.getElementById(id);
+            editor.focus();
+            const selection = getSelection();
+            println(`${id}: anchor=${describe(selection.anchorNode)} offset=${selection.anchorOffset}`);
+            editor.blur();
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/keypress-legacy-key-attributes.html
+++ b/Tests/LibWeb/Text/input/UIEvents/keypress-legacy-key-attributes.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<input id="in">
+<script>
+    test(() => {
+        const input = document.getElementById("in");
+        input.focus();
+        for (const type of ["keydown", "keypress"])
+            input.addEventListener(type, e => println(`${e.type} key=${e.key} keyCode=${e.keyCode} charCode=${e.charCode} which=${e.which}`));
+        internals.sendText(input, "hH1");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/textinput-event.html
+++ b/Tests/LibWeb/Text/input/UIEvents/textinput-event.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="editor" contenteditable="true"></div>
+<input id="field">
+<script>
+    test(() => {
+        const events = [];
+        for (const type of ["beforeinput", "textInput", "input"]) {
+            window.addEventListener(type, e => {
+                events.push(`${e.type}(${e.constructor.name} data=${JSON.stringify(e.data ?? null)} inputType=${e.inputType ?? "-"} cancelable=${e.cancelable} bubbles=${e.bubbles} composed=${e.composed})`);
+            }, true);
+        }
+
+        const editor = document.getElementById("editor");
+        editor.focus();
+        internals.sendText(editor, "a");
+        internals.sendKey(editor, "Return");
+
+        const field = document.getElementById("field");
+        field.focus();
+        internals.sendText(field, "b");
+
+        // Cancelling textInput must prevent the insertion and the input event.
+        field.addEventListener("textInput", e => e.preventDefault());
+        internals.sendText(field, "z");
+
+        println(`editor text: ${JSON.stringify(editor.textContent)}`);
+        println(`field value: ${JSON.stringify(field.value)}`);
+        for (const line of events) println(line);
+    });
+</script>


### PR DESCRIPTION
JavaScript editor frameworks like Lexical (Reddit) and Draft.js (X) drive all
their editing from keyboard and input events, and several long-standing gaps
in our event dispatch left those editors subtly or completely broken.
Cancelling a Backspace keydown did not suppress the delete editing action, so
editors that handle deletion themselves deleted twice. On keypress, keyCode
and which reported the virtual key code instead of the character code that
every other browser reports, corrupting text that React synthesizes from
event.which. The legacy textInput event was never dispatched even though we
expose the TextEvent interface, so React's feature detection routed
onBeforeInput through an event that never came, and Draft.js corrupted its
model on every keystroke. Finally, focusing a contenteditable placed the
cursor at the end of the last text node rather than the first caret position,
so typed text could land outside the editor's rendered leaves where it cannot
map the mutation back to its model.

Each fix was calibrated against Chrome's observable behavior and comes with a
regression test that first documents the old behavior, then flips with the
fix. With this series, typing and Backspace behave correctly in both Reddit's
and X's composers.