### PR TITLE
LibWeb: Invalidate cached canvas commands after WebGL draws

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -90,7 +90,7 @@ void DrawCompositedContext::dump(StringBuilder& builder) const
 
 void DrawCanvas::dump(StringBuilder& builder) const
 {
-    builder.appendff(" dst_rect={}", dst_rect);
+    builder.appendff(" dst_rect={} content_generation={}", dst_rect, content_generation);
 }
 
 void DrawVideoFrame::dump(StringBuilder& builder) const

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
@@ -84,9 +84,12 @@ void WebGL2RenderingContext::did_update_canvas_content()
 {
     m_canvas_element->set_canvas_content_dirty();
 
-    // NB: Don't invalidate the display list here: the recorded DrawCanvas command is unaffected by content
-    //     updates, and re-recording an identical display list would yield an empty damage rectangle. The new
-    //     content reaches the compositor through the canvas surface registry when the canvas is presented.
+    // NB: Invalidate the cached DrawCanvas command so that if another change causes the display list to be
+    //     recorded, it contains the new content generation and damages the canvas. Don't request a display list
+    //     recording here: the new content reaches the compositor through the canvas surface registry when the
+    //     canvas is presented.
+    if (auto paintable = m_canvas_element->unsafe_paintable())
+        paintable->invalidate_paint_cache();
     m_canvas_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -172,9 +172,12 @@ void WebGLRenderingContext::did_update_canvas_content()
 {
     m_canvas_element->set_canvas_content_dirty();
 
-    // NB: Don't invalidate the display list here: the recorded DrawCanvas command is unaffected by content
-    //     updates, and re-recording an identical display list would yield an empty damage rectangle. The new
-    //     content reaches the compositor through the canvas surface registry when the canvas is presented.
+    // NB: Invalidate the cached DrawCanvas command so that if another change causes the display list to be
+    //     recorded, it contains the new content generation and damages the canvas. Don't request a display list
+    //     recording here: the new content reaches the compositor through the canvas surface registry when the
+    //     canvas is presented.
+    if (auto paintable = m_canvas_element->unsafe_paintable())
+        paintable->invalidate_paint_cache();
     m_canvas_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 

--- a/Tests/LibWeb/Text/expected/canvas/webgl-draw-invalidates-cached-command.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-draw-invalidates-cached-command.txt
@@ -1,0 +1,2 @@
+[webgl] cached command has new generation: true
+[webgl2] cached command has new generation: true

--- a/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
@@ -9,5 +9,5 @@ SaveLayer@0
   CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x32]
   CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x32]
   CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 32x32]
-  DrawCanvas@1 dst_rect=[8,8 32x32]
+  DrawCanvas@1 dst_rect=[8,8 32x32] content_generation=0
 Restore@0

--- a/Tests/LibWeb/Text/input/canvas/webgl-draw-does-not-invalidate-display-list.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-draw-does-not-invalidate-display-list.html
@@ -4,9 +4,9 @@
 <script src="../include.js"></script>
 <script>
     // WebGL canvas content updates reach the compositor through the canvas surface registry,
-    // so a draw call must schedule a repaint without invalidating the display list. Re-recording
-    // a display list that is identical to the previous one would produce an empty damage
-    // rectangle, and nothing would be repainted on screen.
+    // so a draw call must schedule a repaint without requesting a display list recording. The
+    // cached DrawCanvas command is invalidated separately, so any recording requested by another
+    // change will include the new content generation and damage the canvas.
     //
     // Creating a WebGL context is the exception: it must invalidate the display list, since the
     // recorded DrawCanvas command refers to the context's canvas id.

--- a/Tests/LibWeb/Text/input/canvas/webgl-draw-invalidates-cached-command.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-draw-invalidates-cached-command.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+        const canvasContentGeneration = () => {
+            const match = internals.dumpDisplayList().match(/DrawCanvas@\d+ .*content_generation=(\d+)/);
+            return Number(match[1]);
+        };
+
+        for (const [contextType, backgroundColor] of [["webgl", "white"], ["webgl2", "black"]]) {
+            const canvas = document.createElement("canvas");
+            canvas.width = 100;
+            canvas.height = 100;
+            document.body.appendChild(canvas);
+
+            const gl = canvas.getContext(contextType);
+            await nextFrame();
+            const generationBeforeDraw = canvasContentGeneration();
+
+            gl.clearColor(0, 1, 0, 1);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+
+            // Trigger an unrelated display list recording in the same rendering update. It must not
+            // reuse the DrawCanvas command cached before the WebGL content update.
+            document.body.style.backgroundColor = backgroundColor;
+            await nextFrame();
+
+            const generationAfterDraw = canvasContentGeneration();
+            println(`[${contextType}] cached command has new generation: ${generationAfterDraw > generationBeforeDraw}`);
+
+            canvas.remove();
+            await nextFrame();
+        }
+        done();
+    });
+</script>


### PR DESCRIPTION
Keep WebGL content updates on the repaint-only fast path, but invalidate the cached `DrawCanvas` command. If another page change records a display list in the same frame, it now observes the new content generation and damages the canvas instead of leaving alternating backing stores stale.

Add WebGL 1 and WebGL 2 coverage for updating canvas content alongside an unrelated display list invalidation.

Fixes bad flickering when zooming/panning on https://streets.gl/