### PR TITLE
Tests/LibWeb: Fix Sanitizer CI flake in parser many-flat-siblings test

### DIFF
--- a/Tests/LibWeb/Text/input/html-parser-script-created-parser-many-flat-siblings.html
+++ b/Tests/LibWeb/Text/input/html-parser-script-created-parser-many-flat-siblings.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
 <script>
-    internals.setTestTimeout(6000);
+    internals.setTestTimeout(45000);
 
-    // Quadratic performance characteristics in our parser could cause this to timeout.
-    const siblingCount = 20000;
+    // Quadratic performance characteristics in our parser could cause this to timeout. The budget's sized so a healthy
+    // linear parse fits easily even in our Sanitizer CI jobs, while a quadratic parser exceeds it on any machine class.
+    const siblingCount = 40000;
     document.write("<span></span>".repeat(siblingCount) + "<span>PASS</span>");
 
     test(() => {


### PR DESCRIPTION
**Problem:** The `html-parser-script-created-parser-many-flat-siblings.html` test timed out often under CI on arm64 Sanitizer jobs.

**Cause:** With our CI Sanitizer builds, a linear parse runs ~6.5 times slower than in a regular build. With the sibling count at 20000 in the test, a linear parse needs 5.2s to 7.0s on our Sanitizer runners — which straddles the 6000ms budget the test set. So, no single budget could both pass a linear parse in a CI Sanitizer job and also catch a quadratic parse on a fast machine at that document size.

**Fix:** Double the sibling count to 40000 — but also raise the budget to 45000ms. Doubling the size that way doubles the linear-to-quadratic gap (to about 15.6x measured under Sanitizer) — widening both margins at once. A 40000-count linear parse easily stays within that — about 12s in the locally-modeled Sanitizer worst case. But in a Sanitizer build, a 40000-count quadratic parse needs at least 50s — even on a fast machine. And it’ll need several *minutes* on our Sanitizer CI — which would also cause the test to exceed the harness-wide 120s per-test ceiling anyway.
