### PR TITLE
LibWebView: Cancel provisional loads on browser UI back

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -46,10 +46,18 @@ namespace Web::HTML {
 
 struct PopulateSessionHistoryEntryDocumentOutput;
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
+// They return "initiator-disallowed", "canceled-by-beforeunload", "canceled-by-navigate", or
+// "applied".
 enum class HistoryStepResult {
     InitiatorDisallowed,
     CanceledByBeforeUnload,
     CanceledByNavigate,
+    // AD-HOC: This is an internal result used when WebContent no longer has the requested page.
+    CanceledByMissingPage,
+    // INTEROP: This is an internal result for browser UI handling and is not one of the results
+    //          returned by the HTML Standard's apply the history step algorithm.
+    CanceledPendingNavigation,
     Applied,
 };
 using OnApplyHistoryStepComplete = GC::Function<void(HistoryStepResult)>;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -2308,6 +2308,24 @@ void LocalTraversableNavigable::check_if_traverse_history_step_is_canceled(int s
             return;
         }
 
+        auto target_entry = get_the_target_history_entry(step);
+        if (ongoing_navigation().has<Utf16String>()
+            && target_entry == current_session_history_entry()
+            && target_entry == active_session_history_entry()
+            && !target_entry->document_state()->reload_pending()) {
+            // https://html.spec.whatwg.org/multipage/browsing-the-web.html#nav-traversal-ui
+            // https://html.spec.whatwg.org/multipage/document-lifecycle.html#stop-document-loading
+            // INTEROP: A browser UI traversal back to the still-active entry while a new document is loading
+            //          cancels the pending navigation before entering the specified apply the history step algorithm.
+            //          The standard describes browser UI traversal and stopping loading separately, but does not
+            //          prescribe how Back interacts with an uncommitted navigation. Chromium, WebKit, and Gecko all
+            //          stop the provisional load in this situation.
+            stop_loading();
+            on_complete->function()(HistoryStepResult::CanceledPendingNavigation);
+            signal->resolve({});
+            return;
+        }
+
         run_the_history_step_prechecks(step, true, nullptr, nullptr, UserNavigationInvolvement::BrowserUI, Bindings::NavigationType::Traverse, LocalNavigable::NavigationAPIAbortBehavior::Abort,
             GC::create_function(heap(), [signal, on_complete](HistoryStepResult result, int, LocalNavigable::NavigationAPIAbortBehavior) {
                 on_complete->function()(result);

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -667,7 +667,7 @@ WebContentHistoryStepResult CanonicalTraversable::did_traverse_the_history_to_st
     return { .dump_reason = pending_step_dump_reason, .should_update_navigation_action_state = true };
 }
 
-HistoryStepCancelationCheckResult CanonicalTraversable::did_check_if_traverse_history_step_is_canceled(u64 request_id, i32 step, bool canceled)
+HistoryStepCancelationCheckResult CanonicalTraversable::did_check_if_traverse_history_step_is_canceled(u64 request_id, i32 step, Web::HTML::HistoryStepResult result)
 {
     if (!m_pending_session_history_traversal.has_value()
         || m_pending_session_history_traversal->stage != PendingSessionHistoryTraversal::Stage::CheckingCancelation
@@ -675,7 +675,31 @@ HistoryStepCancelationCheckResult CanonicalTraversable::did_check_if_traverse_hi
         || m_pending_session_history_traversal->target_step != step)
         return { .dump_reason = "ignored-stale-history-step-cancelation-check-result"sv };
 
-    if (canceled) {
+    if (result == Web::HTML::HistoryStepResult::CanceledPendingNavigation) {
+        auto target = m_session_history.traversal_target_for_step(step);
+        auto const* previous_current_entry = m_pending_session_history_navigation.has_value()
+            ? m_pending_session_history_navigation->previous_session_history.current_entry()
+            : nullptr;
+        // INTEROP: WebContent handled this browser UI traversal as stop loading rather than applying a history
+        //          step. If it preserved the active document, discard the UI process's uncommitted speculative
+        //          entry so both processes continue to expose that document as the current history entry.
+        if (target.has_value()
+            && previous_current_entry
+            && m_pending_session_history_navigation->web_content_restore_mode == PendingSessionHistoryNavigation::WebContentRestoreMode::PreserveCurrentProcessState
+            && target->target_top_level_entry->document_state.id == previous_current_entry->document_state.id) {
+            auto on_cancelation_check_complete = move(m_pending_session_history_traversal->on_cancelation_check_complete);
+            m_pending_session_history_traversal.clear();
+            return {
+                .dump_reason = "traverse-canceled-pending-navigation"sv,
+                .on_cancelation_check_complete = move(on_cancelation_check_complete),
+                .outcome = { .status = HistoryTraversalStatus::Started },
+                .should_restore_pending_navigation = true,
+            };
+        }
+        result = Web::HTML::HistoryStepResult::Applied;
+    }
+
+    if (result != Web::HTML::HistoryStepResult::Applied) {
         auto on_cancelation_check_complete = move(m_pending_session_history_traversal->on_cancelation_check_complete);
         m_pending_session_history_traversal.clear();
         return { .dump_reason = "traverse-fallback-canceled-by-webcontent"sv, .on_cancelation_check_complete = move(on_cancelation_check_complete), .outcome = { .status = HistoryTraversalStatus::Canceled }, .should_update_navigation_action_state = true, .should_complete_webdriver_pending_navigation = true, .should_update_webdriver_pending_navigation_to_current_url = true, .should_reset_webdriver_pending_navigation_completion = true };

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -174,6 +174,7 @@ struct HistoryStepCancelationCheckResult {
     // When set, the UI-owned target entry must be loaded from the UI process after
     // reporting the outcome.
     Optional<TraversableSessionHistory::TraversalTarget> target {};
+    bool should_restore_pending_navigation { false };
     bool should_update_navigation_action_state { false };
     bool should_complete_webdriver_pending_navigation { false };
     bool should_update_webdriver_pending_navigation_to_current_url { false };
@@ -242,7 +243,7 @@ public:
     HistoryTraversalDecision traverse_the_history_by_delta(int delta, CheckForCancelation, URL::URL const& current_url, Function<void(HistoryTraversalOutcome)> on_cancelation_check_complete);
     URL::URL prepare_to_load_session_history_traversal_target_from_ui_process(TraversableSessionHistory::TraversalTarget const&, URL::URL const& current_url);
     WebContentHistoryStepResult did_traverse_the_history_to_step(i32 step, bool step_was_available, Web::HTML::HistoryStepResult);
-    HistoryStepCancelationCheckResult did_check_if_traverse_history_step_is_canceled(u64 request_id, i32 step, bool canceled);
+    HistoryStepCancelationCheckResult did_check_if_traverse_history_step_is_canceled(u64 request_id, i32 step, Web::HTML::HistoryStepResult);
     Optional<WebContentSessionHistorySeed> prepare_web_content_session_history_seed(bool allow_current_entry_reconstruction);
     CurrentSessionHistoryEntryLoad prepare_current_session_history_entry_load(URL::URL const& current_url);
     void did_send_web_content_session_history_seed();

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1872,9 +1872,9 @@ void ViewImplementation::did_traverse_the_history_to_step(Badge<WebContentClient
 }
 
 void ViewImplementation::did_check_if_traverse_history_step_is_canceled(
-    Badge<WebContentClient>, u64 request_id, i32 step, bool canceled)
+    Badge<WebContentClient>, u64 request_id, i32 step, Web::HTML::HistoryStepResult result)
 {
-    auto check_result = m_top_level_traversable.did_check_if_traverse_history_step_is_canceled(request_id, step, canceled);
+    auto check_result = m_top_level_traversable.did_check_if_traverse_history_step_is_canceled(request_id, step, result);
     if (check_result.should_update_webdriver_pending_navigation_to_current_url && m_webdriver_pending_navigation_url.has_value())
         m_webdriver_pending_navigation_url = m_url;
     if (check_result.should_reset_webdriver_pending_navigation_completion)
@@ -1884,6 +1884,20 @@ void ViewImplementation::did_check_if_traverse_history_step_is_canceled(
         complete_webdriver_pending_navigation_if_url_matches(m_url);
     if (check_result.should_update_navigation_action_state)
         update_navigation_action_state();
+
+    if (check_result.should_restore_pending_navigation) {
+        // NB: WebContent's stop_loading() does not send did_cancel_loading(), so clear the UI process's loading
+        //     bookkeeping before restoring the pending navigation.
+        set_loading_state(false);
+        m_is_waiting_for_navigation_start = false;
+        m_loading_navigation_id.clear();
+        m_loading_url.clear();
+        auto restored = restore_pending_session_history_navigation(check_result.dump_reason);
+        VERIFY(restored);
+        if (check_result.on_cancelation_check_complete)
+            check_result.on_cancelation_check_complete(move(check_result.outcome));
+        return;
+    }
 
     if (check_result.target.has_value()) {
         if (check_result.on_cancelation_check_complete)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -173,6 +173,7 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
     }
 
     if (m_client_state.client) {
+        m_client_state.client->async_notify_webdriver_of_window_replacement(m_client_state.page_index);
         m_client_state.client->unregister_view(m_client_state.page_index);
     }
 
@@ -1545,6 +1546,10 @@ void ViewImplementation::set_loading_state(bool is_loading)
 
 bool ViewImplementation::restore_pending_session_history_navigation(StringView reason)
 {
+    Optional<URL::URL> provisional_url;
+    if (auto const& pending_navigation = m_top_level_traversable.pending_session_history_navigation(); pending_navigation.has_value())
+        provisional_url = pending_navigation->url;
+
     auto result = m_top_level_traversable.restore_pending_session_history_navigation();
     if (!result.restored)
         return false;
@@ -1559,7 +1564,18 @@ bool ViewImplementation::restore_pending_session_history_navigation(StringView r
             m_should_suppress_history_for_next_load = false;
             m_webdriver_pending_navigation_url = current_url;
             m_webdriver_pending_navigation_completes_with_session_history_update = true;
-            load_current_session_history_entry_from_ui_process();
+            if (provisional_url.has_value() && SiteIsolationManager::the().navigation_requires_process_swap(*provisional_url, current_url)) {
+                auto load = m_top_level_traversable.prepare_current_session_history_entry_load(current_url);
+                auto view_id = m_view_id;
+                Core::deferred_invoke([view_id, load = move(load)]() mutable {
+                    auto view = ViewImplementation::find_view_by_id(view_id);
+                    if (!view.has_value())
+                        return;
+                    view->create_new_process_for_cross_site_navigation(load.url, move(load.document_resource), load.history_handling);
+                });
+            } else {
+                load_current_session_history_entry_from_ui_process();
+            }
         } else {
             m_webdriver_pending_navigation_url.clear();
             m_webdriver_pending_navigation_completes_with_session_history_update = false;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1785,6 +1785,13 @@ void ViewImplementation::load_current_session_history_entry_from_ui_process()
 
 void ViewImplementation::load_session_history_traversal_target_from_ui_process(TraversableSessionHistory::TraversalTarget const& target, StringView dump_reason)
 {
+    // NB: Preparing the traversal target clears the pending navigation, so capture whether its provisional
+    //     WebContent process must be replaced before preparing the load.
+    auto should_replace_provisional_web_content_process = false;
+    if (auto const& pending_navigation = m_top_level_traversable.pending_session_history_navigation(); pending_navigation.has_value()) {
+        should_replace_provisional_web_content_process = pending_navigation->web_content_restore_mode == PendingSessionHistoryNavigation::WebContentRestoreMode::RestoreFromUIProcess
+            && SiteIsolationManager::the().navigation_requires_process_swap(m_url, target.target_top_level_entry->url);
+    }
     auto target_url = m_top_level_traversable.prepare_to_load_session_history_traversal_target_from_ui_process(target, m_url);
     update_navigation_action_state();
 
@@ -1795,7 +1802,14 @@ void ViewImplementation::load_session_history_traversal_target_from_ui_process(T
     m_webdriver_pending_navigation_completes_with_session_history_update = true;
     set_url(target_url);
     dump_session_history(dump_reason);
-    load_current_session_history_entry_from_ui_process();
+    // NB: A cross-site provisional navigation has already installed its replacement WebContent process. If Back wins
+    //     the race, load the previous-site traversal target in another correctly isolated process.
+    if (should_replace_provisional_web_content_process) {
+        auto load = m_top_level_traversable.prepare_current_session_history_entry_load(m_url);
+        create_new_process_for_cross_site_navigation(load.url, move(load.document_resource), load.history_handling);
+    } else {
+        load_current_session_history_entry_from_ui_process();
+    }
 }
 
 NonnullRefPtr<Core::Promise<Empty>> ViewImplementation::reset_session_history_for_testing()

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -267,7 +267,7 @@ public:
     void did_set_top_level_session_history(Badge<WebContentClient>, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index);
     void did_traverse_the_history_to_step(Badge<WebContentClient>, i32 step, bool step_was_available, Web::HTML::HistoryStepResult);
     void did_check_if_traverse_history_step_is_canceled(
-        Badge<WebContentClient>, u64 request_id, i32 step, bool canceled);
+        Badge<WebContentClient>, u64 request_id, i32 step, Web::HTML::HistoryStepResult);
     void did_reset_session_history_for_testing(Badge<WebContentClient>);
     void mark_web_content_session_history_stale_for_testing(Badge<WebContentClient>);
     void did_start_webdriver_navigation(Badge<WebContentClient>, URL::URL const&);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1474,10 +1474,10 @@ void WebContentClient::did_change_needs_beforeunload_check(u64 page_id, bool nee
 }
 
 void WebContentClient::did_check_if_traverse_history_step_is_canceled(
-    u64 page_id, u64 request_id, i32 step, bool canceled)
+    u64 page_id, u64 request_id, i32 step, Web::HTML::HistoryStepResult result)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
-        view->did_check_if_traverse_history_step_is_canceled({}, request_id, step, canceled);
+        view->did_check_if_traverse_history_step_is_canceled({}, request_id, step, result);
 }
 
 Messages::WebContentClient::DidRequestTraverseTheHistoryByDeltaResponse WebContentClient::did_request_traverse_the_history_by_delta(u64 page_id, i32 delta, Web::HistoryTraversalPrecheck history_traversal_precheck)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -253,7 +253,7 @@ private:
     virtual void did_set_top_level_session_history(u64 page_id, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index) override;
     virtual void did_traverse_the_history_to_step(u64 page_id, i32 step, bool step_was_available, Web::HTML::HistoryStepResult) override;
     virtual void did_check_if_traverse_history_step_is_canceled(
-        u64 page_id, u64 request_id, i32 step, bool canceled) override;
+        u64 page_id, u64 request_id, i32 step, Web::HTML::HistoryStepResult) override;
     virtual void did_reset_session_history_for_testing(u64 page_id) override;
     virtual Messages::WebContentClient::StartWorkerAgentResponse start_worker_agent(u64 page_id, Web::HTML::WorkerAgentStartRequest request) override;
     virtual void close_worker_agent(u64 page_id, Web::HTML::WorkerAgentId agent_id, Web::HTML::WorkerAgentOwnerToken owner_token) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -346,15 +346,14 @@ void ConnectionFromClient::check_if_traverse_history_step_is_canceled(u64 page_i
 {
     auto page = this->page(page_id);
     if (!page.has_value()) {
-        async_did_check_if_traverse_history_step_is_canceled(page_id, request_id, step, true);
+        async_did_check_if_traverse_history_step_is_canceled(page_id, request_id, step, Web::HTML::HistoryStepResult::CanceledByMissingPage);
         return;
     }
 
     auto& heap = Web::HTML::main_thread_event_loop().heap();
     page->page().top_level_traversable()->check_if_traverse_history_step_is_canceled(step,
         GC::create_function(heap, [this, page_id, request_id, step](Web::HTML::HistoryStepResult result) {
-            async_did_check_if_traverse_history_step_is_canceled(
-                page_id, request_id, step, result != Web::HTML::HistoryStepResult::Applied);
+            async_did_check_if_traverse_history_step_is_canceled(page_id, request_id, step, result);
         }));
 }
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -203,6 +203,12 @@ void ConnectionFromClient::connect_to_webdriver(u64 page_id, ByteString webdrive
     }
 }
 
+void ConnectionFromClient::notify_webdriver_of_window_replacement(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->notify_webdriver_of_window_replacement();
+}
+
 void ConnectionFromClient::complete_webdriver_navigation_completion(u64 page_id, u64 request_id, Web::WebDriver::Response response)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -76,6 +76,7 @@ private:
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
     virtual void set_window_handle(u64 page_id, String handle) override;
     virtual void connect_to_webdriver(u64 page_id, ByteString webdriver_endpoint) override;
+    virtual void notify_webdriver_of_window_replacement(u64 page_id) override;
     virtual void complete_webdriver_history_traversal(u64 page_id, u64 request_id, bool accepted, bool will_replace_web_content_process, bool will_change_top_level_entry) override;
     virtual void complete_webdriver_navigation_completion(u64 page_id, u64 request_id, Web::WebDriver::Response response) override;
     virtual void connect_to_web_ui(u64 page_id, IPC::TransportHandle handle) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -224,10 +224,15 @@ Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL co
 
 void PageClient::request_new_process_for_navigation(URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
-    if (m_webdriver)
-        m_webdriver->page_did_start_window_replacement({}, page().top_level_traversable()->window_handle().to_utf8());
+    notify_webdriver_of_window_replacement();
 
     client().async_did_request_new_process_for_navigation(m_id, url, move(document_resource), history_handling);
+}
+
+void PageClient::notify_webdriver_of_window_replacement()
+{
+    if (m_webdriver)
+        m_webdriver->page_did_start_window_replacement({}, page().top_level_traversable()->window_handle().to_utf8());
 }
 
 void PageClient::request_new_process_for_child_frame_navigation(Web::HTML::CrossProcessId frame_id, URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -53,6 +53,7 @@ public:
     virtual bool has_focus() const override { return m_has_focus; }
 
     ErrorOr<void> connect_to_webdriver(ByteString const& webdriver_endpoint);
+    void notify_webdriver_of_window_replacement();
     ErrorOr<void> connect_to_web_ui(IPC::TransportHandle);
 
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -177,7 +177,7 @@ endpoint WebContentClient
     did_update_session_history_and_request_ui_process_session_history_for_testing(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index) => (String session_history)
     did_set_top_level_session_history(u64 page_id, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index) =|
     did_traverse_the_history_to_step(u64 page_id, i32 step, bool step_was_available, Web::HTML::HistoryStepResult result) =|
-    did_check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step, bool canceled) =|
+    did_check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step, Web::HTML::HistoryStepResult result) =|
     did_reset_session_history_for_testing(u64 page_id) =|
 
     did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -44,6 +44,7 @@ endpoint WebContentServer
     set_window_handle(u64 page_id, String handle) =|
 
     connect_to_webdriver(u64 page_id, ByteString webdriver_endpoint) =|
+    notify_webdriver_of_window_replacement(u64 page_id) =|
     complete_webdriver_history_traversal(u64 page_id, u64 request_id, bool accepted, bool will_replace_web_content_process, bool will_change_top_level_entry) =|
     complete_webdriver_navigation_completion(u64 page_id, u64 request_id, Web::WebDriver::Response response) =|
     connect_to_web_ui(u64 page_id, IPC::TransportHandle handle) =|

--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -53,6 +53,8 @@ class TestPageServer(http.server.ThreadingHTTPServer):
         self.release_blocked_navigation = threading.Event()
         self.blocked_navigation_response_finished = threading.Event()
         self.navigation_blocked_document_ran = threading.Event()
+        self.blocked_no_content_navigation_requested = threading.Event()
+        self.release_blocked_no_content_navigation = threading.Event()
         self.a_request_lock = threading.Lock()
         self.a_request_count = 0
         self.state_replace_load_document_ran = threading.Event()
@@ -94,6 +96,7 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
 <a id="pending" href="http://localhost:{server_port}/navigation-blocked">Pending</a>
 <a id="pending-redirect" href="http://localhost:{server_port}/redirect-to-navigation-blocked">Pending redirect</a>
 <a id="pending-cross-site" href="http://127.0.0.1:{server_port}/navigation-blocked">Pending cross-site</a>
+<a id="pending-cross-site-no-content" href="http://127.0.0.1:{server_port}/navigation-no-content-blocked">Pending cross-site no content</a>
 <p>A</p>""".encode()
             )
             return
@@ -176,6 +179,18 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
 
         if self.path == "/document-ran?navigation-blocked":
             server.navigation_blocked_document_ran.set()
+            self.send_response(204)
+            self.end_headers()
+            return
+
+        if self.path == "/navigation-no-content-blocked":
+            server.blocked_no_content_navigation_requested.set()
+            if not server.release_blocked_no_content_navigation.wait(timeout=BLOCKED_RESPONSE_TIMEOUT_SECONDS):
+                self.send_response(500)
+                self.send_header("Content-Type", "text/plain")
+                self.end_headers()
+                self.wfile.write(b"timed out waiting to unblock no-content navigation")
+                return
             self.send_response(204)
             self.end_headers()
             return
@@ -2470,6 +2485,103 @@ def run_cross_process_pending_navigation_browser_ui_back_test(
         request(webdriver_port, "DELETE", f"/session/{session_id}")
 
 
+def run_cross_process_no_content_navigation_restore_test(
+    webdriver_port,
+    page_server,
+    url_a,
+    url_cross_site_no_content,
+):
+    session_id = create_session(webdriver_port)
+    log = [f"cross-process no-content navigation restore initial: {current_url(webdriver_port, session_id)}"]
+    try:
+        load_url_from_ui(webdriver_port, session_id, url_a)
+        expect_url(webdriver_port, session_id, "after no-content navigation setup /a", url_a, log)
+        initial_process_id = session_history(webdriver_port, session_id)["ui"]["webContentProcessID"]
+
+        page_server.blocked_no_content_navigation_requested.clear()
+        page_server.release_blocked_no_content_navigation.clear()
+        page_server.a_document_ran.clear()
+        execute_script(
+            webdriver_port,
+            session_id,
+            'document.querySelector("#pending-cross-site-no-content").click(); return null;',
+        )
+        wait_for_event(page_server.blocked_no_content_navigation_requested, "cross-process no-content request")
+
+        pending_history = session_history(webdriver_port, session_id)
+        pending_navigation = pending_history["ui"]["pendingSessionHistoryNavigation"]
+        provisional_process_id = pending_history["ui"]["webContentProcessID"]
+        if (
+            pending_history["ui"]["currentURL"] != url_cross_site_no_content
+            or pending_navigation.get("previousCurrentURL") != url_a
+            or pending_navigation.get("webContentRestoreMode") != "restore-from-ui-process"
+            or provisional_process_id == initial_process_id
+        ):
+            raise AssertionError(
+                "Expected no-content navigation to install a provisional cross-site process, got "
+                f"{summarize_history_snapshot(pending_history)}\n" + "\n".join(log)
+            )
+
+        page_server.release_blocked_no_content_navigation.set()
+        wait_for_event(page_server.a_document_ran, "restored /a document after no-content navigation")
+        expect_url(webdriver_port, session_id, "after cross-process no-content navigation restores /a", url_a, log)
+        restored_history = expect_ui_session_history(
+            webdriver_port,
+            session_id,
+            "after cross-process no-content navigation restores /a",
+            [url_a],
+            [0],
+            0,
+            False,
+            False,
+            log,
+            expect_web_content_matches_ui=True,
+            expected_web_content_known_used_steps=[0],
+            expected_web_content_current_step=0,
+        )
+        if restored_history["ui"]["webContentProcessID"] == provisional_process_id:
+            raise AssertionError(
+                "Expected no-content restoration to replace the provisional cross-site process\n" + "\n".join(log)
+            )
+        if (
+            restored_history["ui"]["pendingSessionHistoryNavigation"] is not None
+            or restored_history["ui"]["pendingSessionHistoryTraversal"] is not None
+        ):
+            raise AssertionError("Expected no pending history state after no-content restoration\n" + "\n".join(log))
+    finally:
+        page_server.release_blocked_no_content_navigation.set()
+        request(webdriver_port, "DELETE", f"/session/{session_id}")
+
+
+def run_provisional_navigation_browser_ui_back_tests(
+    webdriver_port,
+    page_server,
+    url_a,
+    url_navigation_blocked,
+    url_redirect_to_navigation_blocked,
+    url_cross_site_navigation_blocked,
+):
+    run_pending_navigation_browser_ui_back_test(
+        webdriver_port,
+        page_server,
+        url_a,
+        url_navigation_blocked,
+        url_redirect_to_navigation_blocked,
+    )
+    run_cross_process_pending_navigation_browser_ui_back_test(
+        webdriver_port,
+        page_server,
+        url_a,
+        url_cross_site_navigation_blocked,
+    )
+    run_cross_process_no_content_navigation_restore_test(
+        webdriver_port,
+        page_server,
+        url_a,
+        f"http://127.0.0.1:{page_server.server_port}/navigation-no-content-blocked",
+    )
+
+
 def run_test(webdriver_binary):
     page_server = TestPageServer(("0.0.0.0", 0), TestPageHandler)
     page_server_thread = threading.Thread(target=page_server.serve_forever, daemon=True)
@@ -2535,17 +2647,12 @@ def run_test(webdriver_binary):
 
         expect_ladybird_test_hooks_require_capability(webdriver_port)
 
-        run_pending_navigation_browser_ui_back_test(
+        run_provisional_navigation_browser_ui_back_tests(
             webdriver_port,
             page_server,
             url_a,
             url_navigation_blocked,
             url_redirect_to_navigation_blocked,
-        )
-        run_cross_process_pending_navigation_browser_ui_back_test(
-            webdriver_port,
-            page_server,
-            url_a,
             url_cross_site_navigation_blocked,
         )
 
@@ -5215,6 +5322,7 @@ return [Math.floor(rect.left + rect.width / 2), Math.floor(rect.top + rect.heigh
         page_server.release_blocked_process_swap_back.set()
         page_server.release_blocked_forward.set()
         page_server.release_blocked_navigation.set()
+        page_server.release_blocked_no_content_navigation.set()
         page_server.shutdown()
         page_server.server_close()
 

--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -52,6 +52,7 @@ class TestPageServer(http.server.ThreadingHTTPServer):
         self.blocked_navigation_requested = threading.Event()
         self.release_blocked_navigation = threading.Event()
         self.blocked_navigation_response_finished = threading.Event()
+        self.navigation_blocked_document_ran = threading.Event()
         self.a_request_lock = threading.Lock()
         self.a_request_count = 0
         self.state_replace_load_document_ran = threading.Event()
@@ -92,6 +93,7 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
 <a id="redirect" href="http://localhost:{server_port}/redirect-to-b">Redirect to B</a>
 <a id="pending" href="http://localhost:{server_port}/navigation-blocked">Pending</a>
 <a id="pending-redirect" href="http://localhost:{server_port}/redirect-to-navigation-blocked">Pending redirect</a>
+<a id="pending-cross-site" href="http://127.0.0.1:{server_port}/navigation-blocked">Pending cross-site</a>
 <p>A</p>""".encode()
             )
             return
@@ -164,9 +166,18 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html")
                 self.end_headers()
-                self.wfile.write(b"<!doctype html><title>Pending navigation committed</title>")
+                self.wfile.write(
+                    b"<!doctype html><title>Pending navigation committed</title>"
+                    b"<script>fetch('/document-ran?navigation-blocked');</script>"
+                )
             finally:
                 server.blocked_navigation_response_finished.set()
+            return
+
+        if self.path == "/document-ran?navigation-blocked":
+            server.navigation_blocked_document_ran.set()
+            self.send_response(204)
+            self.end_headers()
             return
 
         if self.path.startswith("/nested"):
@@ -2315,6 +2326,145 @@ return null;
             False,
             log,
         )
+
+        page_server.blocked_navigation_requested.clear()
+        page_server.release_blocked_navigation.clear()
+        page_server.blocked_navigation_response_finished.clear()
+        page_server.navigation_blocked_document_ran.clear()
+        execute_script(
+            webdriver_port,
+            session_id,
+            'document.querySelector("#pending").click(); return null;',
+        )
+        wait_for_event(page_server.blocked_navigation_requested, "navigation that will commit request")
+        page_server.release_blocked_navigation.set()
+        wait_for_event(
+            page_server.blocked_navigation_response_finished, "navigation that will commit response completion"
+        )
+        wait_for_event(page_server.navigation_blocked_document_ran, "navigation that will commit document script")
+        expect_url(webdriver_port, session_id, "after pending navigation commits", url_navigation_blocked, log)
+        expect_ui_session_history(
+            webdriver_port,
+            session_id,
+            "after pending navigation commits",
+            [url_a, url_navigation_blocked],
+            [0, 1],
+            1,
+            True,
+            False,
+            log,
+            expect_web_content_matches_ui=True,
+            expected_web_content_known_used_steps=[0, 1],
+            expected_web_content_current_step=1,
+        )
+
+        traverse_history_from_ui(webdriver_port, session_id, -1)
+        expect_url(webdriver_port, session_id, "after back following pending navigation commit", url_a, log)
+        expect_ui_session_history(
+            webdriver_port,
+            session_id,
+            "after back following pending navigation commit",
+            [url_a, url_navigation_blocked],
+            [0, 1],
+            0,
+            False,
+            True,
+            log,
+            expect_web_content_matches_ui=True,
+            expected_web_content_known_used_steps=[0, 1],
+            expected_web_content_current_step=0,
+        )
+
+    finally:
+        page_server.release_blocked_navigation.set()
+        request(webdriver_port, "DELETE", f"/session/{session_id}")
+
+
+def run_cross_process_pending_navigation_browser_ui_back_test(
+    webdriver_port,
+    page_server,
+    url_a,
+    url_cross_site_navigation_blocked,
+):
+    session_id = create_session(webdriver_port)
+    log = [f"cross-process pending navigation browser UI back initial: {current_url(webdriver_port, session_id)}"]
+    try:
+        with page_server.a_request_lock:
+            initial_a_request_count = page_server.a_request_count
+
+        load_url_from_ui(webdriver_port, session_id, url_a)
+        expect_url(webdriver_port, session_id, "after cross-process pending navigation setup /a", url_a, log)
+        with page_server.a_request_lock:
+            a_request_count_after_setup = page_server.a_request_count
+        if a_request_count_after_setup != initial_a_request_count + 1:
+            raise AssertionError(
+                f"Expected one /a request during cross-process setup, got "
+                f"{a_request_count_after_setup - initial_a_request_count}\n" + "\n".join(log)
+            )
+
+        page_server.blocked_navigation_requested.clear()
+        page_server.release_blocked_navigation.clear()
+        page_server.blocked_navigation_response_finished.clear()
+        execute_script(
+            webdriver_port,
+            session_id,
+            'document.querySelector("#pending-cross-site").click(); return null;',
+        )
+        wait_for_event(page_server.blocked_navigation_requested, "cross-process pending navigation request")
+
+        pending_history = session_history(webdriver_port, session_id)
+        pending_navigation = pending_history["ui"]["pendingSessionHistoryNavigation"]
+        if (
+            pending_history["ui"]["currentURL"] != url_cross_site_navigation_blocked
+            or pending_navigation.get("previousCurrentURL") != url_a
+            or pending_navigation.get("webContentRestoreMode") != "restore-from-ui-process"
+        ):
+            raise AssertionError(
+                "Expected cross-process navigation to require UI-process restoration, got "
+                f"{summarize_history_snapshot(pending_history)}\n" + "\n".join(log)
+            )
+
+        page_server.a_document_ran.clear()
+        traverse_history_from_ui(webdriver_port, session_id, -1, wait_for_navigation_completion=False)
+        wait_for_event(page_server.a_document_ran, "restored /a document after cross-process pending navigation")
+        expect_url(webdriver_port, session_id, "after back during cross-process pending navigation", url_a, log)
+        restored_history = wait_for_session_history(
+            webdriver_port,
+            session_id,
+            "after back during cross-process pending navigation",
+            lambda snapshot: (
+                snapshot["ui"]["currentURL"] == url_a
+                and history_entry_urls(snapshot["ui"]) == [url_a, url_cross_site_navigation_blocked]
+                and snapshot["ui"]["currentUsedStepIndex"] == 0
+                and snapshot["ui"]["backButtonEnabled"] is False
+                and snapshot["ui"]["forwardButtonEnabled"] is True
+                and snapshot["ui"]["pendingSessionHistoryNavigation"] is None
+                and snapshot["ui"]["pendingSessionHistoryTraversal"] is None
+            ),
+            log,
+        )
+        if history_entry_urls(restored_history["webContent"]) != [url_a, url_cross_site_navigation_blocked]:
+            raise AssertionError("Expected replacement WebContent to receive the restored history\n" + "\n".join(log))
+        with page_server.a_request_lock:
+            if page_server.a_request_count != a_request_count_after_setup + 1:
+                raise AssertionError(
+                    "Expected cross-process cancellation to restore /a from the UI process\n" + "\n".join(log)
+                )
+
+        page_server.release_blocked_navigation.set()
+        wait_for_event(
+            page_server.blocked_navigation_response_finished,
+            "cross-process canceled response completion",
+        )
+        expect_url(webdriver_port, session_id, "after releasing cross-process canceled response", url_a, log)
+        expect_navigation_buttons(
+            webdriver_port,
+            session_id,
+            "after releasing cross-process canceled response",
+            False,
+            True,
+            log,
+        )
     finally:
         page_server.release_blocked_navigation.set()
         request(webdriver_port, "DELETE", f"/session/{session_id}")
@@ -2356,6 +2506,7 @@ def run_test(webdriver_binary):
         url_d = f"http://localhost:{page_port}/d"
         url_redirect_to_b = f"http://localhost:{page_port}/redirect-to-b"
         url_navigation_blocked = f"http://localhost:{page_port}/navigation-blocked"
+        url_cross_site_navigation_blocked = f"http://127.0.0.1:{page_port}/navigation-blocked"
         url_redirect_to_navigation_blocked = f"http://localhost:{page_port}/redirect-to-navigation-blocked"
         url_nested = f"http://localhost:{page_port}/nested"
         url_state = f"http://localhost:{page_port}/state"
@@ -2390,6 +2541,12 @@ def run_test(webdriver_binary):
             url_a,
             url_navigation_blocked,
             url_redirect_to_navigation_blocked,
+        )
+        run_cross_process_pending_navigation_browser_ui_back_test(
+            webdriver_port,
+            page_server,
+            url_a,
+            url_cross_site_navigation_blocked,
         )
 
         session_id = create_session(webdriver_port)

--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -49,6 +49,11 @@ class TestPageServer(http.server.ThreadingHTTPServer):
         self.release_blocked_same_site_post = threading.Event()
         self.blocked_same_url_post_requested = threading.Event()
         self.release_blocked_same_url_post = threading.Event()
+        self.blocked_navigation_requested = threading.Event()
+        self.release_blocked_navigation = threading.Event()
+        self.blocked_navigation_response_finished = threading.Event()
+        self.a_request_lock = threading.Lock()
+        self.a_request_count = 0
         self.state_replace_load_document_ran = threading.Event()
         self.a_document_ran = threading.Event()
         self.fragment_source_document_ran = threading.Event()
@@ -74,6 +79,8 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
         server_port = server.server_port
 
         if self.path == "/a":
+            with server.a_request_lock:
+                server.a_request_count += 1
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
             self.end_headers()
@@ -83,6 +90,8 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
 <script>fetch('/document-ran?a');</script>
 <a id="go" href="http://127.0.0.1:{server_port}/b">B</a>
 <a id="redirect" href="http://localhost:{server_port}/redirect-to-b">Redirect to B</a>
+<a id="pending" href="http://localhost:{server_port}/navigation-blocked">Pending</a>
+<a id="pending-redirect" href="http://localhost:{server_port}/redirect-to-navigation-blocked">Pending redirect</a>
 <p>A</p>""".encode()
             )
             return
@@ -134,6 +143,30 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(302)
             self.send_header("Location", f"http://127.0.0.1:{server_port}/b")
             self.end_headers()
+            return
+
+        if self.path == "/redirect-to-navigation-blocked":
+            self.send_response(302)
+            self.send_header("Location", f"http://localhost:{server_port}/navigation-blocked")
+            self.end_headers()
+            return
+
+        if self.path == "/navigation-blocked":
+            server.blocked_navigation_requested.set()
+            if not server.release_blocked_navigation.wait(timeout=BLOCKED_RESPONSE_TIMEOUT_SECONDS):
+                self.send_response(500)
+                self.send_header("Content-Type", "text/plain")
+                self.end_headers()
+                self.wfile.write(b"timed out waiting to unblock navigation")
+                return
+
+            try:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(b"<!doctype html><title>Pending navigation committed</title>")
+            finally:
+                server.blocked_navigation_response_finished.set()
             return
 
         if self.path.startswith("/nested"):
@@ -2114,6 +2147,179 @@ def expect_cross_site_fragment_navigation_from_ui_loads_document(
         raise AssertionError(f"Expected current URL {target_with_fragment}, got {actual_url}")
 
 
+def run_pending_navigation_browser_ui_back_test(
+    webdriver_port,
+    page_server,
+    url_a,
+    url_navigation_blocked,
+    url_redirect_to_navigation_blocked,
+):
+    session_id = create_session(webdriver_port)
+    log = [f"pending navigation browser UI back initial: {current_url(webdriver_port, session_id)}"]
+    try:
+        with page_server.a_request_lock:
+            initial_a_request_count = page_server.a_request_count
+
+        load_url_from_ui(webdriver_port, session_id, url_a)
+        expect_url(webdriver_port, session_id, "after pending navigation setup /a", url_a, log)
+        with page_server.a_request_lock:
+            a_request_count_after_setup = page_server.a_request_count
+        if a_request_count_after_setup != initial_a_request_count + 1:
+            raise AssertionError(
+                f"Expected one /a request during setup, got {a_request_count_after_setup - initial_a_request_count}\n"
+                + "\n".join(log)
+            )
+
+        execute_script(
+            webdriver_port,
+            session_id,
+            f"""
+window.beforeUnloadCount = 0;
+window.pendingNavigateCount = 0;
+window.pendingNavigateAbortCount = 0;
+addEventListener("beforeunload", () => ++window.beforeUnloadCount);
+navigation.addEventListener("navigate", event => {{
+    if (event.destination.url === {json.dumps(url_navigation_blocked)}
+        || event.destination.url === {json.dumps(url_redirect_to_navigation_blocked)}) {{
+        ++window.pendingNavigateCount;
+        event.signal.addEventListener("abort", () => ++window.pendingNavigateAbortCount, {{ once: true }});
+    }}
+}});
+return null;
+""",
+        )
+
+        def cancel_pending_navigation(label, start_navigation):
+            page_server.blocked_navigation_requested.clear()
+            page_server.release_blocked_navigation.clear()
+            page_server.blocked_navigation_response_finished.clear()
+
+            initial_state = execute_script(
+                webdriver_port,
+                session_id,
+                "return [window.beforeUnloadCount, window.pendingNavigateCount, window.pendingNavigateAbortCount];",
+            )
+
+            start_navigation()
+            wait_for_event(page_server.blocked_navigation_requested, f"{label} request")
+
+            before_cancel_state = execute_script(
+                webdriver_port,
+                session_id,
+                "return [location.href, window.beforeUnloadCount, window.pendingNavigateCount, window.pendingNavigateAbortCount];",
+            )
+            if (
+                before_cancel_state[0] != url_a
+                or before_cancel_state[1] != initial_state[0] + 1
+                or before_cancel_state[2] != initial_state[1] + 1
+                or before_cancel_state[3] != initial_state[2]
+            ):
+                raise AssertionError(
+                    f"Expected {label} to remain provisional over /a, got {before_cancel_state}\n" + "\n".join(log)
+                )
+
+            pending_history = session_history(webdriver_port, session_id)
+            pending_navigation = pending_history["ui"]["pendingSessionHistoryNavigation"]
+            if (
+                pending_history["ui"]["currentURL"] not in (url_navigation_blocked, url_redirect_to_navigation_blocked)
+                or pending_navigation.get("previousCurrentURL") != url_a
+                or history_entry_urls(pending_history["webContent"]) != [url_a]
+            ):
+                raise AssertionError(
+                    f"Expected {label} to be pending over /a, got {summarize_history_snapshot(pending_history)}\n"
+                    + "\n".join(log)
+                )
+
+            traverse_history_from_ui(webdriver_port, session_id, -1, wait_for_navigation_completion=False)
+            rolled_back_history = wait_for_session_history(
+                webdriver_port,
+                session_id,
+                f"after canceling {label}",
+                lambda snapshot: (
+                    snapshot["ui"]["currentURL"] == url_a
+                    and history_entry_urls(snapshot["ui"]) == [url_a]
+                    and snapshot["ui"]["pendingSessionHistoryNavigation"] is None
+                    and snapshot["ui"]["pendingSessionHistoryTraversal"] is None
+                    and snapshot["ui"]["webContentHistoryMatchesUI"] is True
+                ),
+                log,
+            )
+            if history_entry_urls(rolled_back_history["webContent"]) != [url_a]:
+                raise AssertionError(
+                    f"Expected WebContent to remain on /a after {label}, got {summarize_history_snapshot(rolled_back_history)}\n"
+                    + "\n".join(log)
+                )
+
+            after_cancel_state = execute_script(
+                webdriver_port,
+                session_id,
+                "return [location.href, window.beforeUnloadCount, window.pendingNavigateCount, window.pendingNavigateAbortCount];",
+            )
+            if (
+                after_cancel_state[0] != url_a
+                or after_cancel_state[1] != before_cancel_state[1]
+                or after_cancel_state[2] != before_cancel_state[2]
+                or after_cancel_state[3] != before_cancel_state[3] + 1
+            ):
+                raise AssertionError(
+                    f"Expected {label} cancellation to abort only the pending navigation, got {after_cancel_state}\n"
+                    + "\n".join(log)
+                )
+
+            with page_server.a_request_lock:
+                if page_server.a_request_count != a_request_count_after_setup:
+                    raise AssertionError(f"{label} reloaded /a instead of preserving it\n" + "\n".join(log))
+
+            page_server.release_blocked_navigation.set()
+            wait_for_event(page_server.blocked_navigation_response_finished, f"{label} canceled response completion")
+            expect_url(webdriver_port, session_id, f"after releasing canceled {label}", url_a, log)
+            expect_ui_session_history(
+                webdriver_port,
+                session_id,
+                f"after releasing canceled {label}",
+                [url_a],
+                [0],
+                0,
+                False,
+                False,
+                log,
+                expect_web_content_matches_ui=True,
+                expected_web_content_known_used_steps=[0],
+                expected_web_content_current_step=0,
+            )
+
+        cancel_pending_navigation(
+            "renderer-initiated navigation",
+            lambda: execute_script(
+                webdriver_port,
+                session_id,
+                'document.querySelector("#pending").click(); return null;',
+            ),
+        )
+        cancel_pending_navigation(
+            "redirected renderer-initiated navigation",
+            lambda: execute_script(
+                webdriver_port,
+                session_id,
+                'document.querySelector("#pending-redirect").click(); return null;',
+            ),
+        )
+
+        traverse_history_from_ui(webdriver_port, session_id, -1, wait_for_navigation_completion=False)
+        expect_url(webdriver_port, session_id, "after redundant back following pending cancellations", url_a, log)
+        expect_navigation_buttons(
+            webdriver_port,
+            session_id,
+            "after redundant back following pending cancellations",
+            False,
+            False,
+            log,
+        )
+    finally:
+        page_server.release_blocked_navigation.set()
+        request(webdriver_port, "DELETE", f"/session/{session_id}")
+
+
 def run_test(webdriver_binary):
     page_server = TestPageServer(("0.0.0.0", 0), TestPageHandler)
     page_server_thread = threading.Thread(target=page_server.serve_forever, daemon=True)
@@ -2149,6 +2355,8 @@ def run_test(webdriver_binary):
         url_c = f"http://127.0.0.1:{page_port}/c"
         url_d = f"http://localhost:{page_port}/d"
         url_redirect_to_b = f"http://localhost:{page_port}/redirect-to-b"
+        url_navigation_blocked = f"http://localhost:{page_port}/navigation-blocked"
+        url_redirect_to_navigation_blocked = f"http://localhost:{page_port}/redirect-to-navigation-blocked"
         url_nested = f"http://localhost:{page_port}/nested"
         url_state = f"http://localhost:{page_port}/state"
         url_state_replace_load = f"http://localhost:{page_port}/state?replace-load"
@@ -2175,6 +2383,14 @@ def run_test(webdriver_binary):
         url_fragment_target = f"http://127.0.0.1:{page_port}/fragment-target"
 
         expect_ladybird_test_hooks_require_capability(webdriver_port)
+
+        run_pending_navigation_browser_ui_back_test(
+            webdriver_port,
+            page_server,
+            url_a,
+            url_navigation_blocked,
+            url_redirect_to_navigation_blocked,
+        )
 
         session_id = create_session(webdriver_port)
         expect_second_ui_forward_during_pending_forward_does_not_hang(
@@ -4841,6 +5057,7 @@ return [Math.floor(rect.left + rect.width / 2), Math.floor(rect.top + rect.heigh
         page_server.release_blocked_reload.set()
         page_server.release_blocked_process_swap_back.set()
         page_server.release_blocked_forward.set()
+        page_server.release_blocked_navigation.set()
         page_server.shutdown()
         page_server.server_close()
 


### PR DESCRIPTION
Make browser UI Back traversals cancel an uncommitted navigation when the target is the still-active session history entry. This matches Chromium, WebKit, and Gecko behavior and allows Back to respond without waiting for the provisional load to finish.

Restore the UI-owned history mirror only when the preserved active document matches the traversal target. When restoration crosses a site boundary, replace the provisional WebContent process and seed the restored history into the correctly isolated process. Preserve WebDriver window identity across UI-initiated process replacement.

Add deterministic WebDriver coverage for same-process and cross-process provisional navigations, redirects, cancellation checks, UI and WebContent history synchronization, and cross-site loads ending with a 204 response.