### PR TITLE
LibWeb: Make display list damage see canvas and video content changes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -472,6 +472,11 @@ void HTMLCanvasElement::prepare_for_compositing()
         return;
     m_canvas_content_dirty = false;
 
+    // NB: The content generation is recorded into DrawCanvas display list commands, letting display list damage
+    //     computation see that the canvas content changed. Canvases are prepared for compositing before painting
+    //     in the rendering update, so display lists recorded in the same update pick up the new generation.
+    ++m_content_generation;
+
     m_context.visit(
         [](GC::Ref<CanvasRenderingContext2D>& context) {
             context->prepare_for_compositing();

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -59,6 +59,8 @@ public:
 
     Optional<Painting::CanvasId> canvas_id() const;
 
+    u64 content_generation() const { return m_content_generation; }
+
     Optional<Gfx::IntSize> canvas_surface_content_size() const;
 
     void ensure_backing_storage();
@@ -90,6 +92,7 @@ private:
 
     Variant<GC::Ref<HTML::CanvasRenderingContext2D>, GC::Ref<WebGL::WebGLRenderingContext>, GC::Ref<WebGL::WebGL2RenderingContext>, Empty> m_context;
     bool m_canvas_content_dirty { false };
+    u64 m_content_generation { 0 };
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1678,6 +1678,10 @@ Painting::VideoFrameResourceId HTMLMediaElement::ensure_video_frame_resource_id(
 
 void HTMLMediaElement::update_compositor_video_frame(NonnullRefPtr<Media::VideoFrame const> frame)
 {
+    // NB: The content generation is recorded into DrawVideoFrame display list commands, letting display list
+    //     damage computation see that the video content changed.
+    ++m_video_frame_content_generation;
+
     auto frame_id = ensure_video_frame_resource_id();
     if (auto navigable = document().navigable(); navigable && navigable->has_compositor_context())
         navigable->compositor_context().update_video_frame(frame_id, move(frame));

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -176,6 +176,7 @@ public:
 
     Painting::VideoFrameResourceId ensure_video_frame_resource_id();
     Optional<Painting::VideoFrameResourceId> video_frame_resource_id() const { return m_video_frame_resource_id; }
+    u64 video_frame_content_generation() const { return m_video_frame_content_generation; }
 
     virtual bool update_intrinsic_video_dimensions() { return false; }
     virtual void update_natural_dimensions() { }
@@ -401,6 +402,7 @@ private:
     bool m_has_selected_preferred_video_track { false };
 
     Optional<Painting::VideoFrameResourceId> m_video_frame_resource_id;
+    u64 m_video_frame_content_generation { 0 };
 };
 
 }

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -266,6 +266,7 @@ public:
 
     bool needs_repaint() const { return m_needs_repaint; }
     void set_needs_repaint() { m_needs_repaint = true; }
+    bool needs_to_record_display_list() const { return m_needs_to_record_display_list; }
     void set_needs_to_record_display_list() { m_needs_to_record_display_list = true; }
     void repaint_after_compositor_process_reconnect();
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -639,6 +639,11 @@ bool Internals::needs_repaint()
     return page().top_level_traversable()->needs_repaint();
 }
 
+bool Internals::needs_display_list_record()
+{
+    return page().top_level_traversable()->needs_to_record_display_list();
+}
+
 bool Internals::screen_wake_lock_active()
 {
     return page().is_screen_wake_lock_active();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -109,6 +109,7 @@ public:
     bool screen_wake_lock_active();
 
     bool needs_repaint();
+    bool needs_display_list_record();
 
     String dump_display_list();
     String dump_accessibility_tree();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -98,6 +98,7 @@ interface Internals {
     readonly attribute boolean screenWakeLockActive;
 
     readonly attribute boolean needsRepaint;
+    readonly attribute boolean needsDisplayListRecord;
 
     DOMString dumpDisplayList();
     DOMString dumpAccessibilityTree();

--- a/Libraries/LibWeb/Painting/CanvasPaintable.cpp
+++ b/Libraries/LibWeb/Painting/CanvasPaintable.cpp
@@ -39,7 +39,7 @@ void CanvasPaintable::paint(DisplayListRecordingContext& context, PaintPhase pha
             auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(),
                 *content_size, canvas_int_rect.size());
             context.display_list_recorder().draw_canvas(canvas_int_rect,
-                *canvas_id, scaling_mode);
+                *canvas_id, canvas_element.content_generation(), scaling_mode);
         }
     }
 }

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -250,6 +250,10 @@ struct DrawCanvas {
 
     Gfx::IntRect dst_rect;
     CanvasId canvas_id;
+    // NB: The canvas pixels live in the compositor's canvas surface registry, so the command bytes don't
+    //     change when the canvas content does. The content generation encodes content changes so that display
+    //     list damage computation can tell that the canvas needs to be repainted.
+    u64 content_generation { 0 };
     Gfx::ScalingMode scaling_mode;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return dst_rect; }

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -266,6 +266,10 @@ struct DrawVideoFrame {
 
     Gfx::IntRect dst_rect;
     VideoFrameResourceId video_frame_id;
+    // NB: The video frame resource updates in place under a stable id, so the command bytes don't change when
+    //     a new frame arrives. The content generation encodes frame changes so that display list damage
+    //     computation can tell that the video needs to be repainted.
+    u64 content_generation { 0 };
     Gfx::ScalingMode scaling_mode;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return dst_rect; }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -523,13 +523,14 @@ void DisplayListRecorder::draw_composited_context(Gfx::IntRect const& dst_rect, 
     });
 }
 
-void DisplayListRecorder::draw_canvas(Gfx::IntRect const& dst_rect, CanvasId canvas_id, Gfx::ScalingMode scaling_mode)
+void DisplayListRecorder::draw_canvas(Gfx::IntRect const& dst_rect, CanvasId canvas_id, u64 content_generation, Gfx::ScalingMode scaling_mode)
 {
     if (dst_rect.is_empty())
         return;
     append_command(DrawCanvas {
         .dst_rect = dst_rect,
         .canvas_id = canvas_id,
+        .content_generation = content_generation,
         .scaling_mode = scaling_mode,
     });
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -535,13 +535,14 @@ void DisplayListRecorder::draw_canvas(Gfx::IntRect const& dst_rect, CanvasId can
     });
 }
 
-void DisplayListRecorder::draw_video_frame(Gfx::IntRect const& dst_rect, VideoFrameResourceId frame_id, RefPtr<Media::VideoFrame const> frame, Gfx::ScalingMode scaling_mode)
+void DisplayListRecorder::draw_video_frame(Gfx::IntRect const& dst_rect, VideoFrameResourceId frame_id, RefPtr<Media::VideoFrame const> frame, u64 content_generation, Gfx::ScalingMode scaling_mode)
 {
     if (dst_rect.is_empty())
         return;
     append_command(DrawVideoFrame {
         .dst_rect = dst_rect,
         .video_frame_id = resource_storage().add_video_frame(frame_id, move(frame)),
+        .content_generation = content_generation,
         .scaling_mode = scaling_mode,
     });
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -75,7 +75,7 @@ public:
     void draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Color> isolated_backdrop_color = {});
     void draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::FloatRect const& src_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Color> isolated_backdrop_color = {});
     void draw_composited_context(Gfx::IntRect const& dst_rect, Web::Compositor::CompositorContextId, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
-    void draw_canvas(Gfx::IntRect const& dst_rect, CanvasId, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
+    void draw_canvas(Gfx::IntRect const& dst_rect, CanvasId, u64 content_generation, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
     void draw_video_frame(Gfx::IntRect const& dst_rect, VideoFrameResourceId, RefPtr<Media::VideoFrame const>, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
 
     void draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Color> isolated_backdrop_color = {});

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -76,7 +76,7 @@ public:
     void draw_scaled_decoded_image_frame(Gfx::IntRect const& dst_rect, Gfx::FloatRect const& src_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Color> isolated_backdrop_color = {});
     void draw_composited_context(Gfx::IntRect const& dst_rect, Web::Compositor::CompositorContextId, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
     void draw_canvas(Gfx::IntRect const& dst_rect, CanvasId, u64 content_generation, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
-    void draw_video_frame(Gfx::IntRect const& dst_rect, VideoFrameResourceId, RefPtr<Media::VideoFrame const>, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
+    void draw_video_frame(Gfx::IntRect const& dst_rect, VideoFrameResourceId, RefPtr<Media::VideoFrame const>, u64 content_generation, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
 
     void draw_repeated_decoded_image_frame(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::DecodedImageFrame frame, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Color> isolated_backdrop_color = {});
     void draw_repeated_display_list(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, DisplayListResource const&, Gfx::ScalingMode, bool repeat_x, bool repeat_y);

--- a/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -85,7 +85,7 @@ void VideoPaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
         auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), src_size, dst_rect.size());
         RefPtr<Media::VideoFrame const> frame = current;
         auto frame_id = const_cast<HTML::HTMLVideoElement&>(video_element).ensure_video_frame_resource_id();
-        context.display_list_recorder().draw_video_frame(dst_rect, frame_id, move(frame), scaling_mode);
+        context.display_list_recorder().draw_video_frame(dst_rect, frame_id, move(frame), video_element.video_frame_content_generation(), scaling_mode);
     };
 
     auto paint_transparent_black = [&]() {

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
@@ -84,7 +84,10 @@ void WebGL2RenderingContext::did_update_canvas_content()
 {
     m_canvas_element->set_canvas_content_dirty();
 
-    m_canvas_element->set_needs_repaint();
+    // NB: Don't invalidate the display list here: the recorded DrawCanvas command is unaffected by content
+    //     updates, and re-recording an identical display list would yield an empty damage rectangle. The new
+    //     content reaches the compositor through the canvas surface registry when the canvas is presented.
+    m_canvas_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 
 Optional<WebGLContextAttributes> WebGL2RenderingContext::get_context_attributes()

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -88,6 +88,10 @@ Optional<RemoteWebGLContext> create_remote_webgl_context(HTML::HTMLCanvasElement
     if (!result.success)
         return {};
 
+    // NB: The display list must be re-recorded so its DrawCanvas command refers to the new remote context's
+    //     canvas id. Content updates alone don't invalidate the display list, so do it here.
+    canvas_element.set_needs_repaint();
+
     return RemoteWebGLContext { transport.release_nonnull(), move(result) };
 }
 
@@ -168,7 +172,10 @@ void WebGLRenderingContext::did_update_canvas_content()
 {
     m_canvas_element->set_canvas_content_dirty();
 
-    m_canvas_element->set_needs_repaint();
+    // NB: Don't invalidate the display list here: the recorded DrawCanvas command is unaffected by content
+    //     updates, and re-recording an identical display list would yield an empty damage rectangle. The new
+    //     content reaches the compositor through the canvas surface registry when the canvas is presented.
+    m_canvas_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 
 Optional<WebGLContextAttributes> WebGLRenderingContext::get_context_attributes()

--- a/Tests/LibWeb/TestDisplayListDamage.cpp
+++ b/Tests/LibWeb/TestDisplayListDamage.cpp
@@ -204,6 +204,25 @@ TEST_CASE(changed_canvas_content_generation_damages_canvas_rect)
     EXPECT_EQ(*damage, (Gfx::IntRect { 9, 9, 22, 22 }));
 }
 
+TEST_CASE(changed_video_frame_content_generation_damages_video_rect)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    DrawVideoFrame command {
+        .dst_rect = { 10, 10, 20, 20 },
+        .video_frame_id = VideoFrameResourceId { 1 },
+        .content_generation = 1,
+        .scaling_mode = Gfx::ScalingMode::NearestNeighbor,
+    };
+    auto old_display_list = command_bytes(command, command.dst_rect);
+    command.content_generation = 2;
+    auto new_display_list = command_bytes(command, command.dst_rect);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT_EQ(*damage, (Gfx::IntRect { 9, 9, 22, 22 }));
+}
+
 TEST_CASE(unchanged_canvas_content_generation_does_not_damage_canvas)
 {
     auto visual_context_tree = AccumulatedVisualContextTree::create();

--- a/Tests/LibWeb/TestDisplayListDamage.cpp
+++ b/Tests/LibWeb/TestDisplayListDamage.cpp
@@ -181,6 +181,48 @@ TEST_CASE(unrelated_inserted_visual_context_does_not_damage_commands)
     EXPECT(damage->is_empty());
 }
 
+static ByteBuffer canvas_command_bytes(Gfx::IntRect rect, u64 content_generation)
+{
+    DrawCanvas command {
+        .dst_rect = rect,
+        .canvas_id = CanvasId { 1 },
+        .content_generation = content_generation,
+        .scaling_mode = Gfx::ScalingMode::NearestNeighbor,
+    };
+    return command_bytes(command, rect);
+}
+
+TEST_CASE(changed_canvas_content_generation_damages_canvas_rect)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto old_display_list = canvas_command_bytes({ 10, 10, 20, 20 }, 1);
+    auto new_display_list = canvas_command_bytes({ 10, 10, 20, 20 }, 2);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT_EQ(*damage, (Gfx::IntRect { 9, 9, 22, 22 }));
+}
+
+TEST_CASE(unchanged_canvas_content_generation_does_not_damage_canvas)
+{
+    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto canvas = canvas_command_bytes({ 10, 10, 20, 20 }, 1);
+    auto old_fill = fill_command_bytes({ 50, 50, 10, 10 }, Gfx::Color::Red);
+    auto new_fill = fill_command_bytes({ 50, 50, 10, 10 }, Gfx::Color::Blue);
+    ByteBuffer old_display_list;
+    old_display_list.append(canvas);
+    old_display_list.append(old_fill);
+    ByteBuffer new_display_list;
+    new_display_list.append(canvas);
+    new_display_list.append(new_fill);
+    ScrollStateSnapshot scroll_state;
+
+    auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });
+    EXPECT(damage.has_value());
+    EXPECT_EQ(*damage, (Gfx::IntRect { 49, 49, 12, 12 }));
+}
+
 TEST_CASE(inserted_and_removed_commands_do_not_damage_shifted_commands)
 {
     auto visual_context_tree = AccumulatedVisualContextTree::create();

--- a/Tests/LibWeb/Text/expected/canvas/webgl-draw-does-not-invalidate-display-list.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-draw-does-not-invalidate-display-list.txt
@@ -1,8 +1,8 @@
-[webgl] needsDisplayListRecord after getContext: false
+[webgl] needsDisplayListRecord after getContext: true
 [webgl] needsDisplayListRecord before draw: false
 [webgl] needsRepaint after draw: true
-[webgl] needsDisplayListRecord after draw: true
-[webgl2] needsDisplayListRecord after getContext: false
+[webgl] needsDisplayListRecord after draw: false
+[webgl2] needsDisplayListRecord after getContext: true
 [webgl2] needsDisplayListRecord before draw: false
 [webgl2] needsRepaint after draw: true
-[webgl2] needsDisplayListRecord after draw: true
+[webgl2] needsDisplayListRecord after draw: false

--- a/Tests/LibWeb/Text/expected/canvas/webgl-draw-does-not-invalidate-display-list.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-draw-does-not-invalidate-display-list.txt
@@ -1,0 +1,8 @@
+[webgl] needsDisplayListRecord after getContext: false
+[webgl] needsDisplayListRecord before draw: false
+[webgl] needsRepaint after draw: true
+[webgl] needsDisplayListRecord after draw: true
+[webgl2] needsDisplayListRecord after getContext: false
+[webgl2] needsDisplayListRecord before draw: false
+[webgl2] needsRepaint after draw: true
+[webgl2] needsDisplayListRecord after draw: true

--- a/Tests/LibWeb/Text/input/canvas/webgl-draw-does-not-invalidate-display-list.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-draw-does-not-invalidate-display-list.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<canvas id="canvas1" width="100" height="100"></canvas>
+<canvas id="canvas2" width="100" height="100"></canvas>
+<script src="../include.js"></script>
+<script>
+    // WebGL canvas content updates reach the compositor through the canvas surface registry,
+    // so a draw call must schedule a repaint without invalidating the display list. Re-recording
+    // a display list that is identical to the previous one would produce an empty damage
+    // rectangle, and nothing would be repainted on screen.
+    //
+    // Creating a WebGL context is the exception: it must invalidate the display list, since the
+    // recorded DrawCanvas command refers to the context's canvas id.
+    asyncTest(async (done) => {
+        const lines = [];
+        const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+
+        // Let rendering settle so the initial display list has been recorded.
+        await nextFrame();
+        await nextFrame();
+
+        for (const [canvas, contextType] of [[canvas1, "webgl"], [canvas2, "webgl2"]]) {
+            const gl = canvas.getContext(contextType);
+            lines.push(`[${contextType}] needsDisplayListRecord after getContext: ${internals.needsDisplayListRecord}`);
+
+            await nextFrame();
+            lines.push(`[${contextType}] needsDisplayListRecord before draw: ${internals.needsDisplayListRecord}`);
+
+            gl.clearColor(0, 1, 0, 1);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+            lines.push(`[${contextType}] needsRepaint after draw: ${internals.needsRepaint}`);
+            lines.push(`[${contextType}] needsDisplayListRecord after draw: ${internals.needsDisplayListRecord}`);
+
+            await nextFrame();
+        }
+
+        for (const line of lines)
+            println(line);
+        done();
+    });
+</script>


### PR DESCRIPTION
The compositor damage changes broke WebGL rendering: once a page like https://phoboslab.org/q1k3/ started animating, the screen stopped updating or flickered between stale frames.

Display list damage computation compares commands by value, but DrawCanvas and DrawVideoFrame commands only refer to a stable resource id while the actual pixels live compositor-side and update in place. A canvas or video whose content changed therefore contributed no damage when the display list was re-recorded, so the compositor never rasterized that region again. q1k3 hit this every frame because it updates its DOM HUD alongside the WebGL canvas, re-recording a display list whose DrawCanvas command compared equal to the previous one.

The fix records a content generation in DrawCanvas and DrawVideoFrame commands, bumped whenever the canvas presents new content or a new video frame is pushed to the compositor. Since canvases are prepared for compositing before painting in the rendering update, display lists recorded in the same update pick up the new generation and the damage diff includes the canvas rectangle.

On top of that, WebGL content updates no longer invalidate the display list at all, matching what 2D canvas and video already do. Pure animation frames now skip display list recording and diffing entirely and repaint with full viewport damage. Creating or restoring a remote WebGL context invalidates the display list explicitly instead, since the recorded DrawCanvas command must pick up the new context's canvas id; this was previously masked by the first draw call invalidating the list.

Covered by new TestDisplayListDamage cases for changed and unchanged content generations, and by a new text test using internals.needsDisplayListRecord (added in the first commit, documenting the broken invalidation behavior, with expectations updated by the fix) that verifies how WebGL context creation and draw calls interact with display list invalidation.