### PR TITLE
LibWeb: Report only audible media playback to browser chrome

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -674,11 +674,13 @@ void HTMLMediaElement::volume_or_muted_attribute_changed()
         pause_element();
 
     update_volume();
+    update_audio_play_state();
 }
 
 void HTMLMediaElement::page_mute_state_changed(Badge<Page>)
 {
     update_volume();
+    update_audio_play_state();
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#effective-media-volume
@@ -1691,14 +1693,14 @@ void HTMLMediaElement::set_audio_track_enabled(Badge<AudioTrack>, GC::Ptr<HTML::
 {
     VERIFY(m_playback_manager);
 
-    if (!m_playback_manager->audio_tracks().contains_slow(audio_track->track_in_playback_manager()))
-        return;
+    if (m_playback_manager->audio_tracks().contains_slow(audio_track->track_in_playback_manager())) {
+        if (enabled)
+            m_playback_manager->enable_an_audio_track(audio_track->track_in_playback_manager());
+        else
+            m_playback_manager->disable_an_audio_track(audio_track->track_in_playback_manager());
+    }
 
-    if (enabled)
-        m_playback_manager->enable_an_audio_track(audio_track->track_in_playback_manager());
-    else
-        m_playback_manager->disable_an_audio_track(audio_track->track_in_playback_manager());
-
+    update_audio_play_state();
     update_screen_wake_lock();
 }
 
@@ -2206,6 +2208,7 @@ void HTMLMediaElement::forget_media_resource_specific_tracks()
         m_playback_manager->on_playback_state_change = nullptr;
     m_audio_tracks->remove_all_tracks();
     m_video_tracks->remove_all_tracks();
+    update_audio_play_state();
     m_playback_manager.clear();
     clear_compositor_video_frame();
     update_screen_wake_lock();
@@ -2719,10 +2722,25 @@ void HTMLMediaElement::notify_about_playing()
     if (m_playback_manager)
         m_playback_manager->play();
 
-    if (m_audio_tracks->has_enabled_track())
-        document().page().client().page_did_change_audio_play_state(AudioPlayState::Playing);
+    m_has_started_playback = true;
+    update_audio_play_state();
 
     update_screen_wake_lock();
+}
+
+void HTMLMediaElement::update_audio_play_state()
+{
+    // AD-HOC: Browser chrome should indicate that this element is playing audio only while it can produce audible
+    //         output. Remember the state reported for each element so that changes to any input remain balanced.
+    auto const is_playing_audio = m_has_started_playback
+        && m_audio_tracks->has_enabled_track()
+        && effective_media_volume() > 0;
+    if (m_is_playing_audio == is_playing_audio)
+        return;
+
+    m_is_playing_audio = is_playing_audio;
+    document().page().client().page_did_change_audio_play_state(
+        m_is_playing_audio ? AudioPlayState::Playing : AudioPlayState::Paused);
 }
 
 void HTMLMediaElement::set_show_poster(bool show_poster)
@@ -2744,11 +2762,12 @@ void HTMLMediaElement::set_paused(bool paused)
     m_paused = paused;
 
     if (m_paused) {
+        m_has_started_playback = false;
+
         if (m_playback_manager)
             m_playback_manager->pause();
 
-        if (m_audio_tracks->has_enabled_track())
-            document().page().client().page_did_change_audio_play_state(AudioPlayState::Paused);
+        update_audio_play_state();
     }
 
     update_screen_wake_lock();

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -146,6 +146,7 @@ public:
     void page_mute_state_changed(Badge<Page>);
 
     double effective_media_volume() const;
+    bool is_playing_audio() const { return m_is_playing_audio; }
 
     GC::Ref<AudioTrackList> audio_tracks() const { return *m_audio_tracks; }
     GC::Ref<VideoTrackList> video_tracks() const { return *m_video_tracks; }
@@ -253,6 +254,7 @@ private:
     void seek_element(double playback_position, MediaSeekMode = MediaSeekMode::Accurate);
     void finish_seeking_element();
     void notify_about_playing();
+    void update_audio_play_state();
     void set_show_poster(bool);
     void set_paused(bool);
     void set_duration(double);
@@ -362,6 +364,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-muted
     bool m_muted { false };
+
+    bool m_has_started_playback { false };
+    bool m_is_playing_audio { false };
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks
     GC::Ptr<AudioTrackList> m_audio_tracks;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -990,6 +990,16 @@ bool Internals::media_element_is_fetching(HTML::HTMLMediaElement& element)
     return element.is_fetching();
 }
 
+bool Internals::media_element_is_playing_audio(HTML::HTMLMediaElement& element)
+{
+    return element.is_playing_audio();
+}
+
+void Internals::set_page_muted(bool muted)
+{
+    window().associated_document().page().set_page_mute_state(muted ? HTML::MuteState::Muted : HTML::MuteState::Unmuted);
+}
+
 JS::Object* Internals::async_scrolling_state()
 {
     auto object = JS::Object::create(realm(), nullptr);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -147,6 +147,8 @@ public:
     bool style_sheet_may_have_has_selectors(CSS::CSSStyleSheet&);
     WebIDL::ExceptionOr<JS::Object*> image_animation_state_for_url(Utf16String const& url);
     bool media_element_is_fetching(HTML::HTMLMediaElement&);
+    bool media_element_is_playing_audio(HTML::HTMLMediaElement&);
+    void set_page_muted(bool muted);
     JS::Object* async_scrolling_state();
     bool async_scrolling_state_blocks_wheel_event_at(double x, double y);
     bool async_scrolling_state_can_wheel_scroll_at(double x, double y, double delta_x, double delta_y, bool force_stale_wheel_event_regions);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -143,6 +143,8 @@ interface Internals {
     boolean styleSheetMayHaveHasSelectors(CSSStyleSheet sheet);
     object imageAnimationStateForURL(Utf16USVString url);
     boolean mediaElementIsFetching(HTMLMediaElement element);
+    boolean mediaElementIsPlayingAudio(HTMLMediaElement element);
+    undefined setPageMuted(boolean muted);
 
     object asyncScrollingState();
     boolean asyncScrollingStateBlocksWheelEventAt(double x, double y);

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-audio-play-state.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-audio-play-state.txt
@@ -1,0 +1,12 @@
+muted playback reported as playing audio: false
+unmuted playback reported as playing audio: true
+zero-volume playback reported as playing audio: false
+nonzero-volume playback reported as playing audio: true
+playback in a muted page reported as playing audio: false
+playback in an unmuted page reported as playing audio: true
+playback without an enabled audio track reported as playing audio: false
+playback with an enabled audio track reported as playing audio: true
+playback after adoption reported as playing audio: true
+paused media reported as playing audio: false
+resumed media reported as playing audio: true
+reset media reported as playing audio: false

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-audio-play-state.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-audio-play-state.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>internals.setAutoplayPolicy("allow-audio-and-video");</script>
+<video autoplay muted loop src="../../../Assets/test-webm.webm"></video>
+<script>
+    asyncTest(async done => {
+        internals.setTestTimeout(15_000);
+        const video = document.querySelector("video");
+        await new Promise(resolve => video.addEventListener("playing", resolve, { once: true }));
+
+        println(`muted playback reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        video.muted = false;
+        println(`unmuted playback reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        video.volume = 0;
+        println(`zero-volume playback reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        video.volume = 0.5;
+        println(`nonzero-volume playback reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        internals.setPageMuted(true);
+        println(`playback in a muted page reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        internals.setPageMuted(false);
+        println(`playback in an unmuted page reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        video.audioTracks[0].enabled = false;
+        println(`playback without an enabled audio track reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        video.audioTracks[0].enabled = true;
+        println(`playback with an enabled audio track reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        video.remove();
+        await video.play();
+        const iframe = document.body.appendChild(document.createElement("iframe"));
+        iframe.contentDocument.body.appendChild(iframe.contentDocument.adoptNode(video));
+        println(`playback after adoption reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        video.pause();
+        println(`paused media reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        await video.play();
+        println(`resumed media reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+
+        video.load();
+        println(`reset media reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Track whether each media element has reported audible playback. Update that state when playback, volume, muting, page muting, audio track selection, or resource loading changes so the page-level counter remains balanced.

Keep muted autoplay video from displaying an audio indicator, while allowing it to appear immediately if the video becomes audible. Add coverage for each state transition and cross-document adoption.