### PR TITLE
LibWeb: Only block scripts on the document's own style sheets

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4297,23 +4297,13 @@ String Document::dump_dom_tree_as_json() const
 bool Document::has_a_style_sheet_that_is_blocking_scripts() const
 {
     // 1. If document's script-blocking style sheet set is not empty, then return true.
-    if (!m_script_blocking_style_sheet_set.is_empty())
-        return true;
-
-    // 2. If document's node navigable is null, then return false.
-    auto navigable = this->navigable();
-    if (!navigable)
-        return false;
-
-    // 3. Let containerDocument be document's node navigable's container document.
-    auto container_document = navigable->container_document();
-
-    // 4. If containerDocument is non-null and containerDocument's script-blocking style sheet set is not empty, then return true.
-    if (container_document && !container_document->m_script_blocking_style_sheet_set.is_empty())
-        return true;
-
-    // 5. Return false
-    return false;
+    // INTEROP: The spec goes on to also return true when the container document's script-blocking style sheet set is
+    //          non-empty (steps 2-4). No engine implements that fully: Blink and WebKit only ever consult the
+    //          document's own set, and Gecko only consults ancestor documents for parser-blocking scripts, not for
+    //          deferred or module scripts. Blocking child document scripts on the container document's style sheets
+    //          makes iframes needlessly wait for the embedding page's CSS, so match Blink and WebKit by only
+    //          considering our own set.
+    return !m_script_blocking_style_sheet_set.is_empty();
 }
 
 String Document::referrer() const
@@ -4766,6 +4756,14 @@ void Document::schedule_html_parser_end_check()
         if (auto container = navigable->container())
             container->document().schedule_html_parser_end_check();
     }
+}
+
+void Document::remove_from_script_blocking_style_sheet_set(Element& element)
+{
+    // NB: Removing from the set can unblock this document's parser or parser end state, both of which wait for the
+    //     set to become empty. Always schedule the wake-up here so no removal site can forget it.
+    m_script_blocking_style_sheet_set.remove(element);
+    schedule_html_parser_end_check();
 }
 
 void Document::set_ready_for_post_load_tasks(bool ready)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1186,6 +1186,7 @@ public:
 
     auto& script_blocking_style_sheet_set() { return m_script_blocking_style_sheet_set; }
     auto const& script_blocking_style_sheet_set() const { return m_script_blocking_style_sheet_set; }
+    void remove_from_script_blocking_style_sheet_set(Element&);
 
     String dump_display_list();
     String dump_stacking_context_tree();

--- a/Libraries/LibWeb/DOM/StyleElementBase.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementBase.cpp
@@ -199,8 +199,7 @@ void StyleElementBase::finished_loading_critical_subresources(AnyFailed any_fail
             VERIFY(element.document().script_blocking_style_sheet_set().contains(element));
             VERIFY(style_element_base->m_associated_css_style_sheet_is_blocking_scripts);
             // 2. Remove element from its node document's script-blocking style sheet set.
-            element.document().script_blocking_style_sheet_set().remove(element);
-            element.document().schedule_html_parser_end_check();
+            element.document().remove_from_script_blocking_style_sheet_set(element);
             style_element_base->m_associated_css_style_sheet_is_blocking_scripts = false;
         }
         // 4. Unblock rendering on element.
@@ -276,11 +275,8 @@ void StyleElementBase::remove_from_script_blocking_style_sheet_set_if_needed()
         return;
 
     auto& element = as_element();
-    auto& script_blocking_style_sheet_set = element.document().script_blocking_style_sheet_set();
-    if (script_blocking_style_sheet_set.contains(element)) {
-        script_blocking_style_sheet_set.remove(element);
-        element.document().schedule_html_parser_end_check();
-    }
+    if (element.document().script_blocking_style_sheet_set().contains(element))
+        element.document().remove_from_script_blocking_style_sheet_set(element);
 
     m_associated_css_style_sheet_is_blocking_scripts = false;
     m_document_load_event_delayer.clear();

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -418,7 +418,7 @@ void HTMLLinkElement::fetch_and_process_linked_resource()
 
     if (m_fetch_controller) {
         m_fetch_controller->stop_fetch();
-        document().script_blocking_style_sheet_set().remove(*this);
+        document().remove_from_script_blocking_style_sheet_set(*this);
     }
 
     if (m_relationship & ~(Relationship::DNSPrefetch | Relationship::Preconnect | Relationship::Preload))
@@ -928,8 +928,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
         VERIFY(document().script_blocking_style_sheet_set().contains(*this));
 
         // 2. Remove el from its node document's script-blocking style sheet set.
-        document().script_blocking_style_sheet_set().remove(*this);
-        document().schedule_html_parser_end_check();
+        document().remove_from_script_blocking_style_sheet_set(*this);
     }
 
     // 7. Unblock rendering on el.

--- a/Tests/LibWeb/Text/expected/HTML/script-blocking-style-sheets-do-not-block-child-documents.txt
+++ b/Tests/LibWeb/Text/expected/HTML/script-blocking-style-sheets-do-not-block-child-documents.txt
@@ -1,0 +1,2 @@
+classic script executed while parent style sheet was pending: true
+module script executed while parent style sheet was pending: true

--- a/Tests/LibWeb/Text/input/HTML/script-blocking-style-sheets-do-not-block-child-documents.html
+++ b/Tests/LibWeb/Text/input/HTML/script-blocking-style-sheets-do-not-block-child-documents.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // A document's script-blocking style sheet set must not hold back script execution in child
+    // navigable documents. The HTML spec includes the container document's set when deciding
+    // whether a document has a style sheet blocking scripts, but Blink and WebKit only consult the
+    // document's own set, and Gecko only consults ancestors for parser-blocking scripts. We match
+    // Blink and WebKit.
+    asyncTest(async done => {
+        const httpServer = httpTestServer();
+        const testID = crypto.randomUUID();
+        const cssToken = `script-blocking-sheet-css-${testID}`;
+
+        const cssURL = await httpServer.createEcho("GET", `/script-blocking-sheet-${testID}.css`, {
+            status: 200,
+            headers: { "Content-Type": "text/css", "Cache-Control": "no-store" },
+            body: "",
+            wait_for_unblock: cssToken,
+        });
+
+        const expectedMessages = new Set(["classic script executed", "module script executed"]);
+        const receivedMessages = new Set();
+        window.addEventListener("message", async event => {
+            if (!expectedMessages.has(event.data))
+                return;
+            receivedMessages.add(event.data);
+            if (receivedMessages.size !== expectedMessages.size)
+                return;
+
+            println("classic script executed while parent style sheet was pending: "
+                + receivedMessages.has("classic script executed"));
+            println("module script executed while parent style sheet was pending: "
+                + receivedMessages.has("module script executed"));
+
+            frameA.contentDocument.querySelector("link").remove();
+            await fetch(new URL(`/unblock/${cssToken}`, cssURL));
+            done();
+        });
+
+        const frameA = document.createElement("iframe");
+        frameA.srcdoc = `
+            <link rel="stylesheet" href="${cssURL}">
+            <iframe srcdoc="<script>top.postMessage('classic script executed', '*');<\/script>"></iframe>
+            <iframe srcdoc="<script type='module'>top.postMessage('module script executed', '*');<\/script>"></iframe>
+        `;
+        document.body.appendChild(frameA);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/script-blocking-style-sheets-do-not-block-child-documents.html.headers
+++ b/Tests/LibWeb/Text/input/HTML/script-blocking-style-sheets-do-not-block-child-documents.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html


### PR DESCRIPTION
Per spec, a document "has a style sheet that is blocking scripts" when its own script-blocking style sheet set is non-empty, but also when its container document's set is non-empty. We implemented that container clause without any wake-up for when the container's set drained, so deferred and module scripts in iframes held back by the parent's set never got another chance to run, and their documents never fired load events. Amazon product pages hit this constantly: the top document keeps loading stylesheets while its ad SafeFrame iframes finish fetching their module scripts, so the iframes stalled forever and the tab spinner never stopped.

No engine implements the container clause fully: Blink and WebKit only ever consult the document's own set, and Gecko consults ancestors only for parser-blocking scripts. Match Blink and WebKit by considering only the document's own set. This removes the stall and also lets child documents start scripting without waiting for the embedder's CSS. Set removals now go through a Document helper that schedules the parser end check, since one removal site forgot to schedule any wake-up.

The regression test holds a real parent style sheet pending while inline classic and module scripts execute in child documents.