### PR TITLE
LibWeb: Clear text selection after clicking within it

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -643,7 +643,14 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
         return EventResult::Dropped;
 
     auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
-    dispatch_a_pointer_event_for_a_device_that_supports_hover(PointerEventType::PointerUp, *node, chrome_widget, coordinates, screen_position, {}, button, buttons, modifiers, click_count);
+    [[maybe_unused]] auto dispatch_result = dispatch_a_pointer_event_for_a_device_that_supports_hover(PointerEventType::PointerUp, *node, chrome_widget, coordinates, screen_position, {}, button, buttons, modifiers, click_count);
+
+#if defined(AK_OS_MACOS)
+    // INTEROP: Blink, WebKit, and Gecko defer changing a selection clicked for a possible drag until an uncancelled
+    //          mouseup. Blink and WebKit clear non-editable selections, while Gecko collapses them to a caret.
+    if (m_mousedown_preserved_selection && dispatch_result == PointerEventDispatchResult::RunDefaultActions)
+        finish_selection_from_preserved_mousedown(*document, visual_viewport_position);
+#endif
 
     // FIXME: Per spec, the click target should be the nearest common inclusive ancestor of the pointerdown
     //        and pointerup targets. Currently we require an exact match.
@@ -2221,6 +2228,29 @@ void EventHandler::start_selection_from_preserved_mousedown(DOM::Document& docum
 
     if (auto container = AutoScrollHandler::find_scrollable_ancestor(*caret_position->paintable))
         m_auto_scroll_handler = make<AutoScrollHandler>(m_navigable, *container);
+}
+
+void EventHandler::finish_selection_from_preserved_mousedown(DOM::Document& document, CSSPixelPoint visual_viewport_position)
+{
+    m_mousedown_preserved_selection = false;
+
+    if (!m_mousedown_visual_viewport_position.has_value() || *m_mousedown_visual_viewport_position != visual_viewport_position)
+        return;
+
+    document.update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseUp);
+    if (!paint_root())
+        return;
+
+    auto caret_position = document.caret_position_from_point_for_selection_start(visual_viewport_position);
+    if (!caret_position.has_value())
+        return;
+
+    if (auto* target = document.active_input_events_target(&*caret_position->boundary.node)) {
+        target->set_selection_anchor(*caret_position->boundary.node, caret_position->boundary.offset, caret_position->affinity);
+    } else if (auto selection = document.get_selection()) {
+        selection->remove_all_ranges();
+        document.set_needs_repaint(Badge<EventHandler> {});
+    }
 }
 #endif
 

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -131,6 +131,7 @@ private:
 #if defined(AK_OS_MACOS)
     bool select_word_at_position(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);
     void start_selection_from_preserved_mousedown(DOM::Document&);
+    void finish_selection_from_preserved_mousedown(DOM::Document&, CSSPixelPoint visual_viewport_position);
 #endif
 
     void update_mouse_selection(CSSPixelPoint visual_viewport_position);

--- a/Tests/LibWeb/Text/expected/UIEvents/right-click-selection.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/right-click-selection.txt
@@ -1,3 +1,5 @@
 PASS: right-click selection matches platform behavior
 PASS: right-click preserves existing selection
 PASS: primary mousedown preserves existing selection on macOS
+PASS: primary click clears existing selection
+PASS: cancelling mouseup preserves existing selection on macOS

--- a/Tests/LibWeb/Text/input/UIEvents/right-click-selection.html
+++ b/Tests/LibWeb/Text/input/UIEvents/right-click-selection.html
@@ -51,5 +51,18 @@ body {
             : `FAIL: expected existing selection, got "${getSelection()}"`);
 
         internals.mouseUp(betaCenter.x, betaCenter.y);
+
+        println(getSelection().toString() === ""
+            ? "PASS: primary click clears existing selection"
+            : `FAIL: expected no selection, got "${getSelection()}"`);
+
+        selectAlphaBeta();
+        beta.addEventListener("mouseup", event => event.preventDefault(), { once: true });
+        internals.mouseDown(betaCenter.x, betaCenter.y);
+        internals.mouseUp(betaCenter.x, betaCenter.y);
+
+        println(!navigator.platform.includes("Mac") || getSelection().toString() === "alpha beta"
+            ? "PASS: cancelling mouseup preserves existing selection on macOS"
+            : `FAIL: expected existing selection, got "${getSelection()}"`);
     });
 </script>


### PR DESCRIPTION
Preserve an existing selection on mouse-down so macOS can begin a text drag or dictionary lookup. When an uncancelled mouseup occurs at the original position, clear a document selection or collapse an editable selection to the clicked caret position.

This follows Blink and WebKit for non-editable content. Gecko likewise defers the selection change until mouseup, but collapses non-editable selections to a caret.

Cover completed primary clicks and cancelled mouseup events.