### PR TITLE
LibWeb: Place text control carets from padding clicks

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -2091,7 +2091,18 @@ Optional<Painting::CaretPosition> EventHandler::prepare_mouse_selection(DOM::Doc
     // NB: Now we can do selection with a caret-position hit test. The pre-focus hit node is only preferred while it
     //     is still connected; focus handlers may have replaced it (e.g. an editor placeholder swapped for the real
     //     editing host), in which case the fresh hit test result points at the replacement.
-    auto caret_position = document.caret_position_from_point_for_selection_start(visual_viewport_position);
+    // NB: Text control padding belongs to the host element, while the selectable text lives in its user-agent shadow
+    //     tree. Constrain the hit test to that text so padding clicks snap to its closest caret position.
+    Optional<Painting::CaretPosition> caret_position;
+    if (auto* text_control = as_if<HTML::FormAssociatedTextControlElement>(document.focused_area().ptr()); text_control && editable_hit_node_before_focus) {
+        auto& text_control_element = text_control->text_control_to_html_element();
+        if (text_control_element.is_shadow_including_inclusive_ancestor_of(*editable_hit_node_before_focus)) {
+            if (auto selection_scope = text_control->mouse_selection_scope())
+                caret_position = document.caret_position_from_point_for_selection(visual_viewport_position, selection_scope);
+        }
+    }
+    if (!caret_position.has_value())
+        caret_position = document.caret_position_from_point_for_selection_start(visual_viewport_position);
     if (editable_hit_node_before_focus && editable_hit_node_before_focus->is_connected() && editing_host_before_focus && should_use_caret_position_from_editable_hit_node(caret_position, *editable_hit_node_before_focus, *editing_host_before_focus)) {
         if (auto caret_position_from_hit_node = caret_position_from_editable_hit_node(*editable_hit_node_before_focus); caret_position_from_hit_node.has_value())
             caret_position = caret_position_from_hit_node;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -708,6 +708,18 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_line(CaretLine co
         && (inline_coordinate < inline_axis_start(line.rect, writing_mode) || inline_coordinate >= inline_axis_end(line.rect, writing_mode)))
         return caret_position_for_item(item_at_line_edge(CaretPositionType::After), local_point, CaretPositionType::After);
 
+    // Points past either inline edge resolve to the corresponding logical line edge. This also accounts for a
+    // reversed inline axis, where the logical start is the physically trailing edge.
+    if (inline_coordinate < inline_axis_start(line.rect, writing_mode)) {
+        auto type = inline_axis_is_reverse ? CaretPositionType::After : CaretPositionType::Before;
+        return caret_position_for_item(item_at_line_edge(type), local_point, type);
+    }
+
+    if (inline_coordinate >= inline_axis_end(line.rect, writing_mode)) {
+        auto type = inline_axis_is_reverse ? CaretPositionType::Before : CaretPositionType::After;
+        return caret_position_for_item(item_at_line_edge(type), local_point, type);
+    }
+
     Optional<size_t> closest_item_index;
     auto closest_block_distance = CSSPixels::max();
     auto closest_inline_distance = CSSPixels::max();

--- a/Tests/LibWeb/Text/expected/text-control-padding-caret-placement.txt
+++ b/Tests/LibWeb/Text/expected/text-control-padding-caret-placement.txt
@@ -1,0 +1,16 @@
+textarea LTR, top padding: 0
+textarea LTR, bottom padding: 6
+textarea LTR, leading padding: 0
+textarea LTR, trailing padding: 6
+input LTR, top padding: 0
+input LTR, bottom padding: 6
+input LTR, leading padding: 0
+input LTR, trailing padding: 6
+textarea RTL, top padding: 0
+textarea RTL, bottom padding: 6
+textarea RTL, leading padding: 0
+textarea RTL, trailing padding: 6
+input RTL, top padding: 0
+input RTL, bottom padding: 6
+input RTL, leading padding: 0
+input RTL, trailing padding: 6

--- a/Tests/LibWeb/Text/input/text-control-padding-caret-placement.html
+++ b/Tests/LibWeb/Text/input/text-control-padding-caret-placement.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    input,
+    textarea {
+        box-sizing: border-box;
+        display: block;
+        width: 300px;
+        height: 60px;
+        padding: 15px 30px;
+        border: 1px solid;
+        font: 16px/20px monospace;
+        resize: none;
+    }
+</style>
+<textarea>abcdef</textarea>
+<input value="abcdef">
+<textarea dir="rtl">אבגדהו</textarea>
+<input dir="rtl" value="אבגדהו">
+<script>
+test(() => {
+    const clickAndReport = (control, label, x, y) => {
+        control.focus();
+        control.setSelectionRange(2, 2);
+        internals.click(x, y);
+        println(`${label}: ${control.selectionStart}`);
+    };
+
+    const testControl = (control, label) => {
+        const rect = control.getBoundingClientRect();
+        const lineCenterY = rect.top + 26;
+
+        clickAndReport(control, `${label}, top padding`, rect.left + rect.width / 2, rect.top + 5);
+        clickAndReport(control, `${label}, bottom padding`, rect.left + rect.width / 2, rect.bottom - 5);
+
+        if (control.dir === "rtl") {
+            clickAndReport(control, `${label}, leading padding`, rect.right - 5, lineCenterY);
+            clickAndReport(control, `${label}, trailing padding`, rect.left + 5, lineCenterY);
+        } else {
+            clickAndReport(control, `${label}, leading padding`, rect.left + 5, lineCenterY);
+            clickAndReport(control, `${label}, trailing padding`, rect.right - 5, lineCenterY);
+        }
+    };
+
+    const controls = document.querySelectorAll("textarea, input");
+    testControl(controls[0], "textarea LTR");
+    testControl(controls[1], "input LTR");
+    testControl(controls[2], "textarea RTL");
+    testControl(controls[3], "input RTL");
+});
+</script>


### PR DESCRIPTION
Google's search field uses a one-line textarea with generous padding. Clicking that padding left the caret unchanged because the initial hit test did not resolve against the text in its user-agent shadow tree.

Constrain initial caret hit testing to a focused text control's internal selection scope. Resolve points beyond a line's inline bounds to the logical line edge, taking reversed inline axes into account.

Add regression coverage for input and textarea padding on every side in LTR and RTL controls.