### PR TITLE
LibWeb: Resolve user-select values without layout nodes

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -47,6 +47,7 @@
 #include <LibWeb/DOM/XMLDocument.h>
 #include <LibWeb/HTML/CustomElements/CustomElementReactionNames.h>
 #include <LibWeb/HTML/CustomElements/CustomElementRegistry.h>
+#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLDocument.h>
 #include <LibWeb/HTML/HTMLFieldSetElement.h>
@@ -125,6 +126,60 @@ Node::Node(Document& document, NodeType type)
 }
 
 Node::~Node() = default;
+
+// https://drafts.csswg.org/css-ui/#propdef-user-select
+CSS::UserSelect Node::user_select_used_value() const
+{
+    auto const* element = as_if<Element>(*this);
+    if (!element) {
+        if (!is_text())
+            return CSS::UserSelect::Text;
+        element = flat_tree_parent_element();
+    }
+
+    if (!element || !element->computed_properties())
+        return CSS::UserSelect::None;
+
+    // The used value is the same as the computed value, except:
+    auto computed_value = element->computed_properties()->user_select();
+
+    // 1. on editable elements where the used value is always 'contain' regardless of the computed value
+
+    // 2. when the computed value is 'auto', in which case the used value is one of the other values as defined below
+
+    // For the purpose of this specification, an editable element is either an editing host or a mutable form control with
+    // textual content, such as textarea.
+    auto* form_control = as_if<HTML::FormAssociatedTextControlElement>(*element);
+    // FIXME: Check if this needs to exclude input elements with types such as color or range, and if so, which ones exactly.
+    if (element->is_editing_host() || (form_control && form_control->text_control_to_html_element().is_mutable()))
+        return CSS::UserSelect::Contain;
+
+    if (computed_value != CSS::UserSelect::Auto)
+        return computed_value;
+
+    // The used value of 'auto' is determined as follows:
+
+    // - On the '::before' and '::after' pseudo-elements, the used value is 'none'
+    // NOTE: Pseudo-elements are handled by Layout::Node::user_select_used_value().
+
+    // - If the element is an editable element, the used value is 'contain'
+    // NOTE: We already handled this above.
+
+    if (auto parent_element = element->element_to_inherit_style_from({})) {
+        auto parent_used_value = parent_element->user_select_used_value();
+
+        // - Otherwise, if the used value of user-select on the parent of this element is 'all', the used value is 'all'
+        if (parent_used_value == CSS::UserSelect::All)
+            return CSS::UserSelect::All;
+
+        // - Otherwise, if the used value of user-select on the parent of this element is 'none', the used value is 'none'
+        if (parent_used_value == CSS::UserSelect::None)
+            return CSS::UserSelect::None;
+    }
+
+    // - Otherwise, the used value is 'text'
+    return CSS::UserSelect::Text;
+}
 
 void Node::finalize()
 {

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -38,6 +38,7 @@ class Document;
 namespace Web::CSS {
 
 class StyleScope;
+enum class UserSelect : u8;
 
 }
 
@@ -173,6 +174,7 @@ public:
     bool is_editing_host() const;
     bool is_editable_or_editing_host() const { return is_editable() || is_editing_host(); }
     GC::Ptr<Node> editing_host();
+    CSS::UserSelect user_select_used_value() const;
 
     bool in_editable_subtree() const { return m_in_editable_subtree; }
     void recompute_editable_subtree_flag();

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -30,7 +30,6 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/Dump.h>
-#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
@@ -1497,50 +1496,22 @@ CSS::UserSelect Node::user_select_used_value() const
     if (!has_style_or_parent_with_style())
         return CSS::UserSelect::None;
 
-    // The used value is the same as the computed value, except:
-    auto computed_value = computed_values().user_select();
-
-    // 1. on editable elements where the used value is always 'contain' regardless of the computed value
-
-    // 2. when the computed value is 'auto', in which case the used value is one of the other values as defined below
-
-    // For the purpose of this specification, an editable element is either an editing host or a mutable form control with
-    // textual content, such as textarea.
-    auto* form_control = as_if<HTML::FormAssociatedTextControlElement>(dom_node());
-    // FIXME: Check if this needs to exclude input elements with types such as color or range, and if so, which ones exactly.
-    if ((dom_node() && dom_node()->is_editing_host()) || (form_control && form_control->text_control_to_html_element().is_mutable())) {
-        return CSS::UserSelect::Contain;
-    } else if (computed_value == CSS::UserSelect::Auto) {
-        // The used value of 'auto' is determined as follows:
-        // - On the '::before' and '::after' pseudo-elements, the used value is 'none'
-        if (is_generated_for_before_pseudo_element() || is_generated_for_after_pseudo_element()) {
-            return CSS::UserSelect::None;
-        }
-
-        // - If the element is an editable element, the used value is 'contain'
-        // NOTE: We already handled this above.
-
-        auto parent_element = parent();
-        if (parent_element) {
-            auto parent_used_value = parent_element->user_select_used_value();
-
-            // - Otherwise, if the used value of user-select on the parent of this element is 'all', the used value is 'all'
-            if (parent_used_value == CSS::UserSelect::All) {
-                return CSS::UserSelect::All;
-            }
-
-            // - Otherwise, if the used value of user-select on the parent of this element is 'none', the used value is
-            //   'none'
-            if (parent_used_value == CSS::UserSelect::None) {
-                return CSS::UserSelect::None;
-            }
-        }
-
-        // - Otherwise, the used value is 'text'
-        return CSS::UserSelect::Text;
+    if (!is_generated_for_pseudo_element()) {
+        if (auto const* node = dom_node())
+            return node->user_select_used_value();
     }
 
-    return computed_value;
+    auto computed_value = computed_values().user_select();
+    if (computed_value != CSS::UserSelect::Auto)
+        return computed_value;
+
+    if (is_generated_for_before_pseudo_element() || is_generated_for_after_pseudo_element())
+        return CSS::UserSelect::None;
+
+    if (auto parent_node = parent())
+        return parent_node->user_select_used_value();
+
+    return CSS::UserSelect::Text;
 }
 
 // https://drafts.csswg.org/css-contain-2/#containment-size

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -2389,11 +2389,6 @@ bool EventHandler::maybe_request_paste_for_middle_click(DOM::Document& document,
 static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_offset, GC::Ptr<DOM::Node> focus_node, size_t focus_offset, Selection::Selection* selection, CSS::UserSelect user_select)
 {
     auto move_focus_before_node = [&](GC::Ref<DOM::Node> node) -> bool {
-        focus_node = node->previous_in_pre_order();
-        if (focus_node) {
-            focus_offset = focus_node->length();
-            return true;
-        }
         if (!node->parent())
             return false;
         focus_node = *node->parent();
@@ -2402,13 +2397,6 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
     };
 
     auto move_focus_after_node = [&](GC::Ref<DOM::Node> node) -> bool {
-        focus_node = node->next_in_pre_order();
-        while (focus_node && node->is_inclusive_ancestor_of(*focus_node))
-            focus_node = focus_node->next_in_pre_order();
-        if (focus_node) {
-            focus_offset = 0;
-            return true;
-        }
         if (!node->parent())
             return false;
         focus_node = *node->parent();
@@ -2427,12 +2415,12 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
         //     focus node, as this means they are inside the same contain element, or not in a contain element at all.
         //     This takes care of the "selection trying to escape from a contain" case.
         while (
-            (!potential_contain_node->is_element() || !potential_contain_node->layout_node() || potential_contain_node->layout_node()->user_select_used_value() != CSS::UserSelect::Contain) && potential_contain_node->parent() && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
+            (!potential_contain_node->is_element() || potential_contain_node->user_select_used_value() != CSS::UserSelect::Contain) && potential_contain_node->parent() && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
             potential_contain_node = potential_contain_node->parent();
         }
 
         if (
-            potential_contain_node->layout_node() && potential_contain_node->layout_node()->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
+            potential_contain_node->is_element() && potential_contain_node->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
             if (focus_node->is_before(*potential_contain_node)) {
                 focus_offset = 0;
             } else {
@@ -2452,11 +2440,11 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
             auto target_node = potential_contain_node;
             potential_contain_node = focus_node;
             while (
-                (!potential_contain_node->is_element() || !potential_contain_node->layout_node() || potential_contain_node->layout_node()->user_select_used_value() != CSS::UserSelect::Contain) && potential_contain_node->parent() && potential_contain_node != target_node) {
+                (!potential_contain_node->is_element() || potential_contain_node->user_select_used_value() != CSS::UserSelect::Contain) && potential_contain_node->parent() && potential_contain_node != target_node) {
                 potential_contain_node = potential_contain_node->parent();
             }
             if (
-                potential_contain_node->layout_node() && potential_contain_node->layout_node()->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*anchor_node)) {
+                potential_contain_node->is_element() && potential_contain_node->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*anchor_node)) {
                 if (potential_contain_node->is_before(*anchor_node)) {
                     if (!move_focus_after_node(*potential_contain_node))
                         return;
@@ -2481,7 +2469,7 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
 
         // A selection started outside of this element must not end in this element. If the user attempts to create such
         // a selection, the UA must instead end the selection range at the element boundary.
-        while (focus_node->parent() && focus_node->parent()->layout_node()->user_select_used_value() == CSS::UserSelect::None) {
+        while (focus_node->parent() && focus_node->parent()->user_select_used_value() == CSS::UserSelect::None) {
             focus_node = focus_node->parent();
         }
         if (focus_node->is_before(*anchor_node)) {
@@ -2500,7 +2488,7 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
         // then the selection must contain the entire element including all its descendants. If the element is selected
         // and the used value of 'user-select' on its parent is 'all', then the parent must be included in the selection,
         // recursively.
-        while (focus_node->parent() && focus_node->parent()->layout_node()->user_select_used_value() == CSS::UserSelect::All) {
+        while (focus_node->parent() && focus_node->parent()->user_select_used_value() == CSS::UserSelect::All) {
             if (anchor_node == focus_node) {
                 anchor_node = focus_node->parent();
             }

--- a/Tests/LibWeb/Text/expected/selection-across-boxless-user-select.txt
+++ b/Tests/LibWeb/Text/expected/selection-across-boxless-user-select.txt
@@ -1,0 +1,13 @@
+control selected anchor: true
+control excluded target: true
+none selected anchor: true
+none excluded target: true
+all selected target: true
+all selected sibling: true
+contain entry selected anchor: true
+contain entry excluded target: true
+contain exit selected anchor: true
+contain exit selected sibling: true
+contain exit excluded target: true
+slot selected anchor: true
+slot excluded target: true

--- a/Tests/LibWeb/Text/input/selection-across-boxless-user-select.html
+++ b/Tests/LibWeb/Text/input/selection-across-boxless-user-select.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body {
+        font: 20px SerenitySans, sans-serif;
+    }
+
+    .case {
+        margin-bottom: 20px;
+    }
+
+    boxless {
+        display: contents;
+    }
+</style>
+
+<div class="case" id="control-case">
+    <span id="controlAnchor">control anchor</span>
+    <boxless><button id="controlTarget">control target</button></boxless>
+</div>
+
+<div class="case" id="none-case">
+    <span id="noneAnchor">none anchor</span>
+    <boxless style="user-select: none">
+        <boxless><span id="noneTarget">none target</span></boxless>
+    </boxless>
+</div>
+
+<div class="case" id="all-case">
+    <span id="allAnchor">all anchor</span>
+    <boxless style="user-select: all">
+        <boxless><span id="allTarget">all target</span></boxless>
+        <span>all sibling</span>
+    </boxless>
+</div>
+
+<div class="case" id="contain-entry-case">
+    <span id="containEntryAnchor">contain entry anchor</span>
+    <boxless style="user-select: contain">
+        <span id="containEntryTarget">contain entry target</span>
+    </boxless>
+</div>
+
+<div class="case" id="contain-exit-case">
+    <boxless style="user-select: contain">
+        <span id="containExitAnchor">contain exit anchor</span>
+        <span>contain sibling</span>
+    </boxless>
+    <span id="containExitTarget">contain exit target</span>
+</div>
+
+<div class="case" id="slot-case">
+    <span id="slotAnchor">slot anchor</span>
+    <span id="slotHost">
+        <template shadowrootmode="open">
+            <slot style="user-select: none"></slot>
+        </template>
+        <span id="slotTarget">slot target</span>
+    </span>
+</div>
+
+<script>
+    function pointInText(element, text, offset) {
+        const node = [...element.childNodes].find(node => node.nodeType === Node.TEXT_NODE && node.data.includes(text));
+        const start = node.data.indexOf(text) + offset;
+        const range = document.createRange();
+        range.setStart(node, start);
+        range.setEnd(node, start + 1);
+        const rect = range.getBoundingClientRect();
+        return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+    }
+
+    function dragSelection(anchor, anchorText, target, targetText) {
+        getSelection().removeAllRanges();
+        const start = pointInText(anchor, anchorText, 1);
+        const end = pointInText(target, targetText, targetText.length - 2);
+        internals.mouseDown(start.x, start.y);
+        internals.mouseMove(end.x, end.y);
+        internals.mouseUp(end.x, end.y);
+        return getSelection().toString();
+    }
+
+    test(() => {
+        document.body.offsetWidth;
+
+        let selection = dragSelection(controlAnchor, "control anchor", controlTarget, "control target");
+        println(`control selected anchor: ${selection.includes("ontrol anchor")}`);
+        println(`control excluded target: ${!selection.includes("control target")}`);
+
+        selection = dragSelection(noneAnchor, "none anchor", noneTarget, "none target");
+        println(`none selected anchor: ${selection.includes("one anchor")}`);
+        println(`none excluded target: ${!selection.includes("none target")}`);
+
+        selection = dragSelection(allAnchor, "all anchor", allTarget, "all target");
+        println(`all selected target: ${selection.includes("all target")}`);
+        println(`all selected sibling: ${selection.includes("all sibling")}`);
+
+        selection = dragSelection(containEntryAnchor, "contain entry anchor", containEntryTarget, "contain entry target");
+        println(`contain entry selected anchor: ${selection.includes("ontain entry anchor")}`);
+        println(`contain entry excluded target: ${!selection.includes("contain entry target")}`);
+
+        selection = dragSelection(containExitAnchor, "contain exit anchor", containExitTarget, "contain exit target");
+        println(`contain exit selected anchor: ${selection.includes("ontain exit anchor")}`);
+        println(`contain exit selected sibling: ${selection.includes("contain sibling")}`);
+        println(`contain exit excluded target: ${!selection.includes("contain exit target")}`);
+
+        selection = dragSelection(slotAnchor, "slot anchor", slotTarget, "slot target");
+        println(`slot selected anchor: ${selection.includes("lot anchor")}`);
+        println(`slot excluded target: ${!selection.includes("slot target")}`);
+    });
+</script>


### PR DESCRIPTION
Resolve user-select used values from DOM computed styles and style inheritance ancestry so display: contents elements participate in the selection algorithm even though they do not generate layout nodes.

Use DOM boundary points when clamping selections. A boxless ancestor can otherwise turn a pre-order position before a control into one after it.

Cover none, all, contain, nested auto, controls, and slotted content across boxless ancestors.

Fixes a crash when dragging selection across comment threads on Reddit.