### PR TITLE
RequestServer: Initialize libcurl before sandboxing

### DIFF
--- a/Services/RequestServer/CURL.cpp
+++ b/Services/RequestServer/CURL.cpp
@@ -6,9 +6,20 @@
  */
 
 #include <AK/Enumerate.h>
+#include <AK/Format.h>
 #include <RequestServer/CURL.h>
 
 namespace RequestServer {
+
+ErrorOr<void> initialize_libcurl()
+{
+    auto result = curl_global_init(CURL_GLOBAL_ALL);
+    if (result != CURLE_OK) {
+        warnln("curl_global_init failed: {}", curl_easy_strerror(result));
+        return Error::from_string_literal("Failed to initialize libcurl");
+    }
+    return {};
+}
 
 ByteString build_curl_resolve_list(DNS::LookupResult const& dns_result, StringView host, u16 port)
 {

--- a/Services/RequestServer/CURL.h
+++ b/Services/RequestServer/CURL.h
@@ -10,7 +10,7 @@
 // Include this header instead of <curl/curl.h>. Only include this header from .cpp files.
 
 #include <AK/ByteString.h>
-#include <AK/Platform.h>
+#include <AK/Error.h>
 #include <AK/StringView.h>
 #include <LibDNS/Resolver.h>
 #include <LibRequests/NetworkError.h>
@@ -25,5 +25,6 @@ namespace RequestServer {
 
 ByteString build_curl_resolve_list(DNS::LookupResult const& dns_result, StringView host, u16 port);
 Requests::NetworkError curl_code_to_network_error(int code);
+ErrorOr<void> initialize_libcurl();
 
 }

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -16,6 +16,7 @@
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
+#include <RequestServer/CURL.h>
 #include <RequestServer/ConnectionFromClient.h>
 #include <RequestServer/Resolver.h>
 #include <RequestServer/ResourceSubstitutionMap.h>
@@ -101,6 +102,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         else
             disk_cache = cache.release_value();
     }
+
+    TRY(RequestServer::initialize_libcurl());
 
     if (!disable_sandbox)
         TRY(RequestServer::apply_sandbox(certificates, cache_path));


### PR DESCRIPTION
`curl_multi_init()` can perform one-time global setup. On macOS, that setup can need filesystem access blocked by the RequestServer sandbox.

Initialize curl before entering the sandbox so per-connection curl setup does not need that access later.