### PR TITLE
RequestServer: Stop setting CURLOPT_PIPEWAIT, to avoid a deadlock

### DIFF
--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -933,7 +933,6 @@ void Request::handle_fetch_state()
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());
     set_option(CURLOPT_PORT, m_url.port_or_default());
     set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
-    set_option(CURLOPT_PIPEWAIT, 1L);
 
     if (m_alt_svc_cache_path.has_value())
         set_option(CURLOPT_ALTSVC, m_alt_svc_cache_path->characters());


### PR DESCRIPTION
**Problem:** A page that issues a same-origin request whose response only becomes available after a later same-origin request reaches the server — the long-poll or SSE-plus-control-channel pattern — can hang forever over HTTP/1: The later control request never reaches the server — so, the first request never completes, and never times out.

**Cause:** RequestServer set `CURLOPT_PIPEWAIT` on every transfer. In curl 8.20.0, a new transfer whose host has a still-connecting connection in the pool is parked in `MSTATE_PENDING` (`CURLE_NO_CONNECTION_AVAILABLE`). A parked transfer is only re-woken when a connection becomes multiplex-capable, when a transfer completes, or when response headers arrive on the busy connection — none of which happen when the awaited connection finishes as HTTP/1 and the first request’s response is itself gated on the parked request. The two requests deadlock — with no error, and no timeout. Along with a problem addressed by a related fix in #10653, this was the root cause of some flakiness in the HTMLMediaElement adoption-round-trip-during-fetch test — whose control request shared a host with the media request it had to release.

**Fix:** Stop setting `CURLOPT_PIPEWAIT`. RequestServer sets no connection-pool limits — so with `PIPEWAIT` off, the `CURLE_NO_CONNECTION_AVAILABLE` path is unreachable, and this deadlock class is impossible by construction. The only cost is that a brand-new HTTP/2 origin may open an extra connection or two during its first connect burst; multiplexing onto established HTTP/2 connections is unaffected.