### PR TITLE
LibWeb: Detach chrome widgets from stale paintables

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -884,6 +884,7 @@ set(SOURCES
     Painting/Canvas2DCommandStream.cpp
     Painting/CanvasPaintable.cpp
     Painting/CheckBoxPaintable.cpp
+    Painting/ChromeWidget.cpp
     Painting/DisplayList.cpp
     Painting/DisplayListCommand.cpp
     Painting/DisplayListDamage.cpp

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1428,6 +1428,9 @@ void Node::clear_paintable()
     if (m_paintable) {
         if (m_paintable->parent())
             m_paintable->remove();
+        // NB: Layout state may retain this paintable after it stops being the node's current paintable, but its
+        //     chrome widgets must no longer use it for input handling.
+        m_paintable->detach_chrome_widgets();
         m_paintable = nullptr;
     }
 }

--- a/Libraries/LibWeb/Painting/ChromeWidget.cpp
+++ b/Libraries/LibWeb/Painting/ChromeWidget.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Painting/ChromeWidget.h>
+#include <LibWeb/Painting/Paintable.h>
+
+namespace Web::Painting {
+
+ChromeWidget::ChromeWidget(Paintable& paintable)
+    : m_paintable(paintable)
+{
+}
+
+RefPtr<Paintable> ChromeWidget::paintable() const
+{
+    return m_paintable.strong_ref();
+}
+
+void ChromeWidget::detach_from_paintable(Badge<Paintable>)
+{
+    m_paintable.clear();
+    did_detach_from_paintable();
+}
+
+}

--- a/Libraries/LibWeb/Painting/ChromeWidget.h
+++ b/Libraries/LibWeb/Painting/ChromeWidget.h
@@ -6,9 +6,12 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/EnumBits.h>
 #include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
 #include <AK/Utf16FlyString.h>
+#include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 #include <LibGC/Cell.h>
 #include <LibWeb/CSS/ComputedValues.h>
@@ -43,6 +46,19 @@ public:
     virtual void mouse_leave() = 0;
 
     virtual Optional<CSS::CursorPredefined> cursor() const { return {}; }
+
+protected:
+    explicit ChromeWidget(Paintable&);
+
+    RefPtr<Paintable> paintable() const;
+
+private:
+    friend class Paintable;
+
+    void detach_from_paintable(Badge<Paintable>);
+    virtual void did_detach_from_paintable() { }
+
+    WeakPtr<Paintable> m_paintable;
 };
 
 }

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -972,6 +972,29 @@ Paintable::~Paintable()
         invalidate_paint_cache();
 }
 
+void Paintable::detach_from_layout_node(Badge<Layout::Node>)
+{
+    m_containing_block.clear();
+    m_layout_node.clear();
+    detach_chrome_widgets();
+}
+
+void Paintable::detach_chrome_widgets()
+{
+    if (m_horizontal_scrollbar) {
+        m_horizontal_scrollbar->detach_from_paintable({});
+        m_horizontal_scrollbar = nullptr;
+    }
+    if (m_vertical_scrollbar) {
+        m_vertical_scrollbar->detach_from_paintable({});
+        m_vertical_scrollbar = nullptr;
+    }
+    if (m_resize_handle) {
+        m_resize_handle->detach_from_paintable({});
+        m_resize_handle = nullptr;
+    }
+}
+
 Layout::NodeWithStyleAndBoxModelMetrics const& Paintable::layout_node_with_style_and_box_metrics() const
 {
     return as<Layout::NodeWithStyleAndBoxModelMetrics const>(layout_node());

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -466,11 +466,8 @@ private:
         Yes,
     };
 
-    void detach_from_layout_node(Badge<Layout::Node>)
-    {
-        m_containing_block.clear();
-        m_layout_node.clear();
-    }
+    void detach_from_layout_node(Badge<Layout::Node>);
+    void detach_chrome_widgets();
 
     void paint_middle_button_scroll_indicator(DisplayListRecordingContext&) const;
     void acquire_cache_references_for_cached_commands(ReadonlyBytes) const;

--- a/Libraries/LibWeb/Painting/ResizeHandle.cpp
+++ b/Libraries/LibWeb/Painting/ResizeHandle.cpp
@@ -21,14 +21,14 @@ NonnullRefPtr<ResizeHandle> ResizeHandle::create(Paintable& paintable_box)
 }
 
 ResizeHandle::ResizeHandle(Paintable& paintable_box)
-    : m_paintable_box(paintable_box)
+    : ChromeWidget(paintable_box)
     , m_element(as<DOM::Element>(*paintable_box.dom_node()))
 {
 }
 
 bool ResizeHandle::contains(CSSPixelPoint position, ChromeMetrics const& metrics) const
 {
-    auto paintable_box = m_paintable_box.strong_ref();
+    auto paintable_box = paintable();
     if (!paintable_box)
         return false;
     return paintable_box->resizer_contains(position, metrics);
@@ -36,7 +36,7 @@ bool ResizeHandle::contains(CSSPixelPoint position, ChromeMetrics const& metrics
 
 Optional<CSS::CursorPredefined> ResizeHandle::cursor() const
 {
-    auto paintable_box = m_paintable_box.strong_ref();
+    auto paintable_box = paintable();
     if (!paintable_box)
         return {};
     auto axes = paintable_box->physical_resize_axes();

--- a/Libraries/LibWeb/Painting/ResizeHandle.h
+++ b/Libraries/LibWeb/Painting/ResizeHandle.h
@@ -27,7 +27,6 @@ public:
 private:
     ResizeHandle(Paintable&);
 
-    WeakPtr<Paintable> m_paintable_box;
     GC::Weak<DOM::Element> m_element;
     OwnPtr<ElementResizeAction> m_resize_action;
 };

--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -20,14 +20,14 @@ NonnullRefPtr<Scrollbar> Scrollbar::create(Paintable& paintable_box, Paintable::
 }
 
 Scrollbar::Scrollbar(Paintable& paintable_box, Paintable::ScrollDirection direction)
-    : m_paintable_box(paintable_box)
+    : ChromeWidget(paintable_box)
     , m_direction(direction)
 {
 }
 
 bool Scrollbar::contains(CSSPixelPoint position, ChromeMetrics const& metrics) const
 {
-    auto paintable_box = m_paintable_box.strong_ref();
+    auto paintable_box = paintable();
     if (!paintable_box)
         return false;
     if (auto rect = paintable_box->absolute_scrollbar_rect(m_direction, is_enlarged(), metrics); rect.has_value())
@@ -44,9 +44,11 @@ MouseAction Scrollbar::handle_pointer_event(Utf16FlyString const& type, unsigned
         return MouseAction::None;
     }
 
-    auto paintable_box = m_paintable_box.strong_ref();
-    if (!paintable_box)
+    auto paintable_box = paintable();
+    if (!paintable_box) {
+        m_thumb_grab_position.clear();
         return MouseAction::None;
+    }
 
     auto position = paintable_box->transform_to_local_coordinates(visual_viewport_position);
     if (!scroll_to_mouse_position(position) && !m_thumb_grab_position.has_value())
@@ -64,7 +66,7 @@ MouseAction Scrollbar::handle_pointer_event(Utf16FlyString const& type, unsigned
 MouseAction Scrollbar::mouse_move(CSSPixelPoint position)
 {
     if (m_thumb_grab_position.has_value()) {
-        auto paintable_box = m_paintable_box.strong_ref();
+        auto paintable_box = paintable();
         if (!paintable_box)
             return MouseAction::None;
         position = paintable_box->transform_to_local_coordinates(position);
@@ -77,7 +79,7 @@ MouseAction Scrollbar::mouse_move(CSSPixelPoint position)
 MouseAction Scrollbar::mouse_up(CSSPixelPoint, unsigned)
 {
     m_thumb_grab_position.clear();
-    if (auto paintable_box = m_paintable_box.strong_ref())
+    if (auto paintable_box = paintable())
         paintable_box->set_needs_repaint();
     return MouseAction::None;
 }
@@ -87,7 +89,7 @@ void Scrollbar::mouse_enter()
     if (m_hovered)
         return;
     m_hovered = true;
-    if (auto paintable_box = m_paintable_box.strong_ref())
+    if (auto paintable_box = paintable())
         paintable_box->set_needs_repaint();
 }
 
@@ -96,13 +98,13 @@ void Scrollbar::mouse_leave()
     if (!m_hovered)
         return;
     m_hovered = false;
-    if (auto paintable_box = m_paintable_box.strong_ref())
+    if (auto paintable_box = paintable())
         paintable_box->set_needs_repaint();
 }
 
 bool Scrollbar::scroll_to_mouse_position(CSSPixelPoint position)
 {
-    auto paintable_box = m_paintable_box.strong_ref();
+    auto paintable_box = paintable();
     if (!paintable_box)
         return false;
 
@@ -138,6 +140,12 @@ bool Scrollbar::scroll_to_mouse_position(CSSPixelPoint position)
     new_scroll_offset.set_primary_offset_for_orientation(orientation, scroll_position_in_pixels);
     paintable_box->set_scroll_offset(new_scroll_offset);
     return true;
+}
+
+void Scrollbar::did_detach_from_paintable()
+{
+    m_hovered = false;
+    m_thumb_grab_position.clear();
 }
 
 }

--- a/Libraries/LibWeb/Painting/Scrollbar.h
+++ b/Libraries/LibWeb/Painting/Scrollbar.h
@@ -31,8 +31,8 @@ private:
     MouseAction mouse_move(CSSPixelPoint);
     MouseAction mouse_up(CSSPixelPoint, unsigned button);
     bool scroll_to_mouse_position(CSSPixelPoint);
+    virtual void did_detach_from_paintable() override;
 
-    WeakPtr<Paintable> m_paintable_box;
     Paintable::ScrollDirection m_direction;
     bool m_hovered { false };
     Optional<CSSPixels> m_thumb_grab_position;

--- a/Tests/LibWeb/Text/input/UIEvents/scrollbar-capture-removed-during-drag.html
+++ b/Tests/LibWeb/Text/input/UIEvents/scrollbar-capture-removed-during-drag.html
@@ -30,6 +30,15 @@ body {
         internals.mouseMove(80, 97);
         internals.mouseUp(80, 97);
 
+        scrollable.style.overflowX = "scroll";
+        internals.mouseDown(50, 97);
+        internals.mouseMove(80, 50);
+        scrollable.addEventListener("mouseover", () => {
+            scrollable.remove();
+        }, { once: true });
+        internals.mouseMove(80, 97);
+        internals.mouseUp(80, 97);
+
         println("PASS");
     });
 </script>


### PR DESCRIPTION
Script can rebuild layout while a scrollbar owns chrome widget capture. Hit-test results and layout state may keep an old paintable alive after it stops being the layout node’s current paintable. Its weak layout-node link can later disappear while a captured scrollbar still refers to it.

Make ChromeWidget own the common weak paintable reference. Explicitly detach chrome widgets whenever a paintable stops being current or loses its layout node, and reset scrollbar interaction state at that boundary. Extend the existing capture regression test to rebuild layout during a drag.