### PR TITLE
LibWeb: Support VERTEX_ARRAY_BINDING_OES in getParameter

### DIFF
--- a/Libraries/LibWeb/WebGL/Extensions/OESVertexArrayObject.cpp
+++ b/Libraries/LibWeb/WebGL/Extensions/OESVertexArrayObject.cpp
@@ -57,6 +57,8 @@ void OESVertexArrayObject::delete_vertex_array_oes(GC::Ptr<WebGLVertexArrayObjec
 
     auto handle = vertex_array_handle.value();
     m_context->context().delete_vertex_arrays_oes(1, &handle);
+    if (m_context->current_vertex_array_binding() == array_object)
+        m_context->set_current_vertex_array_binding(nullptr);
 }
 
 bool OESVertexArrayObject::is_vertex_array_oes(GC::Ptr<WebGLVertexArrayObjectOES> array_object)
@@ -92,6 +94,7 @@ void OESVertexArrayObject::bind_vertex_array_oes(GC::Ptr<WebGLVertexArrayObjectO
     }
 
     m_context->context().bind_vertex_array_oes(vertex_array_handle);
+    m_context->set_current_vertex_array_binding(array_object);
 }
 
 void OESVertexArrayObject::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #include <LibWeb/WebGL/Extensions/WebGLDrawBuffers.h>
 #include <LibWeb/WebGL/TextureUpload.h>
 #include <LibWeb/WebGL/WebGLContextProxy.h>
+#include <LibWeb/WebGL/WebGLObject.h>
 #include <LibWeb/WebGL/WebGLRenderingContext.h>
 #include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 
@@ -199,6 +200,7 @@ void WebGLRenderingContextBase::enable_compressed_texture_format(WebIDL::Unsigne
 void WebGLRenderingContextBase::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_current_vertex_array);
     visitor.visit(m_enabled_extensions);
 }
 

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -77,6 +77,11 @@ public:
 
     void enable_compressed_texture_format(WebIDL::UnsignedLong format);
 
+    // Holds a WebGLVertexArrayObject for WebGL2 contexts, or a WebGLVertexArrayObjectOES for WebGL1 contexts with the
+    // OES_vertex_array_object extension enabled.
+    GC::Ptr<WebGLObject> current_vertex_array_binding() const { return m_current_vertex_array; }
+    void set_current_vertex_array_binding(GC::Ptr<WebGLObject> vertex_array) { m_current_vertex_array = vertex_array; }
+
 protected:
     WebGLRenderingContextBase(JS::Realm&);
 
@@ -303,6 +308,8 @@ protected:
     //      video is still converted to rec709 RGB data, but not then converted to e.g. srgb RGB data) The initial value is
     //      BROWSER_DEFAULT_WEBGL.
     GLenum m_unpack_colorspace_conversion { BROWSER_DEFAULT_WEBGL };
+
+    GC::Ptr<WebGLObject> m_current_vertex_array;
 
 private:
     GLenum m_error { 0 };

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
@@ -1447,6 +1447,16 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
         set_error(GL_INVALID_ENUM);
         return JS::js_null();
     }
+    case GL_VERTEX_ARRAY_BINDING: { // NOTE: This has the same value as VERTEX_ARRAY_BINDING_OES
+        if (extension_enabled("OES_vertex_array_object"sv) || m_context->webgl_version() == WebGLVersion::WebGL2) {
+            if (!m_current_vertex_array)
+                return JS::js_null();
+            return JS::Value(m_current_vertex_array);
+        }
+
+        set_error(GL_INVALID_ENUM);
+        return JS::js_null();
+    }
 
     case COMPRESSED_TEXTURE_FORMATS: {
         auto formats = enabled_compressed_texture_formats();
@@ -1693,11 +1703,6 @@ WebIDL::ExceptionOr<JS::Value> WebGLRenderingContextImpl::get_parameter(WebIDL::
             GLint result { 0 };
             m_context->get_integerv_robust_angle(GL_UNPACK_SKIP_ROWS, 1, nullptr, &result);
             return JS::Value(result);
-        }
-        case GL_VERTEX_ARRAY_BINDING: { // FIXME: Allow this for VERTEX_ARRAY_BINDING_OES
-            if (!m_current_vertex_array)
-                return JS::js_null();
-            return JS::Value(m_current_vertex_array);
         }
         case MAX_CLIENT_WAIT_TIMEOUT_WEBGL:
             // A page must never be able to block the compositor, so clientWaitSync
@@ -2583,7 +2588,6 @@ void WebGLRenderingContextImpl::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_transform_feedback_binding);
     visitor.visit(m_pixel_pack_buffer_binding);
     visitor.visit(m_pixel_unpack_buffer_binding);
-    visitor.visit(m_current_vertex_array);
     visitor.visit(m_any_samples_passed);
     visitor.visit(m_any_samples_passed_conservative);
     visitor.visit(m_transform_feedback_primitives_written);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.h
@@ -169,7 +169,6 @@ protected:
     GC::Ptr<WebGLTexture> m_texture_binding_2d_array;
     GC::Ptr<WebGLTexture> m_texture_binding_3d;
     GC::Ptr<WebGLTransformFeedback> m_transform_feedback_binding;
-    GC::Ptr<WebGLVertexArrayObject> m_current_vertex_array;
     GC::Ptr<WebGLQuery> m_any_samples_passed;
     GC::Ptr<WebGLQuery> m_any_samples_passed_conservative;
     GC::Ptr<WebGLQuery> m_transform_feedback_primitives_written;

--- a/Tests/LibWeb/Text/expected/canvas/webgl-oes-vertex-array-object-binding.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl-oes-vertex-array-object-binding.txt
@@ -1,0 +1,7 @@
+binding before enabling extension: null
+error: INVALID_ENUM
+initial binding: null
+bound VAO is returned: true
+binding after unbind: null
+binding after deleting bound VAO: null
+error: NO_ERROR

--- a/Tests/LibWeb/Text/input/canvas/webgl-oes-vertex-array-object-binding.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-oes-vertex-array-object-binding.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const canvas = document.createElement("canvas");
+        const gl = canvas.getContext("webgl");
+        const VERTEX_ARRAY_BINDING_OES = 0x85b5;
+
+        println(`binding before enabling extension: ${gl.getParameter(VERTEX_ARRAY_BINDING_OES)}`);
+        println(`error: ${gl.getError() === gl.INVALID_ENUM ? "INVALID_ENUM" : "unexpected"}`);
+
+        const ext = gl.getExtension("OES_vertex_array_object");
+        println(`initial binding: ${gl.getParameter(ext.VERTEX_ARRAY_BINDING_OES)}`);
+
+        const vao = ext.createVertexArrayOES();
+        ext.bindVertexArrayOES(vao);
+        println(`bound VAO is returned: ${gl.getParameter(ext.VERTEX_ARRAY_BINDING_OES) === vao}`);
+
+        ext.bindVertexArrayOES(null);
+        println(`binding after unbind: ${gl.getParameter(ext.VERTEX_ARRAY_BINDING_OES)}`);
+
+        ext.bindVertexArrayOES(vao);
+        ext.deleteVertexArrayOES(vao);
+        println(`binding after deleting bound VAO: ${gl.getParameter(ext.VERTEX_ARRAY_BINDING_OES)}`);
+        println(`error: ${gl.getError() === gl.NO_ERROR ? "NO_ERROR" : "unexpected"}`);
+    });
+</script>


### PR DESCRIPTION
Querying `getParameter(VERTEX_ARRAY_BINDING_OES)` on a WebGL1 context with the `OES_vertex_array_object` extension enabled logged an unknown parameter warning and returned `null` with `INVALID_ENUM`, because only WebGL2 contexts handled `GL_VERTEX_ARRAY_BINDING` and the extension never tracked which vertex array object it bound. Move the current vertex array binding to `WebGLRenderingContextBase` so the extension can update it when binding and clear it when deleting the bound VAO, and answer the query for both WebGL versions.

Seen in the wild on https://transip.nl/.