### PR TITLE
LibWeb: Fix input sizing and overflow on Fragonard search

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -186,7 +186,7 @@ static bool is_text_control_input(HTML::HTMLInputElement const& input_element)
     }
 }
 
-static Optional<CSS::SizeWithAspectRatio> appearance_none_text_input_auto_content_box_size(Box const& box)
+static Optional<CSS::SizeWithAspectRatio> default_preferred_size_for_appearance_none_text_input(Box const& box)
 {
     if (box.computed_values().appearance() != CSS::Appearance::None)
         return {};
@@ -195,13 +195,24 @@ static Optional<CSS::SizeWithAspectRatio> appearance_none_text_input_auto_conten
     if (!input_element || !is_text_control_input(*input_element))
         return {};
 
-    // https://drafts.csswg.org/css-ui/#appearance-switching
-    // "Widgets must not have their native appearance, and instead must have their primitive appearance."
+    // https://drafts.csswg.org/css-ui-4/#appearance-switching
+    // The element is rendered following the usual rules of CSS. Replaced elements other than widgets are not affected
+    // by this and remain replaced elements. Widgets must not have their native appearance, and instead must have their
+    // primitive appearance.
     //
-    // https://html.spec.whatwg.org/multipage/input.html#the-size-attribute
-    // "The size attribute gives the number of characters that, in a visual rendering, the user agent is to allow the
-    // user to see while editing the element's value."
-    return TextInputBox::auto_content_box_size_for_text_control(*input_element, box);
+    // https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget
+    // An input element whose type attribute is in one of the above states is an element with default preferred size,
+    // and user agents are expected to apply the 'field-sizing' CSS property to the element.
+    return TextInputBox::default_preferred_size_for_text_control(*input_element, box);
+}
+
+static CSS::SizeWithAspectRatio intrinsic_size_for_replaced_sizing(Box const& box)
+{
+    auto intrinsic_size = box.auto_content_box_size();
+    if (intrinsic_size.has_width() || intrinsic_size.has_height() || intrinsic_size.has_aspect_ratio())
+        return intrinsic_size;
+
+    return default_preferred_size_for_appearance_none_text_input(box).value_or(intrinsic_size);
 }
 
 FormattingContext::FormattingContext(Type type, LayoutMode layout_mode, LayoutState& state, Box const& context_box, FormattingContext* parent)
@@ -965,7 +976,7 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
 
     // If 'height' and 'width' both have computed values of 'auto' and the element also has an intrinsic width,
     // then that intrinsic width is the used value of 'width'.
-    auto intrinsic = box.auto_content_box_size();
+    auto intrinsic = intrinsic_size_for_replaced_sizing(box);
     if (computed_height.is_auto() && computed_width.is_auto() && intrinsic.has_width())
         return intrinsic.width.value();
 
@@ -1069,7 +1080,7 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
 // https://www.w3.org/TR/CSS22/visudet.html#inline-replaced-height
 CSSPixels FormattingContext::tentative_height_for_replaced_element(Box const& box, CSS::Size const& computed_height, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
-    auto intrinsic = box.auto_content_box_size();
+    auto intrinsic = intrinsic_size_for_replaced_sizing(box);
     // If 'height' and 'width' both have computed values of 'auto' and the element also has
     // an intrinsic height, then that intrinsic height is the used value of 'height'.
     if (should_treat_width_as_auto(box, available_space) && should_treat_height_as_auto(box, available_space, containing_block_constraints) && intrinsic.has_height())
@@ -1115,7 +1126,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
     if ((computed_width.is_auto() && computed_height.is_auto() && box.has_preferred_aspect_ratio())) {
         // NOTE: This is a special case where calling tentative_width_for_replaced_element() would call us right back,
         //       and we'd end up in an infinite loop. So we need to handle this case separately.
-        if (auto intrinsic = box.auto_content_box_size(); intrinsic.has_width() || !intrinsic.has_height()) {
+        if (auto intrinsic = intrinsic_size_for_replaced_sizing(box); intrinsic.has_width() || !intrinsic.has_height()) {
             CSSPixels w = tentative_width_for_replaced_element(box, computed_width, available_space, containing_block_constraints);
             CSSPixels h = used_height;
             used_height = solve_replaced_size_constraint(w, h, box, available_space, containing_block_constraints).height();
@@ -2748,9 +2759,9 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
         // size to max-content sizing. Do not use this for min-content sizing: CSS Sizing's "Compressible Replaced
         // Elements" section considers non-button-like <input> controls replaced for the percentage-sized replaced
         // element rule, so their cyclic-percentage min-content contribution can still compress toward zero.
-        if (auto appearance_none_text_input_auto_size = appearance_none_text_input_auto_content_box_size(box);
-            appearance_none_text_input_auto_size.has_value()) {
-            auto_size = appearance_none_text_input_auto_size.value();
+        if (auto default_preferred_size = default_preferred_size_for_appearance_none_text_input(box);
+            default_preferred_size.has_value()) {
+            auto_size = default_preferred_size.value();
         }
     }
     if (auto_size.has_width())

--- a/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
+++ b/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
@@ -118,6 +118,38 @@ static CSSPixelRect apply_css_transform_to_overflow_rect(Box const& box, CSSPixe
     return transformed_rect.to_type<CSSPixels>();
 }
 
+static CSSPixelRect padding_inflated_scrollable_overflow(Box const& box, CSSPixelRect const& in_flow_and_floated_content_bounds)
+{
+    auto const& paintable_box = *box.paintable_box();
+    auto const content_box = paintable_box.absolute_rect();
+    auto const padding_box = paintable_box.absolute_padding_box_rect();
+    auto const& padding = paintable_box.box_model().padding;
+    auto overflow_directions = physical_overflow_directions(box);
+
+    auto left = in_flow_and_floated_content_bounds.left();
+    auto top = in_flow_and_floated_content_bounds.top();
+    auto right = in_flow_and_floated_content_bounds.right();
+    auto bottom = in_flow_and_floated_content_bounds.bottom();
+
+    auto in_flow_bounds_overflow_content_box_in_x_axis = left < content_box.left() || right > content_box.right();
+    if (in_flow_bounds_overflow_content_box_in_x_axis) {
+        if (overflow_directions.x_positive && right > content_box.right())
+            right += padding.right;
+        else if (!overflow_directions.x_positive)
+            left = min(left, padding_box.left()) - padding.left;
+    }
+
+    auto in_flow_bounds_overflow_content_box_in_y_axis = top < content_box.top() || bottom > content_box.bottom();
+    if (in_flow_bounds_overflow_content_box_in_y_axis) {
+        if (overflow_directions.y_positive && bottom > content_box.bottom())
+            bottom += padding.bottom;
+        else if (!overflow_directions.y_positive)
+            top = min(top, padding_box.top()) - padding.top;
+    }
+
+    return { left, top, right - left, bottom - top };
+}
+
 CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const& contained_boxes_map)
 {
     if (!box.paintable_box())
@@ -128,12 +160,14 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
     if (paintable_box.scrollable_overflow_rect().has_value())
         return paintable_box.scrollable_overflow_rect().value();
 
-    // The scrollable overflow area is the union of:
+    // https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-calculation
+    // The scrollable overflow area of a box is the union of:
 
-    // - The scroll container’s own padding box.
+    // - Its own padding box.
     auto const paintable_absolute_padding_box = paintable_box.absolute_padding_box_rect();
     auto const paintable_absolute_content_box = paintable_box.absolute_rect();
     auto scrollable_overflow_rect = paintable_absolute_padding_box;
+    auto in_flow_and_floated_content_bounds = paintable_absolute_content_box;
 
     // Replaced SVG viewports clip their content
     if (is<SVGSVGBox>(box)) {
@@ -145,35 +179,7 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
     }
 
     auto overflow_directions = physical_overflow_directions(box);
-    auto content_overflows_content_box_in_x_axis = false;
-    auto content_overflows_content_box_in_y_axis = false;
-    auto content_overflows_content_box_on_right = false;
-    auto content_overflows_content_box_on_bottom = false;
-
-    auto update_content_overflow_x_axis = [&](CSSPixelRect const& rect) {
-        if (rect.left() < paintable_absolute_content_box.left()
-            || rect.right() > paintable_absolute_content_box.right()) {
-            content_overflows_content_box_in_x_axis = true;
-        }
-        if (rect.right() > paintable_absolute_content_box.right())
-            content_overflows_content_box_on_right = true;
-    };
-
-    auto update_content_overflow_y_axis = [&](CSSPixelRect const& rect) {
-        if (rect.top() < paintable_absolute_content_box.top()
-            || rect.bottom() > paintable_absolute_content_box.bottom()) {
-            content_overflows_content_box_in_y_axis = true;
-        }
-        if (rect.bottom() > paintable_absolute_content_box.bottom())
-            content_overflows_content_box_on_bottom = true;
-    };
-
-    auto update_content_overflow_axes = [&](CSSPixelRect const& rect) {
-        update_content_overflow_x_axis(rect);
-        update_content_overflow_y_axis(rect);
-    };
-
-    // - All line boxes directly contained by the scroll container.
+    // - All line boxes it directly contains.
     if (auto paintable = box.paintable(); auto const* paintable_with_lines = as_if<Painting::PaintableWithLines>(paintable.ptr())) {
         for (auto const& fragment : paintable_with_lines->fragments()) {
             auto fragment_rect = fragment.absolute_rect();
@@ -195,11 +201,9 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
                 }
             }
             scrollable_overflow_rect.unite(fragment_rect);
-            update_content_overflow_axes(fragment_rect);
+            in_flow_and_floated_content_bounds.unite(fragment_rect);
         }
     }
-
-    auto content_overflow_rect = scrollable_overflow_rect;
 
     // - The border boxes of all boxes for which it is the containing block and whose border boxes are positioned not
     //   wholly in the negative scrollable overflow region,
@@ -216,7 +220,8 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
             if (child.is_fixed_position())
                 continue;
 
-            auto child_border_box = apply_css_transform_to_overflow_rect(child, child.paintable_box()->absolute_border_box_rect());
+            auto untransformed_child_border_box = child.paintable_box()->absolute_border_box_rect();
+            auto child_border_box = apply_css_transform_to_overflow_rect(child, untransformed_child_border_box);
 
             // NOTE: Only boxes that are not wholly in the unreachable scrollable overflow region contribute.
             auto wholly_in_unreachable_x = overflow_directions.x_positive
@@ -231,8 +236,8 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
             // Border boxes with zero area do not affect the scrollable overflow area.
             if (!child_border_box.is_empty()) {
                 scrollable_overflow_rect.unite(child_border_box);
-                content_overflow_rect.unite(child_border_box);
-                update_content_overflow_axes(child_border_box);
+                if (child.is_in_flow() || child.is_floating())
+                    in_flow_and_floated_content_bounds.unite(untransformed_child_border_box);
             }
 
             // - The scrollable overflow areas of all of the above boxes (including zero-area boxes and accounting for
@@ -248,11 +253,9 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
                 if (!child_scrollable_overflow.is_empty()) {
                     if (child.computed_values().overflow_x() == CSS::Overflow::Visible) {
                         scrollable_overflow_rect.unite_horizontally(child_scrollable_overflow);
-                        update_content_overflow_x_axis(child_scrollable_overflow);
                     }
                     if (child.computed_values().overflow_y() == CSS::Overflow::Visible) {
                         scrollable_overflow_rect.unite_vertically(child_scrollable_overflow);
-                        update_content_overflow_y_axis(child_scrollable_overflow);
                     }
                 }
             }
@@ -263,40 +266,18 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
 
     // - Additional padding added to the scrollable overflow rectangle as necessary to enable scroll positions that
     //   satisfy the requirements of both place-content: start and place-content: end alignment.
-    auto has_scrollable_overflow_in_x_axis = box.is_scroll_container()
-        && (scrollable_overflow_rect.left() < paintable_absolute_padding_box.left()
-            || scrollable_overflow_rect.right() > paintable_absolute_padding_box.right());
-    auto has_scrollable_overflow_in_y_axis = box.is_scroll_container()
-        && (scrollable_overflow_rect.top() < paintable_absolute_padding_box.top()
-            || scrollable_overflow_rect.bottom() > paintable_absolute_padding_box.bottom());
-    auto has_scrollable_overflow = has_scrollable_overflow_in_x_axis || has_scrollable_overflow_in_y_axis;
-    if (has_scrollable_overflow) {
-        auto left = scrollable_overflow_rect.x();
-        auto top = scrollable_overflow_rect.y();
-        auto right = scrollable_overflow_rect.right();
-        auto bottom = scrollable_overflow_rect.bottom();
+    //
+    // NOTE: This padding represents, within the scrollable overflow rectangle, the box’s own padding so that when its
+    //       content is scrolled to its end, there is padding between the edge of its in-flow (or floated) content and
+    //       the border edge of the box. It typically ends up being exactly the same size as the box's own padding,
+    //       except in a few cases--such as when an out-of-flow positioned element, or the visible overflow of a
+    //       descendent, has already increased the size of the scrollable overflow rectangle outside the conceptual
+    //       “content edge” of the scroll container’s content.
+    if (box.is_scroll_container())
+        scrollable_overflow_rect.unite(padding_inflated_scrollable_overflow(box, in_flow_and_floated_content_bounds));
 
-        if (content_overflows_content_box_in_x_axis) {
-            if (overflow_directions.x_positive && content_overflows_content_box_on_right)
-                right = max(right, content_overflow_rect.right() + paintable_box.box_model().padding.right);
-            else if (!overflow_directions.x_positive)
-                left = min(left, content_overflow_rect.x() - paintable_box.box_model().padding.left);
-        }
-
-        if (content_overflows_content_box_in_y_axis) {
-            if (overflow_directions.y_positive && content_overflows_content_box_on_bottom)
-                bottom = max(bottom, content_overflow_rect.bottom() + paintable_box.box_model().padding.bottom);
-            else if (!overflow_directions.y_positive)
-                top = min(top, content_overflow_rect.y() - paintable_box.box_model().padding.top);
-        }
-
-        scrollable_overflow_rect = {
-            left,
-            top,
-            max(right - left, CSSPixels { 0 }),
-            max(bottom - top, CSSPixels { 0 }),
-        };
-    }
+    auto has_scrollable_overflow = box.is_scroll_container()
+        && !paintable_absolute_padding_box.contains(scrollable_overflow_rect);
 
     // Additionally, due to Web-compatibility constraints (caused by authors exploiting legacy bugs to surreptitiously
     // hide content from visual readers but not search engines and/or speech output), UAs must clip any content in the

--- a/Libraries/LibWeb/Layout/TextInputBox.cpp
+++ b/Libraries/LibWeb/Layout/TextInputBox.cpp
@@ -15,15 +15,27 @@ TextInputBox::TextInputBox(DOM::Document& document, GC::Ptr<DOM::Element> elemen
 
 CSS::SizeWithAspectRatio TextInputBox::compute_auto_content_box_size() const
 {
-    return auto_content_box_size_for_text_control(dom_node(), *this);
+    return default_preferred_size_for_text_control(dom_node(), *this);
 }
 
-CSS::SizeWithAspectRatio TextInputBox::auto_content_box_size_for_text_control(HTML::HTMLInputElement const& input_element, Box const& box)
+CSS::SizeWithAspectRatio TextInputBox::default_preferred_size_for_text_control(HTML::HTMLInputElement const& input_element, Box const& box)
 {
-    // FIXME: Per https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget the
-    //        size attribute should only affect the width of the text entry types (text, search, tel, url, email,
-    //        password). The other types using this box are domain-specific widgets that should ignore it.
+    // https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget
+    // An input element whose type attribute is in one of the above states is an element with default preferred size,
+    // and user agents are expected to apply the 'field-sizing' CSS property to the element. User agents are expected
+    // to determine the inline size of its intrinsic size by the following steps:
+    // [...] If the element has a size attribute, and parsing that attribute's value using the rules for parsing
+    // non-negative integers doesn't generate an error, return the value obtained from applying the converting a
+    // character width to pixels algorithm to the value of the attribute. Otherwise, return the value obtained from
+    // applying the converting a character width to pixels algorithm to the number 20.
+    //
+    // FIXME: Implement the specified "converting a character width to pixels" algorithm. The size attribute should
+    //        also only affect the text entry types (text, search, tel, url, email, password). The other types using
+    //        this box are domain-specific widgets that should ignore it.
     auto width = CSS::Length(input_element.size(), CSS::LengthUnit::Ch).to_px(box);
+
+    // FIXME: HTML does not yet detail the primitive appearance of text inputs. Use one line for the default preferred
+    //        block size, matching the native appearance described by HTML and the behavior of other engines.
     auto height = box.computed_values().line_height();
 
     if (box.computed_values().writing_mode() != CSS::WritingMode::HorizontalTb)

--- a/Libraries/LibWeb/Layout/TextInputBox.h
+++ b/Libraries/LibWeb/Layout/TextInputBox.h
@@ -18,7 +18,7 @@ public:
     TextInputBox(DOM::Document&, GC::Ptr<DOM::Element>, CSS::ComputedProperties const&);
 
     HTML::HTMLInputElement const& dom_node() const { return static_cast<HTML::HTMLInputElement const&>(*Box::dom_node()); }
-    static CSS::SizeWithAspectRatio auto_content_box_size_for_text_control(HTML::HTMLInputElement const&, Box const&);
+    static CSS::SizeWithAspectRatio default_preferred_size_for_text_control(HTML::HTMLInputElement const&, Box const&);
 
     virtual ~TextInputBox() override = default;
 

--- a/Tests/LibWeb/Layout/expected/overflow-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-with-padding.txt
@@ -46,11 +46,11 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x260]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x244]
-      PaintableWithLines (BlockContainer<DIV>.outer) [8,8 452x122] overflow: [9,9 475x152]
+      PaintableWithLines (BlockContainer<DIV>.outer) [8,8 452x122] overflow: [9,9 452x152]
         PaintableWithLines (BlockContainer<DIV>.inner) [34,34 402x102]
           InlinePaintable (InlineNode<SPAN>) [35,35 0x16]
       PaintableWithLines (BlockContainer(anonymous)) [8,130 784x0]
-      PaintableWithLines (BlockContainer<DIV>.outer) [8,130 452x122] overflow: [9,131 475x234]
+      PaintableWithLines (BlockContainer<DIV>.outer) [8,130 452x122] overflow: [9,131 452x234]
         PaintableWithLines (BlockContainer<DIV>.inner) [34,156 402x102]
       PaintableWithLines (BlockContainer(anonymous)) [8,252 784x0]
 

--- a/Tests/LibWeb/Text/expected/css/scrollable-overflow-out-of-flow-end-padding.txt
+++ b/Tests/LibWeb/Text/expected/css/scrollable-overflow-out-of-flow-end-padding.txt
@@ -1,0 +1,2 @@
+at padding edge: 70
+beyond padding edge: 80

--- a/Tests/LibWeb/Text/expected/input-appearance-none-normalized-table-display-height.txt
+++ b/Tests/LibWeb/Text/expected/input-appearance-none-normalized-table-display-height.txt
@@ -1,0 +1,1 @@
+Normalized table-cell height matches block height: true

--- a/Tests/LibWeb/Text/input/css/scrollable-overflow-out-of-flow-end-padding.html
+++ b/Tests/LibWeb/Text/input/css/scrollable-overflow-out-of-flow-end-padding.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-calculation">
+<script src="../include.js"></script>
+<style>
+    .scroller {
+        box-sizing: border-box;
+        display: flex;
+        width: 100px;
+        height: 70px;
+        padding-block: 30px 20px;
+        overflow-x: scroll;
+        scrollbar-width: none;
+    }
+
+    .item {
+        position: relative;
+        flex: none;
+        width: 200px;
+        height: 20px;
+    }
+
+    .item::after {
+        content: "";
+        position: absolute;
+        bottom: var(--bottom);
+        width: 1px;
+        height: 1px;
+    }
+</style>
+<div class="scroller" style="--bottom: -20px"><div class="item"></div></div>
+<div class="scroller" style="--bottom: -30px"><div class="item"></div></div>
+<script>
+    test(() => {
+        const scrollers = document.querySelectorAll(".scroller");
+        println(`at padding edge: ${scrollers[0].scrollHeight}`);
+        println(`beyond padding edge: ${scrollers[1].scrollHeight}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/input-appearance-none-normalized-table-display-height.html
+++ b/Tests/LibWeb/Text/input/input-appearance-none-normalized-table-display-height.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#table-structure">
+<link rel="help" href="https://drafts.csswg.org/css-ui/#appearance-switching">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget">
+<script src="include.js"></script>
+<style>
+    input {
+        appearance: none;
+        border: 0;
+        float: left;
+        font: 16px/18px Arial;
+        height: auto;
+        padding: 12px;
+        width: 200px;
+    }
+
+    #normalized-table-cell {
+        display: table-cell;
+    }
+
+    #block {
+        display: block;
+    }
+</style>
+<input id="normalized-table-cell">
+<input id="block">
+<script>
+    test(() => {
+        const normalizedTableCellHeight = document.getElementById("normalized-table-cell").getBoundingClientRect().height;
+        const blockHeight = document.getElementById("block").getBoundingClientRect().height;
+        println(`Normalized table-cell height matches block height: ${normalizedTableCellHeight === blockHeight}`);
+    });
+</script>


### PR DESCRIPTION
Preserve the default preferred size of `appearance: none` text inputs when table display normalization causes them to use replaced-element sizing. This prevents their automatic height from falling back to the generic 150px replaced-element height.

Also track in-flow content bounds separately when calculating scrollable overflow. This avoids adding end padding again when positioned descendants or propagated visible overflow have already extended the scrollable area.

Add regression coverage for both layout issues and correct the existing in-flow padding expectation.

Before:

<img width="2414" height="1708" alt="Screenshot at 2026-07-14 09-36-05" src="https://github.com/user-attachments/assets/aa444a3d-013d-4ffc-b4f1-8ea2f42a5c14" />

After:

<img width="2414" height="1708" alt="Screenshot at 2026-07-14 09-36-32" src="https://github.com/user-attachments/assets/b63353f4-bfd8-4ba3-b035-cec6db3a0dce" />