### PR TITLE
LibWeb: Dispatch form control events synchronously

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -383,18 +383,19 @@ FileFilter HTMLInputElement::parse_accept_attribute() const
 void HTMLInputElement::update_the_file_selection(GC::Ref<FileAPI::FileList> files)
 {
     // 1. Queue an element task on the user interaction task source given element and the following steps:
-    queue_an_element_task(Task::Source::UserInteraction, [this, files] {
-        // 1. Update element's selected files so that it represents the user's selection.
-        this->set_files(files.ptr());
+    // https://github.com/whatwg/html/issues/1080
+    // INTEROP: Other engines perform these steps synchronously once the user has selected the files.
 
-        // 2. Fire an event named input at the input element, with the bubbles and composed attributes initialized to true.
-        auto input_event = DOM::Event::create(this->realm(), EventNames::input, { .bubbles = true, .composed = true });
-        this->dispatch_event(input_event);
+    // 1. Update element's selected files so that it represents the user's selection.
+    set_files(files.ptr());
 
-        // 3. Fire an event named change at the input element, with the bubbles attribute initialized to true.
-        auto change_event = DOM::Event::create(this->realm(), EventNames::change, { .bubbles = true });
-        this->dispatch_event(change_event);
-    });
+    // 2. Fire an event named input at the input element, with the bubbles and composed attributes initialized to true.
+    auto input_event = DOM::Event::create(realm(), EventNames::input, { .bubbles = true, .composed = true });
+    dispatch_event(input_event);
+
+    // 3. Fire an event named change at the input element, with the bubbles attribute initialized to true.
+    auto change_event = DOM::Event::create(realm(), EventNames::change, { .bubbles = true });
+    dispatch_event(change_event);
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#show-the-picker,-if-applicable
@@ -592,17 +593,7 @@ void HTMLInputElement::did_edit_text_node(FlyString const& input_type, Optional<
 
     CSS::Invalidation::invalidate_style_after_validity_change(*this);
 
-    // https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
-    // https://github.com/whatwg/html/issues/1080
-    // INTEROP: Although HTML specifies queuing this event, other engines dispatch it synchronously for text edits.
-    //          Controlled inputs rely on observing each edit before rendering can restore an older value.
-    Bindings::InputEventInit input_event_init;
-    input_event_init.bubbles = true;
-    input_event_init.composed = true;
-    input_event_init.input_type = input_type.to_string();
-    input_event_init.data = data;
-    auto input_event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, input_event_init);
-    dispatch_event(*input_event);
+    user_interaction_did_change_input_value(input_type, data);
 }
 
 void HTMLInputElement::did_pick_color(Optional<Color> picked_color, ColorPickerUpdateState state)
@@ -622,18 +613,19 @@ void HTMLInputElement::did_pick_color(Optional<Color> picked_color, ColorPickerU
 
             // https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
             // [...] any time the user commits the change, the user agent must queue an element task on the user interaction task source given the input element to
-            queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-                // set its user validity to true
-                m_user_validity = true;
+            // https://github.com/whatwg/html/issues/1080
+            // INTEROP: Other engines synchronously notify script when the user commits the change.
 
-                // AD-HOC: Setting the user validity changes which of the :user-valid and :user-invalid pseudo-classes match.
-                CSS::Invalidation::invalidate_style_after_validity_change(*this);
+            // set its user validity to true
+            m_user_validity = true;
 
-                // and fire an event named change at the input element, with the bubbles attribute initialized to true.
-                auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
-                change_event->set_bubbles(true);
-                dispatch_event(*change_event);
-            });
+            // AD-HOC: Setting the user validity changes which of the :user-valid and :user-invalid pseudo-classes match.
+            CSS::Invalidation::invalidate_style_after_validity_change(*this);
+
+            // and fire an event named change at the input element, with the bubbles attribute initialized to true.
+            auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
+            change_event->set_bubbles(true);
+            dispatch_event(*change_event);
         }
     }
 }
@@ -647,9 +639,9 @@ void HTMLInputElement::did_select_files(Span<SelectedFile> selected_files, Multi
     //    interaction task source given element to fire an event named cancel at element, with the bubbles attribute
     //    initialized to true.
     if (selected_files.is_empty()) {
-        queue_an_element_task(HTML::Task::Source::UserInteraction, [this]() {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::cancel, { .bubbles = true }));
-        });
+        // https://github.com/whatwg/html/issues/1080
+        // INTEROP: Other engines dispatch this event synchronously once the file picker closes.
+        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::cancel, { .bubbles = true }));
 
         return;
     }
@@ -675,25 +667,25 @@ void HTMLInputElement::did_select_files(Span<SelectedFile> selected_files, Multi
 
     // https://html.spec.whatwg.org/multipage/input.html#update-the-file-selection
     // 1. Queue an element task on the user interaction task source given element and the following steps:
-    queue_an_element_task(HTML::Task::Source::UserInteraction, [this, files, multiple_handling]() mutable {
-        auto multiple = has_attribute(HTML::AttributeNames::multiple);
+    // https://github.com/whatwg/html/issues/1080
+    // INTEROP: Other engines perform these steps synchronously once the file picker closes.
+    auto multiple = has_attribute(HTML::AttributeNames::multiple);
 
-        // 1. Update element's selected files so that it represents the user's selection.
-        if (m_selected_files && multiple && multiple_handling == MultipleHandling::Append) {
-            for (size_t i = 0; i < files->length(); ++i)
-                m_selected_files->add_file(*files->item(i));
-        } else {
-            m_selected_files = files;
-        }
+    // 1. Update element's selected files so that it represents the user's selection.
+    if (m_selected_files && multiple && multiple_handling == MultipleHandling::Append) {
+        for (size_t i = 0; i < files->length(); ++i)
+            m_selected_files->add_file(*files->item(i));
+    } else {
+        m_selected_files = files;
+    }
 
-        update_file_input_shadow_tree();
+    update_file_input_shadow_tree();
 
-        // 2. Fire an event named input at the input element, with the bubbles and composed attributes initialized to true.
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::input, { .bubbles = true, .composed = true }));
+    // 2. Fire an event named input at the input element, with the bubbles and composed attributes initialized to true.
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::input, { .bubbles = true, .composed = true }));
 
-        // 3. Fire an event named change at the input element, with the bubbles attribute initialized to true.
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::change, { .bubbles = true }));
-    });
+    // 3. Fire an event named change at the input element, with the bubbles attribute initialized to true.
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::change, { .bubbles = true }));
 }
 
 Utf16String HTMLInputElement::value() const
@@ -1505,16 +1497,17 @@ void HTMLInputElement::user_interaction_did_change_input_value(FlyString const& 
     // and for which the user interface involves both interactive manipulation and an explicit commit action,
     // then when the user changes the element's value, the user agent must queue an element task on the user interaction task source
     // given the input element to fire an event named input at the input element, with the bubbles and composed attributes initialized to true
-    queue_an_element_task(HTML::Task::Source::UserInteraction, [this, input_type, data] {
-        // https://w3c.github.io/uievents/#event-type-input
-        Bindings::InputEventInit input_event_init;
-        input_event_init.bubbles = true;
-        input_event_init.composed = true;
-        input_event_init.input_type = input_type.to_string();
-        input_event_init.data = data;
-        auto input_event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, input_event_init);
-        dispatch_event(*input_event);
-    });
+    // https://github.com/whatwg/html/issues/1080
+    // INTEROP: Other engines dispatch this event synchronously after changing the value. Controlled form controls
+    //          rely on observing each change before rendering can restore an older value.
+    // https://w3c.github.io/uievents/#event-type-input
+    Bindings::InputEventInit input_event_init;
+    input_event_init.bubbles = true;
+    input_event_init.composed = true;
+    input_event_init.input_type = input_type.to_string();
+    input_event_init.data = data;
+    auto input_event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, input_event_init);
+    dispatch_event(*input_event);
     // and any time the user commits the change, the user agent must queue an element task on the user interaction task source given the input
     // element to set its user validity to true and fire an event named change at the input element, with the bubbles attribute initialized to true.
     // NOTE: This is done manually as needed

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -592,7 +592,17 @@ void HTMLInputElement::did_edit_text_node(FlyString const& input_type, Optional<
 
     CSS::Invalidation::invalidate_style_after_validity_change(*this);
 
-    user_interaction_did_change_input_value(input_type, data);
+    // https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
+    // https://github.com/whatwg/html/issues/1080
+    // INTEROP: Although HTML specifies queuing this event, other engines dispatch it synchronously for text edits.
+    //          Controlled inputs rely on observing each edit before rendering can restore an older value.
+    Bindings::InputEventInit input_event_init;
+    input_event_init.bubbles = true;
+    input_event_init.composed = true;
+    input_event_init.input_type = input_type.to_string();
+    input_event_init.data = data;
+    auto input_event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, input_event_init);
+    dispatch_event(*input_event);
 }
 
 void HTMLInputElement::did_pick_color(Optional<Color> picked_color, ColorPickerUpdateState state)

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -502,30 +502,31 @@ void HTMLSelectElement::send_select_update_notifications()
 {
     // To send select update notifications for a select element element, queue an element task on
     // the user interaction task source given element to run these steps:
-    queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-        // 1. Set the select element's user validity to true.
-        m_user_validity = true;
+    // https://github.com/whatwg/html/issues/1080
+    // INTEROP: Other engines perform these steps synchronously after changing the selection.
 
-        // AD-HOC: Setting the user validity changes which of the :user-valid and :user-invalid pseudo-classes match.
-        CSS::Invalidation::invalidate_style_after_validity_change(*this);
+    // 1. Set the select element's user validity to true.
+    m_user_validity = true;
 
-        // 2. Run update a select's selectedcontent given element.
-        MUST(update_selectedcontent());
+    // AD-HOC: Setting the user validity changes which of the :user-valid and :user-invalid pseudo-classes match.
+    CSS::Invalidation::invalidate_style_after_validity_change(*this);
 
-        // 3. Run clone selected option into select button given element.
-        clone_selected_option_into_select_button();
+    // 2. Run update a select's selectedcontent given element.
+    MUST(update_selectedcontent());
 
-        // 4. Fire an event named input at element, with the bubbles and composed attributes initialized to true.
-        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input);
-        input_event->set_bubbles(true);
-        input_event->set_composed(true);
-        dispatch_event(input_event);
+    // 3. Run clone selected option into select button given element.
+    clone_selected_option_into_select_button();
 
-        // 5. Fire an event named change at element, with the bubbles attribute initialized to true.
-        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
-        change_event->set_bubbles(true);
-        dispatch_event(*change_event);
-    });
+    // 4. Fire an event named input at element, with the bubbles and composed attributes initialized to true.
+    auto input_event = DOM::Event::create(realm(), HTML::EventNames::input);
+    input_event->set_bubbles(true);
+    input_event->set_composed(true);
+    dispatch_event(input_event);
+
+    // 5. Fire an event named change at element, with the bubbles attribute initialized to true.
+    auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
+    change_event->set_bubbles(true);
+    dispatch_event(*change_event);
 }
 
 void HTMLSelectElement::set_is_open(bool open)

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -482,18 +482,17 @@ void HTMLTextAreaElement::did_edit_text_node(FlyString const& input_type, Option
     // AD-HOC: Editing the value may change which validity pseudo-classes match.
     CSS::Invalidation::invalidate_style_after_validity_change(*this);
 
-    // Any time the user causes the element's raw value to change, the user agent must queue an element task on the user
-    // interaction task source given the textarea element to fire an event named input at the textarea element, with the
-    // bubbles and composed attributes initialized to true.
-    queue_an_element_task(HTML::Task::Source::UserInteraction, [this, input_type, data]() {
-        Bindings::InputEventInit input_event_init;
-        input_event_init.bubbles = true;
-        input_event_init.composed = true;
-        input_event_init.input_type = input_type.to_string();
-        input_event_init.data = data;
-        auto input_event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, input_event_init);
-        dispatch_event(input_event);
-    });
+    // https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element
+    // https://github.com/whatwg/html/issues/1080
+    // INTEROP: Although HTML specifies queuing this event, other engines dispatch it synchronously for text edits.
+    //          Controlled textareas rely on observing each edit before rendering can restore an older value.
+    Bindings::InputEventInit input_event_init;
+    input_event_init.bubbles = true;
+    input_event_init.composed = true;
+    input_event_init.input_type = input_type.to_string();
+    input_event_init.data = data;
+    auto input_event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, input_event_init);
+    dispatch_event(input_event);
 
     // A textarea element's dirty value flag must be set to true whenever the user interacts with the control in a way that changes the raw value.
     m_dirty_value = true;

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -90,11 +90,11 @@ void HTMLTextAreaElement::did_lose_focus()
 
     // The change event fires when the value is committed, if that makes sense for the control,
     // or else when the control loses focus
-    queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
-        change_event->set_bubbles(true);
-        dispatch_event(change_event);
-    });
+    // https://github.com/whatwg/html/issues/1080
+    // INTEROP: Other engines synchronously notify script when the control loses focus.
+    auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
+    change_event->set_bubbles(true);
+    dispatch_event(change_event);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
@@ -133,13 +133,13 @@ void HTMLTextAreaElement::clear_algorithm()
 
     // Unlike their associated reset algorithms, changes made to form controls as part of these algorithms do count as
     // changes caused by the user (and thus, e.g. do cause input events to fire).
-    queue_an_element_task(HTML::Task::Source::UserInteraction, [this]() {
-        Bindings::InputEventInit input_event_init;
-        input_event_init.bubbles = true;
-        input_event_init.composed = true;
-        auto input_event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, input_event_init);
-        dispatch_event(input_event);
-    });
+    // https://github.com/whatwg/html/issues/1080
+    // INTEROP: Other engines dispatch this event synchronously after clearing the value.
+    Bindings::InputEventInit input_event_init;
+    input_event_init.bubbles = true;
+    input_event_init.composed = true;
+    auto input_event = UIEvents::InputEvent::create_from_platform_event(realm(), HTML::EventNames::input, input_event_init);
+    dispatch_event(input_event);
 }
 
 // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-node-clone-ext

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -2072,11 +2072,8 @@ Web::WebDriver::Response WebDriverConnection::element_send_keys_impl(StringView 
             // 7. Fire these events in order on element:
             //     1. input
             //     2. change
-            // NOTE: These events are fired by `did_select_files` as an element task. So instead of firing them here, we
-            //       spin the event loop once before informing the client that the action is complete.
-            Web::HTML::queue_a_task(Web::HTML::Task::Source::Unspecified, nullptr, nullptr, GC::create_function(connection->current_browsing_context().heap(), [connection]() {
-                connection->async_driver_execution_complete(JsonValue {});
-            }));
+            // NOTE: These events are fired synchronously by `did_select_files`.
+            connection->async_driver_execution_complete(JsonValue {});
         };
 
         read_files_and_apply_selection(move(files), 0, {});

--- a/Tests/LibWeb/Text/expected/UIEvents/form-control-event-ordering.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/form-control-event-ordering.txt
@@ -1,13 +1,17 @@
 range
+input(value="1")
 after sendKey(value="1")
-after controlled render(value="0")
+after controlled render(value="1")
 clear input
+input(value="")
 after clear(value="")
-after controlled render(value="value")
+after controlled render(value="")
 clear textarea
+input(value="")
 after clear(value="")
-after controlled render(value="value")
+after controlled render(value="")
 textarea change
 input(value="x")
 after sendText
+change(value="x")
 after blur

--- a/Tests/LibWeb/Text/expected/UIEvents/form-control-event-ordering.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/form-control-event-ordering.txt
@@ -1,0 +1,13 @@
+range
+after sendKey(value="1")
+after controlled render(value="0")
+clear input
+after clear(value="")
+after controlled render(value="value")
+clear textarea
+after clear(value="")
+after controlled render(value="value")
+textarea change
+input(value="x")
+after sendText
+after blur

--- a/Tests/LibWeb/Text/expected/UIEvents/text-control-input-event-ordering.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/text-control-input-event-ordering.txt
@@ -1,0 +1,10 @@
+input
+beforeinput(value="")
+textInput(value="")
+after sendText(value="i")
+after controlled render(value="")
+textarea
+beforeinput(value="")
+textInput(value="")
+after sendText(value="t")
+after controlled render(value="")

--- a/Tests/LibWeb/Text/expected/UIEvents/text-control-input-event-ordering.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/text-control-input-event-ordering.txt
@@ -1,10 +1,12 @@
 input
 beforeinput(value="")
 textInput(value="")
+input(value="i")
 after sendText(value="i")
-after controlled render(value="")
+after controlled render(value="i")
 textarea
 beforeinput(value="")
 textInput(value="")
+input(value="t")
 after sendText(value="t")
-after controlled render(value="")
+after controlled render(value="t")

--- a/Tests/LibWeb/Text/expected/UIEvents/textinput-event.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/textinput-event.txt
@@ -8,5 +8,6 @@ textInput(TextEvent data="\n" inputType=- cancelable=true bubbles=true composed=
 input(InputEvent data=null inputType=insertParagraph cancelable=false bubbles=true composed=true)
 beforeinput(InputEvent data="b" inputType=insertText cancelable=true bubbles=true composed=true)
 textInput(TextEvent data="b" inputType=- cancelable=true bubbles=true composed=true)
+input(InputEvent data="b" inputType=insertText cancelable=false bubbles=true composed=true)
 beforeinput(InputEvent data="z" inputType=insertText cancelable=true bubbles=true composed=true)
 textInput(TextEvent data="z" inputType=- cancelable=true bubbles=true composed=true)

--- a/Tests/LibWeb/Text/input/UIEvents/form-control-event-ordering.html
+++ b/Tests/LibWeb/Text/input/UIEvents/form-control-event-ordering.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<input id="range" type="range" min="0" max="10" value="0">
+<input id="clear-input" value="value">
+<textarea id="clear-textarea">value</textarea>
+<textarea id="change-textarea"></textarea>
+<button id="blur-target"></button>
+<script>
+    test(() => {
+        const range = document.getElementById("range");
+        let controlledValue = range.value;
+        const rangeEvents = [];
+        range.addEventListener("input", () => {
+            controlledValue = range.value;
+            rangeEvents.push(`input(value=${JSON.stringify(range.value)})`);
+        });
+
+        internals.sendKey(range, "Right");
+        rangeEvents.push(`after sendKey(value=${JSON.stringify(range.value)})`);
+        range.value = controlledValue;
+        rangeEvents.push(`after controlled render(value=${JSON.stringify(range.value)})`);
+
+        println("range");
+        rangeEvents.forEach(println);
+
+        function testClear(control, label) {
+            let controlledValue = control.value;
+            const events = [];
+            control.addEventListener("input", () => {
+                controlledValue = control.value;
+                events.push(`input(value=${JSON.stringify(control.value)})`);
+            });
+
+            internals.clearElement(control);
+            events.push(`after clear(value=${JSON.stringify(control.value)})`);
+            control.value = controlledValue;
+            events.push(`after controlled render(value=${JSON.stringify(control.value)})`);
+
+            println(label);
+            events.forEach(println);
+        }
+
+        testClear(document.getElementById("clear-input"), "clear input");
+        testClear(document.getElementById("clear-textarea"), "clear textarea");
+
+        const textarea = document.getElementById("change-textarea");
+        const textareaEvents = [];
+        for (const type of ["input", "change"])
+            textarea.addEventListener(type, () => textareaEvents.push(`${type}(value=${JSON.stringify(textarea.value)})`));
+
+        internals.sendText(textarea, "x");
+        textareaEvents.push("after sendText");
+        document.getElementById("blur-target").focus();
+        textareaEvents.push("after blur");
+
+        println("textarea change");
+        textareaEvents.forEach(println);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/text-control-input-event-ordering.html
+++ b/Tests/LibWeb/Text/input/UIEvents/text-control-input-event-ordering.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<input id="input">
+<textarea id="textarea"></textarea>
+<script>
+    test(() => {
+        function testControl(control, label, text) {
+            let controlledValue = "";
+            const events = [];
+
+            for (const type of ["beforeinput", "textInput", "input"]) {
+                control.addEventListener(type, () => {
+                    events.push(`${type}(value=${JSON.stringify(control.value)})`);
+                    if (type === "input")
+                        controlledValue = control.value;
+                });
+            }
+
+            control.focus();
+            internals.sendText(control, text);
+            events.push(`after sendText(value=${JSON.stringify(control.value)})`);
+
+            control.value = controlledValue;
+            events.push(`after controlled render(value=${JSON.stringify(control.value)})`);
+
+            println(label);
+            events.forEach(println);
+        }
+
+        testControl(document.getElementById("input"), "input", "i");
+        testControl(document.getElementById("textarea"), "textarea", "t");
+    });
+</script>


### PR DESCRIPTION
Blink, WebKit, and Gecko synchronously notify script after user interaction changes a form control. Ladybird instead queued several input and change events, allowing controlled components to restore stale values before observing an edit. This could cause rapidly typed characters to be lost.

Dispatch form-control notifications synchronously for text editing, range, number, color, select, file selection, and WebDriver clear operations. Also align commit-time change and file-picker cancel delivery while leaving intentionallyscheduled selection events unchanged.

HTML currently specifies queued delivery, but this differs from interoperable browser behavior

Add deterministic coverage that models controlled inputs rendering their last event-observed value without relying on timing or task delays.
