### PR TITLE
UI/Qt: Offset native macOS window controls

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -63,6 +63,10 @@ static constexpr auto TAB_CLOSE_BUTTON_POSITION = QTabBar::RightSide;
 static constexpr auto WINDOW_DRAG_REGION_PROPERTY = "LadybirdWindowDragRegion";
 static constexpr int WINDOW_RESIZE_BORDER_WIDTH = 6;
 static constexpr int WINDOW_RESIZE_CORNER_WIDTH = WINDOW_RESIZE_BORDER_WIDTH * 2;
+#if defined(AK_OS_MACOS)
+static constexpr int NATIVE_WINDOW_CONTROL_X_OFFSET = 6;
+static constexpr int NATIVE_WINDOW_CONTROL_Y_OFFSET = 6;
+#endif
 
 static bool should_use_screen_signal_for_dpi_changes()
 {
@@ -1216,6 +1220,7 @@ bool BrowserWindow::event(QEvent* event)
 #if defined(AK_OS_MACOS)
             QTimer::singleShot(0, this, [this] {
                 hide_appkit_window_title(*this);
+                offset_appkit_window_controls(*this, NATIVE_WINDOW_CONTROL_X_OFFSET, NATIVE_WINDOW_CONTROL_Y_OFFSET);
             });
 #endif
         } else if (platform_surface_event->surfaceEventType() == QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed) {

--- a/UI/Qt/MacWindow.h
+++ b/UI/Qt/MacWindow.h
@@ -21,6 +21,7 @@ namespace Ladybird {
 
 #if defined(AK_OS_MACOS)
 void hide_appkit_window_title(QWidget&);
+void offset_appkit_window_controls(QWidget&, int x_offset, int y_offset);
 void install_appkit_event_capture();
 void make_appkit_window_first_responder(QWidget&);
 bool start_appkit_window_drag(QWidget&);

--- a/UI/Qt/MacWindow.mm
+++ b/UI/Qt/MacWindow.mm
@@ -15,6 +15,97 @@
 
 #import <Cocoa/Cocoa.h>
 #import <UI/AppKit/Utilities/DictionaryLookup.h>
+#import <objc/runtime.h>
+
+@interface LadybirdWindowControlOffsetObserver : NSObject
+{
+    int m_x_offset;
+    int m_y_offset;
+    NSButton* m_buttons[3];
+    NSPoint m_target_origins[3];
+    bool m_update_scheduled;
+    bool m_is_applying_offset;
+}
+
+- (instancetype)initWithWindow:(NSWindow*)window xOffset:(int)x_offset yOffset:(int)y_offset;
+- (void)applyWindowControlOffsets;
+- (void)scheduleWindowControlOffsetUpdate:(NSButton*)button;
+- (void)windowControlFrameDidChange:(NSNotification*)notification;
+
+@end
+
+@implementation LadybirdWindowControlOffsetObserver
+
+- (instancetype)initWithWindow:(NSWindow*)window xOffset:(int)x_offset yOffset:(int)y_offset
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    m_x_offset = x_offset;
+    m_y_offset = y_offset;
+
+    constexpr NSWindowButton button_types[] = { NSWindowCloseButton, NSWindowMiniaturizeButton, NSWindowZoomButton };
+    for (size_t i = 0; i < std::size(button_types); ++i) {
+        auto* button = [window standardWindowButton:button_types[i]];
+        m_buttons[i] = [button retain];
+        button.postsFrameChangedNotifications = YES;
+        [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(windowControlFrameDidChange:) name:NSViewFrameDidChangeNotification object:button];
+        [self scheduleWindowControlOffsetUpdate:button];
+    }
+
+    return self;
+}
+
+- (void)dealloc
+{
+    [NSNotificationCenter.defaultCenter removeObserver:self];
+    for (auto* button : m_buttons)
+        [button release];
+    [super dealloc];
+}
+
+- (void)applyWindowControlOffsets
+{
+    m_is_applying_offset = true;
+    for (size_t i = 0; i < std::size(m_buttons); ++i)
+        [m_buttons[i] setFrameOrigin:m_target_origins[i]];
+    m_is_applying_offset = false;
+    m_update_scheduled = false;
+}
+
+- (void)scheduleWindowControlOffsetUpdate:(NSButton*)button
+{
+    for (size_t i = 0; i < std::size(m_buttons); ++i) {
+        if (m_buttons[i] != button)
+            continue;
+
+        auto origin = button.frame.origin;
+        origin.x += m_x_offset;
+        origin.y -= m_y_offset;
+        m_target_origins[i] = origin;
+        break;
+    }
+
+    if (m_update_scheduled)
+        return;
+
+    // NB: AppKit ignores frame changes made while its titlebar layout is in progress.
+    //     Apply the offset after that layout pass returns to the main event loop.
+    m_update_scheduled = true;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self applyWindowControlOffsets];
+    });
+}
+
+- (void)windowControlFrameDidChange:(NSNotification*)notification
+{
+    if (m_is_applying_offset)
+        return;
+    [self scheduleWindowControlOffsetUpdate:notification.object];
+}
+
+@end
 
 namespace Ladybird {
 
@@ -215,6 +306,22 @@ void hide_appkit_window_title(QWidget& widget)
         return;
 
     window.titleVisibility = NSWindowTitleHidden;
+}
+
+void offset_appkit_window_controls(QWidget& widget, int x_offset, int y_offset)
+{
+    auto* view = reinterpret_cast<NSView*>(widget.winId());
+    if (!view)
+        return;
+
+    auto* window = view.window;
+    if (!window)
+        return;
+
+    static char observer_key;
+    auto* observer = [[LadybirdWindowControlOffsetObserver alloc] initWithWindow:window xOffset:x_offset yOffset:y_offset];
+    objc_setAssociatedObject(window, &observer_key, observer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [observer release];
 }
 
 void make_appkit_window_first_responder(QWidget& widget)


### PR DESCRIPTION
AppKit lays out the standard window controls after Qt creates the native surface, leaving them misaligned with Ladybird's taller tab strip.

Observe frame changes from the native titlebar layout and reapply a six-point offset after AppKit finishes laying out the controls.

Before:

<img width="848" height="505" alt="Screenshot 2026-07-14 at 02 00 15" src="https://github.com/user-attachments/assets/1c9f5326-389b-4e37-b04a-0c258e693e42" />

After:

<img width="848" height="505" alt="Screenshot 2026-07-14 at 02 13 33" src="https://github.com/user-attachments/assets/bd68cee9-0170-4e90-a3ed-c703b00df361" />
