### PR TITLE
LibWebView: Isolate browser state by profile

### DIFF
--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -9,7 +9,6 @@
 #include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
-#include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibHTTP/Cache/CacheRequest.h>
@@ -56,9 +55,9 @@ static constexpr StringView cache_directory_for_mode(DiskCache::Mode mode)
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<DiskCache> DiskCache::create(Mode mode)
+ErrorOr<DiskCache> DiskCache::create(Mode mode, LexicalPath cache_root)
 {
-    auto cache_directory = LexicalPath::join(Core::StandardPaths::cache_directory(), "Ladybird"sv, cache_directory_for_mode(mode));
+    auto cache_directory = cache_root.append(cache_directory_for_mode(mode));
     TRY(Core::Directory::create(cache_directory, Core::Directory::CreateDirectories::Yes));
 
     auto database = mode == DiskCache::Mode::Normal
@@ -71,7 +70,7 @@ ErrorOr<DiskCache> DiskCache::create(Mode mode)
         // Partitioned mode is already a per-process transient cache in its own directory.
         // (A fresh memory-backed database always migrates, so this is necessarily Mode::Normal.)
         dbgln("Disk cache index was created by a newer Ladybird version; using a transient cache this session");
-        return create(Mode::Partitioned);
+        return create(Mode::Partitioned, move(cache_root));
     }
 
     auto index = TRY(CacheIndex::create(database, cache_directory));

--- a/Libraries/LibHTTP/Cache/DiskCache.h
+++ b/Libraries/LibHTTP/Cache/DiskCache.h
@@ -36,7 +36,7 @@ public:
         // response headers will include some status on how the request was handled.
         Testing,
     };
-    static ErrorOr<DiskCache> create(Mode);
+    static ErrorOr<DiskCache> create(Mode, LexicalPath cache_root);
 
     DiskCache(DiskCache&&);
     DiskCache& operator=(DiskCache&&);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -144,8 +144,6 @@ static Vector<AutocompleteBookmark> autocomplete_bookmark_snapshot(BookmarkStore
 }
 
 Application::Application(Optional<ByteString> ladybird_binary_path)
-    : m_settings(Settings::create({}))
-    , m_bookmark_store(BookmarkStore::create({}))
 {
     VERIFY(!s_the);
     s_the = this;
@@ -166,6 +164,7 @@ Application::~Application()
 
     m_spare_web_content_process = nullptr;
     m_process_manager = nullptr;
+    m_browser_process = nullptr;
 
     s_the = nullptr;
 }
@@ -232,30 +231,6 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         warnln("Unable to increase open file limit: {}", result.error());
 #endif
 
-#if defined(AK_OS_MACOS)
-    m_mach_port_server = make<IPC::MachBootstrapListener>(mach_server_name_for_process("Ladybird"sv, Core::System::getpid()));
-    set_mach_server_name(m_mach_port_server->server_port_name());
-
-    m_mach_port_server->on_bootstrap_request = [this](IPC::MachBootstrapListener::BootstrapRequest request) {
-        set_process_mach_port(request.pid, move(request.task_port));
-        auto result = MUST(m_transport_bootstrap_server.handle_bootstrap_request(request.pid, move(request.reply_port)));
-        result.visit(
-            [](IPC::TransportBootstrapMachServer::ChildTransportHandled) {
-            },
-            [this](IPC::TransportBootstrapMachServer::OnDemandTransport& transport) {
-                if (!m_on_browser_process_transport)
-                    return;
-
-                VERIFY(m_event_loop);
-                m_event_loop->deferred_invoke([this, transport = move(transport.ports)]() mutable {
-                    if (!m_on_browser_process_transport)
-                        return;
-                    m_on_browser_process_transport(make<IPC::Transport>(move(transport.receive_right), move(transport.send_right)));
-                });
-            });
-    };
-#endif
-
     Vector<ByteString> raw_urls;
     Vector<ByteString> certificates;
     Optional<HeadlessMode> headless_mode;
@@ -265,6 +240,9 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     Optional<StringView> screenshot_path;
     bool new_window = false;
     bool force_new_process = false;
+    Optional<StringView> profile_name;
+    Optional<StringView> profile_path;
+    bool temporary_profile = false;
     bool allow_popups = false;
     bool disable_scripting = false;
     bool disable_sql_database = false;
@@ -331,7 +309,12 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     args_parser.add_option(window_height, "Set viewport height in pixels (default: 600) (currently only supported for headless mode)", "window-height", 0, "pixels");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(new_window, "Force opening in a new window", "new-window", 'n');
+#if !defined(AK_OS_ANDROID)
     args_parser.add_option(force_new_process, "Force creation of a new browser process", "force-new-process");
+    args_parser.add_option(profile_name, "Select or create a named profile", "profile", 0, "name");
+    args_parser.add_option(profile_path, "Use a self-contained profile at an absolute path", "profile-path", 0, "path");
+    args_parser.add_option(temporary_profile, "Use a temporary profile that is removed on clean shutdown", "temporary-profile");
+#endif
     args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
     args_parser.add_option(disable_scripting, "Disable scripting by default", "disable-scripting");
     args_parser.add_option(disable_sql_database, "Disable SQL database", "disable-sql-database");
@@ -445,10 +428,83 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     create_platform_arguments(args_parser);
     args_parser.parse(m_arguments);
 
-    // Our persisted SQL storage assumes it runs in a singleton process. If we have multiple UI processes accessing
-    // the same underlying database, one of them is likely to fail.
-    if (force_new_process)
-        disable_sql_database = true;
+#if !defined(AK_OS_ANDROID)
+    ProfileSelection profile_selection;
+    if (force_new_process) {
+        if (profile_name.has_value() || profile_path.has_value() || temporary_profile)
+            return Error::from_string_literal("--force-new-process cannot be combined with another profile selector");
+        warnln("--force-new-process is deprecated; using --temporary-profile");
+        temporary_profile = true;
+    }
+    if (profile_name.has_value())
+        profile_selection.name = profile_name->to_byte_string();
+    if (profile_path.has_value())
+        profile_selection.path = profile_path->to_byte_string();
+    profile_selection.temporary = temporary_profile;
+#endif
+
+    ProfileRoots profile_roots {
+        .config = Core::StandardPaths::config_directory(),
+        .data = Core::StandardPaths::user_data_directory(),
+        .cache = Core::StandardPaths::cache_directory(),
+        .runtime = TRY(Core::StandardPaths::runtime_directory()),
+        .temporary = Core::StandardPaths::tempfile_directory(),
+    };
+#if defined(AK_OS_WINDOWS)
+    // NB: These StandardPaths values already contain "Ladybird" on Windows.
+    //     Use their parents as the platform roots for profile layouts.
+    profile_roots.data = LexicalPath { profile_roots.data }.parent().string();
+    profile_roots.cache = LexicalPath { profile_roots.cache }.parent().string();
+#endif
+#if defined(AK_OS_ANDROID)
+    m_profile = TRY(Profile::create_legacy(profile_roots));
+#else
+    m_profile = TRY(Profile::create(profile_selection, profile_roots));
+#endif
+
+    // Synchronous IPC used to forward URLs to an existing browser process requires an event loop.
+    if (!headless_mode.has_value() && should_coordinate_browser_process()) {
+        m_browser_options.headless_mode = headless_mode;
+        m_event_loop = &create_platform_event_loop();
+    }
+
+    auto profile_identity = Profile::routing_identifier(profile().paths().identity);
+#if defined(AK_OS_MACOS)
+    auto mach_process_name = ByteString::formatted("Ladybird-{}", profile_identity);
+    m_mach_port_server = make<IPC::MachBootstrapListener>(mach_server_name_for_process(mach_process_name, Core::System::getpid()));
+    set_mach_server_name(m_mach_port_server->server_port_name());
+
+    m_mach_port_server->on_bootstrap_request = [this](IPC::MachBootstrapListener::BootstrapRequest request) {
+        set_process_mach_port(request.pid, move(request.task_port));
+        auto result = MUST(m_transport_bootstrap_server.handle_bootstrap_request(request.pid, move(request.reply_port)));
+        result.visit(
+            [](IPC::TransportBootstrapMachServer::ChildTransportHandled) {
+            },
+            [this](IPC::TransportBootstrapMachServer::OnDemandTransport& transport) {
+                if (!m_on_browser_process_transport)
+                    return;
+
+                VERIFY(m_event_loop);
+                m_event_loop->deferred_invoke([this, transport = move(transport.ports)]() mutable {
+                    if (!m_on_browser_process_transport)
+                        return;
+                    m_on_browser_process_transport(make<IPC::Transport>(move(transport.receive_right), move(transport.send_right)));
+                });
+            });
+    };
+#endif
+
+    m_browser_process = make<BrowserProcess>();
+    if (!headless_mode.has_value() && should_coordinate_browser_process()) {
+        auto disposition = TRY(m_browser_process->connect(raw_urls, new_window ? NewWindow::Yes : NewWindow::No, profile().paths().runtime, profile_identity));
+        if (disposition == BrowserProcess::ProcessDisposition::ExitProcess) {
+            m_should_exit_after_profile_coordination = true;
+            return {};
+        }
+    }
+
+    m_settings = make<Settings>(Settings::create(LexicalPath::join(profile().paths().config, "Settings.json"sv).string()));
+    m_bookmark_store = make<BookmarkStore>(BookmarkStore::create(LexicalPath::join(profile().paths().config, "Bookmarks.json"sv).string()));
 
     if (!dns_server_port.has_value())
         dns_server_port = use_dns_over_tls ? 853 : 53;
@@ -463,7 +519,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     if (profile_process.has_value())
         profile_process_type = process_type_from_name(*profile_process);
 
-    auto configured_content_blocker_list_paths = m_settings.config_variable_as_string_array(ConfigVariableID::ContentBlockerListPaths);
+    auto configured_content_blocker_list_paths = m_settings->config_variable_as_string_array(ConfigVariableID::ContentBlockerListPaths);
 
     Vector<ByteString> content_blocker_list_paths_as_byte_strings;
     TRY(content_blocker_list_paths_as_byte_strings.try_ensure_capacity(configured_content_blocker_list_paths.size() + content_blocker_list_paths.size()));
@@ -485,7 +541,6 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         .raw_urls = move(raw_urls),
         .headless_mode = headless_mode,
         .new_window = new_window ? NewWindow::Yes : NewWindow::No,
-        .force_new_process = force_new_process ? ForceNewProcess::Yes : ForceNewProcess::No,
         .allow_popups = allow_popups ? AllowPopups::Yes : AllowPopups::No,
         .disable_scripting = disable_scripting ? DisableScripting::Yes : DisableScripting::No,
         .disable_sql_database = disable_sql_database ? DisableSQLDatabase::Yes : DisableSQLDatabase::No,
@@ -517,16 +572,16 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     auto http_disk_cache_mode = HTTPDiskCacheMode::Enabled;
     if (disable_http_disk_cache)
         http_disk_cache_mode = HTTPDiskCacheMode::Disabled;
-    else if (force_new_process)
-        http_disk_cache_mode = HTTPDiskCacheMode::Partitioned;
 
     m_request_server_options = {
         .certificates = move(certificates),
+        .cache_path = profile().paths().cache,
         .http_disk_cache_mode = http_disk_cache_mode,
         .resource_substitution_map_path = resource_substitution_map_path.has_value() ? Optional<ByteString> { *resource_substitution_map_path } : OptionalNone {},
     };
 
     m_web_content_options = {
+        .cache_path = profile().paths().cache,
         .user_agent_preset = move(user_agent_preset),
         .is_test_mode = enable_test_mode ? IsTestMode::Yes : IsTestMode::No,
         .log_all_js_exceptions = log_all_js_exceptions ? LogAllJSExceptions::Yes : LogAllJSExceptions::No,
@@ -567,7 +622,8 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 
     initialize_actions();
 
-    m_event_loop = &create_platform_event_loop();
+    if (!m_event_loop)
+        m_event_loop = &create_platform_event_loop();
     TRY(launch_services());
 
     return {};
@@ -620,7 +676,7 @@ void Application::open_urls_in_new_tabs(ReadonlySpan<URL::URL> urls) const
 
 void Application::open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab activate_tab) const
 {
-    if (auto bookmark = m_bookmark_store.find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
+    if (auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
         open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
 }
 
@@ -639,7 +695,7 @@ static void collect_bookmark_urls(BookmarkItem::Folder const& folder, Vector<URL
 
 void Application::open_bookmark_folder_in_new_tabs(String const& folder_id) const
 {
-    auto folder = m_bookmark_store.find_item_by_id(folder_id);
+    auto folder = m_bookmark_store->find_item_by_id(folder_id);
     if (!folder.has_value() || !folder->is_folder())
         return;
 
@@ -651,7 +707,7 @@ void Application::open_bookmark_folder_in_new_tabs(String const& folder_id) cons
 
 void Application::open_bookmark_in_new_window(String const& bookmark_id, IsPrivate is_private)
 {
-    if (auto bookmark = m_bookmark_store.find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
+    if (auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
         open_url_in_new_window(bookmark->bookmark().url, is_private);
 }
 
@@ -958,8 +1014,7 @@ ErrorOr<void> Application::launch_services()
     Optional<ByteString> history_database_directory;
 
     if (m_browser_options.disable_sql_database == DisableSQLDatabase::No) {
-        // FIXME: Move this to a generic "Ladybird data directory" helper.
-        auto database_path = ByteString::formatted("{}/Ladybird", Core::StandardPaths::user_data_directory());
+        auto database_path = profile().paths().data;
         history_database_directory = database_path;
 
         m_database = TRY(Database::Database::create(database_path, "Ladybird"sv));
@@ -1032,7 +1087,7 @@ ErrorOr<void> Application::launch_services()
 
     VERIFY(m_event_loop);
     m_autocomplete_service = make<AutocompleteService>(*m_event_loop, move(history_database_directory));
-    m_autocomplete_service->update_bookmarks(autocomplete_bookmark_snapshot(m_bookmark_store));
+    m_autocomplete_service->update_bookmarks(autocomplete_bookmark_snapshot(*m_bookmark_store));
 
     // No need to monitor the system time zone if the TZ environment variable is set, as it overrides system preferences.
     if (!Core::Environment::has("TZ"sv)) {
@@ -1206,7 +1261,7 @@ ErrorOr<void> Application::launch_request_server()
     };
 
     if (m_browser_options.dns_settings.has_value())
-        m_settings.set_dns_settings(m_browser_options.dns_settings.value(), true);
+        m_settings->set_dns_settings(m_browser_options.dns_settings.value(), true);
 
     return {};
 }
@@ -1765,16 +1820,16 @@ void Application::initialize_actions()
     m_motion_menu->items().first().get<NonnullRefPtr<Action>>()->set_checked(true);
 
     m_toggle_vertical_tabs_expanded_action = Action::create("Toggle Vertical Tabs Expanded"sv, ActionID::ToggleVerticalTabsExpanded, [this]() {
-        auto tab_settings = m_settings.tab_settings();
+        auto tab_settings = m_settings->tab_settings();
         tab_settings.vertical_tabs_expanded = !tab_settings.vertical_tabs_expanded;
-        m_settings.set_tab_settings(tab_settings);
+        m_settings->set_tab_settings(tab_settings);
     });
     update_vertical_tabs_action();
 
     m_toggle_menu_bar_action = Action::create_checkable("Show Menubar"sv, ActionID::ToggleMenuBar, [this]() {
-        m_settings.set_show_menu_bar(!m_settings.show_menu_bar());
+        m_settings->set_show_menu_bar(!m_settings->show_menu_bar());
     });
-    m_toggle_menu_bar_action->set_checked(m_settings.show_menu_bar());
+    m_toggle_menu_bar_action->set_checked(m_settings->show_menu_bar());
 
     m_bookmarks_menu = Menu::create("Bookmarks"sv);
     m_bookmarks_menu->add_action(Action::create("Manage Bookmarks"sv, ActionID::ManageBookmarks, [this]() {
@@ -1800,16 +1855,16 @@ void Application::initialize_actions()
         auto default_title = MUST(UnixDateTime::now().to_string("Saved Tabs %Y-%m-%d"sv));
         display_add_bookmark_folder_dialog(default_title)
             ->when_resolved([this, bookmarks = move(bookmarks)](BookmarkItem::Folder folder) mutable {
-                auto folder_id = m_bookmark_store.add_folder(move(folder.title));
+                auto folder_id = m_bookmark_store->add_folder(move(folder.title));
                 for (auto& bookmark : bookmarks)
-                    m_bookmark_store.add_bookmark(move(bookmark.url), move(bookmark.title), move(bookmark.favicon_base64_png), folder_id);
+                    m_bookmark_store->add_bookmark(move(bookmark.url), move(bookmark.title), move(bookmark.favicon_base64_png), folder_id);
             });
     }));
 
     m_toggle_bookmark_bar_action = Action::create_checkable("Show Bookmarks Bar"sv, ActionID::ToggleBookmarksBar, [this]() {
-        m_settings.set_show_bookmarks_bar(!m_settings.show_bookmarks_bar());
+        m_settings->set_show_bookmarks_bar(!m_settings->show_bookmarks_bar());
     });
-    m_toggle_bookmark_bar_action->set_checked(m_settings.show_bookmarks_bar());
+    m_toggle_bookmark_bar_action->set_checked(m_settings->show_bookmarks_bar());
     m_bookmarks_menu->add_action(*m_toggle_bookmark_bar_action);
 
     m_bookmarks_menu->add_separator();
@@ -1849,7 +1904,7 @@ void Application::initialize_actions()
     m_inspect_menu->add_action(*m_toggle_devtools_action);
 
     m_debug_menu = Menu::create("Debug"sv);
-    m_debug_menu->set_visible(m_settings.config_variable_as_bool(ConfigVariableID::ShowAdvancedDebugMenu));
+    m_debug_menu->set_visible(m_settings->config_variable_as_bool(ConfigVariableID::ShowAdvancedDebugMenu));
     m_debug_menu->add_action(Action::create("Dump Session History Tree"sv, ActionID::DumpSessionHistoryTree, debug_request("dump-session-history"sv)));
     m_debug_menu->add_action(Action::create("Dump DOM Tree"sv, ActionID::DumpDOMTree, debug_request("dump-dom-tree"sv)));
     m_debug_menu->add_action(Action::create("Dump Layout Tree"sv, ActionID::DumpLayoutTree, debug_request("dump-layout-tree"sv)));
@@ -1942,7 +1997,7 @@ void Application::apply_view_options(Badge<ViewImplementation>, ViewImplementati
 
 void Application::update_vertical_tabs_action()
 {
-    auto const& settings = m_settings.tab_settings();
+    auto const& settings = m_settings->tab_settings();
     m_toggle_vertical_tabs_expanded_action->set_visible(settings.vertical_tabs_enabled);
     m_toggle_vertical_tabs_expanded_action->set_engaged(settings.vertical_tabs_expanded);
     m_toggle_vertical_tabs_expanded_action->set_tooltip(settings.vertical_tabs_expanded ? "Minimize Tabs"sv : "Expand Tabs"sv);
@@ -1957,7 +2012,7 @@ void Application::tab_settings_changed(Badge<ApplicationSettingsObserver>)
 void Application::update_bookmark_action_for_current_web_view()
 {
     auto view = active_web_view();
-    auto is_bookmarked = view.has_value() && m_bookmark_store.is_bookmarked(view->url());
+    auto is_bookmarked = view.has_value() && m_bookmark_store->is_bookmarked(view->url());
 
     m_toggle_bookmark_action->set_text(is_bookmarked ? "Remove Bookmark"sv : "Add Bookmark"sv);
     m_toggle_bookmark_action->set_engaged(is_bookmarked);
@@ -1966,7 +2021,7 @@ void Application::update_bookmark_action_for_current_web_view()
 void Application::bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>)
 {
     if (m_autocomplete_service)
-        m_autocomplete_service->update_bookmarks(autocomplete_bookmark_snapshot(m_bookmark_store));
+        m_autocomplete_service->update_bookmarks(autocomplete_bookmark_snapshot(*m_bookmark_store));
     m_bookmarks_menu->shrink(m_bookmarks_menu_static_size);
     create_bookmark_menu_items();
     rebuild_bookmarks_menu();
@@ -1974,14 +2029,14 @@ void Application::bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>)
 
 void Application::toggle_bookmark_for_view(ViewImplementation& view)
 {
-    if (auto bookmark = m_bookmark_store.find_bookmark_by_url(view.url()); bookmark.has_value()) {
-        m_bookmark_store.remove_item(bookmark->id);
+    if (auto bookmark = m_bookmark_store->find_bookmark_by_url(view.url()); bookmark.has_value()) {
+        m_bookmark_store->remove_item(bookmark->id);
         return;
     }
 
     display_add_bookmark_dialog()
         ->when_resolved([this](AddBookmarkDialogResult result) {
-            m_bookmark_store.add_bookmark(move(result.bookmark.url), move(result.bookmark.title), move(result.bookmark.favicon_base64_png), move(result.target_folder_id));
+            m_bookmark_store->add_bookmark(move(result.bookmark.url), move(result.bookmark.title), move(result.bookmark.favicon_base64_png), move(result.target_folder_id));
         });
 }
 
@@ -1990,7 +2045,7 @@ void Application::create_bookmark_menu_items(Optional<MenuData> data)
     auto const& [menu, items, target_folder_id] = data.ensure([&]() -> MenuData {
         return {
             .menu = *m_bookmarks_menu,
-            .items = m_bookmark_store.root_items(),
+            .items = m_bookmark_store->root_items(),
             .target_folder_id = {},
         };
     });

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -31,12 +31,14 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWebView/BookmarkStore.h>
+#include <LibWebView/BrowserProcess.h>
 #include <LibWebView/FileDownloader.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Options.h>
 #include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/Process.h>
 #include <LibWebView/ProcessManager.h>
+#include <LibWebView/Profile.h>
 #include <LibWebView/Settings.h>
 #include <LibWebView/StorageJar.h>
 
@@ -66,7 +68,10 @@ public:
 
     static Application& the() { return *s_the; }
 
-    static Settings& settings() { return the().m_settings; }
+    static Settings& settings() { return *the().m_settings; }
+    static Profile const& profile() { return *the().m_profile; }
+    BrowserProcess& browser_process() { return *m_browser_process; }
+    bool should_exit_after_profile_coordination() const { return m_should_exit_after_profile_coordination; }
     static AutocompleteService& autocomplete_service() { return *the().m_autocomplete_service; }
 
     static BrowserOptions const& browser_options() { return the().m_browser_options; }
@@ -83,7 +88,7 @@ public:
     virtual bool supports_client_side_window_decorations() const { return false; }
     void tab_settings_changed(Badge<ApplicationSettingsObserver>);
 
-    static BookmarkStore& bookmark_store() { return the().m_bookmark_store; }
+    static BookmarkStore& bookmark_store() { return *the().m_bookmark_store; }
     void update_bookmark_action_for_current_web_view();
     void bookmarks_changed(Badge<ApplicationBookmarkStoreObserver>);
     void show_bookmarks_bar_changed(Badge<ApplicationSettingsObserver>);
@@ -263,6 +268,7 @@ protected:
 
     virtual void create_platform_arguments(Core::ArgsParser&) { }
     virtual void create_platform_options(BrowserOptions&, RequestServerOptions&, WebContentOptions&) { }
+    virtual bool should_coordinate_browser_process() const { return true; }
     virtual Core::EventLoop& create_platform_event_loop();
 
     virtual Optional<ByteString> ask_user_for_download_path([[maybe_unused]] ByteString const& file) const { return {}; }
@@ -379,10 +385,13 @@ private:
 
     static Application* s_the;
 
-    Settings m_settings;
+    Optional<Profile> m_profile;
+    OwnPtr<Settings> m_settings;
+    OwnPtr<BrowserProcess> m_browser_process;
+    bool m_should_exit_after_profile_coordination { false };
     OwnPtr<ApplicationSettingsObserver> m_settings_observer;
 
-    BookmarkStore m_bookmark_store;
+    OwnPtr<BookmarkStore> m_bookmark_store;
     OwnPtr<ApplicationBookmarkStoreObserver> m_bookmark_store_observer;
     OwnPtr<HistoryStore> m_history_store;
     OwnPtr<AutocompleteService> m_autocomplete_service;

--- a/Libraries/LibWebView/BookmarkStore.cpp
+++ b/Libraries/LibWebView/BookmarkStore.cpp
@@ -9,7 +9,6 @@
 #include <AK/JsonObject.h>
 #include <AK/Random.h>
 #include <LibCore/File.h>
-#include <LibCore/StandardPaths.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibURL/Parser.h>
 #include <LibWebView/Application.h>
@@ -170,11 +169,8 @@ static Vector<BookmarkItem> create_default_bookmarks()
     };
 }
 
-BookmarkStore BookmarkStore::create(Badge<Application>)
+BookmarkStore BookmarkStore::create(ByteString bookmarks_path)
 {
-    auto bookmarks_directory = ByteString::formatted("{}/Ladybird", Core::StandardPaths::config_directory());
-    auto bookmarks_path = ByteString::formatted("{}/Bookmarks.json", bookmarks_directory);
-
     BookmarkStore store { move(bookmarks_path) };
 
     if (!FileSystem::exists(store.m_bookmarks_path)) {

--- a/Libraries/LibWebView/BookmarkStore.h
+++ b/Libraries/LibWebView/BookmarkStore.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Badge.h>
 #include <AK/JsonValue.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
@@ -55,7 +54,7 @@ public:
 
 class WEBVIEW_API BookmarkStore {
 public:
-    static BookmarkStore create(Badge<Application>);
+    static BookmarkStore create(ByteString bookmarks_path);
 
     Vector<BookmarkItem> const& root_items() const { return m_items; }
 

--- a/Libraries/LibWebView/BrowserProcess.cpp
+++ b/Libraries/LibWebView/BrowserProcess.cpp
@@ -20,6 +20,12 @@
 #include <LibWebView/URL.h>
 #include <LibWebView/Utilities.h>
 
+#if defined(AK_OS_WINDOWS)
+#    include <AK/Windows.h>
+#else
+#    include <sys/file.h>
+#endif
+
 namespace WebView {
 
 static HashMap<int, RefPtr<UIProcessConnectionFromClient>>& connections()
@@ -36,15 +42,26 @@ private:
     explicit UIProcessClient(NonnullOwnPtr<IPC::Transport>);
 };
 
-ErrorOr<BrowserProcess::ProcessDisposition> BrowserProcess::connect(Vector<ByteString> const& raw_urls, NewWindow new_window)
+ErrorOr<BrowserProcess::ProcessDisposition> BrowserProcess::connect(Vector<ByteString> const& raw_urls, NewWindow new_window, StringView runtime_directory, [[maybe_unused]] StringView profile_identity)
 {
     static constexpr auto process_name = "Ladybird"sv;
 
-    auto [socket_path, pid_path] = TRY(Process::paths_for_process(process_name));
+    auto startup_lock_path = LexicalPath::join(runtime_directory, "startup.lock"sv).string();
+    auto startup_lock = TRY(Core::File::open(startup_lock_path, Core::File::OpenMode::ReadWrite));
+#if defined(AK_OS_WINDOWS)
+    OVERLAPPED overlapped {};
+    if (!LockFileEx(to_handle(startup_lock->fd()), LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD, &overlapped))
+        return Error::from_windows_error();
+#else
+    if (flock(startup_lock->fd(), LOCK_EX) < 0)
+        return Error::from_syscall("flock"sv, errno);
+#endif
+
+    auto [socket_path, pid_path] = TRY(Process::paths_for_process(process_name, runtime_directory));
 
     if (auto pid = TRY(Process::get_process_pid(process_name, pid_path)); pid.has_value()) {
 #if defined(AK_OS_MACOS)
-        TRY(connect_as_client(*pid, raw_urls, new_window));
+        TRY(connect_as_client(*pid, raw_urls, new_window, profile_identity));
 #else
         TRY(connect_as_client(socket_path, raw_urls, new_window));
 #endif
@@ -65,9 +82,10 @@ ErrorOr<BrowserProcess::ProcessDisposition> BrowserProcess::connect(Vector<ByteS
 }
 
 #if defined(AK_OS_MACOS)
-ErrorOr<void> BrowserProcess::connect_as_client(pid_t pid, Vector<ByteString> const& raw_urls, NewWindow new_window)
+ErrorOr<void> BrowserProcess::connect_as_client(pid_t pid, Vector<ByteString> const& raw_urls, NewWindow new_window, StringView profile_identity)
 {
-    auto transport_ports = TRY(IPC::bootstrap_transport_from_mach_server(mach_server_name_for_process("Ladybird"sv, pid)));
+    auto process_name = ByteString::formatted("Ladybird-{}", profile_identity);
+    auto transport_ports = TRY(IPC::bootstrap_transport_from_mach_server(mach_server_name_for_process(process_name, pid)));
     auto client = UIProcessClient::construct(make<IPC::Transport>(move(transport_ports.receive_right), move(transport_ports.send_right)));
 
     switch (new_window) {

--- a/Libraries/LibWebView/BrowserProcess.h
+++ b/Libraries/LibWebView/BrowserProcess.h
@@ -53,7 +53,7 @@ public:
     BrowserProcess() = default;
     ~BrowserProcess();
 
-    ErrorOr<ProcessDisposition> connect(Vector<ByteString> const& raw_urls, NewWindow new_window);
+    ErrorOr<ProcessDisposition> connect(Vector<ByteString> const& raw_urls, NewWindow new_window, StringView runtime_directory, StringView profile_identity);
 
     Function<void(Vector<URL::URL> const&)> on_new_tab;
     Function<void(Vector<URL::URL> const&)> on_new_window;
@@ -61,7 +61,7 @@ public:
 private:
     void accept_transport(NonnullOwnPtr<IPC::Transport>);
 #if defined(AK_OS_MACOS)
-    ErrorOr<void> connect_as_client(pid_t pid, Vector<ByteString> const& raw_urls, NewWindow new_window);
+    ErrorOr<void> connect_as_client(pid_t pid, Vector<ByteString> const& raw_urls, NewWindow new_window, StringView profile_identity);
     ErrorOr<void> connect_as_server();
 #else
     ErrorOr<void> connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, NewWindow new_window);

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     ProcessHandle.cpp
     ProcessManager.cpp
     ProcessMonitor.cpp
+    Profile.cpp
     SearchEngine.cpp
     SessionHistory.cpp
     Settings.cpp
@@ -101,7 +102,7 @@ compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebUIClient.ipc ${CMAKE_B
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebUIServer.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebUIServerEndpoint.h)
 
 ladybird_lib(LibWebView webview EXPLICIT_SYMBOL_EXPORT)
-target_link_libraries(LibWebView PRIVATE LibCore LibDatabase LibDevTools LibFileSystem LibGfx LibHTTP LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL LibSync LibSyntax LibTextCodec LibThreading)
+target_link_libraries(LibWebView PRIVATE LibCore LibCrypto LibDatabase LibDevTools LibFileSystem LibGfx LibHTTP LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL LibSync LibSyntax LibTextCodec LibThreading)
 
 # Third-party
 if (HAS_FONTCONFIG)

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -96,6 +96,10 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsP
         arguments.append("--config-path"sv);
         arguments.append(web_content_options.config_path.value());
     }
+    if (web_content_options.cache_path.has_value()) {
+        arguments.append("--cache-path"sv);
+        arguments.append(web_content_options.cache_path.value());
+    }
     if (web_content_options.is_test_mode == WebView::IsTestMode::Yes)
         arguments.append("--test-mode"sv);
     if (web_content_options.log_all_js_exceptions == WebView::LogAllJSExceptions::Yes)
@@ -170,6 +174,11 @@ ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process()
     auto const& web_content_options = WebView::Application::web_content_options();
 
     Vector<ByteString> arguments;
+
+    if (web_content_options.cache_path.has_value()) {
+        arguments.append("--cache-path"sv);
+        arguments.append(web_content_options.cache_path.value());
+    }
     if (browser_options.disable_sandbox == DisableSandbox::Yes)
         arguments.append("--disable-sandbox"sv);
     if (web_content_options.is_test_mode == WebView::IsTestMode::Yes)
@@ -194,6 +203,11 @@ ErrorOr<NonnullRefPtr<WebWorkerClient>> launch_web_worker_process(Web::Bindings:
     auto const& web_content_options = WebView::Application::web_content_options();
 
     Vector<ByteString> arguments;
+
+    if (web_content_options.cache_path.has_value()) {
+        arguments.append("--cache-path"sv);
+        arguments.append(web_content_options.cache_path.value());
+    }
 
     if (browser_options.disable_sandbox == DisableSandbox::Yes)
         arguments.append("--disable-sandbox"sv);
@@ -236,6 +250,9 @@ ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process()
     auto const& request_server_options = Application::request_server_options();
 
     Vector<ByteString> arguments;
+
+    arguments.append("--cache-path"sv);
+    arguments.append(request_server_options.cache_path);
 
     if (browser_options.disable_sandbox == DisableSandbox::Yes)
         arguments.append("--disable-sandbox"sv);

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -29,11 +29,6 @@ enum class NewWindow {
     Yes,
 };
 
-enum class ForceNewProcess {
-    No,
-    Yes,
-};
-
 enum class AllowPopups {
     No,
     Yes,
@@ -89,7 +84,6 @@ struct BrowserOptions {
     int window_width { 800 };
     int window_height { 600 };
     NewWindow new_window { NewWindow::No };
-    ForceNewProcess force_new_process { ForceNewProcess::No };
     AllowPopups allow_popups { AllowPopups::No };
     DisableScripting disable_scripting { DisableScripting::No };
     DisableSQLDatabase disable_sql_database { DisableSQLDatabase::No };
@@ -112,6 +106,7 @@ enum class HTTPDiskCacheMode {
 
 struct RequestServerOptions {
     Vector<ByteString> certificates;
+    ByteString cache_path;
     HTTPDiskCacheMode http_disk_cache_mode { HTTPDiskCacheMode::Disabled };
     Optional<ByteString> resource_substitution_map_path;
 };
@@ -183,6 +178,7 @@ enum class ReportSessionHistoryUpdatesInTestMode {
 
 struct WebContentOptions {
     Optional<ByteString> config_path {};
+    Optional<ByteString> cache_path {};
     Optional<StringView> user_agent_preset {};
     IsTestMode is_test_mode { IsTestMode::No };
     LogAllJSExceptions log_all_js_exceptions { LogAllJSExceptions::No };

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -204,9 +204,8 @@ ErrorOr<int> Process::create_ipc_socket(ByteString const& socket_path)
     return socket_fd;
 }
 
-ErrorOr<Process::ProcessPaths> Process::paths_for_process(StringView process_name)
+ErrorOr<Process::ProcessPaths> Process::paths_for_process(StringView process_name, StringView runtime_directory)
 {
-    auto runtime_directory = TRY(Core::StandardPaths::runtime_directory());
     auto socket_path = ByteString::formatted("{}/{}.socket", runtime_directory, process_name);
     auto pid_path = ByteString::formatted("{}/{}.pid", runtime_directory, process_name);
 

--- a/Libraries/LibWebView/Process.h
+++ b/Libraries/LibWebView/Process.h
@@ -58,7 +58,7 @@ public:
         ByteString socket_path;
         ByteString pid_path;
     };
-    static ErrorOr<ProcessPaths> paths_for_process(StringView process_name);
+    static ErrorOr<ProcessPaths> paths_for_process(StringView process_name, StringView runtime_directory);
     static ErrorOr<Optional<pid_t>> get_process_pid(StringView process_name, StringView pid_path);
     static ErrorOr<int> create_ipc_socket(ByteString const& socket_path);
 

--- a/Libraries/LibWebView/Profile.cpp
+++ b/Libraries/LibWebView/Profile.cpp
@@ -158,4 +158,19 @@ ErrorOr<Profile> Profile::create(ProfileSelection const& selection, ProfileRoots
     return Profile { move(identifier), move(paths) };
 }
 
+ErrorOr<Profile> Profile::create_legacy(ProfileRoots const& roots)
+{
+    ProfilePaths paths {
+        .config = LexicalPath::join(roots.config, "Ladybird"sv).string(),
+        .data = LexicalPath::join(roots.data, "Ladybird"sv).string(),
+        .cache = LexicalPath::join(roots.cache, "Ladybird"sv).string(),
+        .runtime = roots.runtime,
+        .identity = LexicalPath::join(roots.data, "Ladybird"sv).string(),
+    };
+
+    TRY(create_profile_directories(paths));
+    paths.identity = TRY(FileSystem::real_path(paths.identity));
+    return Profile { "legacy"sv, move(paths) };
+}
+
 }

--- a/Libraries/LibWebView/Profile.cpp
+++ b/Libraries/LibWebView/Profile.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/CharacterTypes.h>
+#include <AK/Hex.h>
+#include <AK/LexicalPath.h>
+#include <AK/Random.h>
+#include <LibCore/Directory.h>
+#include <LibCrypto/Hash/SHA2.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibWebView/Profile.h>
+
+namespace WebView {
+
+static ByteString profile_path(StringView root, StringView identifier)
+{
+    return LexicalPath::join(root, "Ladybird"sv, "Profiles"sv, identifier).string();
+}
+
+static ErrorOr<void> create_profile_directories(ProfilePaths const& paths)
+{
+    TRY(Core::Directory::create(paths.config, Core::Directory::CreateDirectories::Yes, 0700));
+    TRY(Core::Directory::create(paths.data, Core::Directory::CreateDirectories::Yes, 0700));
+    TRY(Core::Directory::create(paths.cache, Core::Directory::CreateDirectories::Yes, 0700));
+    TRY(Core::Directory::create(paths.runtime, Core::Directory::CreateDirectories::Yes, 0700));
+    return {};
+}
+
+Profile::Profile(ByteString identifier, ProfilePaths paths, Optional<ByteString> temporary_root)
+    : m_identifier(move(identifier))
+    , m_paths(move(paths))
+    , m_temporary_root(move(temporary_root))
+{
+}
+
+Profile::Profile(Profile&& other)
+    : m_identifier(move(other.m_identifier))
+    , m_paths(move(other.m_paths))
+    , m_temporary_root(move(other.m_temporary_root))
+{
+    other.m_temporary_root.clear();
+}
+
+Profile& Profile::operator=(Profile&& other)
+{
+    if (this == &other)
+        return *this;
+
+    remove_temporary_root();
+    m_identifier = move(other.m_identifier);
+    m_paths = move(other.m_paths);
+    m_temporary_root = move(other.m_temporary_root);
+    other.m_temporary_root.clear();
+    return *this;
+}
+
+Profile::~Profile()
+{
+    remove_temporary_root();
+}
+
+void Profile::remove_temporary_root()
+{
+    if (!m_temporary_root.has_value())
+        return;
+    if (FileSystem::exists(*m_temporary_root)) {
+        if (auto result = FileSystem::remove(*m_temporary_root, FileSystem::RecursionMode::Allowed); result.is_error())
+            warnln("Unable to remove temporary Ladybird profile '{}': {}", *m_temporary_root, result.error());
+    }
+    m_temporary_root.clear();
+}
+
+bool Profile::is_valid_name(StringView name)
+{
+    if (name.is_empty())
+        return false;
+
+    for (auto character : name.bytes()) {
+        if (!is_ascii_lower_alpha(character) && !is_ascii_digit(character) && character != '_' && character != '-')
+            return false;
+    }
+    return true;
+}
+
+ByteString Profile::routing_identifier(StringView canonical_profile_root)
+{
+    auto digest = Crypto::Hash::SHA256::hash(canonical_profile_root);
+    return encode_hex(digest.bytes().slice(0, 16));
+}
+
+ErrorOr<Profile> Profile::create(ProfileSelection const& selection, ProfileRoots const& roots)
+{
+    auto selector_count = static_cast<unsigned>(selection.name.has_value())
+        + static_cast<unsigned>(selection.path.has_value())
+        + static_cast<unsigned>(selection.temporary);
+    if (selector_count > 1)
+        return Error::from_string_literal("Profile selectors are mutually exclusive");
+
+    if (selection.name.has_value() && !is_valid_name(*selection.name))
+        return Error::from_string_literal("Profile names may only contain lowercase ASCII letters, digits, '_' and '-'");
+
+    if (selection.path.has_value()) {
+        auto root = LexicalPath { *selection.path };
+        if (!root.is_absolute())
+            return Error::from_string_literal("Profile path must be absolute");
+
+        TRY(Core::Directory::create(root, Core::Directory::CreateDirectories::Yes, 0700));
+        root = LexicalPath { TRY(FileSystem::real_path(root.string())) };
+        auto canonical_root = root.string();
+        ProfilePaths paths {
+            .config = root.append("config"sv).string(),
+            .data = root.append("data"sv).string(),
+            .cache = root.append("cache"sv).string(),
+            .runtime = root.append("runtime"sv).string(),
+            .identity = canonical_root,
+        };
+        TRY(create_profile_directories(paths));
+        return Profile { "custom"sv, move(paths) };
+    }
+
+    if (selection.temporary) {
+        TRY(Core::Directory::create(roots.temporary, Core::Directory::CreateDirectories::Yes, 0700));
+
+        auto root = LexicalPath::join(roots.temporary, ByteString::formatted("ladybird-profile-{:016x}-{:016x}", get_random<u64>(), get_random<u64>())).string();
+        TRY(Core::Directory::create(root, Core::Directory::CreateDirectories::Yes, 0700));
+        root = TRY(FileSystem::real_path(root));
+
+        ProfilePaths paths {
+            .config = LexicalPath::join(root, "config"sv).string(),
+            .data = LexicalPath::join(root, "data"sv).string(),
+            .cache = LexicalPath::join(root, "cache"sv).string(),
+            .runtime = LexicalPath::join(root, "runtime"sv).string(),
+            .identity = root,
+        };
+        auto result = create_profile_directories(paths);
+        if (result.is_error()) {
+            MUST(FileSystem::remove(root, FileSystem::RecursionMode::Allowed));
+            return result.release_error();
+        }
+        return Profile { "temporary"sv, move(paths), move(root) };
+    }
+
+    auto identifier = selection.name.value_or("default"sv);
+
+    ProfilePaths paths {
+        .config = profile_path(roots.config, identifier),
+        .data = profile_path(roots.data, identifier),
+        .cache = profile_path(roots.cache, identifier),
+        .runtime = profile_path(roots.runtime, identifier),
+        .identity = profile_path(roots.data, identifier),
+    };
+
+    TRY(create_profile_directories(paths));
+    paths.identity = TRY(FileSystem::real_path(paths.identity));
+    return Profile { move(identifier), move(paths) };
+}
+
+}

--- a/Libraries/LibWebView/Profile.h
+++ b/Libraries/LibWebView/Profile.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <AK/Error.h>
+#include <AK/Optional.h>
+#include <LibWebView/Export.h>
+
+namespace WebView {
+
+struct ProfileSelection {
+    Optional<ByteString> name {};
+    Optional<ByteString> path {};
+    bool temporary { false };
+};
+
+struct ProfileRoots {
+    ByteString config;
+    ByteString data;
+    ByteString cache;
+    ByteString runtime;
+    ByteString temporary;
+};
+
+struct ProfilePaths {
+    ByteString config;
+    ByteString data;
+    ByteString cache;
+    ByteString runtime;
+    ByteString identity;
+};
+
+class WEBVIEW_API Profile {
+    AK_MAKE_NONCOPYABLE(Profile);
+
+public:
+    Profile(Profile&&);
+    Profile& operator=(Profile&&);
+    ~Profile();
+
+    static ErrorOr<Profile> create(ProfileSelection const&, ProfileRoots const&);
+    static ByteString routing_identifier(StringView canonical_profile_root);
+    static bool is_valid_name(StringView);
+
+    ProfilePaths const& paths() const { return m_paths; }
+    StringView identifier() const { return m_identifier; }
+    bool is_temporary() const { return m_temporary_root.has_value(); }
+
+private:
+    Profile(ByteString identifier, ProfilePaths, Optional<ByteString> temporary_root = {});
+    void remove_temporary_root();
+
+    ByteString m_identifier;
+    ProfilePaths m_paths;
+    Optional<ByteString> m_temporary_root;
+};
+
+}

--- a/Libraries/LibWebView/Profile.h
+++ b/Libraries/LibWebView/Profile.h
@@ -44,6 +44,7 @@ public:
     ~Profile();
 
     static ErrorOr<Profile> create(ProfileSelection const&, ProfileRoots const&);
+    static ErrorOr<Profile> create_legacy(ProfileRoots const&);
     static ByteString routing_identifier(StringView canonical_profile_root);
     static bool is_valid_name(StringView);
 

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -9,7 +9,6 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
-#include <LibCore/StandardPaths.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <LibURL/InternalURLs.h>
@@ -189,12 +188,8 @@ static bool config_variable_value_is_valid(ConfigVariableDefinition const& varia
     return true;
 }
 
-Settings Settings::create(Badge<Application>)
+Settings Settings::create(ByteString settings_path)
 {
-    // FIXME: Move this to a generic "Ladybird config directory" helper.
-    auto settings_directory = ByteString::formatted("{}/Ladybird", Core::StandardPaths::config_directory());
-    auto settings_path = ByteString::formatted("{}/Settings.json", settings_directory);
-
     Settings settings { move(settings_path) };
 
     auto settings_json = read_json_file(settings.m_settings_path);

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Array.h>
-#include <AK/Badge.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/JsonValue.h>
@@ -106,7 +105,7 @@ public:
 
 class WEBVIEW_API Settings {
 public:
-    static Settings create(Badge<Application>);
+    static Settings create(ByteString settings_path);
 
     JsonValue serialize_json() const;
 

--- a/Meta/migrate-ladybird-profile.py
+++ b/Meta/migrate-ladybird-profile.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026-present, the Ladybird developers.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import argparse
+import os
+import shutil
+import sys
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Migration:
+    label: str
+    source: Path
+    destination: Path
+
+
+def environment_path(name: str) -> Optional[Path]:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return None
+    return Path(value).expanduser()
+
+
+def platform_roots() -> tuple[Path, Path]:
+    home = Path.home()
+    config = environment_path("XDG_CONFIG_HOME")
+    data = environment_path("XDG_DATA_HOME")
+
+    if sys.platform == "darwin":
+        return config or home / "Library" / "Preferences", data or home / "Library" / "Application Support"
+    return config or home / ".config", data or home / ".local" / "share"
+
+
+def migrations() -> list[Migration]:
+    config_root, data_root = platform_roots()
+    legacy_config = config_root / "Ladybird"
+    legacy_data = data_root / "Ladybird"
+
+    return [
+        Migration("configuration", legacy_config, config_root / "Ladybird" / "Profiles" / "default"),
+        Migration("data", legacy_data, data_root / "Ladybird" / "Profiles" / "default"),
+    ]
+
+
+def migratable_entries(source: Path) -> list[Path]:
+    if not source.is_dir():
+        return []
+    return [entry for entry in source.iterdir() if entry.name != "Profiles"]
+
+
+def directory_is_nonempty(path: Path) -> bool:
+    return path.is_dir() and next(path.iterdir(), None) is not None
+
+
+def copy_entry(source: Path, destination: Path) -> None:
+    if source.is_dir() and not source.is_symlink():
+        shutil.copytree(source, destination, symlinks=True)
+    elif source.is_symlink():
+        destination.symlink_to(os.readlink(source), target_is_directory=source.is_dir())
+    else:
+        shutil.copy2(source, destination, follow_symlinks=False)
+
+
+def migrate(migration: Migration) -> None:
+    migration.destination.mkdir(parents=True, exist_ok=True)
+    for entry in migratable_entries(migration.source):
+        copy_entry(entry, migration.destination / entry.name)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Copy Ladybird's legacy configuration and data into the default profile."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show the migration without copying files")
+    parser.add_argument("--yes", action="store_true", help="Migrate without asking for confirmation")
+    return parser.parse_args()
+
+
+def main() -> int:
+    if sys.platform != "darwin" and not sys.platform.startswith("linux"):
+        print("Ladybird profile migration is only supported on macOS and Linux.", file=sys.stderr)
+        return 1
+
+    arguments = parse_arguments()
+    planned_migrations = migrations()
+
+    if not any(migratable_entries(migration.source) for migration in planned_migrations):
+        print("No legacy Ladybird configuration or data was found.", file=sys.stderr)
+        return 1
+
+    for migration in planned_migrations:
+        if directory_is_nonempty(migration.destination):
+            print(
+                f"Refusing to overwrite non-empty {migration.label} profile: {migration.destination}",
+                file=sys.stderr,
+            )
+            return 1
+
+    print("Ladybird must be fully closed before migrating.")
+    for migration in planned_migrations:
+        if migratable_entries(migration.source):
+            print(f"  {migration.label}: {migration.source} -> {migration.destination}")
+    print("Legacy files will be left in place. Cached data will not be copied.")
+
+    if arguments.dry_run:
+        return 0
+
+    if not arguments.yes:
+        try:
+            confirmation = input("Continue? [y/N] ")
+        except EOFError:
+            confirmation = ""
+        if confirmation.lower() not in ("y", "yes"):
+            print("Migration cancelled.")
+            return 1
+
+    try:
+        for migration in planned_migrations:
+            if migratable_entries(migration.source):
+                migrate(migration)
+    except OSError as error:
+        print(f"Migration failed: {error}", file=sys.stderr)
+        return 1
+
+    print("Migration complete. Ladybird will now use the default profile.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Services/Compositor/Sandbox.h
+++ b/Services/Compositor/Sandbox.h
@@ -10,6 +10,6 @@
 
 namespace Compositor {
 
-[[nodiscard]] ErrorOr<void> apply_sandbox();
+[[nodiscard]] ErrorOr<void> apply_sandbox(StringView cache_path);
 
 }

--- a/Services/Compositor/SandboxLinux.cpp
+++ b/Services/Compositor/SandboxLinux.cpp
@@ -15,7 +15,7 @@
 
 namespace Compositor {
 
-ErrorOr<void> apply_sandbox()
+ErrorOr<void> apply_sandbox(StringView)
 {
     TRY(Sandbox::install_no_new_privileges());
     TRY(Sandbox::configure_runtime());

--- a/Services/Compositor/SandboxMacOS.cpp
+++ b/Services/Compositor/SandboxMacOS.cpp
@@ -8,7 +8,6 @@
 #include <AK/LexicalPath.h>
 #include <Compositor/Sandbox.h>
 #include <LibCore/Directory.h>
-#include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibSandbox/Sandbox.h>
@@ -19,7 +18,7 @@
 
 namespace Compositor {
 
-ErrorOr<void> apply_sandbox()
+ErrorOr<void> apply_sandbox(StringView cache_path)
 {
     TRY(Sandbox::configure_runtime());
 
@@ -36,10 +35,8 @@ ErrorOr<void> apply_sandbox()
         TRY(Sandbox::add_seatbelt_path_if_exists(paths, path, Sandbox::SeatbeltPath::Access::ReadOnly));
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, TRY(String::formatted("{}/fonts", WebView::s_ladybird_resource_root)), Sandbox::SeatbeltPath::Access::ReadOnly));
 
-    auto cache_path = Core::StandardPaths::cache_directory();
-    auto skia_cache_path = TRY(String::formatted("{}/Ladybird", cache_path));
-    TRY(Core::Directory::create(skia_cache_path.to_byte_string(), Core::Directory::CreateDirectories::Yes));
-    TRY(Sandbox::add_seatbelt_path_if_exists(paths, skia_cache_path, Sandbox::SeatbeltPath::Access::ReadWrite));
+    TRY(Core::Directory::create(cache_path, Core::Directory::CreateDirectories::Yes));
+    TRY(Sandbox::add_seatbelt_path_if_exists(paths, cache_path, Sandbox::SeatbeltPath::Access::ReadWrite));
 
     char darwin_user_cache_directory[PATH_MAX];
     if (confstr(_CS_DARWIN_USER_CACHE_DIR, darwin_user_cache_directory, sizeof(darwin_user_cache_directory)) > 0) {

--- a/Services/Compositor/SandboxUnimplemented.cpp
+++ b/Services/Compositor/SandboxUnimplemented.cpp
@@ -8,7 +8,7 @@
 
 namespace Compositor {
 
-ErrorOr<void> apply_sandbox()
+ErrorOr<void> apply_sandbox(StringView)
 {
     return {};
 }

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -22,6 +22,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     AK::set_rich_debug_enabled(true);
 
     StringView mach_server_name;
+    StringView cache_path;
     bool wait_for_debugger = false;
     bool enable_test_mode = false;
     bool force_cpu_painting = false;
@@ -31,6 +32,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
+    args_parser.add_option(cache_path, "Path to the profile cache", "cache-path", 0, "path");
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.add_option(enable_test_mode, "Enable test mode", "test-mode");
     args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
@@ -60,7 +62,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto& event_loop = Core::EventLoop::initialize_for_current_thread();
 
     if (!disable_sandbox)
-        TRY(Compositor::apply_sandbox());
+        TRY(Compositor::apply_sandbox(cache_path));
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<Compositor::ConnectionFromClient>(
         mach_server_name, move(skia_backend_context), !disable_async_scrolling));

--- a/Services/RendererSandbox.h
+++ b/Services/RendererSandbox.h
@@ -12,6 +12,6 @@
 
 namespace RendererSandbox {
 
-[[nodiscard]] ErrorOr<void> apply_sandbox(Optional<StringView> config_path);
+[[nodiscard]] ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringView> cache_path);
 
 }

--- a/Services/RendererSandboxLinux.cpp
+++ b/Services/RendererSandboxLinux.cpp
@@ -17,7 +17,7 @@
 
 namespace RendererSandbox {
 
-ErrorOr<void> apply_sandbox(Optional<StringView> config_path)
+ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringView>)
 {
     TRY(Sandbox::install_no_new_privileges());
     TRY(Sandbox::configure_runtime());

--- a/Services/RendererSandboxMacOS.cpp
+++ b/Services/RendererSandboxMacOS.cpp
@@ -7,7 +7,6 @@
 #include <AK/LexicalPath.h>
 #include <LibCore/Directory.h>
 #include <LibCore/Environment.h>
-#include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibSandbox/Sandbox.h>
@@ -34,7 +33,7 @@ static ErrorOr<Optional<ByteString>> canonicalized_path_if_exists(StringView pat
     return ByteString { resolved_path };
 }
 
-ErrorOr<void> apply_sandbox(Optional<StringView> config_path)
+ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringView> cache_path)
 {
     TRY(Sandbox::configure_runtime());
 
@@ -65,9 +64,10 @@ ErrorOr<void> apply_sandbox(Optional<StringView> config_path)
             TRY(executable_paths.try_append(canonicalized_cranelift_compiler_path.release_value()));
     }
 
-    auto skia_cache_path = TRY(String::formatted("{}/Ladybird", Core::StandardPaths::cache_directory()));
-    TRY(Core::Directory::create(skia_cache_path.to_byte_string(), Core::Directory::CreateDirectories::Yes));
-    TRY(Sandbox::add_seatbelt_path_if_exists(paths, skia_cache_path, Sandbox::SeatbeltPath::Access::ReadWrite));
+    if (cache_path.has_value()) {
+        TRY(Core::Directory::create(*cache_path, Core::Directory::CreateDirectories::Yes));
+        TRY(Sandbox::add_seatbelt_path_if_exists(paths, *cache_path, Sandbox::SeatbeltPath::Access::ReadWrite));
+    }
 
     char darwin_user_cache_directory[PATH_MAX];
     if (confstr(_CS_DARWIN_USER_CACHE_DIR, darwin_user_cache_directory, sizeof(darwin_user_cache_directory)) > 0) {

--- a/Services/RendererSandboxUnimplemented.cpp
+++ b/Services/RendererSandboxUnimplemented.cpp
@@ -8,7 +8,7 @@
 
 namespace RendererSandbox {
 
-ErrorOr<void> apply_sandbox(Optional<StringView>)
+ErrorOr<void> apply_sandbox(Optional<StringView>, Optional<StringView>)
 {
     return {};
 }

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -10,7 +10,6 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/Proxy.h>
 #include <LibCore/Socket.h>
-#include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibIPC/TransportHandle.h>
@@ -82,7 +81,7 @@ static auto time_curl_call(StringView label, F&& f)
 static constexpr i64 BURST_WINDOW_MS = 100;
 static constexpr u64 BURST_REPORT_THRESHOLD = 5;
 
-ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport, IsPrimaryConnection is_primary_connection, IsPrivate is_private, ConnectionMap& connections, Optional<HTTP::DiskCache&> disk_cache)
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport, IsPrimaryConnection is_primary_connection, IsPrivate is_private, ConnectionMap& connections, Optional<HTTP::DiskCache&> disk_cache, ByteString alt_svc_cache_path)
     : IPC::ConnectionFromClient<RequestClientEndpoint, RequestServerEndpoint>(*this, move(transport), s_client_ids.allocate())
     , m_is_private(is_private)
     , m_connections(connections)
@@ -91,7 +90,7 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transpo
     , m_resolver(Resolver::default_resolver())
 {
     if (m_is_private == IsPrivate::No)
-        m_alt_svc_cache_path = ByteString::formatted("{}/Ladybird/alt-svc-cache.txt", Core::StandardPaths::cache_directory());
+        m_alt_svc_cache_path = move(alt_svc_cache_path);
 
     if (is_primary_connection == IsPrimaryConnection::Yes) {
         VERIFY(g_primary_connection == nullptr);
@@ -211,7 +210,7 @@ ErrorOr<IPC::TransportHandle> ConnectionFromClient::create_client_socket(IsPriva
     auto disk_cache = is_private == IsPrivate::Yes ? Optional<HTTP::DiskCache&> {} : m_disk_cache;
 
     // Note: A ref is stored in the m_connections map
-    auto client = adopt_ref(*new ConnectionFromClient(move(paired.local), IsPrimaryConnection::No, is_private, m_connections, disk_cache));
+    auto client = adopt_ref(*new ConnectionFromClient(move(paired.local), IsPrimaryConnection::No, is_private, m_connections, disk_cache, m_alt_svc_cache_path.value_or({})));
 
     return handle;
 }

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -49,7 +49,7 @@ public:
     void request_complete(Badge<Request>, Request const&);
 
 private:
-    ConnectionFromClient(NonnullOwnPtr<IPC::Transport>, IsPrimaryConnection, IsPrivate, ConnectionMap&, Optional<HTTP::DiskCache&>);
+    ConnectionFromClient(NonnullOwnPtr<IPC::Transport>, IsPrimaryConnection, IsPrivate, ConnectionMap&, Optional<HTTP::DiskCache&>, ByteString alt_svc_cache_path);
 
     virtual Messages::RequestServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client(IsPrivate) override;

--- a/Services/RequestServer/Sandbox.h
+++ b/Services/RequestServer/Sandbox.h
@@ -12,6 +12,6 @@
 
 namespace RequestServer {
 
-[[nodiscard]] ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates);
+[[nodiscard]] ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates, StringView cache_path);
 
 }

--- a/Services/RequestServer/SandboxLinux.cpp
+++ b/Services/RequestServer/SandboxLinux.cpp
@@ -7,21 +7,19 @@
 #include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <LibCore/Directory.h>
-#include <LibCore/StandardPaths.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibSandbox/Seccomp.h>
 #include <RequestServer/Sandbox.h>
 
 namespace RequestServer {
 
-ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates)
+ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates, StringView cache_path)
 {
     TRY(Sandbox::install_no_new_privileges());
     TRY(Sandbox::configure_runtime());
 
     Vector<Sandbox::LandlockPath> paths;
-    auto cache_path = TRY(String::formatted("{}/Ladybird", Core::StandardPaths::cache_directory()));
-    TRY(Core::Directory::create(cache_path.to_byte_string(), Core::Directory::CreateDirectories::Yes));
+    TRY(Core::Directory::create(cache_path, Core::Directory::CreateDirectories::Yes));
 
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/ssl"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/etc/host.conf"sv, Sandbox::LandlockPath::Access::ReadOnly));

--- a/Services/RequestServer/SandboxMacOS.cpp
+++ b/Services/RequestServer/SandboxMacOS.cpp
@@ -7,7 +7,6 @@
 #include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <LibCore/Directory.h>
-#include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibSandbox/Sandbox.h>
 #include <RequestServer/ResourceSubstitutionMap.h>
@@ -15,13 +14,12 @@
 
 namespace RequestServer {
 
-ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates)
+ErrorOr<void> apply_sandbox(Vector<ByteString> const& certificates, StringView cache_path)
 {
     TRY(Sandbox::configure_runtime());
 
     Vector<Sandbox::SeatbeltPath> paths;
-    auto cache_path = TRY(String::formatted("{}/Ladybird", Core::StandardPaths::cache_directory()));
-    TRY(Core::Directory::create(cache_path.to_byte_string(), Core::Directory::CreateDirectories::Yes));
+    TRY(Core::Directory::create(cache_path, Core::Directory::CreateDirectories::Yes));
 
     auto executable_path = TRY(Core::System::current_executable_path());
     auto build_root = LexicalPath::dirname(LexicalPath::dirname(LexicalPath::dirname(LexicalPath::dirname(LexicalPath::dirname(executable_path)))));

--- a/Services/RequestServer/SandboxUnimplemented.cpp
+++ b/Services/RequestServer/SandboxUnimplemented.cpp
@@ -8,7 +8,7 @@
 
 namespace RequestServer {
 
-ErrorOr<void> apply_sandbox(Vector<ByteString> const&)
+ErrorOr<void> apply_sandbox(Vector<ByteString> const&, StringView)
 {
     return {};
 }

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -43,6 +43,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     StringView mach_server_name;
     StringView http_disk_cache_mode;
     StringView resource_map_path;
+    StringView cache_path;
     bool wait_for_debugger = false;
     bool disable_sandbox = false;
 
@@ -51,6 +52,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
     args_parser.add_option(http_disk_cache_mode, "HTTP disk cache mode", "http-disk-cache-mode", 0, "mode");
     args_parser.add_option(resource_map_path, "Path to JSON file mapping URLs to local files", "resource-map", 0, "path");
+    args_parser.add_option(cache_path, "Path to the profile cache", "cache-path", 0, "path");
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.add_option(disable_sandbox, "Disable process sandboxing", "disable-sandbox");
     args_parser.parse(arguments);
@@ -94,14 +96,14 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
             return Error::from_string_literal("Unrecognized disk cache mode");
         }());
 
-        if (auto cache = HTTP::DiskCache::create(mode); cache.is_error())
+        if (auto cache = HTTP::DiskCache::create(mode, LexicalPath { cache_path }); cache.is_error())
             warnln("Unable to create disk cache: {}", cache.error());
         else
             disk_cache = cache.release_value();
     }
 
     if (!disable_sandbox)
-        TRY(RequestServer::apply_sandbox(certificates));
+        TRY(RequestServer::apply_sandbox(certificates, cache_path));
 
     // Connections are stored on the stack to ensure they are destroyed before static destruction begins. This prevents
     // crashes from notifiers trying to unregister from already-destroyed thread data during process exit.
@@ -112,7 +114,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes,
         RequestServer::IsPrivate::No,
         connections,
-        disk_cache));
+        disk_cache,
+        LexicalPath::join(cache_path, "alt-svc-cache.txt"sv).string()));
 
     return event_loop.exec();
 }

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -131,6 +131,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPlugin);
 
     auto config_path = WebView::s_ladybird_resource_root;
+    StringView cache_path;
     StringView mach_server_name {};
     Vector<ByteString> certificates;
     bool enable_test_mode = false;
@@ -155,6 +156,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.add_option(config_path, "Ladybird configuration path", "config-path", 0, "config_path");
+    args_parser.add_option(cache_path, "Path to the profile cache", "cache-path", 0, "path");
     args_parser.add_option(enable_test_mode, "Enable test mode", "test-mode");
     args_parser.add_option(expose_experimental_interfaces, "Expose experimental IDL interfaces", "expose-experimental-interfaces");
     args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
@@ -257,7 +259,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     }
 
     if (!disable_sandbox)
-        TRY(RendererSandbox::apply_sandbox(config_path));
+        TRY(RendererSandbox::apply_sandbox(config_path, cache_path));
 
 #if defined(AK_OS_MACOS)
     auto browser_port = TRY(Core::MachPort::look_up_from_bootstrap_server(ByteString { mach_server_name }));

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -52,6 +52,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     StringView serenity_resource_root;
     StringView worker_type_string;
     StringView mach_server_name;
+    StringView cache_path;
     Vector<ByteString> certificates;
     bool expose_experimental_interfaces = false;
     bool enable_http_memory_cache = false;
@@ -67,6 +68,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.add_option(worker_type_string, "Type of WebWorker to start (dedicated, shared, or service)", "type", 't', "type");
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
+    args_parser.add_option(cache_path, "Path to the profile cache", "cache-path", 0, "path");
     args_parser.add_option(file_origins_are_tuple_origins, "Treat file:// URLs as having tuple origins", "tuple-file-origins");
     args_parser.add_option(disable_sandbox, "Disable process sandboxing", "disable-sandbox");
 
@@ -98,7 +100,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Web::Bindings::initialize_main_thread_vm(worker_type);
 
     if (!disable_sandbox)
-        TRY(RendererSandbox::apply_sandbox({}));
+        TRY(RendererSandbox::apply_sandbox({}, cache_path));
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<WebWorker::ConnectionFromClient>(mach_server_name));
 

--- a/Tests/LibHTTP/TestDiskCache.cpp
+++ b/Tests/LibHTTP/TestDiskCache.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <LibCore/ImmutableBytes.h>
+#include <LibCore/StandardPaths.h>
 #include <LibHTTP/Cache/CacheRequest.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibHTTP/Cache/Utilities.h>
@@ -21,6 +22,11 @@ struct TestCacheRequest final : public HTTP::CacheRequest {
 static URL::URL parse_url(StringView url)
 {
     return URL::Parser::basic_parse(url).release_value();
+}
+
+static LexicalPath test_cache_root()
+{
+    return LexicalPath::join(Core::StandardPaths::cache_directory(), "Ladybird"sv);
 }
 
 static NonnullRefPtr<HTTP::HeaderList> create_cacheable_request_headers()
@@ -56,7 +62,7 @@ static HTTP::CacheEntryWriter& create_cache_entry(HTTP::DiskCache& disk_cache, T
 
 TEST_CASE(associated_data_round_trips_with_cache_entry)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -88,7 +94,7 @@ TEST_CASE(associated_data_round_trips_with_cache_entry)
 
 TEST_CASE(replacing_cache_entry_removes_associated_data)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -119,7 +125,7 @@ TEST_CASE(replacing_cache_entry_removes_associated_data)
 
 TEST_CASE(flush_returns_mappable_body_file)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -137,7 +143,7 @@ TEST_CASE(flush_returns_mappable_body_file)
 
 TEST_CASE(replacing_cache_entry_keeps_existing_body_mapping_stable)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -164,7 +170,7 @@ TEST_CASE(replacing_cache_entry_keeps_existing_body_mapping_stable)
 
 TEST_CASE(associated_data_round_trips_with_explicit_vary_key)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -195,7 +201,7 @@ TEST_CASE(associated_data_round_trips_with_explicit_vary_key)
 
 TEST_CASE(associated_data_participates_in_cache_eviction)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -23,6 +23,7 @@ public:
 
     virtual void create_platform_arguments(Core::ArgsParser&) override;
     virtual void create_platform_options(WebView::BrowserOptions&, WebView::RequestServerOptions&, WebView::WebContentOptions&) override;
+    virtual bool should_coordinate_browser_process() const override { return false; }
     virtual bool should_capture_web_content_output() const override { return true; }
 
     ErrorOr<void> launch_test_fixtures();

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_SOURCES
     TestHistoryStore.cpp
     TestHSTSStore.cpp
     TestOmnibox.cpp
+    TestProfile.cpp
     TestSessionHistory.cpp
     TestStorageJar.cpp
     TestWebViewURL.cpp

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -12,7 +12,11 @@ set(TEST_SOURCES
 )
 
 foreach(source IN LISTS TEST_SOURCES)
-    ladybird_test("${source}" LibWebView LIBS LibDatabase LibWebView LibURL)
+    set(test_libraries LibDatabase LibWebView LibURL)
+    if (source STREQUAL "TestProfile.cpp")
+        list(APPEND test_libraries LibHTTP)
+    endif()
+    ladybird_test("${source}" LibWebView LIBS ${test_libraries})
 endforeach()
 
 if (NOT WIN32)

--- a/Tests/LibWebView/TestAutocomplete.cpp
+++ b/Tests/LibWebView/TestAutocomplete.cpp
@@ -35,6 +35,8 @@ public:
         browser_options.disable_sql_database = WebView::DisableSQLDatabase::Yes;
         web_content_options.is_test_mode = WebView::IsTestMode::Yes;
     }
+
+    virtual bool should_coordinate_browser_process() const override { return false; }
 };
 
 }

--- a/Tests/LibWebView/TestProfile.cpp
+++ b/Tests/LibWebView/TestProfile.cpp
@@ -4,13 +4,27 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <AK/LexicalPath.h>
+#include <AK/Time.h>
 #include <LibCore/Directory.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
+#include <LibDatabase/Database.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibHTTP/Cache/DiskCache.h>
+#include <LibHTTP/Cookie/ParsedCookie.h>
+#include <LibHTTP/HSTS/ParsedHSTSPolicy.h>
+#include <LibHTTP/HeaderList.h>
 #include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWebView/BookmarkStore.h>
+#include <LibWebView/CookieJar.h>
+#include <LibWebView/HSTSStore.h>
+#include <LibWebView/HistoryStore.h>
 #include <LibWebView/Profile.h>
+#include <LibWebView/Settings.h>
+#include <LibWebView/StorageJar.h>
 
 static ByteString test_root()
 {
@@ -33,6 +47,11 @@ static void remove_test_root()
 {
     if (FileSystem::exists(test_root()))
         MUST(FileSystem::remove(test_root(), FileSystem::RecursionMode::Allowed));
+}
+
+static URL::URL parse_url(StringView url)
+{
+    return URL::Parser::basic_parse(url).release_value();
 }
 
 TEST_CASE(profile_names)
@@ -91,6 +110,19 @@ TEST_CASE(custom_layout)
     remove_test_root();
 }
 
+TEST_CASE(legacy_layout)
+{
+    remove_test_root();
+    auto profile_roots = roots();
+    auto profile = MUST(WebView::Profile::create_legacy(profile_roots));
+    EXPECT_EQ(profile.identifier(), "legacy"sv);
+    EXPECT_EQ(profile.paths().config, LexicalPath::join(profile_roots.config, "Ladybird"sv).string());
+    EXPECT_EQ(profile.paths().data, LexicalPath::join(profile_roots.data, "Ladybird"sv).string());
+    EXPECT_EQ(profile.paths().cache, LexicalPath::join(profile_roots.cache, "Ladybird"sv).string());
+    EXPECT_EQ(profile.paths().runtime, profile_roots.runtime);
+    remove_test_root();
+}
+
 TEST_CASE(invalid_selection)
 {
     remove_test_root();
@@ -117,5 +149,135 @@ TEST_CASE(temporary_profiles_are_unique_and_removed)
     }
     EXPECT(!FileSystem::exists(first_root));
     EXPECT(!FileSystem::exists(second_root));
+    remove_test_root();
+}
+
+TEST_CASE(profile_settings_and_bookmarks_are_isolated)
+{
+    remove_test_root();
+    auto first_profile = MUST(WebView::Profile::create({ .name = "first" }, roots()));
+    auto second_profile = MUST(WebView::Profile::create({ .name = "second" }, roots()));
+
+    auto first_settings_path = LexicalPath::join(first_profile.paths().config, "Settings.json"sv).string();
+    auto second_settings_path = LexicalPath::join(second_profile.paths().config, "Settings.json"sv).string();
+    auto first_settings = WebView::Settings::create(first_settings_path);
+    first_settings.set_show_menu_bar(true);
+    auto second_settings = WebView::Settings::create(second_settings_path);
+    EXPECT(!second_settings.show_menu_bar());
+    EXPECT(WebView::Settings::create(first_settings_path).show_menu_bar());
+
+    auto first_bookmarks_path = LexicalPath::join(first_profile.paths().config, "Bookmarks.json"sv).string();
+    auto second_bookmarks_path = LexicalPath::join(second_profile.paths().config, "Bookmarks.json"sv).string();
+    auto url = URL::Parser::basic_parse("https://profile-isolation.example/"sv).release_value();
+    auto first_bookmarks = WebView::BookmarkStore::create(first_bookmarks_path);
+    first_bookmarks.add_bookmark(url, {}, {});
+    auto second_bookmarks = WebView::BookmarkStore::create(second_bookmarks_path);
+    EXPECT(!second_bookmarks.is_bookmarked(url));
+    EXPECT(WebView::BookmarkStore::create(first_bookmarks_path).is_bookmarked(url));
+    remove_test_root();
+}
+
+TEST_CASE(profile_databases_are_isolated)
+{
+    remove_test_root();
+    auto first_profile = MUST(WebView::Profile::create({ .name = "first" }, roots()));
+    auto second_profile = MUST(WebView::Profile::create({ .name = "second" }, roots()));
+    auto url = parse_url("https://profile-isolation.example/"sv);
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(first_profile.paths().data, "Ladybird"sv));
+        EXPECT_EQ(TRY_OR_FAIL(WebView::CookieJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+        EXPECT_EQ(TRY_OR_FAIL(WebView::HSTSStore::migrate_schema(*database)), Database::MigrationOutcome::Success);
+        EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+
+        auto cookie_jar = TRY_OR_FAIL(WebView::CookieJar::create(*database));
+        HTTP::Cookie::ParsedCookie cookie {
+            .name = "profile"_string,
+            .value = "first"_string,
+            .expiry_time_from_expires_attribute = UnixDateTime::now() + AK::Duration::from_seconds(3600),
+        };
+        cookie_jar->set_cookie(url, cookie, HTTP::Cookie::Source::Http);
+
+        auto hsts_store = TRY_OR_FAIL(WebView::HSTSStore::create(*database));
+        hsts_store->store_policy("profile-isolation.example"_string, HTTP::HSTS::ParsedHSTSPolicy { AK::Duration::from_seconds(3600), false });
+
+        auto storage_jar = TRY_OR_FAIL(WebView::StorageJar::create(*database));
+        storage_jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://profile-isolation.example"_string, "profile"_string, "first"_string);
+    }
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(second_profile.paths().data, "Ladybird"sv));
+        EXPECT_EQ(TRY_OR_FAIL(WebView::CookieJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+        EXPECT_EQ(TRY_OR_FAIL(WebView::HSTSStore::migrate_schema(*database)), Database::MigrationOutcome::Success);
+        EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+
+        auto cookie_jar = TRY_OR_FAIL(WebView::CookieJar::create(*database));
+        EXPECT(cookie_jar->get_all_cookies().is_empty());
+        auto hsts_store = TRY_OR_FAIL(WebView::HSTSStore::create(*database));
+        EXPECT(!hsts_store->is_known_hsts_host("profile-isolation.example"sv));
+        auto storage_jar = TRY_OR_FAIL(WebView::StorageJar::create(*database));
+        EXPECT(!storage_jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://profile-isolation.example"_string, "profile"_string).has_value());
+    }
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(first_profile.paths().data, "Ladybird"sv));
+        auto cookie_jar = TRY_OR_FAIL(WebView::CookieJar::create(*database));
+        EXPECT_EQ(cookie_jar->get_all_cookies().size(), 1uz);
+        auto hsts_store = TRY_OR_FAIL(WebView::HSTSStore::create(*database));
+        EXPECT(hsts_store->is_known_hsts_host("profile-isolation.example"sv));
+        auto storage_jar = TRY_OR_FAIL(WebView::StorageJar::create(*database));
+        EXPECT_EQ(storage_jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://profile-isolation.example"_string, "profile"_string), Optional<String> { "first"_string });
+    }
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(first_profile.paths().data, "History"sv));
+        EXPECT_EQ(TRY_OR_FAIL(WebView::HistoryStore::migrate_schema(*database)), Database::MigrationOutcome::Success);
+        auto history_store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        history_store->record_visit(url, "First profile"_string, UnixDateTime::from_seconds_since_epoch(1));
+    }
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(second_profile.paths().data, "History"sv));
+        EXPECT_EQ(TRY_OR_FAIL(WebView::HistoryStore::migrate_schema(*database)), Database::MigrationOutcome::Success);
+        auto history_store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        EXPECT(!history_store->entry_for_url(url).has_value());
+    }
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(first_profile.paths().data, "History"sv));
+        auto history_store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        EXPECT(history_store->entry_for_url(url).has_value());
+    }
+
+    remove_test_root();
+}
+
+TEST_CASE(profile_caches_are_isolated)
+{
+    remove_test_root();
+    auto first_profile = MUST(WebView::Profile::create({ .name = "first" }, roots()));
+    auto second_profile = MUST(WebView::Profile::create({ .name = "second" }, roots()));
+    auto url = parse_url("https://profile-isolation.example/script.js"sv);
+    auto request_headers = HTTP::HeaderList::create({});
+    auto bytecode = TRY_OR_FAIL(ByteBuffer::copy("first-profile-bytecode"sv.bytes()));
+
+    {
+        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { first_profile.paths().cache }));
+        EXPECT(TRY_OR_FAIL(cache.create_synthetic_entry(url, "GET"sv)));
+        EXPECT(TRY_OR_FAIL(cache.store_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+    }
+
+    {
+        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { second_profile.paths().cache }));
+        EXPECT(!TRY_OR_FAIL(cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode)).has_value());
+    }
+
+    {
+        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { first_profile.paths().cache }));
+        auto retrieved_bytecode = TRY_OR_FAIL(cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+        VERIFY(retrieved_bytecode.has_value());
+        EXPECT_EQ(retrieved_bytecode->bytes(), bytecode.bytes());
+    }
+
     remove_test_root();
 }

--- a/Tests/LibWebView/TestProfile.cpp
+++ b/Tests/LibWebView/TestProfile.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LexicalPath.h>
+#include <LibCore/Directory.h>
+#include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibTest/TestCase.h>
+#include <LibWebView/Profile.h>
+
+static ByteString test_root()
+{
+    return LexicalPath::join(Core::StandardPaths::tempfile_directory(), ByteString::formatted("test-profile-{}", Core::System::getpid())).string();
+}
+
+static WebView::ProfileRoots roots()
+{
+    auto root = test_root();
+    return {
+        .config = LexicalPath::join(root, "config-root"sv).string(),
+        .data = LexicalPath::join(root, "data-root"sv).string(),
+        .cache = LexicalPath::join(root, "cache-root"sv).string(),
+        .runtime = LexicalPath::join(root, "runtime-root"sv).string(),
+        .temporary = LexicalPath::join(root, "temporary-root"sv).string(),
+    };
+}
+
+static void remove_test_root()
+{
+    if (FileSystem::exists(test_root()))
+        MUST(FileSystem::remove(test_root(), FileSystem::RecursionMode::Allowed));
+}
+
+TEST_CASE(profile_names)
+{
+    EXPECT(WebView::Profile::is_valid_name("default"sv));
+    EXPECT(WebView::Profile::is_valid_name("release-2_0"sv));
+    EXPECT(WebView::Profile::is_valid_name("legacy"sv));
+    EXPECT(!WebView::Profile::is_valid_name({}));
+    EXPECT(!WebView::Profile::is_valid_name("Default"sv));
+    EXPECT(!WebView::Profile::is_valid_name("has.dot"sv));
+    EXPECT(!WebView::Profile::is_valid_name("has/slash"sv));
+}
+
+TEST_CASE(routing_identity)
+{
+    EXPECT_EQ(WebView::Profile::routing_identifier("/profiles/default"sv), WebView::Profile::routing_identifier("/profiles/default"sv));
+    EXPECT_NE(WebView::Profile::routing_identifier("/profiles/default"sv), WebView::Profile::routing_identifier("/profiles/work"sv));
+    EXPECT_EQ(WebView::Profile::routing_identifier("/profiles/default"sv).length(), 32u);
+}
+
+TEST_CASE(named_and_default_layouts)
+{
+    remove_test_root();
+    auto profile_roots = roots();
+
+    auto named = MUST(WebView::Profile::create({ .name = "work" }, profile_roots));
+    EXPECT_EQ(named.identifier(), "work"sv);
+    EXPECT_EQ(named.paths().config, LexicalPath::join(profile_roots.config, "Ladybird/Profiles/work"sv).string());
+    EXPECT_EQ(named.paths().data, LexicalPath::join(profile_roots.data, "Ladybird/Profiles/work"sv).string());
+    EXPECT_EQ(named.paths().cache, LexicalPath::join(profile_roots.cache, "Ladybird/Profiles/work"sv).string());
+    EXPECT_EQ(named.paths().runtime, LexicalPath::join(profile_roots.runtime, "Ladybird/Profiles/work"sv).string());
+
+    auto default_profile = MUST(WebView::Profile::create({}, profile_roots));
+    EXPECT_EQ(default_profile.identifier(), "default"sv);
+    EXPECT_EQ(default_profile.paths().config, LexicalPath::join(profile_roots.config, "Ladybird/Profiles/default"sv).string());
+    EXPECT_EQ(default_profile.paths().data, LexicalPath::join(profile_roots.data, "Ladybird/Profiles/default"sv).string());
+    EXPECT_EQ(default_profile.paths().cache, LexicalPath::join(profile_roots.cache, "Ladybird/Profiles/default"sv).string());
+    EXPECT_EQ(default_profile.paths().runtime, LexicalPath::join(profile_roots.runtime, "Ladybird/Profiles/default"sv).string());
+
+    auto explicit_default_profile = MUST(WebView::Profile::create({ .name = "default" }, profile_roots));
+    EXPECT_EQ(explicit_default_profile.paths().identity, default_profile.paths().identity);
+    remove_test_root();
+}
+
+TEST_CASE(custom_layout)
+{
+    remove_test_root();
+    auto root = LexicalPath::join(test_root(), "custom"sv).string();
+    auto profile = MUST(WebView::Profile::create({ .path = root }, roots()));
+    auto canonical_root = MUST(FileSystem::real_path(root));
+    EXPECT_EQ(profile.paths().config, LexicalPath::join(canonical_root, "config"sv).string());
+    EXPECT_EQ(profile.paths().data, LexicalPath::join(canonical_root, "data"sv).string());
+    EXPECT_EQ(profile.paths().cache, LexicalPath::join(canonical_root, "cache"sv).string());
+    EXPECT_EQ(profile.paths().runtime, LexicalPath::join(canonical_root, "runtime"sv).string());
+    EXPECT_EQ(profile.paths().identity, canonical_root);
+    remove_test_root();
+}
+
+TEST_CASE(invalid_selection)
+{
+    remove_test_root();
+    EXPECT(WebView::Profile::create({ .name = "UPPER" }, roots()).is_error());
+    EXPECT(WebView::Profile::create({ .path = "relative/path" }, roots()).is_error());
+    EXPECT(WebView::Profile::create({ .name = "one", .temporary = true }, roots()).is_error());
+    EXPECT(WebView::Profile::create({ .name = "one", .path = "/absolute" }, roots()).is_error());
+    remove_test_root();
+}
+
+TEST_CASE(temporary_profiles_are_unique_and_removed)
+{
+    remove_test_root();
+    ByteString first_root;
+    ByteString second_root;
+    {
+        auto first = MUST(WebView::Profile::create({ .temporary = true }, roots()));
+        auto second = MUST(WebView::Profile::create({ .temporary = true }, roots()));
+        first_root = first.paths().identity;
+        second_root = second.paths().identity;
+        EXPECT_NE(first_root, second_root);
+        EXPECT(FileSystem::is_directory(first.paths().config));
+        EXPECT(FileSystem::is_directory(second.paths().data));
+    }
+    EXPECT(!FileSystem::exists(first_root));
+    EXPECT(!FileSystem::exists(second_root));
+    remove_test_root();
+}

--- a/UI/Android/src/main/cpp/LadybirdActivity.cpp
+++ b/UI/Android/src/main/cpp/LadybirdActivity.cpp
@@ -32,6 +32,9 @@ class Application : public WebView::Application {
 
 public:
     explicit Application();
+
+private:
+    virtual bool should_coordinate_browser_process() const override { return false; }
 };
 
 Application::Application() = default;

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteString.h>
 #include <AK/Function.h>
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
@@ -30,6 +31,16 @@ static constexpr CGFloat const WINDOW_WIDTH = 1000;
 static constexpr CGFloat const WINDOW_HEIGHT = 800;
 static constexpr CGFloat const TAB_ICON_SIZE = 16;
 static constexpr NSUInteger const TAB_LOADING_SPINNER_SEGMENT_COUNT = 12;
+
+static NSString* window_frame_autosave_name()
+{
+    auto const& profile = WebView::Application::profile();
+    if (profile.is_temporary())
+        return nil;
+
+    auto name = ByteString::formatted("window-{}", WebView::Profile::routing_identifier(profile.paths().identity));
+    return Ladybird::string_to_ns_string(name);
+}
 
 class TabSettingsObserver final : public WebView::SettingsObserver {
 public:
@@ -140,13 +151,15 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
                 ? @"LadybirdPrivateBrowsing"
                 : @"LadybirdBrowsing"];
 
-        if ([self isPrivate] == WebView::IsPrivate::No) {
+        auto* frame_autosave_name = window_frame_autosave_name();
+        if ([self isPrivate] == WebView::IsPrivate::No && frame_autosave_name != nil) {
             // Remember last window position.
-            self.frameAutosaveName = @"window";
+            self.frameAutosaveName = frame_autosave_name;
         } else {
-            // Adopt the last saved frame without persisting changes to it, and keep private windows out of window state
-            // restoration entirely.
-            [self setFrameUsingName:@"window"];
+            // Adopt the last saved frame without persisting changes to it, and keep private and temporary-profile
+            // windows out of window state restoration entirely.
+            if (frame_autosave_name != nil)
+                [self setFrameUsingName:frame_autosave_name];
             [self setRestorable:NO];
         }
 

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -42,18 +42,14 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     AK::set_rich_debug_enabled(true);
 
     auto app = TRY(Ladybird::Application::create(arguments));
-    WebView::BrowserProcess browser_process;
+    if (app->should_exit_after_profile_coordination()) {
+        outln("Opening in existing process");
+        return 0;
+    }
+
+    auto& browser_process = app->browser_process();
 
     if (auto const& browser_options = WebView::Application::browser_options(); !browser_options.headless_mode.has_value()) {
-        if (browser_options.force_new_process == WebView::ForceNewProcess::No) {
-            auto disposition = TRY(browser_process.connect(browser_options.raw_urls, browser_options.new_window));
-
-            if (disposition == WebView::BrowserProcess::ProcessDisposition::ExitProcess) {
-                outln("Opening in existing process");
-                return 0;
-            }
-        }
-
         browser_process.on_new_tab = [&](auto const& raw_urls) {
             open_urls_from_client(raw_urls, WebView::NewWindow::No);
         };

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -363,6 +363,7 @@ Application::~Application() = default;
 
 void Application::create_platform_options(WebView::BrowserOptions&, WebView::RequestServerOptions&, WebView::WebContentOptions& web_content_options)
 {
+    Settings::initialize(profile().paths().config);
     web_content_options.config_path = Settings::the()->directory();
 }
 

--- a/UI/Qt/Settings.cpp
+++ b/UI/Qt/Settings.cpp
@@ -12,9 +12,20 @@
 
 namespace Ladybird {
 
-Settings::Settings()
+Settings* Settings::s_the = nullptr;
+
+Settings* Settings::initialize(ByteString config_path)
 {
-    m_qsettings = make<QSettings>(QSettings::IniFormat, QSettings::UserScope, "Ladybird", "Ladybird", this);
+    VERIFY(!s_the);
+    static Settings settings { move(config_path) };
+    return &settings;
+}
+
+Settings::Settings(ByteString config_path)
+{
+    s_the = this;
+    auto settings_path = LexicalPath::join(config_path, "Ladybird.ini"sv).string();
+    m_qsettings = make<QSettings>(QString::fromUtf8(settings_path.characters()), QSettings::IniFormat, this);
 }
 
 ByteString Settings::directory()

--- a/UI/Qt/Settings.h
+++ b/UI/Qt/Settings.h
@@ -25,11 +25,8 @@ public:
     Settings(Settings const&) = delete;
     Settings& operator=(Settings const&) = delete;
 
-    static Settings* the()
-    {
-        static Settings instance;
-        return &instance;
-    }
+    static Settings* initialize(ByteString config_path);
+    static Settings* the() { return s_the; }
 
     ByteString directory();
 
@@ -43,10 +40,11 @@ public:
     void set_is_maximized(bool is_maximized);
 
 protected:
-    Settings();
+    explicit Settings(ByteString config_path);
 
 private:
     OwnPtr<QSettings> m_qsettings;
+    static Settings* s_the;
 };
 
 }

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -52,19 +52,15 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 #endif
 
     auto app = TRY(Ladybird::Application::create(arguments));
+    if (app->should_exit_after_profile_coordination()) {
+        outln("Opening in existing process");
+        return 0;
+    }
+
     app->initialize_macos_application_menu();
-    WebView::BrowserProcess browser_process;
+    auto& browser_process = app->browser_process();
 
     if (auto const& browser_options = Ladybird::Application::browser_options(); !browser_options.headless_mode.has_value()) {
-        if (browser_options.force_new_process == WebView::ForceNewProcess::No) {
-            auto disposition = TRY(browser_process.connect(browser_options.raw_urls, browser_options.new_window));
-
-            if (disposition == WebView::BrowserProcess::ProcessDisposition::ExitProcess) {
-                outln("Opening in existing process");
-                return 0;
-            }
-        }
-
         app->on_open_file = [&](auto const& file_url) {
             if (auto* window = app->active_window_if_any()) {
                 auto& tab = window->new_tab_from_url(file_url, Web::HTML::ActivateTab::Yes, Ladybird::BrowserWindow::TabLocation::end());


### PR DESCRIPTION
Ladybird currently stores mutable browser state directly below its platform config, data, and cache roots. Every installation and invocation therefore shares settings, browsing data, caches, and process coordination, while `--force-new-process` has to disable or partition persistence to avoid two processes using the same state.

Introduce a stable `default` profile and select it before opening stores or launching helper processes. The command line can override it with:

- `--profile NAME` for a named profile in the platform-standard Ladybird profile directories
- `--profile-path ABSOLUTE_PATH` for a self-contained profile root
- `--temporary-profile` for a unique profile removed on clean shutdown

Profile names are restricted to lowercase ASCII letters, digits, `_`, and `-`. Existing unsuffixed state remains untouched. I've included a simple migration script (manually invoked if you care about this) to copy legacy configuration and data into the default profile without copying caches, deleting the source, or overwriting a populated destination.

Route settings, bookmarks, browsing databases, HTTP and Alt-Svc caches, and Ladybird-owned Skia caches through explicit profile paths. Pass those paths to helper processes so their sandbox allowlists match the selected profile. Downloads and other system-owned resources remain shared.

Derive PID files, sockets, startup locks, Mach routing, and AppKit window state from the canonical profile identity. Different profiles can run concurrently, while a second launch of the same profile forwards its URLs before touching persistent state. Keep `--force-new-process` as a deprecated alias for a temporary profile.

Add coverage for profile validation and layouts, temporary cleanup, and isolation of settings, bookmarks, browsing databases, and HTTP cache entries.
