### PR TITLE
LibWeb: Implement the clipboard actions for Ctrl+C, Ctrl+X and Ctrl+V

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -12,9 +12,12 @@
 #include <LibGfx/Bitmap.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibUnicode/Segmenter.h>
+#include <LibWeb/Bindings/ClipboardEvent.h>
 #include <LibWeb/Bindings/InputEvent.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/VisualViewport.h>
+#include <LibWeb/Clipboard/ClipboardEvent.h>
+#include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Range.h>
@@ -22,6 +25,9 @@
 #include <LibWeb/Editing/Internal/Algorithms.h>
 #include <LibWeb/GraphemeEdgeTracker.h>
 #include <LibWeb/HTML/CloseWatcherManager.h>
+#include <LibWeb/HTML/DataTransfer.h>
+#include <LibWeb/HTML/DragDataStore.h>
+#include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/Focus.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
@@ -1109,6 +1115,17 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         //    instead interpret this interaction as some other action, instead of interpreting it as a close request.
     }
 
+    // https://w3c.github.io/clipboard-apis/#clipboard-actions
+    // AD-HOC: The clipboard action shortcut keys are not specified anywhere, but these combinations are universal.
+    if ((modifiers & UIEvents::Mod_PlatformCtrl) != 0 && (modifiers & (UIEvents::Mod_Shift | UIEvents::Mod_Alt)) == 0) {
+        if (key == UIEvents::KeyCode::Key_C)
+            return perform_copy_action();
+        if (key == UIEvents::KeyCode::Key_X)
+            return perform_cut_action();
+        if (key == UIEvents::KeyCode::Key_V)
+            return perform_paste_action();
+    }
+
     if (auto* target = document->active_input_events_target()) {
         if (auto delete_result = handle_delete_key(*target); delete_result.has_value())
             return delete_result.value();
@@ -1390,6 +1407,184 @@ EventResult EventHandler::handle_pinch_event(CSSPixelPoint point, u32 modifiers,
         return EventResult::Dropped;
 
     document->visual_viewport()->zoom(point, scale_delta);
+    return EventResult::Handled;
+}
+
+// https://w3c.github.io/clipboard-apis/#clipboard-event-target
+static GC::Ptr<DOM::EventTarget> clipboard_event_target(DOM::Document& document)
+{
+    // If the context is editable, the clipboard event target is the element that contains the start of the selection
+    // in document order; otherwise it is the focused node, falling back to the body or document element.
+    if (auto selection = document.get_selection()) {
+        if (auto range = selection->range(); range && range->start_container()->is_editable_or_editing_host())
+            return range->start_container();
+    }
+    if (auto focused_area = document.focused_area())
+        return focused_area;
+    if (auto* body = document.body())
+        return body;
+    return document.document_element();
+}
+
+// https://w3c.github.io/clipboard-apis/#fire-a-clipboard-event
+static bool fire_clipboard_event(DOM::Document& document, FlyString const& event_name, GC::Ref<HTML::DataTransfer> data_transfer)
+{
+    auto target = clipboard_event_target(document);
+    if (!target)
+        return true;
+
+    Bindings::ClipboardEventInit event_init {};
+    event_init.bubbles = true;
+    event_init.cancelable = true;
+    event_init.composed = true;
+    event_init.clipboard_data = data_transfer;
+
+    auto event = Clipboard::ClipboardEvent::construct_impl(document.realm(), event_name, event_init);
+    event->set_is_trusted(true);
+    return target->dispatch_event(event);
+}
+
+// https://w3c.github.io/clipboard-apis/#write-content-to-the-clipboard
+// AD-HOC: Our system clipboard interface carries a single representation, so this writes the plain text one.
+static void write_data_transfer_to_clipboard(DOM::Document& document, HTML::DragDataStore const& data_store)
+{
+    for (auto const& item : data_store.item_list()) {
+        if (item.kind == HTML::DragDataStoreItem::Kind::Text && item.type_string == "text/plain"sv) {
+            document.page().client().page_did_insert_clipboard_entry({ ByteString { item.data.bytes() }, "text/plain"_string }, "unspecified"sv);
+            return;
+        }
+    }
+}
+
+// https://w3c.github.io/clipboard-apis/#the-copy-action
+EventResult EventHandler::perform_copy_action()
+{
+    auto document = m_navigable->active_document();
+    if (!document || !document->is_fully_active())
+        return EventResult::Dropped;
+
+    auto data_store = HTML::DragDataStore::create();
+    data_store->set_mode(HTML::DragDataStore::Mode::ReadWrite);
+    auto data_transfer = HTML::DataTransfer::create(document->realm(), data_store);
+
+    // 2. Fire a clipboard event named copy.
+    bool event_was_not_canceled = fire_clipboard_event(*document, HTML::EventNames::copy, data_transfer);
+    data_store->set_mode(HTML::DragDataStore::Mode::Protected);
+
+    // 3. If the event was not canceled, then:
+    if (event_was_not_canceled) {
+        // 1. Copy the selected contents, if any, to the clipboard. Implementations should create alternate text/html
+        //    and text/plain clipboard formats when content in a web page is selected.
+        // FIXME: Also create a text/html representation of the selection.
+        if (auto text = m_navigable->selected_text(); !text.is_empty())
+            document->page().client().page_did_insert_clipboard_entry({ text.to_byte_string(), "text/plain"_string }, "unspecified"sv);
+
+        // FIXME: 2. Fire a clipboard event named clipboardchange.
+    }
+    // 4. Else, if the event was canceled, then:
+    else {
+        // 1. Call the write content to the clipboard algorithm, passing on the DataTransferItemList list items, a
+        //    clear-was-called flag and a types-to-clear list.
+        write_data_transfer_to_clipboard(*document, data_store);
+    }
+
+    // 5. Return true from the copy action.
+    return EventResult::Handled;
+}
+
+// https://w3c.github.io/clipboard-apis/#the-cut-action
+EventResult EventHandler::perform_cut_action()
+{
+    auto document = m_navigable->active_document();
+    if (!document || !document->is_fully_active())
+        return EventResult::Dropped;
+
+    auto data_store = HTML::DragDataStore::create();
+    data_store->set_mode(HTML::DragDataStore::Mode::ReadWrite);
+    auto data_transfer = HTML::DataTransfer::create(document->realm(), data_store);
+
+    // 2. Fire a clipboard event named cut.
+    bool event_was_not_canceled = fire_clipboard_event(*document, HTML::EventNames::cut, data_transfer);
+    data_store->set_mode(HTML::DragDataStore::Mode::Protected);
+
+    // 3. If the event was not canceled, then:
+    if (event_was_not_canceled) {
+        // 1. If there is a selection in an editable context where cutting is enabled, then:
+        if (auto* target = document->active_input_events_target()) {
+            auto text = m_navigable->selected_text();
+            if (!text.is_empty()) {
+                // 1. Copy the selected contents, if any, to the clipboard. Implementations should create alternate
+                //    text/html and text/plain clipboard formats when content in a web page is selected.
+                document->page().client().page_did_insert_clipboard_entry({ text.to_byte_string(), "text/plain"_string }, "unspecified"sv);
+
+                // 2. Remove the contents of the selection from the document and collapse the selection.
+                // 4. Queue tasks to fire any events that should fire due to the modification.
+                FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::deleteByCut, m_navigable, 0));
+                target->handle_delete(UIEvents::InputTypes::deleteByCut);
+
+                // FIXME: 3. Fire a clipboard event named clipboardchange.
+            }
+        }
+        // 2. Else, there is no selection or the context is not editable; do nothing.
+    }
+    // 4. Else, if the event was canceled, then:
+    else {
+        // 1. Call the write content to the clipboard algorithm, passing on the DataTransferItemList list items, a
+        //    clear-was-called flag and a types-to-clear list.
+        write_data_transfer_to_clipboard(*document, data_store);
+
+        // FIXME: 2. Fire a clipboard event named clipboardchange.
+    }
+
+    // 5. Return true from the cut action.
+    return EventResult::Handled;
+}
+
+// https://w3c.github.io/clipboard-apis/#the-paste-action
+EventResult EventHandler::perform_paste_action()
+{
+    auto document = m_navigable->active_document();
+    if (!document || !document->is_fully_active())
+        return EventResult::Dropped;
+
+    // NB: The system clipboard lives in the UI process, so retrieve its contents first and fire the paste event once
+    //     they arrive.
+    document->page().request_clipboard_entries(GC::create_function(document->heap(), [document = GC::Ref { *document }](Vector<Clipboard::SystemClipboardItem> items) {
+        auto data_store = HTML::DragDataStore::create();
+        if (!items.is_empty()) {
+            for (auto const& representation : items.first().system_clipboard_representations) {
+                // NB: The clipboard representation's type may carry parameters, e.g. "text/plain;charset=utf-8".
+                if (representation.mime_type == "text/plain"sv || representation.mime_type.starts_with_bytes("text/plain;"sv)) {
+                    data_store->add_item({
+                        .kind = HTML::DragDataStoreItem::Kind::Text,
+                        .type_string = "text/plain"_string,
+                        .data = MUST(ByteBuffer::copy(representation.data.bytes())),
+                        .file_name = {},
+                    });
+                    break;
+                }
+            }
+        }
+        data_store->set_mode(HTML::DragDataStore::Mode::ReadOnly);
+        auto data_transfer = HTML::DataTransfer::create(document->realm(), data_store);
+
+        // 2. Fire a clipboard event named paste.
+        bool event_was_not_canceled = fire_clipboard_event(*document, HTML::EventNames::paste, data_transfer);
+        data_store->set_mode(HTML::DragDataStore::Mode::Protected);
+
+        // 3. If the event was not canceled, then: if there is a selection or cursor in an editable context where
+        //    pasting is enabled, insert the most suitable content found on the clipboard, if any, into the context.
+        if (event_was_not_canceled) {
+            for (auto const& item : data_store->item_list()) {
+                if (item.kind == HTML::DragDataStoreItem::Kind::Text && item.type_string == "text/plain"sv) {
+                    if (auto navigable = document->navigable())
+                        navigable->event_handler().handle_paste(Utf16String::from_utf8(StringView { item.data.bytes() }));
+                    break;
+                }
+            }
+        }
+    }));
+
     return EventResult::Handled;
 }
 

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -88,6 +88,10 @@ private:
     [[nodiscard]] EventResult fire_text_input_event(HTML::LocalNavigable&, String const& data);
     [[nodiscard]] EventResult input_event(FlyString const& event_name, FlyString const& input_type, HTML::LocalNavigable&, Variant<u32, Utf16String> code_point_or_string);
 
+    [[nodiscard]] EventResult perform_copy_action();
+    [[nodiscard]] EventResult perform_cut_action();
+    [[nodiscard]] EventResult perform_paste_action();
+
     EventResult focus_next_element();
     EventResult focus_previous_element();
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1221,6 +1221,16 @@ void ViewImplementation::retrieved_clipboard_entries(u64 request_id, ReadonlySpa
     client().async_retrieved_clipboard_entries(page_id(), request_id, items);
 }
 
+void ViewImplementation::insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation entry)
+{
+    Application::the().insert_clipboard_entry(move(entry));
+}
+
+Vector<Web::Clipboard::SystemClipboardRepresentation> ViewImplementation::clipboard_entries() const
+{
+    return Application::the().clipboard_entries();
+}
+
 void ViewImplementation::toggle_page_mute_state()
 {
     m_mute_state = Web::HTML::invert_mute_state(m_mute_state);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -404,6 +404,9 @@ public:
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const = 0;
 
 protected:
+    virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation);
+    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const;
+
     virtual bool defer_backing_store_release(i32) { return false; }
     virtual void did_accept_presented_backing_store(i32, Gfx::IntRect) { }
     void release_backing_store(i32 bitmap_id);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1745,16 +1745,17 @@ void WebContentClient::did_change_background_color(u64 page_id, Gfx::Color color
         view->did_change_background_color({}, color);
 }
 
-void WebContentClient::did_insert_clipboard_entry(u64, Web::Clipboard::SystemClipboardRepresentation entry, String)
+void WebContentClient::did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation entry, String)
 {
-    Application::the().insert_clipboard_entry(move(entry));
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->insert_clipboard_entry(move(entry));
 }
 
 void WebContentClient::did_request_clipboard_entries(u64 page_id, u64 request_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         Vector<Web::Clipboard::SystemClipboardItem> items;
-        if (auto entries = Application::the().clipboard_entries(); !entries.is_empty())
+        if (auto entries = view->clipboard_entries(); !entries.is_empty())
             items.empend(move(entries));
 
         view->retrieved_clipboard_entries(request_id, items);

--- a/Tests/LibWeb/Text/expected/Editing/clipboard-shortcut-copy-cut.txt
+++ b/Tests/LibWeb/Text/expected/Editing/clipboard-shortcut-copy-cut.txt
@@ -1,0 +1,5 @@
+clipboard after copy: null
+editor text after copy: "hello world"
+clipboard after cut: null
+editor text after cut: "hello world"
+clipboard after canceled copy: null

--- a/Tests/LibWeb/Text/expected/Editing/clipboard-shortcut-copy-cut.txt
+++ b/Tests/LibWeb/Text/expected/Editing/clipboard-shortcut-copy-cut.txt
@@ -1,5 +1,8 @@
-clipboard after copy: null
+clipboard after copy: "hello"
 editor text after copy: "hello world"
-clipboard after cut: null
-editor text after cut: "hello world"
-clipboard after canceled copy: null
+clipboard after cut: " world"
+editor text after cut: "hello"
+clipboard after canceled copy: "custom payload"
+copy(cancelable=true composed=true data="")
+cut(cancelable=true composed=true data="")
+copy(cancelable=true composed=true data="")

--- a/Tests/LibWeb/Text/expected/Editing/clipboard-shortcut-paste.txt
+++ b/Tests/LibWeb/Text/expected/Editing/clipboard-shortcut-paste.txt
@@ -1,0 +1,4 @@
+paste event data: "PASTED"
+editor text after paste: "aPASTEDb"
+canceled paste event data: "PASTED"
+editor text after canceled paste: "aPASTEDb"

--- a/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-copy-cut.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-copy-cut.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="editor" contenteditable="true">hello world</div>
+<script>
+    asyncTest(async done => {
+        const modCtrl = (1 << 1) | (1 << 3); // Ctrl and Super, to cover the platform clipboard modifier everywhere.
+        const editor = document.getElementById("editor");
+        const events = [];
+        for (const type of ["copy", "cut", "paste"]) {
+            editor.addEventListener(type, e => {
+                events.push(`${type}(cancelable=${e.cancelable} composed=${e.composed} data=${JSON.stringify(e.clipboardData?.getData("text/plain") ?? null)})`);
+            });
+        }
+        const readClipboard = async () => {
+            internals.dispatchUserActivatedEvent(editor, new Event("mousedown"));
+            return navigator.clipboard.readText().catch(() => null);
+        };
+
+        // Select "hello" and copy it.
+        editor.focus();
+        const text = editor.firstChild;
+        getSelection().setBaseAndExtent(text, 0, text, 5);
+        internals.sendKey(editor, "C", modCtrl);
+        println(`clipboard after copy: ${JSON.stringify(await readClipboard())}`);
+        println(`editor text after copy: ${JSON.stringify(editor.textContent)}`);
+
+        // Select " world" and cut it.
+        getSelection().setBaseAndExtent(text, 5, text, 11);
+        internals.sendKey(editor, "X", modCtrl);
+        println(`clipboard after cut: ${JSON.stringify(await readClipboard())}`);
+        println(`editor text after cut: ${JSON.stringify(editor.textContent)}`);
+
+        // A canceled copy writes the event's data to the clipboard instead (the Lexical pattern).
+        editor.addEventListener("copy", e => {
+            e.clipboardData.setData("text/plain", "custom payload");
+            e.preventDefault();
+        }, { once: true });
+        getSelection().setBaseAndExtent(editor.firstChild, 0, editor.firstChild, 5);
+        internals.sendKey(editor, "C", modCtrl);
+        println(`clipboard after canceled copy: ${JSON.stringify(await readClipboard())}`);
+
+        for (const line of events) println(line);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-paste.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-paste.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="editor" contenteditable="true">ab</div>
+<script>
+    asyncTest(async done => {
+        const modCtrl = (1 << 1) | (1 << 3); // Ctrl and Super, to cover the platform clipboard modifier everywhere.
+        const editor = document.getElementById("editor");
+
+        // Seed the system clipboard.
+        internals.dispatchUserActivatedEvent(editor, new Event("mousedown"));
+        await navigator.clipboard.writeText("PASTED");
+
+        editor.focus();
+        const text = editor.firstChild;
+        getSelection().setBaseAndExtent(text, 1, text, 1);
+
+        const pasteEvent = new Promise(resolve => {
+            editor.addEventListener("paste", e => resolve(e.clipboardData.getData("text/plain")), { once: true });
+        });
+        internals.sendKey(editor, "V", modCtrl);
+        println(`paste event data: ${JSON.stringify(await pasteEvent)}`);
+        while (editor.textContent === "ab")
+            await new Promise(resolve => requestAnimationFrame(resolve));
+        println(`editor text after paste: ${JSON.stringify(editor.textContent)}`);
+
+        // A canceled paste must not insert anything (the Lexical pattern).
+        const canceledPasteEvent = new Promise(resolve => {
+            editor.addEventListener("paste", e => {
+                e.preventDefault();
+                resolve(e.clipboardData.getData("text/plain"));
+            }, { once: true });
+        });
+        internals.sendKey(editor, "V", modCtrl);
+        println(`canceled paste event data: ${JSON.stringify(await canceledPasteEvent)}`);
+        await new Promise(resolve => requestAnimationFrame(resolve));
+        println(`editor text after canceled paste: ${JSON.stringify(editor.textContent)}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/test-web/TestWebView.cpp
+++ b/Tests/LibWeb/test-web/TestWebView.cpp
@@ -43,6 +43,18 @@ pid_t TestWebView::web_content_pid() const
     return client().pid();
 }
 
+void TestWebView::insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation entry)
+{
+    m_clipboard_entry = move(entry);
+}
+
+Vector<Web::Clipboard::SystemClipboardRepresentation> TestWebView::clipboard_entries() const
+{
+    if (!m_clipboard_entry.has_value())
+        return {};
+    return { *m_clipboard_entry };
+}
+
 NonnullRefPtr<Core::Promise<RefPtr<Gfx::Bitmap const>>> TestWebView::take_screenshot()
 {
     VERIFY(!m_pending_screenshot);

--- a/Tests/LibWeb/test-web/TestWebView.h
+++ b/Tests/LibWeb/test-web/TestWebView.h
@@ -35,9 +35,13 @@ public:
 private:
     TestWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewport_size);
 
+    virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
+    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
+
     virtual void did_receive_screenshot(Badge<WebView::WebContentClient>, Gfx::ShareableBitmap const& screenshot) override;
     RefPtr<Core::Promise<RefPtr<Gfx::Bitmap const>>> m_pending_screenshot;
 
+    Optional<Web::Clipboard::SystemClipboardRepresentation> m_clipboard_entry;
     NonnullRefPtr<TestPromise> m_test_promise;
 };
 


### PR DESCRIPTION
The clipboard shortcut keys did nothing inside web content: WebContent
ignored Ctrl+letter keydowns, and the UI menu actions bypass the DOM, so no
copy, cut, or paste events ever fired. Editor frameworks implement their
clipboard support entirely through these events. This implements the
clipboard actions from the Clipboard APIs specification for the standard
shortcuts: copy and cut fire the corresponding ClipboardEvent and write either
the selected text or, when the page cancels the event, the page-provided
DataTransfer payload to the system clipboard; cut also removes the selection
with a deleteByCut input event; paste retrieves the system clipboard from the
UI process, fires a paste event carrying it, and inserts the plain text unless
the page canceled. Our system clipboard interface carries a single
representation per entry, so only text/plain round-trips for now, noted as a
FIXME. Verified against Reddit's Lexical composer, where copy, cut, and paste
now work through Lexical's own event handlers.