### PR TITLE
LibWeb: Keep single-line input text and carets visible and stable

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -1131,7 +1131,12 @@ void FormAssociatedTextControlElement::scroll_cursor_into_view()
     if (!text_node)
         return;
 
-    Painting::Paintable::scroll_text_offset_into_view(*text_node, m_selection_end, m_selection_end_affinity);
+    // https://drafts.csswg.org/css-ui-4/#input-rules
+    // * The content is clipped in the block direction to the padding edge
+    auto scroll_block_direction = is<HTMLInputElement>(element)
+        ? Painting::Paintable::ScrollBlockDirection::No
+        : Painting::Paintable::ScrollBlockDirection::Yes;
+    Painting::Paintable::scroll_text_offset_into_view(*text_node, m_selection_end, m_selection_end_affinity, scroll_block_direction);
 }
 
 void FormAssociatedTextControlElement::selection_was_changed(SelectionSource source)

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -193,12 +193,14 @@ void HTMLInputElement::adjust_computed_style(CSS::ComputedProperties::Builder& s
     if (style.display().is_inline_outside() && style.display().is_flow_inside())
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
 
-    // NOTE: Other browsers apply a minimum height of a single line's line-height to single-line input elements.
-    if (is_single_line() && style.property(CSS::PropertyID::Height).has_auto()) {
+    // https://drafts.csswg.org/css-ui-4/#input-rules
+    // * The content is vertically centered
+    // NB: Blink, WebKit, and Gecko clamp single-line input text to the font's normal line height. This prevents a
+    //     smaller author-specified line height from clipping glyph ink inside the vertically centered editor.
+    if (is_single_line()) {
         auto current_line_height = style.line_height(document().font_computer()).to_double();
         auto minimum_line_height = CSS::ComputedProperties::normal_line_height(style.first_available_computed_font(document().font_computer())->pixel_metrics()).to_double();
 
-        // FIXME: Instead of overriding line-height, we should set height here instead.
         if (current_line_height < minimum_line_height)
             style.set_property(CSS::PropertyID::LineHeight, CSS::KeywordStyleValue::create(CSS::Keyword::Normal));
     }

--- a/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
+++ b/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <AK/Tuple.h>
+#include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/SVGSVGBox.h>
 #include <LibWeb/Layout/ScrollableOverflow.h>
@@ -49,6 +51,15 @@ struct LogicalAxis {
 static bool inline_axis_is_horizontal(CSS::WritingMode writing_mode)
 {
     return writing_mode == CSS::WritingMode::HorizontalTb;
+}
+
+static bool node_is_in_focused_text_control(DOM::Node const& node)
+{
+    auto shadow_root = node.containing_shadow_root();
+    return shadow_root
+        && shadow_root->is_user_agent_internal()
+        && is<HTML::FormAssociatedTextControlElement>(shadow_root->host())
+        && shadow_root->host()->is_focused();
 }
 
 static PhysicalOverflowDirections physical_overflow_directions(Box const& box)
@@ -166,6 +177,23 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
     if (auto first_paintable = box.first_paintable(); auto const* paintable_with_lines = as_if<Painting::PaintableWithLines>(first_paintable.ptr())) {
         for (auto const& fragment : paintable_with_lines->fragments()) {
             auto fragment_rect = fragment.absolute_rect();
+            if (auto const* dom_node = fragment.layout_node().dom_node(); dom_node && node_is_in_focused_text_control(*dom_node)) {
+                // NB: Reserve one pixel of reachable inline-axis overflow for an end-of-line caret. This keeps the
+                //     caret at its insertion position while allowing a text control to scroll the painted bar fully
+                //     into view, matching the caret overflow accounted for by other engines.
+                auto const& computed_values = fragment.layout_node().computed_values();
+                if (inline_axis_is_horizontal(computed_values.writing_mode())) {
+                    if (computed_values.inline_axis_is_reverse())
+                        fragment_rect.set_left(fragment_rect.left() - 1);
+                    else
+                        fragment_rect.set_right(fragment_rect.right() + 1);
+                } else {
+                    if (computed_values.inline_axis_is_reverse())
+                        fragment_rect.set_top(fragment_rect.top() - 1);
+                    else
+                        fragment_rect.set_bottom(fragment_rect.bottom() + 1);
+                }
+            }
             scrollable_overflow_rect.unite(fragment_rect);
             update_content_overflow_axes(fragment_rect);
         }

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -384,7 +384,7 @@ void Paintable::set_selection_state(SelectionState state)
     invalidate_paint_cache();
 }
 
-void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offset, TextAffinity affinity)
+void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offset, TextAffinity affinity, ScrollBlockDirection scroll_block_direction)
 {
     auto scroll_to_cursor = [&](PaintableFragment const& fragment) {
         auto cursor_rect = fragment.range_rect(SelectionState::StartAndEnd, offset, offset);
@@ -400,6 +400,16 @@ void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offse
         }
         for (auto ancestor = fragment.containing_block_paintable(); ancestor; ancestor = ancestor->containing_block()) {
             if (ancestor->has_scrollable_overflow()) {
+                if (scroll_block_direction == ScrollBlockDirection::No) {
+                    auto scrollport = ancestor->absolute_padding_box_rect();
+                    if (computed_values.writing_mode() == CSS::WritingMode::HorizontalTb) {
+                        cursor_rect.set_y(scrollport.y() + ancestor->scroll_offset().y());
+                        cursor_rect.set_height(scrollport.height());
+                    } else {
+                        cursor_rect.set_x(scrollport.x() + ancestor->scroll_offset().x());
+                        cursor_rect.set_width(scrollport.width());
+                    }
+                }
                 ancestor->scroll_into_view(cursor_rect);
                 return;
             }

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -388,6 +388,16 @@ void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offse
 {
     auto scroll_to_cursor = [&](PaintableFragment const& fragment) {
         auto cursor_rect = fragment.range_rect(SelectionState::StartAndEnd, offset, offset);
+        auto const& computed_values = fragment.layout_node().computed_values();
+        if (computed_values.writing_mode() == CSS::WritingMode::HorizontalTb) {
+            if (computed_values.inline_axis_is_reverse())
+                cursor_rect.set_x(cursor_rect.x() - 1);
+            cursor_rect.set_width(1);
+        } else {
+            if (computed_values.inline_axis_is_reverse())
+                cursor_rect.set_y(cursor_rect.y() - 1);
+            cursor_rect.set_height(1);
+        }
         for (auto ancestor = fragment.containing_block_paintable(); ancestor; ancestor = ancestor->containing_block()) {
             if (ancestor->has_scrollable_overflow()) {
                 ancestor->scroll_into_view(cursor_rect);

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -118,7 +118,12 @@ public:
 
     CSSPixelPoint box_type_agnostic_position() const;
 
-    static void scroll_text_offset_into_view(DOM::Text const&, size_t offset, TextAffinity = TextAffinity::Downstream);
+    enum class ScrollBlockDirection {
+        No,
+        Yes,
+    };
+
+    static void scroll_text_offset_into_view(DOM::Text const&, size_t offset, TextAffinity = TextAffinity::Downstream, ScrollBlockDirection = ScrollBlockDirection::Yes);
     void scroll_ancestor_to_offset_into_view(size_t offset);
 
     using SelectionState = Painting::SelectionState;

--- a/Tests/LibWeb/Layout/expected/css-line-height-zero.txt
+++ b/Tests/LibWeb/Layout/expected/css-line-height-zero.txt
@@ -11,7 +11,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TextInputBox <input#b> at [11,30] [0+1+2 200 2+1+578] [0+1+1 16 1+1+0] children: not-inline
         Box <div> at [11,30] flex-container(row) [0+0+0 200 0+0+0] [0+0+0 16 0+0+0] [FFC] children: not-inline
-          BlockContainer <div> at [11,38] flex-item [0+0+0 200 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          BlockContainer <div> at [11,30] flex-item [0+0+0 200 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 11, rect: [11,30 91.953125x16] baseline: 12.796875
                 "Hello World"
             TextNode <#text> (not painted)
@@ -35,7 +35,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,28 784x0]
       PaintableWithLines (TextInputBox<INPUT>#b) [8,28 206x20]
         Paintable (Box<DIV>) [11,30 200x16]
-          PaintableWithLines (BlockContainer<DIV>) [11,38 200x0] overflow: [11,38 91.953125x8]
+          PaintableWithLines (BlockContainer<DIV>) [11,30 200x16]
       PaintableWithLines (BlockContainer(anonymous)) [8,48 784x0]
       PaintableWithLines (TextInputBox<INPUT>#c) [8,48 206x28]
         Paintable (Box<DIV>) [11,50 200x24]

--- a/Tests/LibWeb/Ref/expected/input-descender-visible-ref.html
+++ b/Tests/LibWeb/Ref/expected/input-descender-visible-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+input {
+    box-sizing: border-box;
+    font: 30px/0 sans-serif;
+    width: 200px;
+    height: 50px;
+    padding: 10px;
+    border: 0;
+}
+</style>
+<input value="g">
+<script>
+const input = document.querySelector("input");
+internals.getShadowRoot(input).querySelector("div > div").style.overflow = "visible";
+</script>

--- a/Tests/LibWeb/Ref/input/input-descender-visible.html
+++ b/Tests/LibWeb/Ref/input/input-descender-visible.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/input-descender-visible-ref.html">
+<style>
+input {
+    box-sizing: border-box;
+    font: 30px/0 sans-serif;
+    width: 200px;
+    height: 50px;
+    padding: 10px;
+    border: 0;
+}
+</style>
+<input value="g">

--- a/Tests/LibWeb/Text/expected/input-does-not-scroll-vertically-on-insertion.txt
+++ b/Tests/LibWeb/Text/expected/input-does-not-scroll-vertically-on-insertion.txt
@@ -1,0 +1,4 @@
+before insertion: 0
+after insertion: 0
+vertical inline scrolls: true
+vertical block stays stable: true

--- a/Tests/LibWeb/Text/expected/input-scrolls-caret-width-into-view.txt
+++ b/Tests/LibWeb/Text/expected/input-scrolls-caret-width-into-view.txt
@@ -1,0 +1,3 @@
+scrolls to caret: true
+rect=[18,8 1x16] color=rgb(0, 0, 0)
+RTL scrolls to caret: true

--- a/Tests/LibWeb/Text/input/input-does-not-scroll-vertically-on-insertion.html
+++ b/Tests/LibWeb/Text/input/input-does-not-scroll-vertically-on-insertion.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<style>
+input {
+    box-sizing: border-box;
+    font: 15px/15px Arial, sans-serif;
+    width: 200px;
+    height: 38px;
+    padding: 7px 10px 10px 0;
+    border: 0;
+}
+#vertical {
+    writing-mode: vertical-rl;
+    width: 38px;
+    height: 8px;
+    padding: 0;
+}
+</style>
+<input id="horizontal">
+<input id="vertical">
+<script src="include.js"></script>
+<script>
+test(() => {
+    const input = document.querySelector("#horizontal");
+    input.focus();
+
+    const innerText = internals.getShadowRoot(input).querySelector("div > div");
+    println(`before insertion: ${innerText.scrollTop}`);
+
+    internals.sendText(input, "x");
+    println(`after insertion: ${innerText.scrollTop}`);
+
+    const verticalInput = document.querySelector("#vertical");
+    verticalInput.focus();
+    internals.sendText(verticalInput, "xxxxxxxx");
+    const verticalInnerText = internals.getShadowRoot(verticalInput).querySelector("div > div");
+    println(`vertical inline scrolls: ${verticalInnerText.scrollTop > 0}`);
+    println(`vertical block stays stable: ${verticalInnerText.scrollLeft === 0}`);
+});
+</script>

--- a/Tests/LibWeb/Text/input/input-scrolls-caret-width-into-view.html
+++ b/Tests/LibWeb/Text/input/input-scrolls-caret-width-into-view.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+input {
+    font: 16px monospace;
+    width: 8px;
+    padding: 0;
+    border: 0;
+}
+</style>
+<input id="ltr">
+<input id="rtl" dir="rtl">
+<script src="include.js"></script>
+<script>
+test(() => {
+    const input = document.querySelector("#ltr");
+    input.focus();
+    internals.sendText(input, "x");
+    const innerText = internals.getShadowRoot(input).querySelector("div > div");
+    println(`scrolls to caret: ${innerText.scrollLeft > 0}`);
+    for (const line of internals.dumpDisplayList().split("\n")) {
+        if (line.includes("FillRect") && line.includes("1x16") && line.includes("rgb(0, 0, 0)"))
+            println(line.slice(line.indexOf("rect=")));
+    }
+
+    const rtlInput = document.querySelector("#rtl");
+    rtlInput.focus();
+    internals.sendText(rtlInput, "x");
+    const rtlInnerText = internals.getShadowRoot(rtlInput).querySelector("div > div");
+    println(`RTL scrolls to caret: ${rtlInnerText.scrollLeft > 0}`);
+});
+</script>


### PR DESCRIPTION
Correct the layout and scrolling behavior of single-line text controls.
Clamp their used line height to the normal font line height so text remains
vertically centered and font descenders are not clipped, and avoid changing
the block-axis scroll offset when text is inserted.

Account for the painted caret width when measuring the inline overflow of a
focused text control. This allows the control to scroll the complete caret
into view while keeping it at the actual insertion coordinate. Apply the
scrolling behavior along logical axes so it works with left-to-right,
right-to-left, and vertical text.

Add coverage for zero line-height, descender visibility, stable insertion,
logical-axis scrolling, and caret positioning at inline scrollport edges.
