### PR TITLE
LibWeb: Refresh dynamically propagated viewport overflow

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1737,34 +1737,46 @@ static void propagate_scrollbar_width_to_viewport(Element& root_element, Layout:
 // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
 static void propagate_overflow_to_viewport(Element& root_element, Layout::Viewport& viewport)
 {
+    auto& viewport_computed_values = viewport.mutable_computed_values();
+    viewport_computed_values.set_overflow_x(CSS::Overflow::Auto);
+    viewport_computed_values.set_overflow_y(CSS::Overflow::Auto);
+
     // https://drafts.csswg.org/css-contain-2/#contain-property
     // Additionally, when any containments are active on either the HTML <html> or <body> elements, propagation of
     // properties from the <body> element to the initial containing block, the viewport, or the canvas background, is
     // disabled. Notably, this affects:
     // - 'overflow' and its longhands (see CSS Overflow 3 § 3.3 Overflow Viewport Propagation)
-    if (root_element.is_html_html_element() && !root_element.computed_properties()->contain().is_empty())
-        return;
-
     auto* body_element = root_element.first_child_of_type<HTML::HTMLBodyElement>();
+    bool body_element_can_propagate_overflow = body_element
+        && !body_element->computed_properties()->display().is_none()
+        && body_element->unsafe_layout_node();
+    bool body_propagation_is_disabled_by_containment = root_element.is_html_html_element() && !root_element.computed_properties()->contain().is_empty();
     if (body_element && !body_element->computed_properties()->contain().is_empty())
-        return;
+        body_propagation_is_disabled_by_containment = true;
 
     // UAs must apply the overflow-* values set on the root element to the viewport
     // when the root element’s display value is not none.
-    // NB: Called during layout tree construction.
-    auto overflow_origin_node = root_element.unsafe_layout_node();
-    auto& viewport_computed_values = viewport.mutable_computed_values();
+    auto root_element_layout_node = root_element.unsafe_layout_node();
+    auto& root_element_layout_values = root_element_layout_node->mutable_computed_values();
+    auto const& root_element_computed_properties = *root_element.computed_properties();
+    root_element_layout_values.set_overflow_x(root_element_computed_properties.overflow_x());
+    root_element_layout_values.set_overflow_y(root_element_computed_properties.overflow_y());
+    if (body_element_can_propagate_overflow) {
+        auto& body_element_layout_values = body_element->unsafe_layout_node()->mutable_computed_values();
+        auto const& body_element_computed_properties = *body_element->computed_properties();
+        body_element_layout_values.set_overflow_x(body_element_computed_properties.overflow_x());
+        body_element_layout_values.set_overflow_y(body_element_computed_properties.overflow_y());
+    }
+
+    auto overflow_origin_node = root_element_layout_node;
 
     // However, when the root element is an [HTML] html element (including XML syntax for HTML)
     // whose overflow value is visible (in both axes), and that element has as a child
     // a body element whose display value is also not none,
     // user agents must instead apply the overflow-* values of the first such child element to the viewport.
-    if (root_element.is_html_html_element()) {
-        auto root_element_layout_node = root_element.unsafe_layout_node();
-        auto& root_element_computed_values = root_element_layout_node->mutable_computed_values();
-        if (root_element_computed_values.overflow_x() == CSS::Overflow::Visible && root_element_computed_values.overflow_y() == CSS::Overflow::Visible) {
-            auto* body_element = root_element.first_child_of_type<HTML::HTMLBodyElement>();
-            if (body_element && body_element->unsafe_layout_node())
+    if (root_element.is_html_html_element() && !body_propagation_is_disabled_by_containment) {
+        if (root_element_computed_properties.overflow_x() == CSS::Overflow::Visible && root_element_computed_properties.overflow_y() == CSS::Overflow::Visible) {
+            if (body_element_can_propagate_overflow)
                 overflow_origin_node = body_element->unsafe_layout_node();
         }
     }
@@ -1872,16 +1884,21 @@ void Document::update_layout(UpdateLayoutReason reason)
             m_layout_root = as<Layout::Viewport>(*tree_builder.build(*this));
 
             // NB: Called during layout update.
-            if (document_element && document_element->unsafe_layout_node()) {
-                propagate_overflow_to_viewport(*document_element, *m_layout_root);
+            if (document_element && document_element->unsafe_layout_node())
                 propagate_scrollbar_width_to_viewport(*document_element, *m_layout_root);
-            }
 
             set_needs_full_layout_tree_update(false);
 
             if constexpr (UPDATE_LAYOUT_DEBUG) {
                 dbgln("TREEBUILD {} µs", timer.elapsed_time().to_microseconds());
             }
+        }
+
+        if (document_element && document_element->unsafe_layout_node()) {
+            propagate_overflow_to_viewport(*document_element, *m_layout_root);
+        } else {
+            m_layout_root->mutable_computed_values().set_overflow_x(CSS::Overflow::Auto);
+            m_layout_root->mutable_computed_values().set_overflow_y(CSS::Overflow::Auto);
         }
 
         u32 layout_index_counter = 0;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4504,10 +4504,6 @@ GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_the_viewport(CSSPix
     // NB: Must update layout before accessing paintables.
     doc->update_layout(DOM::UpdateLayoutReason::NavigableViewportScroll);
 
-    // AD-HOC: Skip scrolling unscrollable boxes, unless this scroll can pan the visual viewport.
-    if (!doc->paintable_box()->could_be_scrolled_by_wheel_event() && visual_dx == 0.0 && visual_dy == 0.0)
-        return WebIDL::create_resolved_promise(doc->realm(), JS::js_undefined());
-
     auto scrolling_area = doc->paintable_box()->scrollable_overflow_rect()->to_type<float>();
     auto new_viewport_scroll_offset = m_viewport_scroll_offset.to_type<double>() + Gfx::Point(layout_dx, layout_dy);
     // NOTE: Clamp to the scrolling area.

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -50,6 +50,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Internals/InternalGamepad.h>
 #include <LibWeb/Internals/Internals.h>
+#include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/ContentBlocker.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Page/EventHandler.h>
@@ -1081,6 +1082,26 @@ String Internals::async_scrolling_state_wheel_target_at(double x, double y, doub
     if (scroll_tree.scroll_node_is_viewport(*target.node_id))
         return "viewport"_string;
     return "non-viewport"_string;
+}
+
+String Internals::viewport_overflow_x()
+{
+    auto& document = window().associated_document();
+    document.update_layout(DOM::UpdateLayoutReason::Debugging);
+    auto overflow = document.unsafe_layout_node()->computed_values().overflow_x();
+    switch (overflow) {
+    case CSS::Overflow::Auto:
+        return "auto"_string;
+    case CSS::Overflow::Clip:
+        return "clip"_string;
+    case CSS::Overflow::Hidden:
+        return "hidden"_string;
+    case CSS::Overflow::Scroll:
+        return "scroll"_string;
+    case CSS::Overflow::Visible:
+        return "visible"_string;
+    }
+    VERIFY_NOT_REACHED();
 }
 
 }

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -151,6 +151,7 @@ public:
     String async_scrolling_state_wheel_routing_admission();
     String async_scrolling_state_wheel_scroll_admission_at(double x, double y, double delta_x, double delta_y, bool force_stale_wheel_event_regions);
     String async_scrolling_state_wheel_target_at(double x, double y, double delta_x, double delta_y);
+    String viewport_overflow_x();
 
 private:
     explicit Internals(JS::Realm&);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -149,5 +149,6 @@ interface Internals {
     DOMString asyncScrollingStateWheelRoutingAdmission();
     DOMString asyncScrollingStateWheelScrollAdmissionAt(double x, double y, double deltaX, double deltaY, optional boolean forceStaleWheelEventRegions = false);
     DOMString asyncScrollingStateWheelTargetAt(double x, double y, double deltaX, double deltaY);
+    DOMString viewportOverflowX();
 
 };

--- a/Tests/LibWeb/Layout/expected/hidden-root-element.txt
+++ b/Tests/LibWeb/Layout/expected/hidden-root-element.txt
@@ -1,4 +1,4 @@
-Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
 

--- a/Tests/LibWeb/Text/expected/css/dynamic-viewport-overflow-containment.txt
+++ b/Tests/LibWeb/Text/expected/css/dynamic-viewport-overflow-containment.txt
@@ -1,0 +1,6 @@
+Initial wheel target: none
+Wheel target after body containment: viewport
+Scroll offset after wheel: 1
+Wheel target after root containment: none
+Scroll offset after hidden wheel: 0
+Scroll offset after scrollTo: 1

--- a/Tests/LibWeb/Text/expected/css/dynamic-viewport-overflow-display-none.txt
+++ b/Tests/LibWeb/Text/expected/css/dynamic-viewport-overflow-display-none.txt
@@ -1,0 +1,6 @@
+Initial viewport overflow: hidden
+Viewport overflow with body display none: auto
+Viewport overflow after restoring body: hidden
+Viewport overflow from root: hidden
+Viewport overflow with root display none: auto
+Viewport overflow after restoring root: auto

--- a/Tests/LibWeb/Text/expected/css/dynamic-viewport-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/css/dynamic-viewport-overflow-hidden.txt
@@ -1,0 +1,5 @@
+Content overflows viewport: true
+Scroll width includes overflow: true
+Horizontal wheel target: none
+Scroll offset after wheel: 0
+Scroll offset after scrollTo: 1

--- a/Tests/LibWeb/Text/expected/css/viewport-overflow-hidden-remains-programmatically-scrollable.txt
+++ b/Tests/LibWeb/Text/expected/css/viewport-overflow-hidden-remains-programmatically-scrollable.txt
@@ -1,0 +1,2 @@
+Overflow extends scroll width: true
+Horizontal scroll offset: 50

--- a/Tests/LibWeb/Text/input/css/dynamic-viewport-overflow-containment.html
+++ b/Tests/LibWeb/Text/input/css/dynamic-viewport-overflow-containment.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<style>
+    html, body {
+        margin: 0;
+    }
+
+    html {
+        min-width: 801px;
+    }
+
+    body {
+        overflow-x: hidden;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        println(`Initial wheel target: ${internals.asyncScrollingStateWheelTargetAt(400, 0, 100, 0)}`);
+
+        document.body.style.cssText = "contain: layout; overflow-x: visible";
+        println(`Wheel target after body containment: ${internals.asyncScrollingStateWheelTargetAt(400, 0, 100, 0)}`);
+
+        await internals.wheel(400, 0, 100, 0);
+        println(`Scroll offset after wheel: ${window.scrollX}`);
+
+        window.scrollTo(0, 0);
+        document.body.style.cssText = "overflow-x: visible";
+        document.documentElement.style.cssText = "contain: layout; overflow-x: hidden";
+        println(`Wheel target after root containment: ${internals.asyncScrollingStateWheelTargetAt(400, 0, 100, 0)}`);
+
+        await internals.wheel(400, 0, 100, 0);
+        println(`Scroll offset after hidden wheel: ${window.scrollX}`);
+
+        window.scrollTo(1, 0);
+        println(`Scroll offset after scrollTo: ${window.scrollX}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/dynamic-viewport-overflow-display-none.html
+++ b/Tests/LibWeb/Text/input/css/dynamic-viewport-overflow-display-none.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        overflow-x: hidden;
+    }
+
+    html::before {
+        content: "";
+        display: block;
+        width: 801px;
+        height: 1px;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        println(`Initial viewport overflow: ${internals.viewportOverflowX()}`);
+
+        document.body.style.display = "none";
+        await animationFrame();
+        println(`Viewport overflow with body display none: ${internals.viewportOverflowX()}`);
+
+        document.body.style.display = "block";
+        await animationFrame();
+        println(`Viewport overflow after restoring body: ${internals.viewportOverflowX()}`);
+
+        document.body.style.display = "none";
+        document.documentElement.style.cssText = "overflow-x: hidden";
+        await animationFrame();
+        println(`Viewport overflow from root: ${internals.viewportOverflowX()}`);
+
+        document.documentElement.style.display = "none";
+        await animationFrame();
+        println(`Viewport overflow with root display none: ${internals.viewportOverflowX()}`);
+
+        document.documentElement.style.cssText = "display: block; overflow-x: visible";
+        await animationFrame();
+        println(`Viewport overflow after restoring root: ${internals.viewportOverflowX()}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/dynamic-viewport-overflow-hidden.html
+++ b/Tests/LibWeb/Text/input/css/dynamic-viewport-overflow-hidden.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #navbar {
+        display: flex;
+    }
+
+    #navbar-end {
+        width: 100px;
+        margin-left: auto;
+        margin-right: -1px;
+    }
+
+    #search {
+        width: 100%;
+        height: 1px;
+    }
+</style>
+<div id="navbar"><div id="navbar-end"><div id="search"></div></div></div>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const navbarEndBounds = document.getElementById("navbar-end").getBoundingClientRect();
+        println(`Content overflows viewport: ${navbarEndBounds.right > document.documentElement.clientWidth}`);
+
+        const link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.href = "data:text/css,html { overflow-x: hidden; }";
+        const loaded = new Promise(resolve => link.onload = resolve);
+        document.head.appendChild(link);
+        await loaded;
+
+        println(`Scroll width includes overflow: ${document.documentElement.scrollWidth > document.documentElement.clientWidth}`);
+        println(`Horizontal wheel target: ${internals.asyncScrollingStateWheelTargetAt(400, 0, 100, 0)}`);
+
+        await internals.wheel(400, 0, 100, 0);
+        println(`Scroll offset after wheel: ${window.scrollX}`);
+
+        window.scrollTo(1, 0);
+        println(`Scroll offset after scrollTo: ${window.scrollX}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/viewport-overflow-hidden-remains-programmatically-scrollable.html
+++ b/Tests/LibWeb/Text/input/css/viewport-overflow-hidden-remains-programmatically-scrollable.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+    html {
+        overflow-x: hidden;
+    }
+
+    body {
+        margin: 0;
+    }
+
+    #overflow {
+        position: absolute;
+        left: 0;
+        width: calc(100vw + 100px);
+        height: 1px;
+    }
+</style>
+<div id="overflow"></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(`Overflow extends scroll width: ${document.documentElement.scrollWidth > document.documentElement.clientWidth}`);
+
+        window.scrollTo(50, 0);
+        println(`Horizontal scroll offset: ${window.scrollX}`);
+    });
+</script>


### PR DESCRIPTION
CSS Overflow requires eligible root or body overflow values to apply to the viewport. Refresh those values before layout and reset the viewport to auto when no element is eligible. Keep root propagation active when containment disables the special body propagation.

Ignore display:none bodies even when a stale layout node remains during a style update. Keep hidden viewport overflow in the scrolling area. Let CSSOM programmatic scrolling proceed independently of wheel eligibility.

Add coverage for dynamic stylesheets, containment, display changes and wheel input, as well as programmatic scrolling.