### PR TITLE
LibWeb: Support caret navigation and repaint across nodes in editing hosts

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -580,27 +580,31 @@ Document::Document(JS::Realm& realm, URL::URL const& url)
     m_is_decoded_svg = m_page->client().is_svg_page_client();
 
     m_cursor_blink_timer = heap().allocate<GC::Timer>();
-    m_cursor_blink_timer->start_repeating(500, GC::create_function(heap(), [this] {
-        auto cursor_position = this->cursor_position();
-        if (!cursor_position)
-            return;
-
-        auto navigable = this->navigable();
-        if (!navigable || !navigable->is_focused())
-            return;
-
-        auto node = cursor_position->node();
-        if (auto* text = as_if<DOM::Text>(*node)) {
-            auto* layout_text_node = as_if<Layout::TextNode>(text->unsafe_layout_node());
-            if (!layout_text_node)
+    // NB: In test mode, the caret must not blink so we can deterministically generate display lists. The blink state
+    //     is set whenever the cursor moves (see reset_cursor_blink_cycle()), so the caret is still painted.
+    if (!HTML::Window::in_test_mode()) {
+        m_cursor_blink_timer->start_repeating(500, GC::create_function(heap(), [this] {
+            auto cursor_position = this->cursor_position();
+            if (!cursor_position)
                 return;
-            m_cursor_blink_state = !m_cursor_blink_state;
-            layout_text_node->set_needs_repaint();
-        } else if (node->unsafe_paintable()) {
-            m_cursor_blink_state = !m_cursor_blink_state;
-            node->set_needs_repaint();
-        }
-    }));
+
+            auto navigable = this->navigable();
+            if (!navigable || !navigable->is_focused())
+                return;
+
+            auto node = cursor_position->node();
+            if (auto* text = as_if<DOM::Text>(*node)) {
+                auto* layout_text_node = as_if<Layout::TextNode>(text->unsafe_layout_node());
+                if (!layout_text_node)
+                    return;
+                m_cursor_blink_state = !m_cursor_blink_state;
+                layout_text_node->set_needs_repaint();
+            } else if (node->unsafe_paintable()) {
+                m_cursor_blink_state = !m_cursor_blink_state;
+                node->set_needs_repaint();
+            }
+        }));
+    }
 
     HTML::main_thread_event_loop().register_document({}, *this);
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8101,9 +8101,12 @@ Optional<CSSPixelRect> Document::current_caret_rect()
             return to_viewport_rect(*caret_rect);
     }
 
-    // Empty editable elements have no fragments; fall back to the padding-box corner.
+    // Empty editable elements have no fragments; fall back to the caret position for the cursor's child offset
+    // (which accounts for empty lines rendered by <br>), or the padding-box corner.
     if (auto* node_with_style = as_if<Layout::NodeWithStyleAndBoxModelMetrics>(*layout_node)) {
         auto paintable = node_with_style->first_paintable();
+        if (auto const* with_lines = as_if<Painting::PaintableWithLines>(paintable.ptr()))
+            return to_viewport_rect(with_lines->caret_rect_for_child_offset(position->offset()));
         if (auto const* box = paintable.ptr()) {
             auto content_box = box->absolute_padding_box_rect();
             return to_viewport_rect(CSSPixelRect { content_box.x(), content_box.y(), 1, node_with_style->computed_values().line_height() });

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -808,6 +808,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_dialog_pointerdown_target);
     visitor.visit(m_console_client);
     visitor.visit(m_cursor_blink_timer);
+    visitor.visit(m_previously_repainted_cursor_position);
     visitor.visit(m_editing_host_manager);
     visitor.visit(m_local_storage_holder);
     visitor.visit(m_session_storage_holder);
@@ -8122,18 +8123,25 @@ void Document::reset_cursor_blink_cycle()
 
 void Document::set_cursor_position_needs_repaint()
 {
+    auto repaint_position = [](DOM::Position& position) {
+        auto node = position.node();
+        if (auto* text = as_if<DOM::Text>(*node)) {
+            if (auto* layout_text_node = as_if<Layout::TextNode>(text->unsafe_layout_node()))
+                layout_text_node->set_needs_repaint();
+            return;
+        }
+        node->set_needs_repaint();
+    };
+
     auto position = cursor_position();
-    if (!position)
-        return;
 
-    auto node = position->node();
-    if (auto* text = as_if<DOM::Text>(*node)) {
-        if (auto* layout_text_node = as_if<Layout::TextNode>(text->unsafe_layout_node()))
-            layout_text_node->set_needs_repaint();
-        return;
-    }
+    // NB: Also repaint the node the cursor moved away from, so the old caret disappears.
+    if (m_previously_repainted_cursor_position && (!position || m_previously_repainted_cursor_position->node() != position->node()))
+        repaint_position(*m_previously_repainted_cursor_position);
+    m_previously_repainted_cursor_position = position;
 
-    node->set_needs_repaint();
+    if (position)
+        repaint_position(*position);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#doc-container-document

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1620,6 +1620,10 @@ private:
     GC::Ptr<GC::Timer> m_cursor_blink_timer;
     bool m_cursor_blink_state { false };
 
+    // The cursor position most recently invalidated for caret painting, so that moving the caret to another node
+    // also repaints the node it moved away from.
+    GC::Ptr<DOM::Position> m_previously_repainted_cursor_position;
+
     // NOTE: This is GC::Weak, not GC::Ptr, on purpose. We don't want the document to keep some old detached navigable alive.
     GC::Weak<HTML::LocalNavigable> m_navigable;
 

--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -86,13 +86,13 @@ GC::Ptr<Selection::Selection> EditingHostManager::get_selection_for_navigation(C
     if (!selection)
         return {};
 
-    // and the focus node must be inside a text node,
+    // and the focus node must be a text node or an element directly housing the caret (e.g. an empty line),
     auto focus_node = selection->focus_node();
-    if (!is<Text>(focus_node.ptr()))
+    if (!focus_node || (!is<Text>(*focus_node) && !is<Element>(*focus_node)))
         return {};
 
     // and if we're performing collapsed navigation (i.e. moving the caret), the focus node must be editable.
-    if (collapse == CollapseSelection::Yes && !focus_node->is_editable())
+    if (collapse == CollapseSelection::Yes && !focus_node->is_editable_or_editing_host())
         return {};
 
     return selection;

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -127,6 +127,7 @@ void Range::update_associated_selection()
         return;
 
     document.reset_cursor_blink_cycle();
+    document.set_cursor_position_needs_repaint();
 
     // https://w3c.github.io/selection-api/#selectionchange-event
     // When the selection is dissociated with its range, associated with a new range, or the associated range's boundary

--- a/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -9,8 +9,11 @@
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/Layout/BreakNode.h>
+#include <LibWeb/Layout/ReplacedBox.h>
+#include <LibWeb/VisualLines.h>
 
 namespace Web::HTML {
 
@@ -56,6 +59,53 @@ void HTMLBRElement::apply_presentational_hints(Vector<CSS::StyleProperty>& prope
                 properties.append({ .property_id = CSS::PropertyID::Clear, .value = CSS::KeywordStyleValue::create(CSS::Keyword::Both) });
         }
     });
+}
+
+// Rendered inline content that would appear before a <br> on its line.
+static bool is_rendered_inline_content(DOM::Node const& node)
+{
+    if (auto const* text = as_if<DOM::Text>(node)) {
+        for (auto const& line : collect_visual_lines(*text)) {
+            if (!line.fragments.is_empty())
+                return true;
+        }
+        return false;
+    }
+    if (auto const* element = as_if<DOM::Element>(node)) {
+        auto const* layout_node = element->layout_node();
+        if (!layout_node)
+            return false;
+        if (is<Layout::ReplacedBox>(*layout_node))
+            return true;
+        if (layout_node->display().is_inline_outside() && !layout_node->display().is_flow_inside())
+            return true;
+    }
+    return false;
+}
+
+// NB: Layout produces no fragments for <br>, so this walks the DOM back to the start of the containing block or a
+//     previous <br>, whichever comes first.
+bool HTMLBRElement::represents_empty_line() const
+{
+    if (!layout_node())
+        return false;
+
+    auto const* containing_block = layout_node()->containing_block();
+    if (!containing_block)
+        return false;
+    auto const* containing_block_dom_node = containing_block->dom_node();
+    if (!containing_block_dom_node)
+        return false;
+
+    for (auto const* previous = previous_in_pre_order(); previous && previous != containing_block_dom_node; previous = previous->previous_in_pre_order()) {
+        if (!containing_block_dom_node->is_inclusive_ancestor_of(*previous))
+            break;
+        if (is<HTMLBRElement>(*previous))
+            return true;
+        if (is_rendered_inline_content(*previous))
+            return false;
+    }
+    return true;
 }
 
 void HTMLBRElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)

--- a/Libraries/LibWeb/HTML/HTMLBRElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.h
@@ -22,6 +22,10 @@ public:
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
     virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
 
+    // Whether this <br> renders an empty line, i.e. nothing else renders between the start of its line and the <br>
+    // itself. Such a <br> hosts a caret position on its parent, at its child index.
+    bool represents_empty_line() const;
+
 private:
     virtual bool is_html_br_element() const override { return true; }
 

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -14,6 +14,7 @@
 #include <LibUnicode/Locale.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
+#include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Painting/Paintable.h>
 
@@ -943,6 +944,19 @@ Optional<TextNode::Chunk> TextNode::ChunkIterator::try_commit_chunk(size_t start
 
 void TextNode::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list) const
 {
+    // NB: Fragments for text inside an inline element are owned by that inline element's line paintables rather than
+    //     the containing block's paintable, so invalidate the nearest inline ancestor's paintables when there is one.
+    //     This mirrors the fragment relocation performed by LayoutState::commit().
+    for (auto const* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
+        if (!ancestor->display().is_inline_outside() || !ancestor->display().is_flow_inside())
+            break;
+        if (is<InlineNode>(*ancestor)) {
+            for (auto& paintable : const_cast<NodeWithStyle&>(*ancestor).paintables())
+                paintable->set_needs_repaint(should_invalidate_display_list);
+            break;
+        }
+    }
+
     if (auto* containing_block = this->containing_block()) {
         if (auto paintable_box = const_cast<Box&>(*containing_block).paintable_box())
             paintable_box->set_needs_repaint(should_invalidate_display_list);

--- a/Libraries/LibWeb/Page/AutoScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/AutoScrollHandler.cpp
@@ -109,6 +109,10 @@ CSSPixelPoint AutoScrollHandler::process(CSSPixelPoint mouse_position)
 
 GC::Ptr<DOM::Element> AutoScrollHandler::find_scrollable_ancestor(Painting::Paintable const& paintable)
 {
+    // NB: The caller may have held on to this paintable across script execution that rebuilt the layout tree.
+    if (!paintable.has_layout_node())
+        return {};
+
     RefPtr<Painting::Paintable> paintable_box = const_cast<Painting::Paintable&>(paintable);
     while (paintable_box) {
         if (paintable_box->could_be_scrolled_by_wheel_event()) {

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -156,9 +156,9 @@ static Optional<Painting::CaretPosition> caret_position_from_editable_hit_node(D
     }
 
     auto paintable = boundary_node->paintable();
-    if (!paintable)
+    if (!paintable || !paintable->has_layout_node())
         paintable = hit_node.paintable();
-    if (!paintable)
+    if (!paintable || !paintable->has_layout_node())
         return {};
 
     return Painting::CaretPosition {
@@ -1831,6 +1831,8 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
         return;
     VERIFY(m_selection_mode != SelectionMode::None);
 
+    // NB: Initiating the selection may run script (setting a selection inside an editing host runs the focusing
+    //     steps on it), which may have rebuilt the layout tree and detached the caret position's paintable.
     if (auto container = AutoScrollHandler::find_scrollable_ancestor(*caret_position->paintable))
         m_auto_scroll_handler = make<AutoScrollHandler>(m_navigable, *container);
 }
@@ -1866,11 +1868,13 @@ Optional<Painting::CaretPosition> EventHandler::prepare_mouse_selection(DOM::Doc
     if (!paint_root())
         return {};
 
-    // NB: Now we can do selection with a caret-position hit test.
+    // NB: Now we can do selection with a caret-position hit test. The pre-focus hit node is only preferred while it
+    //     is still connected; focus handlers may have replaced it (e.g. an editor placeholder swapped for the real
+    //     editing host), in which case the fresh hit test result points at the replacement.
     auto caret_position = document.caret_position_from_point_for_selection_start(visual_viewport_position);
-    if (editable_hit_node_before_focus && editing_host_before_focus && should_use_caret_position_from_editable_hit_node(caret_position, *editable_hit_node_before_focus, *editing_host_before_focus)) {
-        if (editable_hit_node_before_focus)
-            caret_position = caret_position_from_editable_hit_node(*editable_hit_node_before_focus);
+    if (editable_hit_node_before_focus && editable_hit_node_before_focus->is_connected() && editing_host_before_focus && should_use_caret_position_from_editable_hit_node(caret_position, *editable_hit_node_before_focus, *editing_host_before_focus)) {
+        if (auto caret_position_from_hit_node = caret_position_from_editable_hit_node(*editable_hit_node_before_focus); caret_position_from_hit_node.has_value())
+            caret_position = caret_position_from_hit_node;
     }
     if (!caret_position.has_value())
         return {};

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -82,6 +82,7 @@ public:
 
     virtual bool forms_unconnected_subtree() const { return false; }
 
+    bool has_layout_node() const { return m_layout_node; }
     Layout::Node const& layout_node() const
     {
         VERIFY(m_layout_node);
@@ -434,7 +435,6 @@ protected:
     explicit Paintable(Layout::InlineNode const&);
 
     void paint_with_inspector_overlay_context(DisplayListRecordingContext&, Function<void()> const&) const;
-    bool has_layout_node() const { return m_layout_node; }
 
     virtual void paint_border(DisplayListRecordingContext&) const;
     virtual void paint_backdrop_filter(DisplayListRecordingContext&) const;

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -476,6 +476,48 @@ Optional<PaintableFragment const&> PaintableWithLines::fragment_at_position(DOM:
     return {};
 }
 
+CSSPixelRect PaintableWithLines::caret_rect_for_child_offset(size_t offset) const
+{
+    auto content_box = absolute_padding_box_rect();
+    auto line_height = computed_values().line_height();
+    CSSPixelRect rect { content_box.x(), content_box.y(), 1, line_height };
+
+    auto dom_node = layout_node().dom_node();
+    if (!dom_node)
+        return rect;
+    auto* child = dom_node->child_at_index(offset);
+    if (!child || !is<HTML::HTMLBRElement>(*child))
+        return rect;
+
+    // A caret parked before a <br> sits on the line below the content preceding the <br>. Layout produces no
+    // fragments for <br>, so start below the fragments of any preceding content, and add one line height for each
+    // empty line rendered by earlier <br>s.
+    Optional<CSSPixels> preceding_content_bottom;
+    for_each_in_inclusive_subtree_of_type<PaintableWithLines>([&](auto const& paintable_with_lines) {
+        for (auto const& fragment : paintable_with_lines.fragments()) {
+            auto* fragment_dom_node = const_cast<DOM::Node*>(fragment.layout_node().dom_node());
+            if (!fragment_dom_node || !(const_cast<DOM::Node&>(*child).compare_document_position(fragment_dom_node) & DOM::Node::DOCUMENT_POSITION_PRECEDING))
+                continue;
+            auto bottom = fragment.absolute_rect().bottom();
+            if (!preceding_content_bottom.has_value() || bottom > *preceding_content_bottom)
+                preceding_content_bottom = bottom;
+        }
+        return TraversalDecision::Continue;
+    });
+
+    size_t preceding_empty_lines = 0;
+    dom_node->for_each_in_subtree_of_type<HTML::HTMLBRElement>([&](auto& br) {
+        if (&br == child)
+            return TraversalDecision::Break;
+        if (br.represents_empty_line())
+            ++preceding_empty_lines;
+        return TraversalDecision::Continue;
+    });
+
+    rect.set_y(preceding_content_bottom.value_or(content_box.y()) + line_height * preceding_empty_lines);
+    return rect;
+}
+
 void PaintableWithLines::paint_cursor(DisplayListRecordingContext& context) const
 {
     if (!document().cursor_blink_state() || !document().navigable()->is_focused())
@@ -511,27 +553,7 @@ void PaintableWithLines::paint_cursor(DisplayListRecordingContext& context) cons
             return;
 
         caret_color = computed_values().caret_color();
-        auto content_box = absolute_padding_box_rect();
-        cursor_rect = { content_box.x(), content_box.y(), 1, computed_values().line_height() };
-
-        // A caret parked before a <br> hosting an empty line paints at that line's position. Layout produces no
-        // fragments for <br>, so the empty line starts where the fragments of the content before the <br> end.
-        if (auto* child = cursor_position->node()->child_at_index(cursor_position->offset()); child && is<HTML::HTMLBRElement>(*child)) {
-            Optional<CSSPixels> preceding_content_bottom;
-            for_each_in_inclusive_subtree_of_type<PaintableWithLines>([&](auto const& paintable_with_lines) {
-                for (auto const& fragment : paintable_with_lines.fragments()) {
-                    auto const* fragment_dom_node = fragment.layout_node().dom_node();
-                    if (!fragment_dom_node || !(child->compare_document_position(const_cast<DOM::Node*>(fragment_dom_node)) & DOM::Node::DOCUMENT_POSITION_PRECEDING))
-                        continue;
-                    auto bottom = fragment.absolute_rect().bottom();
-                    if (!preceding_content_bottom.has_value() || bottom > *preceding_content_bottom)
-                        preceding_content_bottom = bottom;
-                }
-                return TraversalDecision::Continue;
-            });
-            if (preceding_content_bottom.has_value())
-                cursor_rect.set_y(*preceding_content_bottom);
-        }
+        cursor_rect = caret_rect_for_child_offset(cursor_position->offset());
     }
 
     if (caret_color.alpha() == 0)

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/Node.h>
@@ -512,6 +513,25 @@ void PaintableWithLines::paint_cursor(DisplayListRecordingContext& context) cons
         caret_color = computed_values().caret_color();
         auto content_box = absolute_padding_box_rect();
         cursor_rect = { content_box.x(), content_box.y(), 1, computed_values().line_height() };
+
+        // A caret parked before a <br> hosting an empty line paints at that line's position. Layout produces no
+        // fragments for <br>, so the empty line starts where the fragments of the content before the <br> end.
+        if (auto* child = cursor_position->node()->child_at_index(cursor_position->offset()); child && is<HTML::HTMLBRElement>(*child)) {
+            Optional<CSSPixels> preceding_content_bottom;
+            for_each_in_inclusive_subtree_of_type<PaintableWithLines>([&](auto const& paintable_with_lines) {
+                for (auto const& fragment : paintable_with_lines.fragments()) {
+                    auto const* fragment_dom_node = fragment.layout_node().dom_node();
+                    if (!fragment_dom_node || !(child->compare_document_position(const_cast<DOM::Node*>(fragment_dom_node)) & DOM::Node::DOCUMENT_POSITION_PRECEDING))
+                        continue;
+                    auto bottom = fragment.absolute_rect().bottom();
+                    if (!preceding_content_bottom.has_value() || bottom > *preceding_content_bottom)
+                        preceding_content_bottom = bottom;
+                }
+                return TraversalDecision::Continue;
+            });
+            if (preceding_content_bottom.has_value())
+                cursor_rect.set_y(*preceding_content_bottom);
+        }
     }
 
     if (caret_color.alpha() == 0)

--- a/Libraries/LibWeb/Painting/PaintableWithLines.h
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.h
@@ -49,6 +49,10 @@ public:
 
     size_t line_index() const { return m_line_index; }
 
+    // Caret rect for a cursor parked on this paintable's DOM node at the given child offset, e.g. on an empty line
+    // rendered by a <br> child or in an empty editable element.
+    CSSPixelRect caret_rect_for_child_offset(size_t offset) const;
+
 protected:
     PaintableWithLines(Layout::BlockContainer const&);
     PaintableWithLines(Layout::NodeWithStyleAndBoxModelMetrics const&, size_t line_index);

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -17,7 +17,6 @@
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/Layout/Box.h>
-#include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Selection/Selection.h>
@@ -623,50 +622,12 @@ static bool text_node_has_rendered_text(DOM::Text const& text)
     return false;
 }
 
-// Rendered inline content that would appear before a <br> on its line.
-static bool is_rendered_inline_content(DOM::Node& node)
-{
-    if (auto* text = as_if<DOM::Text>(node))
-        return text_node_has_rendered_text(*text);
-    if (auto* element = as_if<DOM::Element>(node)) {
-        auto* layout_node = element->layout_node();
-        if (!layout_node)
-            return false;
-        if (is<Layout::ReplacedBox>(*layout_node))
-            return true;
-        if (layout_node->display().is_inline_outside() && !layout_node->display().is_flow_inside())
-            return true;
-    }
-    return false;
-}
-
 // A <br> that renders an empty line hosts a caret position on its parent, at its child index. This covers a leading
-// <br> in a paragraph with text after it, and the lines between consecutive <br>s. A <br> renders an empty line when
-// nothing else renders between the start of its line and the <br> itself.
-// NB: Layout produces no fragments for <br>, so this walks the DOM back to the start of the containing block or a
-//     previous <br>, whichever comes first.
+// <br> in a paragraph with text after it, and the lines between consecutive <br>s.
 static bool is_empty_line_break(DOM::Node& node)
 {
     auto* br = as_if<HTML::HTMLBRElement>(node);
-    if (!br || !br->is_editable() || !br->layout_node())
-        return false;
-
-    auto* containing_block = br->layout_node()->containing_block();
-    if (!containing_block)
-        return false;
-    auto* containing_block_dom_node = containing_block->dom_node();
-    if (!containing_block_dom_node)
-        return false;
-
-    for (auto* previous = br->previous_in_pre_order(); previous && previous != containing_block_dom_node; previous = previous->previous_in_pre_order()) {
-        if (!containing_block_dom_node->is_inclusive_ancestor_of(*previous))
-            break;
-        if (is<HTML::HTMLBRElement>(*previous))
-            return true;
-        if (is_rendered_inline_content(*previous))
-            return false;
-    }
-    return true;
+    return br && br->is_editable() && br->represents_empty_line();
 }
 
 // A block-level element that renders no text but hosts an empty line where the caret can sit, such as `<p><br></p>`.

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -774,75 +774,83 @@ static bool move_cursor_to_adjacent_caret_host(Selection& selection, DOM::Node& 
 
 void Selection::move_offset_to_next_character(bool collapse_selection)
 {
-    auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
-    if (!text_node) {
-        // The caret is parked on an element, e.g. an empty line; step into the closest caret host after it.
-        if (auto node = anchor_node(); node && is_collapsed())
-            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, anchor_offset()), CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
+    // If there is a selection range, collapse to the end of that range without moving forward
+    if (collapse_selection && !is_collapsed()) {
+        MUST(collapse(m_range->end_container(), m_range->end_offset()));
+        m_document->reset_cursor_blink_cycle();
         scroll_focus_into_view();
         return;
     }
 
-    // If there is a selection range, collapse to the end (max) of that range without moving forward
-    if (collapse_selection && !is_collapsed()) {
-        MUST(collapse(text_node, max(anchor_offset(), focus_offset())));
-        m_document->reset_cursor_blink_cycle();
-    }
-    // Otherwise, move forward if possible
-    else if (auto new_position = compute_cursor_position_on_next_character(*text_node, focus_offset(), m_focus_affinity); new_position.has_value()) {
-        if (collapse_selection) {
-            MUST(collapse(text_node, new_position->offset));
-            m_document->reset_cursor_blink_cycle();
-        } else {
-            MUST(set_base_and_extent(*text_node, anchor_offset(), *text_node, new_position->offset));
+    auto node = focus_node();
+    if (!node)
+        return;
+
+    if (auto* text_node = as_if<DOM::Text>(*node)) {
+        // Move forward within the text node if possible
+        if (auto new_position = compute_cursor_position_on_next_character(*text_node, focus_offset(), m_focus_affinity); new_position.has_value()) {
+            if (collapse_selection) {
+                MUST(collapse(text_node, new_position->offset));
+                m_document->reset_cursor_blink_cycle();
+            } else {
+                MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, new_position->offset));
+            }
+            m_focus_affinity = new_position->affinity;
+            m_document->set_cursor_position_needs_repaint();
         }
-        m_focus_affinity = new_position->affinity;
-        m_document->set_cursor_position_needs_repaint();
+        // At the very end of this text node, move into the closest caret host after it.
+        else {
+            move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
+        }
     }
-    // At the very end of this text node, move into the closest caret host after it.
+    // The focus is parked on an element, e.g. an empty line; step into the closest caret host after it.
     else {
-        move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
+        move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
     }
     scroll_focus_into_view();
 }
 
 void Selection::move_offset_to_previous_character(bool collapse_selection)
 {
-    auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
-    if (!text_node) {
-        // The caret is parked on an element, e.g. an empty line; step into the closest caret host before it.
-        if (auto node = anchor_node(); node && is_collapsed())
-            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, anchor_offset()), CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
+    // If there is a selection range, collapse to the start of that range without moving backward
+    if (collapse_selection && !is_collapsed()) {
+        MUST(collapse(m_range->start_container(), m_range->start_offset()));
+        m_document->reset_cursor_blink_cycle();
         scroll_focus_into_view();
         return;
     }
 
-    // If there is a selection range, collapse to the start (min) of that range without moving backward
-    if (collapse_selection && !is_collapsed()) {
-        MUST(collapse(text_node, min(anchor_offset(), focus_offset())));
-        m_document->reset_cursor_blink_cycle();
-    }
-    // Otherwise, move backward if possible
-    else if (auto new_position = compute_cursor_position_on_previous_character(*text_node, focus_offset(), m_focus_affinity); new_position.has_value()) {
-        if (collapse_selection) {
-            MUST(collapse(text_node, new_position->offset));
-            m_document->reset_cursor_blink_cycle();
-        } else {
-            MUST(set_base_and_extent(*text_node, anchor_offset(), *text_node, new_position->offset));
+    auto node = focus_node();
+    if (!node)
+        return;
+
+    if (auto* text_node = as_if<DOM::Text>(*node)) {
+        // Move backward within the text node if possible
+        if (auto new_position = compute_cursor_position_on_previous_character(*text_node, focus_offset(), m_focus_affinity); new_position.has_value()) {
+            if (collapse_selection) {
+                MUST(collapse(text_node, new_position->offset));
+                m_document->reset_cursor_blink_cycle();
+            } else {
+                MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, new_position->offset));
+            }
+            m_focus_affinity = new_position->affinity;
+            m_document->set_cursor_position_needs_repaint();
         }
-        m_focus_affinity = new_position->affinity;
-        m_document->set_cursor_position_needs_repaint();
+        // At the very start of this text node, move into the closest caret host before it.
+        else {
+            move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
+        }
     }
-    // At the very start of this text node, move into the closest caret host before it.
+    // The focus is parked on an element, e.g. an empty line; step into the closest caret host before it.
     else {
-        move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
+        move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
     }
     scroll_focus_into_view();
 }
 
 void Selection::move_offset_to_next_word(bool collapse_selection)
 {
-    auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
+    auto* text_node = as_if<DOM::Text>(focus_node().ptr());
     if (!text_node)
         return;
 
@@ -856,7 +864,7 @@ void Selection::move_offset_to_next_word(bool collapse_selection)
                 MUST(collapse(text_node, *offset));
                 m_document->reset_cursor_blink_cycle();
             } else {
-                MUST(set_base_and_extent(*text_node, anchor_offset(), *text_node, *offset));
+                MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, *offset));
             }
             auto word = text_node->data().substring_view(focus_offset, *offset - focus_offset);
             if (Unicode::Segmenter::should_continue_beyond_word(word))
@@ -869,7 +877,7 @@ void Selection::move_offset_to_next_word(bool collapse_selection)
 
 void Selection::move_offset_to_previous_word(bool collapse_selection)
 {
-    auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
+    auto* text_node = as_if<DOM::Text>(focus_node().ptr());
     if (!text_node)
         return;
 
@@ -880,7 +888,7 @@ void Selection::move_offset_to_previous_word(bool collapse_selection)
                 MUST(collapse(text_node, *offset));
                 m_document->reset_cursor_blink_cycle();
             } else {
-                MUST(set_base_and_extent(*text_node, anchor_offset(), *text_node, *offset));
+                MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, *offset));
             }
             auto word = text_node->data().substring_view(*offset, focus_offset - *offset);
             if (Unicode::Segmenter::should_continue_beyond_word(word))
@@ -893,11 +901,14 @@ void Selection::move_offset_to_previous_word(bool collapse_selection)
 
 void Selection::move_offset_to_next_line(bool collapse_selection)
 {
-    auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
+    auto node = focus_node();
+    if (!node)
+        return;
+
+    auto* text_node = as_if<DOM::Text>(*node);
     if (!text_node) {
-        // The caret is parked on an element, e.g. an empty line; move to the closest caret host below.
-        if (auto node = anchor_node(); node && is_collapsed())
-            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, anchor_offset()), CaretNavigationDirection::Forward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
+        // The focus is parked on an element, e.g. an empty line; move to the closest caret host below.
+        move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Forward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
         scroll_focus_into_view();
         return;
     }
@@ -919,7 +930,7 @@ void Selection::move_offset_to_next_line(bool collapse_selection)
         MUST(collapse(text_node, new_position->offset));
         m_document->reset_cursor_blink_cycle();
     } else {
-        MUST(set_base_and_extent(*text_node, anchor_offset(), *text_node, new_position->offset));
+        MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, new_position->offset));
     }
     m_focus_affinity = new_position->affinity;
     scroll_focus_into_view();
@@ -927,11 +938,14 @@ void Selection::move_offset_to_next_line(bool collapse_selection)
 
 void Selection::move_offset_to_previous_line(bool collapse_selection)
 {
-    auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
+    auto node = focus_node();
+    if (!node)
+        return;
+
+    auto* text_node = as_if<DOM::Text>(*node);
     if (!text_node) {
-        // The caret is parked on an element, e.g. an empty line; move to the closest caret host above.
-        if (auto node = anchor_node(); node && is_collapsed())
-            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, anchor_offset()), CaretNavigationDirection::Backward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
+        // The focus is parked on an element, e.g. an empty line; move to the closest caret host above.
+        move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Backward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
         scroll_focus_into_view();
         return;
     }
@@ -953,7 +967,7 @@ void Selection::move_offset_to_previous_line(bool collapse_selection)
         MUST(collapse(text_node, new_position->offset));
         m_document->reset_cursor_blink_cycle();
     } else {
-        MUST(set_base_and_extent(*text_node, anchor_offset(), *text_node, new_position->offset));
+        MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, new_position->offset));
     }
     m_focus_affinity = new_position->affinity;
     scroll_focus_into_view();

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -15,6 +15,9 @@
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLBRElement.h>
+#include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Selection/Selection.h>
@@ -620,6 +623,52 @@ static bool text_node_has_rendered_text(DOM::Text const& text)
     return false;
 }
 
+// Rendered inline content that would appear before a <br> on its line.
+static bool is_rendered_inline_content(DOM::Node& node)
+{
+    if (auto* text = as_if<DOM::Text>(node))
+        return text_node_has_rendered_text(*text);
+    if (auto* element = as_if<DOM::Element>(node)) {
+        auto* layout_node = element->layout_node();
+        if (!layout_node)
+            return false;
+        if (is<Layout::ReplacedBox>(*layout_node))
+            return true;
+        if (layout_node->display().is_inline_outside() && !layout_node->display().is_flow_inside())
+            return true;
+    }
+    return false;
+}
+
+// A <br> that renders an empty line hosts a caret position on its parent, at its child index. This covers a leading
+// <br> in a paragraph with text after it, and the lines between consecutive <br>s. A <br> renders an empty line when
+// nothing else renders between the start of its line and the <br> itself.
+// NB: Layout produces no fragments for <br>, so this walks the DOM back to the start of the containing block or a
+//     previous <br>, whichever comes first.
+static bool is_empty_line_break(DOM::Node& node)
+{
+    auto* br = as_if<HTML::HTMLBRElement>(node);
+    if (!br || !br->is_editable() || !br->layout_node())
+        return false;
+
+    auto* containing_block = br->layout_node()->containing_block();
+    if (!containing_block)
+        return false;
+    auto* containing_block_dom_node = containing_block->dom_node();
+    if (!containing_block_dom_node)
+        return false;
+
+    for (auto* previous = br->previous_in_pre_order(); previous && previous != containing_block_dom_node; previous = previous->previous_in_pre_order()) {
+        if (!containing_block_dom_node->is_inclusive_ancestor_of(*previous))
+            break;
+        if (is<HTML::HTMLBRElement>(*previous))
+            return true;
+        if (is_rendered_inline_content(*previous))
+            return false;
+    }
+    return true;
+}
+
 // A block-level element that renders no text but hosts an empty line where the caret can sit, such as `<p><br></p>`.
 static bool is_empty_line_host(DOM::Node& node)
 {
@@ -652,12 +701,24 @@ static GC::Ptr<DOM::Node> adjacent_caret_host_in_editing_host(DOM::Node& from, D
             : node->previous_in_pre_order();
         if (!node || node == &editing_host || !editing_host.is_inclusive_ancestor_of(*node))
             return nullptr;
+        // Walking backwards visits ancestors of the origin; the caret is already inside those.
+        if (node->is_inclusive_ancestor_of(from))
+            continue;
         if (auto* text = as_if<DOM::Text>(*node); text && text->is_editable() && text_node_has_rendered_text(*text))
             return node;
-        if (is_empty_line_host(*node))
+        if (is_empty_line_host(*node) || is_empty_line_break(*node))
             return node;
     }
     return nullptr;
+}
+
+// The node caret navigation should walk from: for a caret anchored on an element, that is the child the offset
+// points at (e.g. the <br> hosting the empty line the caret sits on), not the element itself.
+static DOM::Node& caret_navigation_origin(DOM::Node& node, size_t offset)
+{
+    if (auto* child = node.child_at_index(offset))
+        return *child;
+    return node;
 }
 
 // Moves the caret out of `from` into the closest caret host before or after it in the editing host. Enters text
@@ -677,6 +738,12 @@ static bool move_cursor_to_adjacent_caret_host(Selection& selection, DOM::Node& 
 
     size_t new_offset = 0;
     auto new_affinity = TextAffinity::Downstream;
+
+    // A <br> hosting an empty line houses the caret on its parent, at the child index of the <br>.
+    if (is<HTML::HTMLBRElement>(*target) && target->parent()) {
+        new_offset = target->index();
+        target = target->parent();
+    }
 
     if (auto* text = as_if<DOM::Text>(*target)) {
         Optional<CursorLinePosition> position;
@@ -711,7 +778,7 @@ void Selection::move_offset_to_next_character(bool collapse_selection)
     if (!text_node) {
         // The caret is parked on an element, e.g. an empty line; step into the closest caret host after it.
         if (auto node = anchor_node(); node && is_collapsed())
-            move_cursor_to_adjacent_caret_host(*this, *node, CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
+            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, anchor_offset()), CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
         scroll_focus_into_view();
         return;
     }
@@ -745,7 +812,7 @@ void Selection::move_offset_to_previous_character(bool collapse_selection)
     if (!text_node) {
         // The caret is parked on an element, e.g. an empty line; step into the closest caret host before it.
         if (auto node = anchor_node(); node && is_collapsed())
-            move_cursor_to_adjacent_caret_host(*this, *node, CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
+            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, anchor_offset()), CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
         scroll_focus_into_view();
         return;
     }
@@ -830,7 +897,7 @@ void Selection::move_offset_to_next_line(bool collapse_selection)
     if (!text_node) {
         // The caret is parked on an element, e.g. an empty line; move to the closest caret host below.
         if (auto node = anchor_node(); node && is_collapsed())
-            move_cursor_to_adjacent_caret_host(*this, *node, CaretNavigationDirection::Forward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
+            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, anchor_offset()), CaretNavigationDirection::Forward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
         scroll_focus_into_view();
         return;
     }
@@ -864,7 +931,7 @@ void Selection::move_offset_to_previous_line(bool collapse_selection)
     if (!text_node) {
         // The caret is parked on an element, e.g. an empty line; move to the closest caret host above.
         if (auto node = anchor_node(); node && is_collapsed())
-            move_cursor_to_adjacent_caret_host(*this, *node, CaretNavigationDirection::Backward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
+            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, anchor_offset()), CaretNavigationDirection::Backward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
         scroll_focus_into_view();
         return;
     }

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -411,12 +411,6 @@ WebIDL::ExceptionOr<void> Selection::select_all_children(GC::Ref<DOM::Node> node
 // https://w3c.github.io/selection-api/#dom-selection-modify
 WebIDL::ExceptionOr<void> Selection::modify(Optional<String> alter, Optional<String> direction, Optional<String> granularity)
 {
-    auto anchor_node = this->anchor_node();
-    if (!anchor_node || !is<DOM::Text>(*anchor_node))
-        return {};
-
-    auto& text_node = static_cast<DOM::Text&>(*anchor_node);
-
     // 1. If alter is not ASCII case-insensitive match with "extend" or "move", abort these steps.
     if (!alter.has_value() || !alter.value().bytes_as_string_view().is_one_of_ignoring_ascii_case("extend"sv, "move"sv))
         return {};
@@ -434,6 +428,10 @@ WebIDL::ExceptionOr<void> Selection::modify(Optional<String> alter, Optional<Str
     if (is_empty())
         return {};
 
+    auto focus = focus_node();
+    if (!focus)
+        return {};
+
     // 5. Let effectiveDirection be backwards.
     auto effective_direction = Direction::Backwards;
 
@@ -441,12 +439,21 @@ WebIDL::ExceptionOr<void> Selection::modify(Optional<String> alter, Optional<Str
     if (direction.value().equals_ignoring_ascii_case("forward"sv))
         effective_direction = Direction::Forwards;
 
+    // Inline base direction of this selection's focus.
+    auto focus_directionality = DOM::Element::Directionality::Ltr;
+    if (auto* text = as_if<DOM::Text>(*focus)) {
+        if (auto text_directionality = text->directionality(); text_directionality.has_value())
+            focus_directionality = *text_directionality;
+    } else if (auto* element = as_if<DOM::Element>(*focus)) {
+        focus_directionality = element->directionality();
+    }
+
     // 7. If direction is ASCII case-insensitive match with "right" and inline base direction of this selection's focus is ltr, set effectiveDirection to forwards.
-    if (direction.value().equals_ignoring_ascii_case("right"sv) && text_node.directionality() == DOM::Element::Directionality::Ltr)
+    if (direction.value().equals_ignoring_ascii_case("right"sv) && focus_directionality == DOM::Element::Directionality::Ltr)
         effective_direction = Direction::Forwards;
 
     // 8. If direction is ASCII case-insensitive match with "left" and inline base direction of this selection's focus is rtl, set effectiveDirection to forwards.
-    if (direction.value().equals_ignoring_ascii_case("left"sv) && text_node.directionality() == DOM::Element::Directionality::Rtl)
+    if (direction.value().equals_ignoring_ascii_case("left"sv) && focus_directionality == DOM::Element::Directionality::Rtl)
         effective_direction = Direction::Forwards;
 
     // 9. Set this selection's direction to effectiveDirection.
@@ -456,17 +463,42 @@ WebIDL::ExceptionOr<void> Selection::modify(Optional<String> alter, Optional<Str
     // 11. Otherwise, set this selection's focus and anchor to the location as if the user had requested to move selection by granularity.
     auto collapse_selection = alter.value().equals_ignoring_ascii_case("move"sv);
 
-    // TODO: Implement the other granularity options.
+    auto move_focus_to_visual_line_boundary = [&](bool forwards) {
+        auto* text = as_if<DOM::Text>(focus_node().ptr());
+        if (!text)
+            return;
+        auto position = forwards
+            ? find_visual_line_end(*text, focus_offset(), m_focus_affinity)
+            : CursorLinePosition { find_visual_line_start(*text, focus_offset(), m_focus_affinity), TextAffinity::Downstream };
+        if (collapse_selection)
+            MUST(collapse(text, position.offset));
+        else
+            MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text, position.offset));
+        m_focus_affinity = position.affinity;
+        m_document->reset_cursor_blink_cycle();
+        m_document->set_cursor_position_needs_repaint();
+    };
+
+    // TODO: Implement the sentence, paragraph, and document granularity options.
+    auto granularity_view = granularity.value().bytes_as_string_view();
     if (effective_direction == Direction::Forwards) {
-        if (granularity.value().equals_ignoring_ascii_case("character"sv))
+        if (granularity_view.equals_ignoring_ascii_case("character"sv))
             move_offset_to_next_character(collapse_selection);
-        if (granularity.value().equals_ignoring_ascii_case("word"sv))
+        else if (granularity_view.equals_ignoring_ascii_case("word"sv))
             move_offset_to_next_word(collapse_selection);
+        else if (granularity_view.equals_ignoring_ascii_case("line"sv))
+            move_offset_to_next_line(collapse_selection);
+        else if (granularity_view.equals_ignoring_ascii_case("lineboundary"sv))
+            move_focus_to_visual_line_boundary(true);
     } else {
-        if (granularity.value().equals_ignoring_ascii_case("character"sv))
+        if (granularity_view.equals_ignoring_ascii_case("character"sv))
             move_offset_to_previous_character(collapse_selection);
-        if (granularity.value().equals_ignoring_ascii_case("word"sv))
+        else if (granularity_view.equals_ignoring_ascii_case("word"sv))
             move_offset_to_previous_word(collapse_selection);
+        else if (granularity_view.equals_ignoring_ascii_case("line"sv))
+            move_offset_to_previous_line(collapse_selection);
+        else if (granularity_view.equals_ignoring_ascii_case("lineboundary"sv))
+            move_focus_to_visual_line_boundary(false);
     }
 
     return {};
@@ -812,8 +844,13 @@ void Selection::move_offset_to_previous_character(bool collapse_selection)
 void Selection::move_offset_to_next_word(bool collapse_selection)
 {
     auto* text_node = as_if<DOM::Text>(focus_node().ptr());
-    if (!text_node)
+    if (!text_node) {
+        // The focus is parked on an element, e.g. an empty line; step into the closest caret host after it.
+        if (auto node = focus_node())
+            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
+        scroll_focus_into_view();
         return;
+    }
 
     while (true) {
         auto focus_offset = this->focus_offset();
@@ -839,8 +876,13 @@ void Selection::move_offset_to_next_word(bool collapse_selection)
 void Selection::move_offset_to_previous_word(bool collapse_selection)
 {
     auto* text_node = as_if<DOM::Text>(focus_node().ptr());
-    if (!text_node)
+    if (!text_node) {
+        // The focus is parked on an element, e.g. an empty line; step into the closest caret host before it.
+        if (auto node = focus_node())
+            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
+        scroll_focus_into_view();
         return;
+    }
 
     while (true) {
         auto focus_offset = this->focus_offset();

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -9,12 +9,14 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/Selection.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/VisualLines.h>
 
@@ -594,15 +596,125 @@ GC::Ptr<DOM::Position> Selection::cursor_position() const
     return DOM::Position::create(m_document->realm(), *m_range->start_container(), m_range->start_offset(), m_focus_affinity);
 }
 
-// FIXME: The offset adjustment algorithms below do not handle moving over multiple DOM nodes. For example, if we have:
-//        `<div contenteditable><p>Well hello</p><p>friends</p></div>`, we should be able to move the cursor between the
-//        two <p> elements. But the algorithms below limit us to a single DOM node.
+// Cross-node caret navigation: when character or line movement reaches the edge of the current node, the caret moves
+// to the closest node in the editing host that can house it: either a text node with rendered text, or a block-level
+// element rendering an empty line (such as the `<p><br></p>` paragraphs produced by pressing Enter on an empty line).
+// FIXME: Word movement is still limited to a single DOM node.
+
+enum class CaretNavigationDirection : u8 {
+    Forward,
+    Backward,
+};
+
+enum class CaretEntryMode : u8 {
+    LineEdge,
+    ClosestToInlineCoordinate,
+};
+
+static bool text_node_has_rendered_text(DOM::Text const& text)
+{
+    for (auto const& line : collect_visual_lines(text)) {
+        if (!line.fragments.is_empty())
+            return true;
+    }
+    return false;
+}
+
+// A block-level element that renders no text but hosts an empty line where the caret can sit, such as `<p><br></p>`.
+static bool is_empty_line_host(DOM::Node& node)
+{
+    auto* element = as_if<DOM::Element>(node);
+    if (!element || !element->is_editable())
+        return false;
+    auto element_paintable = element->unsafe_paintable();
+    auto* paintable = as_if<Painting::PaintableWithLines>(element_paintable.ptr());
+    if (!paintable)
+        return false;
+    if (paintable->layout_node().display().is_inline_outside())
+        return false;
+
+    bool has_rendered_text = false;
+    element->for_each_in_subtree_of_type<DOM::Text>([&](auto& text) {
+        if (!text_node_has_rendered_text(text))
+            return TraversalDecision::Continue;
+        has_rendered_text = true;
+        return TraversalDecision::Break;
+    });
+    return !has_rendered_text;
+}
+
+static GC::Ptr<DOM::Node> adjacent_caret_host_in_editing_host(DOM::Node& from, DOM::Node& editing_host, CaretNavigationDirection direction)
+{
+    auto* node = &from;
+    while (node) {
+        node = direction == CaretNavigationDirection::Forward
+            ? node->next_in_pre_order(&editing_host)
+            : node->previous_in_pre_order();
+        if (!node || node == &editing_host || !editing_host.is_inclusive_ancestor_of(*node))
+            return nullptr;
+        if (auto* text = as_if<DOM::Text>(*node); text && text->is_editable() && text_node_has_rendered_text(*text))
+            return node;
+        if (is_empty_line_host(*node))
+            return node;
+    }
+    return nullptr;
+}
+
+// Moves the caret out of `from` into the closest caret host before or after it in the editing host. Enters text
+// nodes at the rendered edge facing `from` (LineEdge, for horizontal movement) or at the position on the edge line
+// closest to the given inline coordinate (for vertical movement). Empty line hosts house the caret at offset 0.
+static bool move_cursor_to_adjacent_caret_host(Selection& selection, DOM::Node& from, CaretNavigationDirection direction, CaretEntryMode entry_mode, Optional<CSSPixels> inline_coordinate, bool collapse_selection)
+{
+    auto editing_host = from.editing_host();
+    if (!editing_host)
+        return false;
+
+    selection.document()->update_layout_if_needed_for_node(*editing_host, DOM::UpdateLayoutReason::CursorLineNavigation);
+
+    auto target = adjacent_caret_host_in_editing_host(from, *editing_host, direction);
+    if (!target)
+        return false;
+
+    size_t new_offset = 0;
+    auto new_affinity = TextAffinity::Downstream;
+
+    if (auto* text = as_if<DOM::Text>(*target)) {
+        Optional<CursorLinePosition> position;
+        if (entry_mode == CaretEntryMode::LineEdge) {
+            position = direction == CaretNavigationDirection::Forward
+                ? cursor_position_at_visual_start(*text)
+                : cursor_position_at_visual_end(*text);
+        } else {
+            position = direction == CaretNavigationDirection::Forward
+                ? cursor_position_on_first_line_closest_to(*text, inline_coordinate)
+                : cursor_position_on_last_line_closest_to(*text, inline_coordinate);
+        }
+        if (!position.has_value())
+            return false;
+        new_offset = position->offset;
+        new_affinity = position->affinity;
+    }
+
+    if (collapse_selection)
+        MUST(selection.collapse(target, new_offset));
+    else
+        MUST(selection.set_base_and_extent(*selection.anchor_node(), selection.anchor_offset(), *target, new_offset));
+    selection.set_focus_affinity(new_affinity);
+    selection.document()->reset_cursor_blink_cycle();
+    selection.document()->set_cursor_position_needs_repaint();
+    return true;
+}
 
 void Selection::move_offset_to_next_character(bool collapse_selection)
 {
     auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
-    if (!text_node)
+    if (!text_node) {
+        // The caret is parked on an element, e.g. an empty line; step into the closest caret host after it.
+        if (auto node = anchor_node(); node && is_collapsed())
+            move_cursor_to_adjacent_caret_host(*this, *node, CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
+        scroll_focus_into_view();
         return;
+    }
 
     // If there is a selection range, collapse to the end (max) of that range without moving forward
     if (collapse_selection && !is_collapsed()) {
@@ -620,14 +732,23 @@ void Selection::move_offset_to_next_character(bool collapse_selection)
         m_focus_affinity = new_position->affinity;
         m_document->set_cursor_position_needs_repaint();
     }
+    // At the very end of this text node, move into the closest caret host after it.
+    else {
+        move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
+    }
     scroll_focus_into_view();
 }
 
 void Selection::move_offset_to_previous_character(bool collapse_selection)
 {
     auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
-    if (!text_node)
+    if (!text_node) {
+        // The caret is parked on an element, e.g. an empty line; step into the closest caret host before it.
+        if (auto node = anchor_node(); node && is_collapsed())
+            move_cursor_to_adjacent_caret_host(*this, *node, CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
+        scroll_focus_into_view();
         return;
+    }
 
     // If there is a selection range, collapse to the start (min) of that range without moving backward
     if (collapse_selection && !is_collapsed()) {
@@ -644,6 +765,10 @@ void Selection::move_offset_to_previous_character(bool collapse_selection)
         }
         m_focus_affinity = new_position->affinity;
         m_document->set_cursor_position_needs_repaint();
+    }
+    // At the very start of this text node, move into the closest caret host before it.
+    else {
+        move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
     }
     scroll_focus_into_view();
 }
@@ -702,8 +827,22 @@ void Selection::move_offset_to_previous_word(bool collapse_selection)
 void Selection::move_offset_to_next_line(bool collapse_selection)
 {
     auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
-    if (!text_node)
+    if (!text_node) {
+        // The caret is parked on an element, e.g. an empty line; move to the closest caret host below.
+        if (auto node = anchor_node(); node && is_collapsed())
+            move_cursor_to_adjacent_caret_host(*this, *node, CaretNavigationDirection::Forward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
+        scroll_focus_into_view();
         return;
+    }
+
+    // On the last visual line of this text node, move to the closest caret host below instead.
+    if (offset_is_on_last_visual_line(*text_node, focus_offset(), m_focus_affinity)) {
+        auto inline_coordinate = cursor_inline_coordinate(*text_node, focus_offset(), m_focus_affinity);
+        if (move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Forward, CaretEntryMode::ClosestToInlineCoordinate, inline_coordinate, collapse_selection)) {
+            scroll_focus_into_view();
+            return;
+        }
+    }
 
     auto new_position = compute_cursor_position_on_next_line(*text_node, focus_offset(), m_focus_affinity);
     if (!new_position.has_value())
@@ -722,8 +861,22 @@ void Selection::move_offset_to_next_line(bool collapse_selection)
 void Selection::move_offset_to_previous_line(bool collapse_selection)
 {
     auto* text_node = as_if<DOM::Text>(anchor_node().ptr());
-    if (!text_node)
+    if (!text_node) {
+        // The caret is parked on an element, e.g. an empty line; move to the closest caret host above.
+        if (auto node = anchor_node(); node && is_collapsed())
+            move_cursor_to_adjacent_caret_host(*this, *node, CaretNavigationDirection::Backward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
+        scroll_focus_into_view();
         return;
+    }
+
+    // On the first visual line of this text node, move to the closest caret host above instead.
+    if (offset_is_on_first_visual_line(*text_node, focus_offset(), m_focus_affinity)) {
+        auto inline_coordinate = cursor_inline_coordinate(*text_node, focus_offset(), m_focus_affinity);
+        if (move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Backward, CaretEntryMode::ClosestToInlineCoordinate, inline_coordinate, collapse_selection)) {
+            scroll_focus_into_view();
+            return;
+        }
+    }
 
     auto new_position = compute_cursor_position_on_previous_line(*text_node, focus_offset(), m_focus_affinity);
     if (!new_position.has_value())

--- a/Libraries/LibWeb/VisualLines.cpp
+++ b/Libraries/LibWeb/VisualLines.cpp
@@ -256,6 +256,65 @@ Optional<CursorLinePosition> compute_cursor_position_on_previous_character(DOM::
     return CursorLinePosition { *previous_offset, TextAffinity::Downstream };
 }
 
+bool offset_is_on_first_visual_line(DOM::Text const& dom_node, size_t offset, TextAffinity affinity)
+{
+    auto lines = visual_lines_with_up_to_date_layout(dom_node);
+    auto line_index = visual_line_index_for_offset(lines, offset, affinity);
+    return !line_index.has_value() || *line_index == 0;
+}
+
+bool offset_is_on_last_visual_line(DOM::Text const& dom_node, size_t offset, TextAffinity affinity)
+{
+    auto lines = visual_lines_with_up_to_date_layout(dom_node);
+    auto line_index = visual_line_index_for_offset(lines, offset, affinity);
+    return !line_index.has_value() || *line_index + 1 >= lines.size();
+}
+
+Optional<CSSPixels> cursor_inline_coordinate(DOM::Text const& dom_node, size_t offset, TextAffinity affinity)
+{
+    auto lines = visual_lines_with_up_to_date_layout(dom_node);
+    auto line_index = visual_line_index_for_offset(lines, offset, affinity);
+    if (!line_index.has_value())
+        return {};
+    return caret_inline_coordinate(lines[*line_index], offset);
+}
+
+Optional<CursorLinePosition> cursor_position_at_visual_start(DOM::Text const& dom_node)
+{
+    auto lines = visual_lines_with_up_to_date_layout(dom_node);
+    if (lines.is_empty())
+        return {};
+    auto offset = lines.first().start_offset;
+    return CursorLinePosition { offset, affinity_for_offset_on_line(lines, 0, offset) };
+}
+
+Optional<CursorLinePosition> cursor_position_at_visual_end(DOM::Text const& dom_node)
+{
+    auto lines = visual_lines_with_up_to_date_layout(dom_node);
+    if (lines.is_empty())
+        return {};
+    auto offset = lines.last().end_offset;
+    return CursorLinePosition { offset, affinity_for_offset_on_line(lines, lines.size() - 1, offset) };
+}
+
+Optional<CursorLinePosition> cursor_position_on_first_line_closest_to(DOM::Text const& dom_node, Optional<CSSPixels> inline_coordinate)
+{
+    auto lines = visual_lines_with_up_to_date_layout(dom_node);
+    if (lines.is_empty())
+        return {};
+    auto offset = offset_in_visual_line_closest_to_inline_coordinate(lines.first(), inline_coordinate);
+    return CursorLinePosition { offset, affinity_for_offset_on_line(lines, 0, offset) };
+}
+
+Optional<CursorLinePosition> cursor_position_on_last_line_closest_to(DOM::Text const& dom_node, Optional<CSSPixels> inline_coordinate)
+{
+    auto lines = visual_lines_with_up_to_date_layout(dom_node);
+    if (lines.is_empty())
+        return {};
+    auto offset = offset_in_visual_line_closest_to_inline_coordinate(lines.last(), inline_coordinate);
+    return CursorLinePosition { offset, affinity_for_offset_on_line(lines, lines.size() - 1, offset) };
+}
+
 size_t find_visual_line_start(DOM::Text const& dom_node, size_t offset, TextAffinity affinity)
 {
     auto lines = visual_lines_with_up_to_date_layout(dom_node);

--- a/Libraries/LibWeb/VisualLines.h
+++ b/Libraries/LibWeb/VisualLines.h
@@ -10,6 +10,7 @@
 #include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/PixelUnits.h>
 #include <LibWeb/TextAffinity.h>
 
 namespace Web {
@@ -45,6 +46,25 @@ Optional<CursorLinePosition> compute_cursor_position_on_previous_character(DOM::
 
 size_t find_visual_line_start(DOM::Text const&, size_t offset, TextAffinity);
 CursorLinePosition find_visual_line_end(DOM::Text const&, size_t offset, TextAffinity);
+
+// Helpers for caret navigation across node boundaries.
+
+// Whether the offset renders on the first/last visual line of the text.
+bool offset_is_on_first_visual_line(DOM::Text const&, size_t offset, TextAffinity);
+bool offset_is_on_last_visual_line(DOM::Text const&, size_t offset, TextAffinity);
+
+// The absolute inline-axis coordinate of the caret at the given offset, used to keep the caret column when moving
+// between lines. Returns nothing for positions on lines without rendered text.
+Optional<CSSPixels> cursor_inline_coordinate(DOM::Text const&, size_t offset, TextAffinity);
+
+// Cursor positions for entering a text node from an adjacent node. The "visual start" and "visual end" positions are
+// the rendered start of the first line and the rendered end of the last line; the "closest to" variants pick the
+// position on the first/last visual line closest to the given inline coordinate (or the line start when there is no
+// coordinate). All return nothing for text with no rendered lines.
+Optional<CursorLinePosition> cursor_position_at_visual_start(DOM::Text const&);
+Optional<CursorLinePosition> cursor_position_at_visual_end(DOM::Text const&);
+Optional<CursorLinePosition> cursor_position_on_first_line_closest_to(DOM::Text const&, Optional<CSSPixels> inline_coordinate);
+Optional<CursorLinePosition> cursor_position_on_last_line_closest_to(DOM::Text const&, Optional<CSSPixels> inline_coordinate);
 
 bool white_space_preserves_newlines(Layout::TextNode const&);
 

--- a/Tests/LibWeb/Ref/expected/caret-on-second-br-line-ref.html
+++ b/Tests/LibWeb/Ref/expected/caret-on-second-br-line-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+    div[contenteditable] {
+        font: 30px/1 monospace;
+        caret-color: transparent;
+    }
+
+    p {
+        margin: 0;
+    }
+
+    #caret {
+        position: absolute;
+        left: 8px;
+        top: 38px;
+        width: 1px;
+        height: 30px;
+        background: black;
+    }
+</style>
+<div contenteditable="true"><p id="p"><br><br></p></div>
+<div id="caret"></div>
+<script>
+    document.querySelector("div[contenteditable]").focus();
+    const p = document.getElementById("p");
+    getSelection().setBaseAndExtent(p, 1, p, 1);
+</script>

--- a/Tests/LibWeb/Ref/expected/caret-repaint-after-move-between-lines-ref.html
+++ b/Tests/LibWeb/Ref/expected/caret-repaint-after-move-between-lines-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    p {
+        margin: 0;
+        font: 30px/1 monospace;
+    }
+</style>
+<div contenteditable="true"><p><span id="a">aaaa</span></p><p><span id="b">bbbb</span></p></div>
+<script>
+    const second = document.getElementById("b").firstChild;
+    document.querySelector("div").focus();
+    getSelection().setBaseAndExtent(second, 2, second, 2);
+</script>

--- a/Tests/LibWeb/Ref/expected/caret-repaint-after-move-in-inline-element-ref.html
+++ b/Tests/LibWeb/Ref/expected/caret-repaint-after-move-in-inline-element-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    div {
+        font: 30px/1 monospace;
+    }
+</style>
+<div contenteditable="true"><p><span>abcd</span></p></div>
+<script>
+    const editor = document.querySelector("div");
+    const text = document.querySelector("span").firstChild;
+    editor.focus();
+    getSelection().setBaseAndExtent(text, 3, text, 3);
+</script>

--- a/Tests/LibWeb/Ref/input/caret-on-second-br-line.html
+++ b/Tests/LibWeb/Ref/input/caret-on-second-br-line.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/caret-on-second-br-line-ref.html">
+<style>
+    div {
+        font: 30px/1 monospace;
+    }
+
+    p {
+        margin: 0;
+    }
+</style>
+<div contenteditable="true"><p id="p"><br><br></p></div>
+<script>
+    document.querySelector("div").focus();
+    const p = document.getElementById("p");
+    getSelection().setBaseAndExtent(p, 1, p, 1);
+</script>

--- a/Tests/LibWeb/Ref/input/caret-repaint-after-move-between-lines.html
+++ b/Tests/LibWeb/Ref/input/caret-repaint-after-move-between-lines.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/caret-repaint-after-move-between-lines-ref.html">
+<style>
+    p {
+        margin: 0;
+        font: 30px/1 monospace;
+    }
+</style>
+<div contenteditable="true"><p><span id="a">aaaa</span></p><p><span id="b">bbbb</span></p></div>
+<script>
+    const first = document.getElementById("a").firstChild;
+    const second = document.getElementById("b").firstChild;
+    document.querySelector("div").focus();
+    getSelection().setBaseAndExtent(first, 2, first, 2);
+
+    // Two nested requestAnimationFrame() calls to force code execution _after_ initial paint,
+    // so that moving the caret to another line must repaint the line it moved away from.
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            getSelection().setBaseAndExtent(second, 2, second, 2);
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    });
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/caret-repaint-after-move-in-inline-element.html
+++ b/Tests/LibWeb/Ref/input/caret-repaint-after-move-in-inline-element.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/caret-repaint-after-move-in-inline-element-ref.html">
+<style>
+    div {
+        font: 30px/1 monospace;
+    }
+</style>
+<div contenteditable="true"><p><span>abcd</span></p></div>
+<script>
+    const editor = document.querySelector("div");
+    const text = document.querySelector("span").firstChild;
+    editor.focus();
+    getSelection().setBaseAndExtent(text, 1, text, 1);
+
+    // Two nested requestAnimationFrame() calls to force code execution _after_ initial paint,
+    // so that moving the caret within the inline element must repaint its cached display list.
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            getSelection().setBaseAndExtent(text, 3, text, 3);
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    });
+</script>
+</html>

--- a/Tests/LibWeb/Text/expected/Editing/caret-extend-selection-across-blocks.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-extend-selection-across-blocks.txt
@@ -1,0 +1,14 @@
+Shift+Left 1: anchor=#text("def")@3 focus=#text("def")@2
+Shift+Left 2: anchor=#text("def")@3 focus=#text("def")@1
+Shift+Left 3: anchor=#text("def")@3 focus=#text("def")@0
+Shift+Left 4: anchor=#text("def")@3 focus=#text("abc")@3
+Shift+Left 5: anchor=#text("def")@3 focus=#text("def")@2
+Shift+Left 6: anchor=#text("def")@3 focus=#text("def")@1
+Shift+Right 1: anchor=#text("abc")@0 focus=#text("abc")@1
+Shift+Right 2: anchor=#text("abc")@0 focus=#text("abc")@2
+Shift+Right 3: anchor=#text("abc")@0 focus=#text("abc")@3
+Shift+Right 4: anchor=#text("abc")@0 focus=#text("def")@0
+Shift+Right 5: anchor=#text("abc")@0 focus=#text("abc")@1
+Shift+Right 6: anchor=#text("abc")@0 focus=#text("abc")@2
+Shift+Up: anchor=#text("def")@1 focus=#text("abc")@1
+Shift+Down: anchor=#text("def")@1 focus=#text("def")@3

--- a/Tests/LibWeb/Text/expected/Editing/caret-extend-selection-across-blocks.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-extend-selection-across-blocks.txt
@@ -2,13 +2,13 @@ Shift+Left 1: anchor=#text("def")@3 focus=#text("def")@2
 Shift+Left 2: anchor=#text("def")@3 focus=#text("def")@1
 Shift+Left 3: anchor=#text("def")@3 focus=#text("def")@0
 Shift+Left 4: anchor=#text("def")@3 focus=#text("abc")@3
-Shift+Left 5: anchor=#text("def")@3 focus=#text("def")@2
-Shift+Left 6: anchor=#text("def")@3 focus=#text("def")@1
+Shift+Left 5: anchor=#text("def")@3 focus=#text("abc")@2
+Shift+Left 6: anchor=#text("def")@3 focus=#text("abc")@1
 Shift+Right 1: anchor=#text("abc")@0 focus=#text("abc")@1
 Shift+Right 2: anchor=#text("abc")@0 focus=#text("abc")@2
 Shift+Right 3: anchor=#text("abc")@0 focus=#text("abc")@3
 Shift+Right 4: anchor=#text("abc")@0 focus=#text("def")@0
-Shift+Right 5: anchor=#text("abc")@0 focus=#text("abc")@1
-Shift+Right 6: anchor=#text("abc")@0 focus=#text("abc")@2
+Shift+Right 5: anchor=#text("abc")@0 focus=#text("def")@1
+Shift+Right 6: anchor=#text("abc")@0 focus=#text("def")@2
 Shift+Up: anchor=#text("def")@1 focus=#text("abc")@1
-Shift+Down: anchor=#text("def")@1 focus=#text("def")@3
+Shift+Down: anchor=#text("def")@1 focus=#text("def")@1

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-across-blocks.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-across-blocks.txt
@@ -1,0 +1,8 @@
+ArrowUp from bbb,0: #text("bbb") @ 0
+ArrowUp again: #text("bbb") @ 0
+ArrowDown from aaa,1: #text("aaa") @ 3
+ArrowDown again: #text("aaa") @ 3
+ArrowRight from aaa,3: #text("aaa") @ 3
+ArrowRight again: #text("aaa") @ 3
+ArrowLeft from bbb,0: #text("bbb") @ 0
+ArrowLeft again: #text("bbb") @ 0

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-across-blocks.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-across-blocks.txt
@@ -1,8 +1,8 @@
-ArrowUp from bbb,0: #text("bbb") @ 0
-ArrowUp again: #text("bbb") @ 0
-ArrowDown from aaa,1: #text("aaa") @ 3
-ArrowDown again: #text("aaa") @ 3
-ArrowRight from aaa,3: #text("aaa") @ 3
-ArrowRight again: #text("aaa") @ 3
-ArrowLeft from bbb,0: #text("bbb") @ 0
-ArrowLeft again: #text("bbb") @ 0
+ArrowUp from bbb,0: p#p2 @ 0
+ArrowUp again: #text("aaa") @ 0
+ArrowDown from aaa,1: p#p2 @ 0
+ArrowDown again: #text("bbb") @ 0
+ArrowRight from aaa,3: p#p2 @ 0
+ArrowRight again: #text("bbb") @ 0
+ArrowLeft from bbb,0: p#p2 @ 0
+ArrowLeft again: #text("aaa") @ 3

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-br-lines.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-br-lines.txt
@@ -1,12 +1,12 @@
-ArrowUp from cd,1: #text("ab") @ 1
+ArrowUp from cd,1: p#p2 @ 0
 ArrowUp again: #text("ab") @ 0
-ArrowDown from ab,1: #text("cd") @ 1
-ArrowDown again: #text("cd") @ 2
-ArrowRight from ab,2: #text("cd") @ 0
-ArrowRight again: #text("cd") @ 1
-ArrowLeft from cd,0: #text("ab") @ 2
-ArrowLeft again: #text("ab") @ 1
-ArrowUp from zw,0: #text("xy") @ 0
+ArrowDown from ab,1: p#p2 @ 0
+ArrowDown again: #text("cd") @ 0
+ArrowRight from ab,2: p#p2 @ 0
+ArrowRight again: #text("cd") @ 0
+ArrowLeft from cd,0: p#p2 @ 0
+ArrowLeft again: #text("ab") @ 2
+ArrowUp from zw,0: p#q @ 2
 ArrowUp again: #text("xy") @ 0
-ArrowDown from xy,1: #text("zw") @ 1
-ArrowDown again: #text("zw") @ 2
+ArrowDown from xy,1: p#q @ 2
+ArrowDown again: #text("zw") @ 0

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-br-lines.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-br-lines.txt
@@ -1,0 +1,12 @@
+ArrowUp from cd,1: #text("ab") @ 1
+ArrowUp again: #text("ab") @ 0
+ArrowDown from ab,1: #text("cd") @ 1
+ArrowDown again: #text("cd") @ 2
+ArrowRight from ab,2: #text("cd") @ 0
+ArrowRight again: #text("cd") @ 1
+ArrowLeft from cd,0: #text("ab") @ 2
+ArrowLeft again: #text("ab") @ 1
+ArrowUp from zw,0: #text("xy") @ 0
+ArrowUp again: #text("xy") @ 0
+ArrowDown from xy,1: #text("zw") @ 1
+ArrowDown again: #text("zw") @ 2

--- a/Tests/LibWeb/Text/expected/Editing/click-editable-hidden-on-focus.txt
+++ b/Tests/LibWeb/Text/expected/Editing/click-editable-hidden-on-focus.txt
@@ -1,0 +1,2 @@
+selection: #text("edit me")@4
+active element: editor

--- a/Tests/LibWeb/Text/expected/Editing/selection-modify-across-blocks.txt
+++ b/Tests/LibWeb/Text/expected/Editing/selection-modify-across-blocks.txt
@@ -1,0 +1,8 @@
+extend backward from def,0: anchor=#text("def")@0 focus=p#p2@0
+extend backward again: anchor=#text("def")@0 focus=#text("abc")@3
+extend forward from empty line: anchor=p#p2@0 focus=p#p2@0
+extend backward from empty line: anchor=p#p2@0 focus=p#p2@0
+move forward from empty line: anchor=p#p2@0 focus=p#p2@0
+move forward by line: anchor=#text("abc")@1 focus=#text("abc")@1
+move to line start: anchor=#text("def")@1 focus=#text("def")@1
+move to line end: anchor=#text("def")@1 focus=#text("def")@1

--- a/Tests/LibWeb/Text/expected/Editing/selection-modify-across-blocks.txt
+++ b/Tests/LibWeb/Text/expected/Editing/selection-modify-across-blocks.txt
@@ -1,8 +1,8 @@
 extend backward from def,0: anchor=#text("def")@0 focus=p#p2@0
 extend backward again: anchor=#text("def")@0 focus=#text("abc")@3
-extend forward from empty line: anchor=p#p2@0 focus=p#p2@0
-extend backward from empty line: anchor=p#p2@0 focus=p#p2@0
-move forward from empty line: anchor=p#p2@0 focus=p#p2@0
-move forward by line: anchor=#text("abc")@1 focus=#text("abc")@1
-move to line start: anchor=#text("def")@1 focus=#text("def")@1
-move to line end: anchor=#text("def")@1 focus=#text("def")@1
+extend forward from empty line: anchor=p#p2@0 focus=#text("def")@0
+extend backward from empty line: anchor=p#p2@0 focus=#text("abc")@3
+move forward from empty line: anchor=#text("def")@0 focus=#text("def")@0
+move forward by line: anchor=p#p2@0 focus=p#p2@0
+move to line start: anchor=#text("def")@0 focus=#text("def")@0
+move to line end: anchor=#text("def")@3 focus=#text("def")@3

--- a/Tests/LibWeb/Text/input/Editing/caret-extend-selection-across-blocks.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-extend-selection-across-blocks.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    p {
+        margin: 0;
+        font: 20px/1.5 monospace;
+    }
+</style>
+<div id="editor" contenteditable="true"><p><span id="s1">abc</span></p><p><span id="s2">def</span></p></div>
+<script>
+    test(() => {
+        const modShift = 1 << 2;
+        const editor = document.getElementById("editor");
+        const abc = document.getElementById("s1").firstChild;
+        const def = document.getElementById("s2").firstChild;
+        const describe = n => !n
+            ? "null"
+            : (n.nodeType === Node.TEXT_NODE ? `#text("${n.data}")` : n.nodeName.toLowerCase());
+        const report = label => {
+            const s = getSelection();
+            println(`${label}: anchor=${describe(s.anchorNode)}@${s.anchorOffset} focus=${describe(s.focusNode)}@${s.focusOffset}`);
+        };
+        editor.focus();
+
+        getSelection().setBaseAndExtent(def, 3, def, 3);
+        for (let i = 1; i <= 6; ++i) {
+            internals.sendKey(editor, "Left", modShift);
+            report(`Shift+Left ${i}`);
+        }
+
+        getSelection().setBaseAndExtent(abc, 0, abc, 0);
+        for (let i = 1; i <= 6; ++i) {
+            internals.sendKey(editor, "Right", modShift);
+            report(`Shift+Right ${i}`);
+        }
+
+        getSelection().setBaseAndExtent(def, 1, def, 1);
+        internals.sendKey(editor, "Up", modShift);
+        report("Shift+Up");
+        internals.sendKey(editor, "Down", modShift);
+        report("Shift+Down");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Editing/caret-navigation-across-blocks.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-navigation-across-blocks.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    p {
+        margin: 0;
+        font: 20px/1.5 monospace;
+    }
+</style>
+<div id="editor" contenteditable="true"><p><span id="s1">aaa</span></p><p id="p2"><br></p><p><span id="s3">bbb</span></p></div>
+<script>
+    test(() => {
+        const editor = document.getElementById("editor");
+        const s1 = document.getElementById("s1").firstChild;
+        const s3 = document.getElementById("s3").firstChild;
+        const describe = n => !n
+            ? "null"
+            : (n.nodeType === Node.TEXT_NODE ? `#text("${n.data}")` : n.nodeName.toLowerCase() + (n.id ? "#" + n.id : ""));
+        const report = label => {
+            const s = getSelection();
+            println(`${label}: ${describe(s.focusNode)} @ ${s.focusOffset}`);
+        };
+        editor.focus();
+        const move = (node, offset, key, label) => {
+            getSelection().setBaseAndExtent(node, offset, node, offset);
+            internals.sendKey(editor, key);
+            report(label);
+        };
+
+        move(s3, 0, "Up", "ArrowUp from bbb,0");
+        internals.sendKey(editor, "Up");
+        report("ArrowUp again");
+
+        move(s1, 1, "Down", "ArrowDown from aaa,1");
+        internals.sendKey(editor, "Down");
+        report("ArrowDown again");
+
+        move(s1, 3, "Right", "ArrowRight from aaa,3");
+        internals.sendKey(editor, "Right");
+        report("ArrowRight again");
+
+        move(s3, 0, "Left", "ArrowLeft from bbb,0");
+        internals.sendKey(editor, "Left");
+        report("ArrowLeft again");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Editing/caret-navigation-br-lines.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-navigation-br-lines.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    p {
+        margin: 0;
+        font: 20px/1.5 monospace;
+    }
+</style>
+<div id="editor1" contenteditable="true"><p id="p1"><span id="sab">ab</span></p><p id="p2"><br><span id="scd">cd</span></p></div>
+<div id="editor2" contenteditable="true"><p id="q">xy<br><br>zw</p></div>
+<script>
+    test(() => {
+        const describe = n => !n
+            ? "null"
+            : (n.nodeType === Node.TEXT_NODE ? `#text("${n.data}")` : n.nodeName.toLowerCase() + (n.id ? "#" + n.id : ""));
+        const report = label => {
+            const s = getSelection();
+            println(`${label}: ${describe(s.focusNode)} @ ${s.focusOffset}`);
+        };
+        const move = (editor, node, offset, key, label) => {
+            getSelection().setBaseAndExtent(node, offset, node, offset);
+            internals.sendKey(editor, key);
+            report(label);
+        };
+
+        // An empty line rendered by a leading <br> in a paragraph with text (as produced by Lexical editors).
+        const editor1 = document.getElementById("editor1");
+        const ab = document.getElementById("sab").firstChild;
+        const cd = document.getElementById("scd").firstChild;
+        editor1.focus();
+        move(editor1, cd, 1, "Up", "ArrowUp from cd,1");
+        internals.sendKey(editor1, "Up");
+        report("ArrowUp again");
+        move(editor1, ab, 1, "Down", "ArrowDown from ab,1");
+        internals.sendKey(editor1, "Down");
+        report("ArrowDown again");
+        move(editor1, ab, 2, "Right", "ArrowRight from ab,2");
+        internals.sendKey(editor1, "Right");
+        report("ArrowRight again");
+        move(editor1, cd, 0, "Left", "ArrowLeft from cd,0");
+        internals.sendKey(editor1, "Left");
+        report("ArrowLeft again");
+
+        // An empty line between two <br>s inside a single block.
+        const editor2 = document.getElementById("editor2");
+        const q = document.getElementById("q");
+        editor2.focus();
+        move(editor2, q.lastChild, 0, "Up", "ArrowUp from zw,0");
+        internals.sendKey(editor2, "Up");
+        report("ArrowUp again");
+        move(editor2, q.firstChild, 1, "Down", "ArrowDown from xy,1");
+        internals.sendKey(editor2, "Down");
+        report("ArrowDown again");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Editing/click-editable-hidden-on-focus.html
+++ b/Tests/LibWeb/Text/input/Editing/click-editable-hidden-on-focus.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #placeholder,
+    #editor {
+        position: absolute;
+        left: 8px;
+        top: 8px;
+        width: 200px;
+        height: 40px;
+        font: 20px/1.5 monospace;
+    }
+</style>
+<textarea id="placeholder"></textarea>
+<div id="editor" contenteditable="true" style="display: none">edit me</div>
+<script>
+    test(() => {
+        // Like Reddit's comment composer: a focusable placeholder is swapped for the real editor when it gains
+        // focus, and the editor's own focus handler (which runs synchronously while the mouse click sets the
+        // selection into it) forces a synchronous relayout. The click's default actions must not keep using
+        // paintables from before that relayout.
+        const placeholder = document.getElementById("placeholder");
+        const editor = document.getElementById("editor");
+        placeholder.addEventListener("focus", () => {
+            placeholder.style.display = "none";
+            editor.style.display = "block";
+        });
+        editor.addEventListener("focus", () => {
+            document.body.appendChild(document.createElement("div"));
+            editor.getBoundingClientRect();
+        });
+
+        internals.click(40, 25);
+
+        const s = getSelection();
+        const describe = n => !n
+            ? "null"
+            : (n.nodeType === Node.TEXT_NODE ? `#text("${n.data}")` : n.nodeName.toLowerCase() + (n.id ? "#" + n.id : ""));
+        println(`selection: ${describe(s.focusNode)}@${s.focusOffset}`);
+        println(`active element: ${document.activeElement.id}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Editing/selection-modify-across-blocks.html
+++ b/Tests/LibWeb/Text/input/Editing/selection-modify-across-blocks.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    p {
+        margin: 0;
+        font: 20px/1.5 monospace;
+    }
+</style>
+<div id="editor" contenteditable="true"><p><span id="s1">abc</span></p><p id="p2"><br><span id="s2">def</span></p></div>
+<script>
+    test(() => {
+        const editor = document.getElementById("editor");
+        const abc = document.getElementById("s1").firstChild;
+        const def = document.getElementById("s2").firstChild;
+        const p2 = document.getElementById("p2");
+        const sel = getSelection();
+        const describe = n => !n
+            ? "null"
+            : (n.nodeType === Node.TEXT_NODE ? `#text("${n.data}")` : n.nodeName.toLowerCase() + (n.id ? "#" + n.id : ""));
+        const report = label => {
+            println(`${label}: anchor=${describe(sel.anchorNode)}@${sel.anchorOffset} focus=${describe(sel.focusNode)}@${sel.focusOffset}`);
+        };
+        editor.focus();
+
+        // Extending backward across the block boundary and the empty line.
+        sel.setBaseAndExtent(def, 0, def, 0);
+        sel.modify("extend", "backward", "character");
+        report("extend backward from def,0");
+        sel.modify("extend", "backward", "character");
+        report("extend backward again");
+
+        // The Lexical deleteCharacter() pattern: an element-anchored caret on the empty line.
+        sel.setBaseAndExtent(p2, 0, p2, 0);
+        sel.modify("extend", "forward", "character");
+        report("extend forward from empty line");
+
+        sel.setBaseAndExtent(p2, 0, p2, 0);
+        sel.modify("extend", "backward", "character");
+        report("extend backward from empty line");
+
+        sel.setBaseAndExtent(p2, 0, p2, 0);
+        sel.modify("move", "forward", "character");
+        report("move forward from empty line");
+
+        // Line and line boundary granularities.
+        sel.setBaseAndExtent(abc, 1, abc, 1);
+        sel.modify("move", "forward", "line");
+        report("move forward by line");
+
+        sel.setBaseAndExtent(def, 1, def, 1);
+        sel.modify("move", "backward", "lineboundary");
+        report("move to line start");
+        sel.modify("move", "forward", "lineboundary");
+        report("move to line end");
+    });
+</script>


### PR DESCRIPTION
Caret movement in editing hosts was confined to a single text node, so the
caret could not move between paragraphs at all, and empty lines were
unreachable and unescapable. This series makes character and line movement
cross node boundaries to the nearest caret host: a text node with rendered
text, a block rendering an empty line, or a `<br>` that renders one (the shape
Lexical produces). Movement now operates on the selection focus rather than
the anchor, fixing Shift+Arrow selections that snapped back and cycled forever
after crossing a block boundary, and Selection.modify() gains element
positions and the line granularities, which is the API Lexical builds
Backspace and Delete on.

On the rendering side, caret repaints now invalidate the paintable that
actually owns the text's fragments (inline elements own their own line
paintables), repaint the node the caret moved away from, and paint
element-anchored carets on the correct empty line. The blink timer no longer
runs in test mode, which it was already supposed not to. The series also
hardens mousedown default actions against paintables detached by script that
runs while a selection is being initiated, which crashed on Reddit's composer
placeholder.

Everything is covered by Text and Ref regression tests with expectations
matching Chrome, except that the caret column is not yet remembered across
vertical moves and word movement is still single-node; both are marked as
FIXMEs.