### PR TITLE
LibWeb: Fix inline fieldset and button layout

### DIFF
--- a/Libraries/LibWeb/Layout/FieldSetBox.cpp
+++ b/Libraries/LibWeb/Layout/FieldSetBox.cpp
@@ -13,6 +13,11 @@ namespace Web::Layout {
 FieldSetBox::FieldSetBox(DOM::Document& document, DOM::Element& element, CSS::ComputedProperties const& style)
     : BlockContainer(document, &element, style)
 {
+    // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+    // If the computed outer display type is inline, the fieldset is expected to behave as inline-block. Otherwise, it
+    // is expected to behave as flow-root. This does not change the computed value.
+    if (display().is_flow_inside())
+        mutable_computed_values().set_display(CSS::Display { display().outside(), CSS::DisplayInside::FlowRoot });
 }
 
 FieldSetBox::~FieldSetBox() = default;

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -364,6 +364,11 @@ bool FormattingContext::creates_block_formatting_context(Box const& box)
         // The element is expected to establish a new block formatting context.
         return true;
 
+    // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
+    // An element using button layout establishes a new formatting context for its contents.
+    if (auto const* html_element = as_if<HTML::HTMLElement>(box.dom_node()); html_element && html_element->uses_button_layout())
+        return true;
+
     return false;
 }
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -144,8 +144,8 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
         return;
     }
 
-    // Any box that has simple flow inside should have generated line box fragments already.
-    if (box.display().is_flow_inside()) {
+    // Any fragmented inline box should have generated line box fragments already.
+    if (box.is_fragmented_inline()) {
         dbgln("FIXME: InlineFormattingContext::dimension_box_on_line got unexpected box in inline context:");
         dump_tree(box);
         return;

--- a/Tests/LibWeb/Layout/expected/block-in-inline-in-floated-fieldset.txt
+++ b/Tests/LibWeb/Layout/expected/block-in-inline-in-floated-fieldset.txt
@@ -1,49 +1,55 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
       BlockContainer <ul> at [48,16] [0+0+40 744 0+0+0] [16+0+0 0 0+0+16] children: inline
         TextNode <#text> (not painted)
-        ListItemBox <li> at [778,16] floating [0+0+0 14 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
-          ListItemMarkerBox <(anonymous)> at [778,16] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
-          BlockContainer <(anonymous)> at [778,16] [0+0+0 14 0+0+0] [0+0+0 0 0+0+0] children: inline
+        ListItemBox <li> at [728.265625,16] floating [0+0+0 63.734375 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+          ListItemMarkerBox <(anonymous)> at [728.265625,16] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> at [728.265625,16] [0+0+0 63.734375 0+0+0] [0+0+0 0 0+0+0] children: inline
             TextNode <#text> (not painted)
-          BlockContainer <form> at [778,16] [0+0+0 14 0+0+0] [0+0+0 20 0+0+0] children: inline
-            frag 0 from FieldSetBox start: 0, length: 0, rect: [780,18 10x16] baseline: 14.796875
+          BlockContainer <form> at [728.265625,16] [0+0+0 63.734375 0+0+0] [0+0+0 24 0+0+0] children: inline
+            frag 0 from FieldSetBox start: 0, length: 0, rect: [730.265625,18 59.734375x20] baseline: 16.796875
             TextNode <#text> (not painted)
-            FieldSetBox <fieldset> at [780,18] inline-block [0+2+0 10 0+2+0] [0+2+0 16 0+2+0] [BFC] children: not-inline
-              BlockContainer <(anonymous)> at [780,18] inline-block [0+0+0 10 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            FieldSetBox <fieldset> at [730.265625,18] inline-block [0+2+0 59.734375 0+2+0] [0+2+0 20 0+2+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [730.265625,18] inline-block [0+0+0 59.734375 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
                 TextNode <#text> (not painted)
-                InlineNode <p> at [785,28] [0+0+0 0 0+0+0] [0+0+0 16 0+0+0]
-                  InlineNode <span.actions> at [785,28] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
-                    frag 0 from BlockContainer start: 0, length: 0, rect: [785,28 0x0] baseline: 4
-                    BlockContainer <input> at [785,28] [0+1+4 0 4+1+0] [0+1+1 0 1+1+0] children: not-inline
-                      BlockContainer <(anonymous)> (not painted) flex-container(column) [FFC] children: not-inline
-                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
-                          BlockContainer <span> (not painted) inline-block [BFC] children: inline
+                InlineNode <p> at [735.265625,20] [0+0+0 49.734375 0+0+0] [0+0+0 16 0+0+0]
+                  InlineNode <span.actions> at [735.265625,20] [0+0+0 49.734375 0+0+0] [0+0+0 16 0+0+0]
+                    frag 0 from BlockContainer start: 0, length: 0, rect: [735.265625,20 49.734375x16] baseline: 14.796875
+                    BlockContainer <input> at [735.265625,20] [0+1+4 49.734375 4+1+0] [0+1+1 16 1+1+0] [BFC] children: not-inline
+                      BlockContainer <(anonymous)> at [735.265625,20] flex-container(column) [0+0+0 49.734375 0+0+0] [0+0+0 16 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [735.265625,20] flex-item [0+0+0 49.734375 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          frag 0 from BlockContainer start: 0, length: 0, rect: [735.265625,20 49.734375x16] baseline: 12.796875
+                          BlockContainer <span> at [735.265625,20] inline-block [0+0+0 49.734375 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                            frag 0 from TextNode start: 0, length: 4, rect: [735.265625,20 49.734375x16] baseline: 12.796875
+                                "PASS"
                             TextNode <#text> (not painted)
                 TextNode <#text> (not painted)
             TextNode <#text> (not painted)
-          BlockContainer <(anonymous)> at [778,36] [0+0+0 14 0+0+0] [0+0+0 0 0+0+0] children: inline
+          BlockContainer <(anonymous)> at [728.265625,40] [0+0+0 63.734375 0+0+0] [0+0+0 0 0+0+0] children: inline
             TextNode <#text> (not painted)
         TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,16] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x0]
       PaintableWithLines (BlockContainer<UL>) [8,16 784x0]
-        PaintableWithLines (ListItemBox<LI>) [778,16 14x20]
-          MarkerPaintable (ListItemMarkerBox(anonymous)) [778,16 0x0]
-          PaintableWithLines (BlockContainer(anonymous)) [778,16 14x0]
-          PaintableWithLines (BlockContainer<FORM>) [778,16 14x20]
-            FieldSetPaintable (FieldSetBox<FIELDSET>) [778,16 14x20]
-              PaintableWithLines (BlockContainer(anonymous)) [780,18 10x16]
-                PaintableWithLines (InlineNode<P>) [785,28 0x16]
-                  PaintableWithLines (InlineNode<SPAN>.actions) [785,28 0x0]
-                    PaintableWithLines (BlockContainer<INPUT>) [780,26 10x4]
-          PaintableWithLines (BlockContainer(anonymous)) [778,36 14x0]
+        PaintableWithLines (ListItemBox<LI>) [728.265625,16 63.734375x24]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [728.265625,16 0x0]
+          PaintableWithLines (BlockContainer(anonymous)) [728.265625,16 63.734375x0]
+          PaintableWithLines (BlockContainer<FORM>) [728.265625,16 63.734375x24]
+            FieldSetPaintable (FieldSetBox<FIELDSET>) [728.265625,16 63.734375x24]
+              PaintableWithLines (BlockContainer(anonymous)) [730.265625,18 59.734375x20]
+                PaintableWithLines (InlineNode<P>) [735.265625,20 49.734375x16]
+                  PaintableWithLines (InlineNode<SPAN>.actions) [735.265625,20 49.734375x16]
+                    PaintableWithLines (BlockContainer<INPUT>) [730.265625,18 59.734375x20]
+                      PaintableWithLines (BlockContainer(anonymous)) [735.265625,20 49.734375x16]
+                        PaintableWithLines (BlockContainer(anonymous)) [735.265625,20 49.734375x16]
+                          PaintableWithLines (BlockContainer<SPAN>) [735.265625,20 49.734375x16]
+          PaintableWithLines (BlockContainer(anonymous)) [728.265625,40 63.734375x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x36] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x40] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-in-inline-in-floated-fieldset.txt
+++ b/Tests/LibWeb/Layout/expected/block-in-inline-in-floated-fieldset.txt
@@ -1,0 +1,49 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
+      BlockContainer <ul> at [48,16] [0+0+40 744 0+0+0] [16+0+0 0 0+0+16] children: inline
+        TextNode <#text> (not painted)
+        ListItemBox <li> at [778,16] floating [0+0+0 14 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          ListItemMarkerBox <(anonymous)> at [778,16] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> at [778,16] [0+0+0 14 0+0+0] [0+0+0 0 0+0+0] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <form> at [778,16] [0+0+0 14 0+0+0] [0+0+0 20 0+0+0] children: inline
+            frag 0 from FieldSetBox start: 0, length: 0, rect: [780,18 10x16] baseline: 14.796875
+            TextNode <#text> (not painted)
+            FieldSetBox <fieldset> at [780,18] inline-block [0+2+0 10 0+2+0] [0+2+0 16 0+2+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [780,18] inline-block [0+0+0 10 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                TextNode <#text> (not painted)
+                InlineNode <p> at [785,28] [0+0+0 0 0+0+0] [0+0+0 16 0+0+0]
+                  InlineNode <span.actions> at [785,28] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
+                    frag 0 from BlockContainer start: 0, length: 0, rect: [785,28 0x0] baseline: 4
+                    BlockContainer <input> at [785,28] [0+1+4 0 4+1+0] [0+1+1 0 1+1+0] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) flex-container(column) [FFC] children: not-inline
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          BlockContainer <span> (not painted) inline-block [BFC] children: inline
+                            TextNode <#text> (not painted)
+                TextNode <#text> (not painted)
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> at [778,36] [0+0+0 14 0+0+0] [0+0+0 0 0+0+0] children: inline
+            TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,16] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x0]
+      PaintableWithLines (BlockContainer<UL>) [8,16 784x0]
+        PaintableWithLines (ListItemBox<LI>) [778,16 14x20]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [778,16 0x0]
+          PaintableWithLines (BlockContainer(anonymous)) [778,16 14x0]
+          PaintableWithLines (BlockContainer<FORM>) [778,16 14x20]
+            FieldSetPaintable (FieldSetBox<FIELDSET>) [778,16 14x20]
+              PaintableWithLines (BlockContainer(anonymous)) [780,18 10x16]
+                PaintableWithLines (InlineNode<P>) [785,28 0x16]
+                  PaintableWithLines (InlineNode<SPAN>.actions) [785,28 0x0]
+                    PaintableWithLines (BlockContainer<INPUT>) [780,26 10x4]
+          PaintableWithLines (BlockContainer(anonymous)) [778,36 14x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x36] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/input-as-button-align-center.txt
+++ b/Tests/LibWeb/Layout/expected/input-as-button-align-center.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 316 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 300 0+0+8] children: not-inline
-      BlockContainer <input.btn> at [13,10] [0+1+4 290 4+1+484] [0+1+1 296 1+1+0] children: not-inline
+      BlockContainer <input.btn> at [13,10] [0+1+4 290 4+1+484] [0+1+1 296 1+1+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> at [13,10] flex-container(column) [0+0+0 290 0+0+0] [0+0+0 296 0+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> at [13,150.5] flex-item [0+0+0 290 0+0+0] [0+0+0 15 0+0+0] [BFC] children: inline
             frag 0 from BlockContainer start: 0, length: 0, rect: [36.75,150.5 242.5x15] baseline: 12

--- a/Tests/LibWeb/Layout/expected/input-as-button-shrink-to-fit.txt
+++ b/Tests/LibWeb/Layout/expected/input-as-button-shrink-to-fit.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 36 0+0+8] children: not-inline
-      BlockContainer <input.btn> at [13,10] [0+1+4 195.796875 4+1+578.203125] [0+1+1 32 1+1+0] children: not-inline
+      BlockContainer <input.btn> at [13,10] [0+1+4 195.796875 4+1+578.203125] [0+1+1 32 1+1+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> at [13,10] flex-container(column) [0+0+0 195.796875 0+0+0] [0+0+0 32 0+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> at [13,18.5] flex-item [0+0+0 195.796875 0+0+0] [0+0+0 15 0+0+0] [BFC] children: inline
             frag 0 from BlockContainer start: 0, length: 0, rect: [13,18.5 195.796875x15] baseline: 12

--- a/Tests/LibWeb/Layout/input/block-in-inline-in-floated-fieldset.html
+++ b/Tests/LibWeb/Layout/input/block-in-inline-in-floated-fieldset.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<style>
+    li {
+        float: right;
+    }
+
+    fieldset, p {
+        margin: 0;
+        padding: 0;
+    }
+
+    fieldset, p, .actions, input {
+        display: inline;
+    }
+
+    p {
+        position: relative;
+    }
+</style>
+<ul>
+    <li>
+        <form>
+            <fieldset>
+                <p><span class="actions"><input type="submit" value="PASS"></span></p>
+            </fieldset>
+        </form>
+    </li>
+</ul>


### PR DESCRIPTION
Inline fieldsets were treated as ordinary inline flow boxes, allowing the containing inline formatting context to traverse their anonymous children. This could use the wrong containing block during intrinsic width measurement and crash when loading https://archiveofourown.org/.

Apply the specified inline-block behavior to inline fieldsets, recognize button layout as establishing a formatting context, and only expect pre-generated fragments from actual fragmented inline boxes. This also prevents repeated diagnostics for native inputs with display: inline while preserving their computed style.

Add regression coverage for the floated fieldset and submit input structure used by the site, and update existing button layout expectations to record their block formatting contexts.