### PR TITLE
LibWeb: Update font faces when stylesheet media changes

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -507,16 +507,28 @@ SelectorInsights const& CSSStyleSheet::selector_insights() const
 
 void CSSStyleSheet::invalidate_owners(DOM::StyleInvalidationReason reason, ShadowRootStylesheetEffects const* previous_sheet_effects)
 {
+    auto previously_matched = m_did_match;
     m_did_match = {};
     invalidate_shared_style_cache();
 
     // The MediaList may have been mutated (e.g. via MediaList::set_media_text), and owner invalidation computes
     // shadow-root effects from effective rules. Refresh the media state first so host-side shadow invalidation
     // sees the updated definitions.
-    if (auto document = owning_document())
+    if (auto document = owning_document()) {
         evaluate_media_queries(*document);
+        if (previously_matched.has_value() && previously_matched.value() != m_did_match.value())
+            reload_fonts_after_media_query_change();
+    }
 
     invalidate_style_for_style_sheet_owners(*this, reason, ShouldInvalidateRuleCache::Yes, previous_sheet_effects);
+}
+
+void CSSStyleSheet::reload_fonts_after_media_query_change()
+{
+    if (auto document = owning_document()) {
+        document->font_computer().unload_fonts_from_sheet(*this);
+        document->font_computer().load_fonts_from_sheet(*this);
+    }
 }
 
 GC::Ptr<DOM::Document> CSSStyleSheet::owning_document() const

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -89,6 +89,7 @@ public:
     // Returns whether the match state of any media queries changed after evaluation.
     bool evaluate_media_queries(DOM::Document const&);
     bool evaluate_media_queries(DOM::Document const&, Function<void(CSSRule const&)> const& changed_rule_callback);
+    void reload_fonts_after_media_query_change();
     void for_each_effective_keyframes_at_rule(Function<void(CSSKeyframesRule const&)> const& callback) const;
     void for_each_effective_counter_style_at_rule(Function<void(CSSCounterStyleRule const&)> const& callback) const;
 

--- a/Libraries/LibWeb/CSS/Invalidation/MediaQueryInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/MediaQueryInvalidator.cpp
@@ -51,8 +51,10 @@ void evaluate_media_rules_and_invalidate_style(DOM::Document& document)
     document.style_scope().for_each_active_css_style_sheet([&](CSS::CSSStyleSheet& style_sheet) {
         if (style_sheet.evaluate_media_queries(document, [&](CSSRule const& changed_rule) {
                 document_invalidation.add_rule(changed_rule);
-            }))
+            })) {
             document_media_queries_changed_match_state = true;
+            style_sheet.reload_fonts_after_media_query_change();
+        }
     });
 
     document.for_each_shadow_root([&](auto& shadow_root) {
@@ -61,8 +63,10 @@ void evaluate_media_rules_and_invalidate_style(DOM::Document& document)
         shadow_root.style_scope().for_each_active_css_style_sheet([&](CSS::CSSStyleSheet& style_sheet) {
             if (style_sheet.evaluate_media_queries(document, [&](CSSRule const& changed_rule) {
                     shadow_root_invalidation.add_rule(changed_rule);
-                }))
+                })) {
                 shadow_root_media_queries_changed_match_state = true;
+                style_sheet.reload_fonts_after_media_query_change();
+            }
         });
 
         if (!shadow_root_media_queries_changed_match_state)

--- a/Tests/LibWeb/Text/expected/css/font-face-activation-after-stylesheet-media-change.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-activation-after-stylesheet-media-change.txt
@@ -1,0 +1,4 @@
+Initial face count: 0
+Matching face count: 1
+Matching face status: loaded
+Final face count: 0

--- a/Tests/LibWeb/Text/input/css/font-face-activation-after-stylesheet-media-change.html
+++ b/Tests/LibWeb/Text/input/css/font-face-activation-after-stylesheet-media-change.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style id="font-sheet" media="not all">
+    @font-face {
+        font-family: MediaFont;
+        src: url("../../../Assets/HashSans.woff");
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const sheet = document.getElementById("font-sheet").sheet;
+
+        println(`Initial face count: ${[...document.fonts].filter(face => face.family === "MediaFont").length}`);
+
+        sheet.media.mediaText = "all";
+        await document.fonts.ready;
+        const matchingFaces = [...document.fonts].filter(face => face.family === "MediaFont");
+        println(`Matching face count: ${matchingFaces.length}`);
+        println(`Matching face status: ${matchingFaces[0].status}`);
+
+        sheet.media.mediaText = "not all";
+        println(`Final face count: ${[...document.fonts].filter(face => face.family === "MediaFont").length}`);
+    });
+</script>


### PR DESCRIPTION
Reload CSS-connected font faces when a stylesheet or nested media query changes its match state. This makes newly effective @font-face rules available and disconnects faces that are no longer effective.

Add coverage for activating, loading, and deactivating a font by changing the owning stylesheet media list.