### PR TITLE
LibWeb: Stretch table grids with flex item wrappers

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1235,7 +1235,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
         make_button_content_box_definite(box, available_space, layout_input.containing_block_constraints, measured_content_height);
 
-        independent_formatting_context->run(layout_input.for_child_formatting_context(inner_available_space));
+        auto inside_layout_input = [&] {
+            auto input = layout_input.for_child_formatting_context(inner_available_space);
+            if (table_formatting_context && layout_input.table_grid_min_border_box_height.has_value())
+                return input.with_table_grid_min_border_box_height(*layout_input.table_grid_min_border_box_height);
+            return input;
+        }();
+        independent_formatting_context->run(inside_layout_input);
         if (table_formatting_context)
             pending_position = table_formatting_context->pending_table_box_content_offset_in_wrapper();
         if (is<TableWrapper>(block_container) && box.display().is_table_inside()) {
@@ -1320,7 +1326,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     // through to the table box unchanged.
     auto child_layout_input = [&]() -> LayoutInput {
         if (is<TableWrapper>(block_container))
-            return LayoutInput { available_space_for_children, layout_input.containing_block_constraints, layout_input.content_box_position_in_bfc_root };
+            return LayoutInput { available_space_for_children, layout_input.containing_block_constraints, layout_input.content_box_position_in_bfc_root, layout_input.table_grid_min_border_box_height };
         else
             return layout_input_for_child_context(m_state.get(block_container), layout_input, available_space_for_children);
     }();

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/FlexFormattingContext.h>
 #include <LibWeb/Layout/ReplacedBox.h>
+#include <LibWeb/Layout/TableWrapper.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 
@@ -251,7 +252,28 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
         // AD-HOC: Finally, layout the inside of all flex items.
         copy_dimensions_from_flex_items_to_boxes();
         for (auto& item : m_flex_items) {
-            auto item_layout_input = LayoutInput { item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space), item_containing_block_constraints() };
+            auto item_layout_input = [&] {
+                auto input = LayoutInput { item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space), item_containing_block_constraints() };
+                if (!is<TableWrapper>(item.box) || cross_axis_is_horizontal() || !flex_item_is_stretched(item))
+                    return input;
+
+                // https://drafts.csswg.org/css-flexbox-1/#flex-items
+                // In the case of flex items with display: table, the table wrapper box becomes the flex item,
+                // so the align-self property applies to it.
+                // The contents of any caption boxes contribute to the calculation of
+                // the table wrapper box's min-content and max-content sizes.
+                // However, like width and height, the flex longhands apply to the table box as follows:
+                // the flex item’s final size is calculated
+                // by performing layout as if the distance between
+                // the table wrapper box's edges and the table box's content edges
+                // were all part of the table box's border+padding area,
+                // and the table box were the flex item.
+                auto intrinsic_available_space = input.available_space;
+                intrinsic_available_space.height = AvailableSize::make_indefinite();
+                auto intrinsic_table_grid_height = compute_table_box_height_inside_table_wrapper(item.box, intrinsic_available_space, input.containing_block_constraints);
+                auto extra_height = max(CSSPixels(0), item.cross_size.value() - item.hypothetical_cross_size);
+                return input.with_table_grid_min_border_box_height(intrinsic_table_grid_height + extra_height);
+            }();
             if (auto independent_formatting_context = layout_inside(item.box, LayoutMode::Normal, item_layout_input))
                 independent_formatting_context->parent_context_did_dimension_child_root_box();
 

--- a/Libraries/LibWeb/Layout/LayoutInput.h
+++ b/Libraries/LibWeb/Layout/LayoutInput.h
@@ -19,10 +19,11 @@ struct ContainingBlockConstraints {
 };
 
 struct LayoutInput {
-    explicit LayoutInput(AvailableSpace new_available_space, ContainingBlockConstraints new_containing_block_constraints = {}, Optional<CSSPixelPoint> new_content_box_position_in_bfc_root = {})
+    explicit LayoutInput(AvailableSpace new_available_space, ContainingBlockConstraints new_containing_block_constraints = {}, Optional<CSSPixelPoint> new_content_box_position_in_bfc_root = {}, Optional<CSSPixels> new_table_grid_min_border_box_height = {})
         : available_space(move(new_available_space))
         , containing_block_constraints(move(new_containing_block_constraints))
         , content_box_position_in_bfc_root(new_content_box_position_in_bfc_root)
+        , table_grid_min_border_box_height(new_table_grid_min_border_box_height)
     {
     }
 
@@ -33,13 +34,19 @@ struct LayoutInput {
 
     [[nodiscard]] LayoutInput with_content_box_position_in_bfc_root(Optional<CSSPixelPoint> position) const
     {
-        return LayoutInput { available_space, containing_block_constraints, position };
+        return LayoutInput { available_space, containing_block_constraints, position, table_grid_min_border_box_height };
+    }
+
+    [[nodiscard]] LayoutInput with_table_grid_min_border_box_height(CSSPixels height) const
+    {
+        return LayoutInput { available_space, containing_block_constraints, content_box_position_in_bfc_root, height };
     }
 
     AvailableSpace const available_space;
     ContainingBlockConstraints const containing_block_constraints;
 
     Optional<CSSPixelPoint> const content_box_position_in_bfc_root;
+    Optional<CSSPixels> const table_grid_min_border_box_height;
 };
 
 }

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1128,6 +1128,12 @@ void TableFormattingContext::compute_table_height()
 
     m_table_height = sum_rows_height;
 
+    if (m_min_border_box_height_from_flex_item.has_value()) {
+        auto const& table_state = m_state.get(table_box());
+        auto min_content_height = *m_min_border_box_height_from_flex_item - table_state.border_box_top() - table_state.border_box_bottom();
+        m_table_height = max(m_table_height, min_content_height);
+    }
+
     if (!table_box().computed_values().height().is_auto()) {
         // If the table has a height property with a value other than auto, it is treated as a minimum height for the
         // table grid, and will eventually be distributed to the height of the rows if their collective minimum height
@@ -1946,6 +1952,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     auto const& available_space = layout_input.available_space;
     FORMATTING_CONTEXT_TRACE();
     m_available_space = available_space;
+    m_min_border_box_height_from_flex_item = layout_input.table_grid_min_border_box_height;
 
     run_until_width_calculation(layout_input);
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -95,6 +95,7 @@ private:
     CSSPixels m_table_height { 0 };
     CSSPixels m_automatic_content_height { 0 };
     CSSPixelPoint m_pending_table_box_content_offset_in_wrapper {};
+    Optional<CSSPixels> m_min_border_box_height_from_flex_item;
 
     Optional<AvailableSpace> m_available_space;
     bool m_needs_fixed_mode_row_measurement { false };

--- a/Tests/LibWeb/Layout/expected/flex/table-flex-item-stretch.txt
+++ b/Tests/LibWeb/Layout/expected/flex/table-flex-item-stretch.txt
@@ -1,15 +1,15 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 216 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 200 0+0+8] children: not-inline
       Box <div.flex> at [8,8] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
         TableWrapper <(anonymous)> at [8,8] flex-item [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
-          Box <div.table> at [8,8] table-box [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [TFC] children: not-inline
-            Box <(anonymous)> at [8,8] table-row [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <div.cell> at [8,8] table-cell [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
-                frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 20x20] baseline: 20
-                BlockContainer <span.content> at [8,8] inline-block [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          Box <div.table> at [8,8] table-box [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [TFC] children: not-inline
+            Box <(anonymous)> at [8,8] table-row [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+              BlockContainer <div.cell> at [8,48] table-cell [0+0+0 20 0+0+0] [0+0+40 20 40+0+0] [BFC] children: inline
+                frag 0 from BlockContainer start: 0, length: 0, rect: [8,48 20x20] baseline: 20
+                BlockContainer <span.content> at [8,48] inline-block [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
         BlockContainer <div.sizer> at [28,8] flex-item [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
@@ -17,18 +17,46 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,108] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
+      Box <div.flex> at [8,108] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [8,108] flex-item [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+          Box <div.table> at [8,128] table-box [0+0+0 20 0+0+0] [0+0+0 60 0+0+20] [TFC] children: not-inline
+            BlockContainer <div.caption> at [8,108] [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+            Box <(anonymous)> at [8,128] table-row [0+0+0 20 0+0+0] [0+0+0 60 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <div.cell> at [8,148] table-cell [0+0+0 20 0+0+0] [0+0+20 20 20+0+0] [BFC] children: inline
+                frag 0 from BlockContainer start: 0, length: 0, rect: [8,148 20x20] baseline: 20
+                BlockContainer <span.content> at [8,148] inline-block [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.sizer> at [28,108] flex-item [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       Paintable (Box<DIV>.flex) [8,8 784x100]
         PaintableWithLines (TableWrapper(anonymous)) [8,8 20x100]
-          Paintable (Box<DIV>.table) [8,8 20x20]
-            Paintable (Box(anonymous)) [8,8 20x20]
-              PaintableWithLines (BlockContainer<DIV>.cell) [8,8 20x20]
-                PaintableWithLines (BlockContainer<SPAN>.content) [8,8 20x20]
+          Paintable (Box<DIV>.table) [8,8 20x100]
+            Paintable (Box(anonymous)) [8,8 20x100]
+              PaintableWithLines (BlockContainer<DIV>.cell) [8,8 20x100]
+                PaintableWithLines (BlockContainer<SPAN>.content) [8,48 20x20]
         PaintableWithLines (BlockContainer<DIV>.sizer) [28,8 20x100]
       PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]
+      Paintable (Box<DIV>.flex) [8,108 784x100]
+        PaintableWithLines (TableWrapper(anonymous)) [8,108 20x100]
+          Paintable (Box<DIV>.table) [8,128 20x60]
+            PaintableWithLines (BlockContainer<DIV>.caption) [8,108 20x20]
+            Paintable (Box(anonymous)) [8,128 20x60]
+              PaintableWithLines (BlockContainer<DIV>.cell) [8,128 20x60]
+                PaintableWithLines (BlockContainer<SPAN>.content) [8,148 20x20]
+        PaintableWithLines (BlockContainer<DIV>.sizer) [28,108 20x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x116] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x216] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/table-flex-item-stretch.txt
+++ b/Tests/LibWeb/Layout/expected/flex/table-flex-item-stretch.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: not-inline
+      Box <div.flex> at [8,8] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [8,8] flex-item [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+          Box <div.table> at [8,8] table-box [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [TFC] children: not-inline
+            Box <(anonymous)> at [8,8] table-row [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <div.cell> at [8,8] table-cell [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+                frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 20x20] baseline: 20
+                BlockContainer <span.content> at [8,8] inline-block [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.sizer> at [28,8] flex-item [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,108] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      Paintable (Box<DIV>.flex) [8,8 784x100]
+        PaintableWithLines (TableWrapper(anonymous)) [8,8 20x100]
+          Paintable (Box<DIV>.table) [8,8 20x20]
+            Paintable (Box(anonymous)) [8,8 20x20]
+              PaintableWithLines (BlockContainer<DIV>.cell) [8,8 20x20]
+                PaintableWithLines (BlockContainer<SPAN>.content) [8,8 20x20]
+        PaintableWithLines (BlockContainer<DIV>.sizer) [28,8 20x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/table-flex-item-stretch.html
+++ b/Tests/LibWeb/Layout/input/flex/table-flex-item-stretch.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+.flex {
+    display: flex;
+}
+.table {
+    display: table;
+}
+.cell {
+    display: table-cell;
+    vertical-align: middle;
+}
+.content {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+}
+.sizer {
+    width: 20px;
+    height: 100px;
+}
+</style>
+<div class="flex">
+    <div class="table"><div class="cell"><span class="content"></span></div></div>
+    <div class="sizer"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/flex/table-flex-item-stretch.html
+++ b/Tests/LibWeb/Layout/input/flex/table-flex-item-stretch.html
@@ -19,8 +19,18 @@
     width: 20px;
     height: 100px;
 }
+.caption {
+    height: 20px;
+}
 </style>
 <div class="flex">
     <div class="table"><div class="cell"><span class="content"></span></div></div>
+    <div class="sizer"></div>
+</div>
+<div class="flex">
+    <div class="table">
+        <div class="caption" style="display: table-caption"></div>
+        <div class="cell"><span class="content"></span></div>
+    </div>
     <div class="sizer"></div>
 </div>

--- a/Tests/LibWeb/Text/expected/selection-drag-past-overflowing-text.txt
+++ b/Tests/LibWeb/Text/expected/selection-drag-past-overflowing-text.txt
@@ -1,1 +1,1 @@
-kept label selected below overflowing text: false
+kept label selected below overflowing text: true


### PR DESCRIPTION
When a table participated in row flex layout, its anonymous table wrapper received the stretched cross size while the inner table grid retained its intrinsic height. This caused table-cell vertical alignment to operate within the smaller grid.

Propagate the wrapper’s flex growth to the table grid as a minimum border-box height while preserving the space occupied by captions. This follows the Flexbox requirement to size the table as though the distance between the wrapper and table content edges were part of the table’s border and padding.

Add layout coverage for plain and captioned tables. Update the affected selection expectation to reflect the corrected geometry, which matches Chrome.
