### PR TITLE
Ladybird: Fix assorted UI papercuts

### DIFF
--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -439,6 +439,19 @@ void Application::set_active_window(BrowserWindow& window)
     update_macos_application_menu();
 }
 
+BrowserWindow* Application::non_private_window_if_any() const
+{
+    if (m_active_window && m_active_window->is_private() == WebView::IsPrivate::No)
+        return m_active_window;
+
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (auto* window = as_if<BrowserWindow>(widget); window && window->is_private() == WebView::IsPrivate::No)
+            return window;
+    }
+
+    return nullptr;
+}
+
 WindowConfiguration Application::configuration_for_new_window() const
 {
     if (auto* previous_active_window = active_window_if_any(); previous_active_window && previous_active_window->isVisible()) {

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -392,7 +392,7 @@ Core::EventLoop& Application::create_platform_event_loop()
     return event_loop;
 }
 
-BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& configuration, BrowserWindow::IsPopupWindow is_popup_window, WebView::IsPrivate is_private, Tab* parent_tab, Optional<u64> page_index)
+BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& configuration, BrowserWindow::IsPopupWindow is_popup_window, WebView::IsPrivate is_private, Tab* parent_tab, Optional<u64> page_index, ShowWindow show_window)
 {
     auto* window = new BrowserWindow(initial_urls, is_popup_window, is_private, parent_tab, move(page_index));
     set_active_window(*window);
@@ -410,13 +410,15 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Win
     }
 
     window->set_window_rect(configuration.x, configuration.y, configuration.width, configuration.height);
-    if (configuration.maximized == true)
-        window->showMaximized();
-    else
-        window->show();
+    if (show_window == ShowWindow::Yes) {
+        if (configuration.maximized == true)
+            window->showMaximized();
+        else
+            window->show();
 
-    window->activateWindow();
-    window->raise();
+        window->activateWindow();
+        window->raise();
+    }
 
     size_t initial_url_index = 0;
     window->for_each_tab([&](Tab& tab) {
@@ -424,7 +426,7 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Win
             tab.navigate(initial_urls[initial_url_index++]);
     });
 
-    if (should_focus_location_editor) {
+    if (should_focus_location_editor && show_window == ShowWindow::Yes) {
         QTimer::singleShot(0, window, [window] {
             if (auto* tab = window->current_tab())
                 tab->focus_location_editor();

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -28,6 +28,11 @@ struct WindowConfiguration {
     Optional<bool> maximized {};
 };
 
+enum class ShowWindow {
+    No,
+    Yes,
+};
+
 class Application final : public WebView::Application {
     WEB_VIEW_APPLICATION(Application)
 
@@ -36,7 +41,7 @@ public:
 
     Function<void(URL::URL)> on_open_file;
 
-    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& = {}, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, WebView::IsPrivate = WebView::IsPrivate::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& = {}, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, WebView::IsPrivate = WebView::IsPrivate::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {}, ShowWindow = ShowWindow::Yes);
     WindowConfiguration configuration_for_new_window() const;
     void open_new_tab();
     void open_new_window(WebView::IsPrivate);

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -52,6 +52,7 @@ public:
     BrowserWindow& active_window() const { return *m_active_window; }
     void set_active_window(BrowserWindow&);
     BrowserWindow* active_window_if_any() const { return m_active_window; }
+    BrowserWindow* non_private_window_if_any() const;
 
     Tab* active_tab() const { return m_active_window ? m_active_window->current_tab() : nullptr; }
     void update_reopen_recently_closed_actions() const;

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -682,6 +682,7 @@ void BrowserWindow::adopt_tab(Tab& tab, int index)
 
     tab.set_window(*this);
     m_tabs_container->insert_tab(index, &tab, "New Tab");
+    tab.view().finish_window_move();
     initialize_tab(&tab);
     tab_title_changed(index, tab.title());
 
@@ -708,6 +709,7 @@ void BrowserWindow::move_tab_to_window(int index, BrowserWindow& target_window, 
         return;
 
     auto* tab = m_tabs_container->tab(index);
+    tab->view().prepare_for_window_move();
     uninitialize_tab(tab);
     m_tabs_container->take_tab(index);
     if (m_current_tab == tab)
@@ -734,8 +736,16 @@ void BrowserWindow::detach_tab_to_new_window(int index, QPoint global_position)
         .maximized = isMaximized(),
     };
 
-    auto& window = Application::the().new_window({}, configuration, IsPopupWindow::No, m_is_private);
+    auto& window = Application::the().new_window({}, configuration, IsPopupWindow::No, m_is_private, nullptr, {}, ShowWindow::No);
     move_tab_to_window(index, window, 0);
+
+    if (configuration.maximized == true)
+        window.showMaximized();
+    else
+        window.show();
+
+    window.activateWindow();
+    window.raise();
 }
 
 void BrowserWindow::set_current_tab(Tab* tab)

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -654,9 +654,10 @@ void BrowserWindow::initialize_tab(Tab* tab)
 
     tab->view().on_new_web_view = [this, tab](auto activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) {
         if (hints.popup) {
+            auto cascaded_configuration = Application::the().configuration_for_new_window();
             WindowConfiguration configuration {
-                .x = hints.screen_x,
-                .y = hints.screen_y,
+                .x = hints.screen_x.has_value() ? hints.screen_x : cascaded_configuration.x,
+                .y = hints.screen_y.has_value() ? hints.screen_y : cascaded_configuration.y,
                 .width = hints.width,
                 .height = hints.height,
             };

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -7,9 +7,11 @@
 #include <LibURL/Parser.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/HistoryStore.h>
+#include <UI/Qt/Application.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/StringUtils.h>
+#include <UI/Qt/Tab.h>
 #include <UI/Qt/WebContentView.h>
 
 #include <QAction>
@@ -108,6 +110,11 @@ private:
                 if (action->is_checkable())
                     action->set_checked(checked);
                 action->activate();
+
+                if (action->id() == WebView::ActionID::BookmarkItem) {
+                    if (auto* active_tab = Application::the().active_tab())
+                        active_tab->view().setFocus();
+                }
             }
         });
         QObject::connect(m_action->parent(), &QObject::destroyed, [this, weak_action = action.make_weak_ptr()]() {

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -36,6 +36,7 @@
 
 #include <QApplication>
 #include <QCursor>
+#include <QEvent>
 #include <QGuiApplication>
 #include <QIcon>
 #include <QInputDevice>
@@ -227,6 +228,26 @@ WebContentView::~WebContentView()
     release_metal_resources();
 #elif defined(LADYBIRD_QT_USE_VULKAN_WINDOW)
     destroy_vulkan_window();
+#endif
+}
+
+void WebContentView::prepare_for_window_move()
+{
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
+    hide();
+
+    QEvent window_about_to_change_event { QEvent::WindowAboutToChangeInternal };
+    QCoreApplication::sendEvent(this, &window_about_to_change_event);
+
+    destroy();
+#endif
+}
+
+void WebContentView::finish_window_move()
+{
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
+    create();
+    show();
 #endif
 }
 

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -94,6 +94,8 @@ public:
     void set_maximum_frames_per_second(double);
     void set_display_metadata(Optional<u64> display_id, double maximum_frames_per_second);
     void set_vertical_tab_overlay_insets(int left, int right);
+    void prepare_for_window_move();
+    void finish_window_move();
 
     enum class PaletteMode {
         Default,

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -67,7 +67,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 #endif
 
         app->on_open_file = [&](auto const& file_url) {
-            if (auto* window = app->active_window_if_any()) {
+            if (auto* window = app->non_private_window_if_any()) {
                 auto& tab = window->new_tab_from_url(file_url, Web::HTML::ActivateTab::Yes, Ladybird::BrowserWindow::TabLocation::end());
                 tab.set_url_is_hidden(false);
                 auto& view = tab.view();


### PR DESCRIPTION
Polish several interactions in the Qt frontend:

- Return focus to the web view after opening a bookmark.
- Open externally requested URLs in a non-private window.
- Safely recreate the rendering surface when detaching a tab.
- Cascade popups when explicit coordinates are not provided.