### PR TITLE
UI: Distinguish profiles with Dock icon badges

### DIFF
--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(ladybird_impl STATIC
     Interface/SearchPanel.mm
     Interface/Tab.mm
     Interface/TabController.mm
+    Utilities/ApplicationIcon.mm
     Utilities/Conversions.mm
     Utilities/DictionaryLookup.mm
 )

--- a/UI/AppKit/Utilities/ApplicationIcon.h
+++ b/UI/AppKit/Utilities/ApplicationIcon.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace WebView {
+
+class Profile;
+
+}
+
+namespace Ladybird {
+
+void set_profile_application_icon(WebView::Profile const&);
+
+}

--- a/UI/AppKit/Utilities/ApplicationIcon.mm
+++ b/UI/AppKit/Utilities/ApplicationIcon.mm
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/Profile.h>
+
+#import <Cocoa/Cocoa.h>
+#import <UI/AppKit/Utilities/ApplicationIcon.h>
+
+namespace Ladybird {
+
+void set_profile_application_icon(WebView::Profile const& profile)
+{
+    if (profile.identifier() == "default"sv)
+        return;
+
+    auto label = profile.is_temporary()
+        ? "tmp"sv
+        : profile.identifier().substring_view(0, min(profile.identifier().length(), 3uz));
+    auto* profile_label = [[[NSString alloc] initWithBytes:label.characters_without_null_termination()
+                                                    length:label.length()
+                                                  encoding:NSUTF8StringEncoding]
+        uppercaseString];
+    auto* application_icon = [NSApp applicationIconImage];
+    if (!application_icon)
+        return;
+
+    NSArray<NSColor*>* badge_colors = @[
+        [NSColor colorWithSRGBRed:0.38
+                            green:0.52
+                             blue:0.96
+                            alpha:1],
+        [NSColor colorWithSRGBRed:0.49
+                            green:0.43
+                             blue:0.91
+                            alpha:1],
+        [NSColor colorWithSRGBRed:0.63
+                            green:0.39
+                             blue:0.88
+                            alpha:1],
+        [NSColor colorWithSRGBRed:0.82
+                            green:0.36
+                             blue:0.65
+                            alpha:1],
+        [NSColor colorWithSRGBRed:0.16
+                            green:0.57
+                             blue:0.65
+                            alpha:1],
+        [NSColor colorWithSRGBRed:0.30
+                            green:0.36
+                             blue:0.72
+                            alpha:1],
+    ];
+    auto* badge_color = badge_colors[profile.paths().identity.hash() % [badge_colors count]];
+
+    auto icon_size = [application_icon size];
+    auto* profile_icon = [NSImage imageWithSize:icon_size
+                                        flipped:NO
+                                 drawingHandler:^BOOL(NSRect destination) {
+                                     [application_icon drawInRect:destination];
+
+                                     auto badge_width = NSWidth(destination) * 0.40;
+                                     auto badge_height = NSHeight(destination) * 0.25;
+                                     auto badge_margin = NSWidth(destination) * 0.025;
+                                     auto badge_rect = NSMakeRect(
+                                         NSMaxX(destination) - badge_width - badge_margin,
+                                         NSMinY(destination) + badge_margin,
+                                         badge_width,
+                                         badge_height);
+                                     auto* badge = [NSBezierPath bezierPathWithRoundedRect:badge_rect
+                                                                                   xRadius:badge_height * 0.28
+                                                                                   yRadius:badge_height * 0.28];
+
+                                     [NSGraphicsContext saveGraphicsState];
+                                     auto* shadow = [[NSShadow alloc] init];
+                                     [shadow setShadowBlurRadius:NSWidth(destination) * 0.025];
+                                     [shadow setShadowColor:[NSColor colorWithWhite:0 alpha:0.5]];
+                                     [shadow setShadowOffset:NSMakeSize(0, -NSHeight(destination) * 0.01)];
+                                     [shadow set];
+                                     [badge_color setFill];
+                                     [badge fill];
+                                     [NSGraphicsContext restoreGraphicsState];
+
+                                     auto* font = [NSFont systemFontOfSize:badge_height * 0.52 weight:NSFontWeightHeavy];
+                                     NSDictionary* attributes = @ {
+                                         NSFontAttributeName : font,
+                                         NSForegroundColorAttributeName : [NSColor whiteColor],
+                                     };
+                                     auto text_size = [profile_label sizeWithAttributes:attributes];
+                                     auto text_origin = NSMakePoint(
+                                         NSMidX(badge_rect) - text_size.width / 2,
+                                         NSMidY(badge_rect) - text_size.height / 2);
+                                     [profile_label drawAtPoint:text_origin withAttributes:attributes];
+                                     return YES;
+                                 }];
+    [NSApp setApplicationIconImage:profile_icon];
+}
+
+}

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -14,6 +14,7 @@
 #import <Application/ApplicationDelegate.h>
 #import <Interface/Tab.h>
 #import <Interface/TabController.h>
+#import <Utilities/ApplicationIcon.h>
 
 #if !__has_feature(objc_arc)
 #    error "This project requires ARC"
@@ -50,6 +51,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto& browser_process = app->browser_process();
 
     if (auto const& browser_options = WebView::Application::browser_options(); !browser_options.headless_mode.has_value()) {
+        Ladybird::set_profile_application_icon(WebView::Application::profile());
+
         browser_process.on_new_tab = [&](auto const& raw_urls) {
             open_urls_from_client(raw_urls, WebView::NewWindow::No);
         };

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(ladybird PRIVATE Qt::Core Qt::Gui Qt::Widgets)
 
 if (APPLE)
     target_sources(ladybird PRIVATE
+        ../AppKit/Utilities/ApplicationIcon.mm
         ../AppKit/Utilities/DictionaryLookup.mm
         MacWindow.mm
         WebContentViewMac.mm

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -18,6 +18,7 @@
 #include <QtGlobal>
 
 #if defined(AK_OS_MACOS)
+#    include <UI/AppKit/Utilities/ApplicationIcon.h>
 #    include <UI/Qt/MacWindow.h>
 #endif
 
@@ -61,6 +62,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto& browser_process = app->browser_process();
 
     if (auto const& browser_options = Ladybird::Application::browser_options(); !browser_options.headless_mode.has_value()) {
+#if defined(AK_OS_MACOS)
+        Ladybird::set_profile_application_icon(Ladybird::Application::profile());
+#endif
+
         app->on_open_file = [&](auto const& file_url) {
             if (auto* window = app->active_window_if_any()) {
                 auto& tab = window->new_tab_from_url(file_url, Web::HTML::ActivateTab::Yes, Ladybird::BrowserWindow::TabLocation::end());


### PR DESCRIPTION
Share one Cocoa badge renderer between the Qt and AppKit frontends on macOS. Keep the standard icon for the default profile and overlay a larger badge on other profiles using a curated Ladybird-adjacent color palette and up to the first three characters of the profile name.

Here's how it looks in the dock with my "development" profile:

<img width="71" height="84" alt="image" src="https://github.com/user-attachments/assets/7f0d6259-c716-4a5c-ae34-77b900156add" />
